### PR TITLE
Set property status to controlled if it has non-null runtime value

### DIFF
--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -420,8 +420,6 @@ export function useInspectorInfo<P extends ParsedPropertiesKeys, T = ParsedPrope
     ),
   )
 
-  const propertyStatus = calculateMultiPropertyStatusForSelection(multiselectAtProps)
-
   const selectedProps = useKeepReferenceEqualityIfPossible(
     useContextSelector(
       InspectorPropsContext,
@@ -445,6 +443,12 @@ export function useInspectorInfo<P extends ParsedPropertiesKeys, T = ParsedPrope
     multiselectAtProps,
     selectedProps,
   )
+
+  const propertyStatus = calculateMultiPropertyStatusForSelection(
+    multiselectAtProps,
+    simpleAndRawValues,
+  )
+
   let isUnknown = false
   const values = Utils.mapArrayToDictionary(
     propKeys,
@@ -586,8 +590,6 @@ export function useInspectorInfoSimpleUntyped(
     ),
   )
 
-  const propertyStatus = calculateMultiStringPropertyStatusForSelection(multiselectAtProps)
-
   const selectedProps = useKeepReferenceEqualityIfPossible(
     useContextSelector(
       InspectorPropsContext,
@@ -608,6 +610,12 @@ export function useInspectorInfoSimpleUntyped(
     multiselectAtProps,
     selectedProps,
   )
+
+  const propertyStatus = calculateMultiStringPropertyStatusForSelection(
+    multiselectAtProps,
+    simpleAndRawValues,
+  )
+
   const values = Utils.mapArrayToDictionary(
     propertyPaths,
     (propertyPath) => propertyPath.propertyElements[propertyPath.propertyElements.length - 1],


### PR DESCRIPTION
Closes https://github.com/concrete-utopia/utopia/issues/5

Basically the issue is that we would like to be able to see which style properties are set using an object spread.
So if we have an object like this:
`paddedH = { paddingLeft: 8, paddingRight: 8 }`
And then we use it to define the style of an element, e.g.:
```
<span
  style={{ ...paddedH }}
  data-uid={'6b9'}
  layout={{ flexBasis: 51.859375, crossBasis: 15 }}
>
```
Then we wanna show `paddingLeft` and `paddingRight` as `controlled` properties in the inspector.
Until now they were shown as `unset`. Why? Because this decision was purely based on the jsx expression itself. And because `paddingLeft` and `paddingRight` is not specified in the jsx itself, they are unset.
`controlled` until now meant that the property is explicitly defined in the jsx, just the value is calculated and not a constant, e.g.
`style={{ paddingLeft: 1+8 }}`

After this PR the property is also controlled if it is not set but still has a runtime value. To be able to detect this I had to pass down the runtime value into a couple of inspector hooks/functions.