### PR TITLE
GitHub Import Fixes Part 1

### DIFF
--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -119,7 +119,9 @@ export function mergeTrees(
 }
 
 export function getProjectContentKeyPathElements(projectContentKey: string): Array<string> {
-  return dropLeadingSlash(projectContentKey).split('/')
+  return dropLeadingSlash(projectContentKey)
+    .split('/')
+    .filter((s) => s.length > 0)
 }
 
 export function pathElementsToProjectContentKey(elements: Array<string>): string {

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -844,7 +844,6 @@ describe('LOAD', () => {
         [secondUIJSFile]: uiJsFile(initiailFileContents, null, RevisionsState.BothMatch, 0),
       },
       exportsInfo: [],
-      buildResult: {},
       openFiles: [],
       selectedFile: null,
       codeEditorErrors: {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4450,7 +4450,7 @@ export async function load(
     codeResultCache = generateCodeResultCache(
       model.projectContents,
       {},
-      model.buildResult,
+      {},
       model.exportsInfo,
       nodeModules,
       dispatch,

--- a/editor/src/components/editor/image-insert.ts
+++ b/editor/src/components/editor/image-insert.ts
@@ -17,7 +17,7 @@ function handleImageSelected(
         const saveImageAction = EditorActions.saveAsset(
           `assets/${result.filename}`,
           file.type,
-          result.dataUrl,
+          result.base64Bytes,
           result.hash,
           EditorActions.saveImageDetails(result.size, afterSave),
         )

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -86,7 +86,6 @@ import { CodeEditorTheme, DefaultTheme } from '../../code-editor/code-editor-the
 import { CursorPosition } from '../../code-editor/code-editor-utils'
 import { EditorPanel } from '../../common/actions/index'
 import {
-  codeCacheToBuildResult,
   CodeResultCache,
   generateCodeResultCache,
   PropertyControlsInfo,
@@ -936,7 +935,6 @@ export interface PersistentModel {
   appID?: string | null
   projectVersion: number
   projectContents: ProjectContents
-  buildResult: MultiFileBuildResult
   exportsInfo: ReadonlyArray<ExportsInfo>
   lastUsedFont: FontSettings | null
   hiddenInstances: Array<TemplatePath>
@@ -981,7 +979,6 @@ export function mergePersistentModel(
       ...second.projectContents,
     },
     exportsInfo: second.exportsInfo,
-    buildResult: second.buildResult,
     lastUsedFont: second.lastUsedFont,
     hiddenInstances: [...first.hiddenInstances, ...second.hiddenInstances],
     openFiles: second.openFiles,
@@ -1421,7 +1418,6 @@ export function persistentModelFromEditorModel(editor: EditorState): PersistentM
     appID: editor.appID,
     projectVersion: editor.projectVersion,
     projectContents: editor.projectContents,
-    buildResult: codeCacheToBuildResult(editor.codeResultCache.cache),
     exportsInfo: editor.codeResultCache.exportsInfo,
     lastUsedFont: editor.lastUsedFont,
     hiddenInstances: editor.hiddenInstances,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1450,7 +1450,6 @@ export function persistentModelForProjectContents(
     projectVersion: CURRENT_PROJECT_VERSION,
     projectContents: projectContents,
     exportsInfo: [],
-    buildResult: {},
     openFiles: [selectedTab],
     selectedFile: selectedTab,
     codeEditorErrors: {

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -478,7 +478,7 @@ class FileBrowserItemInner extends React.PureComponent<
                 EditorActions.saveAsset(
                   targetPath,
                   resultFile.fileType,
-                  resultFile.dataUrl,
+                  resultFile.base64Bytes,
                   resultFile.hash,
                   EditorActions.saveImageDetails(resultFile.size, afterSave),
                 ),
@@ -497,7 +497,7 @@ class FileBrowserItemInner extends React.PureComponent<
                 EditorActions.saveAsset(
                   targetPath,
                   fileType,
-                  resultFile.dataUrl,
+                  resultFile.base64Bytes,
                   resultFile.hash,
                   null,
                 ),

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -1,8 +1,8 @@
 import * as MimeTypes from 'mime-types'
 import * as pathParse from 'path-parse'
 import * as R from 'ramda'
-import { NormalisedFrame } from 'utopia-api'
 import * as PP from '../shared/property-path'
+import { isText } from 'istextorbinary'
 import { intrinsicHTMLElementNamesAsStrings } from '../shared/dom-utils'
 import Utils from '../../utils/utils'
 import { bimapEither, foldEither, mapEither } from '../shared/either'
@@ -385,15 +385,14 @@ export function fileTypeFromFileName(
   if (filename.endsWith('src/app.js')) {
     return 'UI_JS_FILE'
   } else {
-    const mimeType = mimeTypeLookup(filename)
-    if (mimeType === false) {
-      return 'CODE_FILE' // FIXME This is definitely not a safe assumption
+    if (isText(filename)) {
+      return 'CODE_FILE'
     } else {
-      if (mimeType.startsWith('image/')) {
+      const mimeType = mimeTypeLookup(filename)
+      if (mimeType === false) {
+        return 'CODE_FILE' // FIXME This is definitely not a safe assumption
+      } else if (mimeType.startsWith('image/')) {
         return 'IMAGE_FILE'
-      } else if (mimeType.startsWith('application/') || mimeType.startsWith('text/')) {
-        // Note for future us: The 'application/' prefix is possibly a bit wide.
-        return 'CODE_FILE'
       } else {
         return 'ASSET_FILE'
       }

--- a/editor/src/core/model/project-import.ts
+++ b/editor/src/core/model/project-import.ts
@@ -106,7 +106,7 @@ export async function importZippedGitProject(
           assetsToUpload.push({
             fileName: assetResult.filename,
             fileType: fileType,
-            base64: assetResult.dataUrl,
+            base64: assetResult.base64Bytes,
             hash: assetResult.hash,
             size: null,
           })
@@ -120,7 +120,7 @@ export async function importZippedGitProject(
           assetsToUpload.push({
             fileName: imageResult.filename,
             fileType: fileType,
-            base64: imageResult.dataUrl,
+            base64: imageResult.base64Bytes,
             hash: imageResult.hash,
             size: imageResult.size,
           })

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -46,9 +46,16 @@ export type Ellipse = {
   ry: number
 }
 
-export type Size = {
+export interface Size {
   width: number
   height: number
+}
+
+export function size(width: number, height: number): Size {
+  return {
+    width: width,
+    height: height,
+  }
 }
 
 export type RectangleInner = {
@@ -210,13 +217,13 @@ export function rectSize(rectangle: Rectangle<any>): Size {
 
 export function setRectSize<C extends CoordinateMarker>(
   rectangle: Rectangle<C>,
-  size: Size,
+  sizeToSet: Size,
 ): Rectangle<C> {
   return {
     x: rectangle.x,
     y: rectangle.y,
-    width: size.width,
-    height: size.height,
+    width: sizeToSet.width,
+    height: sizeToSet.height,
   } as Rectangle<C>
 }
 
@@ -505,10 +512,10 @@ export function stretchRect<C extends CoordinateMarker>(
   } as Rectangle<C>)
 }
 
-export function scaleSize(size: Size, by: number): Size {
+export function scaleSize(sizeToScale: Size, by: number): Size {
   return {
-    width: size.width * by,
-    height: size.height * by,
+    width: sizeToScale.width * by,
+    height: sizeToScale.height * by,
   }
 }
 
@@ -648,10 +655,10 @@ export function rectFromPointVector<C extends CoordinateMarker>(
   return normalizeRect(rectangle)
 }
 
-export function rectSizeToVector<C extends CoordinateMarker>(size: Size): Point<C> {
+export function rectSizeToVector<C extends CoordinateMarker>(sizeOfVector: Size): Point<C> {
   return {
-    x: size.width,
-    y: size.height,
+    x: sizeOfVector.width,
+    y: sizeOfVector.height,
   } as Point<C>
 }
 

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -250,18 +250,9 @@ export class Editor {
                   })
               }
             })
+          } else if (githubOwner != null && githubRepo != null) {
+            renderProjectLoadError('Github repo import is only supported for logged in users')
           } else {
-            if (githubOwner != null && githubRepo != null) {
-              this.boundDispatch(
-                [
-                  EditorActions.showToast({
-                    message: 'Please log in to fork a github repo',
-                  }),
-                ],
-                'everyone',
-              )
-            }
-
             createNewProject(this.boundDispatch, () =>
               renderRootComponent(
                 this.utopiaStoreHook,

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -225,8 +225,8 @@ export class Editor {
               } else {
                 const projectName = `${githubOwner}-${githubRepo}`
                 replaceLoadingMessage('Downloading Repo...')
-                importZippedGitProject(projectName, repoResult.value).then(
-                  (importProjectResult) => {
+                importZippedGitProject(projectName, repoResult.value)
+                  .then((importProjectResult) => {
                     if (isProjectImportSuccess(importProjectResult)) {
                       replaceLoadingMessage('Importing Project...')
                       createNewProjectFromImportedProject(
@@ -244,8 +244,10 @@ export class Editor {
                     } else {
                       renderProjectLoadError(importProjectResult.errorMessage)
                     }
-                  },
-                )
+                  })
+                  .catch((err) => {
+                    console.error('Import error.', err)
+                  })
               }
             })
           } else {

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -131,7 +131,7 @@ export function createDirectInsertImageActions(
         const saveImageAction = EditorActions.saveAsset(
           image.filename,
           image.fileType,
-          image.dataUrl,
+          image.base64Bytes,
           image.hash,
           EditorActions.saveImageDetails(image.size, insertWith),
         )


### PR DESCRIPTION
Fixes a load of issues with Github importing that affected importing as a whole. We have just bundled these together, since they were mostly and minor fixes.

**Fixes:**
- Mime type to file type assumption was too broad for text files, so we are now using an `isText` check first
- Image extraction was misleading and broken in some cases since it was assuming a a data URL, but was actually using base64 bytes
- When measuring the size of the imported image we needed the data URL so we now craft that from the base64
- SVGs don't have a size, so we (for now) give them an arbitrary size (this needs to be addressed, but not as part of this track)
- The file browser was incorrectly rendering extra empty directories for directories specified with a trailing slash (so e.g. `/src` would render as one directory in the file browser, whereas `/src/` would render as two)
- Removed the build result from the `PersistentModel`, since that massively inflates the size of the JSON we store on the server for no real gain
- Attempting to import a github repo when not logged in now fails more explicitly, rendering the error message screen, rather than failing silently (with a toast) and creating an empty project.