### PR TITLE
Include evaluated project files in editor.nodeModules.files

### DIFF
--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -153,9 +153,6 @@ export function generateCodeResultCache(
   npmDependencies: NpmDependency[],
   fullBuild: BuildType,
 ): CodeResultCache {
-  let nodeModulesAndProjectFiles: NodeModules = {
-    ...nodeModules,
-  }
   // Makes the assumption that `fullBuild` and `updatedModules` are in line
   // with each other.
   let modules: MultiFileBuildResult =
@@ -165,10 +162,10 @@ export function generateCodeResultCache(
           ...existingModules,
           ...updatedModules,
         }
-  incorporateBuildResult(nodeModulesAndProjectFiles, modules)
-  const requireFn = getMemoizedRequireFn(nodeModulesAndProjectFiles, dispatch)
+  incorporateBuildResult(nodeModules, updatedModules)
+  const requireFn = getMemoizedRequireFn(nodeModules, dispatch)
 
-  const exportValues = getExportValuesFromAllModules(modules, requireFn)
+  const exportValues = getExportValuesFromAllModules(updatedModules, requireFn)
   let cache: { [code: string]: CodeResult } = {}
   let propertyControlsInfo: PropertyControlsInfo = getControlsForExternalDependencies(
     npmDependencies,


### PR DESCRIPTION
Fixes #338 

**Problem:**
When any file in a project changed, we were evaluating every file in the project, and binning the previously cached eval result.

**Fix:**
We're already directly mutating the contents of `editor.nodeModules.files` whilst running our memoised `requireFn` (and evaluating imports), but for some reason we were performing a shallow clone before inserting the build result files, meaning we were losing the cached evaluation of those each time, therefore I have removed that shallow clone. I have also stopped us from eagerly fetching all export values from all modules since we're only interested in the updated modules.

**Commit Details:**
- Removed shallow clone creation of `nodeModulesAndProjectFiles` so that the already occurring mutation also includes the project files in `editor.nodeModules.files`
- Only call `incorporateBuildResult` with `updatedModules` so that we don't clear the cached evaluation of unchanged modules
- Only call `getExportValuesFromAllModules` on `updatedModules`