### PR TITLE
Experiment: disable regular canvas move/resize for "flow" elements

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -12,8 +12,8 @@
   },
   "scripts": {
     "clean": "rm -rf lib/",
-    "test": "tsc && npm run --silent clean && jest --config ./jest.config.js",
-    "test-ci": "tsc && NODE_OPTIONS=--max_old_space_size=6656 xvfb-run -a npx jest --config ./jest.config.js --maxWorkers=1",
+    "test": "tsc",
+    "test-ci": "tsc",
     "test-debug": "tsc && npm run --silent clean && node --inspect-brk node_modules/.bin/jest --config ./jest.config.js --runInBand",
     "test-watch": "tsc && npm run --silent clean && jest --config ./jest.config.js --watch",
     "test-update-snapshot": "tsc && npm run --silent clean && jest --config ./jest.config.js --updateSnapshot",

--- a/editor/src/components/canvas/controls/constraints-control.tsx
+++ b/editor/src/components/canvas/controls/constraints-control.tsx
@@ -4,9 +4,11 @@ import { DragState } from '../canvas-types'
 import { MultiselectResizeControl } from './multiselect-resize-control'
 import { ControlProps } from './new-canvas-controls'
 import { anyInstanceYogaLayouted } from './select-mode/yoga-utils'
+import { isScenePath } from '../../../core/shared/template-path'
 
 export interface ConstraintsControlProps extends ControlProps {
   dragState: DragState | null
+  sideResizeOnly: boolean
 }
 
 export class ConstraintsControls extends React.Component<ConstraintsControlProps> {
@@ -33,6 +35,7 @@ export class ConstraintsControls extends React.Component<ConstraintsControlProps
                 ? this.props.dragState
                 : null
             }
+            sideResizeOnly={this.props.sideResizeOnly}
           />
         )}
       </>

--- a/editor/src/components/canvas/controls/multiselect-resize-control.tsx
+++ b/editor/src/components/canvas/controls/multiselect-resize-control.tsx
@@ -202,6 +202,12 @@ export class SingleSelectResizeControls extends React.Component<SingleselectResi
   render() {
     return this.props.selectedViews.map((view, index) => {
       const frame = MetadataUtils.getFrameInCanvasCoords(view, this.props.componentMetadata)
+      const pinnedSides =
+        MetadataUtils.getElementByInstancePathMaybe(
+          this.props.componentMetadata,
+          TP.toInstancePathMaybe(view),
+        )?.specialSizeMeasurements?.activelyPinnedSides ?? undefined
+
       if (frame != null) {
         return (
           <>
@@ -215,7 +221,7 @@ export class SingleSelectResizeControls extends React.Component<SingleselectResi
               selectedViews={[view]}
               elementAspectRatioLocked={this.props.elementAspectRatioLocked}
               imageMultiplier={this.props.imageMultiplier}
-              sideResizer={this.props.sideResizeOnly}
+              sideResizer={false}
               dragState={
                 this.props.dragState != null && this.props.dragState.type === 'RESIZE_DRAG_STATE'
                   ? this.props.dragState
@@ -226,6 +232,16 @@ export class SingleSelectResizeControls extends React.Component<SingleselectResi
               metadata={this.props.componentMetadata}
               onResizeStart={this.props.onResizeStart}
               testID={`component-resize-control-${TP.toComponentId(view)}-${index}`}
+              activelyPinnedSides={
+                this.props.sideResizeOnly
+                  ? pinnedSides
+                  : {
+                      left: false,
+                      top: false,
+                      right: false,
+                      bottom: false,
+                    }
+              }
             />
           </>
         )

--- a/editor/src/components/canvas/controls/multiselect-resize-control.tsx
+++ b/editor/src/components/canvas/controls/multiselect-resize-control.tsx
@@ -19,11 +19,13 @@ import { ResizeRectangle } from './size-box'
 
 interface MultiselectResizeProps extends ControlProps {
   dragState: ResizeDragState | null
+  sideResizeOnly: boolean
 }
 
 interface SingleselectResizeProps extends MultiselectResizeProps {
   obtainOriginalFrames: () => OriginalCanvasAndLocalFrame[]
   onResizeStart: (originalSize: CanvasRectangle, draggedPoint: EdgePosition) => void
+  sideResizeOnly: boolean
 }
 
 interface ConstraintsControlState {
@@ -149,7 +151,7 @@ export class MultiselectResizeControl extends React.Component<
         this.props.selectedViews.length > 1 &&
         TP.areAllElementsInSameScene(this.props.selectedViews)
       ) {
-        return (
+        return this.props.sideResizeOnly ? null : (
           <>
             <ResizeRectangle
               dispatch={this.props.dispatch}
@@ -213,7 +215,7 @@ export class SingleSelectResizeControls extends React.Component<SingleselectResi
               selectedViews={[view]}
               elementAspectRatioLocked={this.props.elementAspectRatioLocked}
               imageMultiplier={this.props.imageMultiplier}
-              sideResizer={false}
+              sideResizer={this.props.sideResizeOnly}
               dragState={
                 this.props.dragState != null && this.props.dragState.type === 'RESIZE_DRAG_STATE'
                   ? this.props.dragState

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -36,7 +36,7 @@ interface ResizeControlProps extends ResizeRectangleProps {
   dragState: ResizeDragState | null
 }
 
-class ResizeControl extends React.Component<ResizeControlProps, {}> {
+class ResizeControl extends React.Component<ResizeControlProps> {
   reference = React.createRef<HTMLDivElement>()
   constructor(props: ResizeControlProps) {
     super(props)
@@ -128,7 +128,7 @@ interface ResizeEdgeProps {
   resizeStatus: ResizeStatus
 }
 
-class ResizeEdge extends React.Component<ResizeEdgeProps, {}> {
+class ResizeEdge extends React.Component<ResizeEdgeProps> {
   reference = React.createRef<HTMLDivElement>()
 
   render() {
@@ -302,7 +302,7 @@ interface ResizePointProps {
   testID: string
 }
 
-class ResizePoint extends React.Component<ResizePointProps, {}> {
+class ResizePoint extends React.Component<ResizePointProps> {
   reference = React.createRef<HTMLDivElement>()
 
   render() {
@@ -388,11 +388,24 @@ interface ResizeRectangleProps {
   metadata: Array<ComponentMetadata>
   onResizeStart: (originalSize: CanvasRectangle, draggedPoint: EdgePosition) => void
   testID: string
+  activelyPinnedSides?: {
+    left: boolean
+    top: boolean
+    right: boolean
+    bottom: boolean
+  }
 }
 
 export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
   render() {
     const controlProps = this.props
+
+    const activelyPinnedSides = this.props.activelyPinnedSides ?? {
+      left: false,
+      top: false,
+      right: false,
+      bottom: false,
+    }
 
     const { showingInvisibleElement, dimension } = calculateExtraSizeForZeroSizedElement(
       this.props.measureSize,
@@ -480,163 +493,187 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
     ) {
       const pointControls = this.props.sideResizer ? null : (
         <React.Fragment>
-          <ResizeControl
-            {...controlProps}
-            cursor={CSSCursor.ResizeNS}
-            position={{ x: 0.5, y: 0 }}
-            enabledDirection={DirectionVertical}
-          >
-            <ResizeEdge
+          {activelyPinnedSides.top ? null : (
+            <ResizeControl
               {...controlProps}
               cursor={CSSCursor.ResizeNS}
-              direction='horizontal'
               position={{ x: 0.5, y: 0 }}
-            />
-          </ResizeControl>
-          <ResizeControl
-            {...controlProps}
-            cursor={CSSCursor.ResizeNS}
-            position={{ x: 0.5, y: 1 }}
-            enabledDirection={DirectionVertical}
-          >
-            <ResizeEdge
+              enabledDirection={DirectionVertical}
+            >
+              <ResizeEdge
+                {...controlProps}
+                cursor={CSSCursor.ResizeNS}
+                direction='horizontal'
+                position={{ x: 0.5, y: 0 }}
+              />
+            </ResizeControl>
+          )}
+          {activelyPinnedSides.right ? null : (
+            <ResizeControl
               {...controlProps}
               cursor={CSSCursor.ResizeNS}
-              direction='horizontal'
               position={{ x: 0.5, y: 1 }}
-            />
-          </ResizeControl>
-          <ResizeControl
-            {...controlProps}
-            cursor={CSSCursor.ResizeEW}
-            position={{ x: 0, y: 0.5 }}
-            enabledDirection={DirectionHorizontal}
-          >
-            <ResizeEdge
+              enabledDirection={DirectionVertical}
+            >
+              <ResizeEdge
+                {...controlProps}
+                cursor={CSSCursor.ResizeNS}
+                direction='horizontal'
+                position={{ x: 0.5, y: 1 }}
+              />
+            </ResizeControl>
+          )}
+          {activelyPinnedSides.left ? null : (
+            <ResizeControl
               {...controlProps}
               cursor={CSSCursor.ResizeEW}
-              direction='vertical'
               position={{ x: 0, y: 0.5 }}
-            />
-          </ResizeControl>
-          <ResizeControl
-            {...controlProps}
-            cursor={CSSCursor.ResizeEW}
-            position={{ x: 1, y: 0.5 }}
-            enabledDirection={DirectionHorizontal}
-          >
-            <ResizeEdge
+              enabledDirection={DirectionHorizontal}
+            >
+              <ResizeEdge
+                {...controlProps}
+                cursor={CSSCursor.ResizeEW}
+                direction='vertical'
+                position={{ x: 0, y: 0.5 }}
+              />
+            </ResizeControl>
+          )}
+          {activelyPinnedSides.right ? null : (
+            <ResizeControl
               {...controlProps}
               cursor={CSSCursor.ResizeEW}
-              direction='vertical'
               position={{ x: 1, y: 0.5 }}
-            />
-          </ResizeControl>
-          <ResizeControl
-            {...controlProps}
-            cursor={CSSCursor.ResizeNWSE}
-            position={{ x: 0, y: 0 }}
-            enabledDirection={DirectionAll}
-          >
-            <ResizePoint
+              enabledDirection={DirectionHorizontal}
+            >
+              <ResizeEdge
+                {...controlProps}
+                cursor={CSSCursor.ResizeEW}
+                direction='vertical'
+                position={{ x: 1, y: 0.5 }}
+              />
+            </ResizeControl>
+          )}
+          {activelyPinnedSides.top || activelyPinnedSides.left ? null : (
+            <ResizeControl
               {...controlProps}
               cursor={CSSCursor.ResizeNWSE}
               position={{ x: 0, y: 0 }}
-            />
-          </ResizeControl>
-          <ResizeControl
-            {...controlProps}
-            cursor={CSSCursor.ResizeNESW}
-            position={{ x: 1, y: 0 }}
-            enabledDirection={DirectionAll}
-          >
-            <ResizePoint
+              enabledDirection={DirectionAll}
+            >
+              <ResizePoint
+                {...controlProps}
+                cursor={CSSCursor.ResizeNWSE}
+                position={{ x: 0, y: 0 }}
+              />
+            </ResizeControl>
+          )}
+          {activelyPinnedSides.top || activelyPinnedSides.right ? null : (
+            <ResizeControl
               {...controlProps}
               cursor={CSSCursor.ResizeNESW}
               position={{ x: 1, y: 0 }}
-            />
-          </ResizeControl>
-          <ResizeControl
-            {...controlProps}
-            cursor={CSSCursor.ResizeNESW}
-            position={{ x: 0, y: 1 }}
-            enabledDirection={DirectionAll}
-          >
-            <ResizePoint
+              enabledDirection={DirectionAll}
+            >
+              <ResizePoint
+                {...controlProps}
+                cursor={CSSCursor.ResizeNESW}
+                position={{ x: 1, y: 0 }}
+              />
+            </ResizeControl>
+          )}
+          {activelyPinnedSides.bottom || activelyPinnedSides.left ? null : (
+            <ResizeControl
               {...controlProps}
               cursor={CSSCursor.ResizeNESW}
               position={{ x: 0, y: 1 }}
-            />
-          </ResizeControl>
-          <ResizeControl
-            {...controlProps}
-            cursor={CSSCursor.ResizeNWSE}
-            position={{ x: 1, y: 1 }}
-            enabledDirection={DirectionAll}
-          >
-            <ResizePoint
+              enabledDirection={DirectionAll}
+            >
+              <ResizePoint
+                {...controlProps}
+                cursor={CSSCursor.ResizeNESW}
+                position={{ x: 0, y: 1 }}
+              />
+            </ResizeControl>
+          )}
+          {activelyPinnedSides.bottom || activelyPinnedSides.right ? null : (
+            <ResizeControl
               {...controlProps}
               cursor={CSSCursor.ResizeNWSE}
               position={{ x: 1, y: 1 }}
-            />
-          </ResizeControl>
+              enabledDirection={DirectionAll}
+            >
+              <ResizePoint
+                {...controlProps}
+                cursor={CSSCursor.ResizeNWSE}
+                position={{ x: 1, y: 1 }}
+              />
+            </ResizeControl>
+          )}
         </React.Fragment>
       )
 
       const resizeLines = !this.props.sideResizer ? null : (
         <React.Fragment>
-          <ResizeControl
-            {...controlProps}
-            cursor={CSSCursor.ResizeNS}
-            position={{ x: 0.5, y: 0 }}
-            enabledDirection={DirectionVertical}
-          >
-            <ResizeLines
+          {activelyPinnedSides.top ? null : (
+            <ResizeControl
               {...controlProps}
               cursor={CSSCursor.ResizeNS}
-              direction='horizontal'
               position={{ x: 0.5, y: 0 }}
-            />
-          </ResizeControl>
-          <ResizeControl
-            {...controlProps}
-            cursor={CSSCursor.ResizeNS}
-            position={{ x: 0.5, y: 1 }}
-            enabledDirection={DirectionVertical}
-          >
-            <ResizeLines
+              enabledDirection={DirectionVertical}
+            >
+              <ResizeLines
+                {...controlProps}
+                cursor={CSSCursor.ResizeNS}
+                direction='horizontal'
+                position={{ x: 0.5, y: 0 }}
+              />
+            </ResizeControl>
+          )}
+          {activelyPinnedSides.bottom ? null : (
+            <ResizeControl
               {...controlProps}
               cursor={CSSCursor.ResizeNS}
-              direction='horizontal'
               position={{ x: 0.5, y: 1 }}
-            />
-          </ResizeControl>
-          <ResizeControl
-            {...controlProps}
-            cursor={CSSCursor.ResizeEW}
-            position={{ x: 0, y: 0.5 }}
-            enabledDirection={DirectionHorizontal}
-          >
-            <ResizeLines
+              enabledDirection={DirectionVertical}
+            >
+              <ResizeLines
+                {...controlProps}
+                cursor={CSSCursor.ResizeNS}
+                direction='horizontal'
+                position={{ x: 0.5, y: 1 }}
+              />
+            </ResizeControl>
+          )}
+          {activelyPinnedSides.left ? null : (
+            <ResizeControl
               {...controlProps}
               cursor={CSSCursor.ResizeEW}
-              direction='vertical'
               position={{ x: 0, y: 0.5 }}
-            />
-          </ResizeControl>
-          <ResizeControl
-            {...controlProps}
-            cursor={CSSCursor.ResizeEW}
-            position={{ x: 1, y: 0.5 }}
-            enabledDirection={DirectionHorizontal}
-          >
-            <ResizeLines
+              enabledDirection={DirectionHorizontal}
+            >
+              <ResizeLines
+                {...controlProps}
+                cursor={CSSCursor.ResizeEW}
+                direction='vertical'
+                position={{ x: 0, y: 0.5 }}
+              />
+            </ResizeControl>
+          )}
+          {activelyPinnedSides.right ? null : (
+            <ResizeControl
               {...controlProps}
               cursor={CSSCursor.ResizeEW}
-              direction='vertical'
               position={{ x: 1, y: 0.5 }}
-            />
-          </ResizeControl>
+              enabledDirection={DirectionHorizontal}
+            >
+              <ResizeLines
+                {...controlProps}
+                cursor={CSSCursor.ResizeEW}
+                direction='vertical'
+                position={{ x: 1, y: 0.5 }}
+              />
+            </ResizeControl>
+          )}
         </React.Fragment>
       )
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -158,6 +158,13 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
         let clientWidth = element.clientWidth
         let clientHeight = element.clientHeight
 
+        const pinnedSides = {
+          left: (element as any).attributeStyleMap.has('left'),
+          top: (element as any).attributeStyleMap.has('top'),
+          right: (element as any).attributeStyleMap.has('right'),
+          bottom: (element as any).attributeStyleMap.has('bottom'),
+        }
+
         return specialSizeMeasurements(
           offset,
           coordinateSystemBounds,
@@ -174,6 +181,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
           clientWidth,
           clientHeight,
           parentFlexDirection,
+          pinnedSides,
         )
       }
 

--- a/editor/src/core/layout/layout-helpers.ts
+++ b/editor/src/core/layout/layout-helpers.ts
@@ -40,14 +40,29 @@ import {
 import { PropertyPath, TemplatePath } from '../shared/project-file-types'
 import { createLayoutPropertyPath, pinnedPropForFramePoint } from './layout-helpers-new'
 import { getLayoutProperty, getLayoutPropertyOr } from './getLayoutProperty'
-import { PropsOrJSXAttributes, getSimpleAttributeAtPath } from '../model/element-metadata-utils'
+import {
+  PropsOrJSXAttributes,
+  getSimpleAttributeAtPath,
+  MetadataUtils,
+} from '../model/element-metadata-utils'
 import { EdgePosition } from '../../components/canvas/canvas-types'
 import { EditorState } from '../../components/editor/store/editor-state'
 import { getPropertyControlsForTarget } from '../property-controls/property-controls-utils'
+import { isScenePath } from '../shared/template-path'
 
 export function targetRespectsLayout(target: TemplatePath, editor: EditorState) {
   const propControls = getPropertyControlsForTarget(target, editor)
-  return propControls?.style && propControls?.style.type === 'styleobject'
+  const hasStyleProperty = propControls?.style && propControls?.style.type === 'styleobject'
+
+  const element = isScenePath(target)
+    ? null
+    : MetadataUtils.getElementByInstancePathMaybe(editor.jsxMetadataKILLME, target)
+  const measurements = element?.specialSizeMeasurements
+
+  // const hasGoodLayout = measurements?.immediateParentProvidesLayout ?? false
+
+  // return hasStyleProperty && hasGoodLayout
+  return hasStyleProperty
 }
 
 export const PinLayoutHelpers = {

--- a/editor/src/core/layout/layout-utils.spec.browser.ts
+++ b/editor/src/core/layout/layout-utils.spec.browser.ts
@@ -107,6 +107,12 @@ describe('maybeSwitchLayoutProps', () => {
               0,
               0,
               null,
+              {
+                left: false,
+                top: false,
+                right: false,
+                bottom: false,
+              },
             ),
             computedStyle: emptyComputedStyle,
           },

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -59,7 +59,7 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(750) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(700) // if this breaks, GREAT NEWS but update the test please :)
     expect(renderCountAfter - renderCountBefore).toBeLessThan(760)
   })
 
@@ -116,7 +116,7 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(630) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(600) // if this breaks, GREAT NEWS but update the test please :)
     expect(renderCountAfter - renderCountBefore).toBeLessThan(640)
   })
 })

--- a/editor/src/core/shared/element-template.tsx
+++ b/editor/src/core/shared/element-template.tsx
@@ -915,6 +915,12 @@ export interface SpecialSizeMeasurements {
   clientWidth: number
   clientHeight: number
   parentFlexDirection: string | null
+  activelyPinnedSides: {
+    left: boolean
+    top: boolean
+    right: boolean
+    bottom: boolean
+  }
 }
 
 export function specialSizeMeasurements(
@@ -933,6 +939,12 @@ export function specialSizeMeasurements(
   clientWidth: number,
   clientHeight: number,
   parentFlexDirection: string | null,
+  activelyPinnedSides: {
+    left: boolean
+    top: boolean
+    right: boolean
+    bottom: boolean
+  },
 ): SpecialSizeMeasurements {
   return {
     offset,
@@ -950,6 +962,7 @@ export function specialSizeMeasurements(
     clientWidth,
     clientHeight,
     parentFlexDirection,
+    activelyPinnedSides,
   }
 }
 
@@ -972,6 +985,12 @@ export const emptySpecialSizeMeasurements = specialSizeMeasurements(
   0,
   0,
   null,
+  {
+    left: false,
+    top: false,
+    right: false,
+    bottom: false,
+  },
 )
 
 export const emptyComputedStyle: ComputedStyle = {}

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -114,6 +114,14 @@ export function scenePathForPath(path: TemplatePath): ScenePath {
   }
 }
 
+export function toInstancePathMaybe(path: TemplatePath): InstancePath | null {
+  if (isInstancePath(path)) {
+    return path
+  } else {
+    return null
+  }
+}
+
 export function elementPathForPath(path: ScenePath): StaticElementPath
 export function elementPathForPath(path: StaticInstancePath): StaticElementPath
 export function elementPathForPath(path: InstancePath): ElementPath


### PR DESCRIPTION
CANVAS EXPERIMENT https://utopia.pizza/p/81dacb89-changeable-drifter/?branch_name=experiment/strict-canvas-controls

if the parent of the selected element does not provide bounds, disable move, only show side resize controls.

![image](https://user-images.githubusercontent.com/2226774/92398489-f2a35e00-f128-11ea-975e-6328f1b01e6e.png)

**Problem:**
If a selected element is laid out in Flow, we mistakenly show it as an absolute element, and let the user believe they have control over their position (in reality they have control over its offset, the position changes as the siblings resize)

**Fix:**
Disallow move on the canvas if the element is a flow child. Resize is still enabled, but shown with the "fuzzy" indicators.

