### PR TITLE
fix(inspector) update while dragging gap control

### DIFF
--- a/editor/src/components/inspector/controls/slider-control.tsx
+++ b/editor/src/components/inspector/controls/slider-control.tsx
@@ -54,7 +54,7 @@ export class SliderControl extends React.Component<SliderControlProps, {}> {
           disabled={!this.props.controlStyles.interactive}
           value={this.props.value}
           onChange={this.props.onTransientSubmitValue}
-          onAfterChange={this.props.onForcedSubmitValue}
+          onAfterChange={this.props.onForcedSubmitValue ?? this.props.onSubmitValue}
           min={controlOptions.minimum}
           max={controlOptions.maximum}
           step={controlOptions.stepSize}

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -258,6 +258,7 @@ export const FlexGapControl = betterReactMemo('FlexGapControl', (props: FlexGapC
               } as SliderControlOptions
             }
             onSubmitValue={props.onSubmitValue}
+            onTransientSubmitValue={props.onTransientSubmitValue}
             controlStatus={props.controlStatus}
             controlStyles={props.controlStyles}
           />


### PR DESCRIPTION
Fixing the bug where the flex gap control cannot be dragged by the slider.

The issue is that it's missing the transient and normal submitvalue callbacks.
