### PR TITLE
fix(shortcut) - cmd-option-2 now toggles right menu

### DIFF
--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -139,7 +139,7 @@ export function handleGlobalKeyDown(
     }
     case '2': {
       if (altCmd) {
-        return [EditorActions.togglePanel('inspector')]
+        return [EditorActions.togglePanel('rightmenu')]
       } else {
         return []
       }


### PR DESCRIPTION
**Problem:**
the right menu holding the inspector used to be toggleable by keyboard shortcut, but this regressed

**Fix:**
Toggle `rightmenu` instead of `inspector`