### PR TITLE
Inserting text into the void of the canvas fixed.

### DIFF
--- a/editor/src/core/shared/array-utils.ts
+++ b/editor/src/core/shared/array-utils.ts
@@ -273,3 +273,11 @@ export function immutablyUpdateArrayIndex<T>(
   working[indexToReplace] = newValue
   return working
 }
+
+export function safeIndex<T>(array: Array<T>, index: number): T | undefined {
+  if (index in array) {
+    return array[index]
+  } else {
+    return undefined
+  }
+}


### PR DESCRIPTION
Fixes #440

**Problem:**
When inserting the text element some logic attempted to construct a path using the parent path determined in the insert container, but TypeScript pretended the value wasn't `undefined` when it was which caused the path construction code to throw an exception.

**Fix:**
Created a `safeIndex` function for use when indexing into arrays and utilised it where the above error occurred which presented some small type errors that needed fixing.

**Commit Details:**
- Fixes #440.
- Added `safeIndex` utility method for arrays so that indexing into arrays
  can be properly typed.
- Used `safeIndex` in the `mouseDown` and `mouseUp` of `InsertModeControlContainer`
  when indexing into `highlightedViews`.
- Fixed errors from the previous change by aligning values back to null, invoking
  `getStoryboardTemplatePath` and adding a null check.
