### PR TITLE
Enable reparenting to all elements

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1298,7 +1298,7 @@ export function filterMultiSelectScenes(targets: Array<TemplatePath>): Array<Tem
   }
 }
 
-export function getTargetAtPosition(
+function getReparentTargetAtPosition(
   editorState: EditorState,
   position: CanvasPoint,
 ): TemplatePath | undefined {
@@ -1324,7 +1324,7 @@ export function getReparentTarget(
   shouldReparent: boolean
   newParent: TemplatePath | null
 } {
-  const result = getTargetAtPosition(editorState, position)
+  const result = getReparentTargetAtPosition(editorState, position)
   const possibleNewParent = result == undefined ? null : result
   const currentParents = Utils.stripNulls(
     toReparent.map((view) => MetadataUtils.getParent(editorState.jsxMetadataKILLME, view)),


### PR DESCRIPTION
Closes #64 

Problem: our reparenting logic previously only allowed reparenting to siblings, parents and top level elements. In a baffling and not really clear set of circumstances, this somehow -still- allowed legacy to enable reparent into anything. But since there was a few refactors of the reparenting logic, and now it is very strictly limited to siblings, parents and top level elements. This was never a desired behavior.

Solution: I simple replaced the rule with `All` elements, so now you can reparent anything into anything. It seems to work? 