### PR TITLE
Handle cases where the project does not exist.

### DIFF
--- a/editor/src/components/editor/persistence.ts
+++ b/editor/src/components/editor/persistence.ts
@@ -506,14 +506,20 @@ export async function loadFromServer(
   dispatch: EditorDispatch,
   workers: UtopiaTsWorkers,
   renderEditorRoot: () => void,
+  renderProjectNotFound: () => void,
 ) {
   const project = await loadProject(projectId)
-  if (project.type === 'ProjectLoaded') {
-    _saveState = saved(true, Date.now(), projectId, project.title, dispatch, null, null, null)
-    _lastThumbnailGenerated = 0
-    await load(dispatch, project.content, project.title, projectId, workers, renderEditorRoot)
-  } else {
-    console.error(`Invalid project load response: ${project}`)
+  switch (project.type) {
+    case 'ProjectLoaded':
+      _saveState = saved(true, Date.now(), projectId, project.title, dispatch, null, null, null)
+      _lastThumbnailGenerated = 0
+      await load(dispatch, project.content, project.title, projectId, workers, renderEditorRoot)
+      break
+    case 'ProjectNotFound':
+      renderProjectNotFound()
+      break
+    default:
+      console.error(`Invalid project load response: ${project}`)
   }
 }
 

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -33,7 +33,11 @@ interface ProjectUnchanged {
   id: string
 }
 
-type LoadProjectResponse = ProjectLoaded | ProjectUnchanged
+interface ProjectNotFound {
+  type: 'ProjectNotFound'
+}
+
+type LoadProjectResponse = ProjectLoaded | ProjectUnchanged | ProjectNotFound
 
 interface SaveAssetResponse {
   id: string
@@ -105,6 +109,8 @@ export async function loadProject(
   })
   if (response.ok) {
     return response.json()
+  } else if (response.status === 404) {
+    return { type: 'ProjectNotFound' }
   } else {
     // FIXME Client should show an error if server requests fail
     throw new Error(`server responded with ${response.status} ${response.statusText}`)

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { hot } from 'react-hot-loader/root'
 import { unstable_trace as trace } from 'scheduler/tracing'
-import { updateCssVars } from 'uuiui'
+import { updateCssVars, UtopiaStyles } from 'uuiui'
 import create from 'zustand'
 import {
   getProjectID,
@@ -210,8 +210,16 @@ export class Editor {
                 renderRootComponent(this.utopiaStoreHook, this.utopiaStoreApi, this.spyCollector),
             )
           } else {
-            loadFromServer(projectId, this.boundDispatch, this.storedState.workers, () =>
-              renderRootComponent(this.utopiaStoreHook, this.utopiaStoreApi, this.spyCollector),
+            loadFromServer(
+              projectId,
+              this.boundDispatch,
+              this.storedState.workers,
+              () => {
+                renderRootComponent(this.utopiaStoreHook, this.utopiaStoreApi, this.spyCollector)
+              },
+              () => {
+                renderProjectNotFound()
+              },
             )
           }
         })
@@ -279,7 +287,7 @@ export const HotRoot: React.FunctionComponent<{
 })
 HotRoot.displayName = 'Utopia Editor Root'
 
-function renderRootComponent(
+async function renderRootComponent(
   useStore: UtopiaStoreHook,
   api: UtopiaStoreAPI,
   spyCollector: UiJsxCanvasContextData,
@@ -295,4 +303,34 @@ function renderRootComponent(
       )
     }
   })
+}
+
+export const ProjectNotFound = () => {
+  return (
+    <div
+      style={{
+        boxShadow: UtopiaStyles.shadowStyles.medium.boxShadow,
+        borderRadius: 3,
+        overflowWrap: 'break-word',
+        wordWrap: 'break-word',
+        hyphens: 'auto',
+        whiteSpace: 'normal',
+        maxWidth: 400,
+        width: 400,
+        padding: 12,
+        fontWeight: 500,
+        letterSpacing: 0.2,
+        margin: '5px',
+      }}
+    >
+      Project could not be found.
+    </div>
+  )
+}
+
+async function renderProjectNotFound(): Promise<void> {
+  const rootElement = document.getElementById(EditorID)
+  if (rootElement != null) {
+    ReactDOM.render(<ProjectNotFound />, rootElement)
+  }
 }


### PR DESCRIPTION
Fixes #470

**Problem:**
Currently if you load a project URL for a project that doesn't exist the loading page for the editor will just stay in view forever.

**Fix:**
When the editor attempts to load the project, if it doesn't exist it renders out some content that indicates the project could not be found.

**Limitations:**
- This is not a proper HTTP 404 page, as we eagerly load the editor code and don't particularly render any web content in the server which would be able to return a 404.
- The message about the project not being found effectively has no design.

**Commit Details:**
- Fixes #470.
- Added `ProjectNotFound` as an additional case to `LoadProjectResponse`.
- On a 404, `loadProject` returns the `ProjectNotFound` case instead of
  throwing an error.
- `loadFromServer` takes an additional parameter for what action to take
  when the project could not be found.
- Added `ProjectNotFound` component to `editor.tsx` which is rendered to
  the page when invoked by `renderProjectNotFound`.