### PR TITLE
Mark new dependencies as loading in the insert menu.

### DIFF
--- a/editor/src/components/editor/npm-dependency/npm-dependency.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.ts
@@ -3,7 +3,11 @@ import * as R from 'ramda'
 import { MapLike } from 'typescript'
 import { UTOPIA_BACKEND } from '../../../common/env-vars'
 import { sameCodeFile } from '../../../core/model/project-file-utils'
-import { NpmDependency, npmDependency } from '../../../core/shared/npm-dependency-types'
+import {
+  NpmDependency,
+  npmDependency,
+  PossiblyUnversionedNpmDependency,
+} from '../../../core/shared/npm-dependency-types'
 import {
   isCodeFile,
   Imports,
@@ -136,7 +140,7 @@ export function usePackageDependencies(): Array<NpmDependency> {
   }, [packageJsonFile])
 }
 
-export function useResolvedPackageDependencies(): Array<NpmDependency> {
+export function useResolvedPackageDependencies(): Array<PossiblyUnversionedNpmDependency> {
   const basePackageDependencies = usePackageDependencies()
   const files = useEditorState((store) => {
     return store.editor.nodeModules.files

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -77,7 +77,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
         }
       },
     )
-    const nodeModules = await fetchNodeModules([{ name: 'react-spring', version: '8.0.27' }])
+    const nodeModules = await fetchNodeModules([npmDependency('react-spring', '8.0.27')])
     const req = getRequireFn(NO_OP, nodeModules)
     const reactSpring = req('/src/index.js', 'react-spring')
     expect(Object.keys(reactSpring)).not.toHaveLength(0)
@@ -99,7 +99,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
         }
       },
     )
-    const nodeModules = await fetchNodeModules([{ name: 'antd', version: '4.2.5' }])
+    const nodeModules = await fetchNodeModules([npmDependency('antd', '4.2.5')])
     function addNewModules(newModules: NodeModules) {
       const updatedNodeModules = { ...nodeModules, ...newModules }
       const updatedReq = getRequireFn(NO_OP, updatedNodeModules, spyEvaluator)
@@ -136,7 +136,7 @@ describe('ES Dependency Manager — d.ts', () => {
       },
     )
 
-    const nodeModules = await fetchNodeModules([{ name: 'react-spring', version: '8.0.27' }])
+    const nodeModules = await fetchNodeModules([npmDependency('react-spring', '8.0.27')])
     const typings = getDependencyTypeDefinitions(nodeModules)
     expect(typings['/node_modules/react-spring/index.d.ts']).toBeDefined()
     expect(typings['/node_modules/react-spring/native.d.ts']).toBeDefined()
@@ -166,7 +166,7 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
         }
       },
     )
-    const nodeModules = await fetchNodeModules([{ name: 'mypackage', version: '0.0.1' }])
+    const nodeModules = await fetchNodeModules([npmDependency('mypackage', '0.0.1')])
     function addNewModules(newModules: NodeModules) {
       const updatedNodeModules = { ...nodeModules, ...newModules }
       const updatedReq = getRequireFn(NO_OP, updatedNodeModules)
@@ -208,7 +208,7 @@ describe('ES Dependency manager - retry behavior', () => {
       },
     )
 
-    fetchNodeModules([{ name: 'react-spring', version: '8.0.27' }]).then((nodeModules) => {
+    fetchNodeModules([npmDependency('react-spring', '8.0.27')]).then((nodeModules) => {
       expect(Object.keys(nodeModules)).toHaveLength(228)
       expect(nodeModules['/node_modules/react-spring/index.d.ts']).toBeDefined()
       done()
@@ -222,7 +222,7 @@ describe('ES Dependency manager - retry behavior', () => {
       },
     )
 
-    fetchNodeModules([{ name: 'react-spring', version: '8.0.27' }]).then((nodeModules) => {
+    fetchNodeModules([npmDependency('react-spring', '8.0.27')]).then((nodeModules) => {
       expect(Object.keys(nodeModules)).toHaveLength(0)
       done()
     })
@@ -247,7 +247,7 @@ describe('ES Dependency manager - retry behavior', () => {
       },
     )
 
-    fetchNodeModules([{ name: 'react-spring', version: '8.0.27' }], false).then((nodeModules) => {
+    fetchNodeModules([npmDependency('react-spring', '8.0.27')], false).then((nodeModules) => {
       expect(Object.keys(nodeModules)).toHaveLength(0)
       done()
     })

--- a/editor/src/core/es-modules/package-manager/package-manager.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.ts
@@ -39,6 +39,21 @@ Error found in: ${filePath}
 ${FriendlyEsModuleErrorMessage}`)
 }
 
+// Ensure this and `resolveBuiltinDependency` are kept in sync.
+export function isBuiltinDependency(toImport: string): boolean {
+  switch (toImport) {
+    case 'utopia-api':
+    case 'uuiui':
+    case 'uuiui-deps':
+    case 'react':
+    case 'react-dom':
+      return true
+    default:
+      return false
+  }
+}
+
+// Ensure this and `isBuiltinDependency` are kept in sync.
 function resolveBuiltinDependency(toImport: string): any | undefined {
   const React = ImportedReact
   const ReactDOM = ImportedReactDOM

--- a/editor/src/core/shared/npm-dependency-types.ts
+++ b/editor/src/core/shared/npm-dependency-types.ts
@@ -3,16 +3,44 @@ export type TypeDefinitions = {
   [fileName: string]: string
 } // the strings are the contents of .d.ts files
 
-export type NpmDependency = {
+export interface NpmDependency {
+  type: 'NPM_DEPENDENCY'
   name: string
   version: string
 }
 
-export function npmDependency(name: string, version: string) {
+export function npmDependency(name: string, version: string): NpmDependency {
   return {
+    type: 'NPM_DEPENDENCY',
     name: name,
     version: version,
   }
+}
+
+export interface UnversionedNpmDependency {
+  type: 'UNVERSIONED_NPM_DEPENDENCY'
+  name: string
+}
+
+export function unversionedNpmDependency(name: string): UnversionedNpmDependency {
+  return {
+    type: 'UNVERSIONED_NPM_DEPENDENCY',
+    name: name,
+  }
+}
+
+export type PossiblyUnversionedNpmDependency = NpmDependency | UnversionedNpmDependency
+
+export function isNpmDependency(
+  dependency: PossiblyUnversionedNpmDependency,
+): dependency is NpmDependency {
+  return dependency.type === 'NPM_DEPENDENCY'
+}
+
+export function isUnversionedNpmDependency(
+  dependency: PossiblyUnversionedNpmDependency,
+): dependency is UnversionedNpmDependency {
+  return dependency.type === 'UNVERSIONED_NPM_DEPENDENCY'
 }
 
 export interface PackagerServerFileDescriptor {


### PR DESCRIPTION


Fixes #276

**Problem:**
When a user adds a new dependency some amount of time may pass before that dependency is loaded such that the editor can present insertion options for it. But it may be unclear to the user that something is happening in the background.

**Fix:**
For dependencies which are still being loaded, we add a placeholder item to the insert menu indicating that it is currently being loaded. This is distinguished this by the dependency being loaded such that the version number can be ascertained from the `package.json` file.

**Commit Details:**
- Fixes #276.
- Added a `type` field to `NpmDependency`, so that it can be distinguished
  more easily in union types.
- Added a new type `UnversionedNpmDependency` for the case where we
  don't have a specific version number.
- `getThirdPartyComponents` now includes dependencies which aren't downloaded
  yet.
- Added `isBuiltinDependency` as a sister function to `resolveBuiltinDependency`.
- Changed the `InsertMenu` component to include dependencies which aren't built-in ones
  in the listing for component insertion, adding a placeholder `InsertGroup` for
  dependencies which are still being loaded.
