### PR TITLE
Fix persistence.spec

### DIFF
--- a/editor/src/components/editor/persistence.ts
+++ b/editor/src/components/editor/persistence.ts
@@ -153,7 +153,16 @@ function saveError(
 
 let _saveState: SaveState = neverSaved()
 
+function clearScheduledSave() {
+  if (isSaved(_saveState) || isSaveError(_saveState)) {
+    if (_saveState.setTimeoutId != null) {
+      clearTimeout(_saveState.setTimeoutId)
+    }
+  }
+}
+
 export function clearSaveState() {
+  clearScheduledSave()
   _saveState = neverSaved()
 }
 
@@ -281,9 +290,7 @@ async function throttledServerSaveInner(
       break
     case 'saved':
     case 'save-error':
-      if (_saveState.setTimeoutId != null) {
-        clearTimeout(_saveState.setTimeoutId)
-      }
+      clearScheduledSave()
       const timeSinceLastSave = Date.now() - _saveState.timestamp
       const waitTime = waitTimeForSaveState() - timeSinceLastSave
       if (waitTime <= 0) {
@@ -323,9 +330,7 @@ async function serverSaveInner(
   const priorErrorCount = isSaveError(_saveState) ? _saveState.errorCount : 0
   const isFirstSave = isLocal()
 
-  if (_saveState.type === 'saved' && _saveState.setTimeoutId != null) {
-    clearTimeout(_saveState.setTimeoutId)
-  }
+  clearScheduledSave()
 
   _saveState = saveInProgress(true, null, null, false)
   const name = nameChange ?? projectName


### PR DESCRIPTION
**Problem:**
`persistence.spec` was occasionally failing because of the async nature of the tests

**Fix:**
Ensure any inflight requests or promises have completed or been cancelled before starting the next test
