### PR TITLE
Force code update after cursor moves.

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/move-utils.ts
+++ b/editor/src/components/canvas/controls/select-mode/move-utils.ts
@@ -218,6 +218,7 @@ export function adjustAllSelectedFrames(
     return []
   }
 
+  let actions: Array<EditorAction> = []
   if (isResizing) {
     let roundedAdjustment: number = 0
     let newBoundingBox: CanvasRectangle
@@ -265,7 +266,7 @@ export function adjustAllSelectedFrames(
         }
       }),
     )
-    return [EditorActions.setCanvasFrames(newFrameAndTargets, keepChildrenAtPlace)]
+    actions = [EditorActions.setCanvasFrames(newFrameAndTargets, keepChildrenAtPlace)]
   } else {
     const originalFrames: CanvasFrameAndTarget[] = Utils.stripNulls(
       editor.selectedViews.map((view) => {
@@ -287,7 +288,7 @@ export function adjustAllSelectedFrames(
       adjustment,
     )
     EditorActions.hideAndShowSelectionControls(dispatch)
-    return dragComponentForActions(
+    actions = dragComponentForActions(
       editor.jsxMetadataKILLME,
       editor.selectedViews,
       originalFrames,
@@ -300,6 +301,9 @@ export function adjustAllSelectedFrames(
       editor.canvas.scale,
     )
   }
+
+  actions.push(EditorActions.startCheckpointTimer())
+  return actions
 }
 
 function getRoundedDeltaForKeyboardShortcut(

--- a/editor/src/components/code-editor/monaco-wrapper.tsx
+++ b/editor/src/components/code-editor/monaco-wrapper.tsx
@@ -119,12 +119,10 @@ export class MonacoWrapper extends React.Component<MonacoWrapperProps, MonacoWra
   private highlightedViewDecorations: string[] = []
   private viewStateCache: ViewStateCache
   private onChangeCallbacksEnabled: boolean = true
-  private decorations: Array<string>
 
   constructor(props: MonacoWrapperProps) {
     super(props)
     this.viewStateCache = {}
-    this.decorations = []
 
     this.initMonacoTypescript()
     this.state = {

--- a/editor/src/components/code-editor/script-editor.tsx
+++ b/editor/src/components/code-editor/script-editor.tsx
@@ -67,7 +67,7 @@ function getFileContents(file: ProjectFile): string {
           return failure.code
         },
         (success: ParseSuccess) => {
-          return success.code || ''
+          return success.code ?? ''
         },
         file.fileContents,
       )

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -722,6 +722,14 @@ export interface UpdatePackageJson {
   dependencies: Array<NpmDependency>
 }
 
+export interface StartCheckpointTimer {
+  action: 'START_CHECKPOINT_TIMER'
+}
+
+export interface FinishCheckpointTimer {
+  action: 'FINISH_CHECKPOINT_TIMER'
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -842,6 +850,8 @@ export type EditorAction =
   | ResetPropToDefault
   | UpdateNodeModulesContents
   | UpdatePackageJson
+  | StartCheckpointTimer
+  | FinishCheckpointTimer
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -75,6 +75,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_SAFE_MODE':
     case 'SET_SAVE_ERROR':
     case 'UPDATE_NODE_MODULES_CONTENTS':
+    case 'START_CHECKPOINT_TIMER':
       return true
 
     case 'NEW':
@@ -130,6 +131,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'INSERT_DROPPED_IMAGE':
     case 'RESET_PROP_TO_DEFAULT':
     case 'UPDATE_PACKAGE_JSON':
+    case 'FINISH_CHECKPOINT_TIMER':
       return false
     case 'SAVE_ASSET':
       return (

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -306,6 +306,8 @@ import {
   ResetPropToDefault,
   UpdateNodeModulesContents,
   UpdatePackageJson,
+  StartCheckpointTimer,
+  FinishCheckpointTimer,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -1256,6 +1258,8 @@ function toastOnGeneratedElementsTargeted(
 
   return result
 }
+
+let checkpointTimeoutId: number | undefined = undefined
 
 // JS Editor Actions:
 export const UPDATE_FNS = {
@@ -3912,6 +3916,25 @@ export const UPDATE_FNS = {
     )
     return updateDependenciesInEditorState(editor, dependencies)
   },
+  START_CHECKPOINT_TIMER: (
+    action: StartCheckpointTimer,
+    editor: EditorState,
+    dispatch: EditorDispatch,
+  ): EditorState => {
+    // Side effects.
+    clearTimeout(checkpointTimeoutId)
+    checkpointTimeoutId = window.setTimeout(() => {
+      dispatch([finishCheckpointTimer()], 'everyone')
+    }, 1000)
+    // No need to actually change the editor state.
+    return editor
+  },
+  FINISH_CHECKPOINT_TIMER: (action: FinishCheckpointTimer, editor: EditorState): EditorState => {
+    // Side effects.
+    checkpointTimeoutId = undefined
+    // No need to actually change the editor state.
+    return editor
+  },
 }
 
 /** DO NOT USE outside of actions.ts, only exported for testing purposes */
@@ -5226,5 +5249,17 @@ export function updatePackageJson(dependencies: Array<NpmDependency>): UpdatePac
   return {
     action: 'UPDATE_PACKAGE_JSON',
     dependencies: dependencies,
+  }
+}
+
+export function startCheckpointTimer(): StartCheckpointTimer {
+  return {
+    action: 'START_CHECKPOINT_TIMER',
+  }
+}
+
+export function finishCheckpointTimer(): FinishCheckpointTimer {
+  return {
+    action: 'FINISH_CHECKPOINT_TIMER',
   }
 }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -296,6 +296,9 @@ export function editorDispatch(
   const forceSave = dispatchedActions.some((action) => action.action === 'SAVE_CURRENT_FILE')
   const onlyNameUpdated = nameUpdated && dispatchedActions.length === 1
   const allTransient = dispatchedActions.every(isTransientAction)
+  const anyFinishCheckpointTimer = dispatchedActions.some((action) => {
+    return action.action === 'FINISH_CHECKPOINT_TIMER'
+  })
   const updateCodeResultCache = dispatchedActions.some(
     (action) => action.action === 'UPDATE_CODE_RESULT_CACHE',
   )
@@ -355,7 +358,10 @@ export function editorDispatch(
     { ...storedState, entireUpdateFinished: Promise.resolve(true), nothingChanged: true },
   )
 
-  const transientOrNoChange = allTransient || result.nothingChanged
+  // The FINISH_CHECKPOINT_TIMER action effectively overrides the case where nothing changed,
+  // as it's likely that action on it's own didn't change anything, but the actions that paired with
+  // START_CHECKPOINT_TIMER likely did.
+  const transientOrNoChange = (allTransient || result.nothingChanged) && !anyFinishCheckpointTimer
   const workerUpdatedModel = dispatchedActions.some(
     (action) => action.action === 'UPDATE_FROM_WORKER',
   )

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -270,6 +270,10 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_NODE_MODULES_CONTENTS(action, state)
     case 'UPDATE_PACKAGE_JSON':
       return UPDATE_FNS.UPDATE_PACKAGE_JSON(action, state)
+    case 'START_CHECKPOINT_TIMER':
+      return UPDATE_FNS.START_CHECKPOINT_TIMER(action, state, dispatch)
+    case 'FINISH_CHECKPOINT_TIMER':
+      return UPDATE_FNS.FINISH_CHECKPOINT_TIMER(action, state)
     default:
       return state
   }


### PR DESCRIPTION
**Problem:**
When changing the position of an element with the cursor keys, the code never updates until another non-transient action is triggered.

**Fix:**
Added in a delayed action which is treated as definitely having made a change so that with the same timing as the controls returning the code is printed from the previously updated model.

**Commit Details:**
- Added an instance of `START_CHECKPOINT_TIMER` to the
  actions executed when a cursor key move is triggered.
- Removed an unnecessary `decorations` field from `MonacoWrapper`.
- Changed an instance of `||` to `??` in `ScriptEditor`.
- Added `StartCheckpointTimer` and `FinishCheckpointTimer` actions.
- `StartCheckpointTimer` action resets a timeout and retriggers it
  to fire a `FinishCheckpointTimer`.
- `FinishCheckpointTimer` action effectively does nothing but is used
  as a marker.
- `editorDispatch` checks for the marker action and overrides the action
  having not changed anything potentially.