### PR TITLE
Handle if-modified-since in the packager.

### DIFF
--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -115,6 +115,8 @@ innerServerExecutor BadRequest = do
   throwError err400
 innerServerExecutor NotAuthenticated = do
   throwError err401
+innerServerExecutor NotModified = do
+  throwError err304
 innerServerExecutor (CheckAuthCode authCode action) = do
   auth0 <- fmap _auth0Resources ask
   sessionStore <- fmap _sessionState ask
@@ -239,9 +241,9 @@ innerServerExecutor (GetHashedAssetPaths action) = do
   AssetsCaches{..} <- fmap _assetsCaches ask
   AssetResultCache{..} <- liftIO $ readIORef _assetResultCache
   return $ action _editorMappings
-innerServerExecutor (GetPackagePackagerContent javascriptPackageName javascriptPackageVersion action) = do
+innerServerExecutor (GetPackagePackagerContent javascriptPackageName javascriptPackageVersion ifModifiedSince action) = do
   semaphore <- fmap _nodeSemaphore ask
-  packagerContent <- liftIO $ getPackagerContent semaphore javascriptPackageName javascriptPackageVersion
+  packagerContent <- liftIO $ getPackagerContent semaphore javascriptPackageName javascriptPackageVersion ifModifiedSince
   return $ action packagerContent
 
 readIndexHtmlFromDisk :: Text -> IO Text

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -73,6 +73,8 @@ innerServerExecutor BadRequest = do
   throwError err400
 innerServerExecutor NotAuthenticated = do
   throwError err401
+innerServerExecutor NotModified = do
+  throwError err304
 innerServerExecutor (CheckAuthCode authCode action) = do
   auth0 <- fmap _auth0Resources ask
   sessionStore <- fmap _sessionState ask
@@ -185,9 +187,9 @@ innerServerExecutor (GetHashedAssetPaths action) = do
   AssetsCaches{..} <- fmap _assetsCaches ask
   AssetResultCache{..} <- liftIO $ readIORef _assetResultCache
   return $ action _editorMappings
-innerServerExecutor (GetPackagePackagerContent javascriptPackageName javascriptPackageVersion action) = do
+innerServerExecutor (GetPackagePackagerContent javascriptPackageName javascriptPackageVersion ifModifiedSince action) = do
   semaphore <- fmap _nodeSemaphore ask
-  packagerContent <- liftIO $ getPackagerContent semaphore javascriptPackageName javascriptPackageVersion
+  packagerContent <- liftIO $ getPackagerContent semaphore javascriptPackageName javascriptPackageVersion ifModifiedSince
   return $ action packagerContent
 
 {-|

--- a/server/src/Utopia/Web/Servant.hs
+++ b/server/src/Utopia/Web/Servant.hs
@@ -19,7 +19,10 @@ module Utopia.Web.Servant where
 import           Data.Aeson
 import           Data.Aeson.Encode.Pretty
 import qualified Data.ByteString.Lazy     as BL
+import           Data.Time.Clock
+import           Data.Time.Format
 import           Network.HTTP.Media       hiding (Accept)
+import           Prelude                  (String)
 import           Protolude
 import           Servant.API
 import           Servant.HTML.Blaze
@@ -104,5 +107,18 @@ instance Accept ForcedJSON where
 
 instance MimeRender ForcedJSON BL.ByteString where
   mimeRender _ bytes =  bytes
+
+
+data LastModifiedTime = LastModifiedTime { getLastModifiedTime :: UTCTime }
+                      deriving (Eq, Ord, Show)
+
+lastModifiedFormat :: String
+lastModifiedFormat = "%a, %_d %b %Y %H:%M:%S %Z"
+
+instance FromHttpApiData LastModifiedTime where
+  parseUrlPiece toParse = fmap LastModifiedTime $ parseTimeM True defaultTimeLocale lastModifiedFormat (toS toParse)
+
+instance ToHttpApiData LastModifiedTime where
+  toUrlPiece (LastModifiedTime lastModifiedTime) = toS $ formatTime defaultTimeLocale lastModifiedFormat lastModifiedTime
 
 

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -86,6 +86,7 @@ listingFromProjectMetadata project = ProjectListing
 data ServiceCallsF a = NotFound
                      | BadRequest
                      | NotAuthenticated
+                     | NotModified
                      | CheckAuthCode Text (Maybe SetCookie -> a)
                      | Logout Text H.Html (SetSessionCookies H.Html -> a)
                      | ValidateAuth Text (Maybe SessionUser -> a)
@@ -113,7 +114,7 @@ data ServiceCallsF a = NotFound
                      | GetEditorIndexHtml (Text -> a)
                      | GetPreviewIndexHtml (Text -> a)
                      | GetHashedAssetPaths (Value -> a)
-                     | GetPackagePackagerContent Text Text (BL.ByteString -> a)
+                     | GetPackagePackagerContent Text Text (Maybe UTCTime) (Maybe (BL.ByteString, UTCTime) -> a)
                      deriving Functor
 
 {-

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -103,7 +103,7 @@ type LoadProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" Text 
 
 type SaveProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" Text :> ReqBody '[BMP, GIF, JPG, PNG, SVG] BL.ByteString :> Post '[JSON] NoContent
 
-type PackagePackagerAPI = "v1" :> "javascript" :> "packager" :> Capture "package_name" Text :> Capture "package_version" Text :> Get '[ForcedJSON] (Headers '[Header "Cache-Control" Text] BL.ByteString)
+type PackagePackagerAPI = "v1" :> "javascript" :> "packager" :> Capture "package_name" Text :> Capture "package_version" Text :> Header "If-Modified-Since" LastModifiedTime :> Get '[ForcedJSON] (Headers '[Header "Cache-Control" Text, Header "Last-Modified" LastModifiedTime] BL.ByteString)
 
 type GetPackageJSONAPI = "v1" :> "javascript" :> "package" :> "metadata" :> Capture "package_name" Text :> Get '[JSON] Value
 


### PR DESCRIPTION
**Problem:**
If a client makes a request to the edge cache or the edge cache makes a request to the packager, we want to get a response to them as soon as possible.

**Fix:**
We handle the `If-Modified-Since` request header and return the `Last-Modified` response header, such that if the request header is the same or newer than the access time on disk of the server, we return a 304 not modified response.

**Notes:**
As this is dependent on the disk access time, the disk content is getting trashed when the server restarts, so this will only slightly reduce pressure there but should make the edge cache more effective.

**Commit Details:**
- Partly covers #3619.
- Bump the `Cache-Control` header to have a max age of a month.
- Packager endpoint parses the `If-Modified-Since` header and includes
  the `Last-Modified` header in the responses.
- `getRoundedAccessTime` to produce a time value with the same precision
  as the one we render into the HTTP headers.
- Modified `cachePackagerContent` to handle checking the last modified
  time and not read the file if it's up to date.
- Added `NotModified` service call and updated `GetPackagePackagerContent`
  service call.
- Implemented parsing for the `Last-Modified`/`If-Modified-Since` headers.