### PR TITLE
fix(code-editor) fixing jsx autocomplete for paste

### DIFF
--- a/editor/src/components/code-editor/monaco-wrapper.tsx
+++ b/editor/src/components/code-editor/monaco-wrapper.tsx
@@ -685,7 +685,7 @@ export class MonacoWrapper extends React.Component<MonacoWrapperProps, MonacoWra
     }
 
     const changeRange = lastChange.range
-    const textChangeArray = lastChange.text.split(/[\n\r]/g)
+    const textChangeArray = lastChange.text.replace(/(\\n)/g, '').split(/[\n\r]/g)
     const textChangeNewLines = textChangeArray.length - 1
     const textChangeEndLineNumber = changeRange.startLineNumber + textChangeNewLines
     const textChangeEndColumnNumber =


### PR DESCRIPTION
Fixing code editor autocomplete for pasting multiline JSX elements.

The problem was when pasting multiline jsx elements the code editor closed wrong jsx tag. Looking into the issue I realized that the string to match the open tag regex did not contain the pasted code.

Solution is calculate the line and column number for the range based on the text change, as it's not available from the monaco content change event directly.