### PR TITLE
fix(Editor) Remove data-uid prop from exotic types

### DIFF
--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -157,10 +157,12 @@ const mangleExoticType = Utils.memoize(
         } else {
           children = React.Children.map(p?.children, (child) => updateChild(child, p?.['data-uid']))
         }
-        const mangledProps = {
+        let mangledProps = {
           ...p,
           children: children,
         }
+
+        delete mangledProps['data-uid']
         return realCreateElement(type as any, mangledProps)
       }
     }


### PR DESCRIPTION
Fixes #209 

**Problem:**
The console was being absolutely filled up with warnings about `data-uid` being attached to fragments.

**Fix:**
As part of the mangling process, for exotic types we will attach the `data-uid` to their children, but then don't remove it from the props of the exotic type itself. This fix just deletes the prop from the exotic type after updating the children.
