### PR TITLE
Catch a case where we were previously trying to recurse null

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -511,7 +511,7 @@ export const InspectorEntryPoint: React.FunctionComponent<{}> = betterReactMemo(
               styleObject: any,
               localPath: Array<string>,
             ): void {
-              if (typeof styleObject === 'object') {
+              if (typeof styleObject === 'object' && styleObject != null) {
                 let selectorLength: TargetSelectorLength = 0
                 const keys = Object.keys(styleObject)
                 keys.forEach((key) => {


### PR DESCRIPTION
Fixes #179 

**Problem:**
When trying to discover style targets we were checking the type of a value was `'object'` but then not checking that it wasn't `null`, meaning the editor would blow out on a `null` value.

**Fix:**
Include a `null` check too
