### PR TITLE
Fix pasting images to insert them

### DIFF
--- a/editor/src/utils/clipboard-utils.ts
+++ b/editor/src/utils/clipboard-utils.ts
@@ -52,8 +52,9 @@ export async function parsePasteEvent(clipboardData: DataTransfer | null): Promi
 }
 
 function extractFiles(items: DataTransferItemList): Promise<Array<FileResult>> {
+  const fileItems = Array.from(items).filter((item) => item.kind === 'file')
   return Promise.all<FileResult>(
-    Array.from(items).map((item) => {
+    fileItems.map((item) => {
       const file = item.getAsFile()
       if (file == null) {
         return Promise.reject('Could not extract file.')


### PR DESCRIPTION
Closes #65 

The issue here is that a paste event will come with two `DataTransferItem`s, one of which is of kind "string", the other is of kind "file". We're only interested in the latter, but were failing the paste because we were still trying to extract the file of the former.