### PR TITLE
Missing S3 files return a 404 error instead of a 500.

### DIFF
--- a/server/src/Utopia/Web/Database.hs
+++ b/server/src/Utopia/Web/Database.hs
@@ -6,15 +6,15 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Utopia.Web.Database where
 
 import           Control.Lens
 import           Control.Monad.Catch
-import Control.Monad.Fail
+import           Control.Monad.Fail
 import           Control.Monad.Logger
 import           Control.Monad.Trans.Identity
 import           Data.Aeson
@@ -54,8 +54,8 @@ data DatabaseMetrics = DatabaseMetrics
                      , _setShowcaseProjectsMetrics    :: InvocationMetric
                      , _updateUserDetailsMetrics      :: InvocationMetric
                      , _getUserDetailsMetrics         :: InvocationMetric
-                     , _getUserConfigurationMetrics        :: InvocationMetric
-                     , _saveUserConfigurationMetrics       :: InvocationMetric
+                     , _getUserConfigurationMetrics   :: InvocationMetric
+                     , _saveUserConfigurationMetrics  :: InvocationMetric
                      }
 
 createDatabaseMetrics :: Store -> IO DatabaseMetrics

--- a/server/src/Utopia/Web/Database/Types.hs
+++ b/server/src/Utopia/Web/Database/Types.hs
@@ -89,7 +89,7 @@ data ProjectMetadata = ProjectMetadata
 $(makeFieldsNoPrefix ''ProjectMetadata)
 
 data DecodedUserConfiguration = DecodedUserConfiguration
-                         { _id      :: Text
+                         { _id             :: Text
                          , _shortcutConfig :: Maybe Value
                          } deriving (Eq, Show)
 

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -341,8 +341,8 @@ editorAssetsEndpoint notProxiedPath possibleBranchName = do
   let loadLocally = fmap addCDNHeaders $ servePath notProxiedPath possibleBranchName
   let loadFromProxy proxyManager = return $ proxyApplication proxyManager 8088 ["editor"]
   case possibleBranchName of
-    Just _          -> loadLocally
-    Nothing         -> maybe loadLocally loadFromProxy possibleProxyManager
+    Just _  -> loadLocally
+    Nothing -> maybe loadLocally loadFromProxy possibleProxyManager
 
 downloadGithubProjectEndpoint :: Maybe Text -> Text -> Text -> ServerMonad BL.ByteString
 downloadGithubProjectEndpoint cookie owner repo = requireUser cookie $ \_ -> do
@@ -416,7 +416,7 @@ emptyUserConfigurationResponse = UserConfigurationResponse { _shortcutConfig = N
 decodedUserConfigurationToResponse :: DecodedUserConfiguration -> UserConfigurationResponse
 decodedUserConfigurationToResponse DecodedUserConfiguration{..} = UserConfigurationResponse { _shortcutConfig = _shortcutConfig }
 
-getUserConfigurationEndpoint :: Maybe Text -> ServerMonad UserConfigurationResponse 
+getUserConfigurationEndpoint :: Maybe Text -> ServerMonad UserConfigurationResponse
 getUserConfigurationEndpoint cookie = requireUser cookie $ \sessionUser -> do
   userConfig <- getUserConfiguration (view id sessionUser)
   return $ maybe emptyUserConfigurationResponse decodedUserConfigurationToResponse userConfig

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Utopia.Web.Github where
 
-import qualified Data.ByteString.Lazy      as BL
-import           Control.Lens              hiding ((.=), (<.>))
-import qualified Network.Wreq              as WR
+import           Control.Lens         hiding ((.=), (<.>))
+import qualified Data.ByteString.Lazy as BL
+import qualified Network.Wreq         as WR
 import           Protolude
 
 fetchRepoArchive :: Text -> Text -> IO (Maybe BL.ByteString)

--- a/server/src/Utopia/Web/Packager/NPM.hs
+++ b/server/src/Utopia/Web/Packager/NPM.hs
@@ -51,7 +51,7 @@ withInstalledProject semaphore versionedPackageName withInstalledPath = do
 isRelevantFilename :: FilePath -> Bool
 isRelevantFilename path = isSuffixOf "package.json" path || isSuffixOf ".d.ts" path || isSuffixOf ".js" path
 
-data FileContentOrPlaceholder = FileContent Text | Placeholder 
+data FileContentOrPlaceholder = FileContent Text | Placeholder
                               deriving (Eq)
 type FilesAndContents = Map.HashMap Text FileContentOrPlaceholder
 


### PR DESCRIPTION
Fixes #345

**Problem:**
When loading a file that doesn't exist in S3 the server would return a 500 error instead of 404.

**Fix:**
The server now does an upfront check to see if a file exists first.

**Commit Details:**
- Fixes #345.
- Added `checkFileExistsInS3` for checking if a file exists before
  requesting it.
- Refactored a few of the functions around loading files from S3
  slightly to make the code a little clearer.
- Minor styling fixes done to other files from a quick restyling pass.