### PR TITLE
Deploy on release

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set Calculated Tag Variable
         # If we haven't explicitly passed in a tag, use the next patch version determined above
         if: ${{ github.event.inputs.tag-name == null }}
-        run: echo ::set-env name=NEW_TAG::${{ steps.get-next-tags.outputs.patch }}
+        run: echo ::set-env name=NEW_TAG::${{ steps.get-next-tags.outputs.v_patch }}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
Part of https://github.com/concrete-utopia/utopia-deploy/issues/13

**Problem:**
We have no smooth process to tag a release and then deploy that to production.

**Fix:**
Added a workflow to do exactly that

**Commit Details:**
- Create the manually triggered `tag-release.yml` workflow
- Use [`actions/create-release@v1`](https://github.com/marketplace/actions/create-a-release) to tag and create a release
- Trigger a new `repository-dispatch` event that will trigger the production deploy using the newly created tag name

**Note:**
It's not clear from the documentation how the `create-release` action determines which SHA to tag, and there is no explicit input for it, so I'm going to effectively have to try this out before actually allowing it to trigger the deploy.

**Corresponding Deploy PR:** https://github.com/concrete-utopia/utopia-deploy/pull/12