### PR TITLE
fix(preload) - add "as='image'"

### DIFF
--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -3,7 +3,7 @@
   <head>
     <!-- ogTags -->
     <link rel="icon" type="image/png" href="/editor/icons/favicons/favicon128.png?hash=%GITHUB_SHA%" />
-    <link rel="preload" type="image/png" href="/editor/fills/light-primaryblue-p3.png" />
+    <link rel="preload" type="image/png" href="/editor/fills/light-primaryblue-p3.png" as="image" />
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossOrigin='use-credentials' />
     <link rel="stylesheet" type="text/css" href="%UTOPIA_DOMAIN%/editor/css/utopions.css?hash=%GITHUB_SHA%" crossorigin="anonymous" />
     <link rel="stylesheet" type="text/css" href="%UTOPIA_DOMAIN%/editor/css/loadscreen.css?hash=%GITHUB_SHA%" crossorigin="anonymous" />


### PR DESCRIPTION
This adds the - apparently required, at least for chrome, `as` parameter with `image` as value. Without it, `preload` is not currently working, this is to see if it will.