### PR TITLE
Remount the canvas on incrementing the mount count.

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -48,6 +48,7 @@ export const CanvasComponentEntry = betterReactMemo(
           filePath={canvasProps.uiFilePath}
           reportError={props.reportError}
           requireFn={canvasProps.requireFn}
+          key={`canvas-error-boundary-${canvasProps.mountCount}`}
         >
           <UiJsxCanvas {...canvasProps} clearErrors={props.clearErrors} />
         </CanvasErrorBoundary>


### PR DESCRIPTION
**Problem:**
While investigating #506, it was observed that if hooks are added/removed to the code via the code editor the React errors for too many or too few hook calls could be triggered.

**Fix:**
Set the `key` for the `CanvasErrorBoundary` so that the hierarchy is recreated thereby side-stepping the error.

**Commit Details:**
- Increment the `key` of `CanvasErrorBoundary` used in the canvas
  so as to prevent changes in the number of hooks in the root from
  surfacing as the React too many/few hook calls invoked calls error.
