### PR TITLE
Use --ignore-scripts flag during serverside npm install

### DIFF
--- a/server/src/Utopia/Web/Packager/NPM.hs
+++ b/server/src/Utopia/Web/Packager/NPM.hs
@@ -40,7 +40,7 @@ withInstalledProject semaphore versionedPackageName withInstalledPath = do
   -- Create temporary folder.
   withSystemTempDirectory "packager" $ \tempDir -> do
     -- Run `npm install "packageName@packageVersion"`.
-    let baseProc = proc "npm" ["install", "--silent", toS versionedPackageName]
+    let baseProc = proc "npm" ["install", "--silent", "--ignore-scripts", toS versionedPackageName]
     let procWithCwd = baseProc { cwd = Just tempDir }
     putText "Starting NPM Install."
     _ <- withSemaphore semaphore $ readCreateProcess procWithCwd ""


### PR DESCRIPTION
**Problem:**
`npm install` could potentially be running malicious code on our server

**Fix:**
Prevent `npm install` from running scripts by using the `--ignore-scripts` flag
