### PR TITLE
Alias '/project' paths to '/p'.

### DIFF
--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -408,8 +408,6 @@ protected authCookie = logoutPage authCookie
 unprotected :: ServerT Unprotected ServerMonad
 unprotected = authenticate
          :<|> emptyProjectPage
-         :<|> emptyProjectPage
-         :<|> projectPage
          :<|> projectPage
          :<|> emptyPreviewPage
          :<|> previewPage
@@ -419,7 +417,6 @@ unprotected = authenticate
          :<|> getProjectMetadataEndpoint
          :<|> getShowcaseEndpoint
          :<|> setShowcaseEndpoint
-         :<|> loadProjectAssetEndpoint
          :<|> loadProjectAssetEndpoint
          :<|> loadProjectAssetEndpoint
          :<|> loadProjectThumbnailEndpoint

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -61,19 +61,17 @@ type LogoutAPI = "logout" :> Get '[HTML] (SetSessionCookies H.Html)
 
 type GetUserAPI = "v1" :> "user" :> Get '[JSON] UserResponse
 
-type EmptyProjectPageAPI = "project" :> Get '[HTML] H.Html
+type EmptyProjectPageAPI = "p" :> Get '[HTML] H.Html
 
-type ShortEmptyProjectPageAPI = "p" :> Get '[HTML] H.Html
+type ProjectPageAPI = "p" :> Capture "project_id" ProjectIdWithSuffix :> Get '[HTML] H.Html
 
-type ProjectPageAPI = "project" :> Capture "project_id" ProjectIdWithSuffix :> Get '[HTML] H.Html
-
-type ShortProjectPageAPI = "p" :> Capture "project_id" ProjectIdWithSuffix :> Get '[HTML] H.Html
+type LoadProjectAssetAPI = "p" :> Capture "project_id" ProjectIdWithSuffix :> Capture "first_path" Text :> CaptureAll "remaining_path" Text :> RawM
 
 type EmptyPreviewPageAPI = "share" :> Get '[HTML] H.Html
 
 type PreviewPageAPI = "share" :> Capture "project_id" ProjectIdWithSuffix :> Get '[HTML] H.Html
 
-type DownloadProjectAPI = "project" :> Capture "project_id" ProjectIdWithSuffix :> "contents.json" :> CaptureAll "remaining_path" Text :> Get '[PrettyJSON] Value
+type DownloadProjectAPI = "v1" :> "project" :> Capture "project_id" ProjectIdWithSuffix :> "contents.json" :> CaptureAll "remaining_path" Text :> Get '[PrettyJSON] Value
 
 type ProjectOwnerAPI = "v1" :> "project" :> Capture "project_id" ProjectIdWithSuffix :> "owner" :> Get '[JSON] ProjectOwnerResponse
 
@@ -94,10 +92,6 @@ type MyProjectsAPI = "v1" :> "projects" :> Get '[JSON] ProjectListResponse
 type ShowcaseAPI = "v1" :> "showcase" :> Get '[JSON] ProjectListResponse
 
 type SetShowcaseAPI = "v1" :> "showcase" :> "overwrite" :> QueryParam' '[Required] "projects" Text :> Post '[JSON] NoContent
-
-type LoadProjectAssetAPI = "project" :> Capture "project_id" ProjectIdWithSuffix :> Capture "first_path" Text :> CaptureAll "remaining_path" Text :> RawM
-
-type ShortLoadProjectAssetAPI = "p" :> Capture "project_id" ProjectIdWithSuffix :> Capture "first_path" Text :> CaptureAll "remaining_path" Text :> RawM
 
 type PreviewProjectAssetAPI = "share" :> Capture "project_id" ProjectIdWithSuffix :> Capture "first_path" Text :> CaptureAll "remaining_path" Text :> RawM
 
@@ -155,9 +149,7 @@ type Protected = LogoutAPI
 
 type Unprotected = AuthenticateAPI
               :<|> EmptyProjectPageAPI
-              :<|> ShortEmptyProjectPageAPI
               :<|> ProjectPageAPI
-              :<|> ShortProjectPageAPI
               :<|> EmptyPreviewPageAPI
               :<|> PreviewPageAPI
               :<|> DownloadProjectAPI
@@ -167,7 +159,6 @@ type Unprotected = AuthenticateAPI
               :<|> ShowcaseAPI
               :<|> SetShowcaseAPI
               :<|> LoadProjectAssetAPI
-              :<|> ShortLoadProjectAssetAPI
               :<|> PreviewProjectAssetAPI
               :<|> LoadProjectThumbnailAPI
               :<|> MonitoringAPI


### PR DESCRIPTION
Fixes #281

**Problem:**
With the introduction of `/p/` prefixed paths, it was done a little inconsistently, such that it's possible for some things to end up with the `/project` prefix.

**Fix:**
Moved anything starting with `/project` to `/p` and then added something to rewrite any `/project` paths to `/p` paths in the server.

**Notes:**
- The `contents.json` endpoint has moved as a result of this because it potentially clashes with the asset path loading. Which results in `http://utopia.app/project/2d4a577b/contents.json` becoming `http://utopia.app/v1/project/2d4a577b/contents.json`

**Commit Details:**
- Fixes #281.
- Add in a redirect for a `/p/<project_id>` path without the trailing slash.
- Removed the "Short" path variations from the server.
- Changed any remaining paths in the types that started with `"project" :>`
  and made them start with `"p" :>`.
- Moved the `contents.json` endpoint to live under the API root so that it
  cannot interfere with asset paths.
