### PR TITLE
Correctly handle contexts for functional components.

### DIFF
--- a/editor/src/utils/canvas-react-utils.spec.tsx
+++ b/editor/src/utils/canvas-react-utils.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import * as PropTypes from 'prop-types'
 import { applyUIDMonkeyPatch } from './canvas-react-utils'
 applyUIDMonkeyPatch()
 import * as ReactDOMServer from 'react-dom/server'
@@ -587,6 +588,39 @@ describe('Monkey Function', () => {
           <div data-uid=\\"bbb\\">Hello Dolly!!</div>
         </div>
       </div>
+      "
+    `)
+  })
+
+  it('function components have a working context', () => {
+    const TestFunction = (props: any, context: any) => {
+      return <div data-uid='bbb'>{context.value}</div>
+    }
+    TestFunction.contextTypes = {
+      value: PropTypes.string,
+    }
+    TestFunction.childContextTypes = {
+      value: PropTypes.string,
+    }
+
+    class App extends React.Component {
+      getChildContext() {
+        return { value: 'hello!' }
+      }
+      render() {
+        return (
+          <div data-uid='aaa'>
+            <TestFunction />
+          </div>
+        )
+      }
+    }
+    ;(App as any).childContextTypes = {
+      value: PropTypes.string,
+    }
+
+    expect(renderToFormattedString(<App />)).toMatchInlineSnapshot(`
+      "<div data-uid=\\"aaa\\"><div data-uid=\\"bbb\\">hello!</div></div>
       "
     `)
   })

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -87,12 +87,14 @@ function attachDataUidToRoot(
 
 const mangleFunctionType = Utils.memoize(
   (type: unknown): React.FunctionComponent => {
-    const mangledFunction = (p: any) => {
-      let originalTypeResponse = (type as React.FunctionComponent)(p)
+    const mangledFunction = (p: any, context?: any) => {
+      let originalTypeResponse = (type as React.FunctionComponent)(p, context)
       const res = attachDataUidToRoot(originalTypeResponse, (p as any)?.['data-uid'])
       return res
     }
     ;(mangledFunction as any).theOriginalType = type
+    ;(mangledFunction as any).contextTypes = (type as any).contextTypes
+    ;(mangledFunction as any).childContextTypes = (type as any).childContextTypes
     return mangledFunction
   },
   {
@@ -138,7 +140,7 @@ const mangleExoticType = Utils.memoize(
      *
      * Instead of that we render these fragment-like components, and mangle with their children
      */
-    const wrapperComponent = (p: any) => {
+    const wrapperComponent = (p: any, context?: any) => {
       if (p?.['data-uid'] == null) {
         // early return for the cases where there's no data-uid
         return realCreateElement(type, p)
@@ -169,6 +171,8 @@ const mangleExoticType = Utils.memoize(
       }
     }
     ;(wrapperComponent as any).theOriginalType = type
+    ;(wrapperComponent as any).contextTypes = (type as any).contextTypes
+    ;(wrapperComponent as any).childContextTypes = (type as any).childContextTypes
     return wrapperComponent
   },
   {


### PR DESCRIPTION
Fixes #288

**Problem:**
The `react-inspector` dependency of `console-feed` uses the mid-transition legacy context API for functional components. Our modified `createElement` function wasn't passing through the context value which meant that the value for the context used in `react-inspector` was undefined, causing it to bomb out taking the editor with it.

**Fix:**
Make sure we pass through the context parameter and copy the special fields that the legacy context API uses to determine what should be included in the context.

**Commit Details:**
- Fixes #288.
- Passes the context through in the `mangleFunctionType` case.
- Copies `contextTypes` and `childContextTypes` as appropriate.
