### PR TITLE
fix checkbox input

### DIFF
--- a/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
+++ b/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
@@ -50,7 +50,7 @@ const FeatureSwitchRow = betterReactMemo('Feature Switch Row', (props: { name: F
   return (
     <StyledFlexRow>
       <CheckboxInput
-        style={{ display: 'flex', alignItems: 'center', marginRight: 4 }}
+        style={{ marginRight: 8 }}
         id={id}
         checked={isFeatureEnabled(name)}
         onChange={onChange}
@@ -88,7 +88,7 @@ export const SettingsPanel = (props: any) => {
       </StyledFlexRow>
       <StyledFlexRow>
         <CheckboxInput
-          style={{ display: 'flex', alignItems: 'center', marginRight: 4 }}
+          style={{ marginRight: 8 }}
           id='showCodeEditorLabel'
           checked={interfaceDesigner.codePaneVisible}
           onChange={toggleCodeEditorVisible}
@@ -97,7 +97,7 @@ export const SettingsPanel = (props: any) => {
       </StyledFlexRow>
       <StyledFlexRow>
         <CheckboxInput
-          style={{ display: 'flex', alignItems: 'center', marginRight: 4 }}
+          style={{ marginRight: 8 }}
           id='toggleInterfaceDesignerLayoutReversed'
           checked={interfaceDesigner.layoutReversed}
           onChange={toggleLayoutReversed}
@@ -106,7 +106,7 @@ export const SettingsPanel = (props: any) => {
       </StyledFlexRow>
       <StyledFlexRow>
         <CheckboxInput
-          style={{ display: 'flex', alignItems: 'center', marginRight: 4 }}
+          style={{ marginRight: 8 }}
           id='toggleInterfaceDesignerAdditionalCanvasControls'
           checked={interfaceDesigner.additionalControls}
           onChange={toggleAdditionalControls}

--- a/editor/src/uuiui/inputs/checkbox-input.tsx
+++ b/editor/src/uuiui/inputs/checkbox-input.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import composeRefs from '@seznam/compose-react-refs'
 import * as React from 'react'
-import { jsx, ObjectInterpolation } from '@emotion/core'
+import { jsx } from '@emotion/core'
 import {
   ControlStatus,
   getControlStyles,

--- a/editor/src/uuiui/inputs/checkbox-input.tsx
+++ b/editor/src/uuiui/inputs/checkbox-input.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import composeRefs from '@seznam/compose-react-refs'
 import * as React from 'react'
-import { jsx } from '@emotion/core'
+import { jsx, ObjectInterpolation } from '@emotion/core'
 import {
   ControlStatus,
   getControlStyles,
@@ -19,7 +19,7 @@ export interface CheckboxInputProps extends React.InputHTMLAttributes<HTMLInputE
 export const CheckboxInput = betterReactMemo(
   'CheckboxInput',
   React.forwardRef<HTMLInputElement, CheckboxInputProps>(
-    ({ controlStatus = 'simple', focusOnMount = false, ...props }, propsRef) => {
+    ({ controlStatus = 'simple', focusOnMount = false, style, ...props }, propsRef) => {
       const ref = React.useRef<HTMLInputElement>(null)
 
       const controlStyles: ControlStyles = getControlStyles(controlStatus)
@@ -36,51 +36,49 @@ export const CheckboxInput = betterReactMemo(
           : false
 
       return (
-        <div style={props.style}>
-          <input
-            {...props}
-            type='checkbox'
-            disabled={!controlStyles.interactive}
-            css={{
-              WebkitAppearance: 'none',
-              outline: 'none',
-              margin: '5px 2px',
-              boxShadow: `0 0 0 1px ${controlStyles.borderColor}`,
-              backgroundColor: controlStyles.backgroundColor,
-              borderRadius: UtopiaTheme.inputBorderRadius,
-              width: 12,
-              height: 12,
-              backgroundRepeat: 'no-repeat',
-              backgroundPosition: '55% 55%',
-              backgroundSize: '12px 12px',
-              cursor: controlStyles.interactive ? 'pointer' : 'default',
-              '&:checked': {
-                backgroundImage:
-                  'url("/editor/icons/light/controls/checkbox/checked-dark-12x12@2x.png")',
-              },
-              '&:focus': {
-                boxShadow: `0 0 0 1px ${UtopiaTheme.color.inspectorFocusedColor.value}`,
-              },
-              '&.widget-status-controlled': {
-                backgroundImage:
-                  'url("/editor/icons/light/controls/checkbox/checked-nodegraph-12x12@2x.png")',
-              },
-              '&:not(:checked)': {
-                backgroundImage: 'none',
-              },
-              '&:indeterminate': {
-                backgroundImage:
-                  'url("/editor/icons/light/controls/checkbox/mixed-dark-12x12@2x.png")',
-              },
-              '&.widget-status-off, &.widget-status-disabled': {
-                cursor: 'inherit',
-              },
-              ...(props.style as any), // The types between React and Emotion don't quite match up here so we shouldn't be doing this
-            }}
-            checked={checked}
-            ref={composeRefs(ref, propsRef)}
-          />
-        </div>
+        <input
+          {...props}
+          type='checkbox'
+          disabled={!controlStyles.interactive}
+          style={style}
+          css={{
+            WebkitAppearance: 'none',
+            outline: 'none',
+            margin: '5px 2px',
+            boxShadow: `0 0 0 1px ${controlStyles.borderColor}`,
+            backgroundColor: controlStyles.backgroundColor,
+            borderRadius: UtopiaTheme.inputBorderRadius,
+            width: 12,
+            height: 12,
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: '55% 55%',
+            backgroundSize: '12px 12px',
+            cursor: controlStyles.interactive ? 'pointer' : 'default',
+            '&:checked': {
+              backgroundImage:
+                'url("/editor/icons/light/controls/checkbox/checked-dark-12x12@2x.png")',
+            },
+            '&:focus': {
+              boxShadow: `0 0 0 1px ${UtopiaTheme.color.inspectorFocusedColor.value}`,
+            },
+            '&.widget-status-controlled': {
+              backgroundImage:
+                'url("/editor/icons/light/controls/checkbox/checked-nodegraph-12x12@2x.png")',
+            },
+            '&:not(:checked)': {
+              backgroundImage: 'none',
+            },
+            '&:indeterminate': {
+              backgroundImage:
+                'url("/editor/icons/light/controls/checkbox/mixed-dark-12x12@2x.png")',
+            },
+            '&.widget-status-off, &.widget-status-disabled': {
+              cursor: 'inherit',
+            },
+          }}
+          checked={checked}
+          ref={composeRefs(ref, propsRef)}
+        />
       )
     },
   ),


### PR DESCRIPTION
Fixes #489

**Problem:**
The checkbox input had its style prop used twice

**Commit Details:**
- style prop goes to the style prop, this fixes the type problem with the latest version of react and emotion
- only use props.style once (on the inputs style prop)
- fix styling that was being doubled up (marginRight used to be "4px", but that was being doubled
