### PR TITLE
experiment(preload) - preload one high-value image asset

### DIFF
--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -3,9 +3,7 @@
   <head>
     <!-- ogTags -->
     <link rel="icon" type="image/png" href="/editor/icons/favicons/favicon128.png?hash=%GITHUB_SHA%" />
-    <link rel="preload" type="image/png" href="/editor/fills/light-primaryblue-p3.png?hash=%GITHUB_SHA%" />
-    <link rel="preload" type="image/png" href="/editor/icons/light/semantic/hamburgermenu-black-24x24@2x.png?hash=%GITHUB_SHA%" />
-    <link rel="preload" type="image/png" href="/editor/icons/light/semantic/hamburgermenu-white-24x24@2x.png?hash=%GITHUB_SHA%" />
+    <link rel="preload" type="image/png" href="/editor/fills/light-primaryblue-p3.png" />
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossOrigin='use-credentials' />
     <link rel="stylesheet" type="text/css" href="%UTOPIA_DOMAIN%/editor/css/utopions.css?hash=%GITHUB_SHA%" crossorigin="anonymous" />
     <link rel="stylesheet" type="text/css" href="%UTOPIA_DOMAIN%/editor/css/loadscreen.css?hash=%GITHUB_SHA%" crossorigin="anonymous" />


### PR DESCRIPTION
The blue background now is loaded with the `preload` attribute to - hopefully - load it together with the landing page.

https://w3c.github.io/preload/#dfn-preload-keyword