### PR TITLE
fix(code-editor.tsx) Stop sending cursor changed actions when it hasn't

### DIFF
--- a/editor/src/components/code-editor/code-editor.tsx
+++ b/editor/src/components/code-editor/code-editor.tsx
@@ -62,6 +62,10 @@ interface CodeEditorState {
   dirty: boolean
 }
 
+function cursorPositionsEqual(l: CursorPosition, r: CursorPosition): boolean {
+  return l.column === r.column && l.line === r.line
+}
+
 export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
   autoSaveTimer: NodeJS.Timer | null = null
   dirty: boolean = false
@@ -176,13 +180,15 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
   }
 
   onChangeCursorPosition = (cursorPosition: CursorPosition, shouldChangeSelection: boolean) => {
-    this.setState({
-      cursorPosition: cursorPosition,
-    })
-    if (shouldChangeSelection) {
-      this.props.onSelect(cursorPosition.line, cursorPosition.column)
+    if (!cursorPositionsEqual(this.state.cursorPosition, cursorPosition)) {
+      this.setState({
+        cursorPosition: cursorPosition,
+      })
+      if (shouldChangeSelection) {
+        this.props.onSelect(cursorPosition.line, cursorPosition.column)
+      }
+      this.props.saveCursorPosition(cursorPosition)
     }
-    this.props.saveCursorPosition(cursorPosition)
   }
 
   render() {


### PR DESCRIPTION
Very minor fix that I happened across in my travels.

**Problem:**
The code editor was sending `'SAVE_CURSOR_POSITION'` actions on every mouse move, probably slowing stuff down and firing unnecessary saves all the time.

**Fix:**
A simple equality check to see if the cursor position had actually changed.
