### PR TITLE
Add back local require function to coderesultcache

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -176,11 +176,15 @@ export function pickUiJsxCanvasProps(
       topLevelElementsIncludingScenes = transientFileState.topLevelElementsIncludingScenes
     }
   }
+  const requireFn =
+    editor.codeResultCache == null
+      ? getMemoizedRequireFn(editor.nodeModules.files, dispatch)
+      : editor.codeResultCache.requireFn
   return {
     offset: editor.canvas.roundedCanvasOffset,
     scale: editor.canvas.scale,
     uiFilePath: getOpenUIJSFileKey(editor),
-    requireFn: getMemoizedRequireFn(editor.nodeModules.files, dispatch),
+    requireFn: requireFn,
     hiddenInstances: editor.hiddenInstances,
     editedTextElement: Utils.optionalMap((textEd) => textEd.templatePath, editor.canvas.textEditor),
     fileBlobs: defaultedFileBlobs,

--- a/editor/src/components/custom-code/__snapshots__/code-file.spec.ts.snap
+++ b/editor/src/components/custom-code/__snapshots__/code-file.spec.ts.snap
@@ -1,5 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Creating require function Creates require function for multi file build result 1`] = `
+Object {
+  "App": [Function],
+  "canvasMetadata": Object {
+    "elementMetadata": Object {},
+    "nodeMetadata": Object {},
+    "scenes": Array [
+      Object {
+        "component": "App",
+        "container": Object {
+          "layoutSystem": "pinSystem",
+        },
+        "frame": Object {
+          "height": 812,
+          "left": 0,
+          "top": 0,
+          "width": 375,
+        },
+        "props": Object {
+          "layout": Object {
+            "bottom": 0,
+            "left": 0,
+            "right": 0,
+            "top": 0,
+          },
+        },
+      },
+    ],
+    "specialNodes": Array [],
+  },
+  "default": [Circular],
+}
+`;
+
+exports[`Creating require function Creates require function for multi file build result 2`] = `
+Object {
+  "ComponentWithProps": [Function],
+  "LABEL": "press me! 😉",
+  "default": [Function],
+}
+`;
+
+exports[`Creating require function Creates require function for single file build result 1`] = `
+Object {
+  "App": [Function],
+  "canvasMetadata": Object {
+    "elementMetadata": Object {},
+    "nodeMetadata": Object {},
+    "scenes": Array [
+      Object {
+        "component": "App",
+        "container": Object {
+          "layoutSystem": "pinSystem",
+        },
+        "frame": Object {
+          "height": 812,
+          "left": 0,
+          "top": 0,
+          "width": 375,
+        },
+        "props": Object {
+          "layout": Object {
+            "bottom": 0,
+            "left": 0,
+            "right": 0,
+            "top": 0,
+          },
+        },
+      },
+    ],
+    "specialNodes": Array [],
+  },
+  "default": [Circular],
+}
+`;
+
+exports[`Creating require function Require throws exception for import from non-existing module 1`] = `"Could not find dependency: 'foo' relative to '/'"`;
+
+exports[`Creating require function Require throws exception for module code 1`] = `"booom"`;
+
 exports[`Filling in SystemJS Fills System with data for multi file build result 1`] = `
 Object {
   "App": [Function],
@@ -204,6 +284,7 @@ ComponentWithProps.propertyControls = {
   "propertyControlsInfo": Object {
     "/src/components": Object {},
   },
+  "requireFn": [Function],
   "skipDeepFreeze": true,
 }
 `;
@@ -839,6 +920,7 @@ ReactDOM.render(<App />, root);
       },
     },
   },
+  "requireFn": [Function],
   "skipDeepFreeze": true,
 }
 `;
@@ -1158,6 +1240,7 @@ export var App = (props) => {
   "propertyControlsInfo": Object {
     "/app.ui": Object {},
   },
+  "requireFn": [Function],
   "skipDeepFreeze": true,
 }
 `;

--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -382,3 +382,46 @@ describe('Filling in SystemJS', () => {
     expect(system.getModule('/', './src/components.js', false)).toMatchSnapshot()
   })
 })
+describe('Creating require function', () => {
+  it('Creates require function for single file build result', () => {
+    const codeResultCache = generateCodeResultCache(
+      SampleSingleFileBuildResult,
+      SampleSingleFileExportsInfo,
+      mockRequire,
+      false,
+    )
+
+    expect(codeResultCache.requireFn('/', './app.ui', false)).toMatchSnapshot()
+  })
+  it('Creates require function for multi file build result', () => {
+    const codeResultCache = generateCodeResultCache(
+      SampleMultiFileBuildResult,
+      SampleMultiFileExportsInfo,
+      mockRequire,
+      false,
+    )
+
+    expect(codeResultCache.requireFn('/', './app.ui', false)).toMatchSnapshot()
+    expect(codeResultCache.requireFn('/', './src/components', false)).toMatchSnapshot()
+  })
+  it('Require throws exception for module code', () => {
+    const codeResultCache = generateCodeResultCache(
+      SampleBuildResultWithException,
+      SampleExportsInfoWithException,
+      mockRequire,
+      false,
+    )
+
+    expect(() => codeResultCache.requireFn('/', './src/code', false)).toThrowErrorMatchingSnapshot()
+  })
+  it('Require throws exception for import from non-existing module', () => {
+    const codeResultCache = generateCodeResultCache(
+      SampleSingleFileBuildResult,
+      SampleSingleFileExportsInfo,
+      mockRequire,
+      false,
+    )
+
+    expect(() => codeResultCache.requireFn('/', 'foo', false)).toThrowErrorMatchingSnapshot()
+  })
+})

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -36,6 +36,7 @@ export type CodeResultCache = {
   exportsInfo: ReadonlyArray<ExportsInfo>
   propertyControlsInfo: PropertyControlsInfo
   error: Error | null
+  requireFn: UtopiaRequireFn
 }
 
 type ModuleExportValues = { [name: string]: any }
@@ -176,6 +177,7 @@ export function generateCodeResultCache(
     cache: cache,
     propertyControlsInfo: propertyControlsInfo,
     error: error,
+    requireFn: requireFn,
   }
 }
 

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -2940,6 +2940,7 @@ export const UPDATE_FNS = {
         exportsInfo: action.codeResultCache.exportsInfo,
         propertyControlsInfo: action.codeResultCache.propertyControlsInfo,
         error: action.codeResultCache.error,
+        requireFn: action.codeResultCache.requireFn,
       },
     }
   },
@@ -4216,6 +4217,7 @@ export async function load(
     exportsInfo: [],
     propertyControlsInfo: {},
     error: null,
+    requireFn: require,
   }
   if (model.exportsInfo.length > 0) {
     workers.sendInitMessage(typeDefinitions, model.projectContents)


### PR DESCRIPTION
Imports from local files stopped working, because we only used the require function generated for the npm dependencies everywhere.
Although we generated the require function which works for local files too here:
https://github.com/concrete-utopia/utopia/blob/master/editor/src/components/custom-code/code-file.ts#L151
But the returned requireFn variable was unused.

I decided to move back to the earlier way to store the require function in codeResultCache.