### PR TITLE
fixing and re-enabling GetClassMonkeyFunction

### DIFF
--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -130,6 +130,9 @@ function getClassMonkeyFunction(monkeyProps: ClassMonkeyFunctionProps): (props: 
   }
 
   monkeyFunction.prototype = React.Component.prototype
+  // we copy over the properties on the original class
+  // this copies over Class.contextType, Class.propTypes, Class.defaultProps among others
+  Object.assign(monkeyFunction, monkeyProps.type)
   return monkeyFunction
 }
 
@@ -158,12 +161,11 @@ function monkeyPatchReactType(
   originalUIDFromProps: string | null,
 ): any {
   if (type.prototype != null && typeof type.prototype.isReactComponent === 'object') {
-    return type
-    // return memoizedGetClassMonkeyFunction({
-    //   type: type,
-    //   dataUIDFromProps: dataUIDFromProps,
-    //   originalUIDFromProps: originalUIDFromProps,
-    // })
+    return memoizedGetClassMonkeyFunction({
+      type: type,
+      dataUIDFromProps: dataUIDFromProps,
+      originalUIDFromProps: originalUIDFromProps,
+    })
   } else if (typeof type === 'function') {
     return memoizedGetFunctionMonkeyFunction({
       type: type,


### PR DESCRIPTION
Fixes #151 

Follow up from #139 

**Problem:**
The inserting the antd DatePicker caused a runtime error `TypeError: getPrefixCls is not a function`. The previous PR was a hotfix that disabled the class monkey patching. 

**Fix:**
This PR fixes the class monkey patching. When we are monkey patching a class, now we also clone all properties that are on it to the monkey function. This means things like `Class.propTypes` and `Class.defaultProps` will work, and most importantly, `Class.contextType` will work too, fixing the original issue that meant the class loosing their React Context.

**Commit Details:**
- Clone properties of the original class to the monkey
- Added new test to make sure that the context API works
- Added a new way to write inline snapshot tests for the canvas, to reduce snapshot clutter.
