### PR TITLE
fix(fileitem.tsx) Handle file names with trailing slashes

### DIFF
--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -26,7 +26,6 @@ import * as EditorActions from '../editor/actions/actions'
 import { openFileTab } from '../editor/store/editor-state'
 import { ExpandableIndicator } from '../navigator/navigator-item/expandable-indicator'
 import { FileBrowserItemInfo, FileBrowserItemType } from './filebrowser'
-import { dropLeadingSlash } from './filepath-utils'
 import { PasteResult } from '../../utils/clipboard-utils'
 import { codeFile } from '../../core/model/project-file-utils'
 import { dragAndDropInsertionSubject, EditorModes } from '../editor/editor-modes'
@@ -231,8 +230,7 @@ class FileBrowserItemInner extends React.PureComponent<
         isRenaming: props.renamingTarget === props.path,
       }
     }
-    // todo this is not very safe. should it be not allowed to use . in folder names?
-    const pathParts = dropLeadingSlash(props.path).split('/')
+    const pathParts = props.path.split('/').filter((s) => s !== '')
     const filename = Utils.last(pathParts)
     return {
       filename: filename,


### PR DESCRIPTION
Fixes #602 

**Problem:**
Folder names with a trailing slash were being rendered as empty strings

**Fix:**
Filter empty values from the result of the string split we were using. I've also removed a comment questioning the allowance of folders with a dot in their names since folders prefixed with a dot are definitely allowed.