### PR TITLE
 Prevent import errors from getting overwritten.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -417,41 +417,45 @@ export const UiJsxCanvas = betterReactMemo(
 
         let topLevelJsxComponents: Map<string, UtopiaJSXComponent> = new Map()
 
-        // Make sure there is something in scope for all of the top level components
-        Utils.fastForEach(orderedTopLevelElements, (topLevelElement) => {
-          if (isUtopiaJSXComponent(topLevelElement)) {
-            topLevelJsxComponents.set(topLevelElement.name, topLevelElement)
-            if (topLevelComponentRendererComponents.current[topLevelElement.name] == null) {
-              topLevelComponentRendererComponents.current[
-                topLevelElement.name
-              ] = createComponentRendererComponent({ topLevelElementName: topLevelElement.name })
+        // Should something have blown up previously, don't execute a bunch of code
+        // after now and potentially rewrite this error.
+        if (codeError == null) {
+          // Make sure there is something in scope for all of the top level components
+          Utils.fastForEach(orderedTopLevelElements, (topLevelElement) => {
+            if (isUtopiaJSXComponent(topLevelElement)) {
+              topLevelJsxComponents.set(topLevelElement.name, topLevelElement)
+              if (topLevelComponentRendererComponents.current[topLevelElement.name] == null) {
+                topLevelComponentRendererComponents.current[
+                  topLevelElement.name
+                ] = createComponentRendererComponent({ topLevelElementName: topLevelElement.name })
+              }
             }
-          }
-        })
+          })
 
-        executionScope = {
-          ...executionScope,
-          ...topLevelComponentRendererComponents.current,
+          executionScope = {
+            ...executionScope,
+            ...topLevelComponentRendererComponents.current,
+          }
+
+          // First make sure everything is in scope
+          Utils.fastForEach(orderedTopLevelElements, (topLevelElement) => {
+            if (isArbitraryJSBlock(topLevelElement)) {
+              runBlockUpdatingScope(requireResult, topLevelElement, executionScope, (error) => {
+                codeError = error
+                reportErrorWithPath(error)
+              })
+            }
+          })
+
+          updateMutableUtopiaContextWithNewProps(mutableContextRef, {
+            requireResult: requireResult,
+            rootScope: executionScope,
+            fileBlobs: fileBlobs,
+            reportError: reportErrorWithPath,
+            spyEnabled: props.spyEnabled,
+            jsxFactoryFunctionName: jsxFactoryFunction,
+          })
         }
-
-        // First make sure everything is in scope
-        Utils.fastForEach(orderedTopLevelElements, (topLevelElement) => {
-          if (isArbitraryJSBlock(topLevelElement)) {
-            runBlockUpdatingScope(requireResult, topLevelElement, executionScope, (error) => {
-              codeError = error
-              reportErrorWithPath(error)
-            })
-          }
-        })
-
-        updateMutableUtopiaContextWithNewProps(mutableContextRef, {
-          requireResult: requireResult,
-          rootScope: executionScope,
-          fileBlobs: fileBlobs,
-          reportError: reportErrorWithPath,
-          spyEnabled: props.spyEnabled,
-          jsxFactoryFunctionName: jsxFactoryFunction,
-        })
 
         const topLevelElementsMap = new Map(topLevelJsxComponents)
 


### PR DESCRIPTION
Fixes #212

**Problem:**
When there is an invalid import, the canvas was storing the error but then continuing to run some of the root code which then might arbitrarily blow up because an import after the invalid import was never run. In the ticket `makeStyles` is imported after the invalid import of `ExpandMoreIcon` and so using `makeStyles` fails as a result.

**Fix:**
A check was added to prevent any other user code from executing should an error arise from the imports.

**Commit Details:**
- Fixes #212.
- In `UiJsxCanvas` when an error is raised by `importResultFromImports`
  prevent other code from being executed which overwrite the value of
  `codeError`.
