### PR TITLE
Fix Code Editor Saving

### DIFF
--- a/editor/src/components/code-editor/script-editor.tsx
+++ b/editor/src/components/code-editor/script-editor.tsx
@@ -30,7 +30,10 @@ import { runtimeErrorInfoToErrorMessage } from './monaco-wrapper'
 import { EditorPanel, setFocus } from '../common/actions'
 import { EditorAction } from '../editor/action-types'
 import * as EditorActions from '../editor/actions/actions'
-import { dependenciesFromPackageJson, usePossiblyResolvedPackageDependencies } from '../editor/npm-dependency/npm-dependency'
+import {
+  dependenciesFromPackageJson,
+  usePossiblyResolvedPackageDependencies,
+} from '../editor/npm-dependency/npm-dependency'
 import {
   ConsoleLog,
   EditorStore,
@@ -49,7 +52,6 @@ import { useKeepReferenceEqualityIfPossible } from '../inspector/common/property
 import * as TP from '../../core/shared/template-path'
 import { CodeEditor } from './code-editor'
 import { CursorPosition } from './code-editor-utils'
-import { forceServerSave } from '../editor/persistence'
 import { Notice } from '../common/notices'
 import { getDependencyTypeDefinitions } from '../../core/es-modules/package-manager/package-manager'
 
@@ -290,14 +292,15 @@ export const ScriptEditor = betterReactMemo('ScriptEditor', (props: ScriptEditor
           EditorActions.updateFile(filePath, updatedFile, false),
           EditorActions.setCodeEditorBuildErrors({}),
         ]
-        const actions =
+        const withToastAction =
           toast == null
             ? updateFileActions
             : updateFileActions.concat(EditorActions.pushToast(toast))
+
+        const actions = manualSave
+          ? withToastAction.concat(EditorActions.saveCurrentFile())
+          : withToastAction
         dispatch(actions, 'everyone')
-        if (manualSave) {
-          forceServerSave()
-        }
       }
     },
     [openFile, dispatch, filePath],

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -80,6 +80,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_SHORTCUT':
     case 'UPDATE_PROPERTY_CONTROLS_INFO':
     case 'PROPERTY_CONTROLS_IFRAME_READY':
+    case 'SAVE_CURSOR_POSITION':
       return true
 
     case 'NEW':
@@ -131,7 +132,6 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UNWRAP_LAYOUTABLE':
     case 'UPDATE_JSX_ELEMENT_NAME':
     case 'SET_ASPECT_RATIO_LOCK':
-    case 'SAVE_CURSOR_POSITION':
     case 'SET_CODE_EDITOR_THEME':
     case 'INSERT_DROPPED_IMAGE':
     case 'RESET_PROP_TO_DEFAULT':

--- a/editor/src/components/editor/persistence.ts
+++ b/editor/src/components/editor/persistence.ts
@@ -178,7 +178,7 @@ export function clearSaveState(): void {
 
 window.addEventListener('beforeunload', (e) => {
   if (!isSafeToClose()) {
-    forceServerSave()
+    forceQueuedSave()
     e.preventDefault()
     e.returnValue = ''
   }
@@ -593,7 +593,7 @@ export async function loadFromLocalStorage(
   }
 }
 
-export async function forceServerSave(): Promise<void> {
+async function forceQueuedSave(): Promise<void> {
   if ((_saveState.type === 'saved' || _saveState.type === 'save-error') && _saveState.remote) {
     serverSaveInner(
       _saveState.dispatch,


### PR DESCRIPTION
Fixes #534 

**Problem:**
Saving when the code editor was focused wasn't actually including the updated model in the save. As well as this, we were seemingly always telling the user that their project had unsaved changed.

**Fix:**
The code editor `cmd`+`s` flow was using a poorly named function that went outside of the correct saving flow. This function is actually for forcing through the currently queued save, which would have been queued up before the model had been updated. To fix this part of the issue we just dispatch the correct action instead of trying to circumvent the correct flow.
Also, for some reason changing the cursor position was treated as a non-transient action, meaning that in itself was constantly queuing up saves to the server, so that's no longer the case.

**Commit Details:**
- Dispatch a `SAVE_CURRENT_FILE` action from `script-editor.tsx` when forcibly saving, which triggers the "force save" process when that set of actions are handled
- Rename (and no longer export) the poorly named `forceServerSave` to `forceQueuedSave`, since that is an internal only function for forcing through the last queued save
- Made `SAVE_CURSOR_POSITION` a transient action