### PR TITLE
add new font variants to project when selecting them from dropdown

### DIFF
--- a/editor/src/components/inspector/sections/style-section/text-subsection/font-variant-select.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/font-variant-select.tsx
@@ -3,16 +3,19 @@ import { OptionsType } from 'react-select'
 import { betterReactMemo } from 'uuiui-deps'
 import { googleFontsList } from '../../../../../../assets/google-fonts-list'
 import { identity } from '../../../../../core/shared/utils'
+import {
+  ExternalResources,
+  googleFontsResource,
+  useExternalResources,
+} from '../../../../../printer-parsers/html/external-resources-parser'
 import utils from '../../../../../utils/utils'
 import { PopupList, Tooltip } from '../../../../../uuiui'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import {
   defaultWebFontWeightsAndStyles,
   prettyNameForFontVariant,
-  WebFontVariant,
   WebFontFamilyVariant,
   webFontFamilyVariant,
-  webFontVariant,
 } from '../../../../navigator/external-resources/google-fonts-utils'
 import { addOnUnsetValues } from '../../../common/context-menu-items'
 import {
@@ -21,11 +24,6 @@ import {
   useInspectorInfo,
   useInspectorStyleInfo,
 } from '../../../common/property-path-hooks'
-import {
-  useExternalResources,
-  ExternalResources,
-  googleFontsResource,
-} from '../../../../../printer-parsers/html/external-resources-parser'
 
 const weightAndStylePaths: Array<'fontWeight' | 'fontStyle'> = ['fontWeight', 'fontStyle']
 


### PR DESCRIPTION
Fixes #457

**Problem:**
When a user selects a variant for a font, it may not be added to the project yet, and won't properly display.

**Fix:**
Selecting a variant checks to see if the variant is already added to the project, and adds it if it isn't.
