### PR TITLE
Supply basic CORS header.

### DIFF
--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -245,6 +245,8 @@ innerServerExecutor (GetPackagePackagerContent javascriptPackageName javascriptP
   semaphore <- fmap _nodeSemaphore ask
   packagerContent <- liftIO $ getPackagerContent semaphore javascriptPackageName javascriptPackageVersion ifModifiedSince
   return $ action packagerContent
+innerServerExecutor (AccessControlAllowOrigin _ action) = do
+  return $ action $ Just "*"
 
 readIndexHtmlFromDisk :: Text -> IO Text
 readIndexHtmlFromDisk fileName = readFile $ toS $ "../editor/lib/" <> fileName

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -191,6 +191,8 @@ innerServerExecutor (GetPackagePackagerContent javascriptPackageName javascriptP
   semaphore <- fmap _nodeSemaphore ask
   packagerContent <- liftIO $ getPackagerContent semaphore javascriptPackageName javascriptPackageVersion ifModifiedSince
   return $ action packagerContent
+innerServerExecutor (AccessControlAllowOrigin _ action) = do
+  return $ action $ Just "*"
 
 {-|
   Invokes a service call using the supplied resources.

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -115,6 +115,7 @@ data ServiceCallsF a = NotFound
                      | GetPreviewIndexHtml (Text -> a)
                      | GetHashedAssetPaths (Value -> a)
                      | GetPackagePackagerContent Text Text (Maybe UTCTime) (Maybe (BL.ByteString, UTCTime) -> a)
+                     | AccessControlAllowOrigin (Maybe Text) (Maybe Text -> a)
                      deriving Functor
 
 {-

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -103,7 +103,14 @@ type LoadProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" Text 
 
 type SaveProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" Text :> ReqBody '[BMP, GIF, JPG, PNG, SVG] BL.ByteString :> Post '[JSON] NoContent
 
-type PackagePackagerAPI = "v1" :> "javascript" :> "packager" :> Capture "package_name" Text :> Capture "package_version" Text :> Header "If-Modified-Since" LastModifiedTime :> Get '[ForcedJSON] (Headers '[Header "Cache-Control" Text, Header "Last-Modified" LastModifiedTime] BL.ByteString)
+type PackagePackagerResponse = Headers '[Header "Cache-Control" Text, Header "Last-Modified" LastModifiedTime, Header "Access-Control-Allow-Origin" Text] BL.ByteString
+
+type PackagePackagerAPI = "v1" :> "javascript" :> "packager"
+                       :> Capture "package_name" Text
+                       :> Capture "package_version" Text
+                       :> Header "If-Modified-Since" LastModifiedTime
+                       :> Header "Origin" Text
+                       :> Get '[ForcedJSON] PackagePackagerResponse
 
 type GetPackageJSONAPI = "v1" :> "javascript" :> "package" :> "metadata" :> Capture "package_name" Text :> Get '[JSON] Value
 


### PR DESCRIPTION
**Problem:**
As production has the packager on a subdomain the call to it is running foul of CORS.

**Fix:**
Supply the wildcard header response for `Access-Control-Allow-Origin` at least for now.

**Commit Details:**
- Refactored out packager response type after adding the CORS response
  header to it.
- Added in `AccessControlAllowOrigin` call to `ServiceCallsF`, with
  basic implementations for development and production for now.
- Processes `Origin` header in packager endpoint and applies the result
  as a header if there is one.