### PR TITLE
Disable idle session invalidation

### DIFF
--- a/server/src/Utopia/Web/Auth/Session.hs
+++ b/server/src/Utopia/Web/Auth/Session.hs
@@ -32,7 +32,8 @@ type SessionState = State SessionStorage
 createSessionState :: Pool SqlBackend -> IO SessionState
 createSessionState pool = do
   let storage = SqlStorage pool
-  createState storage
+  sessionState <- createState storage
+  return $ setIdleTimeout Nothing sessionState
 
 deleteCookie :: SessionState -> SetCookie
 deleteCookie sessionState = def
@@ -70,8 +71,7 @@ getSessionIdFromCookie sessionState possibleCookieContents = do
 getUserIdFromCookie :: SessionState -> Maybe Text -> IO (Maybe Text)
 getUserIdFromCookie sessionState cookieContents = do
   let possibleSessionId = getSessionIdFromCookie sessionState cookieContents
-  (sessionData, saveSessionToken) <- loadSession sessionState $ fmap toS possibleSessionId
-  _ <- saveSession sessionState saveSessionToken sessionData -- Update the last accessed time
+  (sessionData, _) <- loadSession sessionState $ fmap toS possibleSessionId
   let possibleUserId = fmap toS $ M.lookup "user_id" $ unSessionMap sessionData
   return possibleUserId
 


### PR DESCRIPTION
Fixes #292 

**Problem:**
Users were being logged out too frequently

**Fix:**
The library we use on the server side for session storage logs out idle users, and we weren't updating the last time they were active, meaning they were being logged out too soon. This PR now removes the idle session timeout, meaning we stick with a 60 day absolute timeout.

**Commit Details:**
- Remove the idle timeout completely in `Session.hs`
