### PR TITLE
Eager evaluation test.

### DIFF
--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -13,9 +13,28 @@ import {
   getSamplePreviewHTMLFile,
 } from '../core/model/new-project-files'
 import { codeFile, directory } from '../core/model/project-file-utils'
+import { ProjectContents } from '../core/shared/project-file-types'
 import { getSampleComponentsFile, getUiBuilderUIJSFile } from './ui-builder-ui-js-file'
 
 export const UI_BUILDER_PROJECT_ID = 'UI-BUILDER'
+
+let generatedFiles: ProjectContents = {}
+for (let index = 0; index < 2000; index++) {
+  const path = `/src/code${index}.js`
+  const code = `/** @jsx jsx */
+import * as React from 'react'
+import { Scene, Storyboard, jsx } from 'utopia-api'
+console.log('${path} executed')
+export var Component${index} = (props) => {
+  return (
+    <div
+      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
+      layout={{ layoutSystem: 'pinSystem' }}
+    />
+  )
+}`
+  generatedFiles[path] = codeFile(code, null)
+}
 
 export function defaultProject(): PersistentModel {
   const selectedTab: EditorTab = releaseNotesTab()
@@ -24,6 +43,7 @@ export function defaultProject(): PersistentModel {
     appID: null,
     projectVersion: CURRENT_PROJECT_VERSION,
     projectContents: {
+      ...generatedFiles,
       '/package.json': codeFile(JSON.stringify(DefaultPackageJson, null, 2), null),
       '/src': directory(),
       '/src/app.js': getDefaultUIJsFile(),


### PR DESCRIPTION
Several of the points in the issue #510 were already addressed in there.

This adds 2,000 files with a single React component in each, to the default project to magnify eager evaluation issues. The core results from this have been:
- The eager evaluation is surprisingly quick and only costs 2-3 seconds, however it does that on the main thread either ~30 seconds after startup or when first editing a file.
- If `codeResultCache` were shifted to only consist of modules executed by the canvas, the inspector wouldn't be dependent on the execution of all the modules. The navigator relies on exported modules calculated by one of the workers, so would not be effected by that. However, the insert menu relies on it being eagerly executed so would potentially need refactoring to use data from a worker to keep any eager evaluation of off the main thread.