### PR TITLE
Track scope when parsing jsx props in js blocks

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -889,8 +889,8 @@ Object {
                 "children": Array [
                   Object {
                     "definedElsewhere": Array [
-                      "React",
                       "n",
+                      "React",
                       "utopiaCanvasJSXLookup",
                     ],
                     "elementsWithin": Object {
@@ -1095,8 +1095,8 @@ Object {
             },
             "transpiledJavascript": "return [1, 2, 3].map(function (n) {
   return utopiaCanvasJSXLookup(\\"aaa\\", {
-    React: React,
     n: n,
+    React: React,
     utopiaCanvasJSXLookup: utopiaCanvasJSXLookup
   });
 });",

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -821,7 +821,9 @@ export function parseCode(filename: string, sourceText: string): ParseResult {
                 if (paramsValue.length === 1) {
                   // Note: We're explicitly ignoring the `propsUsed` value as
                   // that should be handled by the call to `propNamesForParam` below.
-                  return right(withParserMetadata(paramsValue[0], parsedParams.highlightBounds, []))
+                  return right(
+                    withParserMetadata(paramsValue[0], parsedParams.highlightBounds, [], []),
+                  )
                 } else {
                   return left('Invalid number of params')
                 }
@@ -982,7 +984,7 @@ function parseParams(
       return parseResult
     }
   }
-  return right(withParserMetadata(parsedParams, highlightBounds, propsUsed))
+  return right(withParserMetadata(parsedParams, highlightBounds, propsUsed, []))
 }
 
 function parseParam(
@@ -1000,7 +1002,7 @@ function parseParam(
     WithParserMetadata<JSXAttributeOtherJavaScript | undefined>
   > =
     param.initializer == null
-      ? right(withParserMetadata(undefined, existingHighlightBounds, []))
+      ? right(withParserMetadata(undefined, existingHighlightBounds, [], []))
       : parseAttributeOtherJavaScript(
           file,
           filename,
@@ -1028,6 +1030,7 @@ function parseParam(
           functionParam(dotDotDotToken, bindingName.value),
           bindingName.highlightBounds,
           bindingName.propsUsed,
+          [],
         ),
       parsedBindingName,
     )
@@ -1058,6 +1061,7 @@ function parseBindingName(
           regularParam(paramName, expression.value ?? null),
           highlightBounds,
           propsUsed,
+          [],
         ),
       parsedParamName,
     )
@@ -1100,7 +1104,7 @@ function parseBindingName(
         return parsedPropertyName
       }
     }
-    return right(withParserMetadata(destructuredObject(parts), highlightBounds, propsUsed))
+    return right(withParserMetadata(destructuredObject(parts), highlightBounds, propsUsed, []))
   } else if (TS.isArrayBindingPattern(elem)) {
     let parts: Array<DestructuredArrayPart> = []
     for (const element of elem.elements) {
@@ -1129,7 +1133,7 @@ function parseBindingName(
         }
       }
     }
-    return right(withParserMetadata(destructuredArray(parts), highlightBounds, propsUsed))
+    return right(withParserMetadata(destructuredArray(parts), highlightBounds, propsUsed, []))
   } else {
     return left('Unable to parse binding element')
   }


### PR DESCRIPTION
Fixes #162 

**Problem:**
When parsing JSX elements inside arbitrary JS blocks, we weren't bubbling up the required scope, meaning if a prop inside a JS block referred to a variable defined outside the block, the editor would fail to resolve that.

**Fix:**
Bubble up the `definedWithin` whilst parsing all types of nodes, rather than just the arbitrary JS blocks (we still only need to actually attach that info to the JS blocks themselves, but we need to do this to ensure that it is complete).

**Commit Details:**
- Added `definedElsewhere: Array<string>` to the `WithParserMetadata<T>` interface to allow bubbling up that information
- Thread that through in all of the various `parseX` functions in `parser-printer-parsing.ts`
- Added a test to ensure this is working, and updated a snapshot because it changed the `definedElsewhere` ordering there.
