### PR TITLE
Added a simple packager.

### DIFF
--- a/server/package.yaml
+++ b/server/package.yaml
@@ -42,10 +42,12 @@ dependencies:
   - mtl
   - network-uri
   - path-pieces
+  - pathwalk
   - persistent <2.10.0
   - persistent-postgresql
   - persistent-sqlite
   - persistent-template
+  - process
   - protolude
   - resource-pool
   - servant ==0.15
@@ -57,6 +59,7 @@ dependencies:
   - serversession
   - serversession-backend-persistent
   - split
+  - temporary
   - text
   - time
   - transformers

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -353,6 +353,11 @@ getPackageJSONEndpoint javascriptPackageName = do
 hashedAssetPathsEndpoint :: ServerMonad Value
 hashedAssetPathsEndpoint = getHashedAssetPaths
 
+packagePackagerEndpoint :: Text -> Text -> ServerMonad BL.ByteString
+packagePackagerEndpoint javascriptPackageName javascriptPackageVersionAndSuffix = do
+  let javascriptPackageVersion = fromMaybe javascriptPackageVersionAndSuffix $ T.stripSuffix ".json" javascriptPackageVersionAndSuffix
+  getPackagePackagerContent javascriptPackageName javascriptPackageVersion
+
 {-|
   Compose together all the individual endpoints into a definition for the whole server.
 -}
@@ -386,6 +391,7 @@ unprotected = authenticate
          :<|> loadProjectThumbnailEndpoint
          :<|> websocketsEndpoint
          :<|> monitoringEndpoint
+         :<|> packagePackagerEndpoint
          :<|> getPackageJSONEndpoint
          :<|> hashedAssetPathsEndpoint
          :<|> editorAssetsEndpoint "./editor"

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -251,6 +251,9 @@ innerServerExecutor (GetHashedAssetPaths action) = do
   AssetsCaches{..} <- fmap _assetsCaches ask
   AssetResultCache{..} <- liftIO $ readIORef _assetResultCache
   return $ action _editorMappings
+innerServerExecutor (GetPackagePackagerContent javascriptPackageName javascriptPackageVersion action) = do
+  packagerContent <- liftIO $ getPackagerContent javascriptPackageName javascriptPackageVersion
+  return $ action packagerContent
 
 readIndexHtmlFromDisk :: Text -> IO Text
 readIndexHtmlFromDisk fileName = readFile $ toS $ "../editor/lib/" <> fileName

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -197,6 +197,9 @@ innerServerExecutor (GetHashedAssetPaths action) = do
   AssetsCaches{..} <- fmap _assetsCaches ask
   AssetResultCache{..} <- liftIO $ readIORef _assetResultCache
   return $ action _editorMappings
+innerServerExecutor (GetPackagePackagerContent javascriptPackageName javascriptPackageVersion action) = do
+  packagerContent <- liftIO $ getPackagerContent javascriptPackageName javascriptPackageVersion
+  return $ action packagerContent
 
 {-|
   Invokes a service call using the supplied resources.

--- a/server/src/Utopia/Web/Packager/NPM.hs
+++ b/server/src/Utopia/Web/Packager/NPM.hs
@@ -1,0 +1,38 @@
+module Utopia.Web.Packager.NPM where
+
+import           Control.Monad
+import           Data.List                 (isSuffixOf, stripPrefix)
+import           Protolude
+import           System.Directory.PathWalk
+import           System.FilePath
+import           System.IO.Temp
+import           System.Process
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.IO as TL
+
+withInstalledProject :: Text -> Text -> (FilePath -> IO a) -> IO a
+withInstalledProject jsPackageName jsPackageVersion withInstalledPath = do
+  -- Create temporary folder.
+  withSystemTempDirectory "packager" $ \tempDir -> do
+    -- Run `npm install "packageName@packageVersion"`.
+    let baseProc = proc "npm" ["install", "--loglevel=error", toS jsPackageName <> "@" <> toS jsPackageVersion]
+    let procWithCwd = baseProc { cwd = Just tempDir }
+    _ <- readCreateProcess procWithCwd ""
+    -- Invoke action against path.
+    withInstalledPath tempDir
+
+isRelevantFilename :: FilePath -> Bool
+isRelevantFilename path = isSuffixOf "package.json" path || isSuffixOf ".js" path
+
+getRelevantFiles :: FilePath -> IO [(Text, TL.Text)]
+getRelevantFiles projectPath = do
+  pathWalkAccumulate projectPath $ \dir _ files -> do
+    let strippedDir = fromMaybe dir $ stripPrefix projectPath dir
+    results <- forM files $ \file -> do
+      let relevant = isRelevantFilename file
+      let emptyResult = return []
+      let entryFilename = strippedDir </> file
+      let fullFilename = projectPath </> dir </> file
+      let fileWithContent = fmap (\contents -> [(toS entryFilename, contents)]) $ TL.readFile fullFilename
+      if relevant then fileWithContent else emptyResult
+    return $ mconcat results

--- a/server/src/Utopia/Web/Servant.hs
+++ b/server/src/Utopia/Web/Servant.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 
+{-# OPTIONS_GHC -Wno-warnings-deprecations #-}
 {-|
   Provides some additional utilities for interacting with the servant library.
   Including appropriate mime types and accept headers for a bunch of image types.
@@ -21,7 +22,7 @@ import qualified Data.ByteString.Lazy     as BL
 import           Network.HTTP.Media       hiding (Accept)
 import           Protolude
 import           Servant.API
-import           Servant.HTML.Blaze
+
 
 data BMP
 
@@ -34,6 +35,7 @@ instance MimeRender BMP BL.ByteString where
 instance MimeUnrender BMP BL.ByteString where
   mimeUnrender _ bytes = Right bytes
 
+
 data GIF
 
 instance Accept GIF where
@@ -44,6 +46,7 @@ instance MimeRender GIF BL.ByteString where
 
 instance MimeUnrender GIF BL.ByteString where
   mimeUnrender _ bytes = Right bytes
+
 
 data JPG
 
@@ -56,6 +59,7 @@ instance MimeRender JPG BL.ByteString where
 instance MimeUnrender JPG BL.ByteString where
   mimeUnrender _ bytes = Right bytes
 
+
 data PNG
 
 instance Accept PNG where
@@ -66,6 +70,7 @@ instance MimeRender PNG BL.ByteString where
 
 instance MimeUnrender PNG BL.ByteString where
   mimeUnrender _ bytes = Right bytes
+
 
 data SVG
 
@@ -78,8 +83,6 @@ instance MimeRender SVG BL.ByteString where
 instance MimeUnrender SVG BL.ByteString where
   mimeUnrender _ bytes = Right bytes
 
-instance MimeUnrender HTML Text where
-  mimeUnrender _ bytes = Right $ toS bytes
 
 data PrettyJSON
 
@@ -88,3 +91,14 @@ instance Accept PrettyJSON where
 
 instance ToJSON a => MimeRender PrettyJSON a where
   mimeRender _ val = encodePretty val
+
+
+data ForcedJSON
+
+instance Accept ForcedJSON where
+  contentType _ = "application" // "json"
+
+instance MimeRender ForcedJSON BL.ByteString where
+  mimeRender _ bytes =  bytes
+
+

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -117,6 +117,7 @@ data ServiceCallsF a = NotFound
                      | GetEditorIndexHtml (Text -> a)
                      | GetPreviewIndexHtml (Text -> a)
                      | GetHashedAssetPaths (Value -> a)
+                     | GetPackagePackagerContent Text Text (BL.ByteString -> a)
                      deriving Functor
 
 {-

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -104,6 +104,8 @@ type LoadProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" Text 
 
 type SaveProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" Text :> ReqBody '[BMP, GIF, JPG, PNG, SVG] BL.ByteString :> Post '[JSON] NoContent
 
+type PackagePackagerAPI = "v1" :> "javascript" :> "packager" :> Capture "package_name" Text :> Capture "package_version" Text :> Get '[ForcedJSON] BL.ByteString
+
 type GetPackageJSONAPI = "v1" :> "javascript" :> "package" :> "metadata" :> Capture "package_name" Text :> Get '[JSON] Value
 
 type MonitoringAPI = "monitoring" :> "secret" :> "location" :> Get '[JSON] Value
@@ -152,6 +154,7 @@ type Unprotected = AuthenticateAPI
               :<|> LoadProjectThumbnailAPI
               :<|> WebsocketsAPI
               :<|> MonitoringAPI
+              :<|> PackagePackagerAPI
               :<|> GetPackageJSONAPI
               :<|> HashedAssetPathsAPI
               :<|> EditorAssetsAPI

--- a/server/test/Main.hs
+++ b/server/test/Main.hs
@@ -4,6 +4,7 @@ import           Protolude
 import           Test.Tasty
 import           Test.Tasty.Hspec
 import           Test.Utopia.Web.Endpoints
+import           Test.Utopia.Web.Packager.NPM
 
 main :: IO ()
 main = do
@@ -12,5 +13,6 @@ main = do
 
 tests :: IO TestTree
 tests = do
-  routingTestTree <- testSpec "Routing test" routingTest
-  return $ testGroup "Tests" [routingTestTree]
+  routingTestTree <- testSpec "Routing Tests" routingSpec
+  npmTestTree <- testSpec "NPM Tests" npmSpec
+  return $ testGroup "Tests" [routingTestTree, npmTestTree]

--- a/server/test/Test/Utopia/Web/Endpoints.hs
+++ b/server/test/Test/Utopia/Web/Endpoints.hs
@@ -120,7 +120,7 @@ setShowcaseClient = client (Proxy :: Proxy SetShowcaseAPI)
 saveProjectAssetClient :: Maybe Text -> Text -> [Text] -> (Request -> Request) -> ClientM Response
 saveProjectAssetClient = client (Proxy :: Proxy (AuthCookie :> SaveProjectAssetAPI))
 
-deleteProjectAssetClient :: Maybe Text -> Text -> [Text] -> ClientM NoContent 
+deleteProjectAssetClient :: Maybe Text -> Text -> [Text] -> ClientM NoContent
 deleteProjectAssetClient = client (Proxy :: Proxy (AuthCookie :> DeleteProjectAssetAPI))
 
 loadProjectAssetClient :: Text -> Text -> [Text] -> (Request -> Request) -> ClientM Response
@@ -187,8 +187,8 @@ deleteAssetSpec =
         (Left _)                          -> expectationFailure "Unexpected response type."
         (Right _)                         -> expectationFailure "Unexpected successful response."
 
-routingTest :: Spec
-routingTest = around_ withServer $ do
+routingSpec :: Spec
+routingSpec = around_ withServer $ do
   describe "GET /authenticate" $ do
     it "should set a cookie for valid login" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
       result <- runClientM (authenticateClient (Just "logmein") (Just "")) clientEnv

--- a/server/test/Test/Utopia/Web/Packager/NPM.hs
+++ b/server/test/Test/Utopia/Web/Packager/NPM.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Utopia.Web.Packager.NPM where
+
+import           Protolude
+import           System.Directory
+import           System.FilePath
+import           Test.Hspec
+import           Utopia.Web.Packager.NPM
+
+getNodeModulesSubDirectories :: FilePath -> IO [FilePath]
+getNodeModulesSubDirectories projectFolder = do
+  paths <- listDirectory (projectFolder </> "node_modules")
+  return $ sort paths
+
+npmSpec :: Spec
+npmSpec = do
+  describe "withInstalledProject" $ do
+    it "should have the various dependencies in node_modules for react" $ do
+      result <- withInstalledProject "react" "16.13.1" getNodeModulesSubDirectories
+      result `shouldBe` [".bin", "js-tokens", "loose-envify", "object-assign", "prop-types", "react", "react-is"]
+    it "should fail for a non-existent project" $ do
+      withInstalledProject "non-existent-project-that-will-never-exist" "9.9.9.9.9.9" getNodeModulesSubDirectories `shouldThrow` anyIOException
+  describe "getRelevantFiles" $ do
+    it "should get a bunch of .js and package.json files" $ do
+      result <- withInstalledProject "react" "16.13.1" getRelevantFiles
+      let sortedFilenames = sort $ fmap fst result
+      sortedFilenames `shouldBe` [
+        "/node_modules/js-tokens/index.js",
+        "/node_modules/js-tokens/package.json",
+        "/node_modules/loose-envify/cli.js",
+        "/node_modules/loose-envify/custom.js",
+        "/node_modules/loose-envify/index.js",
+        "/node_modules/loose-envify/loose-envify.js",
+        "/node_modules/loose-envify/package.json",
+        "/node_modules/loose-envify/replace.js",
+        "/node_modules/object-assign/index.js",
+        "/node_modules/object-assign/package.json",
+        "/node_modules/prop-types/checkPropTypes.js",
+        "/node_modules/prop-types/factory.js",
+        "/node_modules/prop-types/factoryWithThrowingShims.js",
+        "/node_modules/prop-types/factoryWithTypeCheckers.js",
+        "/node_modules/prop-types/index.js",
+        "/node_modules/prop-types/lib/ReactPropTypesSecret.js",
+        "/node_modules/prop-types/package.json",
+        "/node_modules/prop-types/prop-types.js",
+        "/node_modules/prop-types/prop-types.min.js",
+        "/node_modules/react-is/cjs/react-is.development.js",
+        "/node_modules/react-is/cjs/react-is.production.min.js",
+        "/node_modules/react-is/index.js",
+        "/node_modules/react-is/package.json",
+        "/node_modules/react-is/umd/react-is.development.js",
+        "/node_modules/react-is/umd/react-is.production.min.js",
+        "/node_modules/react/cjs/react.development.js",
+        "/node_modules/react/cjs/react.production.min.js",
+        "/node_modules/react/index.js",
+        "/node_modules/react/package.json",
+        "/node_modules/react/umd/react.development.js",
+        "/node_modules/react/umd/react.production.min.js",
+        "/node_modules/react/umd/react.profiling.min.js" ]
+

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8b3ec12769c9b902104802b97bdae549218b7552dbae6557016c0939c3ccaf86
+-- hash: b7d40ee807cd086cecb3609198ba1e33f4ba8de7a747983ebad76521ca184273
 
 name:           utopia-web
 version:        0.1.0.4
@@ -38,6 +38,7 @@ executable utopia-web
       Utopia.Web.Executors.Production
       Utopia.Web.JSON
       Utopia.Web.Metrics
+      Utopia.Web.Packager.NPM
       Utopia.Web.Proxy
       Utopia.Web.Redis
       Utopia.Web.Servant
@@ -90,10 +91,12 @@ executable utopia-web
     , mtl
     , network-uri
     , path-pieces
+    , pathwalk
     , persistent <2.10.0
     , persistent-postgresql
     , persistent-sqlite
     , persistent-template
+    , process
     , protolude
     , resource-pool
     , servant ==0.15
@@ -105,6 +108,7 @@ executable utopia-web
     , serversession
     , serversession-backend-persistent
     , split
+    , temporary
     , text
     , time
     , transformers
@@ -125,6 +129,7 @@ test-suite utopia-web-test
   other-modules:
       Test.Utopia.Web.Endpoints
       Test.Utopia.Web.Executors.Test
+      Test.Utopia.Web.Packager.NPM
       Main
       Utopia.Web.Assets
       Utopia.Web.Auth
@@ -141,6 +146,7 @@ test-suite utopia-web-test
       Utopia.Web.Executors.Production
       Utopia.Web.JSON
       Utopia.Web.Metrics
+      Utopia.Web.Packager.NPM
       Utopia.Web.Proxy
       Utopia.Web.Redis
       Utopia.Web.Servant
@@ -195,11 +201,13 @@ test-suite utopia-web-test
     , mtl
     , network-uri
     , path-pieces
+    , pathwalk
     , persistent <2.10.0
     , persistent-postgresql
     , persistent-sqlite
     , persistent-template
     , port-utils
+    , process
     , protolude
     , resource-pool
     , servant ==0.15
@@ -216,6 +224,7 @@ test-suite utopia-web-test
     , tasty-hedgehog
     , tasty-hspec
     , tasty-hunit
+    , temporary
     , text
     , time
     , transformers


### PR DESCRIPTION
**Problem:**
We needed a packager to collate the content of the dependencies of a particular library.

**Fix:**
Implemented it directly into our server with a URL that is something like the following:
`/v1/javascript/packager/react-spring/8.0.27.json`

**Notes:**
This is pretty dumb and is including everything ending in `.js` or with the name `package.json`.

**Commit Details:**
- Adds `getPackagerContent` to turn the result of the lookup into a
  chunk of encoded JSON.
- Added the `GetPackagePackagerContent` service call and implemented it
  identically for development and production.
- Added `ForcedJSON` to allow us to just roll with a lazy bytestring
  being valid for JSON going out of the server.
- Implemented `withInstalledProject` for installing the contents of a project
  and then permitting some manipulation of said project.
- Implemented `getRelevantFiles` for use with `withInstalledProject` to pull
  out the content we are interested in from the various JavaScript packages.