### PR TITLE
Fix for antd DatePicker

### DIFF
--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -77,6 +77,8 @@ function attachDataUidToRoot(
   } else if (Array.isArray(originalResponse)) {
     // the response was an array of elements
     return originalResponse.map((element) => attachDataUidToRoot(element, dataUid))
+  } else if (!React.isValidElement(originalResponse as any)) {
+    return originalResponse
   } else {
     const finalElement = React.cloneElement(originalResponse, { 'data-uid': dataUid })
     return finalElement


### PR DESCRIPTION
Fixes #208 

**Problem:**
In preview mode, clicking to open the date picker caused the canvas to crash.

**Fix:**
I added a missing sanity check in `attachDataUidToRoot`. If the element we are mangling is not a valid react element, we bail out.

**Commit Details:**
- Added a React.isValidElement check.
