### PR TITLE
fix(font) - add missing "inconsolata" editor font

### DIFF
--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -4,6 +4,7 @@
     <!-- ogTags -->
     <link rel="icon" type="image/png" href="/editor/icons/favicons/favicon128.png?hash=%GITHUB_SHA%" />
     <link href="https://fonts.googleapis.com/css?family=Inter&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inconsolata&display=swap" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="/editor/editor.css?hash=%GITHUB_SHA%" />
     <link
       rel="stylesheet"


### PR DESCRIPTION
A one-liner that adds `inconsolata` as a google font. It's been the default for our code editor for a long time, and optically looks smaller in 14.