### PR TITLE
Support dependencies with tagged versions

### DIFF
--- a/editor/src/components/editor/npm-dependency/npm-dependency.spec.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.spec.ts
@@ -1,4 +1,9 @@
-import { findMatchingVersion, packageNotFound, versionLookupSuccess } from './npm-dependency'
+import {
+  findMatchingVersion,
+  getVersionType,
+  packageNotFound,
+  versionLookupSuccess,
+} from './npm-dependency'
 
 require('jest-fetch-mock').enableMocks()
 
@@ -45,5 +50,51 @@ describe('Attempting to match a version for an invalid package', () => {
     const version = '1.0.0'
     const result = await findMatchingVersion('', version)
     expect(result).toEqual(packageNotFound)
+  })
+})
+
+describe('Checking the version type of a dependency', () => {
+  // The below examples are (mostly) taken from https://docs.npmjs.com/files/package.json#dependencies
+
+  it('Returns GITHUB for github repos', () => {
+    expect(getVersionType('expressjs/express')).toEqual('GITHUB')
+    expect(getVersionType('mochajs/mocha#4727d357ea')).toEqual('GITHUB')
+    expect(getVersionType('user/repo#feature/branch')).toEqual('GITHUB')
+  })
+
+  it('Returns LOCAL for local files', () => {
+    expect(getVersionType('../foo/bar')).toEqual('LOCAL')
+    expect(getVersionType('~/foo/bar')).toEqual('LOCAL')
+    expect(getVersionType('./foo/bar')).toEqual('LOCAL')
+    expect(getVersionType('/foo/bar')).toEqual('LOCAL')
+    expect(getVersionType('file:../foo/bar')).toEqual('LOCAL')
+  })
+
+  it('Returns SEMVER for semver versions', () => {
+    expect(getVersionType('1.0.0 - 2.9999.9999')).toEqual('SEMVER')
+    expect(getVersionType('>=1.0.2 <2.1.2')).toEqual('SEMVER')
+    expect(getVersionType('>1.0.2 <=2.3.4')).toEqual('SEMVER')
+    expect(getVersionType('2.0.1')).toEqual('SEMVER')
+    expect(getVersionType('<1.0.0 || >=2.3.1 <2.4.5 || >=2.5.2 <3.0.0')).toEqual('SEMVER')
+    expect(getVersionType('~1.2')).toEqual('SEMVER')
+    expect(getVersionType('~1.2.3')).toEqual('SEMVER')
+    expect(getVersionType('2.x')).toEqual('SEMVER')
+    expect(getVersionType('3.3.x')).toEqual('SEMVER')
+  })
+
+  it('Returns TAG for tagged versions', () => {
+    expect(getVersionType('beta')).toEqual('TAG')
+    expect(getVersionType('experimental')).toEqual('TAG')
+    expect(getVersionType('latest')).toEqual('TAG')
+    expect(getVersionType('next')).toEqual('TAG')
+    expect(getVersionType('unstable')).toEqual('TAG')
+  })
+
+  it('Returns URL for URLs', () => {
+    expect(getVersionType('http://asdf.com/asdf.tar.gz')).toEqual('URL')
+    expect(getVersionType('git+ssh://git@github.com:npm/cli.git#v1.0.27')).toEqual('URL')
+    expect(getVersionType('git+ssh://git@github.com:npm/cli#semver:^5.0')).toEqual('URL')
+    expect(getVersionType('git+https://isaacs@github.com/npm/cli.git')).toEqual('URL')
+    expect(getVersionType('git://github.com/npm/cli.git#v1.0.27')).toEqual('URL')
   })
 })

--- a/editor/src/components/editor/npm-dependency/npm-dependency.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.ts
@@ -114,15 +114,15 @@ async function packageLookupCall(
   }
 }
 
-export async function findLatestVersion(packageName: string): Promise<VersionLookupResult> {
+async function findTaggedVersion(packageName: string, tag: string): Promise<VersionLookupResult> {
   const metadata = await packageLookupCall(packageName, null)
   switch (metadata.type) {
     case 'PACKAGE_LOOKUP_SUCCESS':
-      const latestVersion = Utils.path(['json', 'dist-tags', 'latest'], metadata)
-      if (latestVersion == null || typeof latestVersion != 'string') {
+      const taggedVersion = Utils.path(['json', 'dist-tags', tag], metadata)
+      if (taggedVersion == null || typeof taggedVersion != 'string') {
         return Promise.reject(`Received invalid content for package ${packageName}`)
       } else {
-        return Promise.resolve(versionLookupSuccess(latestVersion))
+        return Promise.resolve(versionLookupSuccess(taggedVersion))
       }
     case 'PACKAGE_NOT_FOUND':
       return packageNotFound
@@ -132,7 +132,58 @@ export async function findLatestVersion(packageName: string): Promise<VersionLoo
   }
 }
 
-export async function findMatchingVersion(
+export const findLatestVersion = (packageName: string): Promise<VersionLookupResult> =>
+  findTaggedVersion(packageName, 'latest')
+
+type DependencyVersionType = 'GITHUB' | 'LOCAL' | 'SEMVER' | 'TAG' | 'URL'
+
+function versionIsGitHubRepo(v: string): boolean {
+  // To satisfy https://docs.npmjs.com/files/package.json#github-urls
+  const parts = v.split('/')
+  if (parts.length === 1) {
+    return false
+  } else if (parts.length === 2) {
+    return true
+  } else {
+    // If there is more than one forward slash, there must be a '#' immediately after the <user>/<repo> to indicate a commit-ish suffix
+    return parts[1].includes('#')
+  }
+}
+
+function versionIsLocal(v: string): boolean {
+  return (
+    v.startsWith('/') ||
+    v.startsWith('./') ||
+    v.startsWith('~/') ||
+    v.startsWith('../') ||
+    v.startsWith('file:')
+  )
+}
+
+function versionIsSemver(v: string): boolean {
+  return Semver.validRange(v) != null // Don't. Just don't.
+}
+
+function versionIsUrl(v: string): boolean {
+  return v.split('://').length === 2
+}
+
+export function getVersionType(version: string): DependencyVersionType {
+  if (versionIsUrl(version)) {
+    return 'URL'
+  } else if (versionIsGitHubRepo(version)) {
+    return 'GITHUB'
+  } else if (versionIsSemver(version)) {
+    return 'SEMVER'
+  } else if (versionIsLocal(version)) {
+    return 'LOCAL'
+  } else {
+    // If all else fails, assume it is a tagged version
+    return 'TAG'
+  }
+}
+
+async function findMatchingSemverVersion(
   packageName: string,
   versionRange: string,
 ): Promise<VersionLookupResult> {
@@ -147,6 +198,28 @@ export async function findMatchingVersion(
     return packageNotFound
   } else {
     return Promise.reject(`Received an error for package ${packageName}@${versionRange}`)
+  }
+}
+
+export async function findMatchingVersion(
+  packageName: string,
+  version: string,
+): Promise<VersionLookupResult> {
+  const versionType = getVersionType(version)
+  switch (versionType) {
+    case 'GITHUB':
+      return Promise.resolve(packageNotFound)
+    case 'LOCAL':
+      return Promise.resolve(packageNotFound)
+    case 'SEMVER':
+      return findMatchingSemverVersion(packageName, version)
+    case 'TAG':
+      return findTaggedVersion(packageName, version)
+    case 'URL':
+      return Promise.resolve(packageNotFound)
+    default:
+      const _exhaustiveCheck: never = versionType
+      throw new Error(`Unhandled version type ${versionType}`)
   }
 }
 


### PR DESCRIPTION
Fixes #582 

**Problem:**
When trying to resolve the dependency version, we weren't checking for tagged versions.

**Fix:**
Check what the type of the "version" is, and if it is a tag we use the package metadata to resolve the actual version.

**Commit Details:**
- Add a function `getVersionType` to distinguish between the different types of "versions" a user can specify
- Use that function to determine how we should attempt to resolve the concrete version
- Tests
