### PR TITLE
fix(defaults) - change to more visible colour with some alpha

### DIFF
--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -21,7 +21,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -40,7 +40,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', width: 100, height: 100, left: 20, top: 20 }}
+          style={{ backgroundColor: '#0091FFAA', width: 100, height: 100, left: 20, top: 20 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -54,7 +54,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -73,7 +73,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', width: 100, height: 100, left: 20, top: 20 }}
+          style={{ backgroundColor: '#0091FFAA', width: 100, height: 100, left: 20, top: 20 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -87,7 +87,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: '50%', height: '20%'  }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: '50%', height: '20%'  }}
           layout={{ layoutSystem: 'pinSystem'}}
           data-uid={'bbb'}
         />
@@ -106,7 +106,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', width: '25%', height: '25%', left: 20, top: 20 }}
+          style={{ backgroundColor: '#0091FFAA', width: '25%', height: '25%', left: 20, top: 20 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -120,7 +120,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -139,7 +139,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 20, top: 20, width: 100, height: 100 }}
+          style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, width: 100, height: 100 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -153,7 +153,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202, bottom: 137, right: 93 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202, bottom: 137, right: 93 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -172,7 +172,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 20, top: 20, width: 100, height: 100 }}
+          style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, width: 100, height: 100 }}
           ${/** notice how the extraneous pins were removed automatically */ ''}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
@@ -187,7 +187,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, right: 50, bottom: 20 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, right: 50, bottom: 20 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -206,7 +206,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 20, top: 20, right: 280, bottom: 280 }}
+          style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, right: 280, bottom: 280 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -220,7 +220,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
           layout={{ layoutSystem: 'pinSystem', centerX: 100, centerY: 100 }}
           data-uid={'bbb'}
         />
@@ -239,7 +239,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 20, top: 20 }}
+          style={{ backgroundColor: '#0091FFAA', left: 20, top: 20 }}
           layout={{ layoutSystem: 'pinSystem', centerX: -130, centerY: -130 }}
           data-uid={'bbb'}
         />
@@ -253,7 +253,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD' }}
+          style={{ backgroundColor: '#0091FFAA' }}
           data-uid={'bbb'}
         />
       </View>
@@ -272,7 +272,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
           ${/** pins are magically created */ ''}
-          style={{ backgroundColor: '#DDDDDD', left: 20, top: 20, width: 100, height: 100 }}
+          style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, width: 100, height: 100 }}
           data-uid={'bbb'}
         />
       </View>`,
@@ -287,7 +287,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 52, top: 61 }}
+            style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'bbb'}
           />
@@ -306,7 +306,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 20, top: 20 }}
+            style={{ backgroundColor: '#0091FFAA', left: 20, top: 20 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'bbb'}
           />
@@ -320,7 +320,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 52, top: 61 }}
+            style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'bbb'}
           />
@@ -339,7 +339,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 20, top: 20 }}
+            style={{ backgroundColor: '#0091FFAA', left: 20, top: 20 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'bbb'}
           />
@@ -353,7 +353,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', right: 50, bottom: 50 }}
+            style={{ backgroundColor: '#0091FFAA', right: 50, bottom: 50 }}
             layout={{ layoutSystem: 'pinSystem'  }}
             data-uid={'bbb'}
           />
@@ -372,7 +372,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', right: 280, bottom: 280 }}
+            style={{ backgroundColor: '#0091FFAA', right: 280, bottom: 280 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'bbb'}
           />
@@ -386,7 +386,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', right: 50 }}
+            style={{ backgroundColor: '#0091FFAA', right: 50 }}
             layout={{ layoutSystem: 'pinSystem'  }}
             data-uid={'bbb'}
           />
@@ -405,7 +405,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', right: 280, top: 20 }}
+            style={{ backgroundColor: '#0091FFAA', right: 280, top: 20 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'bbb'}
           />
@@ -419,7 +419,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', bottom: 50 }}
+            style={{ backgroundColor: '#0091FFAA', bottom: 50 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'bbb'}
           />
@@ -438,7 +438,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', bottom: 280, left: 20 }}
+            style={{ backgroundColor: '#0091FFAA', bottom: 280, left: 20 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'bbb'}
           />
@@ -452,7 +452,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', width: '50%', height: 25, left: 52, top: 61 }}
+          style={{ backgroundColor: '#0091FFAA', width: '50%', height: 25, left: 52, top: 61 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -471,7 +471,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', width: '50%', height: 25, left: 20, top: 20  }}
+          style={{ backgroundColor: '#0091FFAA', width: '50%', height: 25, left: 20, top: 20  }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -485,7 +485,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, right: 50, bottom: 20 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, right: 50, bottom: 20 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -504,7 +504,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 20, top: 20, right: 280, bottom: 280 }}
+          style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, right: 280, bottom: 280 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -518,7 +518,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
           layout={{ layoutSystem: 'pinSystem', centerX: 100, centerY: 100 }}
           data-uid={'bbb'}
         />
@@ -537,7 +537,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 20, top: 20 }}
+          style={{ backgroundColor: '#0091FFAA', left: 20, top: 20 }}
           layout={{ layoutSystem: 'pinSystem', centerX: -130, centerY: -130 }}
           data-uid={'bbb'}
         />
@@ -551,7 +551,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', right: 52, bottom: 61 }}
+          style={{ backgroundColor: '#0091FFAA', right: 52, bottom: 61 }}
           layout={{ layoutSystem: 'pinSystem', centerX: 100, centerY: 100 }}
           data-uid={'bbb'}
         />
@@ -570,7 +570,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', right: 280, bottom: 280 }}
+          style={{ backgroundColor: '#0091FFAA', right: 280, bottom: 280 }}
           layout={{ layoutSystem: 'pinSystem', centerX: -130, centerY: -130 }}
           data-uid={'bbb'}
         />
@@ -584,7 +584,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202, bottom: 137, right: 93 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202, bottom: 137, right: 93 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -610,7 +610,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
                *  */ ''
             }
             style={{
-              backgroundColor: '#DDDDDD',
+              backgroundColor: '#0091FFAA',
               width: 256,
               height: 202,
               left: 20,
@@ -631,7 +631,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, right: 50 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, right: 50 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -650,7 +650,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 20, top: 20, right: 280 }}
+          style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, right: 280 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -666,7 +666,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -688,7 +688,7 @@ describe('moveTemplate', () => {
           data-uid={'${NewUID}'}
         >
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 0, top: 0, width: 256, height: 202 }}
+            style={{ backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'bbb'}
           />
@@ -702,7 +702,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         >
@@ -742,7 +742,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         />
@@ -779,7 +779,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid={'bbb'}
         >
@@ -810,7 +810,7 @@ describe('moveTemplate', () => {
           data-uid={'${NewUID}'}
         >
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 0, top: 0, width: 256, height: 202 }}
+            style={{ backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'bbb'}
           >
@@ -828,7 +828,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202 }}
+            style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
             layout={{ layoutSystem: 'pinSystem'}}
             data-uid={'bbb'}
           >
@@ -861,7 +861,7 @@ describe('moveTemplate', () => {
         <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
           <View data-uid={'eee'}>
             <View
-              style={{ backgroundColor: '#DDDDDD', left: 52, width: 256, height: 202, top: -141 }}
+              style={{ backgroundColor: '#0091FFAA', left: 52, width: 256, height: 202, top: -141 }}
               layout={{ layoutSystem: 'pinSystem'  }}
               data-uid={'bbb'}
             >
@@ -882,7 +882,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202 }}
+            style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'bbb'}
           >
@@ -910,7 +910,7 @@ describe('moveTemplate', () => {
         <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
           <View data-uid={'eee'}>
             <View
-              style={{ backgroundColor: '#DDDDDD', left: 52, width: 256, height: 202, top: -141 }}
+              style={{ backgroundColor: '#0091FFAA', left: 52, width: 256, height: 202, top: -141 }}
               layout={{ layoutSystem: 'pinSystem' }}
               data-uid={'bbb'}
             >
@@ -928,7 +928,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202 }}
+            style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'bbb'}
           >
@@ -957,7 +957,7 @@ describe('moveTemplate', () => {
           <View data-uid={'eee'}>
             <View data-uid={'ddd'} style={{ left: 52, top: -141 }} />
             <View
-              style={{ backgroundColor: '#DDDDDD', left: 52, width: 256, height: 202, top: -141 }}
+              style={{ backgroundColor: '#0091FFAA', left: 52, width: 256, height: 202, top: -141 }}
               layout={{ layoutSystem: 'pinSystem' }}
               data-uid={'bbb'}
             >
@@ -975,7 +975,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
+            style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
@@ -999,7 +999,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...(props.style || {}) }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
+            style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
@@ -1015,7 +1015,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
+            style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
@@ -1087,7 +1087,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
+            style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
@@ -1103,7 +1103,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
+            style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 20, crossBasis: 20 }} />
@@ -1191,12 +1191,12 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#DDDDDD', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
+            style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 20, crossBasis: 20 }} />
             <View
-              style={{ backgroundColor: '#DDDDDD' }}
+              style={{ backgroundColor: '#0091FFAA' }}
               data-uid={'${NewUID}'}
               layout={{ layoutSystem: 'pinSystem', flexBasis: 75, crossBasis: 75 }}
             />

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -32,7 +32,7 @@ export function defaultViewElement(uid: string): JSXElement {
     jsxElementName('View', []),
     {
       style: jsxAttributeValue({
-        backgroundColor: '#DDDDDD',
+        backgroundColor: '#0091FFAA',
       }),
       'data-uid': jsxAttributeValue(uid),
       layout: jsxAttributeValue({
@@ -49,7 +49,7 @@ export function defaultAnimatedDivElement(uid: string): JSXElement {
     jsxElementName('animated', ['div']),
     {
       style: jsxAttributeValue({
-        backgroundColor: '#DDDDDD',
+        backgroundColor: '#0091FFAA',
       }),
       'data-uid': jsxAttributeValue(uid),
     },
@@ -93,7 +93,7 @@ export function defaultRectangleElement(uid: string): JSXElement {
     jsxElementName('Rectangle', []),
     {
       style: jsxAttributeValue({
-        backgroundColor: '#DDDDDD',
+        backgroundColor: '#0091FFAA',
       }),
       'data-uid': jsxAttributeValue(uid),
     },
@@ -107,7 +107,7 @@ export function defaultEllipseElement(uid: string): JSXElement {
     jsxElementName('Ellipse', []),
     {
       style: jsxAttributeValue({
-        backgroundColor: '#DDDDDD',
+        backgroundColor: '#0091FFAA',
       }),
       'data-uid': jsxAttributeValue(uid),
     },


### PR DESCRIPTION
**Problem**

First impression of the editor, as well as visibility of nested elements for demonstration purposes, was marred by the default #DDDDDD colour. 

**Fix**
Change this colour out for a more scenic Blue, somewhat matching legacy
![image](https://user-images.githubusercontent.com/2945037/84814856-fc299800-b009-11ea-9783-714f19f3d2b7.png)
