### PR TITLE
fix(actions) change propertycontrols info update

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4142,7 +4142,10 @@ export const UPDATE_FNS = {
   ): EditorState => {
     return {
       ...editor,
-      propertyControlsInfo: action.propertyControlsInfo,
+      propertyControlsInfo: {
+        ...editor.propertyControlsInfo,
+        ...action.propertyControlsInfo,
+      },
     }
   },
   PROPERTY_CONTROLS_IFRAME_READY: (


### PR DESCRIPTION
I couldn't find the ticket for this.

**Problem:**
Sometimes Views couldn't be resized because the propertyControlsInfo for style properties was missing. Sometimes propertyControls defined in the app.js were missing from the inspector.

**Fix:**
Updating files sets the new propertycontrols but deletes all old ones at the same time, including controls coming from third party components, like View from utopia-api.

Screenshot of the issue where the controls are added to the code but missing from the inspector:
<img width="1398" alt="Screenshot 2020-10-05 at 16 59 57" src="https://user-images.githubusercontent.com/4403069/95099847-b7e51380-0730-11eb-8c9e-8e1a432f2db9.png">