### PR TITLE
Added the embedded preview button to the left menu bar

### DIFF
--- a/editor/src/components/canvas/right-menu.tsx
+++ b/editor/src/components/canvas/right-menu.tsx
@@ -178,7 +178,7 @@ export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) =>
       }}
     >
       <SimpleFlexColumn data-title='group' style={{ marginBottom: 24 }}>
-        <Tooltip title={'Inspector'} placement='left-end'>
+        <Tooltip title={'Inspector'} placement='left'>
           <span>
             <RightMenuTile
               selected={isInspectorSelected}
@@ -188,7 +188,7 @@ export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) =>
             />
           </span>
         </Tooltip>
-        <Tooltip title={'Insert'} placement='left-end'>
+        <Tooltip title={'Insert'} placement='left'>
           <span>
             <RightMenuTile
               selected={isInsertMenuSelected}
@@ -200,7 +200,7 @@ export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) =>
         </Tooltip>
       </SimpleFlexColumn>
       <SimpleFlexColumn data-title='group' style={{ marginBottom: 24 }}>
-        <Tooltip title={'Live Preview'} placement='left-end'>
+        <Tooltip title={'Live Preview'} placement='left'>
           <span>
             <RightMenuTile
               selected={isCanvasLive}
@@ -210,17 +210,19 @@ export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) =>
             />
           </span>
         </Tooltip>
-        <Tooltip title='Reset canvas'>
-          <RightMenuTile
-            selected={false}
-            highlightSelected={false}
-            icon={<LargerIcons.Refresh />}
-          />
+        <Tooltip title='Reset canvas' placement='left'>
+          <span>
+            <RightMenuTile
+              selected={false}
+              highlightSelected={false}
+              icon={<LargerIcons.Refresh />}
+            />
+          </span>
         </Tooltip>
       </SimpleFlexColumn>
 
       <SimpleFlexColumn data-title='group' style={{ marginBottom: 24, flexGrow: 1 }}>
-        <Tooltip title='Zoom in' placement='left-end'>
+        <Tooltip title='Zoom in' placement='left'>
           <span>
             <RightMenuTile
               selected={false}
@@ -233,7 +235,7 @@ export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) =>
         <span style={{ fontSize: 9, width: '100%', textAlign: 'center' }} onClick={zoom100pct}>
           {zoomLevel}x
         </span>
-        <Tooltip title='Zoom out' placement='left-end'>
+        <Tooltip title='Zoom out' placement='left'>
           <span>
             <RightMenuTile
               selected={false}

--- a/editor/src/components/menubar/menubar.tsx
+++ b/editor/src/components/menubar/menubar.tsx
@@ -1,35 +1,26 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
 import styled from '@emotion/styled'
-import { UtopiaStyles } from 'uuiui'
 import * as React from 'react'
-import { Avatar } from 'uuiui'
-import { IcnProps } from 'uuiui'
-import { LeftMenuTab } from '../navigator/left-pane'
-import { EditorState } from '../editor/store/editor-state'
-import { LoginState } from '../../common/user'
-import { EditorDispatch, EditorAction } from '../editor/action-types'
-import { FlexColumn } from 'uuiui'
-import { MenuIcons } from 'uuiui'
 import {
-  setLeftMenuTab,
-  setLeftMenuExpanded,
-  togglePanel,
-  setPanelVisibility,
-} from '../editor/actions/actions'
-
-import { useEditorState } from '../editor/store/store-hook'
-import { SquareButton } from 'uuiui'
+  Avatar,
+  FlexColumn,
+  IcnProps,
+  LargerIcons,
+  MenuIcons,
+  SquareButton,
+  Tooltip,
+  UtopiaStyles,
+} from 'uuiui'
 import { betterReactMemo } from 'uuiui-deps'
 import { FLOATING_PREVIEW_BASE_URL } from '../../common/env-vars'
+import { LoginState } from '../../common/user'
 import { shareURLForProject } from '../../core/shared/utils'
-
-interface MenuBarProps {
-  editorState: EditorState
-  loginState: LoginState
-  editorDispatch: EditorDispatch
-  expandedLeftPanel: boolean
-}
+import { EditorAction, EditorDispatch } from '../editor/action-types'
+import { setLeftMenuTab, setPanelVisibility, togglePanel } from '../editor/actions/actions'
+import { EditorState } from '../editor/store/editor-state'
+import { useEditorState } from '../editor/store/store-hook'
+import { LeftMenuTab } from '../navigator/left-pane'
 
 const Tile = styled.div({
   display: 'flex',
@@ -93,6 +84,7 @@ export const Menubar = betterReactMemo('Menubar', () => {
     leftMenuExpanded,
     projectId,
     projectName,
+    isPreviewPaneVisible,
   } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
@@ -101,10 +93,11 @@ export const Menubar = betterReactMemo('Menubar', () => {
       leftMenuExpanded: store.editor.leftMenu.expanded,
       projectId: store.editor.id,
       projectName: store.editor.projectName,
+      isPreviewPaneVisible: store.editor.preview.visible,
     }
   })
 
-  const onShow = React.useCallback(
+  const onClickTab = React.useCallback(
     (menuTab: LeftMenuTab) => {
       let actions: Array<EditorAction> = []
       if (selectedTab === menuTab) {
@@ -122,21 +115,18 @@ export const Menubar = betterReactMemo('Menubar', () => {
     dispatch([togglePanel('leftmenu')])
   }, [dispatch])
 
-  const onShowNavigateTab = React.useCallback(() => {
-    onShow(LeftMenuTab.UINavigate)
-  }, [onShow])
+  const onClickNavigateTab = React.useCallback(() => {
+    onClickTab(LeftMenuTab.UINavigate)
+  }, [onClickTab])
 
-  const onShowStructureTab = React.useCallback(() => {
-    onShow(LeftMenuTab.ProjectStructure)
-  }, [onShow])
+  const onClickStructureTab = React.useCallback(() => {
+    onClickTab(LeftMenuTab.ProjectStructure)
+  }, [onClickTab])
 
-  const onShowProjectTab = React.useCallback(() => {
-    onShow(LeftMenuTab.ProjectSettings)
-  }, [onShow])
-
-  const onToggleMenu = React.useCallback(() => {
-    dispatch([togglePanel('leftmenu')])
-  }, [dispatch])
+  const togglePreviewPaneVisible = React.useCallback(
+    () => dispatch([setPanelVisibility('preview', !isPreviewPaneVisible)]),
+    [dispatch, isPreviewPaneVisible],
+  )
 
   const previewURL =
     projectId == null ? '' : shareURLForProject(FLOATING_PREVIEW_BASE_URL, projectId, projectName)
@@ -151,22 +141,44 @@ export const Menubar = betterReactMemo('Menubar', () => {
       onDoubleClick={onDoubleClick}
     >
       <FlexColumn style={{ flexGrow: 1 }}>
-        <MenuTile
-          selected={selectedTab === LeftMenuTab.ProjectStructure}
-          menuExpanded={leftMenuExpanded}
-          icon={<MenuIcons.Menu />}
-          onClick={onShowStructureTab}
-        />
+        <Tooltip title={'Project Structure'} placement={'right'}>
+          <span>
+            <MenuTile
+              selected={selectedTab === LeftMenuTab.ProjectStructure}
+              menuExpanded={leftMenuExpanded}
+              icon={<MenuIcons.Menu />}
+              onClick={onClickStructureTab}
+            />
+          </span>
+        </Tooltip>
 
-        <MenuTile
-          selected={selectedTab === LeftMenuTab.UINavigate}
-          menuExpanded={leftMenuExpanded}
-          icon={<MenuIcons.Project />}
-          onClick={onShowNavigateTab}
-        />
+        <Tooltip title={'Navigator'} placement={'right'}>
+          <span>
+            <MenuTile
+              selected={selectedTab === LeftMenuTab.UINavigate}
+              menuExpanded={leftMenuExpanded}
+              icon={<MenuIcons.Project />}
+              onClick={onClickNavigateTab}
+            />
+          </span>
+        </Tooltip>
         <a target='_blank' rel='noopener noreferrer' href={previewURL}>
-          <MenuTile selected={false} menuExpanded={false} icon={<MenuIcons.ExternalLink />} />
+          <Tooltip title={'Launch External Preview'} placement={'right'}>
+            <span>
+              <MenuTile selected={false} menuExpanded={false} icon={<MenuIcons.ExternalLink />} />
+            </span>
+          </Tooltip>
         </a>
+        <Tooltip title={'Embedded Preview'} placement={'right'}>
+          <span>
+            <MenuTile
+              selected={isPreviewPaneVisible}
+              menuExpanded={false}
+              icon={<LargerIcons.PreviewPane />}
+              onClick={togglePreviewPaneVisible}
+            />
+          </span>
+        </Tooltip>
       </FlexColumn>
       <Tile style={{ marginTop: 12, marginBottom: 12 }}>
         <a href='/projects'>


### PR DESCRIPTION
Fixes #555 

**Problem:**
For imported projects that don't have a canvas file there is no way to open the embedded preview (since the right menu bar is never shown)

**Fix:**
Added the embedded preview button to the left menu bar. I've opted to leave it in the right menu bar too since we're all used to it being there, but I don't mind removing it from there. Alternatively, we could choose to always render the right menu bar, but disable all of the other (irrelevant) controls when the canvas isn't open.

**Commit Details:**
- Added a tile for toggling the embedded preview to the left menu bar in `menubar.tsx`
- Added tool tips to all of the left menu bar buttons
- Fixed tool tip alignment in `right-menu.tsx`, and added a missing tool tip
- Some minor cleaning up of function names
