### PR TITLE
fix react-select patch-package

### DIFF
--- a/editor/patches/react-select+3.1.0.patch
+++ b/editor/patches/react-select+3.1.0.patch
@@ -1,7 +1,6 @@
 diff --git a/node_modules/react-select/src/.DS_Store b/node_modules/react-select/src/.DS_Store
 new file mode 100644
-index 0000000..dbd07c1
-Binary files /dev/null and b/node_modules/react-select/src/.DS_Store differ
+index 0000000..e69de29
 diff --git a/node_modules/react-select/src/components/Menu.js b/node_modules/react-select/src/components/Menu.js
 index 2777297..858fa91 100644
 --- a/node_modules/react-select/src/components/Menu.js


### PR DESCRIPTION
Patch package had a mismatched react-select version number with the actual package, and was giving a warning. this simply updates the version target.