### PR TITLE
Placeholder dependency resolution callback

### DIFF
--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -22,7 +22,7 @@ import {
 } from '../../core/shared/project-file-types'
 
 import { EditorDispatch } from '../editor/action-types'
-import { getMemoizedRequireFn } from '../../core/es-modules/package-manager/package-manager'
+import { getEditorRequireFn } from '../../core/es-modules/package-manager/package-manager'
 import { updateNodeModulesContents } from '../editor/actions/actions'
 import { fastForEach } from '../../core/shared/utils'
 import { arrayToObject } from '../../core/shared/array-utils'
@@ -218,7 +218,7 @@ export function generateCodeResultCache(
   // Trigger async call to build the property controls info.
   sendPropertyControlsInfoRequest(exportsInfo, nodeModules, projectContents, onlyProjectFiles)
 
-  const requireFn = getMemoizedRequireFn(nodeModules, dispatch)
+  const requireFn = getEditorRequireFn(nodeModules, dispatch)
 
   let cache: { [code: string]: CodeResult } = {}
   Utils.fastForEach(exportsInfo, (result) => {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -444,10 +444,7 @@ import {
 
 import { Notice } from '../../common/notices'
 import { objectMap } from '../../../core/shared/object-utils'
-import {
-  getMemoizedRequireFn,
-  getDependencyTypeDefinitions,
-} from '../../../core/es-modules/package-manager/package-manager'
+import { getDependencyTypeDefinitions } from '../../../core/es-modules/package-manager/package-manager'
 import { fetchNodeModules } from '../../../core/es-modules/package-manager/fetch-packages'
 import {
   getPropertyControlsForTarget,

--- a/editor/src/components/editor/npm-dependency/npm-dependency.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.ts
@@ -333,20 +333,6 @@ export function dependenciesWithEditorRequirements(
   return [...userDefinedDeps, ...EditorTypePackageDependencies]
 }
 
-export function orderedDependenciesEqual(
-  l: Array<RequestedNpmDependency>,
-  r: Array<RequestedNpmDependency>,
-): boolean {
-  return (
-    l.length === r.length &&
-    l.reduce(
-      (matches: boolean, next: RequestedNpmDependency, index: number) =>
-        matches && shallowEqual(next, r[index]),
-      true,
-    )
-  )
-}
-
 export function immediatelyResolvableDependenciesWithEditorRequirements(
   projectContents: ProjectContentTreeRoot,
 ): Array<PossiblyUnversionedNpmDependency> {

--- a/editor/src/components/editor/npm-dependency/npm-dependency.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.ts
@@ -26,8 +26,8 @@ import {
   packageJsonFileFromProjectContents,
   updatePackageJsonInEditorState,
 } from '../store/editor-state'
-import { objectMap } from '../../../core/shared/object-utils'
-import { mapArrayToDictionary, pluck } from '../../../core/shared/array-utils'
+import { pluck } from '../../../core/shared/array-utils'
+import { shallowEqual } from '../../../core/shared/equality-utils'
 import { useEditorState } from '../store/store-hook'
 import * as React from 'react'
 import { resolvedDependencyVersions } from '../../../core/third-party/third-party-components'
@@ -331,6 +331,20 @@ export function dependenciesWithEditorRequirements(
   const packageJsonFile = packageJsonFileFromProjectContents(projectContents)
   const userDefinedDeps = dependenciesFromPackageJson(packageJsonFile)
   return [...userDefinedDeps, ...EditorTypePackageDependencies]
+}
+
+export function orderedDependenciesEqual(
+  l: Array<RequestedNpmDependency>,
+  r: Array<RequestedNpmDependency>,
+): boolean {
+  return (
+    l.length === r.length &&
+    l.reduce(
+      (matches: boolean, next: RequestedNpmDependency, index: number) =>
+        matches && shallowEqual(next, r[index]),
+      true,
+    )
+  )
 }
 
 export function immediatelyResolvableDependenciesWithEditorRequirements(

--- a/editor/src/core/es-modules/package-manager/fetch-packages.spec.ts
+++ b/editor/src/core/es-modules/package-manager/fetch-packages.spec.ts
@@ -22,10 +22,9 @@ describe('Fetch missing file dependency', () => {
     )
     const updateNodeModules = jest.fn()
     await fetchMissingFileDependency(
-      updateNodeModules,
       esRemoteDependencyPlaceholder(fetchUrl, false),
       'mypackage/dist/style.css',
-    )
+    ).then(updateNodeModules)
     expect(updateNodeModules).toBeCalledWith({
       ['mypackage/dist/style.css']: {
         evalResultCache: null,

--- a/editor/src/core/es-modules/package-manager/fetch-packages.ts
+++ b/editor/src/core/es-modules/package-manager/fetch-packages.ts
@@ -262,10 +262,9 @@ export async function fetchNodeModules(
 }
 
 export async function fetchMissingFileDependency(
-  updateNodeModules: (modulesToAdd: NodeModules) => void,
   dependency: ESRemoteDependencyPlaceholder,
   filepath: string,
-): Promise<string> {
+): Promise<NodeModules> {
   const jsdelivrResponse = await fetch(dependency.url)
   const responseAsString = await jsdelivrResponse.text()
   const newFile: ESCodeFile = esCodeFile(responseAsString, null)
@@ -280,6 +279,6 @@ export async function fetchMissingFileDependency(
    */
   // MUTATION
   dependency.downloadStarted = false
-  updateNodeModules(nodeModulesNewEntry)
-  return responseAsString
+
+  return nodeModulesNewEntry
 }

--- a/editor/src/core/es-modules/package-manager/merge-modules.ts
+++ b/editor/src/core/es-modules/package-manager/merge-modules.ts
@@ -5,11 +5,15 @@ function movePathInsidePackage(mainPackage: string, filePath: string): string {
   return `/node_modules/${mainPackage}${filePath}`
 }
 
+export function pathForMainPackage(mainPackage: string): string {
+  return `/node_modules/${mainPackage}/`
+}
+
 export function mangleNodeModulePaths(
   mainPackage: string,
   nodeModulesContents: NodeModules,
 ): NodeModules {
-  const mainPackagePath = `/node_modules/${mainPackage}/`
+  const mainPackagePath = pathForMainPackage(mainPackage)
   return Object.keys(nodeModulesContents).reduce((newContents, packagePath: string) => {
     if (packagePath.startsWith(`/node_modules/`)) {
       if (packagePath.startsWith(mainPackagePath)) {

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -10,8 +10,7 @@ import {
   fetchNodeModules,
   resetDepPackagerCache,
 } from './fetch-packages'
-import { objectValues } from '../../shared/object-utils'
-import { ESCodeFile, isEsRemoteDependencyPlaceholder } from '../../shared/project-file-types'
+import { ESCodeFile } from '../../shared/project-file-types'
 import { NO_OP } from '../../shared/utils'
 import { NodeModules } from '../../shared/project-file-types'
 import { getPackagerUrl, getJsDelivrFileUrl } from './packager-url'
@@ -21,12 +20,7 @@ import {
   npmVersionLookupSuccess,
   VersionLookupResult,
 } from '../../../components/editor/npm-dependency/npm-dependency'
-import {
-  PackagerServerResponse,
-  requestedNpmDependency,
-  resolvedNpmDependency,
-} from '../../shared/npm-dependency-types'
-import { wait } from '../../../utils/test-utils'
+import { PackagerServerResponse, requestedNpmDependency } from '../../shared/npm-dependency-types'
 
 require('jest-fetch-mock').enableMocks()
 

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -123,7 +123,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
     }
     const nodeModules = fetchNodeModulesResult.nodeModules
     const onRemoteModuleDownload = jest.fn()
-    const req = getRequireFn(NO_OP, nodeModules)
+    const req = getRequireFn(onRemoteModuleDownload, nodeModules)
     const reactSpring = req('/src/index.js', 'react-spring')
     expect(Object.keys(reactSpring)).not.toHaveLength(0)
     expect(onRemoteModuleDownload).toBeCalledTimes(0)

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -109,12 +109,6 @@ describe('ES Dependency Manager — Cycles', () => {
   })
 })
 
-function moduleUpdater(nodeModules: NodeModules): (modulesToAdd: NodeModules) => void {
-  return (modulesToAdd: NodeModules) => {
-    Object.assign(nodeModules, modulesToAdd)
-  }
-}
-
 describe('ES Dependency Manager — Real-life packages', () => {
   it('react-spring@8.0.27', async () => {
     ;(fetch as any).mockResponse(
@@ -134,13 +128,14 @@ describe('ES Dependency Manager — Real-life packages', () => {
       fail(`Expected successful nodeModules fetch`)
     }
     const nodeModules = fetchNodeModulesResult.nodeModules
-    const req = getRequireFn(moduleUpdater(nodeModules), nodeModules)
+    const onRemoteModuleDownload = jest.fn()
+    const req = getRequireFn(NO_OP, nodeModules)
     const reactSpring = req('/src/index.js', 'react-spring')
-    await wait(15)
     expect(Object.keys(reactSpring)).not.toHaveLength(0)
+    expect(onRemoteModuleDownload).toBeCalledTimes(0)
   })
 
-  it('antd@4.2.5', async () => {
+  it('antd@4.2.5', async (done) => {
     const spyEvaluator = jest.fn(evaluator)
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
@@ -159,16 +154,30 @@ describe('ES Dependency Manager — Real-life packages', () => {
       fail(`Expected successful nodeModules fetch`)
     }
     const nodeModules = fetchNodeModulesResult.nodeModules
-    const req = getRequireFn(moduleUpdater(nodeModules), nodeModules, spyEvaluator)
+
+    const onRemoteModuleDownload = async (moduleDownload: Promise<NodeModules>) => {
+      const downloadedModules = await moduleDownload
+      const updatedNodeModules = { ...nodeModules, ...downloadedModules }
+      const innerOnRemoteModuleDownload = jest.fn()
+      const updatedReq = getRequireFn(innerOnRemoteModuleDownload, updatedNodeModules, spyEvaluator)
+
+      // this is like calling `import 'antd/dist/antd.css';`, we only care about the side effect
+      updatedReq('/src/index.js', 'antd/dist/antd.css')
+
+      // our CSS side effect code ran by now, so we should be able to find the relevant style tag on the JSDOM
+      const styleTag = document.getElementById('/node_modules/antd/dist/antd.css')
+      expect(styleTag).toBeDefined()
+      expect(spyEvaluator).toHaveBeenCalledTimes(940)
+      expect(innerOnRemoteModuleDownload).toBeCalledTimes(0)
+
+      done()
+    }
+
+    const req = getRequireFn(onRemoteModuleDownload, nodeModules, spyEvaluator)
     const antd = req('/src/index.js', 'antd')
-    await wait(15)
     expect(Object.keys(antd)).not.toHaveLength(0)
     expect(antd).toHaveProperty('Button')
     req('/src/index.js', 'antd/dist/antd.css')
-    await wait(15)
-    const styleTag = document.getElementById('/node_modules/antd/dist/antd.css')
-    expect(styleTag).toBeDefined()
-    expect(spyEvaluator).toHaveBeenCalledTimes(941)
   })
 })
 
@@ -206,7 +215,7 @@ describe('ES Dependency Manager — d.ts', () => {
 })
 
 describe('ES Dependency Manager — Downloads extra files as-needed', () => {
-  it('downloads a css file from jsdelivr, if needed', async () => {
+  it('downloads a css file from jsdelivr, if needed', async (done) => {
     ;(fetch as any).mockResponse(
       (request: Request): Promise<{ body?: string; status?: number }> => {
         switch (request.url) {
@@ -226,16 +235,29 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
       fail(`Expected successful nodeModules fetch`)
     }
     const nodeModules = fetchNodeModulesResult.nodeModules
-    const req = getRequireFn(moduleUpdater(nodeModules), nodeModules)
+
+    const onRemoteModuleDownload = async (moduleDownload: Promise<NodeModules>) => {
+      const downloadedModules = await moduleDownload
+      const updatedNodeModules = { ...nodeModules, ...downloadedModules }
+      const innerOnRemoteModuleDownload = jest.fn()
+      const updatedReq = getRequireFn(innerOnRemoteModuleDownload, updatedNodeModules)
+
+      // this is like calling `import 'mypackage/dist/style.css';`, we only care about the side effect
+      updatedReq('/src/index.js', 'mypackage/dist/style.css')
+
+      // our CSS side effect code ran by now, so we should be able to find the relevant style tag on the JSDOM
+      const styleTag = document.getElementById(
+        `${InjectedCSSFilePrefix}/node_modules/mypackage/dist/style.css`,
+      )
+      expect(styleTag?.innerHTML).toEqual(simpleCssContent)
+      expect(innerOnRemoteModuleDownload).toBeCalledTimes(0)
+
+      done()
+    }
+
+    const req = getRequireFn(onRemoteModuleDownload, nodeModules)
     const styleCss = req('/src/index.js', 'mypackage/dist/style.css')
     expect(Object.keys(styleCss)).toHaveLength(0)
-
-    await wait(15)
-    // our CSS side effect code ran by now, so we should be able to find the relevant style tag on the JSDOM
-    const styleTag = document.getElementById(
-      `${InjectedCSSFilePrefix}/node_modules/mypackage/dist/style.css`,
-    )
-    expect(styleTag?.innerHTML).toEqual(simpleCssContent)
   })
 })
 

--- a/editor/src/core/property-controls/property-controls-processor.spec.ts
+++ b/editor/src/core/property-controls/property-controls-processor.spec.ts
@@ -1,0 +1,110 @@
+import { PropertyControlsInfo } from '../../components/custom-code/code-file'
+import { npmVersion } from '../../components/editor/npm-dependency/npm-dependency'
+import {
+  extractNodeModulesFromPackageResponse,
+  resetDepPackagerCache,
+} from '../es-modules/package-manager/fetch-packages'
+import { mangleNodeModulePaths } from '../es-modules/package-manager/merge-modules'
+import { getJsDelivrFileUrl } from '../es-modules/package-manager/packager-url'
+import * as antdPackagerResponse from '../es-modules/test-cases/antd-packager-response.json'
+import { PackagerServerResponse, requestedNpmDependency } from '../shared/npm-dependency-types'
+import { initPropertyControlsProcessor } from './property-controls-processor'
+import { fullNodeModulesUpdate, getThirdPartyPropertyControls } from './property-controls-utils'
+
+require('jest-fetch-mock').enableMocks()
+
+const simpleCssContent = '.utopiaClass { background-color: red; }'
+
+beforeEach(() => {
+  resetDepPackagerCache()
+})
+
+describe('Property Controls Processor', () => {
+  it('Returns the expected controls for antd', async (done) => {
+    ;(fetch as any).mockResponse(
+      (request: Request): Promise<{ body?: string; status?: number }> => {
+        switch (request.url) {
+          case getJsDelivrFileUrl('antd@4.2.5', '/dist/antd.css'):
+            return Promise.resolve({ body: simpleCssContent })
+          default:
+            throw new Error(`unexpected fetch called: ${request.url}`)
+        }
+      },
+    )
+
+    const packageName = 'antd'
+    const packageVersion = '4.2.5'
+
+    const fakedPackagerResponse = extractNodeModulesFromPackageResponse(
+      packageName,
+      npmVersion(packageVersion),
+      antdPackagerResponse as PackagerServerResponse,
+    )
+    const nodeModules = mangleNodeModulePaths('antd', fakedPackagerResponse)
+
+    const onControlsProcess = (propertyControlsInfo: PropertyControlsInfo) => {
+      expect(propertyControlsInfo).toEqual(
+        getThirdPartyPropertyControls(packageName, packageVersion),
+      )
+      done()
+    }
+
+    const processControls = initPropertyControlsProcessor(onControlsProcess)
+    processControls(
+      [requestedNpmDependency(packageName, packageVersion)],
+      fullNodeModulesUpdate(nodeModules),
+      {},
+      [],
+    )
+  })
+
+  it('Calls the callback twice if a placeholder dependency is imported', async (done) => {
+    ;(fetch as any).mockResponse(
+      (request: Request): Promise<{ body?: string; status?: number }> => {
+        switch (request.url) {
+          case getJsDelivrFileUrl('antd@4.2.5', '/dist/antd.css'):
+            return Promise.resolve({ body: simpleCssContent })
+          default:
+            throw new Error(`unexpected fetch called: ${request.url}`)
+        }
+      },
+    )
+
+    const packageName = 'antd'
+    const packageVersion = '4.2.5'
+
+    const fakedPackagerResponse = extractNodeModulesFromPackageResponse(
+      packageName,
+      npmVersion(packageVersion),
+      antdPackagerResponse as PackagerServerResponse,
+    )
+    const nodeModules = mangleNodeModulePaths('antd', fakedPackagerResponse)
+
+    let callbackCount = 0
+    const onControlsProcess = (propertyControlsInfo: PropertyControlsInfo) => {
+      callbackCount++
+
+      expect(propertyControlsInfo).toEqual(
+        getThirdPartyPropertyControls(packageName, packageVersion),
+      )
+
+      if (callbackCount === 2) {
+        done()
+      }
+    }
+
+    const processControls = initPropertyControlsProcessor(onControlsProcess)
+    processControls(
+      [requestedNpmDependency(packageName, packageVersion)],
+      fullNodeModulesUpdate(nodeModules),
+      {
+        '/src/index.js': {
+          transpiledCode: `require("antd/dist/antd.css");`,
+          sourceMap: null,
+          errors: [],
+        },
+      },
+      [],
+    )
+  })
+})

--- a/editor/src/core/property-controls/property-controls-processor.ts
+++ b/editor/src/core/property-controls/property-controls-processor.ts
@@ -1,0 +1,83 @@
+import { PropertyControls } from 'utopia-api'
+import {
+  getExportValuesFromAllModules,
+  incorporateBuildResult,
+  processExportsInfo,
+  PropertyControlsInfo,
+} from '../../components/custom-code/code-file'
+import { getRequireFn } from '../es-modules/package-manager/package-manager'
+import {
+  applyNodeModulesUpdate,
+  getControlsForExternalDependencies,
+  NodeModulesUpdate,
+} from '../property-controls/property-controls-utils'
+import { RequestedNpmDependency } from '../shared/npm-dependency-types'
+import { NodeModules } from '../shared/project-file-types'
+import { fastForEach } from '../shared/utils'
+import { resolvedDependencyVersions } from '../third-party/third-party-components'
+import { ExportsInfo, MultiFileBuildResult } from '../workers/ts/ts-worker'
+
+export const initPropertyControlsProcessor = (
+  onControlsProcessed: (propertyControlsInfo: PropertyControlsInfo) => void,
+) => {
+  let currentNodeModules: NodeModules = {}
+
+  const processPropertyControls = async (
+    npmDependencies: RequestedNpmDependency[],
+    nodeModulesUpdate: NodeModulesUpdate,
+    bundledProjectFiles: MultiFileBuildResult,
+    exportsInfo: ReadonlyArray<ExportsInfo>,
+  ) => {
+    currentNodeModules = applyNodeModulesUpdate(currentNodeModules, nodeModulesUpdate)
+    const resolvedNpmDependencies = resolvedDependencyVersions(npmDependencies, currentNodeModules)
+
+    incorporateBuildResult(currentNodeModules, bundledProjectFiles)
+
+    let propertyControlsInfo: PropertyControlsInfo = getControlsForExternalDependencies(
+      resolvedNpmDependencies,
+    )
+
+    processPropertyControlsWithBuildResult(propertyControlsInfo, bundledProjectFiles, exportsInfo)
+  }
+
+  const processPropertyControlsWithBuildResult = async (
+    propertyControlsInfo: PropertyControlsInfo,
+    bundledProjectFiles: MultiFileBuildResult,
+    exportsInfo: ReadonlyArray<ExportsInfo>,
+  ) => {
+    const onRemoteModuleDownload = (moduleDownload: Promise<NodeModules>) => {
+      moduleDownload.then((downloadedModules: NodeModules) => {
+        // MUTATION
+        Object.assign(currentNodeModules, downloadedModules)
+        processPropertyControlsWithBuildResult(
+          propertyControlsInfo,
+          bundledProjectFiles,
+          exportsInfo,
+        )
+      })
+    }
+
+    const requireFn = getRequireFn(onRemoteModuleDownload, currentNodeModules)
+
+    const exportValues = getExportValuesFromAllModules(bundledProjectFiles, requireFn)
+    fastForEach(exportsInfo, (result) => {
+      const codeResult = processExportsInfo(exportValues[result.filename], result.exportTypes)
+      let propertyControls: { [name: string]: PropertyControls } = {}
+      if (codeResult.exports != null) {
+        fastForEach(Object.keys(codeResult.exports), (name) => {
+          const exportedObject = codeResult.exports[name].value
+          if (exportedObject != null && exportedObject.propertyControls != null) {
+            // FIXME validate shape
+            propertyControls[name] = exportedObject.propertyControls
+          }
+        })
+        const filenameNoExtension = result.filename.replace(/\.(js|jsx|ts|tsx)$/, '')
+        propertyControlsInfo[filenameNoExtension] = propertyControls
+      }
+    })
+
+    onControlsProcessed(propertyControlsInfo)
+  }
+
+  return processPropertyControls
+}

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -309,23 +309,36 @@ export function removeIgnored(
   return result
 }
 
+export function getThirdPartyPropertyControls(
+  packageName: string,
+  packageVersion: string,
+): PropertyControlsInfo {
+  let propertyControlsInfo: PropertyControlsInfo = {}
+  const componentDescriptor = getThirdPartyComponents(packageName, packageVersion)
+  if (componentDescriptor != null) {
+    fastForEach(componentDescriptor.components, (descriptor) => {
+      if (descriptor.propertyControls != null) {
+        const jsxElementName = getJSXElementNameAsString(descriptor.element.name)
+        propertyControlsInfo[packageName] = {
+          ...propertyControlsInfo[packageName],
+          [jsxElementName]: descriptor.propertyControls,
+        }
+      }
+    })
+  }
+
+  return propertyControlsInfo
+}
+
 export function getControlsForExternalDependencies(
   npmDependencies: ReadonlyArray<PossiblyUnversionedNpmDependency>,
 ): PropertyControlsInfo {
   let propertyControlsInfo: PropertyControlsInfo = {}
   fastForEach(npmDependencies, (dependency) => {
     if (isResolvedNpmDependency(dependency)) {
-      const componentDescriptor = getThirdPartyComponents(dependency.name, dependency.version)
-      if (componentDescriptor != null) {
-        fastForEach(componentDescriptor.components, (descriptor) => {
-          if (descriptor.propertyControls != null) {
-            const jsxElementName = getJSXElementNameAsString(descriptor.element.name)
-            propertyControlsInfo[dependency.name] = {
-              ...propertyControlsInfo[dependency.name],
-              [jsxElementName]: descriptor.propertyControls,
-            }
-          }
-        })
+      propertyControlsInfo = {
+        ...propertyControlsInfo,
+        ...getThirdPartyPropertyControls(dependency.name, dependency.version),
       }
     }
   })

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -69,7 +69,6 @@ import '../utils/react-shim'
 import Utils from '../utils/utils'
 import { HeartbeatRequestMessage } from '../core/workers/watchdog-worker'
 import { triggerHashedAssetsUpdate } from '../utils/hashed-assets'
-import { getRequireFn } from '../core/es-modules/package-manager/package-manager'
 import { dependenciesWithEditorRequirements } from '../components/editor/npm-dependency/npm-dependency'
 import {
   UiJsxCanvasContextData,

--- a/editor/src/templates/preview.tsx
+++ b/editor/src/templates/preview.tsx
@@ -1,33 +1,22 @@
-import * as json5 from 'json5'
-import * as R from 'ramda'
+import * as fastDeepEquals from 'fast-deep-equal'
 import * as ReactErrorOverlay from 'react-error-overlay'
 import { BASE_URL, getProjectID, getQueryParam, PREVIEW_IS_EMBEDDED } from '../common/env-vars'
 import { fetchLocalProject } from '../common/persistence'
+import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../components/assets'
 import { incorporateBuildResult } from '../components/custom-code/code-file'
 import { sendPreviewModel } from '../components/editor/actions/actions'
-import {
-  dependenciesWithEditorRequirements,
-  orderedDependenciesEqual,
-} from '../components/editor/npm-dependency/npm-dependency'
+import { dependenciesWithEditorRequirements } from '../components/editor/npm-dependency/npm-dependency'
 import { projectIsStoredLocally } from '../components/editor/persistence'
 import { loadProject } from '../components/editor/server'
-import { isPersistentModel, PersistentModel } from '../components/editor/store/editor-state'
+import { isProjectContentsUpdateMessage } from '../components/preview/preview-pane'
 import { fetchNodeModules } from '../core/es-modules/package-manager/fetch-packages'
 import { getRequireFn } from '../core/es-modules/package-manager/package-manager'
 import { pluck } from '../core/shared/array-utils'
-import { isRight } from '../core/shared/either'
+import { getMainHTMLFilename, getMainJSFilename } from '../core/shared/project-contents-utils'
 import { isCodeFile, NodeModules } from '../core/shared/project-file-types'
 import { NewBundlerWorker, RealBundlerWorker } from '../core/workers/bundler-bridge'
 import { createBundle } from '../core/workers/bundler-promise'
-import {
-  getGeneratedExternalLinkText,
-  updateHTMLExternalResourcesLinks,
-} from '../printer-parsers/html/external-resources-parser'
 import Utils from '../utils/utils'
-import { getMainHTMLFilename, getMainJSFilename } from '../core/shared/project-contents-utils'
-import { isProjectContentsUpdateMessage } from '../components/preview/preview-pane'
-import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../components/assets'
-import { pathForMainPackage } from '../core/es-modules/package-manager/merge-modules'
 
 interface PolledLoadParams {
   projectId: string
@@ -219,7 +208,7 @@ const initPreview = () => {
       const lastDependencies =
         lastRenderedModel == null ? [] : dependenciesWithEditorRequirements(lastRenderedModel)
       const npmDependencies = dependenciesWithEditorRequirements(projectContents)
-      if (orderedDependenciesEqual(lastDependencies, npmDependencies)) {
+      if (fastDeepEquals(lastDependencies, npmDependencies)) {
         nodeModules = { ...cachedDependencies }
       } else {
         const fetchNodeModulesResult = await fetchNodeModules(npmDependencies)

--- a/editor/src/templates/property-controls-info.tsx
+++ b/editor/src/templates/property-controls-info.tsx
@@ -1,35 +1,19 @@
 import * as R from 'ramda'
-import * as ReactErrorOverlay from 'react-error-overlay'
-import {
-  getExportValuesFromAllModules,
-  incorporateBuildResult,
-  processExportsInfo,
-  PropertyControlsInfo,
-} from '../components/custom-code/code-file'
+import { PropertyControlsInfo } from '../components/custom-code/code-file'
 import {
   propertyControlsIFrameReady,
   updatePropertyControlsInfo,
 } from '../components/editor/actions/actions'
 import { dependenciesWithEditorRequirements } from '../components/editor/npm-dependency/npm-dependency'
-import { getRequireFn } from '../core/es-modules/package-manager/package-manager'
-import { NodeModules } from '../core/shared/project-file-types'
-import type { ProjectContents } from '../core/shared/project-file-types'
+import { initPropertyControlsProcessor } from '../core/property-controls/property-controls-processor'
+import {
+  createGetPropertyControlsInfoMessage,
+  GetPropertyControlsInfoMessage,
+} from '../core/property-controls/property-controls-utils'
+import { applicative3Either, forEachRight } from '../core/shared/either'
 import { NewBundlerWorker, RealBundlerWorker } from '../core/workers/bundler-bridge'
 import { createBundle } from '../core/workers/bundler-promise'
-import {
-  applyNodeModulesUpdate,
-  createGetPropertyControlsInfoMessage,
-  getControlsForExternalDependencies,
-  GetPropertyControlsInfoMessage,
-  NodeModulesUpdate,
-} from '../core/property-controls/property-controls-utils'
-import { fastForEach } from '../core/shared/utils'
-import { ExportsInfo, MultiFileBuildResult } from '../core/workers/ts/ts-worker'
-import { PropertyControls } from 'utopia-api'
 import { objectKeyParser, parseAny, ParseResult } from '../utils/value-parser-utils'
-import { applicative3Either, forEachRight } from '../core/shared/either'
-import { resolvedDependencyVersions } from '../core/third-party/third-party-components'
-import { ProjectContentTreeRoot } from '../components/assets'
 
 // Not a full parse, just checks the primary fields are there.
 function fastPropertyControlsParse(value: unknown): ParseResult<GetPropertyControlsInfoMessage> {
@@ -41,15 +25,39 @@ function fastPropertyControlsParse(value: unknown): ParseResult<GetPropertyContr
   )
 }
 
-const initPropertyControls = () => {
+const initPropertyControlsWorker = () => {
   const bundlerWorker = new NewBundlerWorker(new RealBundlerWorker())
-
   let lastMessage: GetPropertyControlsInfoMessage | null = null
-  let currentNodeModules: NodeModules = {}
+
+  const onControlsProcessed = (propertyControlsInfo: PropertyControlsInfo) => {
+    window.parent.postMessage(updatePropertyControlsInfo(propertyControlsInfo), '*')
+  }
+
+  const propertyControlsProcessor = initPropertyControlsProcessor(onControlsProcessed)
 
   const modelUpdated = async (model: GetPropertyControlsInfoMessage) => {
     if (!R.equals(lastMessage, model)) {
-      processPropertyControls(model.projectContents, model.nodeModulesUpdate, model.exportsInfo)
+      const projectContents = model.projectContents
+      /**
+       * please note that we are passing in an empty object instead of the .d.ts files
+       * the reason for this is that we only use the bundler as a transpiler here
+       * and we don't care about static type errors
+       *
+       * some libraries, ie Antd have so massive definitions that it took more than 20 seconds
+       * for the bundler to process it, basically with no upside
+       */
+      const emptyTypeDefinitions = {}
+      const bundledProjectFiles = (
+        await createBundle(bundlerWorker, emptyTypeDefinitions, projectContents)
+      ).buildResult
+
+      const npmDependencies = dependenciesWithEditorRequirements(projectContents)
+      propertyControlsProcessor(
+        npmDependencies,
+        model.nodeModulesUpdate,
+        bundledProjectFiles,
+        model.exportsInfo,
+      )
     }
   }
 
@@ -62,75 +70,6 @@ const initPropertyControls = () => {
     })
   }
 
-  const processPropertyControls = async (
-    projectContents: ProjectContentTreeRoot,
-    nodeModulesUpdate: NodeModulesUpdate,
-    exportsInfo: ReadonlyArray<ExportsInfo>,
-  ) => {
-    currentNodeModules = applyNodeModulesUpdate(currentNodeModules, nodeModulesUpdate)
-    const npmDependencies = dependenciesWithEditorRequirements(projectContents)
-    const resolvedNpmDependencies = resolvedDependencyVersions(npmDependencies, currentNodeModules)
-    /**
-     * please note that we are passing in an empty object instead of the .d.ts files
-     * the reason for this is that we only use the bundler as a transpiler here
-     * and we don't care about static type errors
-     *
-     * some libraries, ie Antd have so massive definitions that it took more than 20 seconds
-     * for the bundler to process it, basically with no upside
-     */
-    const emptyTypeDefinitions = {}
-    const bundledProjectFiles = (
-      await createBundle(bundlerWorker, emptyTypeDefinitions, projectContents)
-    ).buildResult
-
-    incorporateBuildResult(currentNodeModules, bundledProjectFiles)
-
-    let propertyControlsInfo: PropertyControlsInfo = getControlsForExternalDependencies(
-      resolvedNpmDependencies,
-    )
-
-    processPropertyControlsWithBuildResult(propertyControlsInfo, bundledProjectFiles, exportsInfo)
-  }
-
-  const processPropertyControlsWithBuildResult = async (
-    propertyControlsInfo: PropertyControlsInfo,
-    bundledProjectFiles: MultiFileBuildResult,
-    exportsInfo: ReadonlyArray<ExportsInfo>,
-  ) => {
-    const onRemoteModuleDownload = (moduleDownload: Promise<NodeModules>) => {
-      moduleDownload.then((downloadedModules: NodeModules) => {
-        // MUTATION
-        Object.assign(currentNodeModules, downloadedModules)
-        processPropertyControlsWithBuildResult(
-          propertyControlsInfo,
-          bundledProjectFiles,
-          exportsInfo,
-        )
-      })
-    }
-
-    const requireFn = getRequireFn(onRemoteModuleDownload, currentNodeModules)
-
-    const exportValues = getExportValuesFromAllModules(bundledProjectFiles, requireFn)
-    fastForEach(exportsInfo, (result) => {
-      const codeResult = processExportsInfo(exportValues[result.filename], result.exportTypes)
-      let propertyControls: { [name: string]: PropertyControls } = {}
-      if (codeResult.exports != null) {
-        fastForEach(Object.keys(codeResult.exports), (name) => {
-          const exportedObject = codeResult.exports[name].value
-          if (exportedObject != null && exportedObject.propertyControls != null) {
-            // FIXME validate shape
-            propertyControls[name] = exportedObject.propertyControls
-          }
-        })
-        const filenameNoExtension = result.filename.replace(/\.(js|jsx|ts|tsx)$/, '')
-        propertyControlsInfo[filenameNoExtension] = propertyControls
-      }
-    })
-
-    window.parent.postMessage(updatePropertyControlsInfo(propertyControlsInfo), '*')
-  }
-
   const loadProjectValuesContent = () => {
     window.addEventListener('message', handleModelUpdateEvent)
 
@@ -139,4 +78,5 @@ const initPropertyControls = () => {
   }
   loadProjectValuesContent()
 }
-initPropertyControls()
+
+initPropertyControlsWorker()


### PR DESCRIPTION
**Problem:**
During a discussion we realised that our resolving of placeholder dependencies was actually very broken, and would not support importing assets to use directly in the Preview would not work, since we were only supporting side effects when importing placeholder dependencies.

**Fix:**
Support a callback to be used whenever the running code requires a placeholder dependency, allowing us to explicitly force a re-render or re-evaluation after that dependency has been downloaded. This also gives us the option to extend the behaviour to display something to signify to the user that the editor is downloading further resources (I have left 2 `// FIXME` s in the code to mark that this has _not_ been done as part of this work).

I've also refactored some of the uses of this code to support better test coverage.

**Commit Details:**
- `fetchMissingFileDependency` now returns a `Promise` containing the newly downloaded modules
- `getEditorRequireFn` now takes a callback `onRemoteModuleDownload` to allow us to explicitly deal with running code triggering a download, as well as the completion of that download
- Split out the core of `property-controls-info.tsx` into `property-controls-processor.ts` to allow testing, specifically so that I could ensure the above change was correctly implemented in the property controls processing
- Updated the preview to now trigger a re-render when a placeholder dependency has been finished downloading
- Tests (and some other refactoring to support them)!
