### PR TITLE
experiment/flow-margin-padding

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1688,7 +1688,18 @@ export function produceResizeSingleSelectCanvasTransientState(
         x: roundedFrame.width - originalFrame.width,
         y: roundedFrame.height - originalFrame.height,
       } as CanvasVector
-      framesAndTargets.push(singleResizeChange(elementToTarget, edgePosition, sizeChange))
+      if (
+        (dragState.edgePosition.x === 0.5 || dragState.edgePosition.y === 0.5) &&
+        dragState.targetProperty !== 'Height' &&
+        dragState.targetProperty !== 'Width'
+      ) {
+        const newDelta = isTargetPropertyHorizontal(dragState.edgePosition)
+          ? dragState.drag?.x ?? 0
+          : dragState.drag?.y ?? 0
+        framesAndTargets.push(flexResizeChange(elementToTarget, dragState.targetProperty, newDelta))
+      } else {
+        framesAndTargets.push(singleResizeChange(elementToTarget, edgePosition, sizeChange))
+      }
     }
   }
 

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -196,6 +196,23 @@ class ResizeEdge extends React.Component<ResizeEdgeProps, ResizeEdgeState> {
       this.props.dragState.edgePosition.x === this.props.position.x &&
       this.props.dragState.edgePosition.y === this.props.position.y
 
+    const options: LayoutTargetableProp[] =
+      this.props.direction === 'horizontal'
+        ? [
+            'Height',
+            edge === 'before' ? 'paddingTop' : 'paddingBottom',
+            edge === 'before' ? 'marginTop' : 'marginBottom',
+            'minHeight',
+            'maxHeight',
+          ]
+        : [
+            'Width',
+            edge === 'before' ? 'paddingLeft' : 'paddingRight',
+            edge === 'before' ? 'marginLeft' : 'marginRight',
+            'minWidth',
+            'maxWidth',
+          ]
+
     return (
       <React.Fragment>
         <div
@@ -219,7 +236,7 @@ class ResizeEdge extends React.Component<ResizeEdgeProps, ResizeEdgeState> {
               top +
               (this.props.direction === 'horizontal'
                 ? edge === 'before' && this.props.direction === 'horizontal'
-                  ? -25
+                  ? -105
                   : 10
                 : -10)
             }
@@ -227,15 +244,11 @@ class ResizeEdge extends React.Component<ResizeEdgeProps, ResizeEdgeState> {
               left +
               (this.props.direction === 'vertical'
                 ? edge === 'before' && this.props.direction === 'vertical'
-                  ? -25
+                  ? -95
                   : 10
                 : -10)
             }
-            options={
-              this.props.direction === 'horizontal'
-                ? ['Height', 'minHeight', 'maxHeight']
-                : ['Width', 'minWidth', 'maxWidth']
-            }
+            options={options}
             selected={this.props.propertyTargetSelectedIndex}
             setOptionsCallback={this.props.setTargetOptionsArray}
             targetComponentMetadata={this.props.targetComponentMetadata}

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -18,6 +18,14 @@ export type LayoutTargetableProp =
   | 'maxWidth'
   | 'minHeight'
   | 'maxHeight'
+  | 'marginTop'
+  | 'marginRight'
+  | 'marginBottom'
+  | 'marginLeft'
+  | 'paddingTop'
+  | 'paddingRight'
+  | 'paddingBottom'
+  | 'paddingLeft'
 
 export type LayoutPinnedProp =
   | LayoutDimension


### PR DESCRIPTION
Canvas experiment

#### How to try it?
Mouseover on the edge of an element to see the Resize Menu that shows option to set margin and padding. Cycle through the menu using the shift modifier key.
It uses the Element Resize Menu feature flag and please uncheck the Flow Resize feature.

https://utopia.pizza/p/644f217d-reminiscent-place/?branch_name=experiment/flow-margin-padding