### PR TITLE
fix(Inspector) Stop context menu bringing down the editor

### DIFF
--- a/editor/src/components/inspector/widgets/property-label.tsx
+++ b/editor/src/components/inspector/widgets/property-label.tsx
@@ -22,14 +22,15 @@ function useMetadataInfoForDomain(target: ReadonlyArray<PropertyPath>) {
 
 export const PropertyLabel = betterReactMemo('PropertyLabel', (props: PropertyLabelProps) => {
   const metadata = useMetadataInfoForDomain(props.target)
+  const propsToUnset = props.propNamesToUnset ?? props.target.map(PP.lastPart)
   const contextMenuItems = optionalAddOnUnsetValues(
     metadata.propertyStatus.set,
-    props.propNamesToUnset ?? props.target.map(PP.lastPart),
+    propsToUnset,
     metadata.onUnsetValues,
   )
   return (
     <InspectorContextMenuWrapper
-      id={`property-label-${props.target}`}
+      id={`property-label-${propsToUnset.join('-')}`}
       data={null}
       items={contextMenuItems}
       style={{


### PR DESCRIPTION
Fixes #17 

**Problem:**
Right clicking in the Inspector would occasionally bring down the editor.

**Fix:**
The problem was with the menu's `id`, which was effectively `property-label-[Object object]-[Object object]-...` etc., meaning there were multiple menus with the same `id`, which `react-contexify` unfortunately doesn't handle gracefully.

**Commit Details:**
- Use the list of property names to set to generate the `id` in `property-label.tsx`
