### PR TITLE
Forcibly call onblur on Inspector inputs before changing selection

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -92,6 +92,17 @@ export const EditorComponentInner = betterReactMemo('EditorComponentInner', () =
           editorStoreRef.current.dispatch([EditorActions.closePopup()], 'everyone')
         }
       }
+      const activeElement = document.activeElement
+      if (
+        event.target !== activeElement &&
+        activeElement != null &&
+        activeElement.getAttribute('data-inspector-input') &&
+        (activeElement as any).blur != null
+      ) {
+        // OMG what a nightmare! This is the only way of keeping the Inspector fast and ensuring the blur handler for inputs
+        // is called before triggering a change that might change the selection
+        ;(activeElement as any).blur()
+      }
     },
     [editorStoreRef],
   )
@@ -125,7 +136,7 @@ export const EditorComponentInner = betterReactMemo('EditorComponentInner', () =
   }, [])
 
   React.useEffect(() => {
-    window.addEventListener('mousedown', onWindowMouseDown)
+    window.addEventListener('mousedown', onWindowMouseDown, true)
     window.addEventListener('keydown', onWindowKeyDown)
     window.addEventListener('keyup', onWindowKeyUp)
     window.addEventListener('contextmenu', preventDefault)

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -59,8 +59,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(855) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(865)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(860) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(870)
   })
 
   it('Changing the selected view', async () => {
@@ -116,7 +116,7 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(700) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(710)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(705) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(715)
   })
 })

--- a/editor/src/uuiui/inputs/base-input.tsx
+++ b/editor/src/uuiui/inputs/base-input.tsx
@@ -1,9 +1,10 @@
 import { ObjectInterpolation } from '@emotion/core'
 import styled from '@emotion/styled'
 import { getChainSegmentEdge } from '../../utils/utils'
-import { ControlStyles } from '../../uuiui-deps'
+import { ControlStyles, betterReactMemo } from '../../uuiui-deps'
 import { IcnProps } from '../icn'
 import { UtopiaTheme } from '../styles/theme'
+import * as React from 'react'
 
 export type ChainedType = 'not-chained' | 'first' | 'last' | 'middle'
 
@@ -93,7 +94,7 @@ export interface BaseInputProps {
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>
 }
 
-interface InspectorInputProps {
+interface InspectorInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   chained?: ChainedType
   controlStyles: ControlStyles
   focused: boolean
@@ -103,7 +104,7 @@ interface InspectorInputProps {
   value?: string | string[] | number
 }
 
-export const InspectorInput = styled.input<InspectorInputProps>(
+const StyledInput = styled.input<InspectorInputProps>(
   ({ chained = 'not-chained', controlStyles, focused, labelInner, roundCorners = 'all' }) => ({
     outline: 'none',
     paddingTop: 2,
@@ -121,5 +122,12 @@ export const InspectorInput = styled.input<InspectorInputProps>(
     ...getChainedBoxShadow(controlStyles, chained, focused),
     ...getBorderRadiusStyles(chained, roundCorners),
     disabled: !controlStyles.interactive,
+  }),
+)
+
+export const InspectorInput = betterReactMemo(
+  'InspectorInput',
+  React.forwardRef<HTMLInputElement, InspectorInputProps>((props, ref) => {
+    return <StyledInput {...props} ref={ref} data-inspector-input={true} />
   }),
 )


### PR DESCRIPTION
Fixes #220 

**Problem:**
Changes made to an Inspector input are not applied when clicking elsewhere in the editor

**Fix:**
(For the TLDR that doesn't require reading my life story, skip to the bit in bold at the bottom.)

I have been to the pits of hell with this one, and whilst this solution may be ugly, let me tell you this - it is the best you're getting without huge amounts of refactoring (even then don't count on it). This has been one of those issues where it seems tiny and easy to fix, so you make a fix and realise that something else is now getting in the way, but over and over and over. To give you an idea:

1. React has a bug with it's onBlur handling when destroying components https://github.com/facebook/react/issues/12363 - this can be fixed by using a wrapper that ties the event handler directly to the DOM element instead, but that doesn't work because
2. Inspector callbacks rely on a mutable ref to fetch the target elements when making a change, because we don't want element selection to trigger a re-render on every input if the value hasn't changed, so since the blur event is fired _after_ selection changes the callback will try to apply the update to the wrong element. So we need some way to capture the context when focusing, right?
3. Capturing the context when focusing requires a lot of messing around (using a ref to store the callback, changing that callback when another function is called, passing that other function down into the individual input fields), and on top of that we would have to *manually* ensure that every input is performing the correct dance to capture that context (*believe me*, I have tried _so many_ different ways of achieving this in the Inspector, and the result was always either excessive rendering, or outdated contexts being used), Ok so let's try using the `onClickOutside` that we use...
4. `onClickOutside` doesn't fire when clicking the canvas. U WOT M8?! No joke. It's because it works by adding an event listener to the `document`, but that event listener ends up being later in the queue than all of the others, meaning the selection has changed before it is reached, _and_ it is removed upon destruction of the wrapped component. Ok fine, let's try adding a click catcher over the top of everything for forcibly blurring this shit...
5. The portal is behind the editor (yep, no idea why it still works for the colour picker but it is). Ok fine, move that in front of the editor and use a clicker catcher on it when an input is focused...
6. Using a clicker catcher means there is _no way at all_ to then allow mouse events to bubble to elements that aren't direct descendants of the first element to handle that event. Totally forgot about this one because it caught us out a long while ago. That means you'd have to click twice to select something on the canvas (once to blur the input and remove the catcher, a second time to actually interact with the canvas). Bonus feature: gone are your cursors.

So, finally, in a case of "one last go before I throw in the towel", **I found an existing case where we were tying a `mousedown` listener to the window, and made that check if the currently focused element was an inspector input (required to prevent it screwing up interaction with `react-select` elements and probably others), and the event was targeting a different element, in which case we forcibly call `blur()`.**

**Commit Details:**
- Use a wrapper component for `InspectorInput` so that we could add the attribute `data-inspector-input` to it
- Use an existing `mousedown` event listener attached to the window to check if a `data-inspector-input` should be blurred, and if so call `blur()` on it
- Pass `true` for the `capture` param when adding the above listener to make sure it is handled before other listeners of that event (which should have been happening before, though I'm not sure if that old functionality is actually used anywhere)
