### PR TITLE
Separate requested and resolved dependencies.

### DIFF
--- a/editor/src/components/code-editor/code-editor.tsx
+++ b/editor/src/components/code-editor/code-editor.tsx
@@ -10,7 +10,7 @@ import {
   ProjectContents,
   TemplatePath,
 } from '../../core/shared/project-file-types'
-import { TypeDefinitions, NpmDependency } from '../../core/shared/npm-dependency-types'
+import { TypeDefinitions, ResolvedNpmDependency, PossiblyUnversionedNpmDependency } from '../../core/shared/npm-dependency-types'
 import { ConsoleLog } from '../editor/store/editor-state'
 import { CodeEditorTheme } from './code-editor-themes'
 import {
@@ -38,7 +38,7 @@ export interface CodeEditorProps {
   enabled: boolean
   autoSave: boolean
   npmTypeDefinitions: {
-    npmDependencies: Array<NpmDependency>
+    npmDependencies: Array<PossiblyUnversionedNpmDependency>
     typeDefinitions: TypeDefinitions
   }
   allErrors: Array<ErrorMessage> | null

--- a/editor/src/components/code-editor/script-editor.tsx
+++ b/editor/src/components/code-editor/script-editor.tsx
@@ -30,7 +30,7 @@ import { runtimeErrorInfoToErrorMessage } from './monaco-wrapper'
 import { EditorPanel, setFocus } from '../common/actions'
 import { EditorAction } from '../editor/action-types'
 import * as EditorActions from '../editor/actions/actions'
-import { dependenciesFromPackageJson } from '../editor/npm-dependency/npm-dependency'
+import { dependenciesFromPackageJson, usePossiblyResolvedPackageDependencies } from '../editor/npm-dependency/npm-dependency'
 import {
   ConsoleLog,
   EditorStore,
@@ -348,8 +348,7 @@ export const ScriptEditor = betterReactMemo('ScriptEditor', (props: ScriptEditor
   const newErrorsForFile = errors.filter((error) => error.fileName === filePath)
   const errorsForFile = useKeepReferenceEqualityIfPossible(newErrorsForFile)
 
-  const newNpmDependencies = dependenciesFromPackageJson(packageJsonFile)
-  const npmDependencies = useKeepReferenceEqualityIfPossible(newNpmDependencies)
+  const npmDependencies = usePossiblyResolvedPackageDependencies()
 
   if (filePath == null || openFile == null) {
     return null

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -1,5 +1,4 @@
 import Utils from '../../utils/utils'
-import { RequireFn, NpmDependency } from '../../core/shared/npm-dependency-types'
 import {
   ExportType,
   ExportsInfo,

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -35,7 +35,7 @@ import { LeftMenuTab } from '../navigator/left-pane'
 import { RightMenuTab } from '../canvas/right-menu'
 import { Mode } from './editor-modes'
 import type {
-  NpmDependency,
+  RequestedNpmDependency,
   PackageStatusMap,
   PackageStatus,
 } from '../../core/shared/npm-dependency-types'
@@ -730,7 +730,7 @@ export interface UpdateNodeModulesContents {
 
 export interface UpdatePackageJson {
   action: 'UPDATE_PACKAGE_JSON'
-  dependencies: Array<NpmDependency>
+  dependencies: Array<RequestedNpmDependency>
 }
 
 export interface StartCheckpointTimer {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -113,10 +113,9 @@ import {
 import type {
   RequireFn,
   TypeDefinitions,
-  npmDependency,
-  NpmDependency,
   PackageStatus,
   PackageStatusMap,
+  RequestedNpmDependency,
 } from '../../../core/shared/npm-dependency-types'
 import {
   InstancePath,
@@ -4049,13 +4048,13 @@ export const UPDATE_FNS = {
   },
   UPDATE_PACKAGE_JSON: (action: UpdatePackageJson, editor: EditorState): EditorState => {
     const dependencies = action.dependencies.reduce(
-      (acc: Array<NpmDependency>, curr: NpmDependency) => {
+      (acc: Array<RequestedNpmDependency>, curr: RequestedNpmDependency) => {
         return {
           ...acc,
           [curr.name]: curr.version,
         }
       },
-      {} as Array<NpmDependency>,
+      [] as Array<RequestedNpmDependency>,
     )
     return updateDependenciesInEditorState(editor, dependencies)
   },
@@ -5485,7 +5484,7 @@ export function updateNodeModulesContents(
   }
 }
 
-export function updatePackageJson(dependencies: Array<NpmDependency>): UpdatePackageJson {
+export function updatePackageJson(dependencies: Array<RequestedNpmDependency>): UpdatePackageJson {
   return {
     action: 'UPDATE_PACKAGE_JSON',
     dependencies: dependencies,

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -60,10 +60,10 @@ import {
   findMissingDefaultsAndGetWarning,
 } from '../../core/property-controls/property-controls-utils'
 import { WarningIcon } from '../../uuiui/warning-icon'
-import { useResolvedPackageDependencies } from './npm-dependency/npm-dependency'
+import { usePossiblyResolvedPackageDependencies } from './npm-dependency/npm-dependency'
 import {
   PossiblyUnversionedNpmDependency,
-  isNpmDependency,
+  isResolvedNpmDependency,
   PackageStatusMap,
   PackageStatus,
 } from '../../core/shared/npm-dependency-types'
@@ -136,7 +136,7 @@ export const InsertMenu = betterReactMemo('InsertMenu', () => {
     }
   })
 
-  const dependencies = useResolvedPackageDependencies()
+  const dependencies = usePossiblyResolvedPackageDependencies()
 
   const propsWithDependencies: InsertMenuProps = {
     ...props,
@@ -435,7 +435,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
           </InsertGroup>
         )}
         {this.props.dependencies.map((dependency, dependencyIndex) => {
-          if (isNpmDependency(dependency)) {
+          if (isResolvedNpmDependency(dependency)) {
             const componentDescriptor = getThirdPartyComponents(dependency.name, dependency.version)
             if (componentDescriptor == null) {
               return null

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -123,7 +123,7 @@ import * as friendlyWords from 'friendly-words'
 import { fastForEach } from '../../../core/shared/utils'
 import { ShortcutConfiguration } from '../shortcut-definitions'
 import { notLoggedIn } from '../../../common/user'
-import { dependenciesWithEditorRequirements } from '../npm-dependency/npm-dependency'
+import { dependenciesWithEditorRequirements, immediatelyResolvableDependenciesWithEditorRequirements } from '../npm-dependency/npm-dependency'
 import { getControlsForExternalDependencies } from '../../../core/property-controls/property-controls-utils'
 
 export interface OriginalPath {
@@ -1286,7 +1286,7 @@ export function editorModelFromPersistentModel(
   persistentModel: PersistentModel,
   dispatch: EditorDispatch,
 ): EditorState {
-  const npmDependencies = dependenciesWithEditorRequirements(persistentModel.projectContents)
+  const npmDependencies = immediatelyResolvableDependenciesWithEditorRequirements(persistentModel.projectContents)
   const editor: EditorState = {
     id: null,
     appID: persistentModel.appID ?? null,

--- a/editor/src/components/editor/store/editor-update.spec.ts
+++ b/editor/src/components/editor/store/editor-update.spec.ts
@@ -59,8 +59,8 @@ import {
   ScenePathForTestUiJsFile,
   ScenePath1ForTestUiJsFile,
 } from '../../../core/model/test-ui-js-file'
-import { npmDependency } from '../../../core/shared/npm-dependency-types'
 import { emptyUiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
+import {requestedNpmDependency} from '../../../core/shared/npm-dependency-types'
 
 const chaiExpect = Chai.expect
 
@@ -861,7 +861,7 @@ describe('action PUSH_TOAST and POP_TOAST', () => {
     const { editor, derivedState } = createEditorStates('/src/app.ui.js')
     const mockDispatch = jest.fn()
 
-    const deps = [npmDependency('mypackage', '1.0.0'), npmDependency('smart', '2.3.1')]
+    const deps = [requestedNpmDependency('mypackage', '1.0.0'), requestedNpmDependency('smart', '2.3.1')]
     const action = updatePackageJson(deps)
     const updatedEditor = runLocalEditorAction(
       editor,

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -12,8 +12,8 @@ import {
   Title,
 } from 'uuiui'
 import {
-  npmDependency,
-  NpmDependency,
+  requestedNpmDependency,
+  RequestedNpmDependency,
   PackageStatusMap,
   PackageStatus,
 } from '../../core/shared/npm-dependency-types'
@@ -99,7 +99,7 @@ export const DefaultPackagesList: Array<PackageDetails> = [
 ]
 
 function packageDetailsFromDependencies(
-  npmDependencies: Array<NpmDependency>,
+  npmDependencies: Array<RequestedNpmDependency>,
   packageStatus: PackageStatusMap,
 ): Array<PackageDetails> {
   const userAddedPackages: Array<PackageDetails> = []
@@ -341,14 +341,14 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
               )
               const updatedNpmDeps = [
                 ...npmDepsWithoutCurrentDep,
-                npmDependency(editedPackageName, editedPackageVersion!),
+                requestedNpmDependency(editedPackageName, editedPackageVersion!),
               ]
 
               this.props.editorDispatch([
                 EditorActions.setPackageStatus(editedPackageName, loadingOrUpdating),
                 EditorActions.updatePackageJson(updatedNpmDeps),
               ])
-              fetchNodeModules([npmDependency(editedPackageName, editedPackageVersion!)])
+              fetchNodeModules([requestedNpmDependency(editedPackageName, editedPackageVersion!)])
                 .then((fetchNodeModulesResult) => {
                   if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
                     this.packagesUpdateFailed(

--- a/editor/src/core/es-modules/package-manager/fetch-packages.spec.ts
+++ b/editor/src/core/es-modules/package-manager/fetch-packages.spec.ts
@@ -1,7 +1,7 @@
 import { fetchMissingFileDependency, resetDepPackagerCache } from './fetch-packages'
 import { esRemoteDependencyPlaceholder } from '../../shared/project-file-types'
 import { getJsDelivrFileUrl } from './packager-url'
-import { npmDependency } from '../../shared/npm-dependency-types'
+import {resolvedNpmDependency} from '../../shared/npm-dependency-types'
 
 require('jest-fetch-mock').enableMocks()
 
@@ -12,7 +12,7 @@ describe('Fetch missing file dependency', () => {
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
         switch (request.url) {
-          case getJsDelivrFileUrl(npmDependency('mypackage', '0.0.1'), '/dist/style.css'):
+          case getJsDelivrFileUrl(resolvedNpmDependency('mypackage', '0.0.1'), '/dist/style.css'):
             return Promise.resolve({ body: simpleCssContent })
           default:
             throw new Error(`unexpected fetch called: ${request.url}`)

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -11,11 +11,10 @@ import { fetchNodeModules, resetDepPackagerCache } from './fetch-packages'
 import { ESCodeFile } from '../../shared/project-file-types'
 import { NO_OP } from '../../shared/utils'
 import { NodeModules } from '../../shared/project-file-types'
-import { npmDependency } from '../../shared/npm-dependency-types'
 import { getPackagerUrl, getJsDelivrListUrl, getJsDelivrFileUrl } from './packager-url'
 import { InjectedCSSFilePrefix } from '../../shared/css-style-loader'
-import { isLeft } from '../../shared/either'
 import { VersionLookupResult } from '../../../components/editor/npm-dependency/npm-dependency'
+import {requestedNpmDependency, resolvedNpmDependency} from '../../shared/npm-dependency-types'
 
 require('jest-fetch-mock').enableMocks()
 
@@ -83,16 +82,16 @@ describe('ES Dependency Manager — Real-life packages', () => {
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
         switch (request.url) {
-          case getPackagerUrl(npmDependency('react-spring', '8.0.27')):
+          case getPackagerUrl(requestedNpmDependency('react-spring', '8.0.27')):
             return Promise.resolve({ status: 200, body: JSON.stringify(reactSpringServerResponse) })
-          case getJsDelivrListUrl(npmDependency('react-spring', '8.0.27')):
+          case getJsDelivrListUrl(resolvedNpmDependency('react-spring', '8.0.27')):
             return Promise.resolve({ status: 404 }) // we don't care about the jsdelivr response now
           default:
             throw new Error(`unexpected fetch called: ${request.url}`)
         }
       },
     )
-    const fetchNodeModulesResult = await fetchNodeModules([npmDependency('react-spring', '8.0.27')])
+    const fetchNodeModulesResult = await fetchNodeModules([requestedNpmDependency('react-spring', '8.0.27')])
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
       fail(`Expected successful nodeModules fetch`)
     }
@@ -107,18 +106,18 @@ describe('ES Dependency Manager — Real-life packages', () => {
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
         switch (request.url) {
-          case getPackagerUrl(npmDependency('antd', '4.2.5')):
+          case getPackagerUrl(requestedNpmDependency('antd', '4.2.5')):
             return Promise.resolve({ status: 200, body: JSON.stringify(antdPackagerResponse) })
-          case getJsDelivrListUrl(npmDependency('antd', '4.2.5')):
+          case getJsDelivrListUrl(resolvedNpmDependency('antd', '4.2.5')):
             return Promise.resolve({ status: 200, body: JSON.stringify(jsdelivrApiResponse) })
-          case getJsDelivrFileUrl(npmDependency('antd', '4.2.5'), '/dist/antd.css'):
+          case getJsDelivrFileUrl(resolvedNpmDependency('antd', '4.2.5'), '/dist/antd.css'):
             return Promise.resolve({ body: simpleCssContent })
           default:
             throw new Error(`unexpected fetch called: ${request.url}`)
         }
       },
     )
-    const fetchNodeModulesResult = await fetchNodeModules([npmDependency('antd', '4.2.5')])
+    const fetchNodeModulesResult = await fetchNodeModules([requestedNpmDependency('antd', '4.2.5')])
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
       fail(`Expected successful nodeModules fetch`)
     }
@@ -149,9 +148,9 @@ describe('ES Dependency Manager — d.ts', () => {
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
         switch (request.url) {
-          case getPackagerUrl(npmDependency('react-spring', '8.0.27')):
+          case getPackagerUrl(requestedNpmDependency('react-spring', '8.0.27')):
             return Promise.resolve({ status: 200, body: JSON.stringify(reactSpringServerResponse) })
-          case getJsDelivrListUrl(npmDependency('react-spring', '8.0.27')):
+          case getJsDelivrListUrl(resolvedNpmDependency('react-spring', '8.0.27')):
             return Promise.resolve({ status: 404 }) // we don't care about the jsdelivr response now
           default:
             throw new Error(`unexpected fetch called: ${request.url}`)
@@ -159,7 +158,7 @@ describe('ES Dependency Manager — d.ts', () => {
       },
     )
 
-    const fetchNodeModulesResult = await fetchNodeModules([npmDependency('react-spring', '8.0.27')])
+    const fetchNodeModulesResult = await fetchNodeModules([requestedNpmDependency('react-spring', '8.0.27')])
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
       fail(`Expected successful nodeModules fetch`)
     }
@@ -182,18 +181,18 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
         switch (request.url) {
-          case getPackagerUrl(npmDependency('mypackage', '0.0.1')):
+          case getPackagerUrl(requestedNpmDependency('mypackage', '0.0.1')):
             return Promise.resolve({ status: 200, body: JSON.stringify(fileNoImports) })
-          case getJsDelivrListUrl(npmDependency('mypackage', '0.0.1')):
+          case getJsDelivrListUrl(resolvedNpmDependency('mypackage', '0.0.1')):
             return Promise.resolve({ status: 200, body: JSON.stringify(jsdelivrApiResponse) })
-          case getJsDelivrFileUrl(npmDependency('mypackage', '0.0.1'), '/dist/style.css'):
+          case getJsDelivrFileUrl(resolvedNpmDependency('mypackage', '0.0.1'), '/dist/style.css'):
             return Promise.resolve({ body: simpleCssContent })
           default:
             throw new Error(`unexpected fetch called: ${request.url}`)
         }
       },
     )
-    const fetchNodeModulesResult = await fetchNodeModules([npmDependency('mypackage', '0.0.1')])
+    const fetchNodeModulesResult = await fetchNodeModules([requestedNpmDependency('mypackage', '0.0.1')])
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
       fail(`Expected successful nodeModules fetch`)
     }
@@ -225,13 +224,13 @@ describe('ES Dependency manager - retry behavior', () => {
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
         switch (request.url) {
-          case getPackagerUrl(npmDependency('react-spring', '8.0.27')):
+          case getPackagerUrl(requestedNpmDependency('react-spring', '8.0.27')):
             if (requestCounter === 0) {
               requestCounter++
               throw new Error('First request fails')
             }
             return Promise.resolve({ status: 200, body: JSON.stringify(reactSpringServerResponse) })
-          case getJsDelivrListUrl(npmDependency('react-spring', '8.0.27')):
+          case getJsDelivrListUrl(resolvedNpmDependency('react-spring', '8.0.27')):
             return Promise.resolve({ status: 404 }) // we don't care about the jsdelivr response now
           default:
             throw new Error(`unexpected fetch called: ${request.url}`)
@@ -239,7 +238,7 @@ describe('ES Dependency manager - retry behavior', () => {
       },
     )
 
-    fetchNodeModules([npmDependency('react-spring', '8.0.27')]).then((fetchNodeModulesResult) => {
+    fetchNodeModules([requestedNpmDependency('react-spring', '8.0.27')]).then((fetchNodeModulesResult) => {
       if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
         fail(`Expected successful nodeModule fetch`)
       }
@@ -258,7 +257,7 @@ describe('ES Dependency manager - retry behavior', () => {
       },
     )
 
-    fetchNodeModules([npmDependency('react-spring', '8.0.27')]).then((fetchNodeModulesResult) => {
+    fetchNodeModules([requestedNpmDependency('react-spring', '8.0.27')]).then((fetchNodeModulesResult) => {
       expect(fetchNodeModulesResult.dependenciesWithError).toHaveLength(1)
       expect(fetchNodeModulesResult.dependenciesWithError[0].name).toBe('react-spring')
       expect(Object.keys(fetchNodeModulesResult.nodeModules)).toHaveLength(0)
@@ -271,13 +270,13 @@ describe('ES Dependency manager - retry behavior', () => {
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
         switch (request.url) {
-          case getPackagerUrl(npmDependency('react-spring', '8.0.27')):
+          case getPackagerUrl(requestedNpmDependency('react-spring', '8.0.27')):
             if (requestCounter === 0) {
               requestCounter++
               throw new Error('First request fails')
             }
             return Promise.resolve({ status: 200, body: JSON.stringify(reactSpringServerResponse) })
-          case getJsDelivrListUrl(npmDependency('react-spring', '8.0.27')):
+          case getJsDelivrListUrl(resolvedNpmDependency('react-spring', '8.0.27')):
             return Promise.resolve({ status: 404 }) // we don't care about the jsdelivr response now
           default:
             throw new Error(`unexpected fetch called: ${request.url}`)
@@ -285,7 +284,7 @@ describe('ES Dependency manager - retry behavior', () => {
       },
     )
 
-    fetchNodeModules([npmDependency('react-spring', '8.0.27')], false).then(
+    fetchNodeModules([requestedNpmDependency('react-spring', '8.0.27')], false).then(
       (fetchNodeModulesResult) => {
         expect(fetchNodeModulesResult.dependenciesWithError).toHaveLength(1)
         expect(fetchNodeModulesResult.dependenciesWithError[0].name).toBe('react-spring')

--- a/editor/src/core/es-modules/package-manager/packager-url.ts
+++ b/editor/src/core/es-modules/package-manager/packager-url.ts
@@ -1,16 +1,16 @@
-import { NpmDependency } from '../../shared/npm-dependency-types'
 import { STATIC_BASE_URL } from '../../../common/env-vars'
+import {RequestedNpmDependency, ResolvedNpmDependency} from '../../shared/npm-dependency-types'
 
-export function getPackagerUrl(dep: NpmDependency) {
+export function getPackagerUrl(dep: RequestedNpmDependency): string {
   return `${STATIC_BASE_URL}v1/javascript/packager/${encodeURIComponent(dep.name)}/${
     dep.version
   }.json`
 }
 
-export function getJsDelivrListUrl(dep: NpmDependency) {
+export function getJsDelivrListUrl(dep: ResolvedNpmDependency): string {
   return `https://data.jsdelivr.com/v1/package/npm/${dep.name}@${dep.version}/flat`
 }
 
-export function getJsDelivrFileUrl(dep: NpmDependency, localFilePath: string) {
+export function getJsDelivrFileUrl(dep: ResolvedNpmDependency, localFilePath: string): string {
   return `https://cdn.jsdelivr.net/npm/${dep.name}@${dep.version}${localFilePath}`
 }

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -15,7 +15,11 @@ import { ParseResult } from '../../utils/value-parser-utils'
 import * as React from 'react'
 import { joinSpecial, pluck } from '../shared/array-utils'
 import { fastForEach } from '../shared/utils'
-import { NpmDependency } from '../shared/npm-dependency-types'
+import {
+  isResolvedNpmDependency,
+  PossiblyUnversionedNpmDependency,
+  ResolvedNpmDependency,
+} from '../shared/npm-dependency-types'
 import { getThirdPartyComponents } from '../third-party/third-party-components'
 import { getJSXElementNameAsString, isIntrinsicHTMLElement } from '../shared/element-template'
 import {
@@ -232,21 +236,23 @@ export function removeIgnored(
 }
 
 export function getControlsForExternalDependencies(
-  npmDependencies: ReadonlyArray<NpmDependency>,
+  npmDependencies: ReadonlyArray<PossiblyUnversionedNpmDependency>,
 ): PropertyControlsInfo {
   let propertyControlsInfo: PropertyControlsInfo = {}
   fastForEach(npmDependencies, (dependency) => {
-    const componentDescriptor = getThirdPartyComponents(dependency.name, dependency.version)
-    if (componentDescriptor != null) {
-      fastForEach(componentDescriptor.components, (descriptor) => {
-        if (descriptor.propertyControls != null) {
-          const jsxElementName = getJSXElementNameAsString(descriptor.element.name)
-          propertyControlsInfo[dependency.name] = {
-            ...propertyControlsInfo[dependency.name],
-            [jsxElementName]: descriptor.propertyControls,
+    if (isResolvedNpmDependency(dependency)) {
+      const componentDescriptor = getThirdPartyComponents(dependency.name, dependency.version)
+      if (componentDescriptor != null) {
+        fastForEach(componentDescriptor.components, (descriptor) => {
+          if (descriptor.propertyControls != null) {
+            const jsxElementName = getJSXElementNameAsString(descriptor.element.name)
+            propertyControlsInfo[dependency.name] = {
+              ...propertyControlsInfo[dependency.name],
+              [jsxElementName]: descriptor.propertyControls,
+            }
           }
-        }
-      })
+        })
+      }
     }
   })
   return propertyControlsInfo

--- a/editor/src/core/shared/npm-dependency-types.ts
+++ b/editor/src/core/shared/npm-dependency-types.ts
@@ -22,20 +22,33 @@ function packageDetails(status: PackageStatus): PackageDetails {
 }
 export type PackageStatusMap = { [packagename: string]: PackageDetails }
 
-export interface NpmDependency {
-  type: 'NPM_DEPENDENCY'
+export interface RequestedNpmDependency {
+  type: 'REQUESTED_NPM_DEPENDENCY'
   name: string
   version: string
 }
 
-export function npmDependency(name: string, version: string): NpmDependency {
+export function requestedNpmDependency(name: string, version: string): RequestedNpmDependency {
   return {
-    type: 'NPM_DEPENDENCY',
+    type: 'REQUESTED_NPM_DEPENDENCY',
     name: name,
     version: version,
   }
 }
 
+export interface ResolvedNpmDependency {
+  type: 'RESOLVED_NPM_DEPENDENCY'
+  name: string
+  version: string
+}
+
+export function resolvedNpmDependency(name: string, version: string): ResolvedNpmDependency {
+  return {
+    type: 'RESOLVED_NPM_DEPENDENCY',
+    name: name,
+    version: version,
+  }
+}
 export interface UnversionedNpmDependency {
   type: 'UNVERSIONED_NPM_DEPENDENCY'
   name: string
@@ -48,12 +61,12 @@ export function unversionedNpmDependency(name: string): UnversionedNpmDependency
   }
 }
 
-export type PossiblyUnversionedNpmDependency = NpmDependency | UnversionedNpmDependency
+export type PossiblyUnversionedNpmDependency = ResolvedNpmDependency | UnversionedNpmDependency
 
-export function isNpmDependency(
+export function isResolvedNpmDependency(
   dependency: PossiblyUnversionedNpmDependency,
-): dependency is NpmDependency {
-  return dependency.type === 'NPM_DEPENDENCY'
+): dependency is ResolvedNpmDependency {
+  return dependency.type === 'RESOLVED_NPM_DEPENDENCY'
 }
 
 export function isUnversionedNpmDependency(

--- a/editor/src/core/workers/workers.ts
+++ b/editor/src/core/workers/workers.ts
@@ -1,4 +1,4 @@
-import { NpmDependency, TypeDefinitions } from '../shared/npm-dependency-types'
+import { TypeDefinitions } from '../shared/npm-dependency-types'
 import { ProjectContents, ParseSuccess, NodeModules } from '../shared/project-file-types'
 import {
   createParseFileMessage,

--- a/editor/src/templates/property-controls-info.tsx
+++ b/editor/src/templates/property-controls-info.tsx
@@ -26,6 +26,7 @@ import { ExportsInfo } from '../core/workers/ts/ts-worker'
 import { PropertyControls } from 'utopia-api'
 import { objectKeyParser, parseAny, ParseResult } from '../utils/value-parser-utils'
 import { applicative3Either, forEachRight } from '../core/shared/either'
+import {resolvedDependencyVersions} from '../core/third-party/third-party-components'
 
 // Not a full parse, just checks the primary fields are there.
 function fastPropertyControlsParse(value: unknown): ParseResult<GetPropertyControlsInfoMessage> {
@@ -63,6 +64,7 @@ const initPropertyControls = () => {
     exportsInfo: ReadonlyArray<ExportsInfo>,
   ) => {
     const npmDependencies = dependenciesWithEditorRequirements(projectContents)
+    const resolvedNpmDependencies = resolvedDependencyVersions(npmDependencies, nodeModules)
     /**
      * please note that we are passing in an empty object instead of the .d.ts files
      * the reason for this is that we only use the bundler as a transpiler here
@@ -85,7 +87,7 @@ const initPropertyControls = () => {
     const exportValues = getExportValuesFromAllModules(bundledProjectFiles, requireFn)
 
     let propertyControlsInfo: PropertyControlsInfo = getControlsForExternalDependencies(
-      npmDependencies,
+      resolvedNpmDependencies,
     )
     fastForEach(exportsInfo, (result) => {
       const codeResult = processExportsInfo(exportValues[result.filename], result.exportTypes)


### PR DESCRIPTION
Fixes #535

**Problem:**
Internally the editor treats dependencies without distinguishing between requested dependencies which may include bounds or keywords, but some aspects like the property controls can only handle resolved version numbers.

**Fix:**
Removed the old type for representing a dependency and replaced it with two representing the two cases and used those as appropriate.

**Commit Details:**
- Fixes #535.
- Get rid of the `NpmDependency` type and replace it with
  `RequestedNpmDependency` and `ResolvedNpmDependency` as appropriate.
  Which is to say the former is used "earlier" in the flow and represents
  a dependency taken directly from the user's `package.json` file.
  The latter is often then derived from that by finding the `package.json`
  for a given dependency and retrieving the version number within.
- Created `immediatelyResolvableDependenciesWithEditorRequirements`
  to help in `editorModelFromPersistentModel` so that tests can still
  more easily work without needing to resolve the dependencies.
- `fetchPackagerResponse` first gets the resolved version before pulling
  anything from JsDelivr.
