### PR TITLE
Change the representation of projectContents to be a tree.

### DIFF
--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -12,6 +12,7 @@ import Utils from '../utils/utils'
 import * as R from 'ramda'
 import { dropLeadingSlash } from './filebrowser/filepath-utils'
 import { fastForEach } from '../core/shared/utils'
+import { mapValues } from 'xstate/lib/utils'
 
 interface ImageAsset {
   assetPath: string
@@ -39,7 +40,7 @@ export function getImageAssets(projectContents: ProjectContents): Array<ImageAss
 export type ProjectContentTreeRoot = { [key: string]: ProjectContentsTree }
 
 export interface ProjectContentDirectory {
-  type: 'DIRECTORY'
+  type: 'PROJECT_CONTENT_DIRECTORY'
   fullPath: string
   directory: Directory
   children: ProjectContentTreeRoot
@@ -50,8 +51,11 @@ export function projectContentDirectory(
   dir: Directory,
   children: ProjectContentTreeRoot,
 ): ProjectContentDirectory {
+  if (dir.type !== 'DIRECTORY') {
+    throw new Error(`Not a directory: ${JSON.stringify(dir)}`)
+  }
   return {
-    type: 'DIRECTORY',
+    type: 'PROJECT_CONTENT_DIRECTORY',
     fullPath: fullPath,
     directory: dir,
     children: children,
@@ -59,7 +63,7 @@ export function projectContentDirectory(
 }
 
 export interface ProjectContentFile {
-  type: 'FILE'
+  type: 'PROJECT_CONTENT_FILE'
   fullPath: string
   content: UIJSFile | CodeFile | ImageFile | AssetFile
 }
@@ -68,14 +72,35 @@ export function projectContentFile(
   fullPath: string,
   content: UIJSFile | CodeFile | ImageFile | AssetFile,
 ): ProjectContentFile {
+  switch (content.type) {
+    case 'CODE_FILE':
+    case 'ASSET_FILE':
+    case 'IMAGE_FILE':
+    case 'UI_JS_FILE':
+      break
+    default:
+      throw new Error(`Not a file: ${JSON.stringify(content)}`)
+  }
   return {
-    type: 'FILE',
+    type: 'PROJECT_CONTENT_FILE',
     fullPath: fullPath,
     content: content,
   }
 }
 
 export type ProjectContentsTree = ProjectContentDirectory | ProjectContentFile
+
+export function getProjectFileFromTree(tree: ProjectContentsTree): ProjectFile {
+  switch (tree.type) {
+    case 'PROJECT_CONTENT_FILE':
+      return tree.content
+    case 'PROJECT_CONTENT_DIRECTORY':
+      return tree.directory
+    default:
+      const _exhaustiveCheck: never = tree
+      throw new Error(`Unhandled tree ${JSON.stringify(tree)}`)
+  }
+}
 
 export function getProjectContentKeyPathElements(projectContentKey: string): Array<string> {
   return dropLeadingSlash(projectContentKey)
@@ -90,7 +115,7 @@ export function pathElementsToProjectContentKey(
   return '/' + pathElements.slice(0, pathIndex + 1).join('/')
 }
 
-export function addToProjectContentTreeRoot(
+function addToProjectContentTreeRoot(
   treeRoot: ProjectContentTreeRoot,
   pathElements: ReadonlyArray<string>,
   file: ProjectFile,
@@ -104,7 +129,7 @@ export function addToProjectContentTreeRoot(
       const pathString = pathElementsToProjectContentKey(pathElements, pathIndex)
       if (isDirectory(file) || !isLastElement) {
         let newTreeRoot: ProjectContentTreeRoot = {}
-        if (innerValue != null && innerValue.type === 'DIRECTORY') {
+        if (innerValue != null && innerValue.type === 'PROJECT_CONTENT_DIRECTORY') {
           newTreeRoot = innerValue.children
         } else {
           workingTreeRoot[pathPart] = projectContentDirectory(
@@ -123,7 +148,7 @@ export function addToProjectContentTreeRoot(
     if (innerValue == null) {
       addNewFile(innerValue)
     } else {
-      if (innerValue.type === 'DIRECTORY') {
+      if (innerValue.type === 'PROJECT_CONTENT_DIRECTORY') {
         addNewFile(innerValue)
       } else {
         if (isLastElement) {
@@ -146,6 +171,7 @@ export function contentsToTree(projectContents: ProjectContents): ProjectContent
   fastForEach(contentKeys, (contentKey) => {
     const pathElements = getProjectContentKeyPathElements(contentKey)
     const file = projectContents[contentKey]
+
     addToProjectContentTreeRoot(treeRoot, pathElements, file)
   })
   return treeRoot
@@ -156,12 +182,12 @@ export function treeToContents(tree: ProjectContentTreeRoot): ProjectContents {
   return treeKeys.reduce((working, treeKey) => {
     const treePart = tree[treeKey]
     switch (treePart.type) {
-      case 'FILE':
+      case 'PROJECT_CONTENT_FILE':
         return {
           ...working,
           [treePart.fullPath]: treePart.content,
         }
-      case 'DIRECTORY':
+      case 'PROJECT_CONTENT_DIRECTORY':
         return {
           ...working,
           [treePart.fullPath]: treePart.directory,
@@ -183,16 +209,191 @@ export function walkContentsTree(
   Utils.fastForEach(treeKeys, (treeKey) => {
     const treeElement = tree[treeKey]
     switch (treeElement.type) {
-      case 'FILE':
+      case 'PROJECT_CONTENT_FILE':
         onElement(treeElement.fullPath, treeElement.content)
         break
-      case 'DIRECTORY':
+      case 'PROJECT_CONTENT_DIRECTORY':
         onElement(treeElement.fullPath, treeElement.directory)
         walkContentsTree(treeElement.children, onElement)
         break
       default:
         const _exhaustiveCheck: never = treeElement
         throw new Error(`Unhandled tree element ${JSON.stringify(treeElement)}`)
+    }
+  })
+}
+
+export function getContentsTreeFileFromElements(
+  tree: ProjectContentTreeRoot,
+  pathElements: ReadonlyArray<string>,
+): ProjectFile | null {
+  if (pathElements.length === 0) {
+    throw new Error(`Invalid pathElements.`)
+  } else {
+    function getFileWithIndex(
+      currentTree: ProjectContentTreeRoot,
+      index: number,
+    ): ProjectFile | null {
+      const pathPart = pathElements[index]
+      const treePart = currentTree[pathPart]
+      if (treePart == null) {
+        return null
+      } else {
+        if (index === pathElements.length - 1) {
+          return getProjectFileFromTree(treePart)
+        } else {
+          if (treePart.type === 'PROJECT_CONTENT_DIRECTORY') {
+            return getFileWithIndex(treePart.children, index + 1)
+          } else {
+            return null
+          }
+        }
+      }
+    }
+    return getFileWithIndex(tree, 0)
+  }
+}
+
+export function getContentsTreeFileFromString(
+  tree: ProjectContentTreeRoot,
+  path: string,
+): ProjectFile | null {
+  return getContentsTreeFileFromElements(tree, getProjectContentKeyPathElements(path))
+}
+
+export function addFileToProjectContents(
+  tree: ProjectContentTreeRoot,
+  path: string,
+  file: ProjectFile,
+): ProjectContentTreeRoot {
+  const pathElements = getProjectContentKeyPathElements(path)
+
+  function createProjectContent(): ProjectContentsTree {
+    if (isDirectory(file)) {
+      return projectContentDirectory(path, file, {})
+    } else {
+      return projectContentFile(path, file)
+    }
+  }
+
+  function addAtCurrentIndex(
+    workingTreeRoot: ProjectContentTreeRoot,
+    index: number,
+  ): ProjectContentTreeRoot {
+    const isLastElement = index === pathElements.length - 1
+    const pathPart = pathElements[index]
+    const treePart = workingTreeRoot[pathPart]
+    if (treePart == null) {
+      if (isLastElement) {
+        return {
+          ...workingTreeRoot,
+          [pathPart]: createProjectContent(),
+        }
+      } else {
+        return {
+          ...workingTreeRoot,
+          [pathPart]: projectContentDirectory(
+            pathElementsToProjectContentKey(pathElements, index),
+            directory(),
+            addAtCurrentIndex({}, index + 1),
+          ),
+        }
+      }
+    } else {
+      if (isLastElement) {
+        return {
+          ...workingTreeRoot,
+          [pathPart]: createProjectContent(),
+        }
+      } else {
+        if (treePart.type === 'PROJECT_CONTENT_FILE') {
+          throw new Error(
+            `Attempting to add something at ${path} which is below a pre-existing file at ${treePart.fullPath}`,
+          )
+        } else {
+          return {
+            ...workingTreeRoot,
+            [pathPart]: projectContentDirectory(
+              treePart.fullPath,
+              treePart.directory,
+              addAtCurrentIndex(treePart.children, index + 1),
+            ),
+          }
+        }
+      }
+    }
+  }
+
+  return addAtCurrentIndex(tree, 0)
+}
+
+export function removeFromProjectContents(
+  projectContents: ProjectContentTreeRoot,
+  path: string,
+): ProjectContentTreeRoot {
+  const pathElements = getProjectContentKeyPathElements(path)
+
+  function removeWithIndex(
+    workingTreeRoot: ProjectContentTreeRoot,
+    pathIndex: number,
+  ): 'NO_CHANGE' | ProjectContentTreeRoot {
+    const isLastElement = pathIndex === pathElements.length - 1
+    const pathPart = pathElements[pathIndex]
+    const treePart = workingTreeRoot[pathPart]
+
+    if (treePart == null) {
+      // Reached a part of the tree that doesn't exist, therefore the target
+      // doesn't exist.
+      return 'NO_CHANGE'
+    } else {
+      if (isLastElement) {
+        let updatedWorkingTreeRoot: ProjectContentTreeRoot = {
+          ...workingTreeRoot,
+        }
+        delete updatedWorkingTreeRoot[pathPart]
+        return updatedWorkingTreeRoot
+      } else {
+        if (treePart.type === 'PROJECT_CONTENT_FILE') {
+          // Attempting to delete something which is hierarchically below a file.
+          // Which means it can't possibly exist.
+          return 'NO_CHANGE'
+        } else {
+          const innerResult = removeWithIndex(treePart.children, pathIndex + 1)
+          if (innerResult === 'NO_CHANGE') {
+            return 'NO_CHANGE'
+          } else {
+            return {
+              ...workingTreeRoot,
+              [pathPart]: projectContentDirectory(
+                treePart.fullPath,
+                treePart.directory,
+                innerResult,
+              ),
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const result = removeWithIndex(projectContents, 0)
+  if (result === 'NO_CHANGE') {
+    return projectContents
+  } else {
+    return result
+  }
+}
+
+export function transformContentsTree(
+  projectContents: ProjectContentTreeRoot,
+  transform: (tree: ProjectContentsTree) => ProjectContentsTree,
+): ProjectContentTreeRoot {
+  return mapValues(projectContents, (tree: ProjectContentsTree) => {
+    if (tree.type === 'PROJECT_CONTENT_DIRECTORY') {
+      const transformedChildren = transformContentsTree(tree.children, transform)
+      return transform(projectContentDirectory(tree.fullPath, tree.directory, transformedChildren))
+    } else {
+      return transform(tree)
     }
   })
 }

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -9,10 +9,9 @@ import {
 } from '../core/shared/project-file-types'
 import { isDirectory, directory, isImageFile } from '../core/model/project-file-utils'
 import Utils from '../utils/utils'
-import * as R from 'ramda'
 import { dropLeadingSlash } from './filebrowser/filepath-utils'
 import { fastForEach } from '../core/shared/utils'
-import { mapValues } from 'xstate/lib/utils'
+import { mapValues } from '../core/shared/object-utils'
 
 interface ImageAsset {
   assetPath: string
@@ -51,9 +50,6 @@ export function projectContentDirectory(
   dir: Directory,
   children: ProjectContentTreeRoot,
 ): ProjectContentDirectory {
-  if (dir.type !== 'DIRECTORY') {
-    throw new Error(`Not a directory: ${JSON.stringify(dir)}`)
-  }
   return {
     type: 'PROJECT_CONTENT_DIRECTORY',
     fullPath: fullPath,
@@ -72,15 +68,6 @@ export function projectContentFile(
   fullPath: string,
   content: UIJSFile | CodeFile | ImageFile | AssetFile,
 ): ProjectContentFile {
-  switch (content.type) {
-    case 'CODE_FILE':
-    case 'ASSET_FILE':
-    case 'IMAGE_FILE':
-    case 'UI_JS_FILE':
-      break
-    default:
-      throw new Error(`Not a file: ${JSON.stringify(content)}`)
-  }
   return {
     type: 'PROJECT_CONTENT_FILE',
     fullPath: fullPath,
@@ -388,14 +375,14 @@ export function transformContentsTree(
   projectContents: ProjectContentTreeRoot,
   transform: (tree: ProjectContentsTree) => ProjectContentsTree,
 ): ProjectContentTreeRoot {
-  return mapValues(projectContents, (tree: ProjectContentsTree) => {
+  return mapValues((tree: ProjectContentsTree) => {
     if (tree.type === 'PROJECT_CONTENT_DIRECTORY') {
       const transformedChildren = transformContentsTree(tree.children, transform)
       return transform(projectContentDirectory(tree.fullPath, tree.directory, transformedChildren))
     } else {
       return transform(tree)
     }
-  })
+  }, projectContents)
 }
 
 export function ensureDirectoriesExist(projectContents: ProjectContents): ProjectContents {

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -164,6 +164,7 @@ import { createSceneTemplatePath, PathForSceneStyle } from '../../core/model/sce
 import { optionalMap } from '../../core/shared/optional-utils'
 import { fastForEach } from '../../core/shared/utils'
 import { UiJsxCanvasContextData } from './ui-jsx-canvas'
+import { addFileToProjectContents, contentsToTree } from '../assets'
 
 export function getOriginalFrames(
   selectedViews: Array<TemplatePath>,
@@ -2450,10 +2451,11 @@ export function createTestProjectWithCode(appUiJsFile: string): PersistentModel 
 
   return {
     ...baseModel,
-    projectContents: {
-      ...baseModel.projectContents,
-      '/src/app.js': uiJsFile(parsedFile, null, RevisionsState.BothMatch, Date.now()),
-    },
+    projectContents: addFileToProjectContents(
+      baseModel.projectContents,
+      '/src/app.js',
+      uiJsFile(parsedFile, null, RevisionsState.BothMatch, Date.now()),
+    ),
     selectedFile: openFileTab('/src/app.js'),
   }
 }

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -51,7 +51,6 @@ import { getLayoutPropertyOr } from '../../../core/layout/getLayoutProperty'
 import { RightMenuTab } from '../right-menu'
 import { safeIndex } from '../../../core/shared/array-utils'
 import { getStoryboardTemplatePath } from '../../editor/store/editor-state'
-import { ProjectContentTreeRoot } from '../../assets'
 
 // I feel comfortable having this function confined to this file only, since we absolutely shouldn't be trying
 // to set values that would fail whilst inserting elements. If that ever changes, this function should be binned

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -14,12 +14,7 @@ import {
   JSXElementChild,
 } from '../../../core/shared/element-template'
 import { setJSXValueAtPath } from '../../../core/shared/jsx-attributes'
-import {
-  ProjectContents,
-  PropertyPath,
-  TemplatePath,
-  Imports,
-} from '../../../core/shared/project-file-types'
+import { PropertyPath, TemplatePath, Imports } from '../../../core/shared/project-file-types'
 import { Either, isLeft, right } from '../../../core/shared/either'
 import { KeysPressed } from '../../../utils/keyboard'
 import Utils from '../../../utils/utils'
@@ -56,6 +51,7 @@ import { getLayoutPropertyOr } from '../../../core/layout/getLayoutProperty'
 import { RightMenuTab } from '../right-menu'
 import { safeIndex } from '../../../core/shared/array-utils'
 import { getStoryboardTemplatePath } from '../../editor/store/editor-state'
+import { ProjectContentTreeRoot } from '../../assets'
 
 // I feel comfortable having this function confined to this file only, since we absolutely shouldn't be trying
 // to set values that would fail whilst inserting elements. If that ever changes, this function should be binned
@@ -78,7 +74,6 @@ interface InsertModeControlContainerProps extends ControlProps {
   keysPressed: KeysPressed
   projectId: string | null
   dragState: InsertDragState | null
-  projectContents: ProjectContents
   canvasOffset: CanvasVector
   scale: number
 }

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -304,7 +304,6 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
             dragState={
               dragState != null && dragState.type === 'INSERT_DRAG_STATE' ? dragState : null
             }
-            projectContents={props.editor.projectContents}
             canvasOffset={props.editor.canvas.realCanvasOffset /* maybe roundedCanvasOffset? */}
             scale={props.editor.canvas.scale}
           />

--- a/editor/src/components/canvas/ui-jsx-test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-test-utils.tsx
@@ -56,6 +56,7 @@ import { emptyUiJsxCanvasContextData } from './ui-jsx-canvas'
 import { testParseCode } from '../../core/workers/parser-printer/parser-printer-test-utils'
 import { printCode, printCodeOptions } from '../../core/workers/parser-printer/parser-printer'
 import { setPropertyControlsIFrameAvailable } from '../../core/property-controls/property-controls-utils'
+import { getContentsTreeFileFromString } from '../assets'
 
 function sanitizeElementMetadata(element: ElementInstanceMetadata): ElementInstanceMetadata {
   return {
@@ -205,15 +206,14 @@ export async function renderTestEditorWithCode(appUiJsFileCode: string) {
 }
 
 export function getPrintedUiJsCode(store: EditorStore): string {
-  return ((store.editor.projectContents['/src/app.js'] as UIJSFile).fileContents as Right<
-    ParseSuccess
-  >).value.code
+  return ((getContentsTreeFileFromString(store.editor.projectContents, '/src/app.js') as UIJSFile)
+    .fileContents as Right<ParseSuccess>).value.code
 }
 
 const TestSceneUID = 'scene-aaa'
 export const TestScenePath = scenePath([BakedInStoryboardUID, TestSceneUID])
 
-export function makeTestProjectCodeWithSnippet(snippet: string) {
+export function makeTestProjectCodeWithSnippet(snippet: string): string {
   const code = `/** @jsx jsx */
   import * as React from 'react'
   import { Scene, Storyboard, View, jsx } from 'utopia-api'

--- a/editor/src/components/code-editor/code-editor.tsx
+++ b/editor/src/components/code-editor/code-editor.tsx
@@ -10,7 +10,11 @@ import {
   ProjectContents,
   TemplatePath,
 } from '../../core/shared/project-file-types'
-import { TypeDefinitions, ResolvedNpmDependency, PossiblyUnversionedNpmDependency } from '../../core/shared/npm-dependency-types'
+import {
+  TypeDefinitions,
+  ResolvedNpmDependency,
+  PossiblyUnversionedNpmDependency,
+} from '../../core/shared/npm-dependency-types'
 import { ConsoleLog } from '../editor/store/editor-state'
 import { CodeEditorTheme } from './code-editor-themes'
 import {
@@ -21,6 +25,7 @@ import {
 import { CodeEditorTabPane } from './code-problems'
 import { MonacoWrapper } from './monaco-wrapper'
 import { Notice } from '../common/notices'
+import { ProjectContentTreeRoot } from '../assets'
 
 const AutoSaveDelay = 300
 export interface CodeEditorProps {
@@ -44,7 +49,7 @@ export interface CodeEditorProps {
   allErrors: Array<ErrorMessage> | null
   errorsForFile: Array<ErrorMessage> | null
   readOnly: boolean
-  projectContents: ProjectContents
+  projectContents: ProjectContentTreeRoot
   workers: UtopiaTsWorkers
   selectedViews: Array<TemplatePath>
   selectedViewsBounds: Array<HighlightBounds>

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -21,6 +21,7 @@ import { updateNodeModulesContents } from '../editor/actions/actions'
 import { fastForEach } from '../../core/shared/utils'
 import { arrayToObject } from '../../core/shared/array-utils'
 import { objectMap } from '../../core/shared/object-utils'
+import { ProjectContentTreeRoot } from '../assets'
 export interface CodeResult {
   exports: ModuleExportTypes
   transpiledCode: string | null
@@ -154,7 +155,7 @@ export function incorporateBuildResult(
 }
 
 export function generateCodeResultCache(
-  projectContents: ProjectContents,
+  projectContents: ProjectContentTreeRoot,
   existingModules: MultiFileBuildResult,
   updatedModules: MultiFileBuildResult,
   exportsInfo: ReadonlyArray<ExportsInfo>,

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -74,6 +74,7 @@ import { TestScenePath } from '../../canvas/ui-jsx-test-utils'
 import { NO_OP } from '../../../core/shared/utils'
 import { CURRENT_PROJECT_VERSION } from './migrations/migrations'
 import { generateCodeResultCache } from '../../custom-code/code-file'
+import { contentsToTree, getContentsTreeFileFromString } from '../../assets'
 const chaiExpect = Chai.expect
 
 describe('SET_PROP', () => {
@@ -117,9 +118,9 @@ describe('SET_PROP', () => {
   )
   const testEditor: EditorState = deepFreeze({
     ...createEditorState(NO_OP),
-    projectContents: {
+    projectContents: contentsToTree({
       '/src/app.js': uiJsFile(right(originalModel), null, RevisionsState.ParsedAhead, 0),
-    },
+    }),
     selectedFile: {
       tab: openFileTab('/src/app.js'),
       initialCursorPosition: null,
@@ -133,7 +134,10 @@ describe('SET_PROP', () => {
       jsxAttributeValue(100),
     )
     const newEditor = UPDATE_FNS.SET_PROP(action, testEditor)
-    const newUiJsFile = newEditor.projectContents['/src/app.js'] as UIJSFile
+    const newUiJsFile = getContentsTreeFileFromString(
+      newEditor.projectContents,
+      '/src/app.js',
+    ) as UIJSFile
     expect(isUIJSFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents)).toBeTruthy()
     const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.value as ParseSuccess)
@@ -209,9 +213,9 @@ describe('SET_CANVAS_FRAMES', () => {
   )
   const testEditor: EditorState = deepFreeze({
     ...createEditorState(NO_OP),
-    projectContents: {
+    projectContents: contentsToTree({
       '/src/app.js': uiJsFile(right(originalModel), null, RevisionsState.ParsedAhead, 0),
-    },
+    }),
     selectedFile: {
       tab: openFileTab('/src/app.js'),
       initialCursorPosition: null,
@@ -231,7 +235,10 @@ describe('SET_CANVAS_FRAMES', () => {
       false,
     )
     const newEditor = UPDATE_FNS.SET_CANVAS_FRAMES(action, testEditor, derivedState)
-    const newUiJsFile = newEditor.projectContents['/src/app.js'] as UIJSFile
+    const newUiJsFile = getContentsTreeFileFromString(
+      newEditor.projectContents,
+      '/src/app.js',
+    ) as UIJSFile
     expect(isUIJSFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents)).toBeTruthy()
     const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.value as ParseSuccess)
@@ -326,9 +333,9 @@ describe('moveTemplate', () => {
   function testEditor(uiFile: Readonly<ParseSuccess>): EditorState {
     let editor: EditorState = {
       ...createEditorState(NO_OP),
-      projectContents: {
+      projectContents: contentsToTree({
         '/src/app.js': uiJsFile(right(uiFile), null, RevisionsState.ParsedAhead, 0),
-      },
+      }),
       selectedFile: {
         tab: openFileTab('/src/app.js'),
         initialCursorPosition: null,
@@ -356,7 +363,10 @@ describe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = newEditor.projectContents['/src/app.js'] as UIJSFile
+    const newUiJsFile = getContentsTreeFileFromString(
+      newEditor.projectContents,
+      '/src/app.js',
+    ) as UIJSFile
     expect(isUIJSFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents)).toBeTruthy()
     const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.value as ParseSuccess)
@@ -396,8 +406,8 @@ describe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = newEditor.projectContents['/src/app.js']
-    if (isUIJSFile(newUiJsFile)) {
+    const newUiJsFile = getContentsTreeFileFromString(newEditor.projectContents, '/src/app.js')
+    if (newUiJsFile != null && isUIJSFile(newUiJsFile)) {
       if (isParseSuccess(newUiJsFile.fileContents)) {
         const newTopLevelElements = newUiJsFile.fileContents.value.topLevelElements
         const updatedRoot = newTopLevelElements[0]
@@ -444,7 +454,10 @@ describe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = newEditor.projectContents['/src/app.js'] as UIJSFile
+    const newUiJsFile = getContentsTreeFileFromString(
+      newEditor.projectContents,
+      '/src/app.js',
+    ) as UIJSFile
     expect(isUIJSFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents)).toBeTruthy()
     const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.value as ParseSuccess)
@@ -474,7 +487,10 @@ describe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = newEditor.projectContents['/src/app.js'] as UIJSFile
+    const newUiJsFile = getContentsTreeFileFromString(
+      newEditor.projectContents,
+      '/src/app.js',
+    ) as UIJSFile
     expect(isUIJSFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents)).toBeTruthy()
     const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.value as ParseSuccess)
@@ -503,7 +519,10 @@ describe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = newEditor.projectContents['/src/app.js'] as UIJSFile
+    const newUiJsFile = getContentsTreeFileFromString(
+      newEditor.projectContents,
+      '/src/app.js',
+    ) as UIJSFile
     expect(isUIJSFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents)).toBeTruthy()
     const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.value as ParseSuccess)
@@ -533,7 +552,10 @@ describe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = newEditor.projectContents['/src/app.js'] as UIJSFile
+    const newUiJsFile = getContentsTreeFileFromString(
+      newEditor.projectContents,
+      '/src/app.js',
+    ) as UIJSFile
     expect(isUIJSFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents)).toBeTruthy()
     const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.value as ParseSuccess)
@@ -562,7 +584,10 @@ describe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = newEditor.projectContents['/src/app.js'] as UIJSFile
+    const newUiJsFile = getContentsTreeFileFromString(
+      newEditor.projectContents,
+      '/src/app.js',
+    ) as UIJSFile
     expect(isUIJSFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents)).toBeTruthy()
     const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.value as ParseSuccess)
@@ -607,7 +632,10 @@ describe('moveTemplate', () => {
       LayoutSystem.Group,
     ).editor
 
-    const newUiJsFile = newEditor.projectContents['/src/app.js'] as UIJSFile
+    const newUiJsFile = getContentsTreeFileFromString(
+      newEditor.projectContents,
+      '/src/app.js',
+    ) as UIJSFile
     expect(isUIJSFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents)).toBeTruthy()
     const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.value as ParseSuccess)
@@ -657,7 +685,10 @@ describe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = newEditor.projectContents['/src/app.js'] as UIJSFile
+    const newUiJsFile = getContentsTreeFileFromString(
+      newEditor.projectContents,
+      '/src/app.js',
+    ) as UIJSFile
     expect(isUIJSFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents)).toBeTruthy()
     const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.value as ParseSuccess)
@@ -703,7 +734,10 @@ describe('moveTemplate', () => {
       null,
     ).editor
 
-    const newUiJsFile = newEditor.projectContents['/src/app.js'] as UIJSFile
+    const newUiJsFile = getContentsTreeFileFromString(
+      newEditor.projectContents,
+      '/src/app.js',
+    ) as UIJSFile
     expect(isUIJSFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents)).toBeTruthy()
     const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.value as ParseSuccess)
@@ -752,9 +786,9 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
   )
   const testEditorWithPins: EditorState = deepFreeze({
     ...createEditorState(NO_OP),
-    projectContents: {
+    projectContents: contentsToTree({
       '/src/app.js': fileForUI,
-    },
+    }),
     selectedFile: {
       tab: openFileTab('/src/app.js'),
       initialCursorPosition: null,
@@ -839,10 +873,10 @@ describe('LOAD', () => {
     const loadedModel: PersistentModel = {
       appID: null,
       projectVersion: CURRENT_PROJECT_VERSION,
-      projectContents: {
+      projectContents: contentsToTree({
         [firstUIJSFile]: uiJsFile(initiailFileContents, null, RevisionsState.BothMatch, 0),
         [secondUIJSFile]: uiJsFile(initiailFileContents, null, RevisionsState.BothMatch, 0),
-      },
+      }),
       exportsInfo: [],
       openFiles: [],
       selectedFile: null,
@@ -881,10 +915,16 @@ describe('LOAD', () => {
 
     const startingState = deepFreeze(createEditorState(NO_OP))
     const result = UPDATE_FNS.LOAD(action, startingState, NO_OP)
-    const newFirstFileContents = (result.projectContents[firstUIJSFile] as UIJSFile).fileContents
+    const newFirstFileContents = (getContentsTreeFileFromString(
+      result.projectContents,
+      firstUIJSFile,
+    ) as UIJSFile).fileContents
     expect(isRight(newFirstFileContents)).toBeTruthy()
     expect(newFirstFileContents.value.code).toEqual(initiailFileContents.value.code)
-    const newSecondFileContents = (result.projectContents[secondUIJSFile] as UIJSFile).fileContents
+    const newSecondFileContents = (getContentsTreeFileFromString(
+      result.projectContents,
+      secondUIJSFile,
+    ) as UIJSFile).fileContents
     expect(isRight(newSecondFileContents)).toBeTruthy()
     expect(newSecondFileContents.value.code).toEqual(initiailFileContents.value.code)
   })

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -1206,6 +1206,7 @@ function replaceFilePath(
   newPath: string,
   projectContentsTree: ProjectContentTreeRoot,
 ): ReplaceFilePathResult {
+  // FIXME: Reimplement this in a way that doesn't require converting to and from `ProjectContents`.
   const projectContents = treeToContents(projectContentsTree)
   // if there is no file in projectContents it's probably a non-empty directory
   const oldFolderRegex = new RegExp('^' + oldPath)

--- a/editor/src/components/editor/npm-dependency/npm-dependency.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.ts
@@ -33,6 +33,7 @@ import * as React from 'react'
 import { resolvedDependencyVersions } from '../../../core/third-party/third-party-components'
 import { deepFreeze } from '../../../utils/deep-freeze'
 import * as Semver from 'semver'
+import { ProjectContentTreeRoot } from '../../assets'
 
 interface PackageNotFound {
   type: 'PACKAGE_NOT_FOUND'
@@ -220,7 +221,7 @@ const EditorTypePackageDependencies: Array<RequestedNpmDependency> = [
 ]
 
 export function dependenciesWithEditorRequirements(
-  projectContents: ProjectContents,
+  projectContents: ProjectContentTreeRoot,
 ): Array<RequestedNpmDependency> {
   const packageJsonFile = packageJsonFileFromProjectContents(projectContents)
   const userDefinedDeps = dependenciesFromPackageJson(packageJsonFile)
@@ -228,7 +229,7 @@ export function dependenciesWithEditorRequirements(
 }
 
 export function immediatelyResolvableDependenciesWithEditorRequirements(
-  projectContents: ProjectContents,
+  projectContents: ProjectContentTreeRoot,
 ): Array<PossiblyUnversionedNpmDependency> {
   const requestedDependencies = dependenciesWithEditorRequirements(projectContents)
   return requestedDependencies.map((requestedDependency) => {

--- a/editor/src/components/editor/persistence.spec.ts
+++ b/editor/src/components/editor/persistence.spec.ts
@@ -13,6 +13,8 @@ import { UIJSFile } from '../../core/shared/project-file-types'
 import { SaveProjectResponse } from './server'
 import { localProjectKey } from '../../common/persistence'
 import { MockUtopiaTsWorkers } from '../../core/workers/workers'
+import { addFileToProjectContents, getContentsTreeFileFromString } from '../assets'
+import { forceNotNull } from '../../core/shared/optional-utils'
 
 let saveLog: { [key: string]: Array<PersistentModel> } = {}
 let projectsToError: Set<string> = new Set<string>()
@@ -89,15 +91,17 @@ const ProjectName = 'Project Name'
 const ModelChange = createPersistentModel()
 
 export function updateModel(model: PersistentModel): PersistentModel {
+  const oldFile = forceNotNull(
+    'Unexpectedly null.',
+    getContentsTreeFileFromString(model.projectContents, '/src/app.js'),
+  )
+  const updatedFile = {
+    ...oldFile,
+    lastRevisedTime: Date.now(),
+  }
   return {
     ...model,
-    projectContents: {
-      ...model.projectContents,
-      '/src/app.js': {
-        ...model.projectContents['/src/app.js'],
-        lastRevisedTime: Date.now(),
-      } as UIJSFile,
-    },
+    projectContents: addFileToProjectContents(model.projectContents, '/src/app.js', updatedFile),
   }
 }
 

--- a/editor/src/components/editor/store/editor-update.spec.ts
+++ b/editor/src/components/editor/store/editor-update.spec.ts
@@ -60,7 +60,8 @@ import {
   ScenePath1ForTestUiJsFile,
 } from '../../../core/model/test-ui-js-file'
 import { emptyUiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
-import {requestedNpmDependency} from '../../../core/shared/npm-dependency-types'
+import { requestedNpmDependency } from '../../../core/shared/npm-dependency-types'
+import { getContentsTreeFileFromString } from '../../assets'
 
 const chaiExpect = Chai.expect
 
@@ -293,7 +294,7 @@ describe('action NAVIGATOR_REORDER', () => {
       [TP.instancePath(ScenePath1ForTestUiJsFile, ['jjj'])],
       TP.instancePath(ScenePathForTestUiJsFile, ['aaa']),
     )
-    const mainUIJSFile = editor.projectContents['/src/app.js']
+    const mainUIJSFile = getContentsTreeFileFromString(editor.projectContents, '/src/app.js')
     if (isUIJSFile(mainUIJSFile) && isRight(mainUIJSFile.fileContents)) {
       const topLevelElements = mainUIJSFile.fileContents.value.topLevelElements
       const utopiaJSXComponents = getUtopiaJSXComponentsFromSuccess(mainUIJSFile.fileContents.value)
@@ -311,7 +312,10 @@ describe('action NAVIGATOR_REORDER', () => {
           emptyUiJsxCanvasContextData(),
         )
 
-        const updatedMainUIJSFile = updatedEditor.projectContents['/src/app.js']
+        const updatedMainUIJSFile = getContentsTreeFileFromString(
+          updatedEditor.projectContents,
+          '/src/app.js',
+        )
         if (isUIJSFile(updatedMainUIJSFile) && isRight(updatedMainUIJSFile.fileContents)) {
           const updatedTopLevelElements = updatedMainUIJSFile.fileContents.value.topLevelElements
           const updatedUtopiaJSXComponents = getUtopiaJSXComponentsFromSuccess(
@@ -368,8 +372,8 @@ describe('action DUPLICATE_SPECIFIC_ELEMENTS', () => {
       dispatch,
       emptyUiJsxCanvasContextData(),
     )
-    const mainUIJSFile = updatedEditor.projectContents['/src/app.js']
-    const oldUIJSFile = editor.projectContents['/src/app.js']
+    const mainUIJSFile = getContentsTreeFileFromString(updatedEditor.projectContents, '/src/app.js')
+    const oldUIJSFile = getContentsTreeFileFromString(editor.projectContents, '/src/app.js')
     if (
       isUIJSFile(oldUIJSFile) &&
       isRight(oldUIJSFile.fileContents) &&
@@ -409,8 +413,8 @@ describe('action DUPLICATE_SPECIFIC_ELEMENTS', () => {
       dispatch,
       emptyUiJsxCanvasContextData(),
     )
-    const mainUIJSFile = updatedEditor.projectContents['/src/app.js']
-    const oldUIJSFile = editor.projectContents['/src/app.js']
+    const mainUIJSFile = getContentsTreeFileFromString(updatedEditor.projectContents, '/src/app.js')
+    const oldUIJSFile = getContentsTreeFileFromString(editor.projectContents, '/src/app.js')
     if (
       isUIJSFile(oldUIJSFile) &&
       isRight(oldUIJSFile.fileContents) &&
@@ -451,7 +455,8 @@ describe('action DELETE_VIEWS', () => {
       [],
       [0, 'rootElement', 'children'],
       getUtopiaJSXComponentsFromSuccess(
-        (editor.projectContents['/src/app.js'] as any).fileContents.value,
+        (getContentsTreeFileFromString(editor.projectContents, '/src/app.js') as any).fileContents
+          .value,
       ),
     ).length
 
@@ -473,7 +478,7 @@ describe('action DELETE_VIEWS', () => {
       dispatch,
       emptyUiJsxCanvasContextData(),
     )
-    const mainUIJSFile = updatedEditor.projectContents['/src/app.js']
+    const mainUIJSFile = getContentsTreeFileFromString(updatedEditor.projectContents, '/src/app.js')
     if (isUIJSFile(mainUIJSFile) && isRight(mainUIJSFile.fileContents)) {
       expect(
         Utils.pathOr(
@@ -651,7 +656,7 @@ describe('action UPDATE_FRAME_DIMENSIONS', () => {
       dispatch,
       emptyUiJsxCanvasContextData(),
     )
-    const mainUIJSFile = updatedEditor.projectContents['/src/app.js']
+    const mainUIJSFile = getContentsTreeFileFromString(updatedEditor.projectContents, '/src/app.js')
     if (isUIJSFile(mainUIJSFile) && isRight(mainUIJSFile.fileContents)) {
       const components = getUtopiaJSXComponentsFromSuccess(mainUIJSFile.fileContents.value)
       const textElement = Utils.forceNotNull(
@@ -861,7 +866,10 @@ describe('action PUSH_TOAST and POP_TOAST', () => {
     const { editor, derivedState } = createEditorStates('/src/app.ui.js')
     const mockDispatch = jest.fn()
 
-    const deps = [requestedNpmDependency('mypackage', '1.0.0'), requestedNpmDependency('smart', '2.3.1')]
+    const deps = [
+      requestedNpmDependency('mypackage', '1.0.0'),
+      requestedNpmDependency('smart', '2.3.1'),
+    ]
     const action = updatePackageJson(deps)
     const updatedEditor = runLocalEditorAction(
       editor,
@@ -874,7 +882,10 @@ describe('action PUSH_TOAST and POP_TOAST', () => {
       emptyUiJsxCanvasContextData(),
     )
 
-    const packageJsonFile = updatedEditor.projectContents['/package.json']
+    const packageJsonFile = getContentsTreeFileFromString(
+      updatedEditor.projectContents,
+      '/package.json',
+    )
     if (packageJsonFile == null || packageJsonFile.type != 'CODE_FILE') {
       fail('Package.json file should exist and should be a CodeFile')
     } else {

--- a/editor/src/components/filebrowser/file-tabs.tsx
+++ b/editor/src/components/filebrowser/file-tabs.tsx
@@ -17,6 +17,11 @@ import {
 import { useEditorState } from '../editor/store/store-hook'
 import { fileHasErrorMessages } from './filebrowser'
 import { getIconTypeForFileBrowserItem } from './fileitem'
+import {
+  getContentsTreeFileFromString,
+  ProjectContentsTree,
+  ProjectContentTreeRoot,
+} from '../assets'
 
 function getKeyForEditorTab(editorTab: EditorTab): string {
   switch (editorTab.type) {
@@ -46,10 +51,14 @@ function getLabelForEditorTab(editorTab: EditorTab): string {
   }
 }
 
-function isModifiedForEditorTab(projectContents: ProjectContents, editorTab: EditorTab): boolean {
+function isModifiedForEditorTab(
+  projectContents: ProjectContentTreeRoot,
+  editorTab: EditorTab,
+): boolean {
   switch (editorTab.type) {
     case 'OPEN_FILE_TAB':
-      return isModifiedFile(projectContents[editorTab.filename])
+      const file = getContentsTreeFileFromString(projectContents, editorTab.filename)
+      return file == null ? false : isModifiedFile(file)
     case 'RELEASE_NOTES_TAB':
       return false
     case 'USER_CONFIGURATION_TAB':
@@ -97,7 +106,10 @@ export const FileTabs = betterReactMemo('FileTabs', () => {
         return getIconTypeForFileBrowserItem(
           'file',
           filepath,
-          Utils.propOrNull('type', store.editor.projectContents[filepath]),
+          Utils.propOrNull(
+            'type',
+            getContentsTreeFileFromString(store.editor.projectContents, filepath),
+          ),
           false,
           false,
         )

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -33,7 +33,7 @@ import {
   importDetails,
   importAlias,
 } from '../../core/shared/project-file-types'
-import { contentsToTree, walkContentsTree } from '../assets'
+import { contentsToTree, ProjectContentTreeRoot, walkContentsTree } from '../assets'
 import { setFocus } from '../common/actions'
 import { CodeResultCache, isJavascriptOrTypescript } from '../custom-code/code-file'
 import * as EditorActions from '../editor/actions/actions'
@@ -72,14 +72,13 @@ export function fileHasErrorMessages(path: string, errorMessages: ErrorMessage[]
 }
 
 function collectFileBrowserItems(
-  projectContents: ProjectContents,
+  projectContents: ProjectContentTreeRoot,
   collapsedPaths: string[],
   codeResultCache: CodeResultCache | null,
   errorMessages: ErrorMessage[] | null,
 ): FileBrowserItemInfo[] {
-  const tree = contentsToTree(projectContents)
   let fileBrowserItems: FileBrowserItemInfo[] = []
-  walkContentsTree(tree, (fullPath, element) => {
+  walkContentsTree(projectContents, (fullPath, element) => {
     const originatingPath = fullPath
 
     const hasErrorMessages = fileHasErrorMessages(fullPath, errorMessages)

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -28,12 +28,11 @@ import {
 import { ErrorMessage } from '../../core/shared/error-messages'
 import {
   isParseSuccess,
-  ProjectContents,
   ProjectFileType,
   importDetails,
   importAlias,
 } from '../../core/shared/project-file-types'
-import { contentsToTree, ProjectContentTreeRoot, walkContentsTree } from '../assets'
+import { ProjectContentTreeRoot, walkContentsTree } from '../assets'
 import { setFocus } from '../common/actions'
 import { CodeResultCache, isJavascriptOrTypescript } from '../custom-code/code-file'
 import * as EditorActions from '../editor/actions/actions'

--- a/editor/src/components/preview/preview-pane.tsx
+++ b/editor/src/components/preview/preview-pane.tsx
@@ -20,7 +20,6 @@ import { useEditorState } from '../editor/store/store-hook'
 import { SelectOption } from '../inspector/controls/select-control'
 import { shareURLForProject } from '../../core/shared/utils'
 import { getMainJSFilename } from '../../core/shared/project-contents-utils'
-import { getContentsTreeFileFromString } from '../assets'
 
 export const PreviewIframeId = 'preview-column-container'
 

--- a/editor/src/components/preview/preview-pane.tsx
+++ b/editor/src/components/preview/preview-pane.tsx
@@ -20,6 +20,7 @@ import { useEditorState } from '../editor/store/store-hook'
 import { SelectOption } from '../inspector/controls/select-control'
 import { shareURLForProject } from '../../core/shared/utils'
 import { getMainJSFilename } from '../../core/shared/project-contents-utils'
+import { getContentsTreeFileFromString } from '../assets'
 
 export const PreviewIframeId = 'preview-column-container'
 

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -38,17 +38,18 @@ import {
 import { MetadataUtils } from '../model/element-metadata-utils'
 import { HtmlElementStyleObjectProps } from '../third-party/html-intrinsic-elements'
 import { ExportsInfo } from '../workers/ts/ts-worker'
+import { ProjectContentTreeRoot } from '../../components/assets'
 
 export interface GetPropertyControlsInfoMessage {
   exportsInfo: ReadonlyArray<ExportsInfo>
   nodeModules: NodeModules
-  projectContents: ProjectContents
+  projectContents: ProjectContentTreeRoot
 }
 
 export function createGetPropertyControlsInfoMessage(
   exportsInfo: ReadonlyArray<ExportsInfo>,
   nodeModules: NodeModules,
-  projectContents: ProjectContents,
+  projectContents: ProjectContentTreeRoot,
 ): GetPropertyControlsInfoMessage {
   return {
     exportsInfo: exportsInfo,
@@ -330,7 +331,7 @@ export function setPropertyControlsIFrameAvailable(value: boolean): void {
 export function sendPropertyControlsInfoRequest(
   exportsInfo: ReadonlyArray<ExportsInfo>,
   nodeModules: NodeModules,
-  projectContents: ProjectContents,
+  projectContents: ProjectContentTreeRoot,
 ): void {
   function scheduleSend(): void {
     if (propertyControlsIFrameAvailable) {

--- a/editor/src/core/workers/bundler-bridge.ts
+++ b/editor/src/core/workers/bundler-bridge.ts
@@ -12,6 +12,7 @@ import {
 } from './ts/ts-worker'
 import utils from '../../utils/utils'
 import { workerForFile } from './utils'
+import { ProjectContentTreeRoot } from '../../components/assets'
 
 export interface BundlerContext {
   queuedUpdateFiles: { [key: string]: FileContent }
@@ -47,13 +48,13 @@ interface InitializeEvent {
   type: 'INITIALIZE'
   payload: {
     typeDefinitions: TypeDefinitions
-    projectContents: ProjectContents
+    projectContents: ProjectContentTreeRoot
     jobID: string | null
   }
 }
 function initializeEvent(
   typeDefinitions: TypeDefinitions,
-  projectContents: ProjectContents,
+  projectContents: ProjectContentTreeRoot,
   jobID: string | null,
 ): InitializeEvent {
   return {
@@ -375,7 +376,7 @@ export class NewBundlerWorker {
 
   sendInitMessage(
     typeDefinitions: TypeDefinitions,
-    projectContents: ProjectContents,
+    projectContents: ProjectContentTreeRoot,
     jobID: string | null,
   ) {
     this.stateMachine.send(initializeEvent(typeDefinitions, projectContents, jobID))
@@ -399,7 +400,7 @@ export class NewBundlerWorker {
 function sendIdGuardedinitializeWorkerPromise(
   worker: BundlerWorker,
   typeDefinitions: TypeDefinitions,
-  projectContents: ProjectContents,
+  projectContents: ProjectContentTreeRoot,
   jobID: string | null,
 ): Promise<InitCompleteMessage> {
   const generatedJobID = jobID == null ? utils.generateUUID() : jobID

--- a/editor/src/core/workers/bundler-promise.ts
+++ b/editor/src/core/workers/bundler-promise.ts
@@ -3,11 +3,12 @@ import type { MultiFileBuildResult, OutgoingWorkerMessage } from './ts/ts-worker
 import type { ProjectContents } from '../shared/project-file-types'
 import { NewBundlerWorker } from './bundler-bridge'
 import utils from '../../utils/utils'
+import { ProjectContentTreeRoot } from '../../components/assets'
 
 export function createBundle(
   worker: NewBundlerWorker,
   typeDefinitions: TypeDefinitions,
-  projectContents: ProjectContents,
+  projectContents: ProjectContentTreeRoot,
 ): Promise<{ buildResult: MultiFileBuildResult }> {
   return new Promise((resolve, reject) => {
     const jobID = utils.generateUUID()

--- a/editor/src/core/workers/common/worker-types.ts
+++ b/editor/src/core/workers/common/worker-types.ts
@@ -1,10 +1,14 @@
+import { ProjectContentTreeRoot } from '../../../components/assets'
 import { TypeDefinitions } from '../../shared/npm-dependency-types'
-import { ProjectContents, UIJSFile, CodeFile, ParseSuccess } from '../../shared/project-file-types'
+import { UIJSFile, CodeFile, ParseSuccess } from '../../shared/project-file-types'
 
 export type FileContent = string | UIJSFile | CodeFile
 
 export interface UtopiaTsWorkers {
-  sendInitMessage: (typeDefinitions: TypeDefinitions, projectContents: ProjectContents) => void
+  sendInitMessage: (
+    typeDefinitions: TypeDefinitions,
+    projectContent: ProjectContentTreeRoot,
+  ) => void
   sendUpdateFileMessage: (filename: string, content: FileContent, emitBuild: boolean) => void
   sendParseFileMessage: (filename: string, content: string) => void
   sendPrintCodeMessage: (parseSuccess: ParseSuccess) => void

--- a/editor/src/core/workers/ts/ts-worker.spec.ts
+++ b/editor/src/core/workers/ts/ts-worker.spec.ts
@@ -4,6 +4,7 @@ import { RevisionsState } from '../../shared/project-file-types'
 import { convertScenesToUtopiaCanvasComponent } from '../../model/scene-utils'
 
 import * as SampleTypeDefinitions from './sample-type-definitions.json'
+import { contentsToTree } from '../../../components/assets'
 
 describe('Typescript worker builds the project', () => {
   it('initializing a new project', (done) => {
@@ -29,7 +30,7 @@ describe('Typescript worker builds the project', () => {
 const SampleInitTSWorkerMessage: IncomingWorkerMessage = {
   type: 'inittsworker',
   typeDefinitions: SampleTypeDefinitions,
-  projectContents: {
+  projectContents: contentsToTree({
     '/package.json': {
       type: 'CODE_FILE',
       fileContents:
@@ -264,7 +265,7 @@ const SampleInitTSWorkerMessage: IncomingWorkerMessage = {
         '<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<title>Utopia React App</title>\n</head>\n<body>\n<div id="root"></div>\n</body>\n</html>',
       lastSavedContents: null,
     },
-  },
+  }),
   buildOrParsePrint: 'build',
   jobID: '9897a53d_15b6_400d_be5f_ca5d66e47087',
 }

--- a/editor/src/core/workers/workers.ts
+++ b/editor/src/core/workers/workers.ts
@@ -16,6 +16,7 @@ import {
 } from './watchdog-worker'
 import { UtopiaTsWorkers, FileContent } from './common/worker-types'
 import { ExportsInfo, MultiFileBuildResult } from './ts/ts-worker'
+import { ProjectContentTreeRoot } from '../../components/assets'
 
 export class UtopiaTsWorkersImplementation implements UtopiaTsWorkers {
   private bundlerWorker: NewBundlerWorker
@@ -29,7 +30,7 @@ export class UtopiaTsWorkersImplementation implements UtopiaTsWorkers {
     this.bundlerWorker = new NewBundlerWorker(bundlerWorker)
   }
 
-  sendInitMessage(typeDefinitions: TypeDefinitions, projectContents: ProjectContents): void {
+  sendInitMessage(typeDefinitions: TypeDefinitions, projectContents: ProjectContentTreeRoot): void {
     this.bundlerWorker.sendInitMessage(typeDefinitions, projectContents, null)
   }
 
@@ -214,7 +215,10 @@ export class RealWatchdogWorker implements WatchdogWorker {
 }
 
 export class MockUtopiaTsWorkers implements UtopiaTsWorkers {
-  sendInitMessage(_typeDefinitions: TypeDefinitions, _projectContents: ProjectContents): void {
+  sendInitMessage(
+    _typeDefinitions: TypeDefinitions,
+    _projectContents: ProjectContentTreeRoot,
+  ): void {
     // empty
   }
 

--- a/editor/src/printer-parsers/html/external-resources-parser.tsx
+++ b/editor/src/printer-parsers/html/external-resources-parser.tsx
@@ -1,5 +1,6 @@
 import * as json5 from 'json5'
 import * as NodeHTMLParser from 'node-html-parser'
+import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../../components/assets'
 import { notice } from '../../components/common/notices'
 import { EditorDispatch } from '../../components/editor/action-types'
 import { pushToast, updateFile } from '../../components/editor/actions/actions'
@@ -87,9 +88,9 @@ export function getGeneratedExternalLinkText(
 }
 
 function getPreviewHTMLFilePath(
-  projectContents: ProjectContents,
+  projectContents: ProjectContentTreeRoot,
 ): Either<DescriptionParseError, string> {
-  const packageJson = projectContents['/package.json']
+  const packageJson = getContentsTreeFileFromString(projectContents, '/package.json')
   if (packageJson != null && isCodeFile(packageJson)) {
     try {
       const parsedJSON = json5.parse(packageJson.fileContents)
@@ -115,9 +116,9 @@ function getPreviewHTMLFilePath(
 
 function getCodeFileContentsFromPath(
   filePath: string,
-  projectContents: ProjectContents,
+  projectContents: ProjectContentTreeRoot,
 ): Either<DescriptionParseError, CodeFile> {
-  const fileContents = projectContents[filePath]
+  const fileContents = getContentsTreeFileFromString(projectContents, filePath)
   if (fileContents != null && isCodeFile(fileContents)) {
     return right(fileContents)
   } else {

--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -1,3 +1,4 @@
+import { contentsToTree } from '../components/assets'
 import {
   DefaultPackageJson,
   openFileTab,
@@ -26,7 +27,7 @@ export function defaultProject(): PersistentModel {
     '/public/index.html': getSamplePreviewHTMLFile(),
   }
 
-  let persistentModel = persistentModelForProjectContents(projectContents)
+  let persistentModel = persistentModelForProjectContents(contentsToTree(projectContents))
   persistentModel.openFiles = [openFileTab('/src/app.js'), ...persistentModel.openFiles]
   return persistentModel
 }
@@ -43,7 +44,7 @@ function uiBuilderProject(): PersistentModel {
     '/public/index.html': getSamplePreviewHTMLFile(),
   }
 
-  let persistentModel = persistentModelForProjectContents(projectContents)
+  let persistentModel = persistentModelForProjectContents(contentsToTree(projectContents))
   persistentModel.openFiles = [
     openFileTab('/src/app.js'),
     openFileTab('/src/components.js'),

--- a/editor/src/templates/preview.tsx
+++ b/editor/src/templates/preview.tsx
@@ -23,6 +23,7 @@ import {
 } from '../printer-parsers/html/external-resources-parser'
 import Utils from '../utils/utils'
 import { getMainHTMLFilename, getMainJSFilename } from '../core/shared/project-contents-utils'
+import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../components/assets'
 
 interface PolledLoadParams {
   projectId: string
@@ -172,7 +173,7 @@ const initPreview = () => {
     }
   }
 
-  const previewRender = async (projectContents: ProjectContents) => {
+  const previewRender = async (projectContents: ProjectContentTreeRoot) => {
     const npmDependencies = dependenciesWithEditorRequirements(projectContents)
     const fetchNodeModulesResult = await fetchNodeModules(npmDependencies)
 
@@ -209,7 +210,10 @@ const initPreview = () => {
 
     // replacing the document body first
     const previewHTMLFileName = getMainHTMLFilename(projectContents)
-    const previewHTMLFile = projectContents[`/${previewHTMLFileName}`]
+    const previewHTMLFile = getContentsTreeFileFromString(
+      projectContents,
+      `/${previewHTMLFileName}`,
+    )
     if (previewHTMLFile != null && isCodeFile(previewHTMLFile)) {
       try {
         try {
@@ -230,7 +234,7 @@ const initPreview = () => {
 
     const previewJSFileName = getMainJSFilename(projectContents)
     const previewJSFilePath = `/${previewJSFileName}`
-    const previewJSFile = projectContents[previewJSFilePath]
+    const previewJSFile = getContentsTreeFileFromString(projectContents, previewJSFilePath)
     if (previewJSFile != null && isCodeFile(previewJSFile)) {
       if (bundledProjectFiles[previewJSFilePath] == null) {
         throw new Error(

--- a/editor/src/templates/property-controls-info.tsx
+++ b/editor/src/templates/property-controls-info.tsx
@@ -26,7 +26,8 @@ import { ExportsInfo } from '../core/workers/ts/ts-worker'
 import { PropertyControls } from 'utopia-api'
 import { objectKeyParser, parseAny, ParseResult } from '../utils/value-parser-utils'
 import { applicative3Either, forEachRight } from '../core/shared/either'
-import {resolvedDependencyVersions} from '../core/third-party/third-party-components'
+import { resolvedDependencyVersions } from '../core/third-party/third-party-components'
+import { ProjectContentTreeRoot } from '../components/assets'
 
 // Not a full parse, just checks the primary fields are there.
 function fastPropertyControlsParse(value: unknown): ParseResult<GetPropertyControlsInfoMessage> {
@@ -59,7 +60,7 @@ const initPropertyControls = () => {
   }
 
   const processPropertyControls = async (
-    projectContents: ProjectContents,
+    projectContents: ProjectContentTreeRoot,
     nodeModules: NodeModules,
     exportsInfo: ReadonlyArray<ExportsInfo>,
   ) => {

--- a/editor/src/utils/test-utils.ts
+++ b/editor/src/utils/test-utils.ts
@@ -60,6 +60,7 @@ import * as PP from '../core/shared/property-path'
 import { getSimpleAttributeAtPath } from '../core/model/element-metadata-utils'
 import { mapArrayToDictionary } from '../core/shared/array-utils'
 import { MapLike } from 'typescript'
+import { contentsToTree } from '../components/assets'
 
 export function delay<T>(time: number): Promise<T> {
   return new Promise((resolve) => setTimeout(resolve, time))
@@ -68,7 +69,7 @@ export function delay<T>(time: number): Promise<T> {
 export function createPersistentModel(): PersistentModel {
   const editor: EditorState = {
     ...createEditorState(NO_OP),
-    projectContents: {
+    projectContents: contentsToTree({
       '/src/app.js': uiJsFile(
         right(
           parseSuccess(
@@ -86,7 +87,7 @@ export function createPersistentModel(): PersistentModel {
         RevisionsState.BothMatch,
         0,
       ),
-    },
+    }),
     selectedFile: {
       tab: openFileTab('/src/app.js'),
       initialCursorPosition: null,
@@ -108,7 +109,7 @@ export function createEditorStates(
     typeof selectedFileOrTab === 'string' ? openFileTab(selectedFileOrTab) : selectedFileOrTab
   const editor: EditorState = {
     ...createEditorState(NO_OP),
-    projectContents: {
+    projectContents: contentsToTree({
       '/package.json': codeFile(JSON.stringify(DefaultPackageJson, null, 2), null),
       '/src/app.js': uiJsFile(
         right(
@@ -127,7 +128,7 @@ export function createEditorStates(
         RevisionsState.BothMatch,
         0,
       ),
-    },
+    }),
     selectedFile: {
       tab: selectedTab,
       initialCursorPosition: null,


### PR DESCRIPTION
**Problem:**
The file browser is highly dependent on a tree form of the project model which was being produced on the fly during the render flow causing the file browser to be particularly slow when a large number of files are in the project. The large dictionary that `projectContents` is currently represented as cannot very easily be paginated, which is a likely route for further improving the file browser performance.

**Fix:**
Switched `EditorState.projectContents` from the type `ProjectContents` to `ProjectContentTreeRoot` and then made all the resultant fixes that were required of that change.

**Commit Details:**
- Changed the type of `EditorState.projectContents` to be `ProjectContentTreeRoot`,
  chaining that change down as far as possible to places where the project contents
  are passed down into.
- Changed the `type` field of `ProjectContentDirectory` and `ProjectContentFile`
  to keep them clearly distinguished from a `ProjectFile`.
- Added `getContentsTreeFileFromElements`, `getContentsTreeFileFromString`,
  `addFileToProjectContents`, `removeFromProjectContents` and
  `transformContentsTree` utility methods for manipulating the new tree form
  of `projectContents`.
- Replaced lookups and modifications of the `projectContents` field/values
  with the above utility functions.
- Updated the type of `PersistentModel.projectContents` to match that of `EditorState`.
- Added a project migration to switch over the `projectContents` value representation.