### PR TITLE
fix crashing bg-size section in color picker

### DIFF
--- a/editor/src/components/inspector/controls/bg-size-metadata-control.tsx
+++ b/editor/src/components/inspector/controls/bg-size-metadata-control.tsx
@@ -161,10 +161,10 @@ function bgSizeValueToSelectOption(value: CSSBGSizeValue): SelectOption {
       return coverSelectOption
     }
   } else {
-    const zeroth = value.value[0]
-    const first = value.value[1] ?? zeroth
+    const first = value.value[0]
+    const second = value.value[1] ?? first
 
-    if (zeroth.value === 'auto' && first.value === 'auto') {
+    if (first.value === 'auto' && second.value === 'auto') {
       return autoSelectOption
     } else {
       return percentageLengthSelectOption


### PR DESCRIPTION
Fixes #111 

**Problem:**
Background Picker was crashing when opening up the gear section due to an undefined value.

**Fix:**
Made the zeroth value the default value for the first array item if not present.