### PR TITLE
experiment/flex-element-move

### DIFF
--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -19,6 +19,7 @@ import { Mode } from '../editor/editor-modes'
 import { EditorState, OriginalCanvasAndLocalFrame } from '../editor/store/editor-state'
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import { xor } from '../../core/shared/utils'
+import { FlexAlignment } from 'utopia-api'
 
 export const enum CSSCursor {
   Select = "-webkit-image-set( url( '/editor/cursors/cursor-default.png ') 1x, url( '/editor/cursors/cursor-default@2x.png ') 2x ) 4 4, default",
@@ -204,6 +205,12 @@ export interface FlexMoveChange {
   newIndex: number
 }
 
+export interface FlexAlignChange {
+  type: 'FLEX_ALIGN'
+  target: TemplatePath
+  alignment: FlexAlignment
+}
+
 export interface FlexResizeChange {
   type: 'FLEX_RESIZE'
   target: TemplatePath
@@ -225,6 +232,7 @@ export type PinOrFlexFrameChange =
   | FlexMoveChange
   | FlexResizeChange
   | SingleResizeChange
+  | FlexAlignChange
 
 export function pinFrameChange(
   target: TemplatePath,
@@ -265,6 +273,14 @@ export function flexMoveChange(target: TemplatePath, newIndex: number): FlexMove
     type: 'FLEX_MOVE',
     target: target,
     newIndex: newIndex,
+  }
+}
+
+export function flexAlignChange(target: TemplatePath, alignment: FlexAlignment): FlexAlignChange {
+  return {
+    type: 'FLEX_ALIGN',
+    target: target,
+    alignment: alignment,
   }
 }
 

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -421,6 +421,7 @@ export function updateFramesOfScenesAndComponents(
           break
         case 'FLEX_MOVE':
         case 'FLEX_RESIZE':
+        case 'FLEX_ALIGN':
           throw new Error(
             `Attempted to change a scene with a flex change ${JSON.stringify(target)}.`,
           )
@@ -468,6 +469,15 @@ export function updateFramesOfScenesAndComponents(
                   staticParentPath,
                 )}.`,
               )
+            case 'FLEX_ALIGN': {
+              propsToSet.push({
+                path: createLayoutPropertyPath('alignSelf'),
+                value: jsxAttributeValue(frameAndTarget.alignment),
+              })
+              propsToSkip.push(createLayoutPropertyPath('FlexFlexBasis'))
+              propsToSkip.push(createLayoutPropertyPath('FlexCrossBasis'))
+              break
+            }
             case 'FLEX_MOVE':
               workingComponentsResult = reorderComponent(
                 workingComponentsResult,
@@ -708,6 +718,7 @@ export function updateFramesOfScenesAndComponents(
             break
           case 'FLEX_MOVE':
           case 'FLEX_RESIZE':
+          case 'FLEX_ALIGN':
             throw new Error(
               `Attempted to make a flex change against a pinned element ${JSON.stringify(
                 staticParentPath,
@@ -2138,6 +2149,7 @@ function produceMoveTransientCanvasState(
     dragState.enableSnapping,
     dragState.constrainDragAxis,
     editorState.canvas.scale,
+    dragState.start,
   )
 
   const componentsIncludingFakeUtopiaScene = utopiaComponentsIncludingScenes

--- a/editor/src/components/canvas/controls/select-mode/move-utils.ts
+++ b/editor/src/components/canvas/controls/select-mode/move-utils.ts
@@ -301,6 +301,8 @@ export function dragComponent(
                         )
                       })
                       dispatch(actions, 'canvas')
+                    } else if (dispatch != null) {
+                      dispatch([EditorActions.clearHighlightedViews()], 'canvas')
                     }
 
                     clearTimeout((window as any)['flexParentHighlightTimer'])

--- a/editor/src/components/canvas/dom-walker.spec.browser.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser.tsx
@@ -58,7 +58,7 @@ function sanitizeJsxMetadata(jsxMetadata: ComponentMetadata[]) {
 
 async function renderTestEditorWithCode(appUiJsFileCode: string) {
   let emptyEditorState = createEditorState(NO_OP)
-  const fromScratchResult = deriveState(emptyEditorState, null, false)
+  const fromScratchResult = deriveState(emptyEditorState, null, false, null)
   emptyEditorState = fromScratchResult.editor
   const derivedState = fromScratchResult.derived
 

--- a/editor/src/components/canvas/ui-jsx-test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-test-utils.tsx
@@ -73,7 +73,7 @@ export async function renderTestEditorWithCode(appUiJsFileCode: string) {
   const renderCountBaseline = renderCount
 
   let emptyEditorState = createEditorState(NO_OP)
-  const fromScratchResult = deriveState(emptyEditorState, null, false)
+  const fromScratchResult = deriveState(emptyEditorState, null, false, null)
   emptyEditorState = fromScratchResult.editor
   const derivedState = fromScratchResult.derived
 

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -218,7 +218,7 @@ describe('SET_CANVAS_FRAMES', () => {
     },
     jsxMetadataKILLME: createFakeMetadataForComponents(originalModel.topLevelElements),
   })
-  const derivedState = deriveState(testEditor, null, false).derived
+  const derivedState = deriveState(testEditor, null, false, null).derived
   it('Updates the frame of the child correctly', () => {
     const action = setCanvasFrames(
       [

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -997,7 +997,7 @@ export function restoreDerivedState(history: StateHistory): DerivedState {
     canvas: {
       descendantsOfHiddenInstances: poppedDerived.canvas.descendantsOfHiddenInstances,
       controls: [],
-      transientState: produceCanvasTransientState(history.current.editor, true),
+      transientState: produceCanvasTransientState(history.current.editor, true, null, null),
     },
     elementWarnings: poppedDerived.elementWarnings,
   }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -139,7 +139,7 @@ function processAction(
         break
       case 'NEW':
       case 'LOAD':
-        const derivedResult = deriveState(editorAfterNavigator, null, false)
+        const derivedResult = deriveState(editorAfterNavigator, null, false, null)
         editorAfterNavigator = derivedResult.editor
         newStateHistory = History.init(derivedResult.editor, derivedResult.derived)
         break
@@ -514,7 +514,12 @@ function editorDispatchInner(
       frozenDerivedState = storedState.derived
     } else {
       const parsedModelUpdated = R.any(isParsedModelUpdate, dispatchedActions)
-      const derivedResult = deriveState(frozenEditorState, storedState.derived, parsedModelUpdated)
+      const derivedResult = deriveState(
+        frozenEditorState,
+        storedState.derived,
+        parsedModelUpdated,
+        storedState.dispatch,
+      )
       frozenEditorState = derivedResult.editor
       frozenDerivedState = optionalDeepFreeze(derivedResult.derived)
     }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -926,7 +926,7 @@ function emptyDerivedState(editorState: EditorState): DerivedState {
     canvas: {
       descendantsOfHiddenInstances: [],
       controls: [],
-      transientState: produceCanvasTransientState(editorState, false),
+      transientState: produceCanvasTransientState(editorState, false, null, null),
     },
     elementWarnings: emptyComplexMap(),
   }
@@ -1196,6 +1196,7 @@ export function deriveState(
   editor: EditorState,
   oldDerivedState: DerivedState | null,
   uidsChanged: boolean,
+  dispatch: EditorDispatch | null,
 ): EditorAndDerivedState {
   const derivedState = oldDerivedState == null ? emptyDerivedState(editor) : oldDerivedState
 
@@ -1209,7 +1210,7 @@ export function deriveState(
     canvas: {
       descendantsOfHiddenInstances: editor.hiddenInstances, // FIXME This has been dead for like ever
       controls: derivedState.canvas.controls,
-      transientState: produceCanvasTransientState(editor, true),
+      transientState: produceCanvasTransientState(editor, true, dispatch, oldDerivedState),
     },
     elementWarnings: keepDeepReferenceEqualityIfPossible(
       oldDerivedState?.elementWarnings,

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -105,7 +105,7 @@ export class Editor {
     startPreviewConnectedMonitoring(this.boundDispatch)
 
     let emptyEditorState = createEditorState(this.boundDispatch)
-    const fromScratchResult = deriveState(emptyEditorState, null, false)
+    const fromScratchResult = deriveState(emptyEditorState, null, false, null)
     emptyEditorState = fromScratchResult.editor
     const derivedState = fromScratchResult.derived
 

--- a/editor/src/utils/test-utils.ts
+++ b/editor/src/utils/test-utils.ts
@@ -133,7 +133,7 @@ export function createEditorStates(
     },
     selectedViews: selectedViews,
   }
-  const derivedResult = deriveState(editor, null, false)
+  const derivedResult = deriveState(editor, null, false, null)
   const componentMetadata = createFakeMetadataForEditor(editor)
   return {
     editor: {


### PR DESCRIPTION
Canvas Experiment

#### How to try it?

Move flex child elements on cross axis to set `alignSelf` style property, keep your cursor on the target alignment area to set `alignItems` style prop on the parent. You should see highlight around the parent when the parent style change happens. The timer is set to 2 seconds.

Link: https://utopia.pizza/p/f1535dc3-humble-carpenter/?branch_name=experiment/flex-element-move

![Sep-21-2020 18-30-58](https://user-images.githubusercontent.com/4403069/93887836-7ba0c480-fce7-11ea-809d-792632a37a0f.gif)

