### PR TITLE
Preload assets where possible

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -90,6 +90,7 @@ import {
   TargetSelectorSection,
   TargetSelectorSectionProps,
 } from './sections/target-selector-section'
+import { addStyleSheetToPage } from '../../core/shared/dom-utils'
 
 export interface InspectorModel {
   layout?: ResolvedLayoutProps
@@ -444,6 +445,17 @@ function getElementsToTarget(paths: Array<TemplatePath>): Array<InstancePath> {
 
 const DefaultStyleTargets: Array<CSSTarget> = [cssTarget(['style'], 0), cssTarget(['css'], 0)]
 
+let InspectorFontsAdded = false
+
+function addFontsForInspectorIfAbsent() {
+  if (!InspectorFontsAdded) {
+    InspectorFontsAdded = true
+    const googleFonts =
+      'https://fonts.googleapis.com/css?family=Arvo:400,400i,700,700i|EB+Garamond:400,400i,500,500i,600,600i,700,700i,800,800i|Lora:400,400i,700,700i|Noto+Sans+JP:100,300,400,500,700,900|Noto+Sans+KR:100,300,400,500,700,900|Noto+Sans+SC:100,300,400,500,700,900|Noto+Sans+TC:100,300,400,500,700,900|Noto+Sans:400,400i,700,700i|Noto+Serif+JP:200,300,400,500,600,700,900|Noto+Serif+KR:200,300,400,500,600,700,900|Noto+Serif+SC:200,300,400,500,600,700,900|Noto+Serif+TC:200,300,400,500,600,700,900|Noto+Serif:400,400i,700,700i|Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i|PT+Sans+Narrow:400,700|PT+Sans:400,400i,700,700i|PT+Serif:400,400i,700,700i|Playfair+Display:400,400i,700,700i,900,900i|Roboto+Condensed:300,300i,400,400i,700,700i|Roboto+Mono:100,100i,300,300i,400,400i,500,500i,700,700i|Roboto+Slab:100,300,400,700|Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i|Sorts+Mill+Goudy:400,400i|Source+Code+Pro:200,300,400,500,600,700,900|Source+Sans+Pro:200,200i,300,300i,400,400i,600,600i,700,700i,900,900i|Source+Serif+Pro:400,600,700|ZCOOL+QingKe+HuangYou'
+    addStyleSheetToPage(googleFonts, false)
+  }
+}
+
 export const InspectorEntryPoint: React.FunctionComponent<{}> = betterReactMemo(
   'InspectorEntryPoint',
   () => {
@@ -464,6 +476,11 @@ export const InspectorEntryPoint: React.FunctionComponent<{}> = betterReactMemo(
         imports: getOpenImportsFromState(store.editor),
       }
     })
+
+    React.useEffect(() => {
+      // Add the google fonts on first render as it's an expensive download
+      addFontsForInspectorIfAbsent()
+    }, [])
 
     let inspectorModel: InspectorModel = {
       isChildOfFlexComponent: false,

--- a/editor/src/templates/editor-entry-point.tsx
+++ b/editor/src/templates/editor-entry-point.tsx
@@ -1,10 +1,10 @@
 // Fire off server requests that later block, to improve initial load on slower connections. These will still block,
 // but this gives us a chance to cache the result first
 import { getLoginState } from '../common/server'
-import { triggerHashedAssetsUpdate } from '../utils/hashed-assets'
+import { triggerHashedAssetsUpdate, preloadPrioritizedAssets } from '../utils/hashed-assets'
 
 getLoginState()
-triggerHashedAssetsUpdate()
+triggerHashedAssetsUpdate().then(() => preloadPrioritizedAssets())
 
 import { addStyleSheetToPage } from '../core/shared/dom-utils'
 import { STATIC_BASE_URL } from '../common/env-vars'

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -68,7 +68,6 @@ import {
   emptyUiJsxCanvasContextData,
   UiJsxCanvasContext,
 } from '../components/canvas/ui-jsx-canvas'
-import { addStyleSheetToPage } from '../core/shared/dom-utils'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
@@ -291,20 +290,9 @@ function renderRootComponent(
       ReactDOM.render(
         <HotRoot api={api} useStore={useStore} spyCollector={spyCollector} />,
         rootElement,
-        addFontsForInspectorIfAbsent, // Add the google fonts after first render as it's an expensive download
       )
     }
   })
-}
-
-let InspectorFontsAdded = false
-
-function addFontsForInspectorIfAbsent() {
-  if (!InspectorFontsAdded) {
-    const googleFonts =
-      'https://fonts.googleapis.com/css?family=Arvo:400,400i,700,700i|EB+Garamond:400,400i,500,500i,600,600i,700,700i,800,800i|Lora:400,400i,700,700i|Noto+Sans+JP:100,300,400,500,700,900|Noto+Sans+KR:100,300,400,500,700,900|Noto+Sans+SC:100,300,400,500,700,900|Noto+Sans+TC:100,300,400,500,700,900|Noto+Sans:400,400i,700,700i|Noto+Serif+JP:200,300,400,500,600,700,900|Noto+Serif+KR:200,300,400,500,600,700,900|Noto+Serif+SC:200,300,400,500,600,700,900|Noto+Serif+TC:200,300,400,500,600,700,900|Noto+Serif:400,400i,700,700i|Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i|PT+Sans+Narrow:400,700|PT+Sans:400,400i,700,700i|PT+Serif:400,400i,700,700i|Playfair+Display:400,400i,700,700i,900,900i|Roboto+Condensed:300,300i,400,400i,700,700i|Roboto+Mono:100,100i,300,300i,400,400i,500,500i,700,700i|Roboto+Slab:100,300,400,700|Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i|Sorts+Mill+Goudy:400,400i|Source+Code+Pro:200,300,400,500,600,700,900|Source+Sans+Pro:200,200i,300,300i,400,400i,600,600i,700,700i,900,900i|Source+Serif+Pro:400,600,700|ZCOOL+QingKe+HuangYou'
-    addStyleSheetToPage(googleFonts, false)
-  }
 }
 
 window.addEventListener('error', (error) => {

--- a/editor/src/utils/hashed-assets.ts
+++ b/editor/src/utils/hashed-assets.ts
@@ -17,9 +17,8 @@ export function triggerHashedAssetsUpdate(): Promise<void> {
         headers: HEADERS,
         mode: MODE,
       })
-      response.json().then((mappingsJSON) => {
-        HASHED_ASSETS_MAPPINGS = mappingsJSON
-      })
+      const mappingsJSON = await response.json()
+      HASHED_ASSETS_MAPPINGS = mappingsJSON
     } else {
       return Promise.resolve()
     }
@@ -37,4 +36,24 @@ function getPossiblyHashedURLInner(url: string): string {
 export function getPossiblyHashedURL(url: string): string {
   const relativeURL = getPossiblyHashedURLInner(url)
   return urljoin(STATIC_BASE_URL, relativeURL)
+}
+
+const prioritisedAssets = [
+  '/editor/icons/light/semantic/hamburgermenu-black-24x24@2x.png',
+  '/editor/icons/light/semantic/closedcube-black-24x24@2x.png',
+  '/editor/icons/light/semantic/closedcube-white-24x24@2x.png',
+  '/editor/icons/light/filetype/ui-darkgray-18x18@2x.png',
+  '/editor/icons/light/filetype/js-darkgray-18x18@2x.png',
+  '/editor/icons/light/semantic/externallink-large-black-24x24@2x.png',
+  '/editor/icons/light/semantic/cross-small-gray-16x16@2x.png',
+]
+
+export function preloadPrioritizedAssets() {
+  if (isBrowserEnvironment) {
+    prioritisedAssets.forEach((asset) => {
+      const url = getPossiblyHashedURL(asset)
+      fetch(url)
+    })
+    fetch('/editor/fills/light-primaryblue-p3.png') // FIXME Theme.ts should be using the cdn
+  }
 }


### PR DESCRIPTION
**Problem:**
Some assets should load sooner to improve initial start up

**Fix:**
Moved the google fonts download later in the process (during first render of the Inspector) and fired off calls to preload hashed assets as soon as possible in the process
