### PR TITLE
experiment/do-not-move-while-reorder

### DIFF
--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -181,6 +181,11 @@ export type HigherOrderControl = SvgControl | DivControl
 
 export type ControlOrHigherOrderControl = SvgFragmentControl | HigherOrderControl
 
+export type ReparentTargetIndicatorPosition = {
+  parent: TemplatePath | null
+  drawBeforeChildIndex: number
+}
+
 export interface FrameAndTarget<C extends CoordinateMarker> {
   target: TemplatePath
   frame: Rectangle<C> | null

--- a/editor/src/components/canvas/canvas-utils-unit-tests.spec.ts
+++ b/editor/src/components/canvas/canvas-utils-unit-tests.spec.ts
@@ -37,6 +37,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       createFakeMetadataForParseSuccess(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      false,
     )
 
     const updatedProject: ParseSuccess = {
@@ -80,6 +81,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       createFakeMetadataForParseSuccess(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      false,
     )
 
     const updatedProject: ParseSuccess = {
@@ -123,6 +125,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       createFakeMetadataForParseSuccess(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      false,
     )
 
     const updatedProject: ParseSuccess = {
@@ -175,6 +178,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       createFakeMetadataForParseSuccess(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      false,
     )
 
     const updatedProject: ParseSuccess = {
@@ -218,6 +222,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       createFakeMetadataForParseSuccess(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      false,
     )
 
     const updatedProject: ParseSuccess = {
@@ -262,6 +267,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       createFakeMetadataForParseSuccess(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      false,
     )
 
     const updatedProject: ParseSuccess = {
@@ -305,6 +311,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       createFakeMetadataForParseSuccess(testProject),
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      false,
     )
 
     const updatedProject: ParseSuccess = {

--- a/editor/src/components/canvas/canvas-utils-unit-tests.spec.ts
+++ b/editor/src/components/canvas/canvas-utils-unit-tests.spec.ts
@@ -42,7 +42,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject: ParseSuccess = {
       ...testProject,
-      topLevelElements: transformedComponents,
+      topLevelElements: transformedComponents.components,
     }
 
     expect(testPrintCode(updatedProject)).toEqual(
@@ -86,7 +86,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject: ParseSuccess = {
       ...testProject,
-      topLevelElements: transformedComponents,
+      topLevelElements: transformedComponents.components,
     }
 
     expect(testPrintCode(updatedProject)).toEqual(
@@ -130,7 +130,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject: ParseSuccess = {
       ...testProject,
-      topLevelElements: transformedComponents,
+      topLevelElements: transformedComponents.components,
     }
 
     expect(testPrintCode(updatedProject)).toEqual(
@@ -183,7 +183,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject: ParseSuccess = {
       ...testProject,
-      topLevelElements: transformedComponents,
+      topLevelElements: transformedComponents.components,
     }
 
     expect(testPrintCode(updatedProject)).toEqual(
@@ -227,7 +227,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject: ParseSuccess = {
       ...testProject,
-      topLevelElements: transformedComponents,
+      topLevelElements: transformedComponents.components,
     }
 
     expect(testPrintCode(updatedProject)).toEqual(
@@ -272,7 +272,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     const updatedProject: ParseSuccess = {
       ...testProject,
-      topLevelElements: transformedComponents,
+      topLevelElements: transformedComponents.components,
     }
 
     expect(testPrintCode(updatedProject)).toEqual(
@@ -306,7 +306,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       { x: 40, y: 30 } as CanvasVector,
     )
 
-    const transformedComponents = updateFramesOfScenesAndComponents(
+    const { components: transformedComponents } = updateFramesOfScenesAndComponents(
       getComponentsFromTopLevelElements(testProject.topLevelElements),
       createFakeMetadataForParseSuccess(testProject),
       [pinChange],

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -16,7 +16,7 @@ import {
   Imports,
   ScenePath,
 } from '../../../core/shared/project-file-types'
-import { CanvasPositions } from '../canvas-types'
+import { CanvasPositions, ReparentTargetIndicatorPosition } from '../canvas-types'
 import { SelectModeControlContainer } from './select-mode-control-container'
 import { InsertModeControlContainer } from './insert-mode-control-container'
 import { HighlightControl } from './highlight-control'
@@ -409,6 +409,9 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
       setTargetOptionsArray: props.setTargetOptionsArray,
     }
     const dragState = props.editor.canvas.dragState
+    const reparentTargetPositions: Array<ReparentTargetIndicatorPosition> =
+      props.derived.canvas.transientState.reparentTargetPositions
+
     if (props.xrayView) {
       return (
         <SelectModeControlContainer
@@ -428,6 +431,7 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
           layoutInspectorSectionHovered={false}
           selectModeState={selectModeState}
           setSelectModeState={setSelectModeState}
+          reparentTargetPositions={reparentTargetPositions}
         />
       )
     }
@@ -456,6 +460,7 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
             setSelectModeState={setSelectModeState}
             xrayMode={false}
             selectedScene={null}
+            reparentTargetPositions={reparentTargetPositions}
           />
         )
       }

--- a/editor/src/components/canvas/controls/reorder-insert-indicator.tsx
+++ b/editor/src/components/canvas/controls/reorder-insert-indicator.tsx
@@ -7,7 +7,8 @@ export const ReorderInsertIndicator = (props: {
   target: TemplatePath | null
   showBeforeChildIndex: number
 }) => {
-  const { x, y } = useEditorState((store) => {
+  const { x, y, horizontal } = useEditorState((store) => {
+    const canvasOffset = store.editor.canvas.roundedCanvasOffset
     const targetParent = MetadataUtils.getElementByTemplatePathMaybe(
       store.editor.jsxMetadataKILLME,
       props.target,
@@ -15,11 +16,15 @@ export const ReorderInsertIndicator = (props: {
     if (targetParent != null) {
       const childToPutIndexBefore = targetParent.children[props.showBeforeChildIndex]
       if (childToPutIndexBefore != null && childToPutIndexBefore.globalFrame != null) {
-        return { x: childToPutIndexBefore.globalFrame.x, y: childToPutIndexBefore.globalFrame.y }
+        return {
+          x: childToPutIndexBefore.globalFrame.x + canvasOffset.x,
+          y: childToPutIndexBefore.globalFrame.y + canvasOffset.y,
+          horizontal: childToPutIndexBefore.specialSizeMeasurements?.parentFlexDirection === 'row',
+        }
       }
     }
 
-    return { x: 0, y: 0 }
+    return { x: 0, y: 0, horizontal: false }
   })
 
   return (
@@ -27,8 +32,8 @@ export const ReorderInsertIndicator = (props: {
       style={{
         position: 'absolute',
         backgroundColor: 'red',
-        height: 150,
-        width: 2,
+        height: horizontal ? 150 : 2,
+        width: horizontal ? 2 : 150,
         left: x,
         top: y,
       }}

--- a/editor/src/components/canvas/controls/reorder-insert-indicator.tsx
+++ b/editor/src/components/canvas/controls/reorder-insert-indicator.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { TemplatePath } from '../../../core/shared/project-file-types'
+import { useEditorState } from '../../editor/store/store-hook'
+
+export const ReorderInsertIndicator = (props: {
+  target: TemplatePath | null
+  showBeforeChildIndex: number
+}) => {
+  const { x, y } = useEditorState((store) => {
+    const targetParent = MetadataUtils.getElementByTemplatePathMaybe(
+      store.editor.jsxMetadataKILLME,
+      props.target,
+    )
+    if (targetParent != null) {
+      const childToPutIndexBefore = targetParent.children[props.showBeforeChildIndex]
+      if (childToPutIndexBefore != null && childToPutIndexBefore.globalFrame != null) {
+        return { x: childToPutIndexBefore.globalFrame.x, y: childToPutIndexBefore.globalFrame.y }
+      }
+    }
+
+    return { x: 0, y: 0 }
+  })
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        backgroundColor: 'red',
+        height: 150,
+        width: 2,
+        left: x,
+        top: y,
+      }}
+    />
+  )
+}

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -13,7 +13,13 @@ import { EditorAction } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/actions'
 import { DuplicationState } from '../../editor/store/editor-state'
 import * as TP from '../../../core/shared/template-path'
-import { CanvasPositions, MoveDragState, ResizeDragState, moveDragState } from '../canvas-types'
+import {
+  CanvasPositions,
+  MoveDragState,
+  ResizeDragState,
+  moveDragState,
+  ReparentTargetIndicatorPosition,
+} from '../canvas-types'
 import { Guidelines, Guideline } from '../guideline'
 import { ConstraintsControls } from './constraints-control'
 import { DistanceGuideline } from './distance-guideline'
@@ -37,6 +43,7 @@ import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { ParentControls } from './parent-controls'
 import { fastForEach } from '../../../core/shared/utils'
 import { flatMapArray, uniqBy } from '../../../core/shared/array-utils'
+import { ReorderInsertIndicator } from './reorder-insert-indicator'
 
 export const SnappingThreshold = 5
 
@@ -67,6 +74,7 @@ interface SelectModeControlContainerProps extends ControlProps {
   setSelectModeState: (newState: SelectModeState) => void
   xrayMode: boolean
   selectedScene: ScenePath | null
+  reparentTargetPositions: Array<ReparentTargetIndicatorPosition>
 }
 
 interface SelectModeControlContainerState {
@@ -1003,6 +1011,15 @@ export class SelectModeControlContainer extends React.Component<
         {this.getDistanceGuidelines()}
         {this.getBoundingMarks()}
         {this.props.selectionEnabled && <ParentControls {...this.props} />}
+        {this.props.reparentTargetPositions.map((reparentTarget) => {
+          return (
+            <ReorderInsertIndicator
+              key={`${TP.toString(reparentTarget.parent!)}-${reparentTarget.drawBeforeChildIndex}`}
+              target={reparentTarget.parent}
+              showBeforeChildIndex={reparentTarget.drawBeforeChildIndex}
+            />
+          )
+        })}
       </div>
     )
   }

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4333,7 +4333,7 @@ function setCanvasFramesInnerNew(
       framesAndTargets,
       optionalParentFrame,
       false,
-    )
+    ).components
   }, editor)
 }
 

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -839,6 +839,7 @@ export function editorMoveTemplate(
       editorForChanges.selectedViews,
       editorForChanges.highlightedViews,
       newParentLayoutSystem,
+      false,
     )
     return {
       parseSuccessTransform: (success: ParseSuccess) => {
@@ -1004,7 +1005,7 @@ export function restoreDerivedState(history: StateHistory): DerivedState {
     canvas: {
       descendantsOfHiddenInstances: poppedDerived.canvas.descendantsOfHiddenInstances,
       controls: [],
-      transientState: produceCanvasTransientState(history.current.editor, true, null, null),
+      transientState: produceCanvasTransientState(history.current.editor, true, null, null, false),
     },
     elementWarnings: poppedDerived.elementWarnings,
   }
@@ -4331,6 +4332,7 @@ function setCanvasFramesInnerNew(
       editor.jsxMetadataKILLME,
       framesAndTargets,
       optionalParentFrame,
+      false,
     )
   }, editor)
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -86,6 +86,7 @@ import {
   DragState,
   FrameAndTarget,
   HigherOrderControl,
+  ReparentTargetIndicatorPosition,
 } from '../../canvas/canvas-types'
 import { produceCanvasTransientState } from '../../canvas/canvas-utils'
 import { CodeEditorTheme, DefaultTheme } from '../../code-editor/code-editor-themes'
@@ -887,17 +888,21 @@ export interface TransientCanvasState {
   selectedViews: Array<TemplatePath>
   highlightedViews: Array<TemplatePath>
   fileState: TransientFileState | null
+
+  reparentTargetPositions: Array<ReparentTargetIndicatorPosition>
 }
 
 export function transientCanvasState(
   selectedViews: Array<TemplatePath>,
   highlightedViews: Array<TemplatePath>,
   fileState: TransientFileState | null,
+  reparentTargetPositions: Array<ReparentTargetIndicatorPosition>,
 ): TransientCanvasState {
   return {
     selectedViews: selectedViews,
     highlightedViews: highlightedViews,
     fileState: fileState,
+    reparentTargetPositions: reparentTargetPositions,
   }
 }
 

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -937,7 +937,7 @@ function emptyDerivedState(editorState: EditorState): DerivedState {
     canvas: {
       descendantsOfHiddenInstances: [],
       controls: [],
-      transientState: produceCanvasTransientState(editorState, false, null, null),
+      transientState: produceCanvasTransientState(editorState, false, null, null, false),
     },
     elementWarnings: emptyComplexMap(),
   }
@@ -1219,7 +1219,7 @@ export function deriveState(
     canvas: {
       descendantsOfHiddenInstances: editor.hiddenInstances, // FIXME This has been dead for like ever
       controls: derivedState.canvas.controls,
-      transientState: produceCanvasTransientState(editor, true, dispatch, oldDerivedState),
+      transientState: produceCanvasTransientState(editor, true, dispatch, oldDerivedState, false),
     },
     elementWarnings: keepDeepReferenceEqualityIfPossible(
       oldDerivedState?.elementWarnings,

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -16,6 +16,7 @@ export type FeatureName =
   | 'Flex Properties (Timer)'
   | 'Mini Navigator'
   | 'Hierarchy View'
+  | 'Reorder Shows Placeholder Line'
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
   // 'Dragging Shows Overlay', // Removing this option so that we can experiment on this later
@@ -31,6 +32,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Flex Properties (Timer)',
   'Mini Navigator',
   'Hierarchy View',
+  'Reorder Shows Placeholder Line',
 ]
 
 let FeatureSwitches: { [feature: string]: boolean } = {
@@ -48,6 +50,7 @@ let FeatureSwitches: { [feature: string]: boolean } = {
   'Flex Properties (Timer)': true,
   'Mini Navigator': true,
   'Hierarchy View': true,
+  'Reorder Shows Placeholder Line': true,
 }
 
 function settingKeyForName(featureName: FeatureName): string {


### PR DESCRIPTION
https://utopia.pizza/p/44a911cb-spark-persimmon/?branch_name=experiment/do-not-move-while-reorder

**Problem:**
The flex drag-to-reorder interaction updates the index of the dragged element live. This makes it intuitive to see what the result of the drag will be. However, it makes our lives very hard if the layout wraps into multiple lines. (flex-wrap or _flow_). Live updating in a multiline layout means that as you move around, the rows shift wildly around, and depending on the situation, it can cause sitations where you cannot move your mouse to indicate the index position correctly. (A too large sibling might shift around in a way that results in a jump of 2-3 indexes at once, and if you try to move the mouse backwards to correct for it, the jump happens again)

**Fix:**
In this experiment the dragged flex child remains in its original position, and we draw a (big ugly red) indicator line to where it will fall if you let go of the mouse. It tries to mimic the `|` cursor of text editors, when you are drag-to-moving a selected snippet of text.

![image](https://user-images.githubusercontent.com/2226774/94901464-f95a9200-0496-11eb-8c69-ced0136d0f29.png)

