### PR TITLE
Prevent code changes from triggering a double render.

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3306,7 +3306,7 @@ export const UPDATE_FNS = {
       projectContents: updatedProjectContents,
       canvas: {
         ...editor.canvas,
-        mountCount: editor.canvas.mountCount + 1,
+        mountCount: editor.canvas.mountCount + (isUIJSFile(file) ? 0 : 1),
       },
       nodeModules: {
         ...editor.nodeModules,


### PR DESCRIPTION
Fixes #422

**Problem:**
When the code is changed for a canvas file, the canvas renders twice. This was because the `mountCount` property incremented once on the code change and then again as the model was updated from the successful parse.

**Fix:**
Only perform the first `mountCount` if the file is not a canvas file.

**Commit Details:**
- Fixes #422.
- Prevent incrementing `mountCount` on a code change because it will be
  incremented by the model change later on.
