### PR TITLE
Toggle background size layers

### DIFF
--- a/editor/src/components/inspector/sections/style-section/background-subsection/background-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/background-subsection.tsx
@@ -52,7 +52,7 @@ function insertBackgroundLayer(
 
 function cssBackgroundLayerToCSSBGSizeOrDefault(v: CSSBackgroundLayer): CSSBGSize {
   if (isCSSBackgroundLayerWithBGSize(v)) {
-    return v.bgSize
+    return { ...v.bgSize, enabled: v.enabled }
   } else {
     return { ...defaultBGSize }
   }


### PR DESCRIPTION
Part of #111

**Problem:**
When I toggle a background layer on and off, i want the backgroundImage layer to be commented out, but also the backgroundSize layer to be commented out too.

**Fix:**
This adds proper `printEnabled` and `printComma` wrappers around the backgroundSize printers.