### PR TITLE
Fix code problems pane performance

### DIFF
--- a/editor/src/components/code-editor/code-problems.tsx
+++ b/editor/src/components/code-editor/code-problems.tsx
@@ -168,28 +168,30 @@ export const CodeEditorTabPane = betterReactMemo<CodeEditorTabPaneProps>(
     }, [])
 
     let outputRows: Array<React.ReactElement> = []
-    const groupErrors = R.groupBy((error: ErrorMessage) => error.fileName)
-    const errorsByFile = groupErrors(errorMessages)
+    if (isOpen) {
+      const groupErrors = R.groupBy((error: ErrorMessage) => error.fileName)
+      const errorsByFile = groupErrors(errorMessages)
 
-    Object.keys(errorsByFile).forEach(function (fileName) {
-      if (fileName != '') {
-        outputRows.push(
-          <FlexRow key={`error-row-${fileName}-filename`} style={{ padding: '4px 8px' }}>
-            <Icons.React />
-            <span style={{ marginLeft: 4 }}> {fileName}</span>
-          </FlexRow>,
-        )
-      }
-      errorsByFile[fileName].forEach(function (errormessage, index) {
-        outputRows.push(
-          <ErrorMessageRow
-            key={`error-row-${fileName}-${index}-${errormessage.startLine}-${errormessage.startColumn}`}
-            errorMessage={errormessage}
-            onOpenFile={onOpenFile}
-          />,
-        )
+      Object.keys(errorsByFile).forEach(function (fileName) {
+        if (fileName != '') {
+          outputRows.push(
+            <FlexRow key={`error-row-${fileName}-filename`} style={{ padding: '4px 8px' }}>
+              <Icons.React />
+              <span style={{ marginLeft: 4 }}> {fileName}</span>
+            </FlexRow>,
+          )
+        }
+        errorsByFile[fileName].forEach(function (errormessage, index) {
+          outputRows.push(
+            <ErrorMessageRow
+              key={`error-row-${fileName}-${index}-${errormessage.startLine}-${errormessage.startColumn}`}
+              errorMessage={errormessage}
+              onOpenFile={onOpenFile}
+            />,
+          )
+        })
       })
-    })
+    }
 
     const [selectedTab, setSelectedTab] = React.useState<OpenCodeEditorTab>('problems')
 

--- a/editor/src/components/code-editor/code-problems.tsx
+++ b/editor/src/components/code-editor/code-problems.tsx
@@ -17,11 +17,14 @@ import { ConsoleLog } from '../editor/store/editor-state'
 import { CursorPosition } from './code-editor-utils'
 import { clampValue } from '../../core/shared/math-utils'
 import { WarningIcon } from '../../uuiui/warning-icon'
+import { VariableSizeList as List } from 'react-window'
 
 interface ErrorMessageRowProps {
   errorMessage: ErrorMessage
   onOpenFile: (path: string, cursorPosition: CursorPosition | null) => void
 }
+
+const ErrorMessageRowHeight = 31
 
 const ErrorMessageRow = (props: ErrorMessageRowProps) => {
   const { onOpenFile } = props
@@ -43,6 +46,7 @@ const ErrorMessageRow = (props: ErrorMessageRowProps) => {
   return (
     <FlexRow
       css={{
+        height: ErrorMessageRowHeight,
         flexGrow: 1,
         color: colorTheme.neutralForeground.value,
         fontSize: 12,
@@ -158,7 +162,7 @@ export const CodeEditorTabPane = betterReactMemo<CodeEditorTabPaneProps>(
       })
     }, [heightWhenOpen])
 
-    const onResizeStop: ResizeCallback = React.useCallback((_, __, elementRef) => {
+    const onResize: ResizeCallback = React.useCallback((_, __, elementRef) => {
       if (elementRef.clientHeight > ProblemTabBarHeight) {
         setHeightWhenOpen(elementRef.clientHeight)
         setIsOpen(true)
@@ -166,32 +170,6 @@ export const CodeEditorTabPane = betterReactMemo<CodeEditorTabPaneProps>(
         setIsOpen(false)
       }
     }, [])
-
-    let outputRows: Array<React.ReactElement> = []
-    if (isOpen) {
-      const groupErrors = R.groupBy((error: ErrorMessage) => error.fileName)
-      const errorsByFile = groupErrors(errorMessages)
-
-      Object.keys(errorsByFile).forEach(function (fileName) {
-        if (fileName != '') {
-          outputRows.push(
-            <FlexRow key={`error-row-${fileName}-filename`} style={{ padding: '4px 8px' }}>
-              <Icons.React />
-              <span style={{ marginLeft: 4 }}> {fileName}</span>
-            </FlexRow>,
-          )
-        }
-        errorsByFile[fileName].forEach(function (errormessage, index) {
-          outputRows.push(
-            <ErrorMessageRow
-              key={`error-row-${fileName}-${index}-${errormessage.startLine}-${errormessage.startColumn}`}
-              errorMessage={errormessage}
-              onOpenFile={onOpenFile}
-            />,
-          )
-        })
-      })
-    }
 
     const [selectedTab, setSelectedTab] = React.useState<OpenCodeEditorTab>('problems')
 
@@ -213,13 +191,11 @@ export const CodeEditorTabPane = betterReactMemo<CodeEditorTabPaneProps>(
       switch (selectedTab) {
         case 'problems':
           return (
-            <SimpleFlexColumn style={{ overflowY: 'scroll', overscrollBehavior: 'contain' }}>
-              {outputRows.length > 0 ? (
-                outputRows
-              ) : (
-                <div style={{ padding: 8 }}>There are no problems 😎</div>
-              )}
-            </SimpleFlexColumn>
+            <ProblemsTab
+              errorMessages={errorMessages}
+              height={heightWhenOpen}
+              onOpenFile={onOpenFile}
+            />
           )
         case 'console':
           return (
@@ -275,7 +251,7 @@ export const CodeEditorTabPane = betterReactMemo<CodeEditorTabPaneProps>(
         ref={resizableRef}
         defaultSize={{ height: ProblemTabBarHeight + (isOpen ? heightWhenOpen : 0), width: '100%' }}
         minHeight={ProblemTabBarHeight}
-        onResizeStop={onResizeStop}
+        onResize={onResize}
         enable={{
           top: true,
         }}
@@ -343,8 +319,142 @@ export const CodeEditorTabPane = betterReactMemo<CodeEditorTabPaneProps>(
             }
           />
         </FlexRow>
-        {getTabContents()}
+        {isOpen ? getTabContents() : null}
       </Resizable>
     )
   },
 )
+
+interface ProblemsTabProps {
+  errorMessages: Array<ErrorMessage>
+  height: number
+  onOpenFile: (path: string, cursorPosition: CursorPosition | null) => void
+}
+
+interface ProblemsHeaderRowData {
+  type: 'HEADER'
+  fileName: string
+}
+
+interface ProblemsErrorRowData {
+  type: 'ERROR_MESSAGE'
+  fileName: string
+  errorMessage: ErrorMessage
+}
+
+type ProblemRowData = ProblemsHeaderRowData | ProblemsErrorRowData
+
+interface ProblemsHeaderRowProps {
+  fileName: string
+}
+
+interface ProblemsErrorRowProps {
+  errorMessage: ErrorMessage
+  onOpenFile: (path: string, cursorPosition: CursorPosition | null) => void
+}
+
+const ProblemsHeaderRowHeight = 25
+
+const ProblemsHeaderRow = betterReactMemo(
+  'Problems Header Row',
+  (props: ProblemsHeaderRowProps) => {
+    const { fileName } = props
+    return (
+      <FlexRow style={{ height: ProblemsHeaderRowHeight, padding: '4px 8px' }}>
+        <Icons.React />
+        <span style={{ marginLeft: 4 }}> {fileName}</span>
+      </FlexRow>
+    )
+  },
+)
+
+const ProblemsErrorRow = betterReactMemo('Problems Error Row', (props: ProblemsErrorRowProps) => {
+  const { errorMessage, onOpenFile } = props
+  return <ErrorMessageRow errorMessage={errorMessage} onOpenFile={onOpenFile} />
+})
+
+function getRowHeight(index: number, data: Array<ProblemRowData>): number {
+  const row = data[index]
+  if (row == null) {
+    return 0
+  } else if (row.type === 'HEADER') {
+    return ProblemsHeaderRowHeight
+  } else {
+    return ErrorMessageRowHeight
+  }
+}
+
+const ProblemsTab = betterReactMemo('Problems Tab', (props: ProblemsTabProps) => {
+  const { errorMessages, height, onOpenFile } = props
+
+  const rowData: Array<ProblemRowData> = React.useMemo(() => {
+    const groupErrors = R.groupBy((error: ErrorMessage) => error.fileName)
+    const errorsByFile = groupErrors(errorMessages)
+
+    let rows: Array<ProblemRowData> = []
+    Object.keys(errorsByFile).forEach(function (fileName) {
+      if (fileName != '') {
+        rows.push({
+          type: 'HEADER',
+          fileName: fileName,
+        })
+      }
+      errorsByFile[fileName].forEach(function (errorMessage) {
+        rows.push({
+          type: 'ERROR_MESSAGE',
+          fileName: fileName,
+          errorMessage: errorMessage,
+        })
+      })
+    })
+
+    return rows
+  }, [errorMessages])
+
+  const getItemSize = React.useCallback(
+    (index: number) => {
+      const row = rowData[index]
+      if (row == null) {
+        return 0
+      } else if (row.type === 'HEADER') {
+        return ProblemsHeaderRowHeight
+      } else {
+        return ErrorMessageRowHeight
+      }
+    },
+    [rowData],
+  )
+
+  const Row = React.useCallback(
+    ({ index, style }: any) => {
+      const row = rowData[index]
+      if (row == null) {
+        return null
+      } else if (row.type === 'HEADER') {
+        return (
+          <div style={style} key={`error-row-${row.fileName}-filename`}>
+            <ProblemsHeaderRow fileName={row.fileName} />
+          </div>
+        )
+      } else {
+        return (
+          <div
+            style={style}
+            key={`error-row-${row.fileName}-${index}-${row.errorMessage.startLine}-${row.errorMessage.startColumn}`}
+          >
+            <ProblemsErrorRow errorMessage={row.errorMessage} onOpenFile={onOpenFile} />
+          </div>
+        )
+      }
+    },
+    [rowData, onOpenFile],
+  )
+
+  return (
+    <SimpleFlexColumn>
+      <List height={height} itemCount={rowData.length} itemSize={getItemSize} width={'100%'}>
+        {Row}
+      </List>
+    </SimpleFlexColumn>
+  )
+})

--- a/editor/src/components/code-editor/monaco-wrapper.tsx
+++ b/editor/src/components/code-editor/monaco-wrapper.tsx
@@ -26,6 +26,7 @@ import { OPENING_TAG_REGEX } from './monaco-wrapper-helper'
 import { arrayEquals } from '../../core/shared/utils'
 import * as TP from '../../core/shared/template-path'
 import * as FontFaceObserver from 'fontfaceobserver'
+import { splitIntoLines } from '../../core/shared/string-utils'
 
 const CodeEditorFont = 'utopian-inconsolata'
 
@@ -114,6 +115,14 @@ SimpleEditorModelResolverService.prototype.findModel = (_: any, resource: any) =
 let extraLibs: { [fileuri: string]: { js: monaco.IDisposable; ts: monaco.IDisposable } } = {}
 let completionProviders: { js: monaco.IDisposable; ts: monaco.IDisposable } | null = null
 let hoverProviders: { js: monaco.IDisposable; ts: monaco.IDisposable } | null = null
+
+const MaxSupportedLineLength = 200
+
+function areAnyCodeLinesTooLong(code: string): boolean {
+  const lines = splitIntoLines(code)
+  const offendingLine = lines.find((line) => line.length > MaxSupportedLineLength)
+  return offendingLine != null
+}
 
 export class MonacoWrapper extends React.Component<MonacoWrapperProps, MonacoWrapperState> {
   private rootRef: HTMLDivElement | null = null
@@ -481,7 +490,7 @@ export class MonacoWrapper extends React.Component<MonacoWrapperProps, MonacoWra
       if (code != null) {
         let model = findModel(filename.toString())
         if (model == null || model.isDisposed()) {
-          model = monaco.editor.createModel(code, undefined, filename)
+          model = this.createModel(code, filename)
           model.updateOptions({ tabSize: this.props.tabSize })
         }
       }
@@ -552,10 +561,16 @@ export class MonacoWrapper extends React.Component<MonacoWrapperProps, MonacoWra
     })
   }
 
+  createModel = (code: string, fileUri: monaco.Uri): monaco.editor.ITextModel => {
+    const linesAreTooLong = areAnyCodeLinesTooLong(code)
+    const language: string | undefined = linesAreTooLong ? 'plaintext' : undefined // disable language support of files with long lines
+    return monaco.editor.createModel(code, language, fileUri)
+  }
+
   getOrCreateModel = (fileUri: monaco.Uri) => {
     let model = findModel(fileUri.toString())
     if (model == null || model.isDisposed()) {
-      model = monaco.editor.createModel(this.props.value, undefined, fileUri)
+      model = this.createModel(this.props.value, fileUri)
       model.updateOptions({ tabSize: this.props.tabSize })
     }
     return model

--- a/editor/src/core/shared/string-utils.ts
+++ b/editor/src/core/shared/string-utils.ts
@@ -21,3 +21,7 @@ export function replaceAll(inString: string, searchFor: string, replaceWith: str
 export function camelCaseToDashed(s: string): string {
   return s.replace(/[A-Z]/g, (l) => `-${l.toLowerCase()}`)
 }
+
+export function splitIntoLines(s: string): Array<string> {
+  return s.split(/[\r\n]/)
+}


### PR DESCRIPTION
Fixes #538 

**Problem:**
The code problems tab was rendering all rows always, meaning it was having a **huge** impact on the performance of the code editor if there were a large number of problems in the user's project.

**Fix:**
Use `react-window` to render the problems tab, and skip rendering any content if the problems pane isn't open.

**Commit Details:**
- Pulled out the problems tab contents into it's own component
- Slight refactoring to support `react-window`'s API (extracted constants for the heights of the rows, added functions for determining the height and the component to render based on the row number)
- Update the `heightWhenOpen` value in the `onResize` callback rather than the `onResizeStop` so that the `VariableSizeList` always has access to the correct height
