### PR TITLE
Much speedier editor internals.

### DIFF
--- a/editor/src/components/assets.spec.ts
+++ b/editor/src/components/assets.spec.ts
@@ -1,7 +1,13 @@
 import * as FastCheck from 'fast-check'
 import * as R from 'ramda'
 import { codeFile, directory, imageFile, isDirectory } from '../core/model/project-file-utils'
-import { CodeFile, Directory, ImageFile, ProjectContents } from '../core/shared/project-file-types'
+import {
+  CodeFile,
+  Directory,
+  ImageFile,
+  ProjectContents,
+  ProjectFile,
+} from '../core/shared/project-file-types'
 import {
   contentsToTree,
   projectContentDirectory,
@@ -43,7 +49,11 @@ function pathArbitrary(): FastCheck.Arbitrary<string> {
       1,
       30,
     ),
-  ).map((arr) => `/${arr.join('/')}`)
+    1,
+    5,
+  ).map((arr) => {
+    return `/${arr.join('/')}`
+  })
 }
 
 function projectContentsFilter(projectContents: ProjectContents): boolean {
@@ -62,11 +72,13 @@ function projectContentsFilter(projectContents: ProjectContents): boolean {
 }
 
 function projectContentsArbitrary(): FastCheck.Arbitrary<ProjectContents> {
-  return FastCheck.object({
-    key: pathArbitrary(),
-    values: [notDirectoryContentFileArbitrary(), directoryContentFileArbitrary()],
-    maxDepth: 1,
-  }).filter(projectContentsFilter)
+  return FastCheck.dictionary<ProjectFile>(
+    pathArbitrary(),
+    FastCheck.oneof<ProjectFile>(
+      notDirectoryContentFileArbitrary(),
+      directoryContentFileArbitrary(),
+    ),
+  ).filter(projectContentsFilter)
 }
 
 function checkContentsToTree(contents: ProjectContents): boolean {

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -5,6 +5,7 @@ import {
   ExportsInfo,
   MultiFileBuildResult,
   BuildType,
+  EmitFileResult,
 } from '../../core/workers/ts/ts-worker'
 import { PropertyControls } from 'utopia-api'
 import { RawSourceMap } from '../../core/workers/ts/ts-typings/RawSourceMap'
@@ -19,6 +20,8 @@ import { EditorDispatch } from '../editor/action-types'
 import { getMemoizedRequireFn } from '../../core/es-modules/package-manager/package-manager'
 import { updateNodeModulesContents } from '../editor/actions/actions'
 import { fastForEach } from '../../core/shared/utils'
+import { arrayToObject } from '../../core/shared/array-utils'
+import { objectMap } from '../../core/shared/object-utils'
 export interface CodeResult {
   exports: ModuleExportTypes
   transpiledCode: string | null
@@ -215,17 +218,14 @@ export function isJavascriptOrTypescript(filePath: string): boolean {
   return regex.test(filePath)
 }
 
-export const codeCacheToBuildResult = (cache: { [filename: string]: CodeResult }) => {
-  const multiFileBuildResult: MultiFileBuildResult = Object.keys(cache).reduce((acc, filename) => {
+export function codeCacheToBuildResult(cache: {
+  [filename: string]: CodeResult
+}): { [filename: string]: EmitFileResult } {
+  return objectMap((entry) => {
     return {
-      ...acc,
-      [filename]: {
-        transpiledCode: cache[filename].transpiledCode,
-        sourceMap: cache[filename].sourceMap,
-        errors: [], // TODO: this is ugly, these errors are the build errors which are not stored in CodeResultCache, but directly in EditorState.codeEditorErrors
-      },
+      transpiledCode: entry.transpiledCode,
+      sourceMap: entry.sourceMap,
+      errors: [], // TODO: this is ugly, these errors are the build errors which are not stored in CodeResultCache, but directly in EditorState.codeEditorErrors
     }
-  }, {})
-
-  return multiFileBuildResult
+  }, cache)
 }


### PR DESCRIPTION
Fixes #537

**Problem:**
With large projects (on the order of 1,000 files was tested), a couple of functions showed up as being terribly non-performant.

**Fix:**
For both `codeCacheToBuildResult` and `contentsToTree`, the underlying performance issue was repeated `Object.assign` calls triggered by use of object spreads either in a reduce or by merging trees containing objects respectively.

**Commit Details:**
- Fixes #537.
- Reworks the entirety of `contentsToTree` to construct the result mutably.
- Fixed an issue in `pathArbitrary` where empty paths ended up being
  constructed which then broke some specs.
- `codeCacheToBuildResult` now constructs the result mutably.