### PR TITLE
Correctly apply changes to layout system for children.

### DIFF
--- a/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
+++ b/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
@@ -9,7 +9,66 @@ Array [
     "param": null,
     "propsUsed": Array [],
     "rootElement": Object {
-      "children": Array [],
+      "children": Array [
+        Object {
+          "children": Array [],
+          "metadata": null,
+          "name": Object {
+            "baseVariable": "View",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Object {
+            "data-uid": Object {
+              "type": "ATTRIBUTE_VALUE",
+              "value": "bbb",
+            },
+            "layout": Object {
+              "content": Array [],
+              "type": "ATTRIBUTE_NESTED_OBJECT",
+            },
+            "style": Object {
+              "content": Array [
+                Object {
+                  "key": "left",
+                  "type": "PROPERTY_ASSIGNMENT",
+                  "value": Object {
+                    "type": "ATTRIBUTE_VALUE",
+                    "value": 0,
+                  },
+                },
+                Object {
+                  "key": "top",
+                  "type": "PROPERTY_ASSIGNMENT",
+                  "value": Object {
+                    "type": "ATTRIBUTE_VALUE",
+                    "value": 0,
+                  },
+                },
+                Object {
+                  "key": "width",
+                  "type": "PROPERTY_ASSIGNMENT",
+                  "value": Object {
+                    "type": "ATTRIBUTE_VALUE",
+                    "value": 200,
+                  },
+                },
+                Object {
+                  "key": "height",
+                  "type": "PROPERTY_ASSIGNMENT",
+                  "value": Object {
+                    "type": "ATTRIBUTE_VALUE",
+                    "value": 300,
+                  },
+                },
+              ],
+              "type": "ATTRIBUTE_NESTED_OBJECT",
+            },
+          },
+          "type": "JSX_ELEMENT",
+        },
+      ],
       "metadata": null,
       "name": Object {
         "baseVariable": "View",
@@ -65,7 +124,50 @@ Array [
     "param": null,
     "propsUsed": Array [],
     "rootElement": Object {
-      "children": Array [],
+      "children": Array [
+        Object {
+          "children": Array [],
+          "metadata": null,
+          "name": Object {
+            "baseVariable": "View",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Object {
+            "data-uid": Object {
+              "type": "ATTRIBUTE_VALUE",
+              "value": "bbb",
+            },
+            "layout": Object {
+              "content": Array [
+                Object {
+                  "key": "flexBasis",
+                  "type": "PROPERTY_ASSIGNMENT",
+                  "value": Object {
+                    "type": "ATTRIBUTE_VALUE",
+                    "value": 200,
+                  },
+                },
+                Object {
+                  "key": "crossBasis",
+                  "type": "PROPERTY_ASSIGNMENT",
+                  "value": Object {
+                    "type": "ATTRIBUTE_VALUE",
+                    "value": 300,
+                  },
+                },
+              ],
+              "type": "ATTRIBUTE_NESTED_OBJECT",
+            },
+            "style": Object {
+              "type": "ATTRIBUTE_VALUE",
+              "value": Object {},
+            },
+          },
+          "type": "JSX_ELEMENT",
+        },
+      ],
       "metadata": null,
       "name": Object {
         "baseVariable": "View",

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -33,7 +33,12 @@ import { deepFreeze } from '../../../utils/deep-freeze'
 import { right, forceRight, left } from '../../../core/shared/either'
 import { createFakeMetadataForComponents } from '../../../utils/test-utils'
 import Utils from '../../../utils/utils'
-import { canvasRectangle, CanvasRectangle, LocalRectangle } from '../../../core/shared/math-utils'
+import {
+  canvasRectangle,
+  CanvasRectangle,
+  LocalRectangle,
+  localRectangle,
+} from '../../../core/shared/math-utils'
 import { createTestProjectWithCode, getFrameChange } from '../../canvas/canvas-utils'
 import * as PP from '../../../core/shared/property-path'
 import * as TP from '../../../core/shared/template-path'
@@ -706,6 +711,20 @@ describe('moveTemplate', () => {
 })
 
 describe('SWITCH_LAYOUT_SYSTEM', () => {
+  const childElement = jsxElement(
+    'View',
+    {
+      'data-uid': jsxAttributeValue('bbb'),
+      style: jsxAttributeValue({
+        left: 5,
+        top: 10,
+        width: 200,
+        height: 300,
+      }),
+    },
+    [],
+    null,
+  )
   const rootElement = jsxElement(
     'View',
     {
@@ -713,7 +732,7 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
       style: jsxAttributeValue({ backgroundColor: '#FFFFFF' }),
       layout: jsxAttributeValue({ layoutSystem: 'pinSystem' }),
     },
-    [],
+    [childElement],
     null,
   )
   const firstTopLevelElement = utopiaJSXComponent('App', true, null, [], rootElement, null)
@@ -747,9 +766,32 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
           props: {
             'data-uid': 'aaa',
           },
-          globalFrame: Utils.zeroRectangle as CanvasRectangle,
-          localFrame: Utils.zeroRectangle as LocalRectangle,
-          children: [],
+          globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
+          localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
+          children: [
+            {
+              navigatorName: 'nope',
+              templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-0']), [
+                'aaa',
+                'bbb',
+              ]),
+              element: right(childElement),
+              props: {
+                'data-uid': 'bbb',
+                style: {
+                  left: 5,
+                  top: 10,
+                  width: 200,
+                  height: 300,
+                },
+              },
+              globalFrame: canvasRectangle({ x: 0, y: 0, width: 200, height: 300 }),
+              localFrame: localRectangle({ x: 0, y: 0, width: 200, height: 300 }),
+              children: [],
+              componentInstance: false,
+              specialSizeMeasurements: emptySpecialSizeMeasurements,
+            },
+          ],
           componentInstance: false,
           specialSizeMeasurements: emptySpecialSizeMeasurements,
         },

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -28,6 +28,7 @@ import {
   maybeSwitchChildrenLayoutProps,
   maybeSwitchLayoutProps,
   roundAttributeLayoutValues,
+  switchLayoutMetadata,
 } from '../../../core/layout/layout-utils'
 import {
   findElementAtPath,
@@ -523,19 +524,7 @@ function setSpecialSizeMeasurementParentLayoutSystemOnAllChildren(
 ): Array<ComponentMetadata> {
   const allChildren = MetadataUtils.getImmediateChildren(scenes, parentPath)
   return allChildren.reduce((transformedScenes, child) => {
-    return MetadataUtils.transformAtPathOptionally(
-      transformedScenes,
-      child.templatePath,
-      (element) => {
-        return {
-          ...element,
-          specialSizeMeasurements: {
-            ...element.specialSizeMeasurements,
-            parentLayoutSystem: value,
-          },
-        }
-      },
-    ).elements
+    return switchLayoutMetadata(transformedScenes, child.templatePath, value, undefined, undefined)
   }, scenes)
 }
 
@@ -685,6 +674,16 @@ function switchAndUpdateFrames(
       withUpdatedLayoutSystem.jsxMetadataKILLME,
       target,
       layoutSystemToSet(),
+    ),
+  }
+  withUpdatedLayoutSystem = {
+    ...withUpdatedLayoutSystem,
+    jsxMetadataKILLME: switchLayoutMetadata(
+      withUpdatedLayoutSystem.jsxMetadataKILLME,
+      target,
+      undefined,
+      layoutSystemToSet(),
+      undefined,
     ),
   }
 

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -48,7 +48,7 @@ import {
   StyleLayoutProp,
 } from './layout-helpers-new'
 import { getLayoutPropertyOr } from './getLayoutProperty'
-import { CSSPosition } from '../../components/inspector/common/css-utils'
+import { CSSPosition, layoutEmptyValues } from '../../components/inspector/common/css-utils'
 
 interface LayoutPropChangeResult {
   components: UtopiaJSXComponent[]
@@ -263,11 +263,12 @@ function keepLayoutProps(
   }
 }
 
-function switchLayoutMetadata(
+export function switchLayoutMetadata(
   components: ComponentMetadata[],
   target: InstancePath,
-  parentLayoutSystem: DetectedLayoutSystem,
-  position: CSSPosition,
+  parentLayoutSystem: DetectedLayoutSystem | undefined,
+  layoutSystemForChildren: DetectedLayoutSystem | undefined,
+  position: CSSPosition | undefined,
 ): ComponentMetadata[] {
   return MetadataUtils.transformAtPathOptionally(components, target, (elementMetadata) => {
     return {
@@ -282,8 +283,12 @@ function switchLayoutMetadata(
          * the measured value will be in the next update, updateFramesOfScenesAndComponents will just undo our
          * frame changes. :(
          */
-        parentLayoutSystem: parentLayoutSystem,
-        position,
+        parentLayoutSystem:
+          parentLayoutSystem ?? elementMetadata.specialSizeMeasurements.parentLayoutSystem,
+        layoutSystemForChildren:
+          layoutSystemForChildren ??
+          elementMetadata.specialSizeMeasurements.layoutSystemForChildren,
+        position: position ?? elementMetadata.specialSizeMeasurements.position,
       },
     }
   }).elements
@@ -355,7 +360,13 @@ export function switchPinnedChildToFlex(
     currentContextMetadata,
   )
 
-  const updatedMetadata = switchLayoutMetadata(currentContextMetadata, target, 'flex', 'static')
+  const updatedMetadata = switchLayoutMetadata(
+    currentContextMetadata,
+    target,
+    'flex',
+    undefined,
+    'static',
+  )
 
   return {
     updatedComponents: updatedComponents,
@@ -414,6 +425,7 @@ export function switchFlexChildToPinned(
     currentContextMetadata,
     target,
     'nonfixed',
+    undefined,
     'absolute',
   )
 
@@ -468,6 +480,7 @@ export function switchFlexChildToGroup(
     currentContextMetadata,
     target,
     'nonfixed',
+    undefined,
     'absolute',
   )
 
@@ -516,7 +529,13 @@ export function switchChildToGroupWithParentFrame(
       height,
     )
 
-    const updatedMetadata = switchLayoutMetadata(componentMetadata, target, 'nonfixed', 'absolute')
+    const updatedMetadata = switchLayoutMetadata(
+      componentMetadata,
+      target,
+      'nonfixed',
+      undefined,
+      'absolute',
+    )
 
     return {
       updatedComponents: updatedComponents,
@@ -536,7 +555,13 @@ export function switchChildToGroupWithParentFrame(
       height,
     )
 
-    const updatedMetadata = switchLayoutMetadata(componentMetadata, target, 'nonfixed', 'absolute')
+    const updatedMetadata = switchLayoutMetadata(
+      componentMetadata,
+      target,
+      'nonfixed',
+      undefined,
+      'absolute',
+    )
 
     return {
       updatedComponents: updatedComponents,
@@ -579,6 +604,7 @@ export function switchPinnedChildToGroup(
     currentContextMetadata,
     target,
     'nonfixed',
+    undefined,
     'absolute',
   )
 
@@ -621,7 +647,13 @@ export function switchChildToPinnedWithParentFrame(
     height,
   )
 
-  const updatedMetadata = switchLayoutMetadata(componentMetadata, target, 'nonfixed', 'absolute')
+  const updatedMetadata = switchLayoutMetadata(
+    componentMetadata,
+    target,
+    'nonfixed',
+    undefined,
+    'absolute',
+  )
 
   return {
     updatedComponents: updatedComponents,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -392,7 +392,7 @@ export const MetadataUtils = {
     }
   },
   isFlexLayoutedContainer(instance: ElementInstanceMetadata | null): boolean {
-    return instance?.specialSizeMeasurements.layoutSystemForChildren === 'flex' ?? false
+    return instance?.specialSizeMeasurements.layoutSystemForChildren === 'flex'
   },
   isPositionAbsolute(instance: ElementInstanceMetadata | null): boolean {
     return instance?.specialSizeMeasurements.position === 'absolute'


### PR DESCRIPTION
Fixes #62

**Problem:**
While processing the layout system change, some logic was not correctly identifying the layout system that an element had been set to or was previously.

**Fix:**
Similar to a previous issue with this, the element instance metadata had effectively gotten out of sync with the primary model. In the fix for this case the contents of the `specialSizeMeasurements` property was updated so that it would be equivalent to what would be seen after the DOM walker had run.

**Commit Details:**
- Fixes #62.
- Refactored `setSpecialSizeMeasurementParentLayoutSystemOnAllChildren`
  to call `switchLayoutMetadata`.
- Added an additional call to `switchLayoutMetadata` in `switchAndUpdateFrames`
  to update the `layoutSystemForChildren` for the element that was updated.
- Added a `layoutSystemForChildren` parameter to `switchLayoutMetadata` and
  made the other property related parameters optional.
- Removed an unnecessary `??` from `isFlexLayoutedContainer`.
- Updated the tests for `SWITCH_LAYOUT_SYSTEM` to include a child of the
  targeted element.