### PR TITLE
move dependencies actions to context menu

### DIFF
--- a/editor/src/components/navigator/dependency-list-input-field.tsx
+++ b/editor/src/components/navigator/dependency-list-input-field.tsx
@@ -122,7 +122,7 @@ export const DependencyListInputField = React.forwardRef(
             }
           >
             <StringInput
-              focusOnMount
+              focusOnMount={openVersionInput}
               value={Utils.defaultIfNull<string>('', stateEditedPackageVersion)}
               id='add-package-version'
               key='add-package-version'


### PR DESCRIPTION
Fixes #478

**Problem:**
The dependencies section has actions that appear on hover. They look a bit messy, don't appear in consistent places, won't scale well, and aren't immediately clear what they do.

**Fix:**
Move all actions to a context menu, with the exception of double-click to edit.

**Commit Details:**
- Context menu that lets users rename, delete, and update packages to latest version
- bug: double clicking on a dependency to rename now is limited to non-default packages, not the other way around
- bug: double clicking on a dependency to rename now focuses into the double-clicked title or version field