### PR TITLE
Fix editor crash on code error

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -38,14 +38,14 @@ export const CanvasComponentEntry = betterReactMemo(
       ),
     }))
 
-    if (canvasProps.uiFilePath == null) {
+    if (canvasProps == null) {
       return null
     } else {
       return (
         <CanvasErrorBoundary
-          uiFilePath={canvasProps.uiFilePath}
+          fileCode={canvasProps.uiFileCode}
+          filePath={canvasProps.uiFilePath}
           reportError={props.reportError}
-          topLevelElementsIncludingScenes={canvasProps.topLevelElementsIncludingScenes}
         >
           <UiJsxCanvas {...canvasProps} clearErrors={props.clearErrors} />
         </CanvasErrorBoundary>

--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -42,7 +42,11 @@ export const CanvasComponentEntry = betterReactMemo(
       return null
     } else {
       return (
-        <CanvasErrorBoundary uiFilePath={canvasProps.uiFilePath} reportError={props.reportError}>
+        <CanvasErrorBoundary
+          uiFilePath={canvasProps.uiFilePath}
+          reportError={props.reportError}
+          topLevelElementsIncludingScenes={canvasProps.topLevelElementsIncludingScenes}
+        >
           <UiJsxCanvas
             {...canvasProps}
             clearErrors={props.clearErrors}

--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -47,11 +47,7 @@ export const CanvasComponentEntry = betterReactMemo(
           reportError={props.reportError}
           topLevelElementsIncludingScenes={canvasProps.topLevelElementsIncludingScenes}
         >
-          <UiJsxCanvas
-            {...canvasProps}
-            clearErrors={props.clearErrors}
-            reportError={props.reportError}
-          />
+          <UiJsxCanvas {...canvasProps} clearErrors={props.clearErrors} />
         </CanvasErrorBoundary>
       )
     }

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -122,6 +122,7 @@ function renderCanvasReturnResultAndError(possibleProps: PartialCanvasProps | nu
   }
   if (possibleProps == null) {
     canvasProps = {
+      uiFileCode: code,
       uiFilePath: uiFilePath,
       requireFn: requireFn,
       fileBlobs: fileBlobs,
@@ -146,6 +147,7 @@ function renderCanvasReturnResultAndError(possibleProps: PartialCanvasProps | nu
   } else {
     canvasProps = {
       ...possibleProps,
+      uiFileCode: code,
       uiFilePath: uiFilePath,
       requireFn: requireFn,
       fileBlobs: fileBlobs,
@@ -174,11 +176,7 @@ function renderCanvasReturnResultAndError(possibleProps: PartialCanvasProps | nu
   try {
     const flatFormat = ReactDOMServer.renderToStaticMarkup(
       <UiJsxCanvasContext.Provider value={spyCollector}>
-        <CanvasErrorBoundary
-          uiFilePath={uiFilePath}
-          reportError={reportError}
-          topLevelElementsIncludingScenes={canvasProps.topLevelElementsIncludingScenes}
-        >
+        <CanvasErrorBoundary fileCode={code} filePath={uiFilePath} reportError={reportError}>
           <UiJsxCanvas {...canvasProps} />
         </CanvasErrorBoundary>
       </UiJsxCanvasContext.Provider>,

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -28,6 +28,7 @@ import {
   UiJsxCanvasProps,
   UiJsxCanvasPropsWithErrorCallback,
   emptyUiJsxCanvasContextData,
+  CanvasErrorBoundary,
 } from './ui-jsx-canvas'
 import { emptyImports } from '../../core/workers/common/project-file-utils'
 import { BakedInStoryboardUID, BakedInStoryboardVariableName } from '../../core/model/scene-utils'
@@ -125,7 +126,6 @@ function renderCanvasReturnResultAndError(possibleProps: PartialCanvasProps | nu
       requireFn: requireFn,
       fileBlobs: fileBlobs,
       onDomReport: Utils.NO_OP,
-      reportError: reportError,
       clearErrors: clearErrors,
       offset: canvasPoint({ x: 0, y: 0 }),
       scale: 1,
@@ -150,7 +150,6 @@ function renderCanvasReturnResultAndError(possibleProps: PartialCanvasProps | nu
       requireFn: requireFn,
       fileBlobs: fileBlobs,
       onDomReport: Utils.NO_OP,
-      reportError: reportError,
       clearErrors: clearErrors,
       walkDOM: false,
       imports: imports,
@@ -175,7 +174,13 @@ function renderCanvasReturnResultAndError(possibleProps: PartialCanvasProps | nu
   try {
     const flatFormat = ReactDOMServer.renderToStaticMarkup(
       <UiJsxCanvasContext.Provider value={spyCollector}>
-        <UiJsxCanvas {...canvasProps} />
+        <CanvasErrorBoundary
+          uiFilePath={uiFilePath}
+          reportError={reportError}
+          topLevelElementsIncludingScenes={canvasProps.topLevelElementsIncludingScenes}
+        >
+          <UiJsxCanvas {...canvasProps} />
+        </CanvasErrorBoundary>
       </UiJsxCanvasContext.Provider>,
     )
     formattedSpyEnabled = Prettier.format(flatFormat, { parser: 'html' })

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -165,9 +165,8 @@ export interface CanvasReactClearErrorsCallback {
   clearErrors: () => void
 }
 
-export interface CanvasReactErrorCallback
-  extends CanvasReactReportErrorCallback,
-    CanvasReactClearErrorsCallback {}
+export type CanvasReactErrorCallback = CanvasReactReportErrorCallback &
+  CanvasReactClearErrorsCallback
 
 export type UiJsxCanvasPropsWithErrorCallback = UiJsxCanvasProps & CanvasReactClearErrorsCallback
 

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -185,6 +185,10 @@ export function createLayoutPropertyPath(layoutProp: LayoutProp | StyleLayoutPro
   return PP.create(LayoutPathMap[layoutProp])
 }
 
+export function createLayoutPropertyPathString(layoutProp: LayoutProp | StyleLayoutProp): string {
+  return PP.toString(createLayoutPropertyPath(layoutProp))
+}
+
 export function getObservedLayoutPixelValue(
   pin: LayoutPinnedProp,
   elementInstanceMetadata: ElementInstanceMetadata,

--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -114,7 +114,12 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath(sampleJsxAttributes(), PP.create(['top']), jsxAttributeValue(55)),
     )
-    const compiledProps = jsxAttributesToProps({}, updatedAttributes, sampleParentProps, {}, NO_OP)
+    const compiledProps = jsxAttributesToProps(
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+      {},
+    )
     expect(compiledProps.top).toEqual(55)
   })
 
@@ -137,7 +142,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('hello'),
       ),
     )
-    const compiledProps = jsxAttributesToProps({}, updatedAttributes, sampleParentProps, {}, NO_OP)
+    const compiledProps = jsxAttributesToProps(
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+      {},
+    )
     expect(compiledProps.my.property.path).toEqual('hello')
   })
 
@@ -149,7 +159,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue(2000),
       ),
     )
-    const compiledProps = jsxAttributesToProps({}, updatedAttributes, sampleParentProps, {}, NO_OP)
+    const compiledProps = jsxAttributesToProps(
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+      {},
+    )
     expect(compiledProps.layout.left).toEqual(2000)
   })
 
@@ -161,7 +176,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('easy!'),
       ),
     )
-    const compiledProps = jsxAttributesToProps({}, updatedAttributes, sampleParentProps, {}, NO_OP)
+    const compiledProps = jsxAttributesToProps(
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+      {},
+    )
     expect(compiledProps.layout.deep.path).toEqual('easy!')
   })
 
@@ -173,7 +193,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('wee'),
       ),
     )
-    const compiledProps = jsxAttributesToProps({}, updatedAttributes, sampleParentProps, {}, NO_OP)
+    const compiledProps = jsxAttributesToProps(
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+      {},
+    )
     expect(compiledProps.objectWithArray.array).toEqual([0, 1, 'wee'])
   })
 
@@ -187,11 +212,10 @@ describe('setJSXValueAtPath', () => {
         ),
       )
       const compiledProps = jsxAttributesToProps(
-        {},
+        { props: sampleParentProps },
         updatedAttributes,
-        sampleParentProps,
         {},
-        NO_OP,
+        {},
       )
     }).toThrow()
   })
@@ -204,7 +228,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('wee'),
       ),
     )
-    const compiledProps = jsxAttributesToProps({}, updatedAttributes, sampleParentProps, {}, NO_OP)
+    const compiledProps = jsxAttributesToProps(
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+      {},
+    )
     expect(compiledProps.style.backgroundColor).toEqual('wee')
   })
 
@@ -223,7 +252,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('hola'),
       ),
     )
-    const compiledProps = jsxAttributesToProps({}, updatedAttributes2, sampleParentProps, {}, NO_OP)
+    const compiledProps = jsxAttributesToProps(
+      { props: sampleParentProps },
+      updatedAttributes2,
+      {},
+      {},
+    )
     expect(compiledProps.my.property.path).toEqual('hello')
     expect(compiledProps.my.property.other.path).toEqual('hola')
   })
@@ -236,7 +270,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('blue'),
       ),
     )
-    const compiledProps = jsxAttributesToProps({}, updatedAttributes, sampleParentProps, {}, NO_OP)
+    const compiledProps = jsxAttributesToProps(
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+      {},
+    )
     expect(compiledProps.style.backgroundColor).toEqual('blue')
   })
 
@@ -272,7 +311,6 @@ describe('jsxAttributesToProps', () => {
       sampleJsxAttributes(),
       sampleParentProps,
       {},
-      NO_OP,
     )
     expect(compiledProps).toEqual(expectedCompiledProps)
   })

--- a/editor/src/core/model/test-ui-js-file.ts
+++ b/editor/src/core/model/test-ui-js-file.ts
@@ -1,5 +1,5 @@
 import { KrazyGeorgeTestUrl } from 'utopia-api'
-import { createLayoutPropertyPath } from '../layout/layout-helpers-new'
+import { createLayoutPropertyPathString } from '../layout/layout-helpers-new'
 import { Imports, importAlias } from '../shared/project-file-types'
 import {
   jsxAttributeFunctionCall,
@@ -63,26 +63,26 @@ const mainComponentForTests = utopiaJSXComponent(
     {
       layout: jsxAttributeNestedObjectSimple({
         left: jsxAttributeOtherJavaScript(
-          `props.${createLayoutPropertyPath('PinnedLeft')}`,
-          `return props.${createLayoutPropertyPath('PinnedLeft')}`,
+          `props.${createLayoutPropertyPathString('PinnedLeft')}`,
+          `return props.${createLayoutPropertyPathString('PinnedLeft')}`,
           ['props'],
           null,
         ),
         top: jsxAttributeOtherJavaScript(
-          `props.${createLayoutPropertyPath('PinnedTop')}`,
-          `return props.${createLayoutPropertyPath('PinnedTop')}`,
+          `props.${createLayoutPropertyPathString('PinnedTop')}`,
+          `return props.${createLayoutPropertyPathString('PinnedTop')}`,
           ['props'],
           null,
         ),
         width: jsxAttributeOtherJavaScript(
-          `props.${createLayoutPropertyPath('Width')}`,
-          `return props.${createLayoutPropertyPath('Width')}`,
+          `props.${createLayoutPropertyPathString('Width')}`,
+          `return props.${createLayoutPropertyPathString('Width')}`,
           ['props'],
           null,
         ),
         height: jsxAttributeOtherJavaScript(
-          `props.${createLayoutPropertyPath('Height')}`,
-          `return props.${createLayoutPropertyPath('Height')}`,
+          `props.${createLayoutPropertyPathString('Height')}`,
+          `return props.${createLayoutPropertyPathString('Height')}`,
           ['props'],
           null,
         ),

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -158,7 +158,6 @@ export const jsxAttributeToValue = (
   inScope: MapLike<any>,
   parentComponentProps: AnyMap,
   requireResult: MapLike<any>,
-  onError: (error: Error) => void,
 ) => (attribute: JSXAttribute): any => {
   switch (attribute.type) {
     case 'ATTRIBUTE_VALUE':
@@ -166,12 +165,7 @@ export const jsxAttributeToValue = (
     case 'ATTRIBUTE_NESTED_ARRAY':
       let returnArray: Array<any> = []
       for (const elem of attribute.content) {
-        const value = jsxAttributeToValue(
-          inScope,
-          parentComponentProps,
-          requireResult,
-          onError,
-        )(elem.value)
+        const value = jsxAttributeToValue(inScope, parentComponentProps, requireResult)(elem.value)
 
         // We don't need to explicitly handle spreads because `concat` will take care of it for us
         returnArray = returnArray.concat(value)
@@ -181,12 +175,7 @@ export const jsxAttributeToValue = (
     case 'ATTRIBUTE_NESTED_OBJECT':
       let returnObject: { [key: string]: any } = {}
       fastForEach(attribute.content, (prop) => {
-        const value = jsxAttributeToValue(
-          inScope,
-          parentComponentProps,
-          requireResult,
-          onError,
-        )(prop.value)
+        const value = jsxAttributeToValue(inScope, parentComponentProps, requireResult)(prop.value)
 
         switch (prop.type) {
           case 'PROPERTY_ASSIGNMENT':
@@ -206,18 +195,13 @@ export const jsxAttributeToValue = (
       const foundFunction = (UtopiaUtils as any)[attribute.functionName]
       if (foundFunction != null) {
         const resolvedParameters = attribute.parameters.map(
-          jsxAttributeToValue(inScope, parentComponentProps, requireResult, onError),
+          jsxAttributeToValue(inScope, parentComponentProps, requireResult),
         )
         return foundFunction(...resolvedParameters)
       }
       throw new Error(`Couldn't find helper function with name ${attribute.functionName}`)
     case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-      try {
-        return resolveParamsAndRunJsCode(attribute, requireResult, inScope)
-      } catch (e) {
-        onError(e)
-        return undefined
-      }
+      return resolveParamsAndRunJsCode(attribute, requireResult, inScope)
     default:
       const _exhaustiveCheck: never = attribute
       throw new Error(`Unhandled attribute ${JSON.stringify(attribute)}`)
@@ -229,12 +213,8 @@ export function jsxAttributesToProps(
   attributes: JSXAttributes,
   parentComponentProps: AnyMap,
   requireResult: MapLike<any>,
-  onError: (error: Error) => void,
 ): MapLike<any> {
-  return objectMap(
-    jsxAttributeToValue(inScope, parentComponentProps, requireResult, onError),
-    attributes,
-  )
+  return objectMap(jsxAttributeToValue(inScope, parentComponentProps, requireResult), attributes)
 }
 
 export type GetModifiableAttributeResult = Either<string, ModifiableAttribute>

--- a/editor/src/utils/test-utils.ts
+++ b/editor/src/utils/test-utils.ts
@@ -178,6 +178,8 @@ export function createFakeMetadataForParseSuccess(success: ParseSuccess): Array<
       },
     )
     const component = components.find((c) => c.name === props.component && isUtopiaJSXComponent(c))
+    const sceneResizesContent =
+      Utils.path<boolean>(PP.getElements(PathForResizeContent), props) ?? true
     let elementMetadata: ElementInstanceMetadata | Array<ElementInstanceMetadata> | null = null
     if (component != null) {
       elementMetadata = createFakeMetadataForJSXElement(
@@ -185,7 +187,7 @@ export function createFakeMetadataForParseSuccess(success: ParseSuccess): Array<
         TP.scenePath([BakedInStoryboardUID, createSceneUidFromIndex(index)]),
         {
           props: {
-            style: props[PP.toString(PathForResizeContent)] ? props.style : undefined,
+            style: sceneResizesContent ? props.style : undefined,
             ...props.props,
           },
         },
@@ -199,7 +201,7 @@ export function createFakeMetadataForParseSuccess(success: ParseSuccess): Array<
       scenePath: TP.scenePath([BakedInStoryboardUID, props[PP.toString(PathForSceneDataUid)]]),
       templatePath: TP.instancePath([], [BakedInStoryboardUID, createSceneUidFromIndex(index)]),
       globalFrame: { x: 0, y: 0, width: 400, height: 400 } as CanvasRectangle,
-      sceneResizesContent: Utils.path(PP.getElements(PathForResizeContent), props) ?? true,
+      sceneResizesContent: sceneResizesContent ?? true,
       style: {},
       rootElements:
         elementMetadata == null

--- a/editor/src/utils/test-utils.ts
+++ b/editor/src/utils/test-utils.ts
@@ -59,6 +59,7 @@ import { NO_OP } from '../core/shared/utils'
 import * as PP from '../core/shared/property-path'
 import { getSimpleAttributeAtPath } from '../core/model/element-metadata-utils'
 import { mapArrayToDictionary } from '../core/shared/array-utils'
+import { MapLike } from 'typescript'
 
 export function delay<T>(time: number): Promise<T> {
   return new Promise((resolve) => setTimeout(resolve, time))
@@ -182,6 +183,13 @@ export function createFakeMetadataForParseSuccess(success: ParseSuccess): Array<
       elementMetadata = createFakeMetadataForJSXElement(
         component.rootElement,
         TP.scenePath([BakedInStoryboardUID, createSceneUidFromIndex(index)]),
+        {
+          props: {
+            style: props[PP.toString(PathForResizeContent)] ? props.style : undefined,
+            ...props.props,
+          },
+        },
+        {},
       )
     }
     return {
@@ -212,6 +220,8 @@ export function createFakeMetadataForComponents(
       const elementMetadata = createFakeMetadataForJSXElement(
         component.rootElement,
         TP.scenePath([BakedInStoryboardUID, createSceneUidFromIndex(index)]),
+        {},
+        {},
       )
       metadata.push({
         scenePath: TP.scenePath([BakedInStoryboardUID, `scene-${index}`]),
@@ -231,18 +241,21 @@ export function createFakeMetadataForComponents(
 function createFakeMetadataForJSXElement(
   element: JSXElementChild,
   rootPath: TemplatePath,
+  inScope: MapLike<any>,
+  parentProps: MapLike<any>,
 ): ElementInstanceMetadata | Array<ElementInstanceMetadata> {
   if (isJSXElement(element)) {
     const elementID = getUtopiaID(element)
     const templatePath = TP.appendToPath(rootPath, elementID)
+    const props = jsxAttributesToProps(inScope, element.props, parentProps, Utils.NO_OP)
     return {
       templatePath: templatePath,
       element: right(element),
-      props: jsxAttributesToProps({}, element.props, {}, Utils.NO_OP, Utils.NO_OP),
+      props: props,
       globalFrame: Utils.zeroRectangle as CanvasRectangle, // this could be parametrized to be able to set real rectangles
       localFrame: Utils.zeroRectangle as LocalRectangle,
       children: element.children.flatMap((child) =>
-        createFakeMetadataForJSXElement(child, templatePath),
+        createFakeMetadataForJSXElement(child, templatePath, inScope, props),
       ),
       componentInstance: false,
       specialSizeMeasurements: emptySpecialSizeMeasurements,
@@ -250,7 +263,7 @@ function createFakeMetadataForJSXElement(
     }
   } else if (isJSXFragment(element)) {
     return element.children.flatMap((child) => {
-      return createFakeMetadataForJSXElement(child, rootPath)
+      return createFakeMetadataForJSXElement(child, rootPath, inScope, parentProps)
     })
   } else {
     throw new Error(`Not a JSX element ${element}`)


### PR DESCRIPTION
Fixes #541 

**Problem:**
Code errors are currently bringing down the editor. This was because of the way we were handling error reporting, combined with the way React deals with error bounds. Effectively we were repeatedly re-rendering code that would capture errors, then throw them at a later point in time so that our error bounds could then catch them. However, since moving the error bounds up a level we no longer needed this, but still needed to make sure we weren't excessively running the code that caused the errors.

**Fix:**
Removed all of the threading of `reportError` through `ui-jsx-canvas.tsx`, since we were calling that in the error bounds anyway, and updated the error bounds to stop re-rendering of the children unless the `topLevelElements` had changed.

**Commit Details:**
- Added `getDerivedStateFromError` to `CanvasErrorBoundary`, which we would use to prevent the `UiJsxCanvas` from being rendered repeatedly if there was an existing runtime error. Also added a `componentDidUpdate` to clear the state if the `topLevelElements` had changed (since in that case we _would_ want to try rendering the `UiJsxCanvas` again)
- Binned off all excessive (and incorrect) error reporting that we were threading through, since we can now just leave the executed user code to throw
- Fixed up some of the test utils around generating metadata, since that was silently failing and squashing errors before
- Fixed up some default test data that was incorrectly interpolating strings, resulting in `props.[object Object]` :facepalm: 
- Fixed `jsx-attributes.spec.ts`, which was incorrectly passing in the wrong props (another silent failure from us squashing errors)
