### PR TITLE
add the gear icon for url background layers

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -2478,15 +2478,11 @@ export function isCSSGradientBackgroundLayer(
   )
 }
 
-export type CSSBackgroundLayer =
-  | CSSSolidBackgroundLayer
-  | CSSGradientBackgroundLayer
-  | CSSURLFunctionBackgroundLayer
-  | CSSUnknownArrayItem
+export type CSSBackgroundImageLayer = CSSGradientBackgroundLayer | CSSURLFunctionBackgroundLayer
 
-export function isCSSBackgroundLayer(
+export function isCSSBackgroundImageLayer(
   cssBackgroundLayer: CSSBackgroundLayer,
-): cssBackgroundLayer is CSSGradientBackgroundLayer {
+): cssBackgroundLayer is CSSBackgroundImageLayer {
   return (
     cssBackgroundLayer.type === 'linear-gradient-background-layer' ||
     cssBackgroundLayer.type === 'radial-gradient-background-layer' ||
@@ -2494,6 +2490,12 @@ export function isCSSBackgroundLayer(
     cssBackgroundLayer.type === 'url-function-background-layer'
   )
 }
+
+export type CSSBackgroundLayer =
+  | CSSSolidBackgroundLayer
+  | CSSGradientBackgroundLayer
+  | CSSURLFunctionBackgroundLayer
+  | CSSUnknownArrayItem
 
 export type CSSBackgroundLayers = ReadonlyArray<CSSBackgroundLayer>
 

--- a/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
@@ -24,7 +24,7 @@ import {
   isCSSRadialGradientBackgroundLayer,
   isCSSSolidBackgroundLayer,
   isCSSBackgroundLayerWithBGSize,
-  isCSSBackgroundLayer,
+  isCSSBackgroundImageLayer,
 } from '../../../common/css-utils'
 import { UseSubmitValueFactory } from '../../../common/property-path-hooks'
 import { stopPropagation, useHandleCloseOnESCOrEnter } from '../../../common/inspector-utils'
@@ -476,7 +476,7 @@ export const BackgroundPicker: React.FunctionComponent<BackgroundPickerProps> = 
               containerMode='noBorder'
             />
           </div>
-          {isCSSBackgroundLayer(props.value) ? (
+          {isCSSBackgroundImageLayer(props.value) ? (
             <Icn type='gear' color='darkgray' width={16} height={16} onClick={toggleSettings} />
           ) : null}
           <Icn


### PR DESCRIPTION
Partially addresses #111 
**Problem:**
URL background layers were not showing the gear icon that would let users toggle on the background size controls.

**Fix:**
Create a new typeguard function for all background image layer types, not just gradients.
