### PR TITLE
Support context elements.

### DIFF
--- a/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
@@ -75,7 +75,6 @@ Array [
         "localFrame": null,
         "props": Object {
           "data-uid": "utopia-storyboard-uid",
-          "data-utopia-original-uid": undefined,
           "skipDeepFreeze": true,
         },
         "specialSizeMeasurements": Object {
@@ -410,7 +409,6 @@ Array [
         },
         "props": Object {
           "data-uid": "aaa",
-          "data-utopia-original-uid": undefined,
           "skipDeepFreeze": true,
           "style": Object {
             "alignContent": undefined,
@@ -597,7 +595,6 @@ Array [
         "localFrame": null,
         "props": Object {
           "data-uid": "utopia-storyboard-uid",
-          "data-utopia-original-uid": undefined,
           "skipDeepFreeze": true,
         },
         "specialSizeMeasurements": Object {
@@ -692,7 +689,6 @@ Array [
         "props": Object {
           "data-label": "Hat",
           "data-uid": "aaa",
-          "data-utopia-original-uid": undefined,
           "skipDeepFreeze": true,
           "style": Object {
             "alignContent": undefined,
@@ -879,7 +875,6 @@ Array [
         "localFrame": null,
         "props": Object {
           "data-uid": "utopia-storyboard-uid",
-          "data-utopia-original-uid": undefined,
           "skipDeepFreeze": true,
         },
         "specialSizeMeasurements": Object {
@@ -977,7 +972,6 @@ Array [
                 },
                 "props": Object {
                   "data-uid": "488",
-                  "data-utopia-original-uid": undefined,
                   "skipDeepFreeze": true,
                   "style": Object {
                     "alignContent": undefined,
@@ -1084,7 +1078,6 @@ Array [
             },
             "props": Object {
               "data-uid": "ef0",
-              "data-utopia-original-uid": undefined,
               "skipDeepFreeze": true,
               "style": Object {
                 "alignContent": undefined,
@@ -1186,7 +1179,6 @@ Array [
         },
         "props": Object {
           "data-uid": "05c",
-          "data-utopia-original-uid": undefined,
           "skipDeepFreeze": true,
           "style": Object {
             "alignContent": undefined,
@@ -1374,7 +1366,6 @@ Array [
         "localFrame": null,
         "props": Object {
           "data-uid": "utopia-storyboard-uid",
-          "data-utopia-original-uid": undefined,
           "skipDeepFreeze": true,
         },
         "specialSizeMeasurements": Object {
@@ -1472,7 +1463,6 @@ Array [
                 },
                 "props": Object {
                   "data-uid": "488",
-                  "data-utopia-original-uid": undefined,
                   "skipDeepFreeze": true,
                   "style": Object {
                     "alignContent": undefined,
@@ -1579,7 +1569,6 @@ Array [
             },
             "props": Object {
               "data-uid": "ef0",
-              "data-utopia-original-uid": undefined,
               "skipDeepFreeze": true,
               "style": Object {
                 "alignContent": undefined,
@@ -1681,7 +1670,6 @@ Array [
         },
         "props": Object {
           "data-uid": "05c",
-          "data-utopia-original-uid": undefined,
           "skipDeepFreeze": true,
           "style": Object {
             "alignContent": undefined,
@@ -1870,7 +1858,6 @@ Array [
         "localFrame": null,
         "props": Object {
           "data-uid": "utopia-storyboard-uid",
-          "data-utopia-original-uid": undefined,
           "skipDeepFreeze": true,
         },
         "specialSizeMeasurements": Object {
@@ -1968,7 +1955,6 @@ Array [
                 },
                 "props": Object {
                   "data-uid": "488",
-                  "data-utopia-original-uid": undefined,
                   "skipDeepFreeze": true,
                   "style": Object {
                     "alignContent": undefined,
@@ -2075,7 +2061,6 @@ Array [
             },
             "props": Object {
               "data-uid": "ef0",
-              "data-utopia-original-uid": undefined,
               "skipDeepFreeze": true,
               "style": Object {
                 "alignContent": undefined,
@@ -2181,7 +2166,6 @@ Array [
         },
         "props": Object {
           "data-uid": "05c",
-          "data-utopia-original-uid": undefined,
           "skipDeepFreeze": true,
           "style": Object {
             "alignContent": undefined,

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -214,7 +214,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -412,7 +411,6 @@ Object {
     "props": Object {
       "data-label": "Hat",
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -548,7 +546,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "567",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -787,7 +784,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -1141,7 +1137,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -1316,7 +1311,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -1391,7 +1385,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -1467,7 +1460,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -1636,7 +1628,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -1903,7 +1894,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -2144,7 +2134,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -2319,7 +2308,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -2394,7 +2382,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -2470,7 +2457,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -2659,7 +2645,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -2952,7 +2937,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -3114,7 +3098,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -3443,7 +3426,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -3605,7 +3587,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -3951,7 +3932,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -4137,7 +4117,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -4489,7 +4468,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -4675,7 +4653,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -4820,7 +4797,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -5922,7 +5898,6 @@ export var storyboard = (props) => {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -6698,7 +6673,6 @@ export var storyboard = (props) => {
     "localFrame": null,
     "props": Object {
       "data-uid": "03a",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -6924,7 +6898,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -7003,7 +6976,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "name": "World!",
       "skipDeepFreeze": true,
     },
@@ -7084,7 +7056,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
-      "data-utopia-original-uid": undefined,
       "name": "Dolly!",
       "skipDeepFreeze": true,
     },
@@ -7251,7 +7222,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -7467,7 +7437,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -7745,7 +7714,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -7904,7 +7872,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "d59",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -8021,7 +7988,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "dd5",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -8283,7 +8249,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -8391,7 +8356,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -8659,7 +8623,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -8901,7 +8864,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -9149,7 +9111,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -9266,7 +9227,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -9347,7 +9307,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -9389,6 +9348,344 @@ Object {
         "sceneElementPath": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
+        ],
+        "type": "scenepath",
+      },
+    },
+  },
+}
+`;
+
+exports[`UiJsxCanvas render renders correctly with a context 1`] = `
+"<div
+  id=\\"canvas-container\\"
+  style=\\"
+    all: initial;
+    position: absolute;
+    zoom: 100%;
+    transform: translate3d(0px, 0px, 0);
+  \\"
+>
+  <div
+    data-utopia-scene-id=\\"ccc/ddd\\"
+    data-utopia-valid-paths=\\"ccc/ddd:aaa ccc/ddd:aaa/bbb\\"
+    style=\\"
+      position: absolute;
+      width: 375px;
+      height: 812px;
+      left: 0;
+      top: 0;
+      background-color: rgba(255, 255, 255, 1);
+      box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+    \\"
+    data-uid=\\"ccc\\"
+  >
+    <div
+      data-uid=\\"bbb\\"
+      style=\\"
+        position: relative;
+        width: 100%;
+        height: 100%;
+        background-color: #eb1010;
+      \\"
+      data-utopia-parents=\\"aaa\\"
+    ></div>
+  </div>
+</div>
+"
+`;
+
+exports[`UiJsxCanvas render renders correctly with a context 2`] = `
+Object {
+  "ccc/ddd:aaa": Object {
+    "childrenTemplatePaths": Array [
+      Object {
+        "element": Array [
+          "aaa",
+          "bbb",
+        ],
+        "scene": Object {
+          "sceneElementPath": Array [
+            "ccc",
+            "ddd",
+          ],
+          "type": "scenepath",
+        },
+      },
+    ],
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [
+          Object {
+            "children": Array [],
+            "metadata": null,
+            "name": Object {
+              "baseVariable": "div",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Object {
+              "data-uid": Object {
+                "type": "ATTRIBUTE_VALUE",
+                "value": "bbb",
+              },
+              "layout": Object {
+                "type": "ATTRIBUTE_VALUE",
+                "value": Object {
+                  "layoutSystem": "pinSystem",
+                },
+              },
+              "style": Object {
+                "type": "ATTRIBUTE_VALUE",
+                "value": Object {
+                  "backgroundColor": "#EB1010",
+                  "height": "100%",
+                  "width": "100%",
+                },
+              },
+            },
+            "type": "JSX_ELEMENT",
+          },
+        ],
+        "metadata": null,
+        "name": Object {
+          "baseVariable": "AppContext",
+          "propertyPath": Object {
+            "propertyElements": Array [
+              "Provider",
+            ],
+          },
+        },
+        "props": Object {
+          "data-uid": Object {
+            "type": "ATTRIBUTE_VALUE",
+            "value": "aaa",
+          },
+          "value": Object {
+            "definedElsewhere": Array [
+              "storeRef",
+            ],
+            "javascript": "storeRef",
+            "sourceMap": Object {
+              "file": "code.tsx",
+              "mappings": "OAUiCA",
+              "names": Array [
+                "storeRef",
+              ],
+              "sources": Array [
+                "code.tsx",
+              ],
+              "sourcesContent": Array [
+                "/** @jsx jsx */
+import * as React from 'react'
+import { Scene, Storyboard, jsx } from 'utopia-api'
+
+const AppContext = React.createContext({})
+const useStoreRef = () => useContext(AppContext)
+
+export var App = (props) => {
+  const storeRef = React.useRef({})
+  return (
+    <AppContext.Provider value={storeRef} data-uid={'aaa'}>
+      <div
+        data-uid={'bbb'}
+        style={{ width: '100%', height: '100%', backgroundColor: '#EB1010' }}
+        layout={{ layoutSystem: 'pinSystem' }}
+      />
+    </AppContext.Provider>
+  )
+}
+
+export var storyboard = (
+  <Storyboard layout={{ layoutSystem: 'pinSystem' }} data-uid={'ccc'}>
+    <Scene
+      data-uid={'ddd'}
+      component={App}
+      props={{}}
+      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+    />
+  </Storyboard>
+)",
+              ],
+              "version": 3,
+            },
+            "transpiledJavascript": "return storeRef;",
+            "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
+            "uniqueID": "",
+          },
+        },
+        "type": "JSX_ELEMENT",
+      },
+    },
+    "globalFrame": null,
+    "localFrame": null,
+    "props": Object {
+      "data-uid": "aaa",
+      "skipDeepFreeze": true,
+      "value": Object {
+        "current": Object {},
+      },
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "usesParentBounds": false,
+    },
+    "templatePath": Object {
+      "element": Array [
+        "aaa",
+      ],
+      "scene": Object {
+        "sceneElementPath": Array [
+          "ccc",
+          "ddd",
+        ],
+        "type": "scenepath",
+      },
+    },
+  },
+  "ccc/ddd:aaa/bbb": Object {
+    "childrenTemplatePaths": Array [],
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "metadata": null,
+        "name": Object {
+          "baseVariable": "div",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Object {
+          "data-uid": Object {
+            "type": "ATTRIBUTE_VALUE",
+            "value": "bbb",
+          },
+          "layout": Object {
+            "type": "ATTRIBUTE_VALUE",
+            "value": Object {
+              "layoutSystem": "pinSystem",
+            },
+          },
+          "style": Object {
+            "type": "ATTRIBUTE_VALUE",
+            "value": Object {
+              "backgroundColor": "#EB1010",
+              "height": "100%",
+              "width": "100%",
+            },
+          },
+        },
+        "type": "JSX_ELEMENT",
+      },
+    },
+    "globalFrame": null,
+    "localFrame": null,
+    "props": Object {
+      "data-uid": "bbb",
+      "data-utopia-parents": "aaa",
+      "skipDeepFreeze": true,
+      "style": Object {
+        "alignContent": undefined,
+        "alignItems": undefined,
+        "alignSelf": undefined,
+        "backgroundColor": "#EB1010",
+        "bottom": undefined,
+        "flexBasis": undefined,
+        "flexDirection": undefined,
+        "flexGrow": undefined,
+        "flexShrink": undefined,
+        "flexWrap": undefined,
+        "height": "100%",
+        "justifyContent": undefined,
+        "left": undefined,
+        "marginBottom": undefined,
+        "marginLeft": undefined,
+        "marginRight": undefined,
+        "marginTop": undefined,
+        "maxHeight": undefined,
+        "maxWidth": undefined,
+        "minHeight": undefined,
+        "minWidth": undefined,
+        "position": "relative",
+        "right": undefined,
+        "top": undefined,
+        "width": "100%",
+      },
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "usesParentBounds": false,
+    },
+    "templatePath": Object {
+      "element": Array [
+        "aaa",
+        "bbb",
+      ],
+      "scene": Object {
+        "sceneElementPath": Array [
+          "ccc",
+          "ddd",
         ],
         "type": "scenepath",
       },
@@ -9615,7 +9912,6 @@ export var storyboard = (
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -9756,7 +10052,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "BBB",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "x": 5,
     },
@@ -10094,7 +10389,6 @@ export var storyboard = (
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -10202,7 +10496,6 @@ export var storyboard = (
     "localFrame": null,
     "props": Object {
       "data-uid": "ddd",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -10380,7 +10673,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -10459,7 +10751,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "src": "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=",
       "style": Object {
@@ -10598,7 +10889,6 @@ Object {
     "props": Object {
       "data-factory-function-works": "true",
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -10871,7 +11161,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -11041,7 +11330,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -11155,7 +11443,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "cloner",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -11237,7 +11524,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "cloned",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
       "style": Object {
         "color": "red",
@@ -11358,7 +11644,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -11474,7 +11759,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
-      "data-utopia-original-uid": undefined,
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -29,8 +29,15 @@ import {
 } from '../inspector/common/css-utils'
 import { CanvasContainerProps } from './ui-jsx-canvas'
 import { camelCaseToDashed } from '../../core/shared/string-utils'
-import { UTOPIA_ORIGINAL_ID_KEY } from '../../core/model/utopia-constants'
 import { useEditorState } from '../editor/store/store-hook'
+import {
+  UTOPIA_DO_NOT_TRAVERSE_KEY,
+  UTOPIA_LABEL_KEY,
+  UTOPIA_ORIGINAL_ID_KEY,
+  UTOPIA_UID_KEY,
+  UTOPIA_UID_ORIGINAL_PARENTS_KEY,
+  UTOPIA_UID_PARENTS_KEY,
+} from '../../core/model/utopia-constants'
 
 function isValidPath(path: TemplatePath | null, validPaths: Array<string>): boolean {
   return path != null && validPaths.indexOf(TP.toString(path)) > -1
@@ -305,9 +312,14 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
           const globalFrame = globalFrameForElement(element)
 
           // Determine the uid of this element if it has one.
-          const uidAttribute = getDOMAttribute(element, 'data-uid')
+          const uidAttribute = getDOMAttribute(element, UTOPIA_UID_KEY)
+          const parentUIDsAttribute = getDOMAttribute(element, UTOPIA_UID_PARENTS_KEY)
           const originalUIDAttribute = getDOMAttribute(element, UTOPIA_ORIGINAL_ID_KEY)
-          const doNotTraverseAttribute = getDOMAttribute(element, 'data-utopia-do-not-traverse')
+          const originalParentUIDsAttribute = getDOMAttribute(
+            element,
+            UTOPIA_UID_ORIGINAL_PARENTS_KEY,
+          )
+          const doNotTraverseAttribute = getDOMAttribute(element, UTOPIA_DO_NOT_TRAVERSE_KEY)
 
           const traverseChildren: boolean = doNotTraverseAttribute !== 'true'
 
@@ -316,12 +328,28 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
             return `index-${index}`
           }
           const pathElement = Utils.defaultIfNullLazy<id>(uidAttribute, makeIndexElement)
-          const uniquePath: TemplatePath = TP.appendToPath(uniqueParentPath, pathElement)
-
-          let originalPath: TemplatePath | null = null
           const originalPathElement = Utils.defaultIfNull(uidAttribute, originalUIDAttribute)
-          if (originalPathElement != null && originalParentPath != null) {
-            originalPath = TP.appendToPath(originalParentPath, originalPathElement)
+          const parentAttribute = Utils.defaultIfNull(
+            parentUIDsAttribute,
+            originalParentUIDsAttribute,
+          )
+
+          // Build the unique path for this element.
+          let uniquePath: TemplatePath = uniqueParentPath
+          if (parentUIDsAttribute != null) {
+            uniquePath = TP.appendToPath(uniquePath, parentUIDsAttribute.split('/'))
+          }
+          uniquePath = TP.appendToPath(uniquePath, pathElement)
+
+          // Build the original path for this element.
+          let originalPath: TemplatePath | null = originalParentPath
+          if (originalPath != null) {
+            if (parentAttribute != null) {
+              originalPath = TP.appendToPath(originalPath, parentAttribute.split('/'))
+            }
+            if (originalPathElement != null) {
+              originalPath = TP.appendToPath(originalPath, originalPathElement)
+            }
           }
 
           // Check this is a path we're interested in, otherwise skip straight to the children
@@ -369,18 +397,18 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
             ? localRectangle(Utils.offsetRect(globalFrame, Utils.negate(parentPoint)))
             : null
 
-        const uidAttribute = getDOMAttribute(element, 'data-uid')
+        const uidAttribute = getDOMAttribute(element, UTOPIA_UID_KEY)
         const originalUIDAttribute = getDOMAttribute(element, UTOPIA_ORIGINAL_ID_KEY)
-        const labelAttribute = getDOMAttribute(element, 'data-label')
+        const labelAttribute = getDOMAttribute(element, UTOPIA_LABEL_KEY)
         let elementProps: any = {}
         if (uidAttribute != null) {
-          elementProps['data-uid'] = uidAttribute
+          elementProps[UTOPIA_UID_KEY] = uidAttribute
         }
         if (originalUIDAttribute != null) {
           elementProps[UTOPIA_ORIGINAL_ID_KEY] = originalUIDAttribute
         }
         if (labelAttribute != null) {
-          elementProps['data-label'] = labelAttribute
+          elementProps[UTOPIA_LABEL_KEY] = labelAttribute
         }
         return elementInstanceMetadata(
           instancePath,

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1888,6 +1888,41 @@ export var storyboard = (
 )`,
     )
   })
+  it('renders correctly with a context', () => {
+    testCanvasRender(
+      null,
+      `/** @jsx jsx */
+import * as React from 'react'
+import { Scene, Storyboard, jsx } from 'utopia-api'
+
+const AppContext = React.createContext({})
+const useStoreRef = () => useContext(AppContext)
+
+export var App = (props) => {
+  const storeRef = React.useRef({})
+  return (
+    <AppContext.Provider value={storeRef} data-uid={'aaa'}>
+      <div
+        data-uid={'bbb'}
+        style={{ width: '100%', height: '100%', backgroundColor: '#EB1010' }}
+        layout={{ layoutSystem: 'pinSystem' }}
+      />
+    </AppContext.Provider>
+  )
+}
+
+export var storyboard = (
+  <Storyboard layout={{ layoutSystem: 'pinSystem' }} data-uid={'ccc'}>
+    <Scene
+      data-uid={'ddd'}
+      component={App}
+      props={{}}
+      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+    />
+  </Storyboard>
+)`,
+    )
+  })
 })
 
 describe('UiJsxCanvas runtime errors', () => {

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -97,7 +97,11 @@ import { getGeneratedExternalLinkText } from '../../printer-parsers/html/externa
 import { Helmet } from 'react-helmet'
 import parse from 'html-react-parser'
 import { cssValueOnlyContainsComments } from '../../printer-parsers/css/css-parser-utils'
-import { UTOPIA_ORIGINAL_ID_KEY } from '../../core/model/utopia-constants'
+import {
+  UTOPIA_ORIGINAL_ID_KEY,
+  UTOPIA_UID_KEY,
+  UTOPIA_UID_ORIGINAL_PARENTS_KEY,
+} from '../../core/model/utopia-constants'
 
 const emptyFileBlobs: UIFileBase64Blobs = {}
 
@@ -1010,13 +1014,27 @@ function renderCoreElement(
         requireResult,
       )
 
-      const passthroughProps: MapLike<any> = {
+      let passthroughProps: MapLike<any> = {
         ...assembledProps,
-        'data-uid': Utils.defaultIfNull(assembledProps['data-uid'], uid),
-        [UTOPIA_ORIGINAL_ID_KEY]: Utils.defaultIfNull(
-          assembledProps[UTOPIA_ORIGINAL_ID_KEY],
-          parentComponentInputProps[UTOPIA_ORIGINAL_ID_KEY],
-        ),
+      }
+      const uidForProps = Utils.defaultIfNull(assembledProps[UTOPIA_UID_KEY], uid)
+      if (uidForProps != null) {
+        passthroughProps[UTOPIA_UID_KEY] = uidForProps
+      }
+
+      const originalIDForProps = Utils.defaultIfNull(
+        assembledProps[UTOPIA_ORIGINAL_ID_KEY],
+        parentComponentInputProps[UTOPIA_ORIGINAL_ID_KEY],
+      )
+      if (originalIDForProps != null) {
+        passthroughProps[UTOPIA_ORIGINAL_ID_KEY] = originalIDForProps
+      }
+      const originalParentIDForProps = Utils.defaultIfNull(
+        assembledProps[UTOPIA_UID_ORIGINAL_PARENTS_KEY],
+        parentComponentInputProps[UTOPIA_UID_ORIGINAL_PARENTS_KEY],
+      )
+      if (originalParentIDForProps != null) {
+        originalParentIDForProps[UTOPIA_UID_ORIGINAL_PARENTS_KEY] = originalParentIDForProps
       }
       return renderJSXElement(
         TP.toString(templatePath),

--- a/editor/src/core/model/utopia-constants.ts
+++ b/editor/src/core/model/utopia-constants.ts
@@ -3,6 +3,8 @@ export const UTOPIA_LABEL_KEY = 'data-label'
 export const UTOPIA_ORIGINAL_ID_KEY = 'data-utopia-original-uid'
 export const UTOPIA_DO_NOT_TRAVERSE_KEY = 'data-utopia-do-not-traverse'
 export const UTOPIA_SCENE_ID_KEY = 'data-utopia-scene-id'
+export const UTOPIA_UID_PARENTS_KEY = 'data-utopia-parents'
+export const UTOPIA_UID_ORIGINAL_PARENTS_KEY = 'data-utopia-original-parents'
 
 export const UtopiaKeys: Array<string> = [
   UTOPIA_UID_KEY,
@@ -10,4 +12,6 @@ export const UtopiaKeys: Array<string> = [
   UTOPIA_ORIGINAL_ID_KEY,
   UTOPIA_DO_NOT_TRAVERSE_KEY,
   UTOPIA_SCENE_ID_KEY,
+  UTOPIA_UID_PARENTS_KEY,
+  UTOPIA_UID_ORIGINAL_PARENTS_KEY,
 ]


### PR DESCRIPTION
Fixes #560

**Problem:**
Context elements are troublesome for our spy and dom walking because they effectively create gaps in the paths used to identify elements in the hierarchy. The spy will take account of a path `aaa/bbb/ccc` for example where the middle element represents a context, but the dom walker will only see something like `aaa/ccc` which results in most of that data being culled and ending up with very little element metadata in the end.

**Fix:**
This fix attempts to resolve the issue by carrying forwards onto the child elements of a context the parts of the path that relate to the context. Then later reconstructing the path using those values so that the dom walker gets the same paths that the spy sees.

**Commit Details:**
- Fixes #560.
- `mangleExoticType` called from `patchedCreateReactElement` now inserts
  a key that represents the missing parts of the hierarchy into the child
  elements of a context element.
- `renderCoreElement` adds in the value for the `data-utopia-original-parents`
  key.
- `walkElements` inside `useDomWalker` will reconstruct the missing path hierarchy
  using the keys added in via the above two functions.
- Various cases of the constants inserted for keys like `data-uid` in and
  around the logic updated across this work.
