### PR TITLE
fix(leftmenu) only show filebrowser for file types on drag and drop events.

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -236,10 +236,7 @@ export const EditorComponentInner = betterReactMemo('EditorComponentInner', () =
       const isDraggedFile =
         draggedTypes != null && draggedTypes.length === 1 && draggedTypes[0] === 'Files'
       const currentMode = editorStoreRef.current.editor.mode
-      if (
-        isSelectMode(currentMode) ||
-        (isDraggedFile && isLiveMode(editorStoreRef.current.editor.mode))
-      ) {
+      if (isDraggedFile && (isSelectMode(currentMode) || isLiveMode(currentMode))) {
         const actions = [
           EditorActions.switchEditorMode(
             EditorModes.insertMode(false, dragAndDropInsertionSubject(null)),


### PR DESCRIPTION
Fixes #31 

**Problem:**
Dragging in the navigator opens the filebrowser tab. Opening the filebrowser happens all the time when a dragstart event happens, even for non file types.

**Fix:**
Only show the filebrowser when a file is dragged.
