### PR TITLE
Support inserting third party dependencies.

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -152,7 +152,7 @@ import {
   xAxisGuideline,
   yAxisGuideline,
 } from './guideline'
-import { addImport } from '../../core/workers/common/project-file-utils'
+import { addImport, mergeImports } from '../../core/workers/common/project-file-utils'
 import { getLayoutProperty } from '../../core/layout/getLayoutProperty'
 import { createSceneTemplatePath, PathForSceneStyle } from '../../core/model/scene-utils'
 import { optionalMap } from '../../core/shared/optional-utils'
@@ -1194,16 +1194,10 @@ export function produceCanvasTransientState(
                   type: 'front',
                 },
               )
-              let updatedImports: Imports = parseSuccess.imports
-              if (insertMode.subject.importFromPath != null) {
-                updatedImports = addImport(
-                  insertMode.subject.importFromPath,
-                  null,
-                  [importAlias(insertMode.subject.element.name.baseVariable)],
-                  null,
-                  updatedImports,
-                )
-              }
+              const updatedImports: Imports = mergeImports(
+                parseSuccess.imports,
+                insertMode.subject.importsToAdd,
+              )
 
               // Sync these back up.
               const topLevelElements = applyUtopiaJSXComponentsChanges(

--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -3,7 +3,12 @@ import { findElementAtPath, MetadataUtils } from '../../core/model/element-metad
 import { ComponentMetadata, ElementInstanceMetadata } from '../../core/shared/element-template'
 import { generateUidWithExistingComponents } from '../../core/model/element-template-utils'
 import { isUtopiaAPITextElement } from '../../core/model/project-file-utils'
-import { InstancePath, TemplatePath } from '../../core/shared/project-file-types'
+import {
+  InstancePath,
+  TemplatePath,
+  importDetails,
+  importAlias,
+} from '../../core/shared/project-file-types'
 import { CanvasMousePositionRaw } from '../../templates/editor-canvas'
 import Keyboard, {
   KeyCharacter,
@@ -575,7 +580,7 @@ const Canvas = {
             EditorActions.enableInsertModeForJSXElement(
               defaultRectangleElement(newUID),
               newUID,
-              'utopia-api',
+              { 'utopia-api': importDetails(null, [importAlias('Rectangle')], null) },
               null,
             ),
           ]
@@ -589,7 +594,7 @@ const Canvas = {
             EditorActions.enableInsertModeForJSXElement(
               defaultEllipseElement(newUID),
               newUID,
-              'utopia-api',
+              { 'utopia-api': importDetails(null, [importAlias('Ellipse')], null) },
               null,
             ),
           ]
@@ -617,7 +622,7 @@ const Canvas = {
             EditorActions.enableInsertModeForJSXElement(
               defaultTextElement(newUID),
               newUID,
-              'utopia-api',
+              { 'utopia-api': importDetails(null, [importAlias('Text')], null) },
               null,
             ),
           ]
@@ -641,7 +646,7 @@ const Canvas = {
             EditorActions.enableInsertModeForJSXElement(
               defaultViewElement(newUID),
               newUID,
-              'utopia-api',
+              { 'utopia-api': importDetails(null, [importAlias('View')], null) },
               null,
             ),
           ]

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -18,6 +18,7 @@ import {
   ProjectContents,
   PropertyPath,
   TemplatePath,
+  Imports,
 } from '../../../core/shared/project-file-types'
 import { Either, isLeft, right } from '../../../core/shared/either'
 import { KeysPressed } from '../../../utils/keyboard'
@@ -164,10 +165,10 @@ export class InsertModeControlContainer extends React.Component<
 
   isUtopiaAPIInsertion(
     element: JSXElementChild,
-    importFromPath: string | null,
+    importsToAdd: Imports,
     elementType: string,
   ): boolean {
-    if (importFromPath === 'utopia-api') {
+    if (importsToAdd['utopia-api'] != null) {
       if (isJSXElement(element)) {
         if (PP.depth(element.name.propertyPath) === 0) {
           return element.name.baseVariable === elementType
@@ -182,16 +183,16 @@ export class InsertModeControlContainer extends React.Component<
     }
   }
 
-  isTextInsertion(element: JSXElementChild, importFromPath: string | null): boolean {
-    return this.isUtopiaAPIInsertion(element, importFromPath, 'Text')
+  isTextInsertion(element: JSXElementChild, importsToAdd: Imports): boolean {
+    return this.isUtopiaAPIInsertion(element, importsToAdd, 'Text')
   }
 
-  isImageInsertion(element: JSXElementChild, importFromPath: string | null): boolean {
-    return this.isUtopiaAPIInsertion(element, importFromPath, 'Image')
+  isImageInsertion(element: JSXElementChild, importsToAdd: Imports): boolean {
+    return this.isUtopiaAPIInsertion(element, importsToAdd, 'Image')
   }
 
-  isViewInsertion(element: JSXElementChild, importFromPath: string | null): boolean {
-    return this.isUtopiaAPIInsertion(element, importFromPath, 'View')
+  isViewInsertion(element: JSXElementChild, importsToAdd: Imports): boolean {
+    return this.isUtopiaAPIInsertion(element, importsToAdd, 'View')
   }
 
   renderControl = (target: TemplatePath): JSX.Element | null => {
@@ -436,7 +437,7 @@ export class InsertModeControlContainer extends React.Component<
       )
 
       let { element } = this.props.mode.subject
-      if (this.isTextInsertion(element, insertionSubject.importFromPath)) {
+      if (this.isTextInsertion(element, insertionSubject.importsToAdd)) {
         element = this.getTextElementAutoSizeWithPosition(element, snappedMousePoint)
       }
       this.props.dispatch(
@@ -448,7 +449,7 @@ export class InsertModeControlContainer extends React.Component<
                 insertionSubject.uid,
                 element,
                 insertionSubject.size,
-                insertionSubject.importFromPath,
+                insertionSubject.importsToAdd,
                 insertionParent(parent, staticParent),
               ),
             ),
@@ -500,11 +501,11 @@ export class InsertModeControlContainer extends React.Component<
       ) {
         // image and text insertion with single click
         if (
-          this.isImageInsertion(insertionElement, insertionSubject.importFromPath) &&
+          this.isImageInsertion(insertionElement, insertionSubject.importsToAdd) &&
           this.state.dragFrame != null
         ) {
           element = this.getImageElementWithSize()
-        } else if (this.isTextInsertion(insertionElement, insertionSubject.importFromPath)) {
+        } else if (this.isTextInsertion(insertionElement, insertionSubject.importsToAdd)) {
           element = insertionElement
         }
       } else {
@@ -512,7 +513,7 @@ export class InsertModeControlContainer extends React.Component<
         element = this.elementWithDragFrame(insertionElement)
       }
 
-      if (this.isTextInsertion(insertionElement, insertionSubject.importFromPath)) {
+      if (this.isTextInsertion(insertionElement, insertionSubject.importsToAdd)) {
         const path = TP.appendToPath(parentPath, insertionSubject.uid)
         extraActions.push(EditorActions.openTextEditor(path, null))
       }
@@ -522,7 +523,7 @@ export class InsertModeControlContainer extends React.Component<
       } else {
         this.props.dispatch(
           [
-            EditorActions.insertJSXElement(element, parentPath, insertionSubject.importFromPath),
+            EditorActions.insertJSXElement(element, parentPath, insertionSubject.importsToAdd),
             ...baseActions,
             ...extraActions,
           ],
@@ -570,7 +571,7 @@ export class InsertModeControlContainer extends React.Component<
           parent,
         )
         let element = this.elementWithDragFrame(insertionSubject.element)
-        if (this.isTextInsertion(element, insertionSubject.importFromPath)) {
+        if (this.isTextInsertion(element, insertionSubject.importsToAdd)) {
           element = this.setTextElementFixedSize(element)
         }
 
@@ -592,7 +593,7 @@ export class InsertModeControlContainer extends React.Component<
                   insertionSubject.uid,
                   element,
                   insertionSubject.size,
-                  insertionSubject.importFromPath,
+                  insertionSubject.importsToAdd,
                   insertionParent(parent, staticParent),
                 ),
               ),

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -24,6 +24,7 @@ import {
   TemplatePath,
   UIJSFile,
   NodeModules,
+  Imports,
 } from '../../core/shared/project-file-types'
 import { CodeResultCache } from '../custom-code/code-file'
 import { ElementContextMenuInstance } from '../element-context-menu'
@@ -127,7 +128,7 @@ export interface InsertJSXElement {
   action: 'INSERT_JSX_ELEMENT'
   jsxElement: JSXElement
   parent: TemplatePath | null
-  importFromPath: string | null
+  importsToAdd: Imports
 }
 
 export type DeleteSelected = {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -129,11 +129,14 @@ import {
   ESCodeFile,
   esCodeFile,
   NodeModules,
+  Imports,
+  importDetails,
 } from '../../../core/shared/project-file-types'
 import {
   addImport,
   codeNeedsParsing,
   codeNeedsPrinting,
+  mergeImports,
 } from '../../../core/workers/common/project-file-utils'
 import { OutgoingWorkerMessage, isJsFile } from '../../../core/workers/ts/ts-worker'
 import { UtopiaTsWorkers } from '../../../core/workers/common/worker-types'
@@ -1816,22 +1819,11 @@ export const UPDATE_FNS = {
     )
   },
   INSERT_JSX_ELEMENT: (action: InsertJSXElement, editor: EditorModel): EditorModel => {
-    let importFilePath: string | null = null
-    const editedFilename = getOpenFilename(editor)
-    if (editedFilename != null && action.importFromPath != null) {
-      importFilePath = getFilePathToImport(action.importFromPath, editedFilename)
-    }
-
-    let importFromWithinToAdd = [importAlias(action.jsxElement.name.baseVariable)]
-
     const editorWithAddedImport = modifyOpenParseSuccess((success) => {
-      const updatedImport =
-        importFilePath == null
-          ? success.imports
-          : addImport(importFilePath, null, importFromWithinToAdd, null, success.imports)
+      const updatedImports = mergeImports(success.imports, action.importsToAdd)
       return {
         ...success,
-        imports: updatedImport,
+        imports: updatedImports,
       }
     }, editor)
 
@@ -2812,7 +2804,7 @@ export const UPDATE_FNS = {
             null,
           )
           const size = width != null && height != null ? { width: width, height: height } : null
-          const switchMode = enableInsertModeForJSXElement(imageElement, newUID, 'utopia-api', size)
+          const switchMode = enableInsertModeForJSXElement(imageElement, newUID, {}, size)
           const editorInsertEnabled = UPDATE_FNS.SWITCH_EDITOR_MODE(switchMode, editor, derived)
           return {
             ...editorInsertEnabled,
@@ -2849,7 +2841,7 @@ export const UPDATE_FNS = {
             null,
           )
 
-          const insertJSXElementAction = insertJSXElement(imageElement, parent, 'utopia-api')
+          const insertJSXElementAction = insertJSXElement(imageElement, parent, {})
 
           const withComponentCreated = UPDATE_FNS.INSERT_JSX_ELEMENT(insertJSXElementAction, {
             ...editor,
@@ -2916,7 +2908,7 @@ export const UPDATE_FNS = {
         {},
       )
       const size = width != null && height != null ? { width: width, height: height } : null
-      const switchMode = enableInsertModeForJSXElement(imageElement, newUID, 'utopia-api', size)
+      const switchMode = enableInsertModeForJSXElement(imageElement, newUID, {}, size)
       return UPDATE_FNS.SWITCH_EDITOR_MODE(switchMode, editor, derived)
     } else {
       return editor
@@ -3799,7 +3791,7 @@ export const UPDATE_FNS = {
         {},
       )
 
-      const insertJSXElementAction = insertJSXElement(imageElement, parent, 'utopia-api')
+      const insertJSXElementAction = insertJSXElement(imageElement, parent, {})
       return UPDATE_FNS.INSERT_JSX_ELEMENT(insertJSXElementAction, editor)
     } else {
       throw new Error(`Could not be found or is not a file: ${action.imagePath}`)
@@ -4123,13 +4115,13 @@ export function insertScene(frame: CanvasRectangle): InsertScene {
 export function insertJSXElement(
   element: JSXElement,
   parent: TemplatePath | null,
-  path: string | null,
+  importsToAdd: Imports,
 ): InsertJSXElement {
   return {
     action: 'INSERT_JSX_ELEMENT',
     jsxElement: element,
     parent: parent,
-    importFromPath: path,
+    importsToAdd: importsToAdd,
   }
 }
 
@@ -4455,14 +4447,11 @@ export function toggleCollapse(target: TemplatePath): ToggleCollapse {
 export function enableInsertModeForJSXElement(
   element: JSXElement,
   uid: string,
-  importFromPath: string | null,
+  importsToAdd: Imports,
   size: Size | null,
 ): SwitchEditorMode {
   return switchEditorMode(
-    EditorModes.insertMode(
-      false,
-      elementInsertionSubject(uid, element, size, importFromPath, null),
-    ),
+    EditorModes.insertMode(false, elementInsertionSubject(uid, element, size, importsToAdd, null)),
   )
 }
 

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -1,4 +1,4 @@
-import { TemplatePath, id, StaticTemplatePath } from '../../core/shared/project-file-types'
+import { TemplatePath, id, StaticTemplatePath, Imports } from '../../core/shared/project-file-types'
 import { JSXElement, JSXElementName } from '../../core/shared/element-template'
 import { Size } from '../../core/shared/math-utils'
 
@@ -7,7 +7,7 @@ export interface ElementInsertionSubject {
   uid: string
   element: JSXElement
   size: Size | null
-  importFromPath: string | null
+  importsToAdd: Imports
   parent: InsertionParent
 }
 
@@ -24,7 +24,7 @@ export function elementInsertionSubject(
   uid: string,
   element: JSXElement,
   size: Size | null,
-  importFromPath: string | null,
+  importsToAdd: Imports,
   parent: InsertionParent,
 ): ElementInsertionSubject {
   return {
@@ -32,7 +32,7 @@ export function elementInsertionSubject(
     uid: uid,
     element: element,
     size: size,
-    importFromPath: importFromPath,
+    importsToAdd: importsToAdd,
     parent: parent,
   }
 }

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -20,7 +20,15 @@ import {
   JSXAttributes,
 } from '../../core/shared/element-template'
 import { generateUID } from '../../core/shared/uid-utils'
-import { TemplatePath, isCodeFile, isUIJSFile } from '../../core/shared/project-file-types'
+import {
+  TemplatePath,
+  isCodeFile,
+  isUIJSFile,
+  importDetails,
+  importAlias,
+  Imports,
+  importsEquals,
+} from '../../core/shared/project-file-types'
 import Utils from '../../utils/utils'
 import {
   defaultAnimatedDivElement,
@@ -52,6 +60,9 @@ import {
   findMissingDefaultsAndGetWarning,
 } from '../../core/property-controls/property-controls-utils'
 import { WarningIcon } from '../../uuiui/warning-icon'
+import { usePackageDependencies } from './npm-dependency/npm-dependency'
+import { NpmDependency } from '../../core/shared/npm-dependency-types'
+import { getThirdPartyComponents } from '../../core/third-party/third-party-components'
 
 interface CurrentFileComponent {
   componentName: string
@@ -67,10 +78,11 @@ interface InsertMenuProps {
   existingUIDs: Array<string>
   currentlyOpenFilename: string | null
   currentFileComponents: Array<CurrentFileComponent>
+  dependencies: Array<NpmDependency>
 }
 
 export const InsertMenu = betterReactMemo('InsertMenu', () => {
-  const props: InsertMenuProps = useEditorState((store) => {
+  const props = useEditorState((store) => {
     const openFileFullPath = getOpenFilename(store.editor)
     let currentlyOpenFilename: string | null = null
     if (openFileFullPath != null) {
@@ -111,20 +123,28 @@ export const InsertMenu = betterReactMemo('InsertMenu', () => {
       currentFileComponents: currentFileComponents,
     }
   })
-  return <InsertMenuInner {...props} />
+
+  const dependencies = usePackageDependencies()
+
+  const propsWithDependencies: InsertMenuProps = {
+    ...props,
+    dependencies: dependencies,
+  }
+
+  return <InsertMenuInner {...propsWithDependencies} />
 })
 
 export interface ComponentBeingInserted {
-  importedFrom: string | null
+  importsToAdd: Imports
   elementName: JSXElementName
 }
 
 export function componentBeingInserted(
-  importedFrom: string | null,
+  importsToAdd: Imports,
   elementName: JSXElementName,
 ): ComponentBeingInserted {
   return {
-    importedFrom: importedFrom,
+    importsToAdd: importsToAdd,
     elementName: elementName,
   }
 }
@@ -140,31 +160,37 @@ export function componentBeingInsertedEquals(
       return false
     } else {
       return (
-        first.importedFrom === second.importedFrom &&
+        importsEquals(first.importsToAdd, second.importsToAdd) &&
         jsxElementNameEquals(first.elementName, second.elementName)
       )
     }
   }
 }
 
-const viewComponentBeingInserted = componentBeingInserted('utopia-api', jsxElementName('View', []))
+const viewComponentBeingInserted = componentBeingInserted(
+  { 'utopia-api': importDetails(null, [importAlias('View')], null) },
+  jsxElementName('View', []),
+)
 
-const imageComponentBeingInserted = componentBeingInserted(null, jsxElementName('img', []))
+const imageComponentBeingInserted = componentBeingInserted({}, jsxElementName('img', []))
 
-const textComponentBeingInserted = componentBeingInserted('utopia-api', jsxElementName('Text', []))
+const textComponentBeingInserted = componentBeingInserted(
+  { 'utopia-api': importDetails(null, [importAlias('Text')], null) },
+  jsxElementName('Text', []),
+)
 
 const ellipseComponentBeingInserted = componentBeingInserted(
-  'utopia-api',
+  { 'utopia-api': importDetails(null, [importAlias('Ellipse')], null) },
   jsxElementName('Ellipse', []),
 )
 
 const rectangleComponentBeingInserted = componentBeingInserted(
-  'utopia-api',
+  { 'utopia-api': importDetails(null, [importAlias('Rectangle')], null) },
   jsxElementName('Rectangle', []),
 )
 
 const animatedDivComponentBeingInserted = componentBeingInserted(
-  'react-spring',
+  { 'react-spring': importDetails(null, [importAlias('animated')], null) },
   jsxElementName('animated', ['div']),
 )
 
@@ -174,7 +200,8 @@ class InsertMenuInner extends React.Component<InsertMenuProps, {}> {
       this.props.lastFontSettings !== nextProps.lastFontSettings ||
       this.props.editorDispatch !== nextProps.editorDispatch ||
       this.props.selectedViews !== nextProps.selectedViews ||
-      this.props.mode !== nextProps.mode
+      this.props.mode !== nextProps.mode ||
+      this.props.dependencies !== nextProps.dependencies
 
     return shouldUpdate
   }
@@ -190,7 +217,14 @@ class InsertMenuInner extends React.Component<InsertMenuProps, {}> {
   viewInsertMode = () => {
     const newUID = generateUID(this.props.existingUIDs)
     this.props.editorDispatch(
-      [enableInsertModeForJSXElement(defaultViewElement(newUID), newUID, 'utopia-api', null)],
+      [
+        enableInsertModeForJSXElement(
+          defaultViewElement(newUID),
+          newUID,
+          { 'utopia-api': importDetails(null, [importAlias('View')], null) },
+          null,
+        ),
+      ],
       'everyone',
     )
   }
@@ -202,7 +236,14 @@ class InsertMenuInner extends React.Component<InsertMenuProps, {}> {
   textInsertMode = () => {
     const newUID = generateUID(this.props.existingUIDs)
     this.props.editorDispatch(
-      [enableInsertModeForJSXElement(defaultTextElement(newUID), newUID, 'utopia-api', null)],
+      [
+        enableInsertModeForJSXElement(
+          defaultTextElement(newUID),
+          newUID,
+          { 'utopia-api': importDetails(null, [importAlias('Text')], null) },
+          null,
+        ),
+      ],
       'everyone',
     )
   }
@@ -214,7 +255,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps, {}> {
         enableInsertModeForJSXElement(
           defaultAnimatedDivElement(newUID),
           newUID,
-          'react-spring',
+          { 'react-spring': importDetails(null, [importAlias('animated')], null) },
           null,
         ),
       ],
@@ -225,7 +266,14 @@ class InsertMenuInner extends React.Component<InsertMenuProps, {}> {
   ellipseInsertMode = () => {
     const newUID = generateUID(this.props.existingUIDs)
     this.props.editorDispatch(
-      [enableInsertModeForJSXElement(defaultEllipseElement(newUID), newUID, 'utopia-api', null)],
+      [
+        enableInsertModeForJSXElement(
+          defaultEllipseElement(newUID),
+          newUID,
+          { 'utopia-api': importDetails(null, [importAlias('Ellipse')], null) },
+          null,
+        ),
+      ],
       'everyone',
     )
   }
@@ -233,7 +281,14 @@ class InsertMenuInner extends React.Component<InsertMenuProps, {}> {
   rectangleInsertMode = () => {
     const newUID = generateUID(this.props.existingUIDs)
     this.props.editorDispatch(
-      [enableInsertModeForJSXElement(defaultRectangleElement(newUID), newUID, 'utopia-api', null)],
+      [
+        enableInsertModeForJSXElement(
+          defaultRectangleElement(newUID),
+          newUID,
+          { 'utopia-api': importDetails(null, [importAlias('Rectangle')], null) },
+          null,
+        ),
+      ],
       'everyone',
     )
   }
@@ -247,7 +302,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps, {}> {
       } else if (insertionSubjectIsJSXElement(this.props.mode.subject)) {
         const insertionSubject: ElementInsertionSubject = this.props.mode.subject
         currentlyBeingInserted = componentBeingInserted(
-          insertionSubject.importFromPath,
+          insertionSubject.importsToAdd,
           insertionSubject.element.name,
         )
       }
@@ -330,7 +385,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps, {}> {
                 props['data-uid'] = jsxAttributeValue(newUID)
                 const newElement = jsxElement(jsxElementName(componentName, []), props, [], null)
                 this.props.editorDispatch(
-                  [enableInsertModeForJSXElement(newElement, newUID, null, null)],
+                  [enableInsertModeForJSXElement(newElement, newUID, {}, null)],
                   'everyone',
                 )
               }
@@ -343,7 +398,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps, {}> {
                   selected={componentBeingInsertedEquals(
                     currentlyBeingInserted,
                     componentBeingInserted(
-                      null,
+                      {},
                       jsxElementName(currentFileComponent.componentName, []),
                     ),
                   )}
@@ -354,6 +409,52 @@ class InsertMenuInner extends React.Component<InsertMenuProps, {}> {
             })}
           </InsertGroup>
         )}
+        {this.props.dependencies.map((dependency, dependencyIndex) => {
+          const componentDescriptor = getThirdPartyComponents(dependency.name, dependency.version)
+          if (componentDescriptor == null) {
+            return null
+          } else {
+            return (
+              <InsertGroup label={componentDescriptor.name}>
+                {componentDescriptor.components.map((component, componentIndex) => {
+                  const insertItemOnMouseDown = () => {
+                    const newUID = generateUID(this.props.existingUIDs)
+                    const newElement = {
+                      ...component.element,
+                      props: {
+                        ...component.element.props,
+                        ['data-uid']: jsxAttributeValue(newUID),
+                      },
+                    }
+                    this.props.editorDispatch(
+                      [
+                        enableInsertModeForJSXElement(
+                          newElement,
+                          newUID,
+                          component.importsToAdd,
+                          null,
+                        ),
+                      ],
+                      'everyone',
+                    )
+                  }
+                  return (
+                    <InsertItem
+                      key={`insert-item-third-party-${dependencyIndex}-${componentIndex}`}
+                      type={'component'}
+                      label={component.name}
+                      selected={componentBeingInsertedEquals(
+                        currentlyBeingInserted,
+                        componentBeingInserted({}, component.element.name),
+                      )}
+                      onMouseDown={insertItemOnMouseDown}
+                    />
+                  )
+                })}
+              </InsertGroup>
+            )
+          }
+        })}
       </React.Fragment>
     )
   }

--- a/editor/src/components/editor/npm-dependency/npm-dependency.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.ts
@@ -22,6 +22,8 @@ import { reactDomTypings, reactGlobalTypings, reactTypings } from './react-typin
 import { utopiaApiTypings } from './utopia-api-typings'
 import { objectMap } from '../../../core/shared/object-utils'
 import { mapArrayToDictionary } from '../../../core/shared/array-utils'
+import { useEditorState } from '../store/store-hook'
+import * as React from 'react'
 
 export async function findLatestVersion(packageName: string): Promise<string> {
   const requestInit: RequestInit = {
@@ -119,6 +121,20 @@ export function dependenciesFromModel(model: {
 }): Array<NpmDependency> {
   const packageJsonFile = packageJsonFileFromModel(model)
   return dependenciesFromPackageJson(packageJsonFile)
+}
+
+export function usePackageDependencies(): Array<NpmDependency> {
+  const packageJsonFile = useEditorState((store) => {
+    return packageJsonFileFromModel(store.editor)
+  })
+
+  return React.useMemo(() => {
+    if (isCodeFile(packageJsonFile)) {
+      return dependenciesFromPackageJsonContents(packageJsonFile.fileContents)
+    } else {
+      return []
+    }
+  }, [packageJsonFile])
 }
 
 export function updateDependenciesInPackageJson(

--- a/editor/src/components/editor/store/editor-update.spec.ts
+++ b/editor/src/components/editor/store/editor-update.spec.ts
@@ -15,6 +15,8 @@ import {
   isUIJSFile,
   CodeFile,
   esCodeFile,
+  importDetails,
+  importAlias,
 } from '../../../core/shared/project-file-types'
 import { MockUtopiaTsWorkers } from '../../../core/workers/workers'
 import { isRight, right } from '../../../core/shared/either'
@@ -480,7 +482,9 @@ describe('INSERT_JSX_ELEMENT', () => {
       [],
       null,
     )
-    const insertAction = insertJSXElement(elementToInsert, parentPath, 'utopia-api')
+    const insertAction = insertJSXElement(elementToInsert, parentPath, {
+      'utopia-api': importDetails(null, [importAlias('View')], null),
+    })
     const updatedEditor = runLocalEditorAction(
       editor,
       derivedState,
@@ -534,7 +538,9 @@ describe('INSERT_JSX_ELEMENT', () => {
       [],
       null,
     )
-    const insertAction = insertJSXElement(elementToInsert, null, 'utopia-api')
+    const insertAction = insertJSXElement(elementToInsert, null, {
+      'utopia-api': importDetails(null, [importAlias('View')], null),
+    })
     const updatedEditor = runLocalEditorAction(
       editorWithNoHighlighted,
       derivedState,

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -30,6 +30,8 @@ import {
   isParseSuccess,
   ProjectContents,
   ProjectFileType,
+  importDetails,
+  importAlias,
 } from '../../core/shared/project-file-types'
 import { contentsToTree, walkContentsTree } from '../assets'
 import { setFocus } from '../common/actions'
@@ -247,7 +249,15 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
               EditorActions.enableInsertModeForJSXElement(
                 element,
                 newUID,
-                insertingToItself ? null : filePathWithoutExtension,
+                insertingToItself
+                  ? {}
+                  : {
+                      [filePathWithoutExtension]: importDetails(
+                        null,
+                        [importAlias(exportVarName)],
+                        null,
+                      ),
+                    },
                 null,
               ),
             ],

--- a/editor/src/components/images.ts
+++ b/editor/src/components/images.ts
@@ -118,7 +118,7 @@ export function createInsertImageAction(
         aspectRatioLocked: true,
       },
     )
-    return insertJSXElement(imageElement, parentPath, null)
+    return insertJSXElement(imageElement, parentPath, {})
   } else {
     throw new Error(`Attempting to insert ${imagePath} as an image when it is not stored as such.`)
   }

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -3,6 +3,7 @@ import { FlexParentProps, LayoutSystem, NormalisedFrame } from 'utopia-api'
 import { Either, Left, Right, isRight, isLeft } from './either'
 import { TopLevelElement, UtopiaJSXComponent } from './element-template'
 import { ErrorMessage } from './error-messages'
+import { arrayEquals, objectEquals } from './utils'
 
 export type id = string
 
@@ -89,12 +90,6 @@ export type PrintedCanvasMetadata = {
   elementMetadata: CanvasElementMetadataMap
 }
 
-export interface ImportDetails {
-  importedWithName: string | null
-  importedFromWithin: Array<ImportAlias>
-  importedAs: string | null
-}
-
 export interface ImportAlias {
   name: string
   alias: string
@@ -107,7 +102,41 @@ export function importAlias(name: string, alias?: string) {
   }
 }
 
+export function importAliasEquals(first: ImportAlias, second: ImportAlias): boolean {
+  return first.name === second.name && first.alias === second.alias
+}
+
+export interface ImportDetails {
+  importedWithName: string | null
+  importedFromWithin: Array<ImportAlias>
+  importedAs: string | null
+}
+
+export function importDetails(
+  importedWithName: string | null,
+  importedFromWithin: Array<ImportAlias>,
+  importedAs: string | null,
+): ImportDetails {
+  return {
+    importedWithName: importedWithName,
+    importedFromWithin: importedFromWithin,
+    importedAs: importedAs,
+  }
+}
+
+export function importDetailsEquals(first: ImportDetails, second: ImportDetails): boolean {
+  return (
+    first.importedWithName === second.importedWithName &&
+    arrayEquals(first.importedFromWithin, second.importedFromWithin, importAliasEquals) &&
+    first.importedAs === second.importedAs
+  )
+}
+
 export type Imports = { [importSource: string]: ImportDetails }
+
+export function importsEquals(first: Imports, second: Imports): boolean {
+  return objectEquals(first, second, importDetailsEquals)
+}
 
 export interface HighlightBounds {
   startLine: number

--- a/editor/src/core/shared/utils.ts
+++ b/editor/src/core/shared/utils.ts
@@ -1,3 +1,5 @@
+import { MapLike } from 'typescript'
+
 // This file shouldn't import anything as it is for exporting simple shared utility functions between various projects
 export const EditorID = 'editor'
 export const PortalTargetID = 'portal-target'
@@ -38,6 +40,36 @@ export function arrayEquals<T>(a: Array<T>, b: Array<T>, eq?: (l: T, r: T) => bo
     } else {
       return false
     }
+  }
+}
+
+export function objectEquals<T>(
+  a: MapLike<T>,
+  b: MapLike<T>,
+  eq?: (l: T, r: T) => boolean,
+): boolean {
+  if (a === b) {
+    return true
+  } else {
+    const equals = eq == null ? (l: T, r: T) => l === r : eq
+    for (const aKey of Object.keys(a)) {
+      if (aKey in b) {
+        if (!equals(a[aKey], b[aKey])) {
+          // Values in each object for the same key differ.
+          return false
+        }
+      } else {
+        // Value for key cannot be found in object 'b'.
+        return false
+      }
+    }
+    for (const bKey of Object.keys(b)) {
+      if (!(bKey in a)) {
+        // This key from 'b' isn't in 'a'.
+        return false
+      }
+    }
+    return true
   }
 }
 

--- a/editor/src/core/third-party/antd-components.ts
+++ b/editor/src/core/third-party/antd-components.ts
@@ -1,0 +1,26 @@
+import { importAlias, importDetails } from '../shared/project-file-types'
+import {
+  componentDescriptor,
+  DependencyBoundDescriptors,
+  ComponentDescriptor,
+} from './third-party-types'
+import { jsxElement, jsxElementName } from '../shared/element-template'
+
+function createBasicComponent(element: string, name: string): ComponentDescriptor {
+  return componentDescriptor(
+    { antd: importDetails(null, [importAlias(element)], null) },
+    jsxElement(jsxElementName(element, []), {}, [], null),
+    name,
+  )
+}
+
+export const AntdComponents: DependencyBoundDescriptors = {
+  '>=4.0.0 <5.0.0': {
+    name: 'Antd',
+    components: [
+      createBasicComponent('DatePicker', 'Date Picker'),
+      createBasicComponent('Button', 'Button'),
+      createBasicComponent('InputNumber', 'Number Input'),
+    ],
+  },
+}

--- a/editor/src/core/third-party/third-party-components.spec.ts
+++ b/editor/src/core/third-party/third-party-components.spec.ts
@@ -1,0 +1,22 @@
+import { getThirdPartyComponents } from './third-party-components'
+import { AntdComponents } from './antd-components'
+
+describe('getThirdPartyComponents', () => {
+  it('returns the descriptor for antd version 4.3.0', () => {
+    const actualResult = getThirdPartyComponents('antd', '4.3.0')
+    const expectedResult = AntdComponents['>=4.0.0 <5.0.0']
+    expect(actualResult).toBe(expectedResult)
+  })
+  it('returns nothing for antd version 5.3.0', () => {
+    const actualResult = getThirdPartyComponents('antd', '5.3.0')
+    expect(actualResult).toBeNull()
+  })
+  it('returns nothing for antd version 3.3.0', () => {
+    const actualResult = getThirdPartyComponents('antd', '3.3.0')
+    expect(actualResult).toBeNull()
+  })
+  it('returns nothing for antantant version 4.3.0', () => {
+    const actualResult = getThirdPartyComponents('antantant', '4.3.0')
+    expect(actualResult).toBeNull()
+  })
+})

--- a/editor/src/core/third-party/third-party-components.ts
+++ b/editor/src/core/third-party/third-party-components.ts
@@ -1,0 +1,29 @@
+import {
+  DependenciesDescriptors,
+  DependencyDescriptor,
+  DependencyBoundDescriptors,
+} from './third-party-types'
+import { AntdComponents } from './antd-components'
+import { satisfies } from 'semver'
+
+const ThirdPartyComponents: DependenciesDescriptors = {
+  antd: AntdComponents,
+}
+
+export function getThirdPartyComponents(
+  dependencyName: string,
+  dependencyVersion: string,
+): DependencyDescriptor | null {
+  if (dependencyName in ThirdPartyComponents) {
+    const boundsDescriptors: DependencyBoundDescriptors = ThirdPartyComponents[dependencyName]
+    const dependencyBounds = Object.keys(boundsDescriptors)
+    for (const bounds of dependencyBounds) {
+      if (satisfies(dependencyVersion, bounds)) {
+        return boundsDescriptors[bounds]
+      }
+    }
+    return null
+  } else {
+    return null
+  }
+}

--- a/editor/src/core/third-party/third-party-types.ts
+++ b/editor/src/core/third-party/third-party-types.ts
@@ -1,0 +1,31 @@
+import { JSXElement } from '../shared/element-template'
+import { Imports } from '../shared/project-file-types'
+
+export interface ComponentDescriptor {
+  importsToAdd: Imports
+  element: JSXElement
+  name: string
+}
+
+export function componentDescriptor(
+  importsToAdd: Imports,
+  element: JSXElement,
+  name: string,
+): ComponentDescriptor {
+  return {
+    importsToAdd: importsToAdd,
+    element: element,
+    name: name,
+  }
+}
+
+export interface DependencyDescriptor {
+  name: string
+  components: Array<ComponentDescriptor>
+}
+
+// A dictionary of bounds to the descriptors for those respective versions.
+export type DependencyBoundDescriptors = { [dependencyBounds: string]: DependencyDescriptor }
+
+// A dictionary of dependency names to the various instances of that dependency.
+export type DependenciesDescriptors = { [dependencyName: string]: DependencyBoundDescriptors }


### PR DESCRIPTION
Fixes #108

**Problem:**
We want to support third party components via the insert menu as well as we support our own.

**Fix:**
In this work a descriptor type was defined for specifying details of a package and the components within and how to construct them for insertion. Along with a lookup that can work with version bounds to determine which descriptor is available for a given package name and version.

**Notes:**
- The `DatePicker` component from `antd` causes the canvas to bail, this doesn't appear to be related to this work as other components work fine.
- If one of the third party components is inserted a little too quickly it doesn't appear to be included in the local bundle and the canvas registers an error with loading the module.
- This work takes the dependencies from the `package.json` file and uses the versions as defined in there, however those can instead be bounds or other non-specific identifiers, what we really need is the resolved versions of those packages.

**Commit Details:**
- Fixes #108.
- In `InsertionSubject`, replaced `importFromPath` with `importsToAdd`,
  which rippled out to some utility functions and a couple of other locations.
- The `InsertMenu` component now takes an array of dependencies which
  are transformed into insert groups for each dependency version
  that we have details for.
- Added `usePackageDependencies` hook.
- Implemented `importsEquals` along with some similar equality checks
  for the types used within it.
- Added the `objectEquals` utility function for comparing dictionary like
  values.
- `getThirdPartyComponents` takes a given name and version and attempts to
  find a descriptor for the components within for that given package.
- Added some component definitions for a handful of `antd` components.