### PR TITLE
micro PR: adding propertyControls for utopia-api

### DIFF
--- a/editor/src/core/third-party/third-party-components.ts
+++ b/editor/src/core/third-party/third-party-components.ts
@@ -15,9 +15,11 @@ import { NodeModules, isEsCodeFile } from '../shared/project-file-types'
 import { fastForEach } from '../shared/utils'
 import { parseVersionPackageJsonFile } from '../../utils/package-parser-utils'
 import { forEachRight } from '../shared/either'
+import { UtopiaApiComponents } from './utopia-api-components'
 
 const ThirdPartyComponents: DependenciesDescriptors = {
   antd: AntdComponents,
+  'utopia-api': UtopiaApiComponents,
 }
 
 export function getThirdPartyComponents(

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -1,0 +1,43 @@
+import { importAlias, importDetails } from '../shared/project-file-types'
+import {
+  componentDescriptor,
+  DependencyBoundDescriptors,
+  ComponentDescriptor,
+} from './third-party-types'
+import { jsxElement, jsxElementName } from '../shared/element-template'
+import { PropertyControls } from 'utopia-api'
+
+function createBasicUtopiaComponent(
+  baseVariable: string,
+  name: string,
+  propertyControls: PropertyControls | null,
+): ComponentDescriptor {
+  return componentDescriptor(
+    {
+      'utopia-api': importDetails(null, [importAlias(baseVariable)], null),
+    },
+    jsxElement(jsxElementName(baseVariable, []), {}, [], null),
+    name,
+    propertyControls,
+  )
+}
+
+const StyleObjectProps: PropertyControls = {
+  style: {
+    type: 'styleobject',
+  },
+}
+
+export const UtopiaApiComponents: DependencyBoundDescriptors = {
+  '>=0.0.0 <1.0.0': {
+    name: 'utopia-api',
+    components: [
+      createBasicUtopiaComponent('Ellipse', 'Ellipse', StyleObjectProps),
+      createBasicUtopiaComponent('Layoutable', 'Layoutable', StyleObjectProps),
+      createBasicUtopiaComponent('Positionable', 'Positionable', StyleObjectProps),
+      createBasicUtopiaComponent('Rectangle', 'Rectangle', StyleObjectProps),
+      createBasicUtopiaComponent('Text', 'Text', StyleObjectProps),
+      createBasicUtopiaComponent('View', 'View', StyleObjectProps),
+    ],
+  },
+}


### PR DESCRIPTION
**Problem:**
As part of changing the Canvas to only show move / resize controls where applicable, we need to be able to tell Utopia that Views are indeed movable and resizable :) 

**Fix:**
The v1 solution is to add a propertyControls entry for them describing a `style` property of the type `styleobject`

**Commit Details:**
- Copy pasted antd's property controls, but made them work for utopia-api elements (View, Rectangle, Ellipse, etc)
