### PR TITLE
fix package.json

### DIFF
--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -22062,13 +22062,9 @@
       }
     },
     "react": {
-      "version": "17.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.0-rc.1.tgz",
-      "integrity": "sha512-sQ7X+k3zwf6cFQu9pD6FFJMwHwoKAV+EKLWRW4rD1ruyRiFkmC09cjtqFySLtaZbUdzYEc8iy4uOwisJNlXytg==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
+      "version": "npm:utopia-react@17.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/utopia-react/-/utopia-react-17.0.0-rc.1.tgz",
+      "integrity": "sha512-3IFdWHB//0To5Pqc+STTm850aZDkNS7dgnAa6Vv8Etge3e9uxhbNjwLwKH3FKaj9RW83blo4PMlzU91JL7LayA=="
     },
     "react-contexify": {
       "version": "4.1.1",
@@ -22453,19 +22449,20 @@
       }
     },
     "react-dom": {
-      "version": "17.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.0-rc.1.tgz",
-      "integrity": "sha512-MyWoPLxFUhSfIwFQa94Axm0h5IwzKJ3kzL7dxsW8iV36v881k+Lq7lVUN1+vDtBF0l51lkMe1mEITB3H5rinVg==",
+      "version": "npm:utopia-react-dom@17.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/utopia-react-dom/-/utopia-react-dom-17.0.0-rc.1.tgz",
+      "integrity": "sha512-Ay7N+izSxk4Qvpi8omYpX0bLQ1a2XDTL+TN8npTBXq9mN5TyOcFDuCE+P/oBVChQ0elQVzmHGrJfP3do1nfidg==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "0.20.0-rc.1"
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.18.0"
       },
       "dependencies": {
         "scheduler": {
-          "version": "0.20.0-rc.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.0-rc.1.tgz",
-          "integrity": "sha512-agEhMxvDawRBHGbx6k+poNuzZ6XD+/XTl67R42sdJ/+yeioNDxaDiwxqTT9MjpvVBBdEzRzvnUvAccueb8Eb2w==",
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+          "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"


### PR DESCRIPTION
Fixes the packages lock that was incorrectly pointing at facebook's react instead of our hand-rolled version. Our editor was then being built with facebook's react instead of ours, meaning error messages were minified in production.