### PR TITLE
Added a notice when there are no component props.

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -561,7 +561,15 @@ export const ComponentSectionInner = betterReactMemo(
             </>
           )
         } else {
-          return null
+          return (
+            <>
+              <InspectorSectionHeader>
+                <SimpleFlexRow style={{ flexGrow: 1 }}>Component props</SimpleFlexRow>
+              </InspectorSectionHeader>
+              <InfoBox message={'No properties available to configure.'} />
+              <InfoBox message={'Use code instead.'} />
+            </>
+          )
         }
       },
       propertyControls,


### PR DESCRIPTION
Fixes #289

**Problem:**
No information was displayed for the component props if none were specified.

**Fix:**
Add a notice to hint that code will be needed to be used instead.

**Commit Details:**
- Fixes #289.
- Replaces a conditional clause which previously meant there would
  be no component props section with one that displays a notice.
