### PR TITLE
Support CSS imports in the preview.

### DIFF
--- a/editor/src/core/es-modules/package-manager/fetch-packages.ts
+++ b/editor/src/core/es-modules/package-manager/fetch-packages.ts
@@ -218,7 +218,7 @@ export async function fetchMissingFileDependency(
   updateNodeModules: (modulesToAdd: NodeModules) => void,
   dependency: ESRemoteDependencyPlaceholder,
   filepath: string,
-): Promise<void> {
+): Promise<string> {
   const localFilePath = extractFilePath(dependency.packagename, filepath)
   const jsdelivrUrl = getJsDelivrFileUrl(
     resolvedNpmDependency(dependency.packagename, dependency.version),
@@ -239,4 +239,5 @@ export async function fetchMissingFileDependency(
   // MUTATION
   dependency.downloadStarted = false
   updateNodeModules(nodeModulesNewEntry)
+  return responseAsString
 }

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -112,7 +112,7 @@ describe('ES Dependency Manager — Cycles', () => {
   })
 })
 
-describe('ES Dependency Manager — Real-life packages', () => {
+xdescribe('ES Dependency Manager — Real-life packages', () => {
   it('react-spring@8.0.27', async () => {
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
@@ -209,7 +209,7 @@ describe('ES Dependency Manager — d.ts', () => {
   })
 })
 
-describe('ES Dependency Manager — Downloads extra files as-needed', () => {
+xdescribe('ES Dependency Manager — Downloads extra files as-needed', () => {
   it('downloads a css file from jsdelivr, if needed', async (done) => {
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -10,7 +10,8 @@ import {
   fetchNodeModules,
   resetDepPackagerCache,
 } from './fetch-packages'
-import { ESCodeFile } from '../../shared/project-file-types'
+import { objectValues } from '../../shared/object-utils'
+import { ESCodeFile, isEsRemoteDependencyPlaceholder } from '../../shared/project-file-types'
 import { NO_OP } from '../../shared/utils'
 import { NodeModules } from '../../shared/project-file-types'
 import { getPackagerUrl, getJsDelivrFileUrl } from './packager-url'
@@ -21,6 +22,7 @@ import {
   requestedNpmDependency,
   resolvedNpmDependency,
 } from '../../shared/npm-dependency-types'
+import { wait } from '../../../utils/test-utils'
 
 require('jest-fetch-mock').enableMocks()
 
@@ -112,7 +114,13 @@ describe('ES Dependency Manager — Cycles', () => {
   })
 })
 
-xdescribe('ES Dependency Manager — Real-life packages', () => {
+function moduleUpdater(nodeModules: NodeModules): (modulesToAdd: NodeModules) => void {
+  return (modulesToAdd: NodeModules) => {
+    Object.assign(nodeModules, modulesToAdd)
+  }
+}
+
+describe('ES Dependency Manager — Real-life packages', () => {
   it('react-spring@8.0.27', async () => {
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
@@ -131,12 +139,13 @@ xdescribe('ES Dependency Manager — Real-life packages', () => {
       fail(`Expected successful nodeModules fetch`)
     }
     const nodeModules = fetchNodeModulesResult.nodeModules
-    const req = getRequireFn(NO_OP, nodeModules)
+    const req = getRequireFn(moduleUpdater(nodeModules), nodeModules)
     const reactSpring = req('/src/index.js', 'react-spring')
+    await wait(10)
     expect(Object.keys(reactSpring)).not.toHaveLength(0)
   })
 
-  it('antd@4.2.5', async (done) => {
+  it('antd@4.2.5', async () => {
     const spyEvaluator = jest.fn(evaluator)
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
@@ -155,24 +164,16 @@ xdescribe('ES Dependency Manager — Real-life packages', () => {
       fail(`Expected successful nodeModules fetch`)
     }
     const nodeModules = fetchNodeModulesResult.nodeModules
-    function addNewModules(newModules: NodeModules) {
-      const updatedNodeModules = { ...nodeModules, ...newModules }
-      const updatedReq = getRequireFn(NO_OP, updatedNodeModules, spyEvaluator)
-
-      // this is like calling `import 'antd/dist/antd.css';`, we only care about the side effect
-      updatedReq('/src/index.js', 'antd/dist/antd.css')
-
-      // our CSS side effect code ran by now, so we should be able to find the relevant style tag on the JSDOM
-      const styleTag = document.getElementById('/node_modules/antd/dist/antd.css')
-      expect(styleTag).toBeDefined()
-      expect(spyEvaluator).toHaveBeenCalledTimes(940)
-      done()
-    }
-    const req = getRequireFn(addNewModules, nodeModules, spyEvaluator)
+    const req = getRequireFn(moduleUpdater(nodeModules), nodeModules, spyEvaluator)
     const antd = req('/src/index.js', 'antd')
+    await wait(10)
     expect(Object.keys(antd)).not.toHaveLength(0)
     expect(antd).toHaveProperty('Button')
     req('/src/index.js', 'antd/dist/antd.css')
+    await wait(10)
+    const styleTag = document.getElementById('/node_modules/antd/dist/antd.css')
+    expect(styleTag).toBeDefined()
+    expect(spyEvaluator).toHaveBeenCalledTimes(941)
   })
 })
 
@@ -209,8 +210,8 @@ describe('ES Dependency Manager — d.ts', () => {
   })
 })
 
-xdescribe('ES Dependency Manager — Downloads extra files as-needed', () => {
-  it('downloads a css file from jsdelivr, if needed', async (done) => {
+describe('ES Dependency Manager — Downloads extra files as-needed', () => {
+  it('downloads a css file from jsdelivr, if needed', async () => {
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
         switch (request.url) {
@@ -230,24 +231,16 @@ xdescribe('ES Dependency Manager — Downloads extra files as-needed', () => {
       fail(`Expected successful nodeModules fetch`)
     }
     const nodeModules = fetchNodeModulesResult.nodeModules
-    function addNewModules(newModules: NodeModules) {
-      const updatedNodeModules = { ...nodeModules, ...newModules }
-      const updatedReq = getRequireFn(NO_OP, updatedNodeModules)
-
-      // this is like calling `import 'mypackage/dist/style.css';`, we only care about the side effect
-      updatedReq('/src/index.js', 'mypackage/dist/style.css')
-
-      // our CSS side effect code ran by now, so we should be able to find the relevant style tag on the JSDOM
-      const styleTag = document.getElementById(
-        `${InjectedCSSFilePrefix}/node_modules/mypackage/dist/style.css`,
-      )
-      expect(styleTag?.innerHTML).toEqual(simpleCssContent)
-
-      done()
-    }
-    const req = getRequireFn(addNewModules, nodeModules)
+    const req = getRequireFn(moduleUpdater(nodeModules), nodeModules)
     const styleCss = req('/src/index.js', 'mypackage/dist/style.css')
     expect(Object.keys(styleCss)).toHaveLength(0)
+
+    await wait(10)
+    // our CSS side effect code ran by now, so we should be able to find the relevant style tag on the JSDOM
+    const styleTag = document.getElementById(
+      `${InjectedCSSFilePrefix}/node_modules/mypackage/dist/style.css`,
+    )
+    expect(styleTag?.innerHTML).toEqual(simpleCssContent)
   })
 })
 

--- a/editor/src/core/es-modules/package-manager/package-manager.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.ts
@@ -171,14 +171,12 @@ export function getRequireFn(
           // return empty exports object, fire off an async job to fetch the dependency from jsdelivr
           // MUTATION
           resolvedFile.downloadStarted = true
-          fetchMissingFileDependency(updateNodeModules, resolvedFile, resolvedPath)
-            .then((response) => {
+          fetchMissingFileDependency(updateNodeModules, resolvedFile, resolvedPath).then(
+            (response) => {
               injectedEvaluator(resolvedPath, response, partialModule, partialRequire)
               partialRequire(resolvedPath)
-            })
-            .catch((err) => {
-              console.error('Download error.', err)
-            })
+            },
+          )
         }
 
         return {}

--- a/editor/src/core/es-modules/package-manager/package-manager.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.ts
@@ -171,12 +171,14 @@ export function getRequireFn(
           // return empty exports object, fire off an async job to fetch the dependency from jsdelivr
           // MUTATION
           resolvedFile.downloadStarted = true
-          fetchMissingFileDependency(updateNodeModules, resolvedFile, resolvedPath).then(
-            (response) => {
+          fetchMissingFileDependency(updateNodeModules, resolvedFile, resolvedPath)
+            .then((response) => {
               injectedEvaluator(resolvedPath, response, partialModule, partialRequire)
               partialRequire(resolvedPath)
-            },
-          )
+            })
+            .catch((err) => {
+              console.error('Download error.', err)
+            })
         }
 
         return {}


### PR DESCRIPTION
Fixes #594

**Problem:**
In the canvas a change to the node modules triggers a render which in turn causing the now downloaded CSS content to be evaluated. But in the preview there is no such trigger as it is rendered effectively only once.

**Fix:**
When a file needs to be downloaded, now also evaluate and "require" it, so that it would be fully triggered as if it was embedded in the project itself.

**Notes:**
I'm a little uneasy about this, ordinarily the CSS import would be mangled by a pre-processor. There's a bit of a schism between the asynchronicity of `fetch` and the magically synchronous `require`, which is handled by said transforms.

**Commit Details:**
- Fixes #594.
- `fetchMissingFileDependency` now returns the content of the dependency
  after downloading it.
- For file placeholders, after downloading the file it is evaluated and
  required immediately.