### PR TITLE
Server now forces requests to use SSL when in production

### DIFF
--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -75,6 +75,7 @@ data EnvironmentRuntime r = EnvironmentRuntime
   , _startupLogging      :: r -> Bool
   , _metricsStore        :: r -> Store
   , _cacheForAssets      :: r -> IO AssetResultCache
+  , _forceSSL            :: r -> Bool
   }
 
 data AssetsCaches = AssetsCaches

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -333,4 +333,5 @@ devEnvironmentRuntime = EnvironmentRuntime
   , _startupLogging = _logOnStartup
   , _metricsStore = view storeForMetrics
   , _cacheForAssets = (\r -> readIORef $ _assetResultCache $ _assetsCaches r)
+  , _forceSSL = const False
   }

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -256,5 +256,6 @@ productionEnvironmentRuntime = EnvironmentRuntime
   , _startupLogging = const True
   , _metricsStore = view storeForMetrics
   , _cacheForAssets = (\r -> readIORef $ _assetResultCache $ _assetsCaches r)
+  , _forceSSL = const True
   }
 

--- a/server/test/Test/Utopia/Web/Executors/Test.hs
+++ b/server/test/Test/Utopia/Web/Executors/Test.hs
@@ -53,4 +53,5 @@ testEnvironmentRuntime = EnvironmentRuntime
   , _startupLogging = _logOnStartup
   , _metricsStore = view storeForMetrics
   , _cacheForAssets = (\r -> readIORef $ _assetResultCache $ _assetsCaches r)
+  , _forceSSL = const False
   }


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/dystopia/issues/3628

**Problem:**
The editor doesn't work on http, and we're not always upgrading to https

**Fix:**
Sean stumbled across a nice way to force SSL and sent it my way after the conversations this morning :slightly_smiling_face:

**Commit Details:**
- Added config for setting whether or not we should force SSL
- Optionally use `Network.Wai.Middleware.ForceSSL` to force SSL based on that setting
