### PR TITLE
background size bugfixes

### DIFF
--- a/editor/src/components/inspector/controls/bg-size-metadata-control.tsx
+++ b/editor/src/components/inspector/controls/bg-size-metadata-control.tsx
@@ -24,6 +24,7 @@ import {
   isUnknownInputValue,
   parsedCurlyBrace,
   UnknownOrEmptyInput,
+  cssPixelLength,
 } from '../common/css-utils'
 import { UseSubmitTransformedValuesFactory } from '../sections/style-section/background-subsection/background-layer-helpers'
 import { MetadataControlsStyle } from '../sections/style-section/background-subsection/background-picker'
@@ -68,7 +69,7 @@ function getIndexedUpdateBGSizePopupList(index: number) {
       const bgSize = ((): CSSBGSize => {
         switch (newValue.value) {
           case 'auto': {
-            return cssBGSize(cssDefault(parsedCurlyBrace([cssKeyword('auto')])))
+            return cssBGSize(cssDefault(parsedCurlyBrace([cssKeyword('auto')]), false))
           }
           case 'contain':
           case 'cover': {
@@ -76,10 +77,7 @@ function getIndexedUpdateBGSizePopupList(index: number) {
           }
           case 'percentage-length': {
             return cssBGSize(
-              cssDefault(
-                parsedCurlyBrace([{ ...cssPixelLengthZero }, { ...cssPixelLengthZero }]),
-                false,
-              ),
+              cssDefault(parsedCurlyBrace([cssPixelLength(100), cssPixelLength(100)]), false),
             )
           }
           default: {

--- a/editor/src/components/inspector/sections/style-section/background-subsection/background-layer-helpers.ts
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/background-layer-helpers.ts
@@ -17,6 +17,7 @@ import {
   EmptyInputValue,
   emptyURLFunctionBackgroundLayer,
   isEmptyInputValue,
+  isCSSBackgroundLayerWithBGSize,
 } from '../../../common/css-utils'
 import { UseSubmitValueFactory } from '../../../common/property-path-hooks'
 import { ControlStatus, ControlStyles } from '../../../common/control-status'
@@ -32,13 +33,18 @@ export interface BackgroundLayerProps {
   unsetContextMenuItem: Array<ContextMenuItem<null>>
 }
 
-export function getIndexedToggleEnabled(index: number) {
+export function getIndexedUpdateEnabled(index: number) {
   return function indexedUpdateEnabled(
     enabled: boolean,
     oldValue: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
     let newCSSBackgroundLayers = [...oldValue]
-    newCSSBackgroundLayers[index].enabled = enabled
+    const workingValue = newCSSBackgroundLayers[index]
+    workingValue.enabled = enabled
+    if (isCSSBackgroundLayerWithBGSize(workingValue)) {
+      workingValue.bgSize.enabled = enabled
+    }
+    newCSSBackgroundLayers[index] = workingValue
     return newCSSBackgroundLayers
   }
 }

--- a/editor/src/components/inspector/sections/style-section/background-subsection/conic-gradient-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/conic-gradient-layer.tsx
@@ -22,7 +22,7 @@ import {
   backgroundLayerTypeSelectOptions,
   conicGradientSelectOption,
   getIndexedOnCSSBackgroundLayerTypeSelectSubmitValue,
-  getIndexedToggleEnabled,
+  getIndexedUpdateEnabled,
   getIndexedUpdateRadialOrConicGradientCenterX,
   getIndexedUpdateRadialOrConicGradientCenterY,
 } from './background-layer-helpers'
@@ -36,7 +36,7 @@ export const ConicGradientBackgroundLayer = betterReactMemo<ConicGradientBackgro
   'ConicGradientBackgroundLayer',
   (props) => {
     const [gradientCheckboxSubmitValue] = props.useSubmitTransformedValuesFactory(
-      getIndexedToggleEnabled(props.index),
+      getIndexedUpdateEnabled(props.index),
     )
     const onEnabledChange = React.useCallback(
       () => gradientCheckboxSubmitValue(!props.value.enabled),

--- a/editor/src/components/inspector/sections/style-section/background-subsection/linear-gradient-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/linear-gradient-layer.tsx
@@ -27,7 +27,7 @@ import {
   BackgroundLayerProps,
   backgroundLayerTypeSelectOptions,
   getIndexedOnCSSBackgroundLayerTypeSelectSubmitValue,
-  getIndexedToggleEnabled,
+  getIndexedUpdateEnabled,
   linearGradientSelectOption,
 } from './background-layer-helpers'
 import { BackgroundSolidOrGradientThumbnailControl } from '../../../controls/background-solid-or-gradient-thumbnail-control'
@@ -60,7 +60,7 @@ export const LinearGradientBackgroundLayer = betterReactMemo<LinearGradientBackg
   'LinearGradientBackgroundLayer',
   (props) => {
     const [gradientCheckboxSubmitValue] = props.useSubmitTransformedValuesFactory(
-      getIndexedToggleEnabled(props.index),
+      getIndexedUpdateEnabled(props.index),
     )
     const onEnabledChange = React.useCallback(
       () => gradientCheckboxSubmitValue(!props.value.enabled),

--- a/editor/src/components/inspector/sections/style-section/background-subsection/radial-gradient-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/radial-gradient-layer.tsx
@@ -21,7 +21,7 @@ import {
   BackgroundLayerProps,
   backgroundLayerTypeSelectOptions,
   getIndexedOnCSSBackgroundLayerTypeSelectSubmitValue,
-  getIndexedToggleEnabled,
+  getIndexedUpdateEnabled,
   getIndexedUpdateRadialOrConicGradientCenterX,
   getIndexedUpdateRadialOrConicGradientCenterY,
   radialGradientSelectOption,
@@ -36,7 +36,7 @@ export const RadialGradientBackgroundLayer = betterReactMemo<RadialGradientBackg
   'RadialGradientBackgroundLayer',
   (props) => {
     const [gradientCheckboxSubmitValue] = props.useSubmitTransformedValuesFactory(
-      getIndexedToggleEnabled(props.index),
+      getIndexedUpdateEnabled(props.index),
     )
     const onEnabledChange = React.useCallback(
       () => gradientCheckboxSubmitValue(!props.value.enabled),

--- a/editor/src/components/inspector/sections/style-section/background-subsection/solid-background-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/solid-background-layer.tsx
@@ -21,7 +21,7 @@ import { stopPropagation } from '../../../common/inspector-utils'
 import { GridRow } from '../../../widgets/grid-row'
 import {
   BackgroundLayerProps,
-  getIndexedToggleEnabled,
+  getIndexedUpdateEnabled,
   UseSubmitTransformedValuesFactory,
 } from './background-layer-helpers'
 import {
@@ -81,7 +81,7 @@ export const SolidBackgroundLayer = betterReactMemo<SolidBackgroundLayerProps>(
   'SolidBackgroundLayer',
   (props) => {
     const [onCheckboxSubmitValue] = props.useSubmitTransformedValuesFactory(
-      getIndexedToggleEnabled(props.index),
+      getIndexedUpdateEnabled(props.index),
     )
     const [
       onAlphaSubmitValue,

--- a/editor/src/components/inspector/sections/style-section/background-subsection/url-background-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/url-background-layer.tsx
@@ -20,7 +20,7 @@ import {
   BackgroundLayerProps,
   backgroundLayerTypeSelectOptions,
   getIndexedOnCSSBackgroundLayerTypeSelectSubmitValue,
-  getIndexedToggleEnabled,
+  getIndexedUpdateEnabled,
   imageSelectOption,
   UseSubmitTransformedValuesFactory,
 } from './background-layer-helpers'
@@ -56,7 +56,7 @@ export const URLBackgroundLayer = betterReactMemo<URLBackgroundLayerProps>(
   'URLBackgroundLayer',
   (props) => {
     const [onCheckboxSubmitValue] = props.useSubmitTransformedValuesFactory(
-      getIndexedToggleEnabled(props.index),
+      getIndexedUpdateEnabled(props.index),
     )
     const [onURLSubmitValue] = props.useSubmitTransformedValuesFactory(
       getIndexedUpdateNewURL(props.index),

--- a/editor/src/printer-parsers/css/css-parser-background-size.spec.ts
+++ b/editor/src/printer-parsers/css/css-parser-background-size.spec.ts
@@ -3,7 +3,7 @@ import { syntaxParsers } from './css-parser-map'
 describe('backgroundSize', () => {
   it("parses the <'background-size'> property with comments", () => {
     const value =
-      'auto, /*auto*/ /*auto auto*/ /*100px 100px*/ contain, 100% 100%, 100px auto, /* auto */ cover, 0 0'
+      'auto, /*auto*/ /*auto auto*/ /*100px 100px*/ contain, 100% 100%, 100px auto, /* auto */ cover, 0 0 /*cover*/'
     const parseResults = syntaxParsers["<'background-size'>"](value)
     expect(parseResults).toMatchInlineSnapshot(`
       Object {
@@ -44,7 +44,7 @@ describe('backgroundSize', () => {
           Object {
             "enabled": false,
             "size": Object {
-              "default": true,
+              "default": false,
               "value": Object {
                 "type": "parsed-curly-brace",
                 "value": Array [
@@ -64,7 +64,7 @@ describe('backgroundSize', () => {
           Object {
             "enabled": false,
             "size": Object {
-              "default": true,
+              "default": false,
               "value": Object {
                 "type": "parsed-curly-brace",
                 "value": Array [
@@ -84,7 +84,7 @@ describe('backgroundSize', () => {
           Object {
             "enabled": true,
             "size": Object {
-              "default": true,
+              "default": false,
               "value": Object {
                 "type": "keyword",
                 "value": "contain",
@@ -95,7 +95,7 @@ describe('backgroundSize', () => {
           Object {
             "enabled": true,
             "size": Object {
-              "default": true,
+              "default": false,
               "value": Object {
                 "type": "parsed-curly-brace",
                 "value": Array [
@@ -115,7 +115,7 @@ describe('backgroundSize', () => {
           Object {
             "enabled": true,
             "size": Object {
-              "default": true,
+              "default": false,
               "value": Object {
                 "type": "parsed-curly-brace",
                 "value": Array [
@@ -151,7 +151,7 @@ describe('backgroundSize', () => {
           Object {
             "enabled": true,
             "size": Object {
-              "default": true,
+              "default": false,
               "value": Object {
                 "type": "keyword",
                 "value": "cover",
@@ -160,9 +160,9 @@ describe('backgroundSize', () => {
             "type": "bg-size",
           },
           Object {
-            "enabled": true,
+            "enabled": false,
             "size": Object {
-              "default": true,
+              "default": false,
               "value": Object {
                 "type": "parsed-curly-brace",
                 "value": Array [
@@ -175,6 +175,17 @@ describe('backgroundSize', () => {
                     "value": 0,
                   },
                 ],
+              },
+            },
+            "type": "bg-size",
+          },
+          Object {
+            "enabled": false,
+            "size": Object {
+              "default": false,
+              "value": Object {
+                "type": "keyword",
+                "value": "cover",
               },
             },
             "type": "bg-size",

--- a/editor/src/printer-parsers/css/css-parser-background-size.ts
+++ b/editor/src/printer-parsers/css/css-parser-background-size.ts
@@ -34,7 +34,11 @@ const parseBGSizeCurlyBrace: Parser<CSSBGSize> = (value: unknown) => {
   /* n.b. this always returns enabled: true, and is overridden by
    *  parseBackgroundSize if need be.
    */
-  return mapEither((v) => cssBGSize(cssDefault(v), true), parsed)
+
+  return mapEither((v) => {
+    const isDefault = v.value.length === 1 && v.value[0].value === 'auto'
+    return cssBGSize(cssDefault(v, isDefault), true)
+  }, parsed)
 }
 
 const parseBGSizeKeyword: Parser<CSSBGSize> = (value: unknown) => {
@@ -42,7 +46,7 @@ const parseBGSizeKeyword: Parser<CSSBGSize> = (value: unknown) => {
   /* n.b. this always returns enabled: true, and is overridden by
    *  parseBackgroundSize if need be.
    */
-  return mapEither((v) => cssBGSize(cssDefault(v), true), parsed)
+  return mapEither((v) => cssBGSize(cssDefault(v, false), true), parsed)
 }
 
 export const parseBGSize: Parser<CSSBGSize> = (value: unknown) => {

--- a/editor/src/printer-parsers/css/css-parser-utils.ts
+++ b/editor/src/printer-parsers/css/css-parser-utils.ts
@@ -453,12 +453,19 @@ export function traverseForPreparsedLayers(
   workingValue = '',
 ): Array<PreparsedLayer> {
   if (remaining.length === 0) {
-    layers.push(preparsedLayer(workingValue.trim(), !inComment))
+    const trimmedWorkingValue = workingValue.trim()
+    if (trimmedWorkingValue !== '') {
+      layers.push(preparsedLayer(trimmedWorkingValue, !inComment))
+    }
     return layers
   }
   switch (remaining[0]) {
     case '/': {
       if (remaining[1] === '*') {
+        const trimmedWorkingValue = workingValue.trim()
+        if (trimmedWorkingValue !== '') {
+          layers.push(preparsedLayer(trimmedWorkingValue, false))
+        }
         return traverseForPreparsedLayers(remaining.slice(2), true, layers, '')
       } else {
         return traverseForPreparsedLayers(remaining.slice(1), inComment, layers, workingValue + '/')


### PR DESCRIPTION
Three small bugs i noticed while playing with background size this afternoon:

- background size only prints when user-defined: parser provides a CSSDefault value that the printer can ignore (#111)
- proper background size toggling: toggling turns off background size in tandem with background layer
- background parsing bug: `contain /* cover */` would be incorrectly parsed as `contain` due to a small bug in the preparser. That has been fixed here, and i've added a test case to check for this.