### PR TITLE
fix(pragma) skip style prop update for react fragments

### DIFF
--- a/utopia-api/src/pragma/pragma.tsx
+++ b/utopia-api/src/pragma/pragma.tsx
@@ -119,10 +119,15 @@ export const jsx = (type: any, ...pragmaParams: any[]) => {
             ...childStyleProps,
             ...childStylesThatOverwriteStyle[index],
           }
-          return React.cloneElement(child as any, {
-            ...removeLayoutPropFromReactBuiltins,
-            style: layoutEnhancedStyleProp,
-          })
+
+          const updatedProps =
+            (child.type as any).theOriginalType.toString() === 'Symbol(react.fragment)'
+              ? (child.props as any)
+              : {
+                  ...removeLayoutPropFromReactBuiltins,
+                  style: layoutEnhancedStyleProp,
+                }
+          return React.cloneElement(child as any, updatedProps)
         } else {
           return child
         }

--- a/utopia-api/src/pragma/pragma.tsx
+++ b/utopia-api/src/pragma/pragma.tsx
@@ -121,7 +121,7 @@ export const jsx = (type: any, ...pragmaParams: any[]) => {
           }
 
           const updatedProps =
-            (child.type as any).theOriginalType.toString() === 'Symbol(react.fragment)'
+            (child.type as any)?.theOriginalType?.toString() === 'Symbol(react.fragment)'
               ? (child.props as any)
               : {
                   ...removeLayoutPropFromReactBuiltins,

--- a/utopia-api/src/pragma/pragma.tsx
+++ b/utopia-api/src/pragma/pragma.tsx
@@ -121,7 +121,7 @@ export const jsx = (type: any, ...pragmaParams: any[]) => {
           }
 
           const updatedProps =
-            (child.type as any)?.theOriginalType?.toString() === 'Symbol(react.fragment)'
+            (child.type as any)?.theOriginalType == React.Fragment
               ? (child.props as any)
               : {
                   ...removeLayoutPropFromReactBuiltins,


### PR DESCRIPTION
**Problem:**
There were errors on the ui-jsx-canvas on every render when you had a text element inside a div.

**Fix:**
Style props are updated for the pragma, even for react fragments. It skips fragments now.

**Commit Details:**
- updated the pragma
