### PR TITLE
Align editor Inter variants with the website Inter variants

### DIFF
--- a/editor/src/templates/editor-entry-point.tsx
+++ b/editor/src/templates/editor-entry-point.tsx
@@ -34,7 +34,7 @@ const editorCSS = [
 ]
 
 const editorCSSDontHash = [
-  'https://fonts.googleapis.com/css?family=Inter&display=swap',
+  'https://fonts.googleapis.com/css?family=Inter:300,400,500,600,700&display=swap',
   'https://fonts.googleapis.com/css2?family=Inconsolata&display=swap',
 ]
 


### PR DESCRIPTION
Fixes #431

**Problem:**
Only one variant of Inter was included in the editor.

**Fix:**
Use the same set of variants the website uses for the editor.

**Commit Details:**
- Fixes #431.
- Added variants to the font in `editorCSSDontHash`.
