### PR TITLE
WIP: Ensure onBlur is called when clicking the canvas

### DIFF
--- a/editor/src/components/inspector/common/property-path-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.spec.tsx
@@ -446,11 +446,7 @@ const makeInspectorHookContextProvider = (
   realValues: Array<{ [key: string]: any }>,
 ) => ({ children }: any) => (
   <InspectorPropsContext.Provider
-    value={{
-      editedMultiSelectedProps: multiselectAttributes,
-      targetPath,
-      realValues: realValues,
-    }}
+    value={{ editedMultiSelectedProps: multiselectAttributes, targetPath, realValues: realValues }}
   >
     {children}
   </InspectorPropsContext.Provider>

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -78,7 +78,7 @@ import {
   ModifiableAttribute,
 } from '../../../core/shared/jsx-attributes'
 import { forEachOptional, optionalMap } from '../../../core/shared/optional-utils'
-import { PropertyPath, InstancePath, ScenePath } from '../../../core/shared/project-file-types'
+import { PropertyPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
 import * as TP from '../../../core/shared/template-path'
 import { fastForEach } from '../../../core/shared/utils'

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -9,7 +9,6 @@ import {
   useInspectorInfo,
   useInspectorStyleInfo,
   InspectorInfo,
-  InspectorPropsContext,
 } from '../../../common/property-path-hooks'
 import { useEditorState } from '../../../../editor/store/store-hook'
 import { switchLayoutSystem } from '../../../../editor/actions/actions'

--- a/editor/src/components/inspector/sections/style-section/text-subsection/text-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/text-subsection.tsx
@@ -11,11 +11,7 @@ import { Icons, useWrappedEmptyOrUnknownOnSubmitValue } from 'uuiui'
 import { NumberInput } from 'uuiui'
 import { Tooltip } from 'uuiui'
 import { InspectorSubsectionHeader } from 'uuiui'
-import {
-  PropertyPath,
-  InstancePath,
-  ScenePath,
-} from '../../../../../core/shared/project-file-types'
+import { PropertyPath } from '../../../../../core/shared/project-file-types'
 import { EditorAction } from '../../../../editor/action-types'
 import * as EditorActions from '../../../../editor/actions/actions'
 import { useRefEditorState } from '../../../../editor/store/store-hook'


### PR DESCRIPTION
Fixes #220 

**Problem:**
There are 2 issues at play here. Firstly, React doesn't doesn't fire its synthetic events on elements that are being removed from the DOM, meaning that `onBlur` was never called. The second issue is that the Inspector hooks use a `useRef` to prevent re-rendering based on the selected views changing, meaning that at the point where the `onSubmitValue` is called, the `selectedElements` will have changed, so the values are applied to the wrong (or no) elements.

**Fix:**
When creating inputs, rather than letting React attach the `onBlur` event handler, we manually attach it to the underlying DOM element. However, because the actual callback will be changing on every render, we need to make sure we're updating the callback that is attached to the event listener (which is why we are removing the previously attached one each time).

For the second problem I took two approaches, one much simpler than the other. The first (far simpler) approach was to remove the `refElementsToTargetForUpdates` (and corresponding scenes ref), and replace them with regular values. This results in the render count test more than doubling for `React Render Count Tests -  › Changing the selected view`, since the callbacks are changing for every input field when selecting a new element.

The second approach taken was to try shoving those two arrays into the context elsewhere and pulling them out later on in the hooks (which you can see here). This ended up being a long winded way of making absolutely no difference - the same render count test sees about the same increase (it's ever so slightly less, which in itself is interesting).

**Edit** I have gone back to the simpler approach for problem 2 here, and then run a performance test. The result is that this increases the time taken to select an element by ~60%, so that's just not going to fly. After discussing with Balazs, I remember the reason behind the decision to put the selected elements in a ref, and it was to stop the empty or unchanging Inspector fields from re-rendering when selecting a different element. I'm now looking into different ways we could capture the targets of a field that would still honour this.