### PR TITLE
fix(canvas) fixing component insertion

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1175,7 +1175,7 @@ export function produceCanvasTransientState(editorState: EditorState): Transient
           case 'insert':
             const insertMode = editorState.mode
             const openComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
-            if (insertionSubjectIsJSXElement(insertMode.subject)) {
+            if (insertionSubjectIsJSXElement(insertMode.subject) && insertMode.insertionStarted) {
               const insertionParent =
                 insertMode.subject.parent == null ? null : insertMode.subject.parent.staticTarget
               const updatedComponents = insertJSXElementChild(


### PR DESCRIPTION
Fixing the issue when clicking on element in the insert menu shows it immediately before the first mousedown happens on the canvas.

Closes https://github.com/concrete-utopia/utopia/issues/25