### PR TITLE
unsafe value removal with objects referencing themselves

### DIFF
--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -208,24 +208,23 @@ export function applyUIDMonkeyPatch(): void {
 
 export function makeCanvasElementPropsSafe(props: any): any {
   function removeUnsafeValues(innerProps: any, visited: any[]): any {
-    let visitedObjects = [...visited]
     switch (typeof innerProps) {
       case 'object': {
         if (Array.isArray(innerProps)) {
           return innerProps.map((prop) => {
-            return removeUnsafeValues(prop, visitedObjects)
+            return removeUnsafeValues(prop, visited)
           })
         } else if (innerProps != null) {
-          visitedObjects.push(innerProps)
+          visited.push(innerProps)
           return Utils.objectMap((value, key) => {
             if (typeof value === 'object') {
-              if (visitedObjects.includes(value)) {
+              if (visited.includes(value)) {
                 return null
               } else {
-                return removeUnsafeValues(value, visitedObjects)
+                return removeUnsafeValues(value, visited)
               }
             } else {
-              return removeUnsafeValues(value, visitedObjects)
+              return removeUnsafeValues(value, visited)
             }
           }, innerProps)
         }


### PR DESCRIPTION
Fixes #127

**Problem:**
When adding antd Menu.Items the canvas elements cannot be selected/navigator is empty.

**Fix:**
The canvas util `removeUnsafeValues` finds a cycle in an object, PropTypes is referring to itself. Fix is to collect which objects were visited previously. 
