### PR TITLE
Fix/imagepicker

### DIFF
--- a/editor/src/components/inspector/sections/style-section/background-subsection/picker-image-preview.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/picker-image-preview.tsx
@@ -17,7 +17,7 @@ export const PickerImagePreview = betterReactMemo(
       setImageNotFound(true)
     }, [])
 
-    const noImageProvided = props.value.url === ''
+    const imageURLempty = props.value.url === ''
 
     return (
       <div
@@ -34,15 +34,15 @@ export const PickerImagePreview = betterReactMemo(
               height: '100%',
               borderRadius: UtopiaTheme.inputBorderRadius,
               backgroundColor: '#FFFFFF88',
-              boxShadow: noImageProvided
+              boxShadow: imageURLempty
                 ? undefined
                 : `0 0 0 1px ${colorTheme.warningForeground.value} inset`,
               justifyContent: 'center',
-              color: noImageProvided ? undefined : colorTheme.warningForeground.value,
+              color: imageURLempty ? undefined : colorTheme.warningForeground.value,
             }}
           >
             <div>
-              {noImageProvided ? (
+              {imageURLempty ? (
                 <div style={{ paddingLeft: 8, whiteSpace: 'normal' }}>
                   <p>
                     Add an image URL, e.g. <span style={{ fontWeight: 600 }}>assets/image.png</span>{' '}


### PR DESCRIPTION
**Problem**

Image picker in empty state shows an error message, and doesn't say what you can paste or type into the input.

**Solution**
- Differentiate visually between empty and error state
- Add guidance for 'what to do here'

![image](https://user-images.githubusercontent.com/2945037/84912229-208c7f80-b0b1-11ea-9305-c4166d17af22.png)
