### PR TITLE
Memoized Scene Root v1

### DIFF
--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -5889,9 +5889,9 @@
       }
     },
     "@welldone-software/why-did-you-render": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@welldone-software/why-did-you-render/-/why-did-you-render-3.3.3.tgz",
-      "integrity": "sha512-aA6uhUO7TdQ92xb3SizKJ3A4DyInDdb1x+WwvqrP/U9qlcJjQ+edXHTuq8WJTEh23ov8w4n2y9fnc0jN5NLs6w==",
+      "version": "5.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@welldone-software/why-did-you-render/-/why-did-you-render-5.0.0-rc.1.tgz",
+      "integrity": "sha512-LksaD/9/q11cNn07iorxtBAJk3MPLULV48TTf6sMw/33YpCWNzOvLUEaWb6Ai1ob2BgUAwLkOh69MaE0winLqQ==",
       "dev": true,
       "requires": {
         "lodash": "^4"

--- a/editor/package.json
+++ b/editor/package.json
@@ -218,7 +218,7 @@
     "@types/uuid": "2.0.29",
     "@typescript-eslint/eslint-plugin": "4.1.1",
     "@typescript-eslint/parser": "4.1.1",
-    "@welldone-software/why-did-you-render": "3.3.3",
+    "@welldone-software/why-did-you-render": "5.0.0-rc.1",
     "antd": "4.3.5",
     "babel-loader": "8.1.0",
     "babel-plugin-syntax-jsx": "6.18.0",

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -9175,12 +9175,12 @@ exports[`UiJsxCanvas render renders a component with a fragment at the root 1`] 
     data-utopia-valid-paths=\\"utopia-storyboard-uid/scene-aaa:aaa utopia-storyboard-uid/scene-aaa:bbb\\"
     style=\\"
       position: absolute;
-      width: 212px;
-      height: 188px;
-      left: 406px;
-      top: 62px;
       background-color: rgba(255, 255, 255, 1);
       box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+      left: 406px;
+      top: 62px;
+      width: 212px;
+      height: 188px;
     \\"
     data-uid=\\"utopia-storyboard-uid\\"
   >
@@ -9371,12 +9371,12 @@ exports[`UiJsxCanvas render renders correctly with a context 1`] = `
     data-utopia-valid-paths=\\"ccc/ddd:aaa ccc/ddd:aaa/bbb\\"
     style=\\"
       position: absolute;
+      background-color: rgba(255, 255, 255, 1);
+      box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
       width: 375px;
       height: 812px;
       left: 0;
       top: 0;
-      background-color: rgba(255, 255, 255, 1);
-      box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
     \\"
     data-uid=\\"ccc\\"
   >
@@ -9709,12 +9709,12 @@ exports[`UiJsxCanvas render renders fine with two circularly referencing arbitra
     data-utopia-valid-paths=\\"utopia-storyboard-uid/scene:aaa\\"
     style=\\"
       position: absolute;
+      background-color: rgba(255, 255, 255, 1);
+      box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
       width: 375px;
       height: 812px;
       left: 0;
       top: 0;
-      background-color: rgba(255, 255, 255, 1);
-      box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
     \\"
     data-uid=\\"utopia-storyboard-uid\\"
   >
@@ -10003,12 +10003,12 @@ exports[`UiJsxCanvas render renders fine with two components that reference each
     data-utopia-valid-paths=\\"utopia-storyboard-uid/scene:BBB\\"
     style=\\"
       position: absolute;
+      background-color: rgba(255, 255, 255, 1);
+      box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
       width: 375px;
       height: 812px;
       left: 0;
       top: 0;
-      background-color: rgba(255, 255, 255, 1);
-      box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
     \\"
     data-uid=\\"utopia-storyboard-uid\\"
   >

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
@@ -173,7 +173,7 @@ export const SceneRootRenderer = betterReactMemo(
     )
   },
   (prevProps, nextProps) => {
-    // TODO BEFORE MERGE remove me, this is only needed until I fix the pragma
+    // TODO BALAZS remove me, this is only needed until I fix the pragma
     return (
       prevProps.sceneElement === nextProps.sceneElement &&
       fastDeepEquals(prevProps.style, nextProps.style)

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -20,6 +20,16 @@ export type ComponentRendererComponent = React.ComponentType<any> & {
   propertyControls?: PropertyControls
 }
 
+export function isComponentRendererComponent(
+  component: ComponentRendererComponent | React.ComponentType | null,
+): component is ComponentRendererComponent {
+  return (
+    component != null &&
+    typeof component === 'function' &&
+    (component as ComponentRendererComponent).topLevelElementName != null
+  )
+}
+
 export function createComponentRendererComponent(params: {
   topLevelElementName: string
 }): ComponentRendererComponent {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -14,6 +14,7 @@ import { applyPropsParamToPassedProps } from './ui-jsx-canvas-props-utils'
 import { runBlockUpdatingScope } from './ui-jsx-canvas-scope-utils'
 import * as TP from '../../../core/shared/template-path'
 import { renderCoreElement } from './ui-jsx-canvas-element-renderer-utils'
+import { useContextSelector } from 'use-context-selector'
 
 export type ComponentRendererComponent = React.ComponentType<any> & {
   topLevelElementName: string
@@ -35,14 +36,17 @@ export function createComponentRendererComponent(params: {
 }): ComponentRendererComponent {
   const Component = (realPassedProps: any) => {
     const { current: mutableContext } = React.useContext(MutableUtopiaContext)
-    const rerenderUtopiaContext = React.useContext(RerenderUtopiaContext)
+    const utopiaJsxComponent = useContextSelector(RerenderUtopiaContext, (c) =>
+      c.topLevelElements.get(params.topLevelElementName),
+    )
+    const shouldIncludeCanvasRootInTheSpy = useContextSelector(
+      RerenderUtopiaContext,
+      (c) => c.shouldIncludeCanvasRootInTheSpy,
+    )
+    const hiddenInstances = useContextSelector(RerenderUtopiaContext, (c) => c.hiddenInstances)
     const sceneContext = React.useContext(SceneLevelUtopiaContext)
 
     let metadataContext: UiJsxCanvasContextData = React.useContext(UiJsxCanvasContext)
-
-    const utopiaJsxComponent = rerenderUtopiaContext.topLevelElements.get(
-      params.topLevelElementName,
-    )
 
     if (utopiaJsxComponent == null) {
       // If this element cannot be found, we want to purposefully cause a 'ReferenceError' to notify the user.
@@ -93,7 +97,7 @@ export function createComponentRendererComponent(params: {
           scope,
           realPassedProps,
           mutableContext.requireResult,
-          rerenderUtopiaContext.hiddenInstances,
+          hiddenInstances,
           mutableContext.fileBlobs,
           sceneContext.validPaths,
           realPassedProps['data-uid'],
@@ -101,7 +105,7 @@ export function createComponentRendererComponent(params: {
           metadataContext,
           mutableContext.jsxFactoryFunctionName,
           codeError,
-          rerenderUtopiaContext.shouldIncludeCanvasRootInTheSpy,
+          shouldIncludeCanvasRootInTheSpy,
         )
       }
     }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import type { MapLike } from 'typescript'
+import { createContext } from 'use-context-selector'
 import { EmptyScenePathForStoryboard } from '../../../core/model/scene-utils'
 import type { UtopiaJSXComponent } from '../../../core/shared/element-template'
 import type { InstancePath, ScenePath, TemplatePath } from '../../../core/shared/project-file-types'
@@ -36,7 +37,7 @@ interface RerenderUtopiaContextProps {
   shouldIncludeCanvasRootInTheSpy: boolean
 }
 
-export const RerenderUtopiaContext = React.createContext<RerenderUtopiaContextProps>({
+export const RerenderUtopiaContext = createContext<RerenderUtopiaContextProps>({
   topLevelElements: new Map(),
   hiddenInstances: [],
   canvasIsLive: false,
@@ -54,3 +55,11 @@ export const SceneLevelUtopiaContext = React.createContext<SceneLevelContextProp
   scenePath: EmptyScenePathForStoryboard,
 })
 SceneLevelUtopiaContext.displayName = 'SceneLevelUtopiaContext'
+
+interface ParentLevelUtopiaContextProps {
+  templatePath: TemplatePath | null
+}
+
+export const ParentLevelUtopiaContext = createContext<ParentLevelUtopiaContextProps>({
+  templatePath: null,
+})

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -25,7 +25,7 @@ import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/workers/parser-pr
 import { Utils } from '../../../uuiui-deps'
 import { UIFileBase64Blobs } from '../../editor/store/editor-state'
 import { UiJsxCanvasContextData } from '../ui-jsx-canvas'
-import { SceneRoot } from './scene-root'
+import { SceneRootRenderer } from './scene-root'
 import * as PP from '../../../core/shared/property-path'
 import * as TP from '../../../core/shared/template-path'
 import { Storyboard } from 'utopia-api'
@@ -56,33 +56,7 @@ export function renderCoreElement(
     throw codeError
   }
   if (isJSXElement(element) && isSceneElement(element)) {
-    const sceneProps = jsxAttributesToProps(inScope, element.props, requireResult)
-
-    const rootComponent = sceneProps.component
-    const rootComponentName = sceneProps.component?.topLevelElementName
-    const resizesContent = Boolean(
-      Utils.path(PP.getElements(PathForResizeContent), sceneProps) ?? false,
-    )
-
-    const sceneId: string = sceneProps['data-uid'] || ''
-    return (
-      <SceneRoot
-        content={rootComponent} // this is the child component
-        componentProps={sceneProps.props}
-        container={sceneProps.layout}
-        hiddenInstances={hiddenInstances}
-        jsxFactoryFunctionName={jsxFactoryFunctionName}
-        fileBlobs={fileBlobs}
-        style={sceneProps.style}
-        inScope={inScope}
-        requireResult={requireResult}
-        templatePath={templatePath}
-        component={rootComponentName}
-        sceneResizesContent={resizesContent}
-        sceneUID={sceneId}
-        sceneLabel={sceneProps['data-label']}
-      />
-    )
+    return <SceneRootRenderer sceneElement={element} />
   }
   switch (element.type) {
     case 'JSX_ELEMENT': {

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -61,6 +61,7 @@ import {
 import {
   MutableUtopiaContext,
   MutableUtopiaContextProps,
+  ParentLevelUtopiaContext,
   RerenderUtopiaContext,
   SceneLevelUtopiaContext,
   updateMutableUtopiaContextWithNewProps,
@@ -344,7 +345,7 @@ export const UiJsxCanvas = betterReactMemo(
         storyboardRootElementPath,
         storyboardRootSceneMetadata,
         rootScenePath,
-      } = getStoryboardRoot(topLevelElementsMap, executionScope)
+      } = useGetStoryboardRoot(topLevelElementsMap, executionScope)
 
       if (props.shouldIncludeCanvasRootInTheSpy) {
         metadataContext.current.spyValues.scenes[
@@ -375,7 +376,13 @@ export const UiJsxCanvas = betterReactMemo(
                 <SceneLevelUtopiaContext.Provider
                   value={{ validPaths: rootValidPaths, scenePath: rootScenePath }}
                 >
-                  {StoryboardRootComponent == null ? null : <StoryboardRootComponent />}
+                  <ParentLevelUtopiaContext.Provider
+                    value={{
+                      templatePath: storyboardRootElementPath,
+                    }}
+                  >
+                    {StoryboardRootComponent == null ? null : <StoryboardRootComponent />}
+                  </ParentLevelUtopiaContext.Provider>
                 </SceneLevelUtopiaContext.Provider>
               </CanvasContainer>
             </RerenderUtopiaContext.Provider>
@@ -388,7 +395,7 @@ export const UiJsxCanvas = betterReactMemo(
   },
 )
 
-function getStoryboardRoot(
+function useGetStoryboardRoot(
   topLevelElementsMap: Map<string, UtopiaJSXComponent>,
   executionScope: MapLike<any>,
 ): {
@@ -407,7 +414,7 @@ function getStoryboardRoot(
     storyboardRootJsxComponent == null
       ? []
       : getValidTemplatePaths(storyboardRootJsxComponent, EmptyScenePathForStoryboard)
-  const storyboardRootElementPath = validPaths[0] // >:D
+  const storyboardRootElementPath = useKeepReferenceEqualityIfPossible(validPaths[0]) // >:D
 
   const storyboardRootSceneMetadata: ComponentMetadataWithoutRootElements = {
     component: BakedInStoryboardVariableName,

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -59,8 +59,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(695) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(705)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(605) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(615)
   })
 
   it('Changing the selected view', async () => {

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -210,7 +210,7 @@ export function jsxAttributesToProps(
   inScope: MapLike<any>,
   attributes: JSXAttributes,
   requireResult: MapLike<any>,
-): MapLike<any> {
+): any {
   return objectMap(jsxAttributeToValue(inScope, requireResult), attributes)
 }
 

--- a/editor/src/templates/editor-entry-point.tsx
+++ b/editor/src/templates/editor-entry-point.tsx
@@ -1,3 +1,9 @@
+// import * as React from 'react'
+// const whyDidYouRender = require('@welldone-software/why-did-you-render')
+// whyDidYouRender(React, {
+//   trackAllPureComponents: true,
+// })
+
 // Fire off server requests that later block, to improve initial load on slower connections. These will still block,
 // but this gives us a chance to cache the result first
 import { getLoginState } from '../common/server'

--- a/editor/src/utils/react-memoize-test-utils.ts
+++ b/editor/src/utils/react-memoize-test-utils.ts
@@ -3,7 +3,7 @@ import { UpdateInfo } from '@welldone-software/why-did-you-render'
 import * as WDYRTypes from '@welldone-software/why-did-you-render'
 // another sad case where the typescript typing is erroneous.
 // unfortunately it claims that whyDidYouRender is a default export whereas it's a module export
-export const whyDidYouRender = require('@welldone-software/why-did-you-render/dist/no-classes-transpile/umd/whyDidYouRender.min.js') as typeof WDYRTypes.default
+export const whyDidYouRender = require('@welldone-software/why-did-you-render') as typeof WDYRTypes.default
 
 /**
  * sets up why-did-you-render and


### PR DESCRIPTION
**Problem:**
The entire canvas with all its elements rerender for every single change, including scroll events.

**Fix:**
This is a first PR. I am trying to come up with a new way to replace/wrap the canvas renderer functions (such as `renderCoreElement`) with react components so they can be memoized. As a first, kind of exploratory step I replaced the SceneRoot by a new component which is memoized. It uses way less props (1) and uses context to get everything it needs. (A lot of the props were kinda hanging around just because the code was old)

**Commit Details:**
- Made new component called `SceneRootRenderer`. This is memoized aggressively.
- turned `RerenderUtopiaContext` into a use-context-selector type context so we can select a certain top level element without needing to rerender if an unrelated top level element changes
- added `ParentLevelUtopiaContext` which contains the parent template path. I use this to avoid having to pass the parent template path as parameter to the scene root. I'm not yet sure about this but I think this will be one important tool in my toolbelt when I start working on `renderCoreElement` since that function has 14 properties and most of them are things like scope and information about the parent and other context.
- I had to do ugly things in `sceneStyle` to be still compatible with our Jsx Pragma. More about the pragma later.

**Notes:**
- The JSX Pragma screws with memoized components because it creates a new style object reference for every render. Even for components that had no style object previously. This is something I want to look into tomorrow.
