### PR TITLE
remove autofocus

### DIFF
--- a/editor/.eslintrc.js
+++ b/editor/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
     },
   },
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'prettier', 'react', 'react-hooks'],
+  plugins: ['@typescript-eslint', 'prettier', 'react', 'react-hooks', 'jsx-a11y'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
@@ -160,6 +160,10 @@ module.exports = {
     '@typescript-eslint/prefer-interface': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/no-var-requires': 'off',
+    /** This is here to make sure we use refs to focus. Autofocus is meant to only be used
+     *  on one element, and acts inconsistently and dangerously otherwise.
+     */
+    'jsx-a11y/no-autofocus': 'error',
   },
   overrides: [
     {

--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -1485,7 +1485,6 @@
       "version": "7.10.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.3.tgz",
       "integrity": "sha512-HA7RPj5xvJxQl429r5Cxr2trJwOfPjKiqhCXcdQPSqO2G0RHPZpXu4fkYmBaTKCp2c/jRaMK9GB/lN+7zvvFPw==",
-      "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
@@ -5712,12 +5711,12 @@
       }
     },
     "aria-query": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
-      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
       "requires": {
-        "ast-types-flow": "0.0.7",
-        "commander": "^2.11.0"
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
       }
     },
     "arr-diff": {
@@ -5977,6 +5976,11 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
+    },
+    "axe-core": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
+      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q=="
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -8075,8 +8079,7 @@
     "core-js-pure": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
-      "dev": true
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -9181,7 +9184,8 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -9700,19 +9704,28 @@
       }
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
-      "integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",
+      "integrity": "sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==",
       "requires": {
-        "@babel/runtime": "^7.4.5",
-        "aria-query": "^3.0.0",
-        "array-includes": "^3.0.3",
+        "@babel/runtime": "^7.10.2",
+        "aria-query": "^4.2.2",
+        "array-includes": "^3.1.1",
         "ast-types-flow": "^0.0.7",
-        "axobject-query": "^2.0.2",
-        "damerau-levenshtein": "^1.0.4",
-        "emoji-regex": "^7.0.2",
+        "axe-core": "^3.5.4",
+        "axobject-query": "^2.1.2",
+        "damerau-levenshtein": "^1.0.6",
+        "emoji-regex": "^9.0.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.2.1"
+        "jsx-ast-utils": "^2.4.1",
+        "language-tags": "^1.0.5"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
+          "integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w=="
+        }
       }
     },
     "eslint-plugin-prettier": {
@@ -17121,6 +17134,19 @@
       "requires": {
         "inherits": "^2.0.1",
         "stream-splicer": "^2.0.0"
+      }
+    },
+    "language-subtag-registry": {
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz",
+      "integrity": "sha512-KPMwROklF4tEx283Xw0pNKtfTj1gZ4UByp4EsIFWLgBavJltF4TiYPc39k06zSTsLzxTVXXDSpbwaQXaFB4Qeg=="
+    },
+    "language-tags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
+      "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
+      "requires": {
+        "language-subtag-registry": "~0.3.2"
       }
     },
     "latest-version": {

--- a/editor/package.json
+++ b/editor/package.json
@@ -95,7 +95,7 @@
     "draft-js-custom-styles": "2.0.1",
     "eases": "1.0.8",
     "eslint-plugin-import": "2.20.1",
-    "eslint-plugin-jsx-a11y": "6.2.3",
+    "eslint-plugin-jsx-a11y": "6.3.1",
     "eslint-plugin-react": "7.18.0",
     "eslint-plugin-react-hooks": "2.5.0",
     "eslint4b": "6.6.0",

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -735,7 +735,7 @@ class FileBrowserItemInner extends React.PureComponent<
           >
             <StringInput
               value={this.state.addingChildName}
-              autoFocus
+              focusOnMount
               onKeyDown={this.inputLabelKeyDown}
               onChange={this.inputLabelChange}
               onBlur={this.abandonAddingFile}

--- a/editor/src/components/inspector/sections/header-section/target-selector.tsx
+++ b/editor/src/components/inspector/sections/header-section/target-selector.tsx
@@ -355,7 +355,7 @@ const TargetListItem = betterReactMemo('TargetListItem', (props: TargetListItemP
             onKeyDown={onRenameKeydown}
             onChange={onRenameChange}
             onBlurCapture={clearRenameState}
-            autoFocus
+            focusOnMount
             placeholder={itemLabel}
             defaultValue={renameValue !== null ? renameValue : undefined}
           />
@@ -466,7 +466,7 @@ const AddingRow = betterReactMemo('AddingRow', (props: AddingRowProps) => {
       <OnClickOutsideHOC onClickOutside={finishAdding}>
         <StringInput
           style={{ flexGrow: 1 }}
-          autoFocus
+          focusOnMount
           onKeyDown={onAddKeydown}
           onChange={onAddChange}
           value={value}

--- a/website/src/projects.tsx
+++ b/website/src/projects.tsx
@@ -143,6 +143,8 @@ export class Projects extends React.Component<{}, ProjectsState> {
     }
   }
 
+  inputRef: React.RefObject<HTMLInputElement>
+
   componentDidMount() {
     fetchProjectListFromLocalStorage().then((projects) => {
       var orderedProjects = projects.sort(function (a, b) {
@@ -173,6 +175,10 @@ export class Projects extends React.Component<{}, ProjectsState> {
     })
 
     window.addEventListener('keydown', this.keyHandler)
+
+    if (this.inputRef.current != null) {
+      this.inputRef.current.focus()
+    }
   }
 
   componentWillUnmount() {
@@ -387,7 +393,7 @@ export class Projects extends React.Component<{}, ProjectsState> {
             {this.state.mode === 'filter' ? (
               <div style={{ padding: layout.margins.wide, minHeight: '80px' }}>
                 <input
-                  autoFocus={true}
+                  ref={this.inputRef}
                   onChange={this.onFilterChange}
                   style={{
                     fontSize: 40,


### PR DESCRIPTION
The HTML autofocus attribute is meant to only be used on one element per document, and acts inconsistently and dangerously otherwise. More here:

html spec: https://www.w3.org/TR/html52/sec-forms.html#autofocusing-a-form-control-the-autofocus-attribute
explainer: https://blog.danieljohnson.io/react-ref-autofocus/

Removes `autofocus` from all inputs and replaces with a ref solution. For string inputs the `focusOnMount` suffices.

Adds an eslint rule to make sure this isn't done in the future.