### PR TITLE
Increase max_old_space_size with tests in CI

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "clean": "rm -rf lib/",
     "test": "tsc && npm run --silent clean && jest --config ./jest.config.js",
-    "test-ci": "tsc && npm run --silent clean && xvfb-run -a npx jest --config ./jest.config.js --maxWorkers=1",
+    "test-ci": "tsc && npm run --silent clean && NODE_OPTIONS=--max_old_space_size=6656 xvfb-run -a npx jest --config ./jest.config.js --maxWorkers=1",
     "test-debug": "tsc && npm run --silent clean && node --inspect-brk node_modules/.bin/jest --config ./jest.config.js --runInBand",
     "test-watch": "tsc && npm run --silent clean && jest --config ./jest.config.js --watch",
     "test-update-snapshot": "tsc && npm run --silent clean && jest --config ./jest.config.js --updateSnapshot",


### PR DESCRIPTION
Hopefully fixes the issues we seem to be having with the tests periodically failing with an out of memory error on CI.

The issue is possibly related to [this bug report](https://github.com/facebook/jest/issues/7874), but may just be a case of us leaking memory somewhere in the tests.

I'm going to repeatedly run the checks on this PR to see if they fail