### PR TITLE
fix(components) scrollable insert menu

### DIFF
--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -373,7 +373,10 @@ export const InsertMenuPane = betterReactMemo('InsertMenuPane', () => {
           <Title>Insert</Title>
         </FlexRow>
       </SectionTitleRow>
-      <SectionBodyArea minimised={false} style={{ paddingLeft: 8, paddingRight: 8 }}>
+      <SectionBodyArea
+        minimised={false}
+        style={{ paddingLeft: 8, paddingRight: 8, overflow: 'auto' }}
+      >
         <InsertMenu />
       </SectionBodyArea>
     </Section>


### PR DESCRIPTION
Fixes #138 

**Problem:**
Insert menu with antd components doesn't scroll.

**Fix:**
Added css overflow to insert menu inner div.

