### PR TITLE
Fall back to standard React handling of undefined elements

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -11819,7 +11819,7 @@ Array [
   Object {
     "columnNumber": undefined,
     "lineNumber": undefined,
-    "message": "MyCard imported from utopia-api is undefined.",
+    "message": "Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.",
     "name": "Error",
     "originalCode": undefined,
   },
@@ -11831,7 +11831,7 @@ Array [
   Object {
     "columnNumber": undefined,
     "lineNumber": undefined,
-    "message": "MyCard from this file is undefined.",
+    "message": "Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.",
     "name": "Error",
     "originalCode": undefined,
   },

--- a/editor/src/core/shared/element-template.tsx
+++ b/editor/src/core/shared/element-template.tsx
@@ -765,18 +765,6 @@ export interface ArbitraryJSBlock {
 
 export type TopLevelElement = UtopiaJSXComponent | ArbitraryJSBlock
 
-export function getDefinedWithin(element: TopLevelElement): Array<string> {
-  switch (element.type) {
-    case 'UTOPIA_JSX_COMPONENT':
-      return [element.name]
-    case 'ARBITRARY_JS_BLOCK':
-      return element.definedWithin
-    default:
-      const _exhaustiveCheck: never = element
-      throw new Error(`Unhandled element ${JSON.stringify(element)}`)
-  }
-}
-
 export function clearArbitraryJSBlockUniqueIDs(block: ArbitraryJSBlock): ArbitraryJSBlock {
   return {
     ...block,

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -1,10 +1,9 @@
 import * as TS from 'typescript'
-import { FlexParentProps, LayoutSystem, NormalisedFrame } from 'utopia-api'
+import { LayoutSystem, NormalisedFrame } from 'utopia-api'
 import { Either, Left, Right, isRight, isLeft } from './either'
-import { ArbitraryJSBlock, TopLevelElement, UtopiaJSXComponent } from './element-template'
+import { ArbitraryJSBlock, TopLevelElement } from './element-template'
 import { ErrorMessage } from './error-messages'
-import { forEachValue } from './object-utils'
-import { arrayEquals, fastForEach, objectEquals } from './utils'
+import { arrayEquals, objectEquals } from './utils'
 
 export type id = string
 
@@ -133,43 +132,7 @@ export function importDetailsEquals(first: ImportDetails, second: ImportDetails)
   )
 }
 
-export function importedNamesFromImportDetails(details: ImportDetails): Array<string> {
-  let result: Array<string> = []
-  fastForEach(details.importedFromWithin, (fromWithin) => {
-    result.push(fromWithin.alias)
-  })
-  if (details.importedAs != null) {
-    result.push(details.importedAs)
-  }
-  if (details.importedWithName != null) {
-    result.push(details.importedWithName)
-  }
-  return result
-}
-
 export type Imports = { [importSource: string]: ImportDetails }
-
-export function importedNamesFromImports(imports: Imports): Array<string> {
-  let result: Array<string> = []
-  forEachValue((details) => {
-    result.push(...importedNamesFromImportDetails(details))
-  }, imports)
-  return result
-}
-
-export function findPossibleImport(toCheck: string, imports: Imports): string | null {
-  for (const importSource of Object.keys(imports)) {
-    const details = imports[importSource]
-    if (details.importedFromWithin.some((fromWithin) => fromWithin.alias === toCheck)) {
-      return importSource
-    } else if (details.importedWithName === toCheck) {
-      return importSource
-    } else if (details.importedAs === toCheck) {
-      return importSource
-    }
-  }
-  return null
-}
 
 export function importsEquals(first: Imports, second: Imports): boolean {
   return objectEquals(first, second, importDetailsEquals)


### PR DESCRIPTION
Follow up to the conversation on #591, specifically [here](https://github.com/concrete-utopia/utopia/pull/591#discussion_r501040300)

This removes our custom handling of undefined elements, allowing us to fall through to using whatever factory function is in scope to attempt (and fail) to create them, resulting in an error that is _almost_ in line with what you'd expect from React:

![Screenshot_20201009_173047](https://user-images.githubusercontent.com/1044774/95612208-eded0500-0a5a-11eb-9d8d-b4b5942e7436.png)
(note the `ForwardRef`, which should actually be `App`)

From my testing this appears to give consistently the same error, but maybe @seanparsons you were trying something that I've missed? 

Happy to discuss this approach further because I'm not attached to it, but it does feel closer to what we should be doing than the current custom logic.