### PR TITLE
Use npm ci on CI and separate install step

### DIFF
--- a/.github/workflows/master-pushes.yml
+++ b/.github/workflows/master-pushes.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Cache editor modules
+        id: cache-editor-modules
         uses: actions/cache@v2
         with:
           path: editor/node_modules
@@ -36,6 +37,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-utopia-api-master-2-
       - name: Cache website modules
+        id: cache-website-modules
         uses: actions/cache@v2
         with:
           path: website/node_modules
@@ -44,6 +46,12 @@ jobs:
             ${{ runner.os }}-node-website-master-
       - name: Install nix
         uses: Rheeseyb/install-nix-action@master
+      - name: Install website modules
+        if: steps.cache-website-modules.output.cache-hit != 'true'
+        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run install-website-ci
+      - name: Install editor modules
+        if: steps.cache-editor-modules.output.cache-hit != 'true'
+        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run install-editor-ci
       - name: Run the tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run test-editor-all-ci

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Cache editor modules
+        id: cache-editor-modules
         uses: actions/cache@v2
         with:
           path: editor/node_modules
@@ -34,6 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-utopia-api-PRs-
       - name: Cache website modules
+        id: cache-website-modules
         uses: actions/cache@v2
         with:
           path: website/node_modules
@@ -42,6 +44,12 @@ jobs:
             ${{ runner.os }}-node-website-PRs-
       - name: Install nix
         uses: Rheeseyb/install-nix-action@master
+      - name: Install website modules
+        if: steps.cache-website-modules.output.cache-hit != 'true'
+        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run install-website-ci
+      - name: Install editor modules
+        if: steps.cache-editor-modules.output.cache-hit != 'true'
+        run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run install-editor-ci
       - name: Run the tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run test-editor-all-ci

--- a/shell.nix
+++ b/shell.nix
@@ -26,11 +26,23 @@ let
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor
       ${node}/bin/npm --scripts-prepend-node-path=true install
     '')
+    (pkgs.writeScriptBin "install-editor-ci" ''
+      #!/usr/bin/env bash
+      set -e
+      cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/editor
+      ${node}/bin/npm --scripts-prepend-node-path=true ci
+    '')
     (pkgs.writeScriptBin "install-website" ''
       #!/usr/bin/env bash
       set -e
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/website
       ${node}/bin/npm --scripts-prepend-node-path=true install
+    '')
+    (pkgs.writeScriptBin "install-website-ci" ''
+      #!/usr/bin/env bash
+      set -e
+      cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/website
+      ${node}/bin/npm --scripts-prepend-node-path=true ci
     '')
     (pkgs.writeScriptBin "test-editor" ''
       #!/usr/bin/env bash
@@ -65,8 +77,6 @@ let
     (pkgs.writeScriptBin "test-editor-all-ci" ''
       #!/usr/bin/env bash
       set -e
-      install-editor
-      install-website
       test-editor-ci
       test-website
     '')


### PR DESCRIPTION
**Problem:**
`npm install` doesn't really treat `package-lock.json` as a lock on the dependencies, but instead treats it as a suggested starting point.

**Fix:**
Use `npm ci` which does (except this fails if the install result doesn't match so this might even be worse!). Also separated out the install steps of the workflow so we can skip them.
