### PR TITLE
Prevent onBlur applying zero change updates.

### DIFF
--- a/editor/src/components/inspector/controls/string-control.tsx
+++ b/editor/src/components/inspector/controls/string-control.tsx
@@ -26,14 +26,16 @@ export const StringControl = betterReactMemo(
       }
 
       const getValueString = (e: React.SyntheticEvent<HTMLInputElement>): string => {
-        return e.currentTarget.value || ''
+        return e.currentTarget.value
       }
 
       const inputOnBlur = (e: React.FocusEvent<HTMLInputElement>) => {
         if (props.onBlur != null) {
           props.onBlur(e)
         }
-        props.onSubmitValue(getDisplayValue())
+        if (propsValue !== stateValue) {
+          props.onSubmitValue(stateValue)
+        }
       }
 
       const inputOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/editor/src/uuiui/inputs/string-input.tsx
+++ b/editor/src/uuiui/inputs/string-input.tsx
@@ -105,8 +105,14 @@ export const StringInput = betterReactMemo(
           if (inputProps.onBlur != null) {
             inputProps.onBlur(e)
           }
-          if (onSubmitValue != null && inputProps.value != null) {
-            onSubmitValue(inputProps.value + '')
+          if (onSubmitValue != null && e.target.value != null) {
+            // Coerce the content of the input to a string.
+            const inputValue = `${e.target.value}`
+            // If the input element currently has some content but the props do not _or_
+            // if the value from the props differs from the value currently in the input element.
+            if (inputProps.value == null || `${inputProps.value}` !== inputValue) {
+              onSubmitValue(inputValue)
+            }
           }
         },
         [inputProps, onSubmitValue],


### PR DESCRIPTION
Fixes #80

**Problem:**
The `onBlur` functions for string inputs in the inspector would fire an update even if no changes had been made which would put an empty string into a field just by clicking in and out of it.

**Fix:**
Both `StringInput` and `StringControl` validate their starting value against the value in the field before firing an update.

**Commit Details:**
- Fixes #80.
- Changed the `onBlur` of `StringInput` to see if the text has changed
  before firing `onSubmitValue`.
- Modified the `inputOnBlur` function of `StringControl` to only fire
  if the value from the props and state differ.
- Removed some unnecessary truthiness.
