### PR TITLE
Stop dragging on the canvas from updating unchanged pins

### DIFF
--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -861,7 +861,7 @@ describe('moveTemplate', () => {
         <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
           <View data-uid={'eee'}>
             <View
-              style={{ backgroundColor: '#DDDDDD', width: 256, height: 202, left: 52, top: -141 }}
+              style={{ backgroundColor: '#DDDDDD', left: 52, width: 256, height: 202, top: -141 }}
               layout={{ layoutSystem: 'pinSystem'  }}
               data-uid={'bbb'}
             >
@@ -869,8 +869,8 @@ describe('moveTemplate', () => {
                 <View data-uid={'ddd'} />
               </View>
             </View>
-            <View data-uid={'ggg'} style={{ left: 0, top: 0, width: 400, height: 0 }} />
-            <View data-uid={'hhh'} style={{ left: 0, top: 0, width: 400, height: 0 }} />
+            <View data-uid={'ggg'} />
+            <View data-uid={'hhh'} style={{ top: 0 }} />
           </View>
           <View data-uid={'fff'} />
         </View>
@@ -910,7 +910,7 @@ describe('moveTemplate', () => {
         <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
           <View data-uid={'eee'}>
             <View
-              style={{ backgroundColor: '#DDDDDD', width: 256, height: 202, left: 52, top: -141 }}
+              style={{ backgroundColor: '#DDDDDD', left: 52, width: 256, height: 202, top: -141 }}
               layout={{ layoutSystem: 'pinSystem' }}
               data-uid={'bbb'}
             >
@@ -955,9 +955,9 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
           <View data-uid={'eee'}>
-            <View data-uid={'ddd'} style={{ left: 52, top: -141, width: 0, height: 0 }} />
+            <View data-uid={'ddd'} style={{ left: 52, top: -141 }} />
             <View
-              style={{ backgroundColor: '#DDDDDD', width: 256, height: 202, left: 52, top: -141 }}
+              style={{ backgroundColor: '#DDDDDD', left: 52, width: 256, height: 202, top: -141 }}
               layout={{ layoutSystem: 'pinSystem' }}
               data-uid={'bbb'}
             >

--- a/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
+++ b/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
@@ -45,38 +45,6 @@ Array [
                 "value": "#FFFFFF",
               },
             },
-            Object {
-              "key": "width",
-              "type": "PROPERTY_ASSIGNMENT",
-              "value": Object {
-                "type": "ATTRIBUTE_VALUE",
-                "value": 0,
-              },
-            },
-            Object {
-              "key": "height",
-              "type": "PROPERTY_ASSIGNMENT",
-              "value": Object {
-                "type": "ATTRIBUTE_VALUE",
-                "value": 0,
-              },
-            },
-            Object {
-              "key": "left",
-              "type": "PROPERTY_ASSIGNMENT",
-              "value": Object {
-                "type": "ATTRIBUTE_VALUE",
-                "value": 0,
-              },
-            },
-            Object {
-              "key": "top",
-              "type": "PROPERTY_ASSIGNMENT",
-              "value": Object {
-                "type": "ATTRIBUTE_VALUE",
-                "value": 0,
-              },
-            },
           ],
           "type": "ATTRIBUTE_NESTED_OBJECT",
         },
@@ -130,38 +98,6 @@ Array [
               "value": Object {
                 "type": "ATTRIBUTE_VALUE",
                 "value": "flex",
-              },
-            },
-            Object {
-              "key": "left",
-              "type": "PROPERTY_ASSIGNMENT",
-              "value": Object {
-                "type": "ATTRIBUTE_VALUE",
-                "value": 0,
-              },
-            },
-            Object {
-              "key": "top",
-              "type": "PROPERTY_ASSIGNMENT",
-              "value": Object {
-                "type": "ATTRIBUTE_VALUE",
-                "value": 0,
-              },
-            },
-            Object {
-              "key": "width",
-              "type": "PROPERTY_ASSIGNMENT",
-              "value": Object {
-                "type": "ATTRIBUTE_VALUE",
-                "value": 0,
-              },
-            },
-            Object {
-              "key": "height",
-              "type": "PROPERTY_ASSIGNMENT",
-              "value": Object {
-                "type": "ATTRIBUTE_VALUE",
-                "value": 0,
               },
             },
           ],

--- a/editor/src/core/shared/property-path.ts
+++ b/editor/src/core/shared/property-path.ts
@@ -132,6 +132,10 @@ export function pathsEqual(l: PropertyPath | null, r: PropertyPath | null): bool
   }
 }
 
+export function contains(paths: Array<PropertyPath>, path: PropertyPath): boolean {
+  return paths.some((p) => pathsEqual(p, path))
+}
+
 export function containsAll(l: PropertyPath, elements: Array<PropertyPathPart>): boolean {
   const propertyElements = getElements(l)
   return elements.every(


### PR DESCRIPTION
Closes #4 

**Problem**
Dragging to move or resize was always triggering an update to all pins, regardless of if they had changed

**Solution**
Only actually update pins that have changed. As a byproduct, this also prevents the user from accidentally overwriting pins that were set via an expression when dragging.

To actually do this, we now compare the resultant updated absolute values with the previous absolute values for each of the relevant pins, and skip ones where the value hasn't changed or where the value is set via an expression.