### PR TITLE
Fix Property Controls On Built In Modules

### DIFF
--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -68,7 +68,7 @@ import {
   PackageStatus,
 } from '../../core/shared/npm-dependency-types'
 import { getThirdPartyComponents } from '../../core/third-party/third-party-components'
-import { isBuiltinDependency } from '../../core/es-modules/package-manager/package-manager'
+import { isBuiltInDependency } from '../../core/es-modules/package-manager/built-in-dependencies'
 import { NpmDependencyVersionAndStatusIndicator } from '../navigator/dependecy-version-status-indicator'
 import { PropertyControlsInfo } from '../custom-code/code-file'
 
@@ -488,7 +488,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
               )
             }
           } else {
-            if (isBuiltinDependency(dependency.name)) {
+            if (isBuiltInDependency(dependency.name)) {
               return null
             } else {
               return (

--- a/editor/src/core/es-modules/package-manager/built-in-dependencies.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies.ts
@@ -1,0 +1,51 @@
+import * as UtopiaAPI from 'utopia-api'
+import * as UUIUI from 'uuiui'
+import * as UUIUIDeps from 'uuiui-deps'
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+
+interface BuiltInDependency {
+  moduleName: string
+  nodeModule: any
+  version: string
+}
+
+function builtInDependency(
+  moduleName: string,
+  baseModule: any,
+  version: string,
+): BuiltInDependency {
+  return {
+    moduleName: moduleName,
+    nodeModule: {
+      ...baseModule,
+      default: baseModule,
+    },
+    version: version,
+  }
+}
+
+// TODO Figure out how to sync this with our package.json
+const BuiltInDependencies: Array<BuiltInDependency> = [
+  builtInDependency('utopia-api', UtopiaAPI, '0.4.2'),
+  builtInDependency('uuiui', UUIUI, '0.1.0'),
+  builtInDependency('uuiui-deps', UUIUIDeps, '0.1.0'),
+  builtInDependency('react', React, '17.0.0-rc.1'),
+  builtInDependency('react-dom', ReactDOM, '17.0.0-rc.1'),
+]
+
+function findBuiltInForName(moduleName: string): BuiltInDependency | undefined {
+  return BuiltInDependencies.find((builtIn) => builtIn.moduleName === moduleName)
+}
+
+export function isBuiltInDependency(moduleName: string): boolean {
+  return findBuiltInForName(moduleName) != null
+}
+
+export function resolveBuiltInDependency(moduleName: string): any | undefined {
+  return findBuiltInForName(moduleName)?.nodeModule
+}
+
+export function versionForBuiltInDependency(moduleName: string): string | undefined {
+  return findBuiltInForName(moduleName)?.version
+}

--- a/editor/src/core/es-modules/package-manager/built-in-dependencies.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies.ts
@@ -4,6 +4,9 @@ import * as UUIUIDeps from 'uuiui-deps'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 
+import * as editorPackageJSON from '../../../../package.json'
+import * as utopiaAPIPackageJSON from '../../../../../utopia-api/package.json'
+
 interface BuiltInDependency {
   moduleName: string
   nodeModule: any
@@ -25,13 +28,12 @@ function builtInDependency(
   }
 }
 
-// TODO Figure out how to sync this with our package.json
 const BuiltInDependencies: Array<BuiltInDependency> = [
-  builtInDependency('utopia-api', UtopiaAPI, '0.4.2'),
-  builtInDependency('uuiui', UUIUI, '0.1.0'),
-  builtInDependency('uuiui-deps', UUIUIDeps, '0.1.0'),
-  builtInDependency('react', React, '17.0.0-rc.1'),
-  builtInDependency('react-dom', ReactDOM, '17.0.0-rc.1'),
+  builtInDependency('utopia-api', UtopiaAPI, utopiaAPIPackageJSON.version),
+  builtInDependency('uuiui', UUIUI, editorPackageJSON.version),
+  builtInDependency('uuiui-deps', UUIUIDeps, editorPackageJSON.version),
+  builtInDependency('react', React, editorPackageJSON.dependencies.react),
+  builtInDependency('react-dom', ReactDOM, editorPackageJSON.dependencies['react-dom']),
 ]
 
 function findBuiltInForName(moduleName: string): BuiltInDependency | undefined {

--- a/editor/src/core/es-modules/package-manager/fetch-packages.ts
+++ b/editor/src/core/es-modules/package-manager/fetch-packages.ts
@@ -19,7 +19,7 @@ import { objectMap } from '../../shared/object-utils'
 import { mangleNodeModulePaths, mergeNodeModules } from './merge-modules'
 import { getPackagerUrl, getJsDelivrFileUrl } from './packager-url'
 import { Either, right, left, isLeft, isRight } from '../../shared/either'
-import { isBuiltinDependency } from './package-manager'
+import { isBuiltInDependency } from './built-in-dependencies'
 import {
   findMatchingVersion,
   isNpmVersion,
@@ -197,7 +197,7 @@ export async function fetchNodeModules(
   newDeps: Array<RequestedNpmDependency>,
   shouldRetry: boolean = true,
 ): Promise<NodeFetchResult> {
-  const dependenciesToDownload = newDeps.filter((d) => !isBuiltinDependency(d.name))
+  const dependenciesToDownload = newDeps.filter((d) => !isBuiltInDependency(d.name))
   const nodeModulesArr = await Promise.all(
     dependenciesToDownload.map(
       async (newDep): Promise<Either<DependencyFetchError, NodeModules>> => {

--- a/editor/src/core/shared/npm-dependency-types.ts
+++ b/editor/src/core/shared/npm-dependency-types.ts
@@ -36,10 +36,6 @@ export function requestedNpmDependency(name: string, version: string): Requested
   }
 }
 
-export interface BuiltInDependency {
-  type: 'BUILT_IN_DEPENDENCY'
-}
-
 export interface ResolvedNpmDependency {
   type: 'RESOLVED_NPM_DEPENDENCY'
   name: string

--- a/editor/src/core/shared/npm-dependency-types.ts
+++ b/editor/src/core/shared/npm-dependency-types.ts
@@ -36,6 +36,10 @@ export function requestedNpmDependency(name: string, version: string): Requested
   }
 }
 
+export interface BuiltInDependency {
+  type: 'BUILT_IN_DEPENDENCY'
+}
+
 export interface ResolvedNpmDependency {
   type: 'RESOLVED_NPM_DEPENDENCY'
   name: string

--- a/editor/src/core/third-party/third-party-components.ts
+++ b/editor/src/core/third-party/third-party-components.ts
@@ -41,7 +41,7 @@ export function getThirdPartyComponents(
   }
 }
 
-export function parseDependencyVersionFromNodeModules(
+function parseDependencyVersionFromNodeModules(
   nodeModules: NodeModules,
   dependencyName: string,
 ): string | null {

--- a/editor/src/utils/package-parser-utils.ts
+++ b/editor/src/utils/package-parser-utils.ts
@@ -26,18 +26,3 @@ export function parseVersionPackageJsonObject(value: unknown): ParseResult<strin
 export function parseVersionPackageJsonFile(value: unknown): ParseResult<string> {
   return flatMapEither(parseVersionPackageJsonObject, parseStringToJSON(value))
 }
-
-export function parseDependencyVersionFromNodeModules(
-  nodeModules: NodeModules,
-  dependencyName: string,
-): string | null {
-  let version: string | null = null
-  const packageJsonFile = nodeModules[`/node_modules/${dependencyName}/package.json`]
-  if (packageJsonFile != null && isEsCodeFile(packageJsonFile)) {
-    const parseResult = parseVersionPackageJsonFile(packageJsonFile.fileContents)
-    forEachRight(parseResult, (resolvedVersion) => {
-      version = resolvedVersion
-    })
-  }
-  return version
-}


### PR DESCRIPTION
Fixes #605 

**Problem:**
When fetching the property controls info we were only using dependencies with resolved versions, which was then excluding any modules that we swap in (and have explicit requirements on).

**Fix:**
I've extracted those built in modules into a separate file and provided versions for them by tying them to the editor's and utopia-api's `package.json`.

**Commit Details:**
- Extracted functionality around built in modules to `built-in-dependencies.ts`
- Reference the versions in `editor/package.json` and `utopia-api/package.json` directly in there
- Moved `parseDependencyVersionFromNodeModules` to the only place it is used so that it's not accidentally used elsewhere
