### PR TITLE
Add an endpoint for downloading a github project

### DIFF
--- a/server/package.yaml
+++ b/server/package.yaml
@@ -27,6 +27,7 @@ dependencies:
   - exceptions
   - filepath
   - free
+  - github-rest
   - zlib
   - http-api-data
   - http-client

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -27,7 +27,6 @@ dependencies:
   - exceptions
   - filepath
   - free
-  - github-rest
   - zlib
   - http-api-data
   - http-client

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -344,6 +344,11 @@ editorAssetsEndpoint notProxiedPath possibleBranchName = do
     Just _          -> loadLocally
     Nothing         -> maybe loadLocally loadFromProxy possibleProxyManager
 
+downloadGithubProjectEndpoint :: Text -> Text -> ServerMonad BL.ByteString
+downloadGithubProjectEndpoint owner repo = do
+  zipball <- getGithubProject owner repo
+  return zipball
+
 monitoringEndpoint :: ServerMonad Value
 monitoringEndpoint = getMetrics
 
@@ -432,6 +437,7 @@ unprotected = authenticate
          :<|> loadProjectAssetEndpoint
          :<|> loadProjectAssetEndpoint
          :<|> loadProjectThumbnailEndpoint
+         :<|> downloadGithubProjectEndpoint
          :<|> monitoringEndpoint
          :<|> packagePackagerEndpoint
          :<|> getPackageJSONEndpoint

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -42,6 +42,7 @@ import           Utopia.Web.Database.Types
 import           Utopia.Web.Editor.Branches
 import           Utopia.Web.Endpoints
 import           Utopia.Web.Executors.Common
+import           Utopia.Web.Github
 import           Utopia.Web.ServiceTypes
 import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
@@ -232,6 +233,9 @@ innerServerExecutor (GetProxyManager action) = do
 innerServerExecutor (GetPackagerProxyManager action) = do
   manager <- fmap _packagerProxy ask
   return $ action manager
+innerServerExecutor (GetGithubProject owner repo action) = do
+  zipball <- liftIO $ fetchRepoArchive owner repo
+  return $ action zipball
 innerServerExecutor (GetMetrics action) = do
   store <- fmap _storeForMetrics ask
   sample <- liftIO $ sampleAll store

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -38,6 +38,7 @@ import qualified Utopia.Web.Database         as DB
 import           Utopia.Web.Editor.Branches
 import           Utopia.Web.Endpoints
 import           Utopia.Web.Executors.Common
+import           Utopia.Web.Github
 import           Utopia.Web.ServiceTypes
 import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
@@ -169,6 +170,9 @@ innerServerExecutor (GetProxyManager action) = do
 innerServerExecutor (GetPackagerProxyManager action) = do
   manager <- fmap _packagerProxy ask
   return $ action manager
+innerServerExecutor (GetGithubProject owner repo action) = do
+  zipball <- liftIO $ fetchRepoArchive owner repo
+  return $ action zipball
 innerServerExecutor (GetMetrics action) = do
   store <- fmap _storeForMetrics ask
   sample <- liftIO $ sampleAll store

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts  #-}
+
+module Utopia.Web.Github where
+
+import qualified Data.ByteString.Lazy      as BL
+import           Control.Lens              hiding ((.=), (<.>))
+import qualified Network.Wreq              as WR
+import           Protolude
+
+fetchRepoArchive :: Text -> Text -> IO BL.ByteString
+fetchRepoArchive owner repo = do
+  -- https://docs.github.com/en/rest/reference/repos#download-a-repository-archive
+  -- https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required
+  let options = WR.defaults & WR.header "User-Agent" .~ ["concrete-utopia/utopia"] & WR.header "Accept" .~ ["application/vnd.github.v3+json"]
+  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repo <> "/zipball/"
+  repoResult <- WR.getWith options (toS repoUrl)
+  return $ repoResult ^. WR.responseBody

--- a/server/src/Utopia/Web/Servant.hs
+++ b/server/src/Utopia/Web/Servant.hs
@@ -91,6 +91,17 @@ instance MimeUnrender SVG BL.ByteString where
 instance MimeUnrender HTML Text where
   mimeUnrender _ bytes = Right $ toS bytes
 
+data ZIP
+
+instance Accept ZIP where
+  contentType _ = "application" // "zip"
+
+instance MimeRender ZIP BL.ByteString where
+  mimeRender _ bytes = bytes
+
+instance MimeUnrender ZIP BL.ByteString where
+  mimeUnrender _ bytes = Right bytes
+
 
 data PrettyJSON
 

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -106,6 +106,7 @@ data ServiceCallsF a = NotFound
                      | GetProjectsForUser Text ([ProjectListing] -> a)
                      | GetShowcaseProjects ([ProjectListing] -> a)
                      | SetShowcaseProjects [Text] a
+                     | GetGithubProject Text Text (BL.ByteString -> a)
                      | GetMetrics (Value -> a)
                      | GetPackageJSON Text (Maybe Value -> a)
                      | GetPackageVersionJSON Text Text (Maybe Value -> a)

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -107,6 +107,8 @@ type LoadProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" Proje
 
 type SaveProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" ProjectIdWithSuffix :> ReqBody '[BMP, GIF, JPG, PNG, SVG] BL.ByteString :> Post '[JSON] NoContent
 
+type DownloadGithubProjectAPI = "v1" :> "github" :> Capture "owner" Text :> Capture "project" Text :> Get '[ZIP] BL.ByteString
+
 type PackagePackagerResponse = Headers '[Header "Cache-Control" Text, Header "Last-Modified" LastModifiedTime, Header "Access-Control-Allow-Origin" Text] BL.ByteString
 
 type PackagePackagerAPI = "v1" :> "javascript" :> "packager"
@@ -165,6 +167,7 @@ type Unprotected = AuthenticateAPI
               :<|> LoadProjectAssetAPI
               :<|> PreviewProjectAssetAPI
               :<|> LoadProjectThumbnailAPI
+              :<|> DownloadGithubProjectAPI
               :<|> MonitoringAPI
               :<|> PackagePackagerAPI
               :<|> GetPackageJSONAPI

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1b9d5ec207eeb055b866c5bbb80c43a8781ed46eb10bdecee7fa2911beb46361
+-- hash: 4cb1dd9fc27c79307d6b508d32cd9641e84c35cf054fd98a64b5d592aeff58d0
 
 name:           utopia-web
 version:        0.1.0.4
@@ -36,6 +36,7 @@ executable utopia-web
       Utopia.Web.Executors.Common
       Utopia.Web.Executors.Development
       Utopia.Web.Executors.Production
+      Utopia.Web.Github
       Utopia.Web.JSON
       Utopia.Web.Metrics
       Utopia.Web.Packager.NPM
@@ -73,6 +74,7 @@ executable utopia-web
     , exceptions
     , filepath
     , free
+    , github-rest
     , http-api-data
     , http-client
     , http-client-tls
@@ -145,6 +147,7 @@ test-suite utopia-web-test
       Utopia.Web.Executors.Common
       Utopia.Web.Executors.Development
       Utopia.Web.Executors.Production
+      Utopia.Web.Github
       Utopia.Web.JSON
       Utopia.Web.Metrics
       Utopia.Web.Packager.NPM
@@ -183,6 +186,7 @@ test-suite utopia-web-test
     , exceptions
     , filepath
     , free
+    , github-rest
     , hedgehog
     , hspec
     , http-api-data

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4cb1dd9fc27c79307d6b508d32cd9641e84c35cf054fd98a64b5d592aeff58d0
+-- hash: 59365a7cae4d2a726cdca15fd8fc3bfbf56f429e927cc5fe7295c4498d64fec9
 
 name:           utopia-web
 version:        0.1.0.4
@@ -74,7 +74,6 @@ executable utopia-web
     , exceptions
     , filepath
     , free
-    , github-rest
     , http-api-data
     , http-client
     , http-client-tls
@@ -186,7 +185,6 @@ test-suite utopia-web-test
     , exceptions
     , filepath
     , free
-    , github-rest
     , hedgehog
     , hspec
     , http-api-data


### PR DESCRIPTION
Fixes #491 

**Problem:**
There is no possible way for the client to download a github repo in the browser due to CORS constraints.

**Fix:**
Add an endpoint to the server to perform the download the repo instead.

**Commit Details:**
- Added `Github.hs` which currently only supplies a single function (for downloading the repo's default branch as a zipball)
- Defined a new endpoint in `Types.hs` and `Endpoints.hs` for exposing this functionality
- Made the relevant changes to `ServiceTypes.hs`, `Production.hs` and `Development.hs` to handle that new endpoint
