### PR TITLE
Github Project Import

### DIFF
--- a/editor/src/components/editor/image-insert.ts
+++ b/editor/src/components/editor/image-insert.ts
@@ -1,7 +1,6 @@
-import { extractImage } from '../../utils/clipboard-utils'
+import { extractImage } from '../../core/shared/file-utils'
 import { EditorDispatch } from './action-types'
 import * as EditorActions from './actions/actions'
-import * as stringHash from 'string-hash'
 
 function handleImageSelected(
   files: FileList | null,
@@ -12,16 +11,14 @@ function handleImageSelected(
     const file = files[0]
     extractImage(file)
       .then((result) => {
-        const mimeStrippedBase64 = result.dataUrl.split(',')[1]
         const afterSave = createImageElement
           ? EditorActions.saveImageSwitchMode()
           : EditorActions.saveImageDoNothing()
-        const hash = stringHash(mimeStrippedBase64)
         const saveImageAction = EditorActions.saveAsset(
           `assets/${result.filename}`,
           file.type,
-          mimeStrippedBase64,
-          hash,
+          result.dataUrl,
+          result.hash,
           EditorActions.saveImageDetails(result.size, afterSave),
         )
         dispatch([saveImageAction], 'everyone')

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -53,7 +53,7 @@ import { useEditorState } from './store/store-hook'
 import { last } from '../../core/shared/array-utils'
 import { defaultIfNull } from '../../core/shared/optional-utils'
 import { forEachRight } from '../../core/shared/either'
-import { dropExtension } from '../../core/shared/string-utils'
+import { dropFileExtension } from '../../core/shared/file-utils'
 import { objectMap } from '../../core/shared/object-utils'
 import {
   defaultPropertiesForComponentInFile,
@@ -107,7 +107,7 @@ export const InsertMenu = betterReactMemo('InsertMenu', () => {
             const componentName = topLevelElement.name
             const defaultProps = defaultPropertiesForComponentInFile(
               componentName,
-              dropExtension(openFileFullPath),
+              dropFileExtension(openFileFullPath),
               store.editor.codeResultCache,
             )
             const detectedProps = topLevelElement.propsUsed

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1335,6 +1335,41 @@ export function persistentModelFromEditorModel(editor: EditorState): PersistentM
   }
 }
 
+export function persistentModelForProjectContents(
+  projectContents: ProjectContents,
+): PersistentModel {
+  const selectedTab: EditorTab = releaseNotesTab()
+
+  return {
+    appID: null,
+    projectVersion: CURRENT_PROJECT_VERSION,
+    projectContents: projectContents,
+    exportsInfo: [],
+    buildResult: {},
+    openFiles: [selectedTab],
+    selectedFile: selectedTab,
+    codeEditorErrors: {
+      buildErrors: {},
+      lintErrors: {},
+    },
+    codeEditorTheme: DefaultTheme,
+    lastUsedFont: null,
+    hiddenInstances: [],
+    fileBrowser: {
+      minimised: false,
+    },
+    dependencyList: {
+      minimised: false,
+    },
+    projectSettings: {
+      minimised: false,
+    },
+    navigator: {
+      minimised: false,
+    },
+  }
+}
+
 const defaultDependencies = Utils.mapArrayToDictionary(
   DefaultPackagesList,
   (p) => p.name,

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -46,7 +46,7 @@ import {
 import { useEditorState } from '../editor/store/store-hook'
 import { useKeepReferenceEqualityIfPossible } from '../inspector/common/property-path-hooks'
 import { FileBrowserItem } from './fileitem'
-import { dropExtension } from '../../core/shared/string-utils'
+import { dropFileExtension } from '../../core/shared/file-utils'
 import { objectMap } from '../../core/shared/object-utils'
 import { defaultPropertiesForComponentInFile } from '../../core/property-controls/property-controls-utils'
 
@@ -234,7 +234,7 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
           const fileVarSeparatorIdx = item.path.lastIndexOf('/')
           const exportVarName = item.path.slice(fileVarSeparatorIdx + 1)
           const filePath = item.path.slice(0, fileVarSeparatorIdx)
-          const filePathWithoutExtension = dropExtension(filePath)
+          const filePathWithoutExtension = dropFileExtension(filePath)
           const insertingToItself = openUiFileName === filePath
           const defaultProps = defaultPropertiesForComponentInFile(
             exportVarName,

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -5,7 +5,6 @@ import * as pathParse from 'path-parse'
 import * as R from 'ramda'
 import * as React from 'react'
 import { ConnectableElement, ConnectDragPreview, useDrag, useDrop } from 'react-dnd'
-import * as stringHash from 'string-hash'
 import {
   Button,
   colorTheme,
@@ -28,10 +27,11 @@ import { openFileTab } from '../editor/store/editor-state'
 import { ExpandableIndicator } from '../navigator/navigator-item/expandable-indicator'
 import { FileBrowserItemInfo, FileBrowserItemType } from './filebrowser'
 import { dropLeadingSlash } from './filepath-utils'
-import { FileResult, PasteResult } from '../../utils/clipboard-utils'
+import { PasteResult } from '../../utils/clipboard-utils'
 import { codeFile } from '../../core/model/project-file-utils'
 import { dragAndDropInsertionSubject, EditorModes } from '../editor/editor-modes'
 import { last } from '../../core/shared/array-utils'
+import { FileResult } from '../../core/shared/file-utils'
 import { WarningIcon } from '../../uuiui/warning-icon'
 
 export interface FileBrowserItemProps extends FileBrowserItemInfo {
@@ -472,16 +472,14 @@ class FileBrowserItemInner extends React.PureComponent<
         }
         switch (resultFile.type) {
           case 'IMAGE_RESULT': {
-            const mimeStrippedBase64 = resultFile.dataUrl.split(',')[1]
             const afterSave = EditorActions.saveImageReplace()
             if (targetPath != null) {
-              const hash = stringHash(mimeStrippedBase64)
               actions.push(
                 EditorActions.saveAsset(
                   targetPath,
                   resultFile.fileType,
-                  mimeStrippedBase64,
-                  hash,
+                  resultFile.dataUrl,
+                  resultFile.hash,
                   EditorActions.saveImageDetails(resultFile.size, afterSave),
                 ),
               )
@@ -489,16 +487,20 @@ class FileBrowserItemInner extends React.PureComponent<
             break
           }
           case 'ASSET_RESULT': {
-            const mimeStrippedBase64 = resultFile.dataUrl.split(',')[1]
             if (targetPath != null) {
               let fileType: string = ''
               const splitPath = targetPath.split('.')
               if (splitPath.length > 1) {
                 fileType = splitPath[splitPath.length - 1]
               }
-              const hash = stringHash(mimeStrippedBase64)
               actions.push(
-                EditorActions.saveAsset(targetPath, fileType, mimeStrippedBase64, hash, null),
+                EditorActions.saveAsset(
+                  targetPath,
+                  fileType,
+                  resultFile.dataUrl,
+                  resultFile.hash,
+                  null,
+                ),
               )
             }
             break

--- a/editor/src/components/inspector/sections/scene-inspector/scene-section.tsx
+++ b/editor/src/components/inspector/sections/scene-inspector/scene-section.tsx
@@ -28,7 +28,7 @@ import {
   isJSXAttributeOtherJavaScript,
   jsxAttributeOtherJavaScript,
 } from '../../../../core/shared/element-template'
-import { dropExtension } from '../../../../core/shared/string-utils'
+import { dropFileExtension } from '../../../../core/shared/file-utils'
 import { getWarningIconProps } from '../../../../uuiui/warning-icon'
 import {
   getOpenFilename,
@@ -89,7 +89,7 @@ export const SceneSection = betterReactMemo('SceneSection', () => {
           const componentName = component.name
           const defaultProps = defaultPropertiesForComponentInFile(
             componentName,
-            dropExtension(openFileFullPath),
+            dropFileExtension(openFileFullPath),
             codeResultCache,
           )
           const detectedProps = component.propsUsed

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -369,7 +369,16 @@ export function mimeTypeLookup(filename: string): string | false {
   }
 }
 
-export function fileTypeFromFileName(filename: string | null): ProjectFileType | null {
+type ProjectFileTypeExcludingDirectory = Exclude<ProjectFileType, 'DIRECTORY'>
+
+export function fileTypeFromFileName(filename: null): null
+export function fileTypeFromFileName(filename: string): ProjectFileTypeExcludingDirectory
+export function fileTypeFromFileName(
+  filename: string | null,
+): ProjectFileTypeExcludingDirectory | null
+export function fileTypeFromFileName(
+  filename: string | null,
+): ProjectFileTypeExcludingDirectory | null {
   if (filename == null) {
     return null
   }
@@ -378,7 +387,7 @@ export function fileTypeFromFileName(filename: string | null): ProjectFileType |
   } else {
     const mimeType = mimeTypeLookup(filename)
     if (mimeType === false) {
-      return null
+      return 'CODE_FILE' // FIXME This is definitely not a safe assumption
     } else {
       if (mimeType.startsWith('image/')) {
         return 'IMAGE_FILE'

--- a/editor/src/core/model/project-import.ts
+++ b/editor/src/core/model/project-import.ts
@@ -1,0 +1,133 @@
+import * as JSZip from 'jszip'
+import { JSZipObject } from 'jszip'
+import { isText } from 'istextorbinary'
+import { ProjectContents, RevisionsState } from '../shared/project-file-types'
+import {
+  assetFile,
+  codeFile,
+  directory,
+  fileTypeFromFileName,
+  imageFile,
+  uiJsFile,
+} from './project-file-utils'
+import { lintAndParse } from '../workers/parser-printer/parser-printer'
+import { assetResultForBase64, getFileExtension, imageResultForBase64 } from '../shared/file-utils'
+import { Size } from '../shared/math-utils'
+import { left } from '../shared/either'
+import { parseFailure } from '../workers/common/project-file-utils'
+
+async function attemptedTextFileLoad(fileName: string, file: JSZipObject): Promise<string | null> {
+  const fileBuffer = await file.async('nodebuffer')
+  if (isText(fileName, fileBuffer)) {
+    return file.async('string')
+  } else {
+    return null
+  }
+}
+
+export interface UnsavedAsset {
+  fileName: string
+  fileType: string
+  base64: string
+  hash: string
+  size: Size | null
+}
+
+export interface ProjectImportResult {
+  projectName: string
+  contents: ProjectContents
+  assetsToUpload: Array<UnsavedAsset>
+}
+
+export async function importZippedGitProject(
+  projectName: string,
+  zipped: JSZip,
+): Promise<ProjectImportResult> {
+  let loadedProject: ProjectContents = {}
+  let promises: Array<Promise<void>> = []
+  let assetsToUpload: Array<UnsavedAsset> = []
+
+  const loadFile = async (fileName: string, file: JSZip.JSZipObject) => {
+    const shiftedFileName = fileName.replace(/[^\/]*\//, '/') // Github uses the project name and a commit hash as the root directory
+    if (shiftedFileName.trim() === '/') {
+      // We don't need to create a root directory
+      return
+    }
+    if (file.dir) {
+      loadedProject[shiftedFileName] = directory()
+    } else {
+      const expectedFileType = fileTypeFromFileName(shiftedFileName)
+      switch (expectedFileType) {
+        case 'ASSET_FILE': {
+          const fileType = getFileExtension(shiftedFileName)
+          const base64 = await file.async('base64')
+          const assetResult = assetResultForBase64(shiftedFileName, base64)
+          assetsToUpload.push({
+            fileName: assetResult.filename,
+            fileType: fileType,
+            base64: assetResult.dataUrl,
+            hash: assetResult.hash,
+            size: null,
+          })
+          loadedProject[shiftedFileName] = assetFile()
+          break
+        }
+        case 'IMAGE_FILE': {
+          const fileType = getFileExtension(shiftedFileName)
+          const base64 = await file.async('base64')
+          const imageResult = await imageResultForBase64(shiftedFileName, fileType, base64)
+          assetsToUpload.push({
+            fileName: imageResult.filename,
+            fileType: fileType,
+            base64: imageResult.dataUrl,
+            hash: imageResult.hash,
+            size: imageResult.size,
+          })
+          loadedProject[shiftedFileName] = imageFile(
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            imageResult.hash,
+          )
+          break
+        }
+        case 'UI_JS_FILE':
+        case 'CODE_FILE':
+          const loadedFile = await attemptedTextFileLoad(shiftedFileName, file)
+          if (loadedFile == null) {
+            // FIXME Client should show an error if loading a text file fails
+            console.error(`Failed to parse file ${shiftedFileName} as a text file`)
+          } else {
+            if (expectedFileType === 'UI_JS_FILE') {
+              // TODO We really need a way to represent unparsed files, or a way to separate the parsed file from the contents
+              loadedProject[shiftedFileName] = uiJsFile(
+                left(parseFailure(null, null, null, [], loadedFile)),
+                null,
+                RevisionsState.BothMatch,
+                Date.now(),
+              )
+            } else {
+              loadedProject[shiftedFileName] = codeFile(loadedFile, null)
+            }
+          }
+          break
+        default:
+          const _exhaustiveCheck: never = expectedFileType
+          throw new Error(`Unknown file type ${expectedFileType}`)
+      }
+    }
+  }
+
+  zipped.forEach((fileName, file) => {
+    promises.push(loadFile(fileName, file))
+  })
+
+  await Promise.all(promises)
+
+  return {
+    projectName: projectName,
+    contents: loadedProject,
+    assetsToUpload: assetsToUpload,
+  }
+}

--- a/editor/src/core/shared/file-utils.ts
+++ b/editor/src/core/shared/file-utils.ts
@@ -1,0 +1,132 @@
+import * as stringHash from 'string-hash'
+import { Size } from './math-utils'
+
+export interface ImageResult {
+  type: 'IMAGE_RESULT'
+  filename: string
+  dataUrl: string
+  size: Size
+  fileType: string
+  hash: string
+}
+
+export interface AssetResult {
+  type: 'ASSET_RESULT'
+  filename: string
+  dataUrl: string
+  hash: string
+}
+
+export interface TextResult {
+  type: 'TEXT_RESULT'
+  filename: string
+  content: string
+}
+
+export type FileResult = ImageResult | AssetResult | TextResult
+
+export function extractText(file: File): Promise<TextResult> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = async () => {
+      const result: string = reader.result as string
+      resolve({
+        type: 'TEXT_RESULT',
+        filename: file.name,
+        content: result,
+      })
+    }
+    reader.onerror = (error) => {
+      reject(error)
+    }
+    reader.readAsText(file)
+  })
+}
+
+export function extractAsset(file: File): Promise<AssetResult> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = async () => {
+      const result = assetResultForBase64(file.name, reader.result as string)
+      resolve(result)
+    }
+    reader.onerror = (error) => {
+      reject(error)
+    }
+    reader.readAsDataURL(file)
+  })
+}
+
+export function assetResultForBase64(filename: string, base64: string): AssetResult {
+  const mimeStrippedBase64 = base64.split(',')[1]
+  const hash = stringHash(mimeStrippedBase64)
+  return {
+    type: 'ASSET_RESULT',
+    filename: filename,
+    dataUrl: mimeStrippedBase64,
+    hash: hash,
+  }
+}
+
+export function extractImage(file: File): Promise<ImageResult> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = async () => {
+      const result = await imageResultForBase64(file.name, file.type, reader.result as string)
+      resolve(result)
+    }
+    reader.onerror = (error) => {
+      reject(error)
+    }
+    reader.readAsDataURL(file)
+  })
+}
+
+export async function imageResultForBase64(
+  filename: string,
+  fileType: string,
+  base64: string,
+): Promise<ImageResult> {
+  const mimeStrippedBase64 = base64.split(',')[1]
+  const hash = stringHash(mimeStrippedBase64)
+  const imageSize = await getImageSize(base64)
+  return {
+    type: 'IMAGE_RESULT',
+    filename: filename,
+    dataUrl: mimeStrippedBase64,
+    size: imageSize,
+    fileType: fileType,
+    hash: hash,
+  }
+}
+
+function getImageSize(imageDataUrl: string): Promise<Size> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => {
+      resolve({
+        width: image.naturalWidth,
+        height: image.naturalHeight,
+      })
+    }
+    image.src = imageDataUrl
+  })
+}
+
+export function dropFileExtension(filename: string): string {
+  const lastDotIndex = filename.lastIndexOf('.')
+  if (lastDotIndex > 0) {
+    return filename.slice(0, lastDotIndex)
+  } else {
+    return filename
+  }
+}
+
+export function getFileExtension(filename: string): string {
+  const lastDotIndex = filename.lastIndexOf('.')
+  if (lastDotIndex > 0) {
+    return filename.slice(lastDotIndex)
+  } else {
+    return '' // TODO How do we handle files with no extension?
+  }
+}

--- a/editor/src/core/shared/string-utils.ts
+++ b/editor/src/core/shared/string-utils.ts
@@ -18,15 +18,6 @@ export function replaceAll(inString: string, searchFor: string, replaceWith: str
   return inString.split(searchFor).join(replaceWith)
 }
 
-export function dropExtension(filename: string): string {
-  const lastDotIndex = filename.lastIndexOf('.')
-  if (lastDotIndex > 0) {
-    return filename.slice(0, lastDotIndex)
-  } else {
-    return filename
-  }
-}
-
 export function camelCaseToDashed(s: string): string {
   return s.replace(/[A-Z]/g, (l) => `-${l.toLowerCase()}`)
 }

--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -1,11 +1,8 @@
-import { DefaultTheme } from '../components/code-editor/code-editor-themes'
-import { CURRENT_PROJECT_VERSION } from '../components/editor/actions/migrations/migrations'
 import {
   DefaultPackageJson,
-  EditorTab,
   openFileTab,
   PersistentModel,
-  releaseNotesTab,
+  persistentModelForProjectContents,
 } from '../components/editor/store/editor-state'
 import {
   getDefaultUIJsFile,
@@ -13,95 +10,47 @@ import {
   getSamplePreviewHTMLFile,
 } from '../core/model/new-project-files'
 import { codeFile, directory } from '../core/model/project-file-utils'
+import { ProjectContents } from '../core/shared/project-file-types'
 import { getSampleComponentsFile, getUiBuilderUIJSFile } from './ui-builder-ui-js-file'
 
 export const UI_BUILDER_PROJECT_ID = 'UI-BUILDER'
 
 export function defaultProject(): PersistentModel {
-  const selectedTab: EditorTab = releaseNotesTab()
-  const openFiles: Array<EditorTab> = [openFileTab('/src/app.js'), selectedTab]
-  return {
-    appID: null,
-    projectVersion: CURRENT_PROJECT_VERSION,
-    projectContents: {
-      '/package.json': codeFile(JSON.stringify(DefaultPackageJson, null, 2), null),
-      '/src': directory(),
-      '/src/app.js': getDefaultUIJsFile(),
-      '/assets': directory(),
-      '/public': directory(),
-      '/src/index.js': getSamplePreviewFile(),
-      '/public/index.html': getSamplePreviewHTMLFile(),
-    },
-    exportsInfo: [],
-    buildResult: {},
-    openFiles: openFiles,
-    selectedFile: selectedTab,
-    codeEditorErrors: {
-      buildErrors: {},
-      lintErrors: {},
-    },
-    codeEditorTheme: DefaultTheme,
-    lastUsedFont: null,
-    hiddenInstances: [],
-    fileBrowser: {
-      minimised: false,
-    },
-    dependencyList: {
-      minimised: false,
-    },
-    projectSettings: {
-      minimised: false,
-    },
-    navigator: {
-      minimised: false,
-    },
+  const projectContents: ProjectContents = {
+    '/package.json': codeFile(JSON.stringify(DefaultPackageJson, null, 2), null),
+    '/src': directory(),
+    '/src/app.js': getDefaultUIJsFile(),
+    '/assets': directory(),
+    '/public': directory(),
+    '/src/index.js': getSamplePreviewFile(),
+    '/public/index.html': getSamplePreviewHTMLFile(),
   }
+
+  let persistentModel = persistentModelForProjectContents(projectContents)
+  persistentModel.openFiles = [openFileTab('/src/app.js'), ...persistentModel.openFiles]
+  return persistentModel
 }
 
 function uiBuilderProject(): PersistentModel {
-  const selectedTab: EditorTab = releaseNotesTab()
-  const openFiles: Array<EditorTab> = [
+  const projectContents: ProjectContents = {
+    '/package.json': codeFile(JSON.stringify(DefaultPackageJson, null, 2), null),
+    '/src': directory(),
+    '/src/app.js': getUiBuilderUIJSFile(),
+    '/src/components.js': getSampleComponentsFile(),
+    '/assets': directory(),
+    '/public': directory(),
+    '/src/index.js': getSamplePreviewFile(),
+    '/public/index.html': getSamplePreviewHTMLFile(),
+  }
+
+  let persistentModel = persistentModelForProjectContents(projectContents)
+  persistentModel.openFiles = [
     openFileTab('/src/app.js'),
     openFileTab('/src/components.js'),
-    selectedTab,
+    ...persistentModel.openFiles,
   ]
-  return {
-    appID: null,
-    projectVersion: CURRENT_PROJECT_VERSION,
-    projectContents: {
-      '/package.json': codeFile(JSON.stringify(DefaultPackageJson, null, 2), null),
-      '/src': directory(),
-      '/src/app.js': getUiBuilderUIJSFile(),
-      '/src/components.js': getSampleComponentsFile(),
-      '/assets': directory(),
-      '/public': directory(),
-      '/src/index.js': getSamplePreviewFile(),
-      '/public/index.html': getSamplePreviewHTMLFile(),
-    },
-    exportsInfo: [],
-    buildResult: {},
-    openFiles: openFiles,
-    selectedFile: selectedTab,
-    codeEditorErrors: {
-      buildErrors: {},
-      lintErrors: {},
-    },
-    codeEditorTheme: DefaultTheme,
-    lastUsedFont: null,
-    hiddenInstances: [],
-    fileBrowser: {
-      minimised: false,
-    },
-    dependencyList: {
-      minimised: false,
-    },
-    projectSettings: {
-      minimised: false,
-    },
-    navigator: {
-      minimised: false,
-    },
-  }
+
+  return persistentModel
 }
 
 export interface SampleProject {

--- a/editor/src/templates/editor-canvas.ts
+++ b/editor/src/templates/editor-canvas.ts
@@ -74,7 +74,7 @@ import {
   WindowPoint,
   WindowRectangle,
 } from '../core/shared/math-utils'
-import { ImageResult } from '../utils/clipboard-utils'
+import { ImageResult } from '../core/shared/file-utils'
 import { fastForEach } from '../core/shared/utils'
 import { arrayToMaybe } from '../core/shared/optional-utils'
 

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -84,6 +84,13 @@ if (PROBABLY_ELECTRON) {
   webFrame.setLayoutZoomLevelLimits(0, 0)
 }
 
+function replaceLoadingMessage(newMessage: string) {
+  const loadingMessageElement = document.getElementById('loading-message')
+  if (loadingMessageElement != null) {
+    loadingMessageElement.innerHTML = newMessage
+  }
+}
+
 export class Editor {
   storedState: EditorStore
   utopiaStoreHook: UtopiaStoreHook
@@ -212,7 +219,9 @@ export class Editor {
                 console.error(repoResult.value)
               } else {
                 const projectName = `${githubOwner}-${githubRepo}`
+                replaceLoadingMessage('Downloading Repo...')
                 importZippedGitProject(projectName, repoResult.value).then((loadedProject) => {
+                  replaceLoadingMessage('Importing Project...')
                   createNewProjectFromImportedProject(
                     loadedProject,
                     this.storedState.workers,

--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -64,6 +64,7 @@
               </div>
               <div class="canvas flex-grow-2 relative  ">
                 <div
+                  id="loading-message"
                   class="absolute"
                   style="
                   bottom: 30px;

--- a/editor/src/utils/clipboard-utils.ts
+++ b/editor/src/utils/clipboard-utils.ts
@@ -1,27 +1,5 @@
+import { extractAsset, extractImage, extractText, FileResult } from '../core/shared/file-utils'
 import { CopyData } from './clipboard'
-import { Size } from '../core/shared/math-utils'
-
-export interface ImageResult {
-  type: 'IMAGE_RESULT'
-  filename: string
-  dataUrl: string
-  size: Size
-  fileType: string
-}
-
-export interface AssetResult {
-  type: 'ASSET_RESULT'
-  filename: string
-  dataUrl: string
-}
-
-export interface TextResult {
-  type: 'TEXT_RESULT'
-  filename: string
-  content: string
-}
-
-export type FileResult = ImageResult | AssetResult | TextResult
 
 export interface PasteResult {
   utopiaData: CopyData[]
@@ -69,75 +47,6 @@ function extractFiles(items: DataTransferItemList): Promise<Array<FileResult>> {
       }
     }),
   )
-}
-
-export function extractText(file: File): Promise<TextResult> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = async () => {
-      const result: string = reader.result as string
-      resolve({
-        type: 'TEXT_RESULT',
-        filename: file.name,
-        content: result,
-      })
-    }
-    reader.onerror = (error) => {
-      reject(error)
-    }
-    reader.readAsText(file)
-  })
-}
-
-export function extractImage(file: File): Promise<ImageResult> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = async () => {
-      const result: string = reader.result as string
-      const imageSize = await getImageSize(result)
-      resolve({
-        type: 'IMAGE_RESULT',
-        filename: file.name,
-        dataUrl: result,
-        size: imageSize,
-        fileType: file.type,
-      })
-    }
-    reader.onerror = (error) => {
-      reject(error)
-    }
-    reader.readAsDataURL(file)
-  })
-}
-
-export function extractAsset(file: File): Promise<AssetResult> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = async () => {
-      const result: string = reader.result as string
-      resolve({
-        type: 'ASSET_RESULT',
-        filename: file.name,
-        dataUrl: result,
-      })
-    }
-    reader.onerror = (error) => {
-      reject(error)
-    }
-    reader.readAsDataURL(file)
-  })
-}
-function getImageSize(imageDataUrl: string): Promise<Size> {
-  return new Promise((resolve, reject) => {
-    const image = new Image()
-    image.onload = () => {
-      resolve({
-        width: image.naturalWidth,
-        height: image.naturalHeight,
-      })
-    }
-    image.src = imageDataUrl
-  })
 }
 
 function filterNone(node: Node) {

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -1,5 +1,4 @@
 import * as R from 'ramda'
-import * as stringHash from 'string-hash'
 import { EditorAction } from '../components/editor/action-types'
 import * as EditorActions from '../components/editor/actions/actions'
 import { EditorModes } from '../components/editor/editor-modes'
@@ -10,16 +9,11 @@ import { findElementAtPath, MetadataUtils } from '../core/model/element-metadata
 import { ComponentMetadata } from '../core/shared/element-template'
 import { getUtopiaJSXComponentsFromSuccess } from '../core/model/project-file-utils'
 import { Imports, InstancePath, TemplatePath } from '../core/shared/project-file-types'
-import {
-  encodeUtopiaDataToHtml,
-  ImageResult,
-  parsePasteEvent,
-  PasteResult,
-  FileResult,
-} from './clipboard-utils'
+import { encodeUtopiaDataToHtml, parsePasteEvent, PasteResult } from './clipboard-utils'
 import { isLeft } from '../core/shared/either'
 import { setLocalClipboardData } from './local-clipboard'
 import Utils from './utils'
+import { FileResult, ImageResult } from '../core/shared/file-utils'
 import { CanvasPoint, CanvasRectangle } from '../core/shared/math-utils'
 import json5 = require('json5')
 import { fastForEach } from '../core/shared/utils'
@@ -127,7 +121,6 @@ export function createDirectInsertImageActions(
     return [
       EditorActions.switchEditorMode(EditorModes.selectMode()),
       ...Utils.flatMapArray((image) => {
-        const mimeStrippedBase64 = image.dataUrl.split(',')[1]
         const { frame, multiplier } = getFrameAndMultiplier(
           centerPoint,
           image.filename,
@@ -135,12 +128,11 @@ export function createDirectInsertImageActions(
           overrideDefaultMultiplier,
         )
         const insertWith = EditorActions.saveImageInsertWith(parentPath, frame, multiplier)
-        const hash = stringHash(mimeStrippedBase64)
         const saveImageAction = EditorActions.saveAsset(
           image.filename,
           image.fileType,
-          mimeStrippedBase64,
-          hash,
+          image.dataUrl,
+          image.hash,
           EditorActions.saveImageDetails(image.size, insertWith),
         )
         return [saveImageAction]

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -344,8 +344,8 @@ editorAssetsEndpoint notProxiedPath possibleBranchName = do
     Just _          -> loadLocally
     Nothing         -> maybe loadLocally loadFromProxy possibleProxyManager
 
-downloadGithubProjectEndpoint :: Text -> Text -> ServerMonad BL.ByteString
-downloadGithubProjectEndpoint owner repo = do
+downloadGithubProjectEndpoint :: Maybe Text -> Text -> Text -> ServerMonad BL.ByteString
+downloadGithubProjectEndpoint cookie owner repo = requireUser cookie $ \_ -> do
   zipball <- getGithubProject owner repo
   return zipball
 
@@ -439,6 +439,7 @@ protected authCookie = logoutPage authCookie
                   :<|> deleteProjectAssetEndpoint authCookie
                   :<|> saveProjectAssetEndpoint authCookie
                   :<|> saveProjectThumbnailEndpoint authCookie
+                  :<|> downloadGithubProjectEndpoint authCookie
 
 unprotected :: ServerT Unprotected ServerMonad
 unprotected = authenticate
@@ -455,7 +456,6 @@ unprotected = authenticate
          :<|> loadProjectAssetEndpoint
          :<|> loadProjectAssetEndpoint
          :<|> loadProjectThumbnailEndpoint
-         :<|> downloadGithubProjectEndpoint
          :<|> monitoringEndpoint
          :<|> packagePackagerEndpoint
          :<|> getPackageJSONEndpoint

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -162,6 +162,7 @@ type Protected = LogoutAPI
             :<|> DeleteProjectAssetAPI
             :<|> SaveProjectAssetAPI
             :<|> SaveProjectThumbnailAPI
+            :<|> DownloadGithubProjectAPI
 
 type Unprotected = AuthenticateAPI
               :<|> EmptyProjectPageAPI
@@ -177,7 +178,6 @@ type Unprotected = AuthenticateAPI
               :<|> LoadProjectAssetAPI
               :<|> PreviewProjectAssetAPI
               :<|> LoadProjectThumbnailAPI
-              :<|> DownloadGithubProjectAPI
               :<|> MonitoringAPI
               :<|> PackagePackagerAPI
               :<|> GetPackageJSONAPI


### PR DESCRIPTION
Fixes #494 
Fixes #495 

**Problem:**
We want to import and load a github project.

**Fix:**
Trigger a repo download when hitting the url `/p?github_owner=<owner>&github_repo=<repo>` as part of the editor start up. After downloading the repo, we iterate through the contents to generate a `ProjectContents` object, along with an array of assets to upload to the server. To handle the next stage, a `createNewProjectFromImportedProject` flow was added, which generates a `PersistentModel`, a project ID, and then uploads everything to the server.

A lot of this flow was forced by the fact local projects don't support arbitrary assets, meaning that to import a github project we require the user to be signed in so that the assets can be immediately uploaded.

**Commit Details:**
- Extracted some of the image and asset extraction logic to a new file `core/shared/file-utils.ts`, including the stripping of the mime type from the start of assets' base64 (we were already doing this everywhere)
- `downloadGithubRepo` in `server.ts` now returns a `Either` of the zipped response or an error message (rather than trying to do some project conversion)
- Added `project-import.ts` for iterating through a zipped git repo and creating the `ProjectContents` object, along with an array of assets to upload
- Added a helper function for creating `PersistentModel`s from a `ProjectContents`
- Made a very bad assumption that `fileTypeFromFileName` should return `'CODE_FILE'` for files with no extension, with a `FIXME` in place because that definitely needs changing
- Added `createNewProjectFromImportedProject` to `persistence.ts`, which forces a server save of the assets and project as part of the load
- Trigger the whole flow in `editor.tsx` when determining whether to create or load a project
- Restrict github project download on the server side to logged in users only to somewhat mitigate abuse

**Note** that this doesn't handle error cases very well at all, but that is due to be tackled in #509. ~This also just shows the regular loading animation until it is completed, which is due to be fixed in #495~ This now replaces the message in the loading screen to indicate what is happening.