### PR TITLE
Preview only processes the latest update

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -171,14 +171,14 @@ function processActions(
   }, working)
 }
 
-export function updateFloaterPreview(
+export function updateEmbeddedPreview(
   modelId: string | null,
   projectContents: ProjectContents,
 ): void {
-  const floaterElement = document.getElementById(PreviewIframeId)
-  if (floaterElement != null) {
-    const iFrameFloaterElement = (floaterElement as any) as HTMLIFrameElement
-    const contentWindow = iFrameFloaterElement.contentWindow
+  const embeddedPreviewElement = document.getElementById(PreviewIframeId)
+  if (embeddedPreviewElement != null) {
+    const embeddedPreviewIframe = (embeddedPreviewElement as any) as HTMLIFrameElement
+    const contentWindow = embeddedPreviewIframe.contentWindow
     if (contentWindow != null) {
       try {
         contentWindow.postMessage(projectContentsUpdateMessage(projectContents), '*')
@@ -416,7 +416,7 @@ export function editorDispatch(
   const shouldUpdatePreview =
     anySendPreviewModel || frozenEditorState.projectContents !== storedState.editor.projectContents
   if (shouldUpdatePreview) {
-    updateFloaterPreview(frozenEditorState.id, frozenEditorState.projectContents)
+    updateEmbeddedPreview(frozenEditorState.id, frozenEditorState.projectContents)
   }
 
   if (frozenEditorState.id != null && frozenEditorState.id != storedState.editor.id) {

--- a/editor/src/components/preview/preview-pane.tsx
+++ b/editor/src/components/preview/preview-pane.tsx
@@ -18,10 +18,45 @@ import { DeviceInfo, deviceInfoList } from '../../common/devices'
 import { BASE_URL, FLOATING_PREVIEW_BASE_URL } from '../../common/env-vars'
 import { useEditorState } from '../editor/store/store-hook'
 import { SelectOption } from '../inspector/controls/select-control'
+import { isCodeFile, CodeFile, ProjectContents } from '../../core/shared/project-file-types'
+import { objectKeyParser, parseString } from '../../utils/value-parser-utils'
+import { eitherToMaybe } from '../../core/shared/either'
 import { shareURLForProject } from '../../core/shared/utils'
 import { getMainJSFilename } from '../../core/shared/project-contents-utils'
 
 export const PreviewIframeId = 'preview-column-container'
+
+export interface ProjectContentsUpdateMessage {
+  type: 'PROJECT_CONTENTS_UPDATE'
+  projectContents: ProjectContents
+}
+
+export function projectContentsUpdateMessage(
+  projectContents: ProjectContents,
+): ProjectContentsUpdateMessage {
+  return {
+    type: 'PROJECT_CONTENTS_UPDATE',
+    projectContents: projectContents,
+  }
+}
+
+export function isProjectContentsUpdateMessage(
+  data: unknown,
+): data is ProjectContentsUpdateMessage {
+  return (
+    data != null &&
+    typeof data === 'object' &&
+    !Array.isArray(data) &&
+    (data as ProjectContentsUpdateMessage).type === 'PROJECT_CONTENTS_UPDATE'
+  )
+}
+
+interface IntermediatePreviewColumnProps {
+  id: string | null
+  projectName: string
+  connected: boolean
+  packageJSONFile: CodeFile | null
+}
 
 export interface PreviewColumnProps {
   id: string | null

--- a/editor/src/templates/preview.tsx
+++ b/editor/src/templates/preview.tsx
@@ -265,8 +265,6 @@ const initPreview = () => {
         `Error processing the project files: the preview path (${previewJSFilePath}) did not point to a valid file`,
       )
     }
-
-    handlePossiblyQueuedModel()
   }
 
   const addWindowListeners = () => {


### PR DESCRIPTION
Fixes #563 

**Problem:**
There is no queuing system in the preview, meaning it process every single model update in turn. As well as that, we're updating the preview with every model change even though we only care about changes to the `projectContents`

**Fix:**
Only send updates to the preview on changes to the `projectContents`, and queue up the latest model update if the preview is currently being updated with a previous model.

**Commit Details:**
- Added an interface for sending project contents update messages to the floater preview
- `dispatch.tsx` only updates the floater preview if there are project contents changes (rather than any change that would trigger a save), or an explicit request to send the latest project
- Track whether a model is being loaded by the preview, and if so queue up the latest model change (replacing the previously queued change each time)
- Ensure that we handle any queued model change after a preview render, regardless of if there was an error or not.