### PR TITLE
Inserting no longer relies on layoutSystem

### DIFF
--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -133,6 +133,14 @@ export class InsertModeControlContainer extends React.Component<
     }
   }
 
+  parentIsFlex = (parentPath: TemplatePath | null | undefined): boolean => {
+    const parentInstance =
+      parentPath != null && TP.isInstancePath(parentPath)
+        ? MetadataUtils.getElementByInstancePathMaybe(this.props.componentMetadata, parentPath)
+        : null
+    return MetadataUtils.isFlexLayoutedContainer(parentInstance)
+  }
+
   onHover = (target: TemplatePath) => {
     // The goal of highlight in insert mode is to show which component will be the parent of the
     // newly inserted component. If the user already started to draw the new component, then we should
@@ -291,6 +299,7 @@ export class InsertModeControlContainer extends React.Component<
 
       const parentAttributes = this.getParentAttributes(this.props.highlightedViews[0])
       const updatedAttributes = LayoutHelpers.updateLayoutPropsWithFrame(
+        this.parentIsFlex(this.props.highlightedViews[0]),
         parentAttributes,
         attributes,
         frame,
@@ -327,6 +336,7 @@ export class InsertModeControlContainer extends React.Component<
         const attributes = element.props
         const parentAttributes = this.getParentAttributes(this.props.highlightedViews[0])
         const updatedAttributes = LayoutHelpers.updateLayoutPropsWithFrame(
+          this.parentIsFlex(this.props.highlightedViews[0]),
           parentAttributes,
           attributes,
           frame,
@@ -380,6 +390,7 @@ export class InsertModeControlContainer extends React.Component<
 
     const parentAttributes = this.getParentAttributes(this.props.highlightedViews[0])
     const updatedAttributes = LayoutHelpers.updateLayoutPropsWithFrame(
+      this.parentIsFlex(this.props.highlightedViews[0]),
       parentAttributes,
       attributes,
       frame,

--- a/editor/src/core/layout/layout-helpers.ts
+++ b/editor/src/core/layout/layout-helpers.ts
@@ -228,36 +228,26 @@ export const FlexLayoutHelpers = {
 
 export const LayoutHelpers = {
   updateLayoutPropsWithFrame(
+    parentIsFlex: boolean,
     parentProps: PropsOrJSXAttributes | null,
     elementProps: JSXAttributes,
     frame: TopLeftWidthHeight,
   ): Either<string, JSXAttributes> {
-    let layoutSystemEither: Either<string, LayoutSystem> = right(LayoutSystem.PinSystem)
-    if (parentProps != null) {
-      layoutSystemEither = this.getLayoutSystemFromAttributes(parentProps)
+    if (parentIsFlex && parentProps != null) {
+      return FlexLayoutHelpers.updateLayoutPropsToFlexWithFrame(
+        parentProps,
+        elementProps,
+        frame.width,
+        frame.height,
+      )
+    } else {
+      return PinLayoutHelpers.updateLayoutPropsWithFrame(elementProps, frame)
     }
-
-    return flatMapEither((layoutSystem) => {
-      if (layoutSystem === LayoutSystem.Flex && parentProps != null) {
-        return FlexLayoutHelpers.updateLayoutPropsToFlexWithFrame(
-          parentProps,
-          elementProps,
-          frame.width,
-          frame.height,
-        )
-      } else {
-        return PinLayoutHelpers.updateLayoutPropsWithFrame(elementProps, frame)
-      }
-    }, layoutSystemEither)
   },
   getLayoutSystemFromAttributes(props: PropsOrJSXAttributes): Either<string, LayoutSystem> {
     return getSimpleAttributeAtPath(props, createLayoutPropertyPath('LayoutSystem')) // TODO LAYOUT investigate if we should use the DOM walker results here
   },
-  getDefaultedLayoutSystemFromAttributes(props: JSXAttributes): LayoutSystem {
-    return defaultEither(LayoutSystem.PinSystem, this.getLayoutSystemFromAttributes(right(props))) // TODO LAYOUT investigate if we should use the DOM walker results here
-  },
   getLayoutSystemFromProps(props: PropsOrJSXAttributes): LayoutSystem {
-    // TODO add a new layout type: "none"
     const parsedLayoutSystem = this.getLayoutSystemFromAttributes(props)
     return isRight(parsedLayoutSystem) ? parsedLayoutSystem.value : LayoutSystem.PinSystem
   },


### PR DESCRIPTION
Closes #29 

This isn't a great fix but it's a quick one. I want to tackle the fuller issue of our reliance on `layoutSystem` in multiple places in the code as a separate (upcoming) PR.

**Problem**
Inserting a new element relies on the `layoutSystem` of the parent, but we no longer use that for flex layout

**Solution**
Check if the parent is a flex container based on the detected metadata.