### PR TITLE
context menu items for resources

### DIFF
--- a/editor/src/components/navigator/external-resources/generic-external-resources-input.tsx
+++ b/editor/src/components/navigator/external-resources/generic-external-resources-input.tsx
@@ -47,8 +47,8 @@ export const GenericExternalResourcesInput = betterReactMemo(
     }, [])
 
     return (
-      <FlexRow>
-        <GridRow {...ResourcesListGridRowConfig}>
+      <FlexRow style={{ paddingLeft: 12, paddingRight: 8 }}>
+        <GridRow {...ResourcesListGridRowConfig} style={{ paddingRight: 8 }}>
           <StringInput
             ref={hrefInputRef}
             value={hrefValue}

--- a/editor/src/components/navigator/external-resources/generic-external-resources-list-item.tsx
+++ b/editor/src/components/navigator/external-resources/generic-external-resources-list-item.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react'
-import { GenericExternalResource } from '../../../printer-parsers/html/external-resources-parser'
-import { betterReactMemo } from '../../../uuiui-deps'
+import {
+  GenericExternalResource,
+  useExternalResources,
+  ExternalResources,
+} from '../../../printer-parsers/html/external-resources-parser'
+import { betterReactMemo, MomentumContextMenu } from '../../../uuiui-deps'
 import { GridRow } from '../../inspector/widgets/grid-row'
 import { ResourcesListGridRowConfig } from './generic-external-resources-list'
+import { MenuProvider } from 'react-contexify'
+import { ContextMenuItem } from '../../context-menu-items'
+import { NO_OP } from '../../../core/shared/utils'
 
 interface GenericExternalResourcesListItemProps {
   value: GenericExternalResource
@@ -10,35 +17,76 @@ interface GenericExternalResourcesListItemProps {
   setEditingIndex: React.Dispatch<number | null>
 }
 
+function indexedUpdateDeleteGenericResource(
+  index: number,
+  oldValue: ExternalResources,
+): ExternalResources {
+  const workingResources = [...oldValue.genericExternalResources]
+  workingResources.splice(index, 1)
+  return {
+    ...oldValue,
+    genericExternalResources: workingResources,
+  }
+}
+
 export const GenericExternalResourcesListItem = betterReactMemo<
   GenericExternalResourcesListItemProps
 >('GenericExternalResourcesListItem', ({ value, index, setEditingIndex }) => {
+  const { useSubmitValueFactory } = useExternalResources()
+  const [deleteResource] = useSubmitValueFactory(indexedUpdateDeleteGenericResource)
+
   const onDoubleClick = React.useCallback(() => {
     setEditingIndex(index)
   }, [index, setEditingIndex])
+
+  const menuId = `generic-external-resources-list-item-contextmenu-${index}`
+  const menuItems: Array<ContextMenuItem<any>> = [
+    {
+      name: 'Delete',
+      enabled: true,
+      action: () => {
+        deleteResource(index)
+      },
+    },
+    {
+      name: 'Rename',
+      enabled: true,
+      action: () => {
+        setEditingIndex(index)
+      },
+    },
+  ]
+
   return (
-    <GridRow {...ResourcesListGridRowConfig} onDoubleClick={onDoubleClick}>
-      <div
-        style={{
-          textOverflow: 'ellipsis',
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
-        }}
+    <MenuProvider id={menuId} storeRef={false}>
+      <GridRow
+        {...ResourcesListGridRowConfig}
+        style={{ paddingLeft: 12, paddingRight: 8 }}
+        onDoubleClick={onDoubleClick}
       >
-        {value.href}
-      </div>
-      <div
-        style={{
-          textOverflow: 'ellipsis',
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
-          textAlign: 'right',
-          fontStyle: 'italic',
-          paddingRight: 1,
-        }}
-      >
-        {value.rel}
-      </div>
-    </GridRow>
+        <div
+          style={{
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {value.href}
+        </div>
+        <div
+          style={{
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textAlign: 'right',
+            fontStyle: 'italic',
+            paddingRight: 1,
+          }}
+        >
+          {value.rel}
+        </div>
+        <MomentumContextMenu id={menuId} items={menuItems} getData={NO_OP} />
+      </GridRow>
+    </MenuProvider>
   )
 })

--- a/editor/src/components/navigator/external-resources/generic-external-resources-list.tsx
+++ b/editor/src/components/navigator/external-resources/generic-external-resources-list.tsx
@@ -24,7 +24,6 @@ import { GenericExternalResourcesListItem } from './generic-external-resources-l
 export const ResourcesListGridRowConfig: GridRowProps = {
   padded: false,
   type: '<-------auto------->|---60px---|',
-  style: { paddingLeft: 12, paddingRight: 8 },
 }
 
 function updatePushNewGenericResource(


### PR DESCRIPTION
Fixes #353

**Problem:**
Users couldn't delete generic external resources.

**Fix:**
Adds in a context menu that lets users delete or rename resources from the external resources pane.

**Commit Details:**
- adds context menu
- cleans up some grid system styling that was off