### PR TITLE
fix antd dragging

### DIFF
--- a/editor/src/core/third-party/antd-components.ts
+++ b/editor/src/core/third-party/antd-components.ts
@@ -8,6 +8,12 @@ import { jsxElement, jsxElementName } from '../shared/element-template'
 import { AntdControls } from '../property-controls/third-party-property-controls/antd-controls'
 import { PropertyControls } from 'utopia-api'
 
+const StyleObjectProps: PropertyControls = {
+  style: {
+    type: 'styleobject',
+  },
+}
+
 function createBasicComponent(
   baseVariable: string,
   propertyPathParts: PropertyPathPart[],
@@ -21,7 +27,7 @@ function createBasicComponent(
     },
     jsxElement(jsxElementName(baseVariable, propertyPathParts), {}, [], null),
     name,
-    propertyControls,
+    { ...StyleObjectProps, ...propertyControls },
   )
 }
 


### PR DESCRIPTION
**Problem:**
Antd components didn't have propertyControl defined for `props.style` which means the canvas dragging got disabled on them

**Fix:**
Add a propertyControl for style for antd

**Commit Details:**
- Added a default propertyControl for all antd element, spreading the specific propertyControls over it
