### PR TITLE
Include cache control headers in requests for editor assets

### DIFF
--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -325,7 +325,7 @@ addCacheControl :: Middleware
 addCacheControl = addMiddlewareHeader "Cache-Control" "public, immutable, max-age=2592000"
 
 addCDNHeaders :: Middleware
-addCDNHeaders = fmap addAccessControlAllowOrigin $ addCacheControl
+addCDNHeaders = addCacheControl . addAccessControlAllowOrigin
 
 editorAssetsEndpoint :: FilePath -> ServerMonad Application
 editorAssetsEndpoint notProxiedPath = do


### PR DESCRIPTION
**Problem:**
I realised that we're not including these headers in the requests for regular editor assets, meaning that every request via the CDN required the CDN to check with the servers that the resource hadn't changed. This was still a lot faster since it would have returned a 304, but we don't need to make that check since we use hashes to cache bust anyway.

**Fix:**
Include the same cache-control headers for regular editor assets as we do when making packager requests.

**Commit Details:**
- Refactored the code around adding headers in the server when the server is acting as a `Middleware`
- Set the `cache-control` header to `public, immutable, max-age=2592000` when making requests via `/editor/`
