### PR TITLE
Fix Insert Menu Highlighting of Selected 3rd Party Components

### DIFF
--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -445,7 +445,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps, {}> {
                       label={component.name}
                       selected={componentBeingInsertedEquals(
                         currentlyBeingInserted,
-                        componentBeingInserted({}, component.element.name),
+                        componentBeingInserted(component.importsToAdd, component.element.name),
                       )}
                       onMouseDown={insertItemOnMouseDown}
                     />


### PR DESCRIPTION
Fixes #150 

**Problem:**
When inserting a 3rd party component the insert menu doesn't highlight which one is selected

**Fix:**
The comparison function used to check which element is being inserted also checks the imports that the element should add, but we weren't including those in the objects we were checking against

**Commit Details:**
It's literally 1 line, look at the diff and don't be so lazy k?!
