### PR TITLE
allow reparenting into zero dimension elements

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1325,6 +1325,7 @@ function getReparentTargetAtPosition(
     position,
     [TargetSearchType.All],
     false,
+    'loose',
   )
   // filtering for non-selected views from alltargets
   return R.head(


### PR DESCRIPTION
Problem: you cannot reparent into something that has a width or height that is 0.

Solution: I changed the `getAllTargetsAtPoint` logic so when you are reparenting, we find every target that is in a 5x5 pixel vicinity of the mouse, even if it has zero size. 

If the 5x5 pixels are too generous, we can fine tune it later.

Note this PR does not make inivisble elements visible, you can only see a their highlight (either hairline of dot-like mini rectangle) once they are the target for reparenting.
This PR does not allow you to click to select zero-sized elements.