### PR TITLE
Turn Resize Content into a proper checkbox

### DIFF
--- a/editor/src/components/common/size-warnings.ts
+++ b/editor/src/components/common/size-warnings.ts
@@ -1,0 +1,1 @@
+export const ChildWithPercentageSize = 'Dynamic scene has child with percentage size'

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -17,6 +17,7 @@ import { useScrollToThisIfSelected } from './scroll-to-element-if-selected-hook'
 import { EmptyScenePathForStoryboard } from '../../../core/model/scene-utils'
 import { WarningIcon } from '../../../uuiui/warning-icon'
 import { ElementWarnings } from '../../editor/store/editor-state'
+import { ChildWithPercentageSize } from '../../common/size-warnings'
 
 interface ComputedLook {
   style: React.CSSProperties
@@ -197,7 +198,7 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
 
     let warningText: string | null = null
     if (elementWarnings.dynamicSceneChildWidthHeightPercentage) {
-      warningText = 'Dynamic scene has child with percentage size'
+      warningText = ChildWithPercentageSize
     } else if (elementWarnings.widthOrHeightZero) {
       warningText = 'Missing width or height'
     } else if (elementWarnings.absoluteWithUnpositionedParent) {

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -269,8 +269,7 @@ export function isSceneElement(element: JSXElement): boolean {
   return element.name.baseVariable === 'Scene'
 }
 
-export function isDynamicSceneChildWidthHeightPercentage(scene: ComponentMetadata): boolean {
-  const isDynamicScene = scene.sceneResizesContent
+export function isSceneChildWidthHeightPercentage(scene: ComponentMetadata): boolean {
   const rootElementSizes = scene.rootElements.map((element) => {
     return {
       width: element.props?.style?.width,
@@ -278,8 +277,11 @@ export function isDynamicSceneChildWidthHeightPercentage(scene: ComponentMetadat
     }
   })
 
-  return (
-    isDynamicScene &&
-    rootElementSizes.some((size) => isPercentPin(size.width) || isPercentPin(size.height))
-  )
+  return rootElementSizes.some((size) => isPercentPin(size.width) || isPercentPin(size.height))
+}
+
+export function isDynamicSceneChildWidthHeightPercentage(scene: ComponentMetadata): boolean {
+  const isDynamicScene = scene.sceneResizesContent
+
+  return isDynamicScene && isSceneChildWidthHeightPercentage(scene)
 }


### PR DESCRIPTION
Fixes part of #407

**Problem:**
I forgot to turn the Resize Content button into a proper checkbox in the inspector.

**Fix:**
Turning it into a checkbox


