### PR TITLE
fix(preview) adding ID guard for preview outer promise

### DIFF
--- a/editor/src/core/workers/bundler-bridge.spec.ts
+++ b/editor/src/core/workers/bundler-bridge.spec.ts
@@ -8,6 +8,7 @@ const initEvent = {
   payload: {
     typeDefinitions: {},
     projectContents: {},
+    jobID: null,
   },
 } as const
 

--- a/editor/src/core/workers/bundler-bridge.ts
+++ b/editor/src/core/workers/bundler-bridge.ts
@@ -48,17 +48,20 @@ interface InitializeEvent {
   payload: {
     typeDefinitions: TypeDefinitions
     projectContents: ProjectContents
+    jobID: string | null
   }
 }
 function initializeEvent(
   typeDefinitions: TypeDefinitions,
   projectContents: ProjectContents,
+  jobID: string | null,
 ): InitializeEvent {
   return {
     type: 'INITIALIZE',
     payload: {
       typeDefinitions,
       projectContents,
+      jobID: jobID,
     },
   }
 }
@@ -362,6 +365,7 @@ export class NewBundlerWorker {
               this.worker,
               event.payload.typeDefinitions,
               event.payload.projectContents,
+              event.payload.jobID,
             ),
         },
       }),
@@ -369,8 +373,12 @@ export class NewBundlerWorker {
     this.stateMachine.start()
   }
 
-  sendInitMessage(typeDefinitions: TypeDefinitions, projectContents: ProjectContents) {
-    this.stateMachine.send(initializeEvent(typeDefinitions, projectContents))
+  sendInitMessage(
+    typeDefinitions: TypeDefinitions,
+    projectContents: ProjectContents,
+    jobID: string | null,
+  ) {
+    this.stateMachine.send(initializeEvent(typeDefinitions, projectContents, jobID))
   }
 
   sendUpdateFileMessage(filename: string, content: FileContent) {
@@ -392,8 +400,9 @@ function sendIdGuardedinitializeWorkerPromise(
   worker: BundlerWorker,
   typeDefinitions: TypeDefinitions,
   projectContents: ProjectContents,
+  jobID: string | null,
 ): Promise<InitCompleteMessage> {
-  const generatedJobID = utils.generateUUID()
+  const generatedJobID = jobID == null ? utils.generateUUID() : jobID
 
   return new Promise((resolve, reject) => {
     function handleMessage(event: MessageEvent) {

--- a/editor/src/core/workers/bundler-promise.ts
+++ b/editor/src/core/workers/bundler-promise.ts
@@ -2,6 +2,7 @@ import type { TypeDefinitions } from '../shared/npm-dependency-types'
 import type { MultiFileBuildResult, OutgoingWorkerMessage } from './ts/ts-worker'
 import type { ProjectContents } from '../shared/project-file-types'
 import { NewBundlerWorker } from './bundler-bridge'
+import utils from '../../utils/utils'
 
 export function createBundle(
   worker: NewBundlerWorker,
@@ -9,14 +10,15 @@ export function createBundle(
   projectContents: ProjectContents,
 ): Promise<{ buildResult: MultiFileBuildResult }> {
   return new Promise((resolve, reject) => {
+    const jobID = utils.generateUUID()
     function bundleMessageHandler(bundleResultMessage: MessageEvent) {
       const data: OutgoingWorkerMessage = bundleResultMessage.data
-      if (data.type === 'build') {
+      if (data.type === 'build' && data.jobID === jobID) {
         resolve({ buildResult: data.buildResult })
         worker.removeBundleResultEventListener(bundleMessageHandler)
       }
     }
     worker.addBundleResultEventListener(bundleMessageHandler)
-    worker.sendInitMessage(typeDefinitions, projectContents)
+    worker.sendInitMessage(typeDefinitions, projectContents, jobID)
   })
 }

--- a/editor/src/core/workers/workers.ts
+++ b/editor/src/core/workers/workers.ts
@@ -29,7 +29,7 @@ export class UtopiaTsWorkersImplementation implements UtopiaTsWorkers {
   }
 
   sendInitMessage(typeDefinitions: TypeDefinitions, projectContents: ProjectContents) {
-    this.bundlerWorker.sendInitMessage(typeDefinitions, projectContents)
+    this.bundlerWorker.sendInitMessage(typeDefinitions, projectContents, null)
   }
 
   sendUpdateFileMessage(filename: string, content: FileContent) {


### PR DESCRIPTION
Fixes #408 

**Problem:**
When changing elements on the canvas the preview doesn't update or shows a previous version of the model.

**Fix:**
I noticed that `previewRender` has bundler results that are using promises without the id guard, there are incoming build result messages where the preview `createBundle` is already resolved.

**Commit Details:**
- create job ID outside of the worker
- added ID parameter to `sendInitMessage`
- the `OutgoingWorkerMessage` already has an ID
