### PR TITLE
add a default propertyControls to html intrinsic elements (such as div)

### DIFF
--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -43,6 +43,7 @@ import {
   JSXElementName,
   getJSXElementNameAsString,
   isIntrinsicElement,
+  jsxElementName,
 } from '../shared/element-template'
 import {
   getModifiableJSXAttributeAtPath,
@@ -1104,11 +1105,11 @@ export const MetadataUtils = {
     path: TemplatePath,
     components: Array<UtopiaJSXComponent>,
     metadata: ComponentMetadata[],
-  ): string | null {
+  ): JSXElementName | null {
     if (TP.isScenePath(path)) {
       const scene = MetadataUtils.findSceneByTemplatePath(metadata, path)
-      if (scene != null) {
-        return scene.component
+      if (scene != null && scene.component != null) {
+        return jsxElementName(scene.component, [])
       } else {
         return null
       }
@@ -1116,7 +1117,7 @@ export const MetadataUtils = {
       const jsxElement = findElementAtPath(path, components, metadata)
       if (jsxElement != null) {
         if (isJSXElement(jsxElement)) {
-          return getJSXElementNameLastPart(jsxElement.name)
+          return jsxElement.name
         } else {
           return null
         }
@@ -1419,17 +1420,17 @@ export const MetadataUtils = {
     if (TP.isScenePath(path)) {
       return false
     } else {
-      const jsxElementName = MetadataUtils.getStaticElementName(path, rootElements, metadata)
+      const elementName = MetadataUtils.getStaticElementName(path, rootElements, metadata)
       const instanceMetadata = MetadataUtils.getElementByInstancePathMaybe(metadata, path)
       return (
-        jsxElementName != null &&
+        elementName != null &&
         instanceMetadata != null &&
         !MetadataUtils.isGivenUtopiaAPIElementFromImports(
           imports,
           instanceMetadata,
-          getJSXElementNameLastPart(jsxElementName),
+          getJSXElementNameLastPart(elementName),
         ) &&
-        !isIntrinsicElement(jsxElementName)
+        !isIntrinsicElement(elementName)
       )
     }
   },

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -18,7 +18,7 @@ import { fastForEach } from '../shared/utils'
 import { AntdControls } from './third-party-property-controls/antd-controls'
 import { NpmDependency } from '../shared/npm-dependency-types'
 import { getThirdPartyComponents } from '../third-party/third-party-components'
-import { getJSXElementNameAsString } from '../shared/element-template'
+import { getJSXElementNameAsString, isIntrinsicHTMLElement } from '../shared/element-template'
 import { TemplatePath } from '../shared/project-file-types'
 import {
   getOpenImportsFromState,
@@ -28,6 +28,7 @@ import {
   EditorState,
 } from '../../components/editor/store/editor-state'
 import { MetadataUtils } from '../model/element-metadata-utils'
+import { HtmlElementStyleObjectProps } from '../third-party/html-intrinsic-elements'
 
 export function defaultPropertiesForComponentInFile(
   componentName: string,
@@ -246,11 +247,21 @@ export function getPropertyControlsForTarget(
     rootComponents,
     editor.jsxMetadataKILLME,
   )
+  const jsxName = MetadataUtils.getJSXElementName(target, rootComponents, editor.jsxMetadataKILLME)
   if (importedName != null && tagName != null) {
     // TODO default and star imports
     let filename = Object.keys(imports).find((key) => {
       return pluck(imports[key].importedFromWithin, 'name').includes(importedName)
     })
+    if (filename == null && jsxName != null && isIntrinsicHTMLElement(jsxName)) {
+      /**
+       * We detected an intrinsic HTML Element (such as div, a, span, etc...)
+       * for the sake of simplicity, we assume here that they all support the style prop. if we need more detailed
+       * information for them, feel free to turn this into a real data structure that contains specific props for specific elements,
+       * but for now, I just return a one-size-fits-all PropertyControls result here
+       */
+      return HtmlElementStyleObjectProps
+    }
     if (filename == null && openFilePath != null) {
       filename = openFilePath.replace(/\.(js|jsx|ts|tsx)$/, '')
     }

--- a/editor/src/core/third-party/html-intrinsic-elements.ts
+++ b/editor/src/core/third-party/html-intrinsic-elements.ts
@@ -1,0 +1,7 @@
+import { PropertyControls } from 'utopia-api'
+
+export const HtmlElementStyleObjectProps: PropertyControls = {
+  style: {
+    type: 'styleobject',
+  },
+}


### PR DESCRIPTION
Fixes part of https://github.com/concrete-utopia/dystopia/issues/3616

**Problem:**
#368 will disable dragging and resizing for any element that doesn't have propertyControls defined for `props.style`. This includes `div`s and other HTML Elements. 

**Fix:**
This PR adds propertyControls to HtmlElements. For now they all get the same cookie-cutter propertyControl, which just defines `props.style` as a `styleobject`. This will allow resizing and dragging them!

**Commit Details:**
- changed the signature of (the otherwise unused) `MetadataUtils.getJSXElementName` from `string | null` to `JSXElementName | null`
- extended `getPropertyControlsForTarget` to special case handle HTML intrinsic elements