### PR TITLE
fix(antd) Include the antd CSS import when inserting components.

### DIFF
--- a/editor/src/core/third-party/antd-components.ts
+++ b/editor/src/core/third-party/antd-components.ts
@@ -15,7 +15,10 @@ function createBasicComponent(
   propertyControls: PropertyControls | null,
 ): ComponentDescriptor {
   return componentDescriptor(
-    { antd: importDetails(null, [importAlias(baseVariable)], null) },
+    {
+      antd: importDetails(null, [importAlias(baseVariable)], null),
+      'antd/dist/antd.css': importDetails(null, [], null),
+    },
     jsxElement(jsxElementName(baseVariable, propertyPathParts), {}, [], null),
     name,
     propertyControls,


### PR DESCRIPTION
Fixes #291

**Problem:**
The CSS import for antd wasn't included when inserting it.

**Fix:**
The CSS import for antd is included when inserting it.

**Commit Details:**
- Fixes #291.
- Adds the import path to the imports for antd.
