### PR TITLE
Support adding a storyboard file.

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -768,6 +768,10 @@ export interface PropertyControlsIFrameReady {
   action: 'PROPERTY_CONTROLS_IFRAME_READY'
 }
 
+export interface AddStoryboardFile {
+  action: 'ADD_STORYBOARD_FILE'
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -896,6 +900,7 @@ export type EditorAction =
   | SetShortcut
   | UpdatePropertyControlsInfo
   | PropertyControlsIFrameReady
+  | AddStoryboardFile
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -138,6 +138,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_PACKAGE_JSON':
     case 'FINISH_CHECKPOINT_TIMER':
     case 'ADD_MISSING_DIMENSIONS':
+    case 'ADD_STORYBOARD_FILE':
       return false
     case 'SAVE_ASSET':
       return (

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -60,6 +60,8 @@ import {
   isJSXAttributeOtherJavaScript,
   SettableLayoutSystem,
   walkElements,
+  isUtopiaJSXComponent,
+  utopiaJSXComponent,
 } from '../../../core/shared/element-template'
 import {
   generateUidWithExistingComponents,
@@ -347,6 +349,7 @@ import {
   SetShortcut,
   UpdatePropertyControlsInfo,
   PropertyControlsIFrameReady,
+  AddStoryboardFile,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -423,18 +426,20 @@ import {
 } from '../store/editor-state'
 import { loadStoredState } from '../stored-state'
 import { applyMigrations } from './migrations/migrations'
-import { getProjectLockedKey } from '../../../core/shared/utils'
+import { fastForEach, getProjectLockedKey } from '../../../core/shared/utils'
 import {
-  createNewSceneElement,
   PathForSceneDataLabel,
   PathForSceneContainer,
   createSceneTemplatePath,
   PathForSceneComponent,
   PathForSceneProps,
+  fishOutUtopiaCanvasFromTopLevelElements,
+  createSceneFromComponent,
+  BakedInStoryboardVariableName,
 } from '../../../core/model/scene-utils'
 import { addUtopiaUtilsImportIfUsed } from '../import-utils'
 import { getFrameAndMultiplier } from '../../images'
-import { arrayToMaybe } from '../../../core/shared/optional-utils'
+import { arrayToMaybe, forceNotNull } from '../../../core/shared/optional-utils'
 
 import {
   updateRightMenuExpanded,
@@ -454,6 +459,10 @@ import { UiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
 import { lintAndParse } from '../../../core/workers/parser-printer/parser-printer'
 import { ShortcutConfiguration } from '../shortcut-definitions'
 import { objectKeyParser, parseString } from '../../../utils/value-parser-utils'
+import {
+  addStoryboardFileToProject,
+  StoryboardFilePath,
+} from '../../../core/model/storyboard-utils'
 
 export function clearSelection(): EditorAction {
   return {
@@ -498,53 +507,6 @@ function setPropertyOnTargetAtElementPath(
       applyUpdateToJSXElement(e, updateFn),
     )
   }, editor)
-}
-
-function setSceneContainerValueAtPath(
-  editor: EditorModel,
-  target: ScenePath,
-  updateFn: (attributes: JSXAttributes) => Either<string, JSXAttributes>,
-): EditorModel {
-  return modifyOpenSceneAtPath(
-    target,
-    (scene): JSXElement => {
-      let attributes: JSXAttributes = {}
-      const layoutProps = Utils.defaultIfNull(
-        {},
-        eitherToMaybe(jsxSimpleAttributeToValue(scene.props.layout)),
-      )
-      const keys = Object.keys(layoutProps) as Array<keyof SceneContainer>
-      Utils.fastForEach(keys, (key) => {
-        attributes[key] = jsxAttributeValue(layoutProps[key])
-      })
-
-      const updatedAttributes = updateFn(attributes)
-      if (isRight(updatedAttributes)) {
-        const updatedContainer: SceneContainer = Utils.objectMap(
-          (attr) => jsxSimpleAttributeToValue(attr).value,
-          updatedAttributes.value,
-        ) as SceneContainer
-        const updatedSceneProps = setJSXValueAtPath(
-          scene.props,
-          PathForSceneContainer,
-          jsxAttributeValue(updatedContainer),
-        )
-        return foldEither(
-          () => scene,
-          (sceneProps) => {
-            return {
-              ...scene,
-              props: sceneProps,
-            }
-          },
-          updatedSceneProps,
-        )
-      } else {
-        return scene
-      }
-    },
-    editor,
-  )
 }
 
 function setSpecialSizeMeasurementParentLayoutSystemOnAllChildren(
@@ -4150,6 +4112,11 @@ export const UPDATE_FNS = {
     setPropertyControlsIFrameReady(true)
     return editor
   },
+  ADD_STORYBOARD_FILE: (_action: AddStoryboardFile, editor: EditorModel): EditorModel => {
+    const updatedEditor = addStoryboardFileToProject(editor)
+    const openTab = openEditorTab(openFileTab(StoryboardFilePath), null)
+    return UPDATE_FNS.OPEN_EDITOR_TAB(openTab, updatedEditor)
+  },
 }
 
 /** DO NOT USE outside of actions.ts, only exported for testing purposes */
@@ -5571,5 +5538,11 @@ export function updatePropertyControlsInfo(
 export function propertyControlsIFrameReady(): PropertyControlsIFrameReady {
   return {
     action: 'PROPERTY_CONTROLS_IFRAME_READY',
+  }
+}
+
+export function addStoryboardFile(): AddStoryboardFile {
+  return {
+    action: 'ADD_STORYBOARD_FILE',
   }
 }

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4114,8 +4114,12 @@ export const UPDATE_FNS = {
   },
   ADD_STORYBOARD_FILE: (_action: AddStoryboardFile, editor: EditorModel): EditorModel => {
     const updatedEditor = addStoryboardFileToProject(editor)
-    const openTab = openEditorTab(openFileTab(StoryboardFilePath), null)
-    return UPDATE_FNS.OPEN_EDITOR_TAB(openTab, updatedEditor)
+    if (updatedEditor == null) {
+      return editor
+    } else {
+      const openTab = openEditorTab(openFileTab(StoryboardFilePath), null)
+      return UPDATE_FNS.OPEN_EDITOR_TAB(openTab, updatedEditor)
+    }
   },
 }
 

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -286,6 +286,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_PROPERTY_CONTROLS_INFO(action, state)
     case 'PROPERTY_CONTROLS_IFRAME_READY':
       return UPDATE_FNS.PROPERTY_CONTROLS_IFRAME_READY(action, state)
+    case 'ADD_STORYBOARD_FILE':
+      return UPDATE_FNS.ADD_STORYBOARD_FILE(action, state)
     default:
       return state
   }

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -1,4 +1,5 @@
 /** @jsx jsx */
+/** @jsxFrag React.Fragment */
 import { jsx } from '@emotion/core'
 import * as React from 'react'
 import {
@@ -10,6 +11,7 @@ import {
   SectionTitleRow,
   SquareButton,
   Title,
+  Button,
 } from 'uuiui'
 import { betterReactMemo } from 'uuiui-deps'
 import {
@@ -143,18 +145,29 @@ export const FileBrowser = betterReactMemo('FileBrowser', () => {
     [dispatch, focusedPanel],
   )
 
+  const storyboardFileAdd = React.useCallback(() => {
+    dispatch([EditorActions.addStoryboardFile()])
+  }, [dispatch])
+
   return (
-    <Section data-name='FileBrowser' onFocus={onFocus} tabIndex={-1}>
-      <SectionTitleRow minimised={minimised} toggleMinimised={toggleMinimised}>
-        <FlexRow flexGrow={1} style={{ position: 'relative' }}>
-          <Title>Project</Title>
-          <FileBrowserActionSheet visible={!minimised} />
-        </FlexRow>
-      </SectionTitleRow>
-      <SectionBodyArea minimised={minimised}>
-        {minimised ? null : <FileBrowserItems />}
-      </SectionBodyArea>
-    </Section>
+    <>
+      <Section data-name='AddStoryboardFile'>
+        <SectionBodyArea minimised={false}>
+          <Button onClick={storyboardFileAdd}>Add Storyboard File</Button>
+        </SectionBodyArea>
+      </Section>
+      <Section data-name='FileBrowser' onFocus={onFocus} tabIndex={-1}>
+        <SectionTitleRow minimised={minimised} toggleMinimised={toggleMinimised}>
+          <FlexRow flexGrow={1} style={{ position: 'relative' }}>
+            <Title>Project</Title>
+            <FileBrowserActionSheet visible={!minimised} />
+          </FlexRow>
+        </SectionTitleRow>
+        <SectionBodyArea minimised={minimised}>
+          {minimised ? null : <FileBrowserItems />}
+        </SectionBodyArea>
+      </Section>
+    </>
   )
 })
 

--- a/editor/src/core/model/__snapshots__/storyboard-utils.spec.ts.snap
+++ b/editor/src/core/model/__snapshots__/storyboard-utils.spec.ts.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`addStoryboardFileToProject adds storyboard file to project that does not have one 1`] = `
+Array [
+  Object {
+    "arbitraryJSBlock": null,
+    "isFunction": false,
+    "name": "storyboard",
+    "param": null,
+    "propsUsed": Array [],
+    "rootElement": Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "metadata": null,
+          "name": Object {
+            "baseVariable": "Scene",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Object {
+            "component": Object {
+              "definedElsewhere": Array [
+                "App",
+              ],
+              "javascript": "App",
+              "sourceMap": null,
+              "transpiledJavascript": "return App",
+              "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
+              "uniqueID": "",
+            },
+            "data-uid": Object {
+              "type": "ATTRIBUTE_VALUE",
+              "value": "scene-1",
+            },
+            "props": Object {
+              "type": "ATTRIBUTE_VALUE",
+              "value": Object {},
+            },
+            "style": Object {
+              "type": "ATTRIBUTE_VALUE",
+              "value": Object {
+                "height": 812,
+                "left": 0,
+                "position": "absolute",
+                "top": 0,
+                "width": 375,
+              },
+            },
+          },
+          "type": "JSX_ELEMENT",
+        },
+      ],
+      "metadata": null,
+      "name": Object {
+        "baseVariable": "Storyboard",
+        "propertyPath": Object {
+          "propertyElements": Array [],
+        },
+      },
+      "props": Object {
+        "data-uid": Object {
+          "type": "ATTRIBUTE_VALUE",
+          "value": "utopia-storyboard-uid",
+        },
+        "layout": Object {
+          "type": "ATTRIBUTE_VALUE",
+          "value": Object {
+            "layoutSystem": "pinSystem",
+          },
+        },
+      },
+      "type": "JSX_ELEMENT",
+    },
+    "type": "UTOPIA_JSX_COMPONENT",
+  },
+]
+`;

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -39,6 +39,7 @@ import {
 } from '../shared/jsx-attributes'
 import { stripNulls } from '../shared/array-utils'
 import { isPercentPin } from 'utopia-api'
+import { UTOPIA_UID_KEY } from './utopia-constants'
 
 export const EmptyScenePathForStoryboard = TP.scenePath([])
 
@@ -154,6 +155,35 @@ export function convertScenesToUtopiaCanvasComponent(
   )
 }
 
+export function createSceneFromComponent(component: UtopiaJSXComponent, uid: string): JSXElement {
+  const sceneProps = {
+    component: jsxAttributeOtherJavaScript(
+      component.name,
+      `return ${component.name}`,
+      [component.name],
+      null,
+    ),
+    [UTOPIA_UID_KEY]: jsxAttributeValue(uid),
+    props: jsxAttributeValue({}),
+    style: jsxAttributeValue({
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      width: 375,
+      height: 812,
+    }),
+  }
+  return jsxElement('Scene', sceneProps, [], null)
+}
+
+export function createStoryboardElement(scenes: Array<JSXElement>, uid: string): JSXElement {
+  const storyboardProps = {
+    [UTOPIA_UID_KEY]: jsxAttributeValue(uid),
+    layout: jsxAttributeValue({ layoutSystem: 'pinSystem' }),
+  }
+  return jsxElement('Storyboard', storyboardProps, scenes, null)
+}
+
 export function convertUtopiaCanvasComponentToScenes(
   utopiaCanvasComponent: UtopiaJSXComponent | null,
 ): Array<SceneMetadata> | null {
@@ -215,10 +245,9 @@ export function fishOutUtopiaCanvasFromTopLevelElements(
   topLevelElements: Array<TopLevelElement>,
 ): UtopiaJSXComponent | null {
   return (
-    topLevelElements.find(
-      (e): e is UtopiaJSXComponent =>
-        isUtopiaJSXComponent(e) && e.name === BakedInStoryboardVariableName,
-    ) ?? null
+    topLevelElements.find((e): e is UtopiaJSXComponent => {
+      return isUtopiaJSXComponent(e) && e.name === BakedInStoryboardVariableName
+    }) ?? null
   )
 }
 

--- a/editor/src/core/model/storyboard-utils.spec.ts
+++ b/editor/src/core/model/storyboard-utils.spec.ts
@@ -1,0 +1,67 @@
+import { addFileToProjectContents, getContentsTreeFileFromString } from '../../components/assets'
+import { createTestProjectWithCode } from '../../components/canvas/canvas-utils'
+import {
+  editorModelFromPersistentModel,
+  EditorState,
+} from '../../components/editor/store/editor-state'
+import { foldEither } from '../shared/either'
+import { clearTopLevelElementUniqueIDs } from '../shared/element-template'
+import { isUIJSFile } from '../shared/project-file-types'
+import { NO_OP } from '../shared/utils'
+import { codeFile } from './project-file-utils'
+import { addStoryboardFileToProject, StoryboardFilePath } from './storyboard-utils'
+
+function createTestProjectLackingStoryboardFile(): EditorState {
+  const appFile = `/** @jsx jsx */
+import * as React from 'react'
+import { jsx } from 'utopia-api'
+export var App = (props) => {
+  return <div style={{ ...props.style}} data-uid={'aaa'} data-label={'Hat'} />
+}`
+  const persistentModel = createTestProjectWithCode(appFile)
+  return editorModelFromPersistentModel(persistentModel, NO_OP)
+}
+
+describe('addStoryboardFileToProject', () => {
+  it('adds storyboard file to project that does not have one', () => {
+    const actualResult = addStoryboardFileToProject(createTestProjectLackingStoryboardFile())
+    const storyboardFile = getContentsTreeFileFromString(
+      actualResult.projectContents,
+      StoryboardFilePath,
+    )
+    if (storyboardFile == null) {
+      fail('No storyboard file was created.')
+    } else {
+      if (isUIJSFile(storyboardFile)) {
+        const topLevelElements = foldEither(
+          (_) => [],
+          (success) => {
+            return success.topLevelElements.map(clearTopLevelElementUniqueIDs)
+          },
+          storyboardFile.fileContents,
+        )
+        expect(topLevelElements).toMatchSnapshot()
+      } else {
+        fail('Storyboard file is not a UI JS file.')
+      }
+    }
+  })
+  it('does not add a storyboard file to a project that already has one', () => {
+    const expectedFile = codeFile('oh no, this is not a real storyboard file', null)
+    let editorModel = createTestProjectLackingStoryboardFile()
+    editorModel = {
+      ...editorModel,
+      projectContents: addFileToProjectContents(
+        editorModel.projectContents,
+        StoryboardFilePath,
+        expectedFile,
+      ),
+    }
+    const actualResult = addStoryboardFileToProject(editorModel)
+    const storyboardFile = getContentsTreeFileFromString(
+      actualResult.projectContents,
+      StoryboardFilePath,
+    )
+    expect(storyboardFile).toEqual(expectedFile)
+  })
+})

--- a/editor/src/core/model/storyboard-utils.spec.ts
+++ b/editor/src/core/model/storyboard-utils.spec.ts
@@ -25,24 +25,28 @@ export var App = (props) => {
 describe('addStoryboardFileToProject', () => {
   it('adds storyboard file to project that does not have one', () => {
     const actualResult = addStoryboardFileToProject(createTestProjectLackingStoryboardFile())
-    const storyboardFile = getContentsTreeFileFromString(
-      actualResult.projectContents,
-      StoryboardFilePath,
-    )
-    if (storyboardFile == null) {
-      fail('No storyboard file was created.')
+    if (actualResult == null) {
+      fail('Editor state was not updated.')
     } else {
-      if (isUIJSFile(storyboardFile)) {
-        const topLevelElements = foldEither(
-          (_) => [],
-          (success) => {
-            return success.topLevelElements.map(clearTopLevelElementUniqueIDs)
-          },
-          storyboardFile.fileContents,
-        )
-        expect(topLevelElements).toMatchSnapshot()
+      const storyboardFile = getContentsTreeFileFromString(
+        actualResult.projectContents,
+        StoryboardFilePath,
+      )
+      if (storyboardFile == null) {
+        fail('No storyboard file was created.')
       } else {
-        fail('Storyboard file is not a UI JS file.')
+        if (isUIJSFile(storyboardFile)) {
+          const topLevelElements = foldEither(
+            (_) => [],
+            (success) => {
+              return success.topLevelElements.map(clearTopLevelElementUniqueIDs)
+            },
+            storyboardFile.fileContents,
+          )
+          expect(topLevelElements).toMatchSnapshot()
+        } else {
+          fail('Storyboard file is not a UI JS file.')
+        }
       }
     }
   })
@@ -58,10 +62,6 @@ describe('addStoryboardFileToProject', () => {
       ),
     }
     const actualResult = addStoryboardFileToProject(editorModel)
-    const storyboardFile = getContentsTreeFileFromString(
-      actualResult.projectContents,
-      StoryboardFilePath,
-    )
-    expect(storyboardFile).toEqual(expectedFile)
+    expect(actualResult).toBeNull()
   })
 })

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -1,0 +1,131 @@
+import {
+  addFileToProjectContents,
+  getContentsTreeFileFromString,
+  walkContentsTree,
+} from '../../components/assets'
+import { EditorModel } from '../../components/editor/action-types'
+import { EditorState } from '../../components/editor/store/editor-state'
+import { forEachRight, left, right } from '../shared/either'
+import {
+  isUtopiaJSXComponent,
+  UtopiaJSXComponent,
+  utopiaJSXComponent,
+} from '../shared/element-template'
+import { importAlias, isUIJSFile, RevisionsState } from '../shared/project-file-types'
+import { generateUID } from '../shared/uid-utils'
+import { addImport, parseSuccess } from '../workers/common/project-file-utils'
+import { uiJsFile } from './project-file-utils'
+import {
+  BakedInStoryboardVariableName,
+  createSceneFromComponent,
+  createStoryboardElement,
+} from './scene-utils'
+
+export const StoryboardFilePath: string = '/src/storyboard.js'
+
+const PossiblyMainComponentNames: Array<string> = ['App', 'Application', 'Main']
+
+interface ComponentToImport {
+  path: string
+  component: UtopiaJSXComponent
+}
+
+function componentToImport(path: string, component: UtopiaJSXComponent): ComponentToImport {
+  return {
+    path: path,
+    component: component,
+  }
+}
+
+export function addStoryboardFileToProject(editorModel: EditorModel): EditorModel {
+  const storyboardFile = getContentsTreeFileFromString(
+    editorModel.projectContents,
+    StoryboardFilePath,
+  )
+  if (storyboardFile == null) {
+    let namedComponentToImport: ComponentToImport | null = null as any
+    let firstComponentToImport: ComponentToImport | null = null as any
+    walkContentsTree(editorModel.projectContents, (fullPath, file) => {
+      // Just in case we ever find a main looking component, skip everything else.
+      if (namedComponentToImport == null) {
+        if (isUIJSFile(file)) {
+          // For those successfully parsed files, we want to search all of the components.
+          forEachRight(file.fileContents, (success) => {
+            for (const topLevelElement of success.topLevelElements) {
+              if (isUtopiaJSXComponent(topLevelElement)) {
+                // Check for components that have a name which _looks_ like it is the main one.
+                if (PossiblyMainComponentNames.includes(topLevelElement.name)) {
+                  namedComponentToImport = componentToImport(fullPath, topLevelElement)
+                }
+                // Capture one at the start.
+                if (firstComponentToImport == null) {
+                  firstComponentToImport = componentToImport(fullPath, topLevelElement)
+                }
+              }
+            }
+          })
+        }
+      }
+    })
+
+    const createFileWithComponent: ComponentToImport | null =
+      firstComponentToImport ?? namedComponentToImport
+    if (createFileWithComponent == null) {
+      return editorModel
+    } else {
+      return addStoryboardFileForComponent(createFileWithComponent, editorModel)
+    }
+  } else {
+    return editorModel
+  }
+}
+
+function addStoryboardFileForComponent(
+  createFileWithComponent: ComponentToImport,
+  editorModel: EditorState,
+) {
+  // Add import of storyboard and scene components.
+  const baseImports = addImport(
+    'utopia-api',
+    null,
+    [importAlias('Storyboard'), importAlias('Scene'), importAlias('jsx')],
+    null,
+    {},
+  )
+  // Generate these IDs upfront, ensuring their uniqueness.
+  const sceneUID = generateUID([])
+  const storyboardUID = generateUID([sceneUID])
+  // Create the storyboard variable.
+  const sceneElement = createSceneFromComponent(createFileWithComponent.component, sceneUID)
+  const storyboardElement = createStoryboardElement([sceneElement], storyboardUID)
+  const storyboardComponent = utopiaJSXComponent(
+    BakedInStoryboardVariableName,
+    true,
+    null,
+    [],
+    storyboardElement,
+    null,
+  )
+  // Add the component import.
+  const imports = addImport(
+    createFileWithComponent.path,
+    null,
+    [importAlias(createFileWithComponent.component.name)],
+    null,
+    baseImports,
+  )
+  // Create the file.
+  const success = parseSuccess(imports, [storyboardComponent], left({}), false, '', {}, 'jsx', null)
+  const storyboardFileContents = uiJsFile(right(success), null, RevisionsState.ParsedAhead, 0)
+
+  // Update the model.
+  const updatedProjectContents = addFileToProjectContents(
+    editorModel.projectContents,
+    StoryboardFilePath,
+    storyboardFileContents,
+  )
+  return {
+    ...editorModel,
+    projectContents: updatedProjectContents,
+  }
+}

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -38,7 +38,7 @@ function componentToImport(path: string, component: UtopiaJSXComponent): Compone
   }
 }
 
-export function addStoryboardFileToProject(editorModel: EditorModel): EditorModel {
+export function addStoryboardFileToProject(editorModel: EditorModel): EditorModel | null {
   const storyboardFile = getContentsTreeFileFromString(
     editorModel.projectContents,
     StoryboardFilePath,
@@ -72,12 +72,12 @@ export function addStoryboardFileToProject(editorModel: EditorModel): EditorMode
     const createFileWithComponent: ComponentToImport | null =
       firstComponentToImport ?? namedComponentToImport
     if (createFileWithComponent == null) {
-      return editorModel
+      return null
     } else {
       return addStoryboardFileForComponent(createFileWithComponent, editorModel)
     }
   } else {
-    return editorModel
+    return null
   }
 }
 

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -16,6 +16,7 @@ import { generateUID } from '../shared/uid-utils'
 import { addImport, parseSuccess } from '../workers/common/project-file-utils'
 import { uiJsFile } from './project-file-utils'
 import {
+  BakedInStoryboardUID,
   BakedInStoryboardVariableName,
   createSceneFromComponent,
   createStoryboardElement,
@@ -92,15 +93,12 @@ function addStoryboardFileForComponent(
     null,
     {},
   )
-  // Generate these IDs upfront, ensuring their uniqueness.
-  const sceneUID = generateUID([])
-  const storyboardUID = generateUID([sceneUID])
   // Create the storyboard variable.
-  const sceneElement = createSceneFromComponent(createFileWithComponent.component, sceneUID)
-  const storyboardElement = createStoryboardElement([sceneElement], storyboardUID)
+  const sceneElement = createSceneFromComponent(createFileWithComponent.component, 'scene-1')
+  const storyboardElement = createStoryboardElement([sceneElement], BakedInStoryboardUID)
   const storyboardComponent = utopiaJSXComponent(
     BakedInStoryboardVariableName,
-    true,
+    false,
     null,
     [],
     storyboardElement,

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.ts.snap
@@ -224,30 +224,5 @@ return { storyboard: storyboard };",
     "type": "ARBITRARY_JS_BLOCK",
     "uniqueID": "",
   },
-  Object {
-    "arbitraryJSBlock": null,
-    "isFunction": false,
-    "name": "storyboard",
-    "param": null,
-    "propsUsed": Array [],
-    "rootElement": Object {
-      "children": Array [],
-      "metadata": null,
-      "name": Object {
-        "baseVariable": "Storyboard",
-        "propertyPath": Object {
-          "propertyElements": Array [],
-        },
-      },
-      "props": Object {
-        "data-uid": Object {
-          "type": "ATTRIBUTE_VALUE",
-          "value": "utopia-storyboard-uid",
-        },
-      },
-      "type": "JSX_ELEMENT",
-    },
-    "type": "UTOPIA_JSX_COMPONENT",
-  },
 ]
 `;

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -377,31 +377,6 @@ export var whatever = (props) => {
         },
         "type": "UTOPIA_JSX_COMPONENT",
       },
-      Object {
-        "arbitraryJSBlock": null,
-        "isFunction": false,
-        "name": "storyboard",
-        "param": null,
-        "propsUsed": Array [],
-        "rootElement": Object {
-          "children": Array [],
-          "metadata": null,
-          "name": Object {
-            "baseVariable": "Storyboard",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Object {
-            "data-uid": Object {
-              "type": "ATTRIBUTE_VALUE",
-              "value": "utopia-storyboard-uid",
-            },
-          },
-          "type": "JSX_ELEMENT",
-        },
-        "type": "UTOPIA_JSX_COMPONENT",
-      },
     ],
   },
 }
@@ -617,31 +592,6 @@ const b = (n) => n > 0 ? n : a(10)
 return { b: b };",
         "type": "ARBITRARY_JS_BLOCK",
         "uniqueID": "",
-      },
-      Object {
-        "arbitraryJSBlock": null,
-        "isFunction": false,
-        "name": "storyboard",
-        "param": null,
-        "propsUsed": Array [],
-        "rootElement": Object {
-          "children": Array [],
-          "metadata": null,
-          "name": Object {
-            "baseVariable": "Storyboard",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Object {
-            "data-uid": Object {
-              "type": "ATTRIBUTE_VALUE",
-              "value": "utopia-storyboard-uid",
-            },
-          },
-          "type": "JSX_ELEMENT",
-        },
-        "type": "UTOPIA_JSX_COMPONENT",
       },
     ],
   },
@@ -873,31 +823,6 @@ export var App = (props) => <View data-uid={'bbb'}>
             "data-uid": Object {
               "type": "ATTRIBUTE_VALUE",
               "value": "bbb",
-            },
-          },
-          "type": "JSX_ELEMENT",
-        },
-        "type": "UTOPIA_JSX_COMPONENT",
-      },
-      Object {
-        "arbitraryJSBlock": null,
-        "isFunction": false,
-        "name": "storyboard",
-        "param": null,
-        "propsUsed": Array [],
-        "rootElement": Object {
-          "children": Array [],
-          "metadata": null,
-          "name": Object {
-            "baseVariable": "Storyboard",
-            "propertyPath": Object {
-              "propertyElements": Array [],
-            },
-          },
-          "props": Object {
-            "data-uid": Object {
-              "type": "ATTRIBUTE_VALUE",
-              "value": "utopia-storyboard-uid",
             },
           },
           "type": "JSX_ELEMENT",

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
@@ -23,11 +23,7 @@ import {
   testParseCode,
   testParseModifyPrint,
 } from './parser-printer-test-utils'
-import {
-  EmptyUtopiaCanvasComponent,
-  BakedInStoryboardUID,
-  BakedInStoryboardVariableName,
-} from '../../model/scene-utils'
+import { BakedInStoryboardUID, BakedInStoryboardVariableName } from '../../model/scene-utils'
 
 describe('JSX parser', () => {
   it('should add in uid attributes for elements', () => {
@@ -200,7 +196,7 @@ export var whatever = props => (
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -298,7 +294,7 @@ return { arr: arr };`
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -398,7 +394,7 @@ return { arr: arr };`
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -499,7 +495,7 @@ return { arr: arr };`
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -583,7 +579,7 @@ export var whatever = (props) => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -684,7 +680,7 @@ return { arr: arr };`
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -768,7 +764,7 @@ export var whatever = (props) => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -869,7 +865,7 @@ return { arr: arr };`
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,

--- a/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
@@ -19,7 +19,6 @@ import {
 } from '../../shared/element-template'
 import { right, isRight } from '../../shared/either'
 import { parseSuccess, defaultCanvasMetadata } from '../common/project-file-utils'
-import { EmptyUtopiaCanvasComponent } from '../../model/scene-utils'
 import { printCode, printCodeOptions } from './parser-printer'
 import { ParseSuccess } from '../../shared/project-file-types'
 
@@ -155,7 +154,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithBasicPropsObject,
@@ -198,7 +197,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithBasicPropsObjectWithDefault,
@@ -226,7 +225,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithRenamedBasicPropsObject,
@@ -258,7 +257,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithDestructuredPropsObject,
@@ -298,7 +297,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithDestructuredPropsObjectWithDefault,
@@ -333,7 +332,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithDestructuredPropsObjectWithRenamedParam,
@@ -373,7 +372,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithDestructuredPropsObjectWithRenamedParamAndDefault,
@@ -409,7 +408,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithDestructuredPropsObjectWithRestParam,
@@ -438,7 +437,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithDestructuredArray,
@@ -475,7 +474,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithDestructuredArrayWithDefault,
@@ -510,7 +509,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithDestructuredArrayWithOmittedParam,
@@ -565,7 +564,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithNestedDestructuredPropsMess,
@@ -639,7 +638,7 @@ describe('Parsing a function component with props', () => {
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         codeWithNestedDestructuredPropsMessWithDefaults,

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -1,7 +1,6 @@
 import * as FastCheck from 'fast-check'
-import * as PP from '../../shared/property-path'
 import { getSourceMapConsumer } from '../../../third-party/react-error-overlay/utils/getSourceMap'
-import { foldEither, isRight, left, right } from '../../shared/either'
+import { foldEither, isRight, right } from '../../shared/either'
 import {
   arbitraryJSBlock,
   clearTopLevelElementUniqueIDs,
@@ -34,7 +33,6 @@ import {
   addImport,
   defaultCanvasMetadata,
   emptyImports,
-  parseFailure,
   parseSuccess,
 } from '../common/project-file-utils'
 import { sampleImportsForTests } from '../../model/test-ui-js-file'
@@ -51,7 +49,6 @@ import {
   getHighlightBoundsWithoutUID,
 } from './parser-printer'
 import { applyPrettier } from './prettier-utils'
-import { CanvasMetadataName } from './parser-printer-parsing'
 import { transpileJavascriptFromCode } from './parser-printer-transpiling'
 import {
   clearParseResultPassTimes,
@@ -62,13 +59,8 @@ import {
   printableProjectContentArbitrary,
   testParseCode,
 } from './parser-printer-test-utils'
-import { NodesBounds } from './parser-printer-utils'
 import { InfiniteLoopError, InfiniteLoopMaxIterations } from './transform-prevent-infinite-loops'
-import {
-  EmptyUtopiaCanvasComponent,
-  BakedInStoryboardUID,
-  BakedInStoryboardVariableName,
-} from '../../model/scene-utils'
+import { BakedInStoryboardUID, BakedInStoryboardVariableName } from '../../model/scene-utils'
 
 describe('JSX parser', () => {
   it('parses the code when it is a const', () => {
@@ -115,7 +107,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right(
         parseSuccess(
           imports,
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -159,7 +151,7 @@ export var whatever = () => <View data-uid={'aaa'}>
       right(
         parseSuccess(
           imports,
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -219,7 +211,7 @@ export function whatever(props) {
       right(
         parseSuccess(
           imports,
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -267,7 +259,7 @@ export function whatever() {
       right(
         parseSuccess(
           imports,
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -327,7 +319,7 @@ export default function whatever(props) {
       right(
         parseSuccess(
           imports,
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -375,7 +367,7 @@ export default function whatever() {
       right(
         parseSuccess(
           imports,
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -433,7 +425,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right(
         parseSuccess(
           importsWithStylecss,
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -503,7 +495,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right(
         parseSuccess(
           imports,
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -565,7 +557,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         right(
           parseSuccess(
             imports,
-            [exported, EmptyUtopiaCanvasComponent],
+            [exported],
             right(defaultCanvasMetadata()),
             false,
             code,
@@ -642,7 +634,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         right(
           parseSuccess(
             imports,
-            [exported, EmptyUtopiaCanvasComponent],
+            [exported],
             right(defaultCanvasMetadata()),
             false,
             code,
@@ -704,7 +696,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right(
         parseSuccess(
           imports,
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -794,7 +786,7 @@ return { getSizing: getSizing, spacing: spacing };`
     const expectedResult = right(
       parseSuccess(
         imports,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -870,7 +862,7 @@ return { getSizing: getSizing };`
     const expectedResult = right(
       parseSuccess(
         imports,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -962,7 +954,7 @@ return { getSizing: getSizing };`
     const expectedResult = right(
       parseSuccess(
         imports,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1038,7 +1030,7 @@ return {  };`
     const expectedResult = right(
       parseSuccess(
         imports,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1104,7 +1096,7 @@ return { spacing: spacing };`
     const expectedResult = right(
       parseSuccess(
         imports,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1173,7 +1165,7 @@ return { bgs: bgs, bg: bg };`
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1242,7 +1234,7 @@ return { greys: greys };`
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1309,7 +1301,7 @@ return { a: a, b: b };`
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1379,7 +1371,7 @@ return { a: a, b: b, c: c };`
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1453,7 +1445,7 @@ return { a: a };`
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1522,7 +1514,7 @@ return { a: a, b: b };`
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1592,7 +1584,7 @@ return { bg: bg };`
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1658,7 +1650,7 @@ return { count: count };`
     const expectedResult = right(
       parseSuccess(
         imports,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1725,7 +1717,7 @@ return { use20: use20 };`
     const expectedResult = right(
       parseSuccess(
         imports,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1772,7 +1764,7 @@ return { mySet: mySet };`
     const expectedResult = right(
       parseSuccess(
         sampleImportsForTests,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1839,7 +1831,7 @@ return { spacing: spacing };`
     const expectedResult = right(
       parseSuccess(
         imports,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -1926,7 +1918,7 @@ return { MyComp: MyComp };`
     const expectedResult = right(
       parseSuccess(
         sampleImportsForTests,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -2016,7 +2008,7 @@ export var whatever = props => (
       right(
         parseSuccess(
           sampleImportsForTests,
-          [...topLevelElements, EmptyUtopiaCanvasComponent],
+          [...topLevelElements],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -2046,7 +2038,7 @@ export var Whatever = (props) => <View>
 `
     const actualResult = parseCode('code.tsx', code)
     if (isParseSuccess(actualResult)) {
-      if (actualResult.value.topLevelElements.length === 2) {
+      if (actualResult.value.topLevelElements.length === 1) {
         const result = actualResult.value.topLevelElements[0]
         expect(isArbitraryJSBlock(result)).toBeTruthy()
       } else {
@@ -2067,7 +2059,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
 `
     const actualResult = testParseCode(code)
     if (isParseSuccess(actualResult)) {
-      if (actualResult.value.topLevelElements.length === 2) {
+      if (actualResult.value.topLevelElements.length === 1) {
         const result = actualResult.value.topLevelElements[0]
         if (isUtopiaJSXComponent(result)) {
           if (isJSXElement(result.rootElement)) {
@@ -2141,7 +2133,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right(
         parseSuccess(
           imports,
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -2185,7 +2177,7 @@ export var whatever = <View data-uid={'aaa'}>
     const expectedResult = right(
       parseSuccess(
         imports,
-        [exported, EmptyUtopiaCanvasComponent],
+        [exported],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -2228,7 +2220,7 @@ export var whatever = <View data-uid={'aaa'}>
     const expectedResult = right(
       parseSuccess(
         imports,
-        [exported, EmptyUtopiaCanvasComponent],
+        [exported],
         right({}),
         false,
         code,
@@ -2264,7 +2256,7 @@ export var App = (props) => <View data-uid={'bbb'}>
     const expectedResult = right(
       parseSuccess(
         sampleImportsForTests,
-        [exported, EmptyUtopiaCanvasComponent],
+        [exported],
         right(defaultCanvasMetadata()),
         false,
         code,
@@ -2309,17 +2301,12 @@ export var App = (props) => <View data-uid={'bbb'}>
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
     const exported = utopiaJSXComponent('whatever', false, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
-    const printedCode = printCode(
-      printCodeOptions(false, true, true),
-      imports,
-      [exported, EmptyUtopiaCanvasComponent],
-      null,
-    )
+    const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
     const actualResult = testParseCode(printedCode)
     const expectedResult = right(
       parseSuccess(
         imports,
-        [exported, EmptyUtopiaCanvasComponent],
+        [exported],
         right(defaultCanvasMetadata()),
         false,
         printedCode,
@@ -2376,14 +2363,14 @@ return { getSizing: getSizing, spacing: spacing };`
     const printedCode = printCode(
       printCodeOptions(false, true, true),
       imports,
-      [...topLevelElements, EmptyUtopiaCanvasComponent],
+      [...topLevelElements],
       null,
     )
     const actualResult = clearParseResultUniqueIDs(testParseCode(printedCode))
     const expectedResult = right(
       parseSuccess(
         imports,
-        [...topLevelElements, EmptyUtopiaCanvasComponent],
+        [...topLevelElements],
         right(defaultCanvasMetadata()),
         false,
         printedCode,
@@ -2407,17 +2394,12 @@ return { getSizing: getSizing, spacing: spacing };`
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
     const exported = utopiaJSXComponent('whatever', false, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
-    const printedCode = printCode(
-      printCodeOptions(false, true, true),
-      imports,
-      [exported, EmptyUtopiaCanvasComponent],
-      null,
-    )
+    const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
     const actualResult = testParseCode(printedCode)
     const expectedResult = right(
       parseSuccess(
         imports,
-        [exported, EmptyUtopiaCanvasComponent],
+        [exported],
         right(defaultCanvasMetadata()),
         false,
         printedCode,
@@ -2482,7 +2464,6 @@ export var whatever = props => {
     </View>
   );
 };
-export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
 `,
       false,
     ).formatted
@@ -2512,17 +2493,12 @@ export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [cake], null)
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
-    const printedCode = printCode(
-      printCodeOptions(false, true, true),
-      imports,
-      [exported, EmptyUtopiaCanvasComponent],
-      null,
-    )
+    const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
     const actualResult = testParseCode(printedCode)
     const expectedResult = right(
       parseSuccess(
         imports,
-        [exported, EmptyUtopiaCanvasComponent],
+        [exported],
         canvasMetadata,
         false,
         printedCode,
@@ -2550,12 +2526,7 @@ export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [cake], null)
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
-    const printedCode = printCode(
-      printCodeOptions(false, true, true),
-      imports,
-      [exported, EmptyUtopiaCanvasComponent],
-      null,
-    )
+    const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
     const actualResult = clearParseResultUniqueIDs(testParseCode(printedCode))
     // As false properties are eliminated from the output,
     // create a copy of the original and snip that value out.
@@ -2579,7 +2550,7 @@ export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
       right(
         parseSuccess(
           imports,
-          [withoutFalseProp, EmptyUtopiaCanvasComponent],
+          [withoutFalseProp],
           canvasMetadata,
           false,
           printedCode,
@@ -2640,18 +2611,13 @@ export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
       null,
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
-    const printedCode = printCode(
-      printCodeOptions(false, true, true),
-      imports,
-      [exported, EmptyUtopiaCanvasComponent],
-      null,
-    )
+    const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
     const actualResult = clearParseResultUniqueIDs(testParseCode(printedCode))
     const expectedResult = clearParseResultUniqueIDs(
       right(
         parseSuccess(
           imports,
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           printedCode,
@@ -2666,7 +2632,9 @@ export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
   it('preserves modifiers on variables', () => {
     const code = applyPrettier(
       `const first = 100
-let second = 'cake'`,
+let second = 'cake'
+export var ${BakedInStoryboardVariableName} = <Storyboard data-uid={'${BakedInStoryboardUID}'} />
+`,
       false,
     ).formatted
     const expectedCode = applyPrettier(
@@ -2772,7 +2740,6 @@ return { test: test };`
               ),
               clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
             ),
-            EmptyUtopiaCanvasComponent,
           ],
           right(defaultCanvasMetadata()),
           false,
@@ -2868,7 +2835,23 @@ return { test: test };`
           ),
         ),
       ),
-      EmptyUtopiaCanvasComponent,
+      clearTopLevelElementUniqueIDs(
+        utopiaJSXComponent(
+          BakedInStoryboardVariableName,
+          false,
+          null,
+          [],
+          jsxElement(
+            'Storyboard',
+            {
+              'data-uid': jsxAttributeValue(BakedInStoryboardUID),
+            },
+            [],
+            null,
+          ),
+          null,
+        ),
+      ),
     ]
     const printedCode = printCode(printCodeOptions(false, true, true), imports, components, null)
     const actualResult = clearParseResultUniqueIDs(testParseCode(printedCode))
@@ -2941,7 +2924,7 @@ export var App = props => {
       right(
         parseSuccess(
           sampleImportsForTests,
-          [component, EmptyUtopiaCanvasComponent],
+          [component],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -2990,7 +2973,7 @@ export var App = props => {
       right(
         parseSuccess(
           sampleImportsForTests,
-          [component, EmptyUtopiaCanvasComponent],
+          [component],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -3060,7 +3043,7 @@ export var App = props => {
       right(
         parseSuccess(
           sampleImportsForTests,
-          [component, EmptyUtopiaCanvasComponent],
+          [component],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -3097,7 +3080,6 @@ export var App = props => {
     </View>
   );
 };
-export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
 `,
       false,
     ).formatted
@@ -3146,7 +3128,7 @@ export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
     const printedCode = printCode(
       printCodeOptions(false, true, true),
       sampleImportsForTests,
-      [component, EmptyUtopiaCanvasComponent],
+      [component],
       null,
     )
     const actualResult = clearParseResultUniqueIDs(testParseCode(printedCode))
@@ -3154,7 +3136,7 @@ export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
       right(
         parseSuccess(
           sampleImportsForTests,
-          [component, EmptyUtopiaCanvasComponent],
+          [component],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -3318,7 +3300,7 @@ return { a: a, b: b, MyCustomCompomnent: MyCustomCompomnent };`,
       right(
         parseSuccess(
           sampleImportsForTests,
-          [component, EmptyUtopiaCanvasComponent],
+          [component],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -3369,7 +3351,7 @@ export var App = props => {
       right(
         parseSuccess(
           sampleImportsForTests,
-          [component, EmptyUtopiaCanvasComponent],
+          [component],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -3396,7 +3378,6 @@ import {
 export var whatever = props => {
   return <View data-uid={"aaa"} booleanProperty />;
 };
-export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
 `,
       false,
     ).formatted
@@ -3410,7 +3391,7 @@ export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
     const actualResult = printCode(
       printCodeOptions(false, true, true),
       sampleImportsForTests,
-      [exported, EmptyUtopiaCanvasComponent],
+      [exported],
       null,
     )
     expect(actualResult).toEqual(expectedResult)
@@ -3430,7 +3411,6 @@ import {
 export var whatever = props => {
   return <View data-uid={"aaa"} />;
 };
-export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
 `,
       false,
     ).formatted
@@ -3444,7 +3424,7 @@ export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
     const actualResult = printCode(
       printCodeOptions(false, true, true),
       sampleImportsForTests,
-      [exported, EmptyUtopiaCanvasComponent],
+      [exported],
       null,
     )
     expect(actualResult).toEqual(expectedResult)
@@ -3510,7 +3490,7 @@ return {  };`
       right(
         parseSuccess(
           { react: sampleImportsForTests['react'] },
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -3592,7 +3572,7 @@ return { result: result };`
       right(
         parseSuccess(
           { react: sampleImportsForTests['react'] },
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -3671,7 +3651,7 @@ export var whatever = props => {
       right(
         parseSuccess(
           { react: sampleImportsForTests['react'] },
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -3773,7 +3753,7 @@ return { a: a };`,
       right(
         parseSuccess(
           { react: sampleImportsForTests['react'] },
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,
@@ -3797,7 +3777,7 @@ export var whatever = props => {
       right(
         parseSuccess(
           { react: sampleImportsForTests['react'] },
-          [exported, EmptyUtopiaCanvasComponent],
+          [exported],
           right(defaultCanvasMetadata()),
           false,
           code,

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -1008,7 +1008,7 @@ export function parseCode(filename: string, sourceText: string): ParseResult {
       utopiaComponentFromSceneMetadata,
     } = convertPrintedMetadataToCanvasMetadata(canvasMetadata)
 
-    const topLevelElementsIncludingScenes = addUtopiaCanvasComponentOrDefault(
+    const topLevelElementsIncludingScenes = addUtopiaCanvasComponent(
       topLevelElementsWithMetadataAttached.map((e) => e.element),
       utopiaComponentFromSceneMetadata,
     )
@@ -1237,7 +1237,7 @@ function parseBindingName(
   }
 }
 
-function addUtopiaCanvasComponentOrDefault(
+function addUtopiaCanvasComponent(
   topLevelElements: Array<TopLevelElement>,
   maybeUtopiaComponent: UtopiaJSXComponent | null,
 ): Array<TopLevelElement> {
@@ -1245,11 +1245,11 @@ function addUtopiaCanvasComponentOrDefault(
     (tle) => isUtopiaJSXComponent(tle) && tle.name === BakedInStoryboardVariableName,
   )
   if (existingUtopiaCanvasTopLevelElements.length === 0) {
-    const utopiaCanvasComponentToAppend = defaultIfNull(
-      EmptyUtopiaCanvasComponent,
-      maybeUtopiaComponent,
-    )
-    return [...topLevelElements, utopiaCanvasComponentToAppend]
+    if (maybeUtopiaComponent == null) {
+      return topLevelElements
+    } else {
+      return [...topLevelElements, maybeUtopiaComponent]
+    }
   } else if (existingUtopiaCanvasTopLevelElements.length === 1) {
     // there is already an UtopiaCanvas, nothing to do here
     return topLevelElements


### PR DESCRIPTION
Fixes #619

**Problem:**
For an imported project, a user needs a way of bringing their project into the fold of Utopia so that they can see their work.

**Fix:**
Added functionality that searches a project for components, prioritising certain key names but otherwise defaulting to the first component found. If anything has been found, a file containing a `Storyboard` definition is generated pointing at that component.

**Commit Details:**
- Fixes #619.
- Adds `AddStoryboardFile` editor action.
- Deleted `setSceneContainerValueAtPath` because it was unused.
- Added triggering button to the `FileBrowser` component.
- Adds `createSceneFromComponent` and `createStoryboardElement`
  utility functions.
- Changed `addUtopiaCanvasComponentOrDefault` to not insert an empty
  canvas component.
- Implemented `addStoryboardFileToProject` which does the work of
  searching for potential "main" components and then builds a storyboard
  file for one.
