### PR TITLE
Handle React hooks at the file root without the editor dying.

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -11112,6 +11112,38 @@ Object {
 }
 `;
 
+exports[`UiJsxCanvas runtime errors React.useEffect at the root fails usefully 1`] = `
+"<div
+  id=\\"canvas-container\\"
+  style=\\"
+    all: initial;
+    position: absolute;
+    zoom: 100%;
+    transform: translate3d(0px, 0px, 0);
+  \\"
+>
+  <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
+    data-utopia-valid-paths=\\"\\"
+    style=\\"
+      position: relative;
+      width: 400px;
+      height: 400px;
+      left: 0;
+      top: 0;
+      background-color: rgba(255, 255, 255, 1);
+      box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+    \\"
+    data-uid=\\"utopia-storyboard-uid\\"
+  >
+    hello!
+  </div>
+</div>
+"
+`;
+
+exports[`UiJsxCanvas runtime errors React.useEffect at the root fails usefully 2`] = `Object {}`;
+
 exports[`UiJsxCanvas runtime errors an arbitrary jsx attribute has correct source map 1`] = `
 Array [
   Object {

--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react'
 import { useEditorState } from '../editor/store/store-hook'
-import { UiJsxCanvas, pickUiJsxCanvasProps, CanvasReactErrorCallback } from './ui-jsx-canvas'
+import {
+  UiJsxCanvas,
+  pickUiJsxCanvasProps,
+  CanvasReactErrorCallback,
+  CanvasErrorBoundary,
+} from './ui-jsx-canvas'
 import { betterReactMemo } from 'uuiui-deps'
 import { saveDOMReport } from '../editor/actions/actions'
 import { ElementInstanceMetadata } from '../../core/shared/element-template'
@@ -32,12 +37,19 @@ export const CanvasComponentEntry = betterReactMemo(
         store.dispatch,
       ),
     }))
-    return (
-      <UiJsxCanvas
-        {...canvasProps}
-        clearErrors={props.clearErrors}
-        reportError={props.reportError}
-      />
-    )
+
+    if (canvasProps.uiFilePath == null) {
+      return null
+    } else {
+      return (
+        <CanvasErrorBoundary uiFilePath={canvasProps.uiFilePath} reportError={props.reportError}>
+          <UiJsxCanvas
+            {...canvasProps}
+            clearErrors={props.clearErrors}
+            reportError={props.reportError}
+          />
+        </CanvasErrorBoundary>
+      )
+    }
   },
 )

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -2044,4 +2044,32 @@ export var ${BakedInStoryboardVariableName} = (props) => {
 `,
     )
   })
+
+  it('React.useEffect at the root fails usefully', () => {
+    testCanvasRender(
+      null,
+      `
+import * as React from "react"
+import { View, jsx, Storyboard, Scene } from 'utopia-api'
+React.useEffect()
+export var App = (props) => {
+  return "hello!"
+}
+export var ${BakedInStoryboardVariableName} = (props) => {
+  return (
+    <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+      <Scene
+        static
+        style={{ left: 0, top: 0, width: 400, height: 400 }}
+        component={App}
+        layout={{ layoutSystem: 'pinSystem' }}
+        props={{ layout: { bottom: 0, left: 0, right: 0, top: 0 } }}
+        data-uid={'scene-aaa'}
+      />
+    </Storyboard>
+  )
+}
+`,
+    )
+  })
 })

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -321,7 +321,7 @@ function renderComponentUsingJsxFactoryFunction(
   ...children: Array<any>
 ): any {
   const fixedProps = fixStyleObjectRemoveCommentOnlyValues(props)
-  let factoryFunction: Function = React.createElement
+  let factoryFunction = React.createElement
   if (factoryFunctionName != null) {
     if (factoryFunctionName in inScope) {
       factoryFunction = inScope[factoryFunctionName]
@@ -585,7 +585,7 @@ export const UiJsxCanvas = betterReactMemo(
         }
 
         return (
-          <CanvasErrorBoundary uiFilePath={uiFilePath} reportError={props.reportError}>
+          <>
             <Helmet>{parse(linkTags)}</Helmet>
             <MutableUtopiaContext.Provider value={mutableContextRef}>
               <RerenderUtopiaContext.Provider
@@ -613,7 +613,7 @@ export const UiJsxCanvas = betterReactMemo(
                 </CanvasContainer>
               </RerenderUtopiaContext.Provider>
             </MutableUtopiaContext.Provider>
-          </CanvasErrorBoundary>
+          </>
         )
       } else {
         return null
@@ -1502,7 +1502,7 @@ function asErrorObject(e: unknown): Error {
   }
 }
 
-class CanvasErrorBoundary extends React.PureComponent<CanvasErrorBoundaryProps, {}> {
+export class CanvasErrorBoundary extends React.PureComponent<CanvasErrorBoundaryProps, unknown> {
   componentDidCatch(error: unknown, errorInfo: React.ErrorInfo) {
     this.props.reportError(this.props.uiFilePath, asErrorObject(error), errorInfo)
   }


### PR DESCRIPTION
Fixes #490

**Problem:**
If a user put a `React.useEffect()` call at the root of a canvas file, the entire editor would get unmounted by React.

**Fix:**
The error boundary didn't quite cover where the error occurred, but bizarrely sometimes wouldn't fail and would manifest as a hook invocation count change error. Moving the error boundary up one level captures the real error.

**Notes:**
Ordinarily this error in a non-Utopia situation would should an "invalid hook call" error, non-minified code will show `TypeError: create is not a function`. Ideally the proper React error would be shown but this will have to be addressed separately.

**Commit Details:**
- Fix #490.
- Shifted `CanvasErrorBoundary` up to the `CanvasComponentEntry` level from
  within `UiJsxCanvas`.
- Small tweaks relating to eslint updates.