### PR TITLE
Correctly walk the hierarchy for selection.

### DIFF
--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -23,6 +23,7 @@ import {
 } from '../shared/element-template'
 import { sampleImportsForTests } from './test-ui-js-file'
 import { BakedInStoryboardUID } from './scene-utils'
+import { TemplatePath } from '../shared/project-file-types'
 
 const TestScenePath = 'scene-aaa'
 
@@ -335,5 +336,20 @@ describe('getElementLabel', () => {
   it('the label of a spin containing text is that text', () => {
     const actualResult = MetadataUtils.getElementLabel(spanPath, metadata)
     expect(actualResult).toEqual('test text')
+  })
+})
+
+describe('getAllPaths', () => {
+  it('returns the paths in a depth first manner', () => {
+    const actualResult = MetadataUtils.getAllPaths(testComponentMetadata)
+    const expectedResult: Array<TemplatePath> = [
+      testComponentScene.scenePath,
+      testComponentRoot1.templatePath,
+      testComponentMetadataChild1.templatePath,
+      testComponentMetadataChild2.templatePath,
+      testComponentMetadataChild3.templatePath,
+      TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View', 'View2', 'View0']),
+    ]
+    expect(actualResult).toEqual(expectedResult)
   })
 })

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -76,6 +76,7 @@ import * as TP from '../shared/template-path'
 import { findJSXElementChildAtPath, getUtopiaID } from './element-template-utils'
 import { isGivenUtopiaAPIElement, isUtopiaAPIComponent } from './project-file-utils'
 import { EmptyScenePathForStoryboard } from './scene-utils'
+import { fastForEach } from '../shared/utils'
 const ObjectPathImmutable: any = OPI
 
 export const UTOPIA_ORIGINAL_ID_KEY = 'data-utopia-original-uid'
@@ -752,16 +753,24 @@ export const MetadataUtils = {
     )
   },
   getAllPaths(scenes: ComponentMetadata[]): TemplatePath[] {
-    function allPaths(siblings: ElementInstanceMetadata[]): TemplatePath[] {
-      return [
-        ...Utils.pluck(siblings, 'templatePath'),
-        ...Utils.flatMapArray((instance) => allPaths(instance.children), siblings),
-      ]
+    let result: Array<TemplatePath> = []
+    function recurseElement(element: ElementInstanceMetadata): void {
+      result.push(element.templatePath)
+      fastForEach(element.children, recurseElement)
     }
 
     const scenePaths = this.getAllScenePaths(scenes)
-    const rootElements = mapDropNulls((s) => s.rootElement, scenes)
-    return [...scenePaths, ...allPaths(rootElements)]
+    fastForEach(scenePaths, (scenePath) => {
+      const scene = scenes.find((s) => TP.pathsEqual(scenePath, s.scenePath))
+      if (scene != null) {
+        result.push(scenePath)
+        if (scene.rootElement != null) {
+          recurseElement(scene.rootElement)
+        }
+      }
+    })
+
+    return result
   },
   isElementOfType(instance: ElementInstanceMetadata, elementType: string): boolean {
     return foldEither(


### PR DESCRIPTION
Fixes #171

**Problem:**
When using cmd-selection, the targeted elements don't appear to make sense to the user. The underlying cause was that the process of building the paths to check was running breadth-first.

**Fix:**
Change the paths construction to be depth-first instead of breadth-first.

**Commit Details:**
- Fixes #171.
- `MetadataUtils.getAllPaths` switched from a breadth-first search
  to a depth-first search.