### PR TITLE
feature(editor) Support friendly project URLs.

### DIFF
--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -10882,6 +10882,11 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
+    "friendly-words": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/friendly-words/-/friendly-words-1.1.10.tgz",
+      "integrity": "sha512-KFrW1RS5qr7uIFF3RXITtmTHQhLA0J6htpKkoTcTSNxyXeOTio5venOr8AdOiS9KAQlxhnONcCifyJcj0kM7/A=="
+    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",

--- a/editor/package.json
+++ b/editor/package.json
@@ -97,6 +97,7 @@
     "eslint-plugin-react-hooks": "2.5.0",
     "eslint4b": "6.6.0",
     "fast-deep-equal": "2.0.1",
+    "friendly-words": "1.1.10",
     "graphlib": "2.1.1",
     "html-entities": "1.2.1",
     "immer": "3.2.0",

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -346,7 +346,7 @@ import {
   updateDependenciesInEditorState,
   updateDependenciesInPackageJson,
 } from '../npm-dependency/npm-dependency'
-import { updateRemoteThumbnail } from '../persistence'
+import { updateRemoteThumbnail, pushProjectURLToBrowserHistory } from '../persistence'
 import { deleteAssetFile, saveAsset as saveAssetToServer, updateAssetFileName } from '../server'
 import {
   applyParseAndEditorChanges,
@@ -424,6 +424,7 @@ import {
 } from '../../../core/es-modules/package-manager/package-manager'
 import { fetchNodeModules } from '../../../core/es-modules/package-manager/fetch-packages'
 import { getPropertyControlsForTarget } from '../../../core/property-controls/property-controls-utils'
+import { urlSafeText } from '../../../core/shared/dom-utils'
 
 export function clearSelection(): EditorAction {
   return {
@@ -2972,6 +2973,10 @@ export const UPDATE_FNS = {
     }
   },
   SET_PROJECT_NAME: (action: SetProjectName, editor: EditorModel): EditorModel => {
+    // Side effect.
+    if (editor.id != null) {
+      pushProjectURLToBrowserHistory(`Utopia ${action.name}`, editor.id, urlSafeText(action.name))
+    }
     return {
       ...editor,
       projectName: action.name,

--- a/editor/src/components/editor/persistence.ts
+++ b/editor/src/components/editor/persistence.ts
@@ -26,6 +26,8 @@ import { PersistentModel } from './store/editor-state'
 import { UtopiaTsWorkers } from '../../core/workers/common/worker-types'
 import { arrayContains } from '../../core/shared/utils'
 import { getPNGBufferOfElementWithID } from './screenshot-utils'
+import * as friendlyWords from 'friendly-words'
+
 const domtoimage = require('domtoimage')
 
 const SAVE_THROTTLE_DELAY = 30000
@@ -171,9 +173,22 @@ export async function createNewProjectFromSampleProject(
   await loadSampleProject(projectId, dispatch, workers, renderEditorRoot)
 }
 
+export function pushProjectURLToBrowserHistory(
+  title: string,
+  projectId: string,
+  suffix: string,
+): void {
+  window.top.history.pushState({}, title, `/p/${projectId}-${suffix}/`)
+}
+
 function onFirstSaveCompleted(projectId: string, dispatch: EditorDispatch) {
   dispatch([setProjectID(projectId)], 'everyone')
-  window.top.history.pushState({}, `Utopia ${projectId}`, `/project/${projectId}/`)
+  const friendlyWordsPredicate =
+    friendlyWords.predicates[Math.floor(Math.random() * friendlyWords.predicates.length)]
+  const friendlyWordsObject =
+    friendlyWords.objects[Math.floor(Math.random() * friendlyWords.objects.length)]
+  const friendlyWordsSuffix = `${friendlyWordsPredicate}-${friendlyWordsObject}`
+  pushProjectURLToBrowserHistory(`Utopia ${projectId}`, projectId, friendlyWordsSuffix)
 }
 
 export async function saveToServer(

--- a/editor/src/core/shared/dom-utils.spec.ts
+++ b/editor/src/core/shared/dom-utils.spec.ts
@@ -1,0 +1,13 @@
+import { urlSafeText } from './dom-utils'
+
+describe('urlSafeText', () => {
+  it('for a simple string returns the same thing', () => {
+    expect(urlSafeText('hat')).toEqual('hat')
+  })
+  it('for a string with a space in it replaces the space', () => {
+    expect(urlSafeText('cat hat mat')).toEqual('cat-hat-mat')
+  })
+  it('for a string with all sorts in it, makes the url safe', () => {
+    expect(urlSafeText('Awesome Pile Of Hats 😊?')).toEqual('awesome-pile-of-hats-%F0%9F%98%8A%3F')
+  })
+})

--- a/editor/src/core/shared/dom-utils.ts
+++ b/editor/src/core/shared/dom-utils.ts
@@ -1,5 +1,6 @@
 import { ReactDOM } from 'react'
 import { canvasRectangle, CanvasRectangle, scaleRect } from './math-utils'
+import { replaceAll } from './string-utils'
 
 export const intrinsicHTMLElementNames: Array<keyof ReactDOM> = [
   'a',
@@ -218,4 +219,8 @@ export function getCanvasRectangleFromElement(
     }),
     scale,
   )
+}
+
+export function urlSafeText(text: string): string {
+  return encodeURIComponent(replaceAll(text.toLowerCase(), ' ', '-'))
 }

--- a/editor/src/missing-types/index.d.ts
+++ b/editor/src/missing-types/index.d.ts
@@ -76,3 +76,10 @@ declare module 'console-feed/lib/Hook/parse'
 declare module 'react-merge-refs'
 
 declare module 'platform-detect'
+
+declare module 'friendly-words' {
+  export const predicates: Array<string>
+  export const objects: Array<string>
+  export const teams: Array<string>
+  export const collections: Array<string>
+}

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -87,6 +87,7 @@ tests:
     dependencies:
       - servant-client-core
       - hspec
+      - hedgehog
       - port-utils
       - tasty
       - tasty-hedgehog

--- a/server/src/Utopia/Web/Servant.hs
+++ b/server/src/Utopia/Web/Servant.hs
@@ -19,6 +19,7 @@ module Utopia.Web.Servant where
 import           Data.Aeson
 import           Data.Aeson.Encode.Pretty
 import qualified Data.ByteString.Lazy     as BL
+import qualified Data.Text                as T
 import           Data.Time.Clock
 import           Data.Time.Format
 import           Network.HTTP.Media       hiding (Accept)
@@ -121,4 +122,11 @@ instance FromHttpApiData LastModifiedTime where
 instance ToHttpApiData LastModifiedTime where
   toUrlPiece (LastModifiedTime lastModifiedTime) = toS $ formatTime defaultTimeLocale lastModifiedFormat lastModifiedTime
 
+data ProjectIdWithSuffix = ProjectIdWithSuffix Text Text
+                         deriving (Eq, Ord, Show)
 
+instance FromHttpApiData ProjectIdWithSuffix where
+  parseUrlPiece toParse = fmap (\(pid, pidsuffix) -> ProjectIdWithSuffix pid (T.drop 1 pidsuffix)) $ fmap (T.breakOn "-") $ parseUrlPiece toParse
+
+instance ToHttpApiData ProjectIdWithSuffix where
+  toUrlPiece (ProjectIdWithSuffix projectId projectSuffix) = projectId <> (if T.null projectSuffix then T.empty else "-" <> projectSuffix)

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -63,25 +63,27 @@ type GetUserAPI = "v1" :> "user" :> Get '[JSON] UserResponse
 
 type EmptyProjectPageAPI = "project" :> Get '[HTML] H.Html
 
-type ProjectPageAPI = "project" :> Capture "project_id" Text :> Get '[HTML] H.Html
+type ProjectPageAPI = "project" :> Capture "project_id" ProjectIdWithSuffix :> Get '[HTML] H.Html
+
+type ShortProjectPageAPI = "p" :> Capture "project_id" ProjectIdWithSuffix :> Get '[HTML] H.Html
 
 type EmptyPreviewPageAPI = "share" :> Get '[HTML] H.Html
 
-type PreviewPageAPI = "share" :> Capture "project_id" Text :> Get '[HTML] H.Html
+type PreviewPageAPI = "share" :> Capture "project_id" ProjectIdWithSuffix :> Get '[HTML] H.Html
 
-type DownloadProjectAPI = "project" :> Capture "project_id" Text :> "contents.json" :> CaptureAll "remaining_path" Text :> Get '[PrettyJSON] Value
+type DownloadProjectAPI = "project" :> Capture "project_id" ProjectIdWithSuffix :> "contents.json" :> CaptureAll "remaining_path" Text :> Get '[PrettyJSON] Value
 
-type ProjectOwnerAPI = "v1" :> "project" :> Capture "project_id" Text :> "owner" :> Get '[JSON] ProjectOwnerResponse
+type ProjectOwnerAPI = "v1" :> "project" :> Capture "project_id" ProjectIdWithSuffix :> "owner" :> Get '[JSON] ProjectOwnerResponse
 
-type LoadProjectAPI = "v1" :> "project" :> Capture "project_id" Text :> QueryParam "last_saved" UTCTime :> Get '[JSON] LoadProjectResponse
+type LoadProjectAPI = "v1" :> "project" :> Capture "project_id" ProjectIdWithSuffix :> QueryParam "last_saved" UTCTime :> Get '[JSON] LoadProjectResponse
 
 type CreateProjectAPI = "v1" :> "projectid" :> Post '[JSON] CreateProjectResponse
 
-type ForkProjectAPI = "v1" :> "project" :> QueryParam' '[Required, Strict] "original" Text :> QueryParam "title" Text :> Post '[JSON] ForkProjectResponse
+type ForkProjectAPI = "v1" :> "project" :> QueryParam' '[Required, Strict] "original" ProjectIdWithSuffix :> QueryParam "title" Text :> Post '[JSON] ForkProjectResponse
 
-type SaveProjectAPI = "v1" :> "project" :> Capture "project_id" Text :> ReqBody '[JSON] SaveProjectRequest :> Put '[JSON] SaveProjectResponse
+type SaveProjectAPI = "v1" :> "project" :> Capture "project_id" ProjectIdWithSuffix :> ReqBody '[JSON] SaveProjectRequest :> Put '[JSON] SaveProjectResponse
 
-type DeleteProjectAPI = "v1" :> "project" :> Capture "project_id" Text :> Delete '[JSON] NoContent
+type DeleteProjectAPI = "v1" :> "project" :> Capture "project_id" ProjectIdWithSuffix :> Delete '[JSON] NoContent
 
 type MyProjectsAPI = "v1" :> "projects" :> Get '[JSON] ProjectListResponse
 
@@ -89,19 +91,21 @@ type ShowcaseAPI = "v1" :> "showcase" :> Get '[JSON] ProjectListResponse
 
 type SetShowcaseAPI = "v1" :> "showcase" :> "overwrite" :> QueryParam' '[Required] "projects" Text :> Post '[JSON] NoContent
 
-type LoadProjectAssetAPI = "project" :> Capture "project_id" Text :> Capture "first_path" Text :> CaptureAll "remaining_path" Text :> RawM
+type LoadProjectAssetAPI = "project" :> Capture "project_id" ProjectIdWithSuffix :> Capture "first_path" Text :> CaptureAll "remaining_path" Text :> RawM
 
-type PreviewProjectAssetAPI = "share" :> Capture "project_id" Text :> Capture "first_path" Text :> CaptureAll "remaining_path" Text :> RawM
+type ShortLoadProjectAssetAPI = "p" :> Capture "project_id" ProjectIdWithSuffix :> Capture "first_path" Text :> CaptureAll "remaining_path" Text :> RawM
 
-type RenameProjectAssetAPI = "v1" :> "asset" :> Capture "project_id" Text :> CaptureAll "path" Text :> QueryParam' '[Required] "old_file_name" Text :> Put '[JSON] NoContent
+type PreviewProjectAssetAPI = "share" :> Capture "project_id" ProjectIdWithSuffix :> Capture "first_path" Text :> CaptureAll "remaining_path" Text :> RawM
 
-type DeleteProjectAssetAPI = "v1" :> "asset" :> Capture "project_id" Text :> CaptureAll "path" Text :> Delete '[JSON] NoContent
+type RenameProjectAssetAPI = "v1" :> "asset" :> Capture "project_id" ProjectIdWithSuffix :> CaptureAll "path" Text :> QueryParam' '[Required] "old_file_name" Text :> Put '[JSON] NoContent
 
-type SaveProjectAssetAPI = "v1" :> "asset" :> Capture "project_id" Text :> CaptureAll "path" Text :> RawM
+type DeleteProjectAssetAPI = "v1" :> "asset" :> Capture "project_id" ProjectIdWithSuffix :> CaptureAll "path" Text :> Delete '[JSON] NoContent
 
-type LoadProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" Text :> Get '[BMP, GIF, JPG, PNG, SVG] BL.ByteString
+type SaveProjectAssetAPI = "v1" :> "asset" :> Capture "project_id" ProjectIdWithSuffix :> CaptureAll "path" Text :> RawM
 
-type SaveProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" Text :> ReqBody '[BMP, GIF, JPG, PNG, SVG] BL.ByteString :> Post '[JSON] NoContent
+type LoadProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" ProjectIdWithSuffix :> Get '[BMP, GIF, JPG, PNG, SVG] BL.ByteString
+
+type SaveProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" ProjectIdWithSuffix :> ReqBody '[BMP, GIF, JPG, PNG, SVG] BL.ByteString :> Post '[JSON] NoContent
 
 type PackagePackagerResponse = Headers '[Header "Cache-Control" Text, Header "Last-Modified" LastModifiedTime, Header "Access-Control-Allow-Origin" Text] BL.ByteString
 
@@ -148,6 +152,7 @@ type Protected = LogoutAPI
 type Unprotected = AuthenticateAPI
               :<|> EmptyProjectPageAPI
               :<|> ProjectPageAPI
+              :<|> ShortProjectPageAPI
               :<|> EmptyPreviewPageAPI
               :<|> PreviewPageAPI
               :<|> DownloadProjectAPI
@@ -156,6 +161,7 @@ type Unprotected = AuthenticateAPI
               :<|> ShowcaseAPI
               :<|> SetShowcaseAPI
               :<|> LoadProjectAssetAPI
+              :<|> ShortLoadProjectAssetAPI
               :<|> PreviewProjectAssetAPI
               :<|> LoadProjectThumbnailAPI
               :<|> MonitoringAPI

--- a/server/test/Main.hs
+++ b/server/test/Main.hs
@@ -5,6 +5,7 @@ import           Test.Tasty
 import           Test.Tasty.Hspec
 import           Test.Utopia.Web.Endpoints
 import           Test.Utopia.Web.Packager.NPM
+import           Test.Utopia.Web.Servant
 
 main :: IO ()
 main = do
@@ -15,4 +16,4 @@ tests :: IO TestTree
 tests = do
   routingTestTree <- testSpec "Routing Tests" routingSpec
   npmTestTree <- testSpec "NPM Tests" npmSpec
-  return $ testGroup "Tests" [routingTestTree, npmTestTree]
+  return $ testGroup "Tests" [routingTestTree, npmTestTree, servantTestTree]

--- a/server/test/Test/Utopia/Web/Servant.hs
+++ b/server/test/Test/Utopia/Web/Servant.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Utopia.Web.Servant where
+
+import           Hedgehog
+import qualified Hedgehog.Gen        as Gen
+import qualified Hedgehog.Range      as Range
+import           Protolude
+import           Servant.API
+import           Test.Tasty
+import           Test.Tasty.Hedgehog
+import           Utopia.Web.Servant
+
+servantTestTree :: TestTree
+servantTestTree = do
+  testGroup "ProjectIdWithSuffix"
+    [ testProperty "parseUrlPiece handles a bare bones project id correctly" $
+        property $ do
+          projectId <- forAll $ Gen.text (Range.constant 0 10) Gen.alphaNum
+          footnoteShow ("projectId" :: Text, projectId)
+          parseUrlPiece projectId === Right (ProjectIdWithSuffix projectId "")
+    , testProperty "parseUrlPiece handles a project id with a suffix correctly" $
+        property $ do
+          projectId <- forAll $ Gen.text (Range.constant 0 10) Gen.alphaNum
+          footnoteShow ("projectId" :: Text, projectId)
+          projectSuffix <- forAll $ Gen.text (Range.constant 0 30) Gen.unicode
+          footnoteShow ("projectSuffix" :: Text, projectSuffix)
+          let combinedProjectId = projectId <> "-" <> projectSuffix
+          parseUrlPiece combinedProjectId === Right (ProjectIdWithSuffix projectId projectSuffix)
+    , testProperty "parseUrlPiece mirrors toUrlPiece" $
+        property $ do
+          projectId <- forAll $ Gen.text (Range.constant 0 10) Gen.alphaNum
+          footnoteShow ("projectId" :: Text, projectId)
+          projectSuffix <- forAll $ Gen.text (Range.constant 0 30) Gen.unicode
+          footnoteShow ("projectSuffix" :: Text, projectSuffix)
+          let combinedProjectId = projectId <> "-" <> projectSuffix
+          fmap toUrlPiece (parseUrlPiece combinedProjectId :: Either Text ProjectIdWithSuffix) === Right combinedProjectId
+    ]

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1e5b18ecbc7d1b9622726a3153f6ae452afa99495958319fe93d79314e8439fd
+-- hash: 31ecf0bea451f5b557dc92d8156463974dcf373091bd51c9808e8ce926beb3a1
 
 name:           utopia-web
 version:        0.1.0.4
@@ -125,6 +125,7 @@ test-suite utopia-web-test
       Test.Utopia.Web.Endpoints
       Test.Utopia.Web.Executors.Test
       Test.Utopia.Web.Packager.NPM
+      Test.Utopia.Web.Servant
       Main
       Utopia.Web.Assets
       Utopia.Web.Auth
@@ -176,6 +177,7 @@ test-suite utopia-web-test
     , exceptions
     , filepath
     , free
+    , hedgehog
     , hspec
     , http-api-data
     , http-client


### PR DESCRIPTION
Fixes #193

**Problem:**
We want the user to be able to use more memorable URLs which are potentially also shorter.

**Fix:**
For the server, we ensure that URLs containing a project ID will strip the suffix to get the underlying ID. In the editor itself we add a friendly suffix on project creation and also when updating the project name.

**Commit Details:**
- Fixes #193.
- Added `friendly-words` dependency to main editor project.
- Added `hedgehog` dependency to server project.
- Added `pushProjectURLToBrowserHistory` utility function as we need to
  apply that change in more than one place now.
- Updating the project name now triggers a call to `pushProjectURLToBrowserHistory`.
- `onFirstSaveCompleted` puts a `friendly-words` derived suffix onto the
  URL which is pushed into the browser history.
- Added `urlSafeText` as a way of taking some text and making it
  URL compatible, with some slight tweaks to remove spaces for example.
- Added types for `friendly-words` package.
- Changed the various query parameter types for project IDs from `Text` to
  a newly defined type of `ProjectIdWithSuffix`, adding a parser which
  splits the project URLs at the first hyphen.
- Added project paths in the backend to support `/p/<project_id>` in addition
  to `/project/<project_id>`.
