### PR TITLE
Fallback to static element name if we need to

### DIFF
--- a/editor/src/components/navigator/navigator-item/item-preview.tsx
+++ b/editor/src/components/navigator/navigator-item/item-preview.tsx
@@ -1,10 +1,19 @@
 import * as React from 'react'
 import { Icn, IcnProps } from 'uuiui'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { ElementInstanceMetadata, isJSXElement } from '../../../core/shared/element-template'
+import {
+  ElementInstanceMetadata,
+  isJSXElement,
+  JSXElementName,
+} from '../../../core/shared/element-template'
 import {
   isHTMLComponent,
-  isHTMLComponentFromBaseName,
+  isViewAgainstImports,
+  isEllipseAgainstImports,
+  isRectangleAgainstImports,
+  isImg,
+  isTextAgainstImports,
+  isAnimatedElementAgainstImports,
 } from '../../../core/model/project-file-utils'
 import { Imports, TemplatePath } from '../../../core/shared/project-file-types'
 import { isLeft } from '../../../core/shared/either'
@@ -12,6 +21,7 @@ import { isLeft } from '../../../core/shared/either'
 interface ItemPreviewProps {
   isAutosizingView: boolean
   element: ElementInstanceMetadata | null
+  staticElementName: JSXElementName | null
   componentInstance: boolean
   path: TemplatePath
   collapsed: boolean
@@ -22,7 +32,7 @@ interface ItemPreviewProps {
 
 export const ItemPreview: React.StatelessComponent<ItemPreviewProps> = (props) => {
   const isGroup = props.isAutosizingView
-  const element = props.element
+  const { element, staticElementName, imports } = props
 
   // preview depends on three things:
   // 1 - role
@@ -45,37 +55,29 @@ export const ItemPreview: React.StatelessComponent<ItemPreviewProps> = (props) =
   const flexWrap = MetadataUtils.getYogaWrap(element)
   const flexWrapped: boolean = flexWrap === 'wrap' || flexWrap === 'wrap-reverse'
 
-  if (element == null) {
+  if (staticElementName == null) {
     role = 'scene'
   } else {
-    if (MetadataUtils.isViewAgainstImports(props.imports, element)) {
+    if (isViewAgainstImports(staticElementName, imports)) {
       if (isGroup) {
         role = 'group'
       } else {
         role = 'view'
       }
-    } else if (MetadataUtils.isEllipseAgainstImports(props.imports, element)) {
+    } else if (isEllipseAgainstImports(staticElementName, imports)) {
       role = 'ellipse'
-    } else if (MetadataUtils.isRectangleAgainstImports(props.imports, element)) {
+    } else if (isRectangleAgainstImports(staticElementName, imports)) {
       role = 'rectangle'
-    } else if (MetadataUtils.isImg(element)) {
+    } else if (isImg(staticElementName)) {
       role = 'image'
-    } else if (MetadataUtils.isTextAgainstImports(props.imports, element)) {
+    } else if (isTextAgainstImports(staticElementName, imports)) {
       role = 'text'
-    } else if (MetadataUtils.isAnimatedElementAgainstImports(props.imports, element)) {
+    } else if (isAnimatedElementAgainstImports(staticElementName, imports)) {
       role = 'animated'
     } else if (props.componentInstance) {
       role = 'componentinstance'
-    } else if (isLeft(element.element)) {
-      if (isHTMLComponentFromBaseName(element.element.value, props.imports)) {
-        role = 'div'
-      } else {
-        role = 'ghost'
-      }
-    } else if (isJSXElement(element.element.value)) {
-      if (isHTMLComponent(element.element.value.name, props.imports)) {
-        role = 'div'
-      }
+    } else if (isHTMLComponent(staticElementName, imports)) {
+      role = 'div'
     }
   }
 

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -27,7 +27,7 @@ import { DropTargetHint } from '../navigator'
 import { ExpansionArrowWidth } from './expandable-indicator'
 import { BasePaddingUnit, getElementPadding, NavigatorItem } from './navigator-item'
 import { NavigatorHintBottom, NavigatorHintTop } from './navigator-item-components'
-import { ElementInstanceMetadata } from '../../../core/shared/element-template'
+import { ElementInstanceMetadata, JSXElementName } from '../../../core/shared/element-template'
 
 const BaseRowHeight = 35
 const PreviewIconSize = BaseRowHeight
@@ -51,9 +51,10 @@ export interface NavigatorItemDragAndDropWrapperProps {
   getSelectedViewsInRange: (index: number) => Array<TemplatePath> // TODO remove me
   supportsChildren: boolean
   noOfChildren: number
+  staticElementName: JSXElementName | null
+  label: string
   element: ElementInstanceMetadata | null
   elementOriginType: ElementOriginType
-  name: string
   componentInstance: boolean
   isAutosizingView: boolean
   isElementVisible: boolean
@@ -250,7 +251,8 @@ export class NavigatorItemDndWrapper extends PureComponent<
           getSelectedViewsInRange={this.props.getSelectedViewsInRange}
           noOfChildren={this.props.noOfChildren}
           isAutosizingView={this.props.isAutosizingView}
-          name={this.props.name}
+          staticElementName={this.props.staticElementName}
+          label={this.props.label}
           element={this.props.element}
           componentInstance={this.props.componentInstance}
           dispatch={this.props.editorDispatch}

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -37,7 +37,8 @@ export const NavigatorItemWrapper: React.FunctionComponent<NavigatorItemWrapperP
       noOfChildren,
       supportsChildren,
       elementOriginType,
-      name,
+      staticElementName,
+      label,
       element,
       componentInstance,
       isAutosizingView,
@@ -67,7 +68,7 @@ export const NavigatorItemWrapper: React.FunctionComponent<NavigatorItemWrapperP
         componentsIncludingScenes,
         store.editor.jsxMetadataKILLME,
       )
-      const nameInner = MetadataUtils.getElementLabel(
+      const labelInner = MetadataUtils.getElementLabel(
         props.templatePath,
         store.editor.jsxMetadataKILLME,
         staticName,
@@ -100,7 +101,8 @@ export const NavigatorItemWrapper: React.FunctionComponent<NavigatorItemWrapperP
         )
       }
       return {
-        name: nameInner,
+        staticElementName: staticName,
+        label: labelInner,
         element: elementInner,
         componentInstance: componentInstanceInner,
         isAutosizingView: MetadataUtils.isAutoSizingView(elementInner),
@@ -139,7 +141,8 @@ export const NavigatorItemWrapper: React.FunctionComponent<NavigatorItemWrapperP
       supportsChildren: supportsChildren,
       noOfChildren: noOfChildren,
       elementOriginType: elementOriginType,
-      name: name,
+      staticElementName: staticElementName,
+      label: label,
       element: element,
       componentInstance: componentInstance,
       isAutosizingView: isAutosizingView,

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -3,7 +3,7 @@ import { jsx } from '@emotion/core'
 import * as React from 'react'
 import { colorTheme, FlexRow, IcnProps, Icons, Tooltip, UtopiaStyles, UtopiaTheme } from 'uuiui'
 import { betterReactMemo } from 'uuiui-deps'
-import { ElementInstanceMetadata } from '../../../core/shared/element-template'
+import { ElementInstanceMetadata, JSXElementName } from '../../../core/shared/element-template'
 import { ElementOriginType, Imports, TemplatePath } from '../../../core/shared/project-file-types'
 import { EditorDispatch } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/actions'
@@ -40,8 +40,9 @@ export interface NavigatorItemInnerProps {
   getSelectedViewsInRange: (index: number) => Array<TemplatePath> // TODO KILLME
   noOfChildren: number
   isAutosizingView: boolean
-  name: string
+  label: string
   element: ElementInstanceMetadata | null
+  staticElementName: JSXElementName | null
   componentInstance: boolean
   dispatch: EditorDispatch
   isHighlighted: boolean
@@ -139,7 +140,8 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
   'NavigatorItem',
   (props) => {
     const {
-      name,
+      staticElementName,
+      label,
       element,
       isAutosizingView,
       dispatch,
@@ -198,7 +200,7 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
       <WarningIcon tooltipText='Missing width or height' />
     ) : (
       <ItemPreview
-        key={`preview-${name}`}
+        key={`preview-${label}`}
         {...props}
         isAutosizingView={isAutosizingView}
         collapsed={collapsed}
@@ -250,8 +252,8 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
           />
           {preview}
           <ItemLabel
-            key={`label-${name}`}
-            name={name}
+            key={`label-${label}`}
+            name={label}
             isDynamic={isDynamic}
             target={templatePath}
             canRename={selected}

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -772,22 +772,11 @@ export const MetadataUtils = {
     instance: ElementInstanceMetadata,
     elementType: string,
   ): boolean {
+    // KILLME Replace with isGivenUtopiaAPIElementFromName from project-file-utils.ts
     return foldEither(
       (_) => false,
       (element) => isGivenUtopiaAPIElement(element, imports, elementType),
       instance.element,
-    )
-  },
-  isEllipseAgainstImports(imports: Imports, instance: ElementInstanceMetadata | null): boolean {
-    return (
-      instance != null &&
-      MetadataUtils.isGivenUtopiaAPIElementFromImports(imports, instance, 'Ellipse')
-    )
-  },
-  isRectangleAgainstImports(imports: Imports, instance: ElementInstanceMetadata | null): boolean {
-    return (
-      instance != null &&
-      MetadataUtils.isGivenUtopiaAPIElementFromImports(imports, instance, 'Rectangle')
     )
   },
   isViewAgainstImports(imports: Imports, instance: ElementInstanceMetadata | null): boolean {
@@ -815,25 +804,6 @@ export const MetadataUtils = {
         MetadataUtils.isGivenUtopiaAPIElementFromImports(imports, instance, 'Positionable') ||
         MetadataUtils.isGivenUtopiaAPIElementFromImports(imports, instance, 'Resizeable'))
     )
-  },
-  isAnimatedElementAgainstImports(
-    imports: Imports,
-    instance: ElementInstanceMetadata | null,
-  ): boolean {
-    const possibleReactSpring = imports['react-spring']
-    if (possibleReactSpring == null || instance == null) {
-      return false
-    } else {
-      if (pluck(possibleReactSpring.importedFromWithin, 'name').includes('animated')) {
-        return foldEither(
-          (name) => name.startsWith('animated.'),
-          (element) => isJSXElement(element) && element.name.baseVariable === 'animated',
-          instance.element,
-        )
-      } else {
-        return false
-      }
-    }
   },
   isButton(instance: ElementInstanceMetadata): boolean {
     return this.isElementOfType(instance, 'button')

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -36,6 +36,7 @@ import {
   JSXElementName,
   TopLevelElement,
   UtopiaJSXComponent,
+  getJSXElementNameLastPart,
 } from '../shared/element-template'
 import {
   sceneMetadata as _sceneMetadata,
@@ -66,43 +67,90 @@ export function isUtopiaAPIComponent(elementName: JSXElementName, imports: Impor
 export function isGivenUtopiaAPIElement(
   element: JSXElementChild,
   imports: Imports,
-  elementName: string,
+  componentName: string,
+): boolean {
+  return (
+    isJSXElement(element) && isGivenUtopiaAPIElementFromName(element.name, imports, componentName)
+  )
+}
+
+function isGivenUtopiaAPIElementFromName(
+  jsxElementName: JSXElementName,
+  imports: Imports,
+  componentName: string,
 ): boolean {
   const utopiaAPI = imports['utopia-api']
   if (utopiaAPI == null) {
     return false
   } else {
-    if (isJSXElement(element)) {
-      const elemName = element.name
-      if (PP.depth(elemName.propertyPath) === 0) {
-        return (
-          pluck(utopiaAPI.importedFromWithin, 'name').includes(elemName.baseVariable) &&
-          elemName.baseVariable === elementName
-        )
-      } else {
-        return (
-          utopiaAPI.importedAs === elemName.baseVariable &&
-          PP.isSameProperty(elemName.propertyPath, elementName)
-        )
-      }
+    if (PP.depth(jsxElementName.propertyPath) === 0) {
+      return (
+        pluck(utopiaAPI.importedFromWithin, 'name').includes(jsxElementName.baseVariable) &&
+        jsxElementName.baseVariable === componentName
+      )
+    } else {
+      return (
+        utopiaAPI.importedAs === jsxElementName.baseVariable &&
+        PP.isSameProperty(jsxElementName.propertyPath, componentName)
+      )
+    }
+  }
+}
+
+export function isUtopiaAPITextElement(element: JSXElementChild, imports: Imports): boolean {
+  return isJSXElement(element) && isTextAgainstImports(element.name, imports)
+}
+
+export function isEllipseAgainstImports(jsxElementName: JSXElementName, imports: Imports): boolean {
+  return isGivenUtopiaAPIElementFromName(jsxElementName, imports, 'Ellipse')
+}
+
+export function isRectangleAgainstImports(
+  jsxElementName: JSXElementName,
+  imports: Imports,
+): boolean {
+  return isGivenUtopiaAPIElementFromName(jsxElementName, imports, 'Rectangle')
+}
+
+export function isViewAgainstImports(jsxElementName: JSXElementName, imports: Imports): boolean {
+  return isGivenUtopiaAPIElementFromName(jsxElementName, imports, 'View')
+}
+
+export function isTextAgainstImports(jsxElementName: JSXElementName, imports: Imports): boolean {
+  return isGivenUtopiaAPIElementFromName(jsxElementName, imports, 'Text')
+}
+
+export function isImg(jsxElementName: JSXElementName): boolean {
+  return (
+    PP.depth(jsxElementName.propertyPath) === 0 &&
+    getJSXElementNameLastPart(jsxElementName) === 'img'
+  )
+}
+
+export function isAnimatedElementAgainstImports(
+  jsxElementName: JSXElementName,
+  imports: Imports,
+): boolean {
+  const possibleReactSpring = imports['react-spring']
+  if (possibleReactSpring == null) {
+    return false
+  } else {
+    if (pluck(possibleReactSpring.importedFromWithin, 'name').includes('animated')) {
+      return jsxElementName.baseVariable === 'animated'
     } else {
       return false
     }
   }
 }
 
-export function isUtopiaAPITextElement(element: JSXElementChild, imports: Imports): boolean {
-  return isGivenUtopiaAPIElement(element, imports, 'Text')
-}
-
-export function isHTMLComponent(elementName: JSXElementName, imports: Imports): boolean {
+export function isHTMLComponent(jsxElementName: JSXElementName, imports: Imports): boolean {
   return (
-    PP.depth(elementName.propertyPath) === 0 &&
-    isHTMLComponentFromBaseName(elementName.baseVariable, imports)
+    PP.depth(jsxElementName.propertyPath) === 0 &&
+    isHTMLComponentFromBaseName(jsxElementName.baseVariable, imports)
   )
 }
 
-export function isHTMLComponentFromBaseName(baseName: string, imports: Imports): boolean {
+function isHTMLComponentFromBaseName(baseName: string, imports: Imports): boolean {
   const imported = Object.keys(imports).some((importKey) => {
     const fromImports = imports[importKey]
     return pluck(fromImports.importedFromWithin, 'name').includes(baseName)


### PR DESCRIPTION
Closes #67 

~This one isn't great, but is better than what we have. We grab the static element name and fall back to that if we can't get the real element label.~

Ok I've gone back and changed the way that we determine the label and icon in the Navigator row so that it uses the static element name (i.e. that tag on the JSX element in code). This brings it back much closer to what we used to have here (previously we were attaching the original JSX Element to the metadata, which we were using at the time to populate this data).