### PR TITLE
[bugfix]: property-path's toString

### DIFF
--- a/editor/src/core/shared/property-path.ts
+++ b/editor/src/core/shared/property-path.ts
@@ -55,7 +55,8 @@ export function create(elements: Array<PropertyPathPart>): PropertyPath {
   }
 }
 
-export function toString(propertyPath: PropertyPath, joinWith: string = '.'): string {
+export function toString(propertyPath: PropertyPath): string {
+  const joinWith = '.'
   const pathCache = getPathCache(propertyPath.propertyElements)
   if (pathCache.cachedToString == null) {
     let result: string = ''
@@ -71,10 +72,6 @@ export function toString(propertyPath: PropertyPath, joinWith: string = '.'): st
   } else {
     return pathCache.cachedToString
   }
-}
-
-export function toVarSafeString(propertyPath: PropertyPath): string {
-  return toString(propertyPath, '_')
 }
 
 export function lastPart(propertyPath: PropertyPath): PropertyPathPart {


### PR DESCRIPTION
**Problem:**
property-path's`toString(propertyPath: PropertyPath, joinWith: string = '.'): string` cached the results not taking into account the joinWith parameter. This means that if it was first called with joinWith: '___', it would cache that result and return that for every subsequent call!

**Fix:**
The only callsite using the joinWith paramter was the no-longer-used `toVarSafeString` so I just deleted it all

