### PR TITLE
Modifier key up in code editor updates correctly.

### DIFF
--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -765,7 +765,7 @@ export function handleKeyUp(
     updatedKeysPressed = updateKeysPressed(
       editor.keysPressed,
       key,
-      true,
+      false,
       Modifier.modifiersForKeyboardEvent(event),
     )
   }


### PR DESCRIPTION
**Problem:**
The wrong parameter was passed into `updateKeysPressed` for `isKeyDown`.

**Fix:**
Passed `false` instead of `true`.

**Commit Details:**
- Treats a modifier keyup when the code editor is focused as a keyup
  instead of a keydown.