### PR TITLE
Remove the behaviour which made emitting optional.

### DIFF
--- a/editor/src/core/workers/bundler-bridge.spec.ts
+++ b/editor/src/core/workers/bundler-bridge.spec.ts
@@ -16,7 +16,6 @@ const updateFileEvent = {
   payload: {
     fileName: 'test_filename.js',
     fileContent: '',
-    weWantToEmit: true,
   },
 } as const
 
@@ -133,7 +132,6 @@ describe('Bundler State Machine', () => {
       payload: {
         fileName: 'test_filename1.js',
         fileContent: '',
-        weWantToEmit: true,
       },
     })
 
@@ -144,7 +142,6 @@ describe('Bundler State Machine', () => {
       payload: {
         fileName: 'test_filename2.js',
         fileContent: '',
-        weWantToEmit: true,
       },
     })
     const promise3 = utils.defer()
@@ -154,7 +151,6 @@ describe('Bundler State Machine', () => {
       payload: {
         fileName: 'test_filename3.js',
         fileContent: '',
-        weWantToEmit: false,
       },
     })
     const promise4 = utils.defer()
@@ -164,7 +160,6 @@ describe('Bundler State Machine', () => {
       payload: {
         fileName: 'test_filename4.js',
         fileContent: '',
-        weWantToEmit: false,
       },
     })
 
@@ -177,11 +172,9 @@ describe('Bundler State Machine', () => {
     await promise1
 
     // now the queue should be 2 remaining files, one file loaded in "up next", and weWantToEmit should be true
-    expect(stateMachine.state.context.weWantToEmit).toBeTruthy()
     expect(stateMachine.state.context.fileQueuedForProcessing).toEqual({
       fileContent: '',
       fileName: 'test_filename2.js',
-      shouldEmit: false,
     })
     expect(stateMachine.state.context.queuedUpdateFiles).toEqual({
       'test_filename3.js': '',
@@ -197,19 +190,15 @@ describe('Bundler State Machine', () => {
     await promise4
 
     expect(mockUpdateFileService.mock.calls.length).toBe(4)
-    expect(mockUpdateFileService.mock.calls[0][0].fileQueuedForProcessing.shouldEmit).toBeTruthy()
     expect(mockUpdateFileService.mock.calls[0][0].fileQueuedForProcessing.fileName).toEqual(
       'test_filename1.js',
     )
-    expect(mockUpdateFileService.mock.calls[1][0].fileQueuedForProcessing.shouldEmit).toBeFalsy()
     expect(mockUpdateFileService.mock.calls[1][0].fileQueuedForProcessing.fileName).toEqual(
       'test_filename2.js',
     )
-    expect(mockUpdateFileService.mock.calls[2][0].fileQueuedForProcessing.shouldEmit).toBeFalsy()
     expect(mockUpdateFileService.mock.calls[2][0].fileQueuedForProcessing.fileName).toEqual(
       'test_filename3.js',
     )
-    expect(mockUpdateFileService.mock.calls[3][0].fileQueuedForProcessing.shouldEmit).toBeTruthy()
     expect(mockUpdateFileService.mock.calls[3][0].fileQueuedForProcessing.fileName).toEqual(
       'test_filename4.js',
     )

--- a/editor/src/core/workers/bundler-bridge.ts
+++ b/editor/src/core/workers/bundler-bridge.ts
@@ -8,18 +8,15 @@ import {
   createInitTSWorkerMessage,
   BuildResultMessage,
   createUpdateFileMessage,
-  NoEmitMessage,
 } from './ts/ts-worker'
 import utils from '../../utils/utils'
 import { workerForFile } from './utils'
 
 export interface BundlerContext {
   queuedUpdateFiles: { [key: string]: FileContent }
-  weWantToEmit: boolean
   fileQueuedForProcessing: null | {
     fileName: string
     fileContent: FileContent
-    shouldEmit: boolean
   }
 }
 
@@ -70,16 +67,14 @@ interface PushEvent {
   payload: {
     fileName: string
     fileContent: FileContent
-    weWantToEmit: boolean
   }
 }
-function pushEvent(fileName: string, fileContent: FileContent, weWantToEmit: boolean): PushEvent {
+function pushEvent(fileName: string, fileContent: FileContent): PushEvent {
   return {
     type: 'PUSH',
     payload: {
       fileName,
       fileContent,
-      weWantToEmit,
     },
   }
 }
@@ -96,26 +91,19 @@ type BundlerEvent = InitializeEvent | PushEvent | PopEvent | ProcessFileFromQueu
 
 function popFromQueue(context: BundlerContext): BundlerContext {
   const filenames = Object.keys(context.queuedUpdateFiles)
-  const queueLength = filenames.length
-  const lastOne = queueLength === 1
-  // Only emit if this is the last queued file and we actually wanted it to emit
-  const emitWithThisFile = context.weWantToEmit && lastOne
-  const emitNextBuild = lastOne ? false : context.weWantToEmit
-  const filename = filenames[0]
-  const content = context.queuedUpdateFiles[filename]
+  const firstItemFilename = filenames[0]
+  const content = context.queuedUpdateFiles[firstItemFilename]
   const updatedQueue = {
     ...context.queuedUpdateFiles,
   }
-  delete updatedQueue[filename]
+  delete updatedQueue[firstItemFilename]
   return {
     ...context,
     queuedUpdateFiles: updatedQueue,
     fileQueuedForProcessing: {
-      fileName: filename,
+      fileName: firstItemFilename,
       fileContent: content,
-      shouldEmit: emitWithThisFile,
     },
-    weWantToEmit: emitNextBuild,
   }
 }
 
@@ -127,14 +115,12 @@ function pushToQueue(context: BundlerContext, event: any): BundlerContext {
   return {
     ...context,
     queuedUpdateFiles: updatedQueue,
-    weWantToEmit: context.weWantToEmit || event.payload.weWantToEmit,
   }
 }
 
 function emptyContext(context: BundlerContext, event: any): BundlerContext {
   return {
     queuedUpdateFiles: {},
-    weWantToEmit: false,
     fileQueuedForProcessing: null,
   }
 }
@@ -147,7 +133,6 @@ export const bundlerMachine = Machine<BundlerContext, BundlerSchema, BundlerEven
   // the Action to change the context's value is called `assign`. dont ask me why.
   context: {
     queuedUpdateFiles: {},
-    weWantToEmit: false,
     fileQueuedForProcessing: null,
   },
   // the top level state machine has two sub-machines: worker, and queue.
@@ -296,8 +281,7 @@ export const bundlerMachine = Machine<BundlerContext, BundlerSchema, BundlerEven
           // it has a dual, called `exit`
           entry: [
             // assign is like React.setState for the `context` object. here we describe that we want to set
-            // the value of queuedUpdateFiles to include event.payload.fileContent, and
-            // weWantToEmit to be event.payload.weWantToEmit
+            // the value of queuedUpdateFiles to include event.payload.fileContent.
             assign((context, event) => pushToQueue(context, event)),
           ],
           on: {
@@ -370,7 +354,6 @@ export class NewBundlerWorker {
               this.worker,
               context.fileQueuedForProcessing.fileName,
               context.fileQueuedForProcessing.fileContent,
-              context.fileQueuedForProcessing.shouldEmit,
             )
           },
           initializeWorkerPromise: (context, event) =>
@@ -389,8 +372,8 @@ export class NewBundlerWorker {
     this.stateMachine.send(initializeEvent(typeDefinitions, projectContents))
   }
 
-  sendUpdateFileMessage(filename: string, content: FileContent, emitBuild: boolean) {
-    this.stateMachine.send(pushEvent(filename, content, emitBuild))
+  sendUpdateFileMessage(filename: string, content: FileContent) {
+    this.stateMachine.send(pushEvent(filename, content))
   }
 
   // TODO KILLME
@@ -433,15 +416,13 @@ function sendIdGuardedUpdateFilePromise(
   worker: BundlerWorker,
   filename: string,
   content: string | UIJSFile | CodeFile,
-  emitBuild: boolean,
-): Promise<BuildResultMessage | NoEmitMessage> {
+): Promise<BuildResultMessage> {
   const generatedJobID = utils.generateUUID()
   return new Promise((resolve, reject) => {
     function handleMessage(event: MessageEvent) {
       const data: OutgoingWorkerMessage = event.data
       switch (data.type) {
         case 'build':
-        case 'noemit':
           if (data.jobID === generatedJobID) {
             worker.removeMessageListener(handleMessage)
             resolve(data)
@@ -450,6 +431,6 @@ function sendIdGuardedUpdateFilePromise(
       }
     }
     worker.addMessageListener(handleMessage)
-    worker.postMessage(createUpdateFileMessage(filename, content, emitBuild, generatedJobID))
+    worker.postMessage(createUpdateFileMessage(filename, content, generatedJobID))
   })
 }

--- a/editor/src/core/workers/ts/ts-worker.spec.ts
+++ b/editor/src/core/workers/ts/ts-worker.spec.ts
@@ -279,7 +279,6 @@ const SampleUpdateFileMessage: IncomingWorkerMessage = {
     lastSavedContents:
       "// component library\nimport * as React from 'react'\nimport { Text, View } from 'utopia-api'\n\nexport default (props) => (\n  <View layout={props.layout} style={props.style} onMouseDown={props.onMouseDown}>\n    <Text\n      style={{ fontSize: 16, textAlign: 'center' }}\n      text={props.text}\n      layout={{\n        left: 0,\n        top: 10,\n        width: '100%',\n        height: '100%',\n      }}\n      textSizing={'fixed'}\n    />\n  </View>\n)\n\nexport const LABEL = 'press me! 😉'\n\nexport const ComponentWithProps = (props) => {\n  return (\n    <div\n      style={{\n        ...props.style,\n        backgroundColor: props.pink ? 'hotpink' : 'transparent',\n        whiteSpace: 'normal',\n      }}\n    >\n      {(props.text + ' ').repeat(props.num)}\n    </div>\n  )\n}\n\nComponentWithProps.propertyControls = {\n  text: {\n    type: 'string',\n    title: 'Title',\n    defaultValue: 'Change me',\n  },\n  num: {\n    type: 'number',\n    title: 'amount',\n    defaultValue: 2,\n  },\n  pink: {\n    type: 'boolean',\n    title: 'Enabled',\n    defaultValue: true,\n  },\n}\n",
   },
-  emitBuild: true,
   jobID: '689b7b1b_d5ed_4876_ba62_bc66e2096bf6',
 }
 
@@ -293,6 +292,5 @@ const SampleUpdateFileMessageWithError: IncomingWorkerMessage = {
     lastSavedContents:
       "// component library\nimport * as React from 'react'\nimport { Text, View } from 'utopia-api'\n\n\nexport default (props) => (\n  <View layout={props.layout} style={props.style} onMouseDown={props.onMouseDown}>\n    <Text\n      style={{ fontSize: 16, textAlign: 'center' }}\n      text={props.text}\n      layout={{\n        left: 0,\n        top: 10,\n        width: '100%',\n        height: '100%',\n      }}\n      textSizing={'fixed'}\n    />\n  </View>\n)\n\nexport const LABEL = 'press me! 😉'\n\nexport const ComponentWithProps = (props) => {\n  return (\n    <div\n      style={{\n        ...props.style,\n        backgroundColor: props.pink ? 'hotpink' : 'transparent',\n        whiteSpace: 'normal',\n      }}\n    >\n      {(props.text + ' ').repeat(props.num)}\n    </div>\n  )\n}\n\nComponentWithProps.propertyControls = {\n  text: {\n    type: 'string',\n    title: 'Title',\n    defaultValue: 'Change me',\n  },\n  num: {\n    type: 'number',\n    title: 'amount',\n    defaultValue: 2,\n  },\n  pink: {\n    type: 'boolean',\n    title: 'Enabled',\n    defaultValue: true,\n  },\n}\n",
   },
-  emitBuild: true,
   jobID: 'ffcc378d_6bc8_4635_9fd9_e54565241f27',
 }

--- a/editor/src/core/workers/workers.ts
+++ b/editor/src/core/workers/workers.ts
@@ -32,8 +32,8 @@ export class UtopiaTsWorkersImplementation implements UtopiaTsWorkers {
     this.bundlerWorker.sendInitMessage(typeDefinitions, projectContents)
   }
 
-  sendUpdateFileMessage(filename: string, content: FileContent, emitBuild: boolean) {
-    this.bundlerWorker.sendUpdateFileMessage(filename, content, emitBuild)
+  sendUpdateFileMessage(filename: string, content: FileContent) {
+    this.bundlerWorker.sendUpdateFileMessage(filename, content)
   }
 
   sendParseFileMessage(filename: string, content: string) {


### PR DESCRIPTION
Fixes #164.

**Problem:**
This relates to the following set of events:
1) File is added to project, triggering a reinitialisation of the bundling.
2) Added file is edited to include an exported property.
3) Switching to an existing file, the exported property from the new file is imported.
4) The bundling initialisation completes.
5) The bundler logic concludes that for the newly added file it should not emit the build for the newly added file, as it is not the last file in the queue. This prevents it from being included in the module loader.
6) The error on the canvas continues to be displayed because (somewhat) validly the require function is unable to retrieve the import.

Normally this will never be triggered because processing the file changed update is "instant", so it's rare that updates for two different files would ever be in the queue at the same time. Two or more updates for the same file is even totally fine because the last will ensure that everything is up to date.

**Fix:**
As the file changed updates are pretty cheap to process, the logic that previously made those emits optional has been completely removed as there's little to gain and it can be prone to this kind of obscure edge case.

**Commit Details:**
- Fixes #164.
- Removed emit related properties from various types and functions
  along with the `NoEmitMessage` type.
- `watch` function logic simplified to only emit files when
  `contentChanged` is true.