### PR TITLE
patch for a race condition when `LOAD`ing the project

### DIFF
--- a/editor/src/core/es-modules/package-manager/fetch-packages.ts
+++ b/editor/src/core/es-modules/package-manager/fetch-packages.ts
@@ -175,5 +175,13 @@ export async function fetchMissingFileDependency(
   const nodeModulesNewEntry: NodeModules = {
     [filepath]: newFile,
   }
+  /**
+   * we flip dependency.downloadStarted back to false. the reason is that there might be a race condition
+   * between saving the nodeModules that triggered this fetchMissingFileDependency and saving the updateNodeModules itself.
+   * in case the other nodeModules wins, we want to re-run fetchMissingFileDependency, to be able to dispatch updateNodeModules for a second time.
+   * this solution is not nice and I hope we can remove it soon
+   */
+  // MUTATION
+  dependency.downloadStarted = false
   updateNodeModules(nodeModulesNewEntry)
 }

--- a/editor/src/core/es-modules/package-manager/package-manager.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.ts
@@ -163,6 +163,7 @@ export function getRequireFn(
       } else if (isEsRemoteDependencyPlaceholder(resolvedFile)) {
         if (!resolvedFile.downloadStarted) {
           // return empty exports object, fire off an async job to fetch the dependency from jsdelivr
+          // MUTATION
           resolvedFile.downloadStarted = true
           fetchMissingFileDependency(updateNodeModules, resolvedFile, resolvedPath)
         }


### PR DESCRIPTION
Fixes #3625 https://github.com/concrete-utopia/dystopia/issues/3625

**Problem:**
There is a race condition between loading a not-yet-loaded dependency from jsdelivr VS saving nodeModules when `LOAD`-ing the project. This resulted in the project load eating the antd.css and the system never tried to download it again. This caused a **very** hard to reproduce bug where the css would just never load. It was very annoying / scary!

**Fix:**
Instead of fixing the race condition, I only changed the code so that once the `fetchMissingFileDependency` is done fetching, it resets the missing file descriptors' status as "not downloading". This way, if we refresh the canvas a few seconds later, the `fetchMissingFileDependency` will be triggered again, and hopefully this time around no race condition will be lurking to prevent it from succeeding. 

**Commit Details:**
- `fetchMissingFileDependency` resets the `dependency.downloadStarted` to `false` 
- Added comment explaining why
