### PR TITLE
Removed the unused canvas metadata fields.

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -67,7 +67,6 @@ Object {
             "elementsWithin": Object {
               "bbb": Object {
                 "children": Array [],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "div",
                   "propertyPath": Object {
@@ -137,7 +136,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -333,7 +331,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -526,7 +523,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "InputElement",
           "propertyPath": Object {
@@ -697,7 +693,6 @@ Object {
                     "uniqueID": "",
                   },
                 ],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "div",
                   "propertyPath": Object {
@@ -764,7 +759,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -962,7 +956,6 @@ Object {
                             "uniqueID": "",
                           },
                         ],
-                        "metadata": null,
                         "name": Object {
                           "baseVariable": "div",
                           "propertyPath": Object {
@@ -1035,7 +1028,6 @@ Object {
                     "uniqueID": "",
                   },
                 ],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "div",
                   "propertyPath": Object {
@@ -1117,7 +1109,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -1258,7 +1249,6 @@ Object {
         "children": Array [
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "Thing",
               "propertyPath": Object {
@@ -1275,7 +1265,6 @@ Object {
           },
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "Thing",
               "propertyPath": Object {
@@ -1291,7 +1280,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -1365,7 +1353,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Thing",
           "propertyPath": Object {
@@ -1440,7 +1427,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Thing",
           "propertyPath": Object {
@@ -1553,7 +1539,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -1756,7 +1741,6 @@ Object {
             "elementsWithin": Object {
               "bbb": Object {
                 "children": Array [],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "MyCard",
                   "propertyPath": Object {
@@ -1874,7 +1858,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -1996,7 +1979,6 @@ Object {
             "elementsWithin": Object {
               "bbb": Object {
                 "children": Array [],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "MyCard",
                   "propertyPath": Object {
@@ -2114,7 +2096,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -2255,7 +2236,6 @@ Object {
         "children": Array [
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "Thing",
               "propertyPath": Object {
@@ -2272,7 +2252,6 @@ Object {
           },
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "Thing",
               "propertyPath": Object {
@@ -2288,7 +2267,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -2362,7 +2340,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Thing",
           "propertyPath": Object {
@@ -2437,7 +2414,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Thing",
           "propertyPath": Object {
@@ -2559,7 +2535,6 @@ Object {
             "elementsWithin": Object {
               "aaa": Object {
                 "children": Array [],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "Thing",
                   "propertyPath": Object {
@@ -2625,7 +2600,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -2765,7 +2739,6 @@ Object {
         "children": Array [
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "Card",
               "propertyPath": Object {
@@ -2841,7 +2814,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -3018,7 +2990,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Card",
           "propertyPath": Object {
@@ -3254,7 +3225,6 @@ Object {
         "children": Array [
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "Card",
               "propertyPath": Object {
@@ -3330,7 +3300,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -3507,7 +3476,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Card",
           "propertyPath": Object {
@@ -3736,7 +3704,6 @@ Object {
         "children": Array [
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "Card",
               "propertyPath": Object {
@@ -3836,7 +3803,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -4013,7 +3979,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Card",
           "propertyPath": Object {
@@ -4272,7 +4237,6 @@ Object {
         "children": Array [
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "Card",
               "propertyPath": Object {
@@ -4372,7 +4336,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -4549,7 +4512,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Card",
           "propertyPath": Object {
@@ -4777,7 +4739,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Widget",
           "propertyPath": Object {
@@ -5126,7 +5087,6 @@ export var storyboard = (props) => {
                         "uniqueID": "",
                       },
                     ],
-                    "metadata": null,
                     "name": Object {
                       "baseVariable": "div",
                       "propertyPath": Object {
@@ -5262,7 +5222,6 @@ export var storyboard = (props) => {
                     "children": Array [
                       Object {
                         "children": Array [],
-                        "metadata": null,
                         "name": Object {
                           "baseVariable": "KeyboardShortcut",
                           "propertyPath": Object {
@@ -5395,7 +5354,6 @@ export var storyboard = (props) => {
                         "type": "JSX_ELEMENT",
                       },
                     ],
-                    "metadata": null,
                     "name": Object {
                       "baseVariable": "div",
                       "propertyPath": Object {
@@ -5667,7 +5625,6 @@ export var storyboard = (props) => {
                 "uniqueID": "",
               },
             ],
-            "metadata": null,
             "name": Object {
               "baseVariable": "Grid",
               "propertyPath": Object {
@@ -5683,7 +5640,6 @@ export var storyboard = (props) => {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -6112,7 +6068,6 @@ export var storyboard = (props) => {
                     "uniqueID": "",
                   },
                 ],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "div",
                   "propertyPath": Object {
@@ -6248,7 +6203,6 @@ export var storyboard = (props) => {
                 "children": Array [
                   Object {
                     "children": Array [],
-                    "metadata": null,
                     "name": Object {
                       "baseVariable": "KeyboardShortcut",
                       "propertyPath": Object {
@@ -6381,7 +6335,6 @@ export var storyboard = (props) => {
                     "type": "JSX_ELEMENT",
                   },
                 ],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "div",
                   "propertyPath": Object {
@@ -6653,7 +6606,6 @@ export var storyboard = (props) => {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Grid",
           "propertyPath": Object {
@@ -6837,7 +6789,6 @@ Object {
         "children": Array [
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "Thing",
               "propertyPath": Object {
@@ -6858,7 +6809,6 @@ Object {
           },
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "Thang",
               "propertyPath": Object {
@@ -6878,7 +6828,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -6952,7 +6901,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Thing",
           "propertyPath": Object {
@@ -7032,7 +6980,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Thang",
           "propertyPath": Object {
@@ -7147,7 +7094,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Thing",
           "propertyPath": Object {
@@ -7314,7 +7260,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -7622,7 +7567,6 @@ Object {
             "children": Array [
               Object {
                 "children": Array [],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "View",
                   "propertyPath": Object {
@@ -7653,7 +7597,6 @@ Object {
                 "type": "JSX_ELEMENT",
               },
             ],
-            "metadata": null,
             "name": Object {
               "baseVariable": "Inner",
               "propertyPath": Object {
@@ -7678,7 +7621,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -7812,7 +7754,6 @@ Object {
         "children": Array [
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "View",
               "propertyPath": Object {
@@ -7843,7 +7784,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "Inner",
           "propertyPath": Object {
@@ -7953,7 +7893,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -8138,7 +8077,6 @@ Object {
                 "uniqueID": "",
               },
             ],
-            "metadata": null,
             "name": Object {
               "baseVariable": "View",
               "propertyPath": Object {
@@ -8154,7 +8092,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -8336,7 +8273,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -8485,7 +8421,6 @@ Object {
             "elementsWithin": Object {
               "bbb": Object {
                 "children": Array [],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "MyCard",
                   "propertyPath": Object {
@@ -8603,7 +8538,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -8725,7 +8659,6 @@ Object {
             "elementsWithin": Object {
               "bbb": Object {
                 "children": Array [],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "MyCard",
                   "propertyPath": Object {
@@ -8844,7 +8777,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -8967,7 +8899,6 @@ Object {
             "elementsWithin": Object {
               "bbb": Object {
                 "children": Array [],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "MyCard",
                   "propertyPath": Object {
@@ -9091,7 +9022,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -9207,7 +9137,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -9287,7 +9216,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -9421,7 +9349,6 @@ Object {
         "children": Array [
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "div",
               "propertyPath": Object {
@@ -9451,7 +9378,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "AppContext",
           "propertyPath": Object {
@@ -9582,7 +9508,6 @@ export var storyboard = (
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -9878,7 +9803,6 @@ export var storyboard = (
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -10028,7 +9952,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "B",
           "propertyPath": Object {
@@ -10199,7 +10122,6 @@ Object {
                     "children": Array [
                       Object {
                         "children": Array [],
-                        "metadata": null,
                         "name": Object {
                           "baseVariable": "div",
                           "propertyPath": Object {
@@ -10231,7 +10153,6 @@ Object {
                     "uniqueID": "",
                   },
                 ],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "div",
                   "propertyPath": Object {
@@ -10276,7 +10197,6 @@ Object {
                 "uniqueID": "",
               },
             ],
-            "metadata": null,
             "name": Object {
               "baseVariable": "div",
               "propertyPath": Object {
@@ -10292,7 +10212,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -10476,7 +10395,6 @@ export var storyboard = (
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -10633,7 +10551,6 @@ Object {
         "children": Array [
           Object {
             "children": Array [],
-            "metadata": null,
             "name": Object {
               "baseVariable": "img",
               "propertyPath": Object {
@@ -10653,7 +10570,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -10727,7 +10643,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "img",
           "propertyPath": Object {
@@ -10868,7 +10783,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "MyComp",
           "propertyPath": Object {
@@ -11051,7 +10965,6 @@ Object {
                         "uniqueID": "",
                       },
                     ],
-                    "metadata": null,
                     "name": Object {
                       "baseVariable": "div",
                       "propertyPath": Object {
@@ -11067,7 +10980,6 @@ Object {
                     "type": "JSX_ELEMENT",
                   },
                 ],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "div",
                   "propertyPath": Object {
@@ -11141,7 +11053,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "View",
           "propertyPath": Object {
@@ -11278,7 +11189,6 @@ Object {
                     "uniqueID": "",
                   },
                 ],
-                "metadata": null,
                 "name": Object {
                   "baseVariable": "div",
                   "propertyPath": Object {
@@ -11294,7 +11204,6 @@ Object {
                 "type": "JSX_ELEMENT",
               },
             ],
-            "metadata": null,
             "name": Object {
               "baseVariable": "ClonerComponent",
               "propertyPath": Object {
@@ -11310,7 +11219,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -11407,7 +11315,6 @@ Object {
                 "uniqueID": "",
               },
             ],
-            "metadata": null,
             "name": Object {
               "baseVariable": "div",
               "propertyPath": Object {
@@ -11423,7 +11330,6 @@ Object {
             "type": "JSX_ELEMENT",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "ClonerComponent",
           "propertyPath": Object {
@@ -11504,7 +11410,6 @@ Object {
             "uniqueID": "",
           },
         ],
-        "metadata": null,
         "name": Object {
           "baseVariable": "div",
           "propertyPath": Object {
@@ -11624,7 +11529,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "MyComp",
           "propertyPath": Object {
@@ -11739,7 +11643,6 @@ Object {
       "type": "RIGHT",
       "value": Object {
         "children": Array [],
-        "metadata": null,
         "name": Object {
           "baseVariable": "MyComp",
           "propertyPath": Object {

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -62,7 +62,6 @@ import {
   jsxSimpleAttributeToValue,
 } from '../../core/shared/jsx-attributes'
 import {
-  CanvasMetadata,
   Imports,
   InstancePath,
   isParseFailure,
@@ -77,7 +76,6 @@ import {
   getOrDefaultScenes,
   getUtopiaJSXComponentsFromSuccess,
   uiJsFile,
-  updateCanvasMetadataParseResult,
 } from '../../core/model/project-file-utils'
 import { lintAndParse } from '../../core/workers/parser-printer/parser-printer'
 import { defaultProject } from '../../sample-projects/sample-project-utils'

--- a/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
+++ b/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
@@ -12,7 +12,6 @@ Array [
       "children": Array [
         Object {
           "children": Array [],
-          "metadata": null,
           "name": Object {
             "baseVariable": "View",
             "propertyPath": Object {
@@ -69,7 +68,6 @@ Array [
           "type": "JSX_ELEMENT",
         },
       ],
-      "metadata": null,
       "name": Object {
         "baseVariable": "View",
         "propertyPath": Object {
@@ -127,7 +125,6 @@ Array [
       "children": Array [
         Object {
           "children": Array [],
-          "metadata": null,
           "name": Object {
             "baseVariable": "View",
             "propertyPath": Object {
@@ -168,7 +165,6 @@ Array [
           "type": "JSX_ELEMENT",
         },
       ],
-      "metadata": null,
       "name": Object {
         "baseVariable": "View",
         "propertyPath": Object {

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -27,7 +27,6 @@ import {
   ParseResult,
 } from '../../../core/shared/project-file-types'
 import {
-  defaultCanvasMetadata,
   emptyImports,
   parseSuccess,
   parseFailure,
@@ -100,16 +99,12 @@ describe('SET_PROP', () => {
                   'data-uid': jsxAttributeValue('bbb'),
                 },
                 [],
-                null,
               ),
             ],
-            null,
           ),
           null,
         ),
       ],
-      right(defaultCanvasMetadata()),
-      false,
       '',
       {},
       null,
@@ -190,27 +185,14 @@ describe('SET_CANVAS_FRAMES', () => {
               'data-uid': jsxAttributeValue('bbb'),
             },
             [],
-            null,
           ),
         ],
-        null,
       ),
       null,
     ),
   ]
 
-  const originalModel = deepFreeze(
-    parseSuccess(
-      emptyImports(),
-      components,
-      right(defaultCanvasMetadata()),
-      false,
-      '',
-      {},
-      null,
-      null,
-    ),
-  )
+  const originalModel = deepFreeze(parseSuccess(emptyImports(), components, '', {}, null, null))
   const testEditor: EditorState = deepFreeze({
     ...createEditorState(NO_OP),
     projectContents: contentsToTree({
@@ -269,8 +251,6 @@ describe('moveTemplate', () => {
         rootElements.map((element, index) =>
           utopiaJSXComponent(`MyView${index}`, true, defaultPropsParam, [], element, null),
         ),
-        right(defaultCanvasMetadata()),
-        false,
         '',
         {},
         null,
@@ -300,7 +280,6 @@ describe('moveTemplate', () => {
         'data-uid': jsxAttributeValue(uid),
       },
       children,
-      null,
     )
   }
 
@@ -326,7 +305,6 @@ describe('moveTemplate', () => {
         'data-uid': jsxAttributeValue(uid),
       },
       children,
-      null,
     )
   }
 
@@ -614,7 +592,6 @@ describe('moveTemplate', () => {
         'data-uid': jsxAttributeValue('bbb'),
       },
       [],
-      null,
     )
     const group1 = group('ddd', [], -10, -10, 100, 100, 'Group')
     const root1 = view('aaa', [view1])
@@ -670,7 +647,6 @@ describe('moveTemplate', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const editor = testEditor(fileModel([flexView, group1]))
 
@@ -717,7 +693,6 @@ describe('moveTemplate', () => {
         'data-uid': jsxAttributeValue('bbb'),
       },
       [],
-      null,
     )
     const group1 = group('ddd', [view1], 50, 50, 100, 100, 'Group')
     const root1 = view('aaa', [], 0, 0, 200, 200)
@@ -763,7 +738,6 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
       }),
     },
     [],
-    null,
   )
   const rootElement = jsxElement(
     'View',
@@ -773,22 +747,10 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
       layout: jsxAttributeValue({ layoutSystem: 'pinSystem' }),
     },
     [childElement],
-    null,
   )
   const firstTopLevelElement = utopiaJSXComponent('App', true, null, [], rootElement, null)
   const fileForUI = uiJsFile(
-    right(
-      parseSuccess(
-        sampleDefaultImports,
-        [firstTopLevelElement],
-        left({}),
-        false,
-        '',
-        {},
-        null,
-        null,
-      ),
-    ),
+    right(parseSuccess(sampleDefaultImports, [firstTopLevelElement], '', {}, null, null)),
     null,
     RevisionsState.BothMatch,
     0,

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -85,7 +85,6 @@ import {
   canUpdateFile,
   codeFile,
   directory,
-  emptyElementCanvasMetadata,
   fileTypeFromFileName,
   getHighlightBoundsFromParseResult,
   getUtopiaJSXComponentsFromSuccess,
@@ -2871,7 +2870,6 @@ export const UPDATE_FNS = {
               'data-aspect-ratio-locked': jsxAttributeValue(true),
             },
             [],
-            null,
           )
           const size = width != null && height != null ? { width: width, height: height } : null
           const switchMode = enableInsertModeForJSXElement(imageElement, newUID, {}, size)
@@ -2908,7 +2906,6 @@ export const UPDATE_FNS = {
               'data-aspect-ratio-locked': jsxAttributeValue(true),
             },
             [],
-            null,
           )
 
           const insertJSXElementAction = insertJSXElement(imageElement, parent, {})
@@ -2975,7 +2972,6 @@ export const UPDATE_FNS = {
           'data-aspect-ratio-locked': jsxAttributeValue(true),
         },
         [],
-        {},
       )
       const size = width != null && height != null ? { width: width, height: height } : null
       const switchMode = enableInsertModeForJSXElement(imageElement, newUID, {}, size)
@@ -3903,7 +3899,6 @@ export const UPDATE_FNS = {
           'data-aspect-ratio-locked': jsxAttributeValue(true),
         },
         [],
-        {},
       )
 
       const insertJSXElementAction = insertJSXElement(imageElement, parent, {})

--- a/editor/src/components/editor/actions/migrations/migrations.ts
+++ b/editor/src/components/editor/actions/migrations/migrations.ts
@@ -6,7 +6,6 @@ import {
   isParseSuccess,
   SceneMetadata,
   UIJSFile,
-  CanvasMetadataParseResult,
   isCodeFile,
 } from '../../../../core/shared/project-file-types'
 import { isRight, right } from '../../../../core/shared/either'
@@ -68,9 +67,9 @@ function migrateFromVersion1(
       if (
         isUIJSFile(file) &&
         isParseSuccess(file.fileContents) &&
-        isRight(file.fileContents.value.canvasMetadata)
+        isRight((file.fileContents.value as any).canvasMetadata)
       ) {
-        const canvasMetadataParseSuccess = file.fileContents.value.canvasMetadata.value
+        const canvasMetadataParseSuccess = (file.fileContents.value as any).canvasMetadata.value
         // this old canvas metadata might store an array of `scenes: Array<SceneMetadata>`, whereas we expect a UtopiaJSXComponent here
         if (
           (canvasMetadataParseSuccess as any).utopiaCanvasJSXComponent == null &&
@@ -78,7 +77,7 @@ function migrateFromVersion1(
         ) {
           const scenes = (canvasMetadataParseSuccess as any)['scenes'] as Array<SceneMetadata>
           const utopiaCanvasComponent = convertScenesToUtopiaCanvasComponent(scenes)
-          const updatedCanvasMetadataParseSuccess: CanvasMetadataParseResult = right({
+          const updatedCanvasMetadataParseSuccess: any = right({
             utopiaCanvasJSXComponent: utopiaCanvasComponent,
           })
           return {
@@ -115,12 +114,13 @@ function migrateFromVersion2(
     const updatedFiles = objectMap((file: ProjectFile, fileName) => {
       if (isUIJSFile(file) && isParseSuccess(file.fileContents)) {
         if (
-          isRight(file.fileContents.value.canvasMetadata) &&
+          isRight((file.fileContents.value as any).canvasMetadata) &&
           // the parseSuccess contained a utopiaCanvasJSXComponent which we now merge to the array of topLevelElements
-          (file.fileContents.value.canvasMetadata.value as any).utopiaCanvasJSXComponent != null
+          ((file.fileContents.value as any).canvasMetadata.value as any).utopiaCanvasJSXComponent !=
+            null
         ) {
-          const utopiaCanvasJSXComponent = (file.fileContents.value.canvasMetadata.value as any)
-            .utopiaCanvasJSXComponent
+          const utopiaCanvasJSXComponent = ((file.fileContents.value as any).canvasMetadata
+            .value as any).utopiaCanvasJSXComponent
           const updatedTopLevelElements = [
             ...file.fileContents.value.topLevelElements,
             utopiaCanvasJSXComponent,

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -27,7 +27,7 @@ export function defaultSceneElement(
     }),
   }
 
-  return jsxElement(jsxElementName('Scene', []), props, [], null)
+  return jsxElement(jsxElementName('Scene', []), props, [])
 }
 
 export function defaultViewElement(uid: string): JSXElement {
@@ -43,7 +43,6 @@ export function defaultViewElement(uid: string): JSXElement {
       }),
     },
     [],
-    null,
   )
 }
 
@@ -57,7 +56,6 @@ export function defaultAnimatedDivElement(uid: string): JSXElement {
       'data-uid': jsxAttributeValue(uid),
     },
     [],
-    null,
   )
 }
 
@@ -72,7 +70,6 @@ export function defaultTransparentViewElement(uid: string, layoutSystem: LayoutS
       'data-uid': jsxAttributeValue(uid),
     },
     [],
-    null,
   )
 }
 
@@ -87,7 +84,6 @@ export function defaultTextElement(uid: string): JSXElement {
       'data-uid': jsxAttributeValue(uid),
     },
     [],
-    null,
   )
 }
 
@@ -101,7 +97,6 @@ export function defaultRectangleElement(uid: string): JSXElement {
       'data-uid': jsxAttributeValue(uid),
     },
     [],
-    null,
   )
 }
 
@@ -115,7 +110,6 @@ export function defaultEllipseElement(uid: string): JSXElement {
       'data-uid': jsxAttributeValue(uid),
     },
     [],
-    null,
   )
 }
 
@@ -132,6 +126,5 @@ export function defaultDivElement(uid: string): JSXElement {
       }),
     },
     [],
-    null,
   )
 }

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -408,7 +408,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
                 const newUID = generateUID(this.props.existingUIDs)
                 let props: JSXAttributes = objectMap(jsxAttributeValue, defaultProps)
                 props['data-uid'] = jsxAttributeValue(newUID)
-                const newElement = jsxElement(jsxElementName(componentName, []), props, [], null)
+                const newElement = jsxElement(jsxElementName(componentName, []), props, [])
                 this.props.editorDispatch(
                   [enableInsertModeForJSXElement(newElement, newUID, {}, null)],
                   'everyone',

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -24,13 +24,11 @@ import {
   getOrDefaultScenes,
   getUtopiaJSXComponentsFromSuccess,
   saveUIJSFileContents,
-  updateCanvasMetadataParseResult,
   getHighlightBoundsFromParseResult,
 } from '../../../core/model/project-file-utils'
 import { ErrorMessage } from '../../../core/shared/error-messages'
 import type { PackageStatusMap } from '../../../core/shared/npm-dependency-types'
 import {
-  CanvasMetadataParseResult,
   CodeFile,
   Imports,
   InstancePath,
@@ -475,18 +473,15 @@ export function getOpenUIJSFile(model: EditorState): UIJSFile | null {
 export interface SimpleParseSuccess {
   imports: Imports
   utopiaComponents: Array<UtopiaJSXComponent>
-  canvasMetadata: CanvasMetadataParseResult
 }
 
 export function simpleParseSuccess(
   imports: Imports,
   utopiaComponents: Array<UtopiaJSXComponent>,
-  canvasMetadata: CanvasMetadataParseResult,
 ): SimpleParseSuccess {
   return {
     imports: imports,
     utopiaComponents: utopiaComponents,
-    canvasMetadata: canvasMetadata,
   }
 }
 
@@ -497,7 +492,6 @@ export function modifyParseSuccessWithSimple(
   const oldSimpleParseSuccess: SimpleParseSuccess = {
     imports: success.imports,
     utopiaComponents: getUtopiaJSXComponentsFromSuccess(success),
-    canvasMetadata: success.canvasMetadata,
   }
   const newSimpleParseSuccess: SimpleParseSuccess = transform(oldSimpleParseSuccess)
   const newTopLevelElements = applyUtopiaJSXComponentsChanges(
@@ -507,8 +501,6 @@ export function modifyParseSuccessWithSimple(
   return {
     imports: newSimpleParseSuccess.imports,
     topLevelElements: newTopLevelElements,
-    canvasMetadata: newSimpleParseSuccess.canvasMetadata,
-    projectContainedOldSceneMetadata: success.projectContainedOldSceneMetadata,
     code: success.code,
     highlightBounds: {},
     jsxFactoryFunction: success.jsxFactoryFunction,

--- a/editor/src/components/editor/store/editor-update.spec.ts
+++ b/editor/src/components/editor/store/editor-update.spec.ts
@@ -525,7 +525,6 @@ describe('INSERT_JSX_ELEMENT', () => {
       jsxElementName('View', []),
       { 'data-uid': jsxAttributeValue('TestView') },
       [],
-      null,
     )
     const insertAction = insertJSXElement(elementToInsert, parentPath, {
       'utopia-api': importDetails(null, [importAlias('View')], null),
@@ -582,7 +581,6 @@ describe('INSERT_JSX_ELEMENT', () => {
       jsxElementName('View', []),
       { 'data-uid': jsxAttributeValue('TestView') },
       [],
-      null,
     )
     const insertAction = insertJSXElement(elementToInsert, null, {
       'utopia-api': importDetails(null, [importAlias('View')], null),

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -251,7 +251,7 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
           )
           let props: JSXAttributes = objectMap(jsxAttributeValue, defaultProps)
           props['data-uid'] = jsxAttributeValue(newUID)
-          const element: JSXElement = jsxElement(jsxElementName(exportVarName, []), props, [], null)
+          const element: JSXElement = jsxElement(jsxElementName(exportVarName, []), props, [])
           dispatch(
             [
               EditorActions.enableInsertModeForJSXElement(

--- a/editor/src/components/images.ts
+++ b/editor/src/components/images.ts
@@ -114,9 +114,6 @@ export function createInsertImageAction(
         'data-uid': jsxAttributeValue(newUID),
       },
       [],
-      {
-        aspectRatioLocked: true,
-      },
     )
     return insertJSXElement(imageElement, parentPath, {})
   } else {

--- a/editor/src/components/inspector/common/property-path-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.spec.tsx
@@ -452,19 +452,6 @@ function getPropsForStyleProp(
     View
   } from "utopia-api";
   import { cake } from 'cake'
-  export var ${CanvasMetadataName} = {
-    scenes: [],
-    elementMetadata: {
-      aab: {
-        name: 'hello',
-        aspectRatioLocked: true,
-      },
-      "111": {
-        name: 'hi',
-        aspectRatioLocked: true,
-      }
-    },
-  }
   
   export var App = (props) => {
     return (

--- a/editor/src/core/layout/layout-utils.spec.browser.ts
+++ b/editor/src/core/layout/layout-utils.spec.browser.ts
@@ -6,7 +6,6 @@ import {
 } from '../../components/canvas/ui-jsx-test-utils'
 import { pasteJSXElements, selectComponents } from '../../components/editor/actions/actions'
 import * as TP from '../shared/template-path'
-import * as Utils from '../../utils/utils'
 import {
   ComponentMetadata,
   jsxAttributeNestedObjectSimple,
@@ -19,7 +18,6 @@ import { generateUidWithExistingComponents } from '../model/element-template-uti
 import { right } from '../shared/either'
 import { CanvasRectangle, LocalRectangle } from '../shared/math-utils'
 import { BakedInStoryboardUID } from '../model/scene-utils'
-import { wait } from '../../utils/test-utils'
 
 const NewUID = 'catdog'
 
@@ -67,7 +65,6 @@ describe('maybeSwitchLayoutProps', () => {
         'data-uid': jsxAttributeValue(NewUID),
       },
       [],
-      null,
     )
     const metadata: ComponentMetadata[] = [
       {

--- a/editor/src/core/model/__snapshots__/storyboard-utils.spec.ts.snap
+++ b/editor/src/core/model/__snapshots__/storyboard-utils.spec.ts.snap
@@ -12,7 +12,6 @@ Array [
       "children": Array [
         Object {
           "children": Array [],
-          "metadata": null,
           "name": Object {
             "baseVariable": "Scene",
             "propertyPath": Object {
@@ -52,7 +51,6 @@ Array [
           "type": "JSX_ELEMENT",
         },
       ],
-      "metadata": null,
       "name": Object {
         "baseVariable": "Storyboard",
         "propertyPath": Object {

--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -315,12 +315,7 @@ describe('getElementLabel', () => {
   const divPath = TP.appendToPath(scenePath, 'div-1')
   const spanPath = TP.appendToPath(divPath, 'span-1')
   const textBlock = jsxTextBlock('test text')
-  const spanElement = jsxElement(
-    'span',
-    { 'data-uid': jsxAttributeValue('span-1') },
-    [textBlock],
-    null,
-  )
+  const spanElement = jsxElement('span', { 'data-uid': jsxAttributeValue('span-1') }, [textBlock])
   const spanElementMetadata = elementInstanceMetadata(
     spanPath,
     right(spanElement),
@@ -334,12 +329,7 @@ describe('getElementLabel', () => {
     emptySpecialSizeMeasurements,
     emptyComputedStyle,
   )
-  const divElement = jsxElement(
-    'div',
-    { 'data-uid': jsxAttributeValue('div-1') },
-    [spanElement],
-    null,
-  )
+  const divElement = jsxElement('div', { 'data-uid': jsxAttributeValue('div-1') }, [spanElement])
   const divElementMetadata = elementInstanceMetadata(
     divPath,
     right(divElement),

--- a/editor/src/core/model/element-template-utils.spec.ts
+++ b/editor/src/core/model/element-template-utils.spec.ts
@@ -19,8 +19,8 @@ import { BakedInStoryboardUID } from './scene-utils'
 describe('guaranteeUniqueUids', () => {
   it('if two siblings have the same ID, one will be replaced', () => {
     const exampleElements = [
-      jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [], null),
-      jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [], null),
+      jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, []),
+      jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, []),
     ]
     const fixedElements = guaranteeUniqueUids(exampleElements, [])
 
@@ -32,8 +32,8 @@ describe('guaranteeUniqueUids', () => {
 
   it('if an element has an existing value, it will be replaced', () => {
     const exampleElements = [
-      jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [], null),
-      jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [], null),
+      jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, []),
+      jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, []),
     ]
     const existingIDs = ['aab', 'bbb']
     const fixedElements = guaranteeUniqueUids(exampleElements, existingIDs)
@@ -49,7 +49,6 @@ describe('guaranteeUniqueUids', () => {
       'View',
       { 'data-uid': jsxAttributeFunctionCall('someFunction', []) },
       [],
-      null,
     )
     const fixedElements = guaranteeUniqueUids([exampleElement], [])
 
@@ -64,25 +63,20 @@ describe('guaranteeUniqueUids', () => {
 
 describe('getUtopiaID', () => {
   it('returns an id if there is one', () => {
-    const element = jsxElement('View', { 'data-uid': jsxAttributeValue('hello') }, [], null)
+    const element = jsxElement('View', { 'data-uid': jsxAttributeValue('hello') }, [])
     const id = getUtopiaID(element as JSXElement)
     expect(id).toEqual('hello')
   })
 
   it('throws if there is no ID', () => {
-    const element = jsxElement('View', {} as any, [], null)
+    const element = jsxElement('View', {} as any, [])
     expect(() => {
       getUtopiaID(element as JSXElement)
     }).toThrow()
   })
 
   it('throws if there is an ID which is not a simple jsx attribute value', () => {
-    const element = jsxElement(
-      'View',
-      { 'data-uid': jsxAttributeFunctionCall('hello', []) },
-      [],
-      null,
-    )
+    const element = jsxElement('View', { 'data-uid': jsxAttributeFunctionCall('hello', []) }, [])
     expect(() => {
       getUtopiaID(element as JSXElement)
     }).toThrow()
@@ -96,12 +90,7 @@ describe('removeJSXElementChild', () => {
       true,
       defaultPropsParam,
       [],
-      jsxElement(
-        'View',
-        { 'data-uid': jsxAttributeValue('aaa'), prop1: jsxAttributeValue(5) },
-        [],
-        null,
-      ),
+      jsxElement('View', { 'data-uid': jsxAttributeValue('aaa'), prop1: jsxAttributeValue(5) }, []),
       null,
     ),
     utopiaJSXComponent(
@@ -109,21 +98,15 @@ describe('removeJSXElementChild', () => {
       true,
       defaultPropsParam,
       [],
-      jsxElement(
-        'View',
-        { 'data-uid': jsxAttributeValue('aab'), prop2: jsxAttributeValue(15) },
-        [
-          jsxElement('View', { 'data-uid': jsxAttributeValue('aac') }, [], null),
-          jsxElement(
-            'View',
-            { 'data-uid': jsxAttributeValue('aad'), prop3: jsxAttributeValue(100) },
-            [],
-            null,
-          ),
-          jsxElement('View', { 'data-uid': jsxAttributeValue('aae') }, [], null),
-        ],
-        null,
-      ),
+      jsxElement('View', { 'data-uid': jsxAttributeValue('aab'), prop2: jsxAttributeValue(15) }, [
+        jsxElement('View', { 'data-uid': jsxAttributeValue('aac') }, []),
+        jsxElement(
+          'View',
+          { 'data-uid': jsxAttributeValue('aad'), prop3: jsxAttributeValue(100) },
+          [],
+        ),
+        jsxElement('View', { 'data-uid': jsxAttributeValue('aae') }, []),
+      ]),
       null,
     ),
   ]

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -7,11 +7,8 @@ import { intrinsicHTMLElementNamesAsStrings } from '../shared/dom-utils'
 import Utils from '../../utils/utils'
 import { bimapEither, foldEither, mapEither } from '../shared/either'
 import {
-  CanvasMetadata,
-  CanvasMetadataParseResult,
   CodeFile,
   Directory,
-  ElementCanvasMetadata,
   HighlightBoundsForUids,
   ImageFile,
   Imports,
@@ -52,10 +49,6 @@ import {
   ProjectContentTreeRoot,
   transformContentsTree,
 } from '../../components/assets'
-
-export function emptyElementCanvasMetadata(): ElementCanvasMetadata {
-  return {}
-}
 
 export const sceneMetadata = _sceneMetadata // This is a hotfix for a circular dependency AND a leaking of utopia-api into the workers
 
@@ -181,13 +174,6 @@ export function getOrDefaultScenes(parsedSuccess: ParseSuccess): UtopiaJSXCompon
   }
   // If all fails, let's return an empty default component
   return defaultEmptyUtopiaComponent
-}
-
-export function updateCanvasMetadataParseResult(
-  transform: (metadata: CanvasMetadata) => CanvasMetadata,
-  parseResult: CanvasMetadataParseResult,
-): CanvasMetadataParseResult {
-  return mapEither(transform, parseResult)
 }
 
 export function getComponentsFromTopLevelElements(

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -97,7 +97,7 @@ export function mapScene(scene: SceneMetadata): JSXElement {
     'data-uid': jsxAttributeValue(scene.uid),
     'data-label': jsxAttributeValue(scene.label),
   }
-  return jsxElement('Scene', sceneProps, [], null)
+  return jsxElement('Scene', sceneProps, [])
 }
 
 export function unmapScene(element: JSXElementChild): SceneMetadata | null {
@@ -149,7 +149,6 @@ export function convertScenesToUtopiaCanvasComponent(
       'Storyboard',
       { 'data-uid': jsxAttributeValue(BakedInStoryboardUID) },
       scenes.map(mapScene),
-      null,
     ),
     null,
   )
@@ -173,7 +172,7 @@ export function createSceneFromComponent(component: UtopiaJSXComponent, uid: str
       height: 812,
     }),
   }
-  return jsxElement('Scene', sceneProps, [], null)
+  return jsxElement('Scene', sceneProps, [])
 }
 
 export function createStoryboardElement(scenes: Array<JSXElement>, uid: string): JSXElement {
@@ -181,7 +180,7 @@ export function createStoryboardElement(scenes: Array<JSXElement>, uid: string):
     [UTOPIA_UID_KEY]: jsxAttributeValue(uid),
     layout: jsxAttributeValue({ layoutSystem: 'pinSystem' }),
   }
-  return jsxElement('Storyboard', storyboardProps, scenes, null)
+  return jsxElement('Storyboard', storyboardProps, scenes)
 }
 
 export function convertUtopiaCanvasComponentToScenes(

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -113,7 +113,7 @@ function addStoryboardFileForComponent(
     baseImports,
   )
   // Create the file.
-  const success = parseSuccess(imports, [storyboardComponent], left({}), false, '', {}, 'jsx', null)
+  const success = parseSuccess(imports, [storyboardComponent], '', {}, 'jsx', null)
   const storyboardFileContents = uiJsFile(right(success), null, RevisionsState.ParsedAhead, 0)
 
   // Update the model.

--- a/editor/src/core/model/test-ui-js-file.ts
+++ b/editor/src/core/model/test-ui-js-file.ts
@@ -111,7 +111,6 @@ const mainComponentForTests = utopiaJSXComponent(
               'data-uid': jsxAttributeValue('bbb'),
             },
             [],
-            null,
           ),
           jsxElement(
             'Rectangle',
@@ -128,7 +127,6 @@ const mainComponentForTests = utopiaJSXComponent(
               'data-uid': jsxAttributeValue('ccc'),
             },
             [],
-            null,
           ),
         ],
         false,
@@ -166,7 +164,6 @@ const mainComponentForTests = utopiaJSXComponent(
               'data-uid': jsxAttributeValue('eee'),
             },
             [],
-            null,
           ),
           jsxElement(
             'Rectangle',
@@ -183,10 +180,8 @@ const mainComponentForTests = utopiaJSXComponent(
               'data-uid': jsxAttributeValue('fff'),
             },
             [],
-            null,
           ),
         ],
-        null,
       ),
       jsxElement(
         'View',
@@ -204,7 +199,6 @@ const mainComponentForTests = utopiaJSXComponent(
           'data-uid': jsxAttributeValue('ggg'),
         },
         [],
-        null,
       ),
       jsxElement(
         'Text',
@@ -223,7 +217,6 @@ const mainComponentForTests = utopiaJSXComponent(
           'data-uid': jsxAttributeValue('hhh'),
         },
         [],
-        null,
       ),
       jsxElement(
         'Image',
@@ -239,11 +232,9 @@ const mainComponentForTests = utopiaJSXComponent(
           'data-uid': jsxAttributeValue('iii'),
         },
         [],
-        null,
       ),
-      jsxElement('MyComponent', { 'data-uid': jsxAttributeValue('mycomponent') }, [], null),
+      jsxElement('MyComponent', { 'data-uid': jsxAttributeValue('mycomponent') }, []),
     ],
-    null,
   ),
   null,
 )
@@ -260,7 +251,6 @@ const scene = utopiaJSXComponent(
       'data-uid': jsxAttributeValue('jjj'),
     },
     [],
-    null,
   ),
   null,
 )
@@ -288,12 +278,10 @@ const TestStoryboard = utopiaJSXComponent(
   false,
   null,
   [],
-  jsxElement(
-    'Storyboard',
-    { 'data-uid': jsxAttributeValue(BakedInStoryboardUID) },
-    [Scene1, Scene2],
-    null,
-  ),
+  jsxElement('Storyboard', { 'data-uid': jsxAttributeValue(BakedInStoryboardUID) }, [
+    Scene1,
+    Scene2,
+  ]),
   null,
 )
 

--- a/editor/src/core/shared/element-template.tsx
+++ b/editor/src/core/shared/element-template.tsx
@@ -1,9 +1,7 @@
 import {
   PropertyPath,
-  ElementCanvasMetadata,
   InstancePath,
   PropertyPathPart,
-  CanvasElementMetadataMap,
   SceneContainer,
   ScenePath,
   StaticElementPath,
@@ -433,7 +431,6 @@ export interface JSXElement {
   name: JSXElementName
   props: JSXAttributes
   children: JSXElementChildren
-  metadata: ElementCanvasMetadata | null
 }
 
 export type ElementsWithin = { [uid: string]: JSXElement }
@@ -554,14 +551,12 @@ export function jsxElement(
   name: JSXElementName | string,
   props: JSXAttributes,
   children: JSXElementChildren,
-  metadata: ElementCanvasMetadata | null,
 ): JSXElement {
   return {
     type: 'JSX_ELEMENT',
     name: typeof name === 'string' ? jsxElementName(name, []) : name,
     props: props,
     children: children,
-    metadata: metadata,
   }
 }
 
@@ -569,10 +564,9 @@ export function jsxTestElement(
   name: JSXElementName | string,
   props: JSXAttributes,
   children: Array<JSXElement>,
-  metadata: ElementCanvasMetadata | null = null,
   uid: string = 'aaa',
 ): JSXElement {
-  return jsxElement(name, { ...props, 'data-uid': jsxAttributeValue(uid) }, children, metadata)
+  return jsxElement(name, { ...props, 'data-uid': jsxAttributeValue(uid) }, children)
 }
 
 export function utopiaJSXComponent(

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -58,11 +58,6 @@ export const enum PinType {
   Relative = 'relative',
 }
 
-export interface ElementCanvasMetadata {}
-
-export type CanvasElementMetadataMap = { [utopiaID: string]: ElementCanvasMetadata }
-
-// KILLME CanvasMetadata is dead
 export interface ScenePinnedContainer {
   layoutSystem: LayoutSystem.PinSystem
 }
@@ -76,18 +71,6 @@ export interface SceneMetadata {
   frame: NormalisedFrame
   container: SceneContainer
   label?: string
-}
-
-export interface CanvasMetadata {}
-
-export type CanvasMetadataRightBeforePrinting = {
-  scenes: Array<Omit<SceneMetadata, 'uid'>> | null
-  elementMetadata: CanvasElementMetadataMap
-}
-
-export type PrintedCanvasMetadata = {
-  scenes: Array<SceneMetadata> | null
-  elementMetadata: CanvasElementMetadataMap
 }
 
 export interface ImportAlias {
@@ -148,13 +131,9 @@ export interface HighlightBounds {
 
 export type HighlightBoundsForUids = { [uid: string]: HighlightBounds }
 
-export type CanvasMetadataParseResult = Either<unknown, CanvasMetadata>
-
 export interface ParseSuccess {
   imports: Imports
   topLevelElements: Array<TopLevelElement>
-  canvasMetadata: CanvasMetadataParseResult
-  projectContainedOldSceneMetadata: boolean
   code: string
   highlightBounds: HighlightBoundsForUids
   jsxFactoryFunction: string | null

--- a/editor/src/core/third-party/antd-components.ts
+++ b/editor/src/core/third-party/antd-components.ts
@@ -25,7 +25,7 @@ function createBasicComponent(
       antd: importDetails(null, [importAlias(baseVariable)], null),
       'antd/dist/antd.css': importDetails(null, [], null),
     },
-    jsxElement(jsxElementName(baseVariable, propertyPathParts), {}, [], null),
+    jsxElement(jsxElementName(baseVariable, propertyPathParts), {}, []),
     name,
     { ...StyleObjectProps, ...propertyControls },
   )

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -16,7 +16,7 @@ function createBasicUtopiaComponent(
     {
       'utopia-api': importDetails(null, [importAlias(baseVariable)], null),
     },
-    jsxElement(jsxElementName(baseVariable, []), {}, [], null),
+    jsxElement(jsxElementName(baseVariable, []), {}, []),
     name,
     propertyControls,
   )

--- a/editor/src/core/workers/common/project-file-utils.ts
+++ b/editor/src/core/workers/common/project-file-utils.ts
@@ -8,9 +8,6 @@ import {
   RevisionsState,
   ImportDetails,
   Imports,
-  CanvasMetadata,
-  PrintedCanvasMetadata,
-  CanvasMetadataParseResult,
   HighlightBoundsForUids,
   ParsedJSONFailure,
   ParsedJSONSuccess,
@@ -142,22 +139,9 @@ export function addImport(
   return mergeImports(imports, toAdd)
 }
 
-export function defaultCanvasMetadata(): CanvasMetadata {
-  return {}
-}
-
-export function defaultPrintedCanvasMetadata(): PrintedCanvasMetadata {
-  return {
-    scenes: null,
-    elementMetadata: {},
-  }
-}
-
 export function parseSuccess(
   imports: Imports,
   topLevelElements: Array<TopLevelElement>,
-  canvasMetadata: CanvasMetadataParseResult,
-  projectContainedOldSceneMetadata: boolean,
   code: string,
   highlightBounds: HighlightBoundsForUids,
   jsxFactoryFunction: string | null,
@@ -166,8 +150,6 @@ export function parseSuccess(
   return {
     imports: imports,
     topLevelElements: topLevelElements,
-    canvasMetadata: canvasMetadata,
-    projectContainedOldSceneMetadata: projectContainedOldSceneMetadata,
     code: code,
     highlightBounds: highlightBounds,
     jsxFactoryFunction: jsxFactoryFunction,

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.ts.snap
@@ -4,10 +4,6 @@ exports[`JSX parser circularly referenced arbitrary blocks parse and produce a c
 Object {
   "type": "RIGHT",
   "value": Object {
-    "canvasMetadata": Object {
-      "type": "RIGHT",
-      "value": Object {},
-    },
     "code": "/** @jsx jsx */
 import * as React from 'react'
 import { Scene, Storyboard, jsx } from 'utopia-api'
@@ -202,7 +198,6 @@ return { a: a, b: b };",
       },
     },
     "jsxFactoryFunction": "jsx",
-    "projectContainedOldSceneMetadata": false,
     "topLevelElements": Array [
       Object {
         "definedElsewhere": Array [
@@ -445,7 +440,6 @@ export var storyboard = (
               "uniqueID": "",
             },
           ],
-          "metadata": null,
           "name": Object {
             "baseVariable": "div",
             "propertyPath": Object {
@@ -577,7 +571,6 @@ return { b: b };",
           "children": Array [
             Object {
               "children": Array [],
-              "metadata": null,
               "name": Object {
                 "baseVariable": "Scene",
                 "propertyPath": Object {
@@ -669,7 +662,6 @@ export var storyboard = (
               "type": "JSX_ELEMENT",
             },
           ],
-          "metadata": null,
           "name": Object {
             "baseVariable": "Storyboard",
             "propertyPath": Object {

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.ts.snap
@@ -41,7 +41,6 @@ Array [
           "elementsWithin": Object {
             "bbb": Object {
               "children": Array [],
-              "metadata": null,
               "name": Object {
                 "baseVariable": "div",
                 "propertyPath": Object {
@@ -94,7 +93,6 @@ export var storyboard = (props) => {
           "uniqueID": "",
         },
       ],
-      "metadata": null,
       "name": Object {
         "baseVariable": "Utopia",
         "propertyPath": Object {

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -69,10 +69,6 @@ exports[`JSX parser parses back and forth as a function, with an arbitrary piece
 Object {
   "type": "RIGHT",
   "value": Object {
-    "canvasMetadata": Object {
-      "type": "RIGHT",
-      "value": Object {},
-    },
     "code": "import { cake } from 'cake'
 import * as React from 'react'
 import { Ellipse, Image, Rectangle, Storyboard, Text, UtopiaUtils, View } from 'utopia-api'
@@ -219,7 +215,6 @@ return { cakeFn: cakeFn, otherFn: otherFn };",
       },
     },
     "jsxFactoryFunction": null,
-    "projectContainedOldSceneMetadata": false,
     "topLevelElements": Array [
       Object {
         "definedElsewhere": Array [],
@@ -300,7 +295,6 @@ return { cakeFn: cakeFn, otherFn: otherFn };",
           "children": Array [
             Object {
               "children": Array [],
-              "metadata": null,
               "name": Object {
                 "baseVariable": "cake",
                 "propertyPath": Object {
@@ -360,7 +354,6 @@ export var whatever = (props) => {
               "type": "JSX_ELEMENT",
             },
           ],
-          "metadata": null,
           "name": Object {
             "baseVariable": "View",
             "propertyPath": Object {
@@ -386,10 +379,6 @@ exports[`JSX parser parses fine with a circular dependency. 1`] = `
 Object {
   "type": "RIGHT",
   "value": Object {
-    "canvasMetadata": Object {
-      "type": "RIGHT",
-      "value": Object {},
-    },
     "code": "import * as React from \\"react\\";
 import {
   View
@@ -472,7 +461,6 @@ return { a: a, b: b };",
       },
     },
     "jsxFactoryFunction": null,
-    "projectContainedOldSceneMetadata": false,
     "topLevelElements": Array [
       Object {
         "definedElsewhere": Array [
@@ -533,7 +521,6 @@ return { a: a };",
         "propsUsed": Array [],
         "rootElement": Object {
           "children": Array [],
-          "metadata": null,
           "name": Object {
             "baseVariable": "View",
             "propertyPath": Object {
@@ -602,10 +589,6 @@ exports[`JSX parser parses the code when it has a JSX block with an object defin
 Object {
   "type": "RIGHT",
   "value": Object {
-    "canvasMetadata": Object {
-      "type": "RIGHT",
-      "value": Object {},
-    },
     "code": "import * as React from \\"react\\";
 import {
   Ellipse,
@@ -714,7 +697,6 @@ return { a: a };",
       },
     },
     "jsxFactoryFunction": null,
-    "projectContainedOldSceneMetadata": false,
     "topLevelElements": Array [
       Object {
         "definedElsewhere": Array [],
@@ -812,7 +794,6 @@ export var App = (props) => <View data-uid={'bbb'}>
               "uniqueID": "",
             },
           ],
-          "metadata": null,
           "name": Object {
             "baseVariable": "View",
             "propertyPath": Object {
@@ -838,9 +819,9 @@ exports[`getHighlightBounds gets some bounds 1`] = `
 Array [
   Object {
     "endCol": 15,
-    "endLine": 32,
+    "endLine": 28,
     "startCol": 8,
-    "startLine": 21,
+    "startLine": 17,
   },
 ]
 `;
@@ -858,10 +839,6 @@ Object {
       Text,
       View
     } from \\"utopia-api\\";
-    export var canvasMetadata = {
-      scenes: [],
-      elementMetadata: {}
-    }
     
     export var App = props => {
       const a = 20
@@ -878,13 +855,13 @@ Object {
     "errorMessage": null,
     "errorMessages": Array [
       Object {
-        "codeSnippet": "  19 |       return (
-  20 |         <View
-> 21 |           style={{ backgroundColor: \\"darkgrey\\", position: \\"absolute\\" }, ...hello}
+        "codeSnippet": "  15 |       return (
+  16 |         <View
+> 17 |           style={{ backgroundColor: \\"darkgrey\\", position: \\"absolute\\" }, ...hello}
      |                                                                         ^
-  22 |         >
-  23 |         </View>
-  24 |       )",
+  18 |         >
+  19 |         </View>
+  20 |       )",
         "endColumn": undefined,
         "endLine": undefined,
         "errorCode": null,
@@ -894,7 +871,7 @@ Object {
         "severity": "fatal",
         "source": "eslint",
         "startColumn": 73,
-        "startLine": 21,
+        "startLine": 17,
         "type": "fatal",
       },
     ],

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
@@ -15,7 +15,7 @@ import {
 import { setJSXValueAtPath } from '../../shared/jsx-attributes'
 import { foldEither, forEachRight, right } from '../../shared/either'
 import { ParseSuccess } from '../../shared/project-file-types'
-import { defaultCanvasMetadata, parseSuccess } from '../common/project-file-utils'
+import { parseSuccess } from '../common/project-file-utils'
 import { applyPrettier } from './prettier-utils'
 import {
   clearParseResultUniqueIDs,
@@ -174,7 +174,7 @@ export var whatever = props => (
       true,
       defaultPropsParam,
       [],
-      jsxElement('div', { 'data-uid': jsxAttributeValue('abc') }, [], null),
+      jsxElement('div', { 'data-uid': jsxAttributeValue('abc') }, []),
       null,
     )
 
@@ -188,17 +188,15 @@ export var whatever = props => (
         version: 3,
         file: 'code.tsx',
       }),
-      { aab: jsxElement('MyComp', { 'data-uid': jsxAttributeValue('aab') }, [], null) },
+      { aab: jsxElement('MyComp', { 'data-uid': jsxAttributeValue('aab') }, []) },
     )
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [codeBlock], null)
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [codeBlock])
     const whatever = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const topLevelElements = [myComp, whatever].map(clearTopLevelElementUniqueIDs)
     const expectedResult = right(
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -259,12 +257,10 @@ export var whatever = (props) => {
                 ),
               },
               [],
-              null,
             ),
           },
         ),
       ],
-      null,
     )
     const jsCode = `const arr = [{ n: 1 }];`
     const transpiledJsCode = `var arr = [{
@@ -295,8 +291,6 @@ return { arr: arr };`
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -357,12 +351,10 @@ export var whatever = (props) => {
                 ),
               },
               [],
-              null,
             ),
           },
         ),
       ],
-      null,
     )
     const jsCode = `const arr = [{ a: { n: 1 } }];`
     const transpiledJsCode = `var arr = [{
@@ -395,8 +387,6 @@ return { arr: arr };`
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -462,12 +452,10 @@ export var whatever = (props) => {
                 ),
               },
               [],
-              null,
             ),
           },
         ),
       ],
-      null,
     )
     const jsCode = `const arr = [[1]];`
     const transpiledJsCode = `var arr = [[1]];
@@ -496,8 +484,6 @@ return { arr: arr };`
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -564,15 +550,12 @@ export var whatever = (props) => {
                       {},
                     ),
                   ],
-                  null,
                 ),
               ],
-              null,
             ),
           },
         ),
       ],
-      null,
     )
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
@@ -580,8 +563,6 @@ export var whatever = (props) => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -647,12 +628,10 @@ export var whatever = (props) => {
                 ),
               },
               [],
-              null,
             ),
           },
         ),
       ],
-      null,
     )
     const jsCode = `const arr = [ [ [ 1 ] ] ]`
     const transpiledJsCode = `var arr = [[[1]]];
@@ -681,8 +660,6 @@ return { arr: arr };`
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -749,15 +726,12 @@ export var whatever = (props) => {
                       {},
                     ),
                   ],
-                  null,
                 ),
               ],
-              null,
             ),
           },
         ),
       ],
-      null,
     )
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
@@ -765,8 +739,6 @@ export var whatever = (props) => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -832,12 +804,10 @@ export var whatever = (props) => {
                 ),
               },
               [],
-              null,
             ),
           },
         ),
       ],
-      null,
     )
     const jsCode = `const arr = [ [ [ 1 ] ] ]`
     const transpiledJsCode = `var arr = [[[1]]];
@@ -866,8 +836,6 @@ return { arr: arr };`
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,

--- a/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
@@ -18,7 +18,7 @@ import {
   jsxAttributeOtherJavaScript,
 } from '../../shared/element-template'
 import { right, isRight } from '../../shared/either'
-import { parseSuccess, defaultCanvasMetadata } from '../common/project-file-utils'
+import { parseSuccess } from '../common/project-file-utils'
 import { printCode, printCodeOptions } from './parser-printer'
 import { ParseSuccess } from '../../shared/project-file-types'
 
@@ -147,7 +147,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
@@ -155,8 +154,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithBasicPropsObject,
         expect.objectContaining({}),
         null,
@@ -176,7 +173,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const propsParam = functionParam(
       false,
@@ -198,8 +194,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithBasicPropsObjectWithDefault,
         expect.objectContaining({}),
         null,
@@ -217,7 +211,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const propsParam = functionParam(false, regularParam('myProps', null))
     const exported = utopiaJSXComponent('whatever', true, propsParam, [], view, null)
@@ -226,8 +219,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithRenamedBasicPropsObject,
         expect.objectContaining({}),
         null,
@@ -245,7 +236,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const destructuredParam = functionParam(false, regularParam('prop', null))
     const propsParam = functionParam(
@@ -258,8 +248,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithDestructuredPropsObject,
         expect.objectContaining({}),
         null,
@@ -279,7 +267,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const destructuredParam = functionParam(
       false,
@@ -298,8 +285,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithDestructuredPropsObjectWithDefault,
         expect.objectContaining({}),
         null,
@@ -320,7 +305,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const destructuredParam = functionParam(false, regularParam('renamedProp', null))
     const propsParam = functionParam(
@@ -333,8 +317,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithDestructuredPropsObjectWithRenamedParam,
         expect.objectContaining({}),
         null,
@@ -354,7 +336,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const destructuredParam = functionParam(
       false,
@@ -373,8 +354,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithDestructuredPropsObjectWithRenamedParamAndDefault,
         expect.objectContaining({}),
         null,
@@ -394,7 +373,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const destructuredParam1 = functionParam(false, regularParam('prop', null))
     const destructuredRestParam = functionParam(true, regularParam('otherProps', null))
@@ -409,8 +387,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithDestructuredPropsObjectWithRestParam,
         expect.objectContaining({}),
         null,
@@ -428,7 +404,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const destructuredParam = functionParam(false, regularParam('prop', null))
     const propsParam = functionParam(false, destructuredArray([destructuredParam]))
@@ -438,8 +413,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithDestructuredArray,
         expect.objectContaining({}),
         null,
@@ -459,7 +432,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const destructuredParam = functionParam(
       false,
@@ -475,8 +447,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithDestructuredArrayWithDefault,
         expect.objectContaining({}),
         null,
@@ -496,7 +466,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const destructuredParam1 = functionParam(false, regularParam('prop1', null))
     const destructuredParam2 = functionParam(false, regularParam('prop2', null))
@@ -510,8 +479,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithDestructuredArrayWithOmittedParam,
         expect.objectContaining({}),
         null,
@@ -531,7 +498,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const otherArrayProps = functionParam(true, regularParam('otherArrayProps', null))
     const renamedProp2 = functionParam(false, regularParam('renamedProp2', null))
@@ -565,8 +531,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithNestedDestructuredPropsMess,
         expect.objectContaining({}),
         null,
@@ -586,7 +550,6 @@ describe('Parsing a function component with props', () => {
         'data-uid': jsxAttributeValue('aaa'),
       },
       [],
-      null,
     )
     const otherArrayProps = functionParam(true, regularParam('otherArrayProps', null))
     const renamedProp2 = functionParam(
@@ -639,8 +602,6 @@ describe('Parsing a function component with props', () => {
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         codeWithNestedDestructuredPropsMessWithDefaults,
         expect.objectContaining({}),
         null,

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -1454,7 +1454,7 @@ function createJSXElementAllocatingUID(
   )
   return withParserMetadata(
     {
-      value: jsxElement(name, updatedProps.value, children, null),
+      value: jsxElement(name, updatedProps.value, children),
       startLine: startPosition.line,
       startColumn: startPosition.character,
     },

--- a/editor/src/core/workers/parser-printer/parser-printer-test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-test-utils.ts
@@ -50,10 +50,9 @@ import {
   defaultPropsParam,
   clearArbitraryJSBlockUniqueIDs,
 } from '../../shared/element-template'
-import { addImport, defaultCanvasMetadata } from '../common/project-file-utils'
+import { addImport } from '../common/project-file-utils'
 import { ErrorMessage } from '../../shared/error-messages'
 import {
-  CanvasMetadataParseResult,
   Imports,
   ParseResult,
   ParseSuccess,
@@ -438,7 +437,7 @@ export function jsxElementArbitrary(depth: number): Arbitrary<JSXElement> {
     jsxAttributesArbitrary(),
     FastCheck.array(childArbitrary, 3),
   ).map(([elementName, elementAttributes, elementChildren]) => {
-    return jsxElement(elementName, elementAttributes, elementChildren, null)
+    return jsxElement(elementName, elementAttributes, elementChildren)
   })
 }
 
@@ -611,7 +610,6 @@ export function ensureArbitraryJSXBlockCodeHasUIDs(jsxElementChild: JSXElementCh
 export interface PrintableProjectContent {
   imports: Imports
   topLevelElements: Array<TopLevelElement>
-  canvasMetadata: CanvasMetadataParseResult
   projectContainedOldSceneMetadata: boolean
   jsxFactoryFunction: string | null
 }
@@ -663,11 +661,9 @@ export function printableProjectContentArbitrary(): Arbitrary<PrintableProjectCo
     const imports: Imports = allBaseVariables.reduce((workingImports, baseVariable) => {
       return addImport('testlib', baseVariable, [], null, workingImports)
     }, JustImportViewAndReact)
-    const canvasMetadata = right(defaultCanvasMetadata())
     return {
       imports: imports,
       topLevelElements: topLevelElements,
-      canvasMetadata: canvasMetadata,
       projectContainedOldSceneMetadata: projectContainedOldSceneMetadata,
       jsxFactoryFunction: jsxFactoryFunction,
     }

--- a/editor/src/core/workers/parser-printer/parser-printer-utils.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-utils.spec.ts
@@ -38,7 +38,7 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
       true,
       defaultPropsParam,
       [],
-      jsxElement('View', { 'data-uid': jsxAttributeValue('aa') }, [], null),
+      jsxElement('View', { 'data-uid': jsxAttributeValue('aa') }, []),
       null,
     )
     const fixedComponent = guaranteeUniqueUidsFromTopLevel([withBounds(exampleComponent)])[0]
@@ -53,15 +53,10 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
       true,
       defaultPropsParam,
       [],
-      jsxElement(
-        'View',
-        { 'data-uid': jsxAttributeValue('root') },
-        [
-          jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [], null),
-          jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [], null),
-        ],
-        null,
-      ),
+      jsxElement('View', { 'data-uid': jsxAttributeValue('root') }, [
+        jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, []),
+        jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, []),
+      ]),
       null,
     )
     const fixedComponent = guaranteeUniqueUidsFromTopLevel([withBounds(exampleComponent)])[0]
@@ -83,7 +78,7 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
       true,
       defaultPropsParam,
       [],
-      jsxElement('View', { 'data-uid': jsxAttributeFunctionCall('someFunction', []) }, [], null),
+      jsxElement('View', { 'data-uid': jsxAttributeFunctionCall('someFunction', []) }, []),
       null,
     )
     const fixedComponent = guaranteeUniqueUidsFromTopLevel([withBounds(exampleComponent)])[0]
@@ -105,15 +100,10 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
       true,
       defaultPropsParam,
       [],
-      jsxElement(
-        'View',
-        { 'data-uid': jsxAttributeValue('baa') },
-        [
-          jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [], null),
-          jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [], null),
-        ],
-        null,
-      ),
+      jsxElement('View', { 'data-uid': jsxAttributeValue('baa') }, [
+        jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, []),
+        jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, []),
+      ]),
       null,
     )
     const fixedComponent = guaranteeUniqueUidsFromTopLevel([withBounds(exampleComponent)])[0]
@@ -130,15 +120,10 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
         true,
         defaultPropsParam,
         [],
-        jsxElement(
-          'View',
-          { 'data-uid': jsxAttributeValue('baa') },
-          [
-            jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [], null),
-            jsxElement('View', {} as any, [], null),
-          ],
-          null,
-        ),
+        jsxElement('View', { 'data-uid': jsxAttributeValue('baa') }, [
+          jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, []),
+          jsxElement('View', {} as any, []),
+        ]),
         null,
       ),
     )
@@ -156,23 +141,13 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
         true,
         defaultPropsParam,
         [],
-        jsxElement(
-          'View',
-          { 'data-uid': jsxAttributeValue('baa') },
-          [
-            jsxElement(
-              'View',
-              { 'data-uid': jsxAttributeValue('aaa') },
-              [
-                jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [], null),
-                jsxElement('View', { 'data-uid': jsxAttributeValue('aac') }, [], null),
-              ],
-              null,
-            ),
-            jsxElement('View', {}, [], null),
-          ],
-          null,
-        ),
+        jsxElement('View', { 'data-uid': jsxAttributeValue('baa') }, [
+          jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [
+            jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, []),
+            jsxElement('View', { 'data-uid': jsxAttributeValue('aac') }, []),
+          ]),
+          jsxElement('View', {}, []),
+        ]),
         null,
       ),
     )

--- a/editor/src/core/workers/parser-printer/parser-printer-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-utils.ts
@@ -1,31 +1,7 @@
-import * as G from 'graphlib'
-import { Graph } from 'graphlib'
 import * as TS from 'typescript'
-import { addToMapOfArraysUnique } from '../../shared/array-utils'
-import { Either, left, right } from '../../shared/either'
-import {
-  isJSXArbitraryBlock,
-  isJSXElement,
-  isUtopiaJSXComponent,
-  JSXAttribute,
-  JSXAttributes,
-  JSXElementChild,
-  TopLevelElement,
-  UtopiaJSXComponent,
-  JSXElement,
-  isJSXFragment,
-} from '../../shared/element-template'
-import { ErrorMessage } from '../../shared/error-messages'
-import { defaultIfNull, forceNotNull } from '../../shared/optional-utils'
-import {
-  CanvasElementMetadataMap,
-  ElementCanvasMetadata,
-  ParseFailure,
-} from '../../shared/project-file-types'
-import { fixUtopiaElement, getUtopiaIDFromJSXElement } from '../../shared/uid-utils'
+import { TopLevelElement, JSXElement } from '../../shared/element-template'
+import { fixUtopiaElement } from '../../shared/uid-utils'
 import { fastForEach } from '../../shared/utils'
-import { parseFailure } from '../common/project-file-utils'
-import { createCodeSnippetFromCode } from '../ts/ts-utils'
 import { RawSourceMap } from '../ts/ts-typings/RawSourceMap'
 import { SourceMapConsumer, SourceNode } from 'source-map'
 
@@ -99,50 +75,6 @@ export function guaranteeUniqueUidsFromTopLevel(
         element: {
           ...tle.element,
           rootElement: fixUtopiaElement(tle.element.rootElement, []),
-        },
-      }
-    } else {
-      return tle
-    }
-  })
-}
-
-export function attachMetadataToElements(
-  topLevelElements: TopLevelElementAndCodeContext[],
-  elementMetadataMap: CanvasElementMetadataMap,
-): TopLevelElementAndCodeContext[] {
-  function attachMetadataToElementsInner(element: JSXElementChild): JSXElementChild {
-    if (isJSXElement(element)) {
-      const fixedChildren = element.children.map(attachMetadataToElementsInner)
-      let elementMetadata: ElementCanvasMetadata | null = null
-      try {
-        const elementUID = getUtopiaIDFromJSXElement(element)
-        elementMetadata = defaultIfNull<ElementCanvasMetadata | null>(
-          null,
-          elementMetadataMap[elementUID],
-        )
-      } catch (e) {
-        elementMetadata = null
-      }
-
-      return {
-        ...element,
-        metadata: elementMetadata,
-        children: fixedChildren,
-      }
-    } else {
-      return element
-    }
-  }
-
-  return topLevelElements.map((tle) => {
-    if (tle.element.type === 'UTOPIA_JSX_COMPONENT') {
-      const utopiaComponent: UtopiaJSXComponent = tle.element
-      return {
-        ...tle,
-        element: {
-          ...utopiaComponent,
-          rootElement: attachMetadataToElementsInner(utopiaComponent.rootElement),
         },
       }
     } else {

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -29,18 +29,9 @@ import {
   clearArbitraryJSBlockUniqueIDs,
 } from '../../shared/element-template'
 import { sampleCode } from '../../model/new-project-files'
-import {
-  addImport,
-  defaultCanvasMetadata,
-  emptyImports,
-  parseSuccess,
-} from '../common/project-file-utils'
+import { addImport, emptyImports, parseSuccess } from '../common/project-file-utils'
 import { sampleImportsForTests } from '../../model/test-ui-js-file'
-import {
-  CanvasMetadataParseResult,
-  isParseSuccess,
-  importAlias,
-} from '../../shared/project-file-types'
+import { isParseSuccess, importAlias } from '../../shared/project-file-types'
 import {
   lintAndParse,
   parseCode,
@@ -92,8 +83,8 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -104,18 +95,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      right(
-        parseSuccess(
-          imports,
-          [exported],
-          right(defaultCanvasMetadata()),
-          false,
-          code,
-          expect.objectContaining({}),
-          null,
-          null,
-        ),
-      ),
+      right(parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null)),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -143,23 +123,12 @@ export var whatever = () => <View data-uid={'aaa'}>
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      right(
-        parseSuccess(
-          imports,
-          [exported],
-          right(defaultCanvasMetadata()),
-          false,
-          code,
-          expect.objectContaining({}),
-          null,
-          null,
-        ),
-      ),
+      right(parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null)),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -196,8 +165,8 @@ export function whatever(props) {
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -208,18 +177,7 @@ export function whatever(props) {
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      right(
-        parseSuccess(
-          imports,
-          [exported],
-          right(defaultCanvasMetadata()),
-          false,
-          code,
-          expect.objectContaining({}),
-          null,
-          null,
-        ),
-      ),
+      right(parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null)),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -251,23 +209,12 @@ export function whatever() {
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      right(
-        parseSuccess(
-          imports,
-          [exported],
-          right(defaultCanvasMetadata()),
-          false,
-          code,
-          expect.objectContaining({}),
-          null,
-          null,
-        ),
-      ),
+      right(parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null)),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -304,8 +251,8 @@ export default function whatever(props) {
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -316,18 +263,7 @@ export default function whatever(props) {
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      right(
-        parseSuccess(
-          imports,
-          [exported],
-          right(defaultCanvasMetadata()),
-          false,
-          code,
-          expect.objectContaining({}),
-          null,
-          null,
-        ),
-      ),
+      right(parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null)),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -359,23 +295,12 @@ export default function whatever() {
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      right(
-        parseSuccess(
-          imports,
-          [exported],
-          right(defaultCanvasMetadata()),
-          false,
-          code,
-          expect.objectContaining({}),
-          null,
-          null,
-        ),
-      ),
+      right(parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null)),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -409,8 +334,8 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -426,8 +351,6 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         parseSuccess(
           importsWithStylecss,
           [exported],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -479,9 +402,9 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const cake2 = jsxElement('cake2', cake2Attributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake, cake2], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const cake2 = jsxElement('cake2', cake2Attributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake, cake2])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -492,18 +415,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     )
     const imports = addImport('cake', 'cake', [importAlias('cake2')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      right(
-        parseSuccess(
-          imports,
-          [exported],
-          right(defaultCanvasMetadata()),
-          false,
-          code,
-          expect.objectContaining({}),
-          null,
-          null,
-        ),
-      ),
+      right(parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null)),
     )
     expect(actualResult).toEqual(expectedResult)
   }),
@@ -536,8 +448,8 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         right: jsxAttributeValue(20),
         top: jsxAttributeValue(-20),
       }
-      const cake2 = jsxElement('cake2', cake2Attributes, [], null)
-      const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake2], null)
+      const cake2 = jsxElement('cake2', cake2Attributes, [])
+      const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake2])
       const exported = utopiaJSXComponent(
         'whatever',
         true,
@@ -554,18 +466,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         sampleImportsForTests,
       )
       const expectedResult = clearParseResultUniqueIDs(
-        right(
-          parseSuccess(
-            imports,
-            [exported],
-            right(defaultCanvasMetadata()),
-            false,
-            code,
-            expect.objectContaining({}),
-            null,
-            null,
-          ),
-        ),
+        right(parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null)),
       )
       expect(actualResult).toEqual(expectedResult)
     }),
@@ -600,7 +501,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         right: jsxAttributeValue(20),
         top: jsxAttributeValue(-20),
       }
-      const firstCake = jsxElement('cake', firstCakeAttributes, [], null)
+      const firstCake = jsxElement('cake', firstCakeAttributes, [])
       const secondCakeAttributes: JSXAttributes = {
         'data-uid': jsxAttributeValue('111'),
         'data-label': jsxAttributeValue('Second cake'),
@@ -614,13 +515,11 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         right: jsxAttributeValue(10),
         top: jsxAttributeValue(-10),
       }
-      const secondCake = jsxElement('cake', secondCakeAttributes, [], null)
-      const view = jsxElement(
-        'View',
-        { 'data-uid': jsxAttributeValue('aaa') },
-        [firstCake, secondCake],
-        null,
-      )
+      const secondCake = jsxElement('cake', secondCakeAttributes, [])
+      const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [
+        firstCake,
+        secondCake,
+      ])
       const exported = utopiaJSXComponent(
         'whatever',
         true,
@@ -631,18 +530,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       )
       const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
       const expectedResult = clearParseResultUniqueIDs(
-        right(
-          parseSuccess(
-            imports,
-            [exported],
-            right(defaultCanvasMetadata()),
-            false,
-            code,
-            expect.objectContaining({}),
-            null,
-            null,
-          ),
-        ),
+        right(parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null)),
       )
       expect(actualResult).toEqual(expectedResult)
     })
@@ -681,8 +569,8 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       trueProp: jsxAttributeValue(true),
       falseProp: jsxAttributeValue(false),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -693,18 +581,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      right(
-        parseSuccess(
-          imports,
-          [exported],
-          right(defaultCanvasMetadata()),
-          false,
-          code,
-          expect.objectContaining({}),
-          null,
-          null,
-        ),
-      ),
+      right(parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null)),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -757,8 +634,8 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         }),
       ),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const jsCode = `function getSizing(n) {
   return 100 + n;
@@ -787,8 +664,6 @@ return { getSizing: getSizing, spacing: spacing };`
       parseSuccess(
         imports,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -829,8 +704,8 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -863,8 +738,6 @@ return { getSizing: getSizing };`
       parseSuccess(
         imports,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -910,8 +783,8 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -955,8 +828,6 @@ return { getSizing: getSizing };`
       parseSuccess(
         imports,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -997,8 +868,8 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -1031,8 +902,6 @@ return {  };`
       parseSuccess(
         imports,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1075,8 +944,8 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const transpiledJSCode = `var spacing = 20;
 return { spacing: spacing };`
@@ -1097,8 +966,6 @@ return { spacing: spacing };`
       parseSuccess(
         imports,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1136,7 +1003,7 @@ export var whatever = (props) => {
         ),
       }),
     }
-    const view = jsxElement('View', viewAttributes, [], null)
+    const view = jsxElement('View', viewAttributes, [])
     const jsCode = `const bgs = ['black', 'grey'];
 const bg = bgs[0];`
     const transpiledJsCode = `var bgs = ['black', 'grey'];
@@ -1166,8 +1033,6 @@ return { bgs: bgs, bg: bg };`
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1207,7 +1072,7 @@ export var whatever = (props) => {
         ),
       ]),
     }
-    const view = jsxElement('View', viewAttributes, [], null)
+    const view = jsxElement('View', viewAttributes, [])
     const jsCode = `const greys = ['lightGrey', 'grey'];`
     const transpiledJsCode = `var greys = ['lightGrey', 'grey'];
 return { greys: greys };`
@@ -1235,8 +1100,6 @@ return { greys: greys };`
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1272,7 +1135,7 @@ export var whatever = (props) => {
         }),
       ),
     }
-    const view = jsxElement('View', viewAttributes, [], null)
+    const view = jsxElement('View', viewAttributes, [])
     const jsCode = `const a = 10;
 const b = 20;`
     const transpiledJsCode = `var a = 10;
@@ -1302,8 +1165,6 @@ return { a: a, b: b };`
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1340,7 +1201,7 @@ export var whatever = (props) => {
         }),
       ),
     }
-    const view = jsxElement('View', viewAttributes, [], null)
+    const view = jsxElement('View', viewAttributes, [])
     const jsCode = `const a = true;
 const b = 10;
 const c = 20;`
@@ -1372,8 +1233,6 @@ return { a: a, b: b, c: c };`
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1418,7 +1277,7 @@ export var whatever = (props) => {
         }),
       ),
     }
-    const view = jsxElement('View', viewAttributes, [], null)
+    const view = jsxElement('View', viewAttributes, [])
     const jsCode = `let a = 10;`
     const transpiledJsCode = `var a = 10;
 return { a: a };`
@@ -1446,8 +1305,6 @@ return { a: a };`
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1483,7 +1340,7 @@ export var whatever = (props) => {
         }),
       ),
     }
-    const view = jsxElement('View', viewAttributes, [], null)
+    const view = jsxElement('View', viewAttributes, [])
     const jsCode = `const a = 10;
 const b = { a: a };`
     const transpiledJsCode = `var a = 10;
@@ -1515,8 +1372,6 @@ return { a: a, b: b };`
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1555,7 +1410,7 @@ export var whatever = (props) => {
         ),
       ]),
     }
-    const view = jsxElement('View', viewAttributes, [], null)
+    const view = jsxElement('View', viewAttributes, [])
     const jsCode = `const bg = { backgroundColor: 'grey' };`
     const transpiledJsCode = `var bg = {
   backgroundColor: 'grey'
@@ -1585,8 +1440,6 @@ return { bg: bg };`
       parseSuccess(
         JustImportViewAndReact,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1628,8 +1481,8 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         }),
       ),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const jsCode = `var count = 10;`
     const transpiledJSCode = `var count = 10;
@@ -1651,8 +1504,6 @@ return { count: count };`
       parseSuccess(
         imports,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1696,8 +1547,8 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const transpiledJSCode = `var use20 = true;
 return { use20: use20 };`
@@ -1718,8 +1569,6 @@ return { use20: use20 };`
       parseSuccess(
         imports,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1745,7 +1594,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [], null)
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const transpiledJSCode = `var mySet = new Set();
 return { mySet: mySet };`
@@ -1765,8 +1614,6 @@ return { mySet: mySet };`
       parseSuccess(
         sampleImportsForTests,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1810,8 +1657,8 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, ['left'], view, null)
     const transpiledJSCode = `var spacing = 20;
 return { spacing: spacing };`
@@ -1832,8 +1679,6 @@ return { spacing: spacing };`
       parseSuccess(
         imports,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1911,16 +1756,14 @@ return { MyComp: MyComp };`
       'data-uid': jsxAttributeValue('aab'),
       layout: jsxAttributeValue({ left: 100 }),
     }
-    const myCompElement = jsxElement('MyComp', myCompAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [myCompElement], null)
+    const myCompElement = jsxElement('MyComp', myCompAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [myCompElement])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const topLevelElements = [MyComp, exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = right(
       parseSuccess(
         sampleImportsForTests,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -1992,7 +1835,7 @@ export var whatever = props => (
       ]),
     }
 
-    const rootDiv = jsxElement('div', rootDivAttributes, [jsxTextBlock('hello')], null)
+    const rootDiv = jsxElement('div', rootDivAttributes, [jsxTextBlock('hello')])
 
     const myComp = utopiaJSXComponent('MyComp', true, defaultPropsParam, ['layout'], rootDiv, null)
 
@@ -2000,8 +1843,8 @@ export var whatever = props => (
       'data-uid': jsxAttributeValue('aab'),
       layout: jsxAttributeValue({ left: 100 }),
     }
-    const myCompElement = jsxElement('MyComp', myCompAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [myCompElement], null)
+    const myCompElement = jsxElement('MyComp', myCompAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [myCompElement])
     const whatever = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const topLevelElements = [myComp, whatever].map(clearTopLevelElementUniqueIDs)
     const expectedResult = clearParseResultUniqueIDs(
@@ -2009,8 +1852,6 @@ export var whatever = props => (
         parseSuccess(
           sampleImportsForTests,
           [...topLevelElements],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -2124,24 +1965,12 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         }),
       },
       [],
-      null,
     )
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, ['color'], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      right(
-        parseSuccess(
-          imports,
-          [exported],
-          right(defaultCanvasMetadata()),
-          false,
-          code,
-          expect.objectContaining({}),
-          null,
-          null,
-        ),
-      ),
+      right(parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null)),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2169,22 +1998,12 @@ export var whatever = <View data-uid={'aaa'}>
         style: jsxAttributeValue({ backgroundColor: 'red' }),
       },
       [],
-      null,
     )
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', false, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = right(
-      parseSuccess(
-        imports,
-        [exported],
-        right(defaultCanvasMetadata()),
-        false,
-        code,
-        expect.objectContaining({}),
-        null,
-        null,
-      ),
+      parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2212,22 +2031,12 @@ export var whatever = <View data-uid={'aaa'}>
         style: jsxAttributeValue({ backgroundColor: 'red' }),
       },
       [],
-      null,
     )
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', false, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = right(
-      parseSuccess(
-        imports,
-        [exported],
-        right({}),
-        false,
-        code,
-        expect.objectContaining({}),
-        null,
-        null,
-      ),
+      parseSuccess(imports, [exported], code, expect.objectContaining({}), null, null),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2251,14 +2060,12 @@ export var App = (props) => <View data-uid={'bbb'}>
       ...jsxArbitraryBlock('', '', 'return undefined', [], null, {}),
       uniqueID: expect.any(String),
     }
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('bbb') }, [emptyBrackets], null)
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('bbb') }, [emptyBrackets])
     const exported = utopiaJSXComponent('App', true, defaultPropsParam, [], view, null)
     const expectedResult = right(
       parseSuccess(
         sampleImportsForTests,
         [exported],
-        right(defaultCanvasMetadata()),
-        false,
         code,
         expect.objectContaining({}),
         null,
@@ -2296,24 +2103,14 @@ export var App = (props) => <View data-uid={'bbb'}>
         name: jsxAttributeValue('test'),
       },
       [],
-      null,
     )
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', false, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
     const actualResult = testParseCode(printedCode)
     const expectedResult = right(
-      parseSuccess(
-        imports,
-        [exported],
-        right(defaultCanvasMetadata()),
-        false,
-        printedCode,
-        expect.objectContaining({}),
-        null,
-        null,
-      ),
+      parseSuccess(imports, [exported], printedCode, expect.objectContaining({}), null, null),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2334,8 +2131,8 @@ export var App = (props) => <View data-uid={'bbb'}>
       right: jsxAttributeValue(20),
       top: jsxAttributeValue(-20),
     }
-    const cake = jsxElement('cake', cakeAttributes, [], null)
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const cake = jsxElement('cake', cakeAttributes, [])
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const jsCode = `function getSizing(n) {
   return 100 + n;
@@ -2371,8 +2168,6 @@ return { getSizing: getSizing, spacing: spacing };`
       parseSuccess(
         imports,
         [...topLevelElements],
-        right(defaultCanvasMetadata()),
-        false,
         printedCode,
         expect.objectContaining({}),
         null,
@@ -2389,29 +2184,17 @@ return { getSizing: getSizing, spacing: spacing };`
         style: jsxAttributeValue({ backgroundColor: 'red' }),
       },
       [],
-      null,
     )
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', false, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
     const actualResult = testParseCode(printedCode)
     const expectedResult = right(
-      parseSuccess(
-        imports,
-        [exported],
-        right(defaultCanvasMetadata()),
-        false,
-        printedCode,
-        expect.objectContaining({}),
-        null,
-        null,
-      ),
+      parseSuccess(imports, [exported], printedCode, expect.objectContaining({}), null, null),
     )
     expect(actualResult).toEqual(expectedResult)
   })
-
-  const canvasMetadata: CanvasMetadataParseResult = right({})
 
   it('parses back and forth as a function, with an arbitrary piece of JavaScript', () => {
     const code = applyPrettier(
@@ -2488,24 +2271,14 @@ export var whatever = props => {
         style: jsxAttributeValue({ backgroundColor: 'red' }),
       },
       [],
-      null,
     )
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [cake], null)
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
     const actualResult = testParseCode(printedCode)
     const expectedResult = right(
-      parseSuccess(
-        imports,
-        [exported],
-        canvasMetadata,
-        false,
-        printedCode,
-        expect.objectContaining({}),
-        null,
-        null,
-      ),
+      parseSuccess(imports, [exported], printedCode, expect.objectContaining({}), null, null),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2521,9 +2294,8 @@ export var whatever = props => {
         undefinedProp: jsxAttributeValue(undefined),
       },
       [],
-      null,
     )
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [cake], null)
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
@@ -2551,8 +2323,6 @@ export var whatever = props => {
         parseSuccess(
           imports,
           [withoutFalseProp],
-          canvasMetadata,
-          false,
           printedCode,
           expect.objectContaining({}),
           null,
@@ -2599,9 +2369,8 @@ export var whatever = props => {
         }),
       },
       [],
-      null,
     )
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake], null)
+    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -2615,16 +2384,7 @@ export var whatever = props => {
     const actualResult = clearParseResultUniqueIDs(testParseCode(printedCode))
     const expectedResult = clearParseResultUniqueIDs(
       right(
-        parseSuccess(
-          imports,
-          [exported],
-          right(defaultCanvasMetadata()),
-          false,
-          printedCode,
-          expect.objectContaining({}),
-          null,
-          null,
-        ),
+        parseSuccess(imports, [exported], printedCode, expect.objectContaining({}), null, null),
       ),
     )
     expect(actualResult).toEqual(expectedResult)
@@ -2733,16 +2493,12 @@ return { test: test };`
                       ),
                     },
                     [],
-                    null,
                   ),
                 ],
-                null,
               ),
               clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
             ),
           ],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -2817,10 +2573,8 @@ return { test: test };`
                   ),
                 },
                 [],
-                null,
               ),
             ],
-            null,
           ),
           arbitraryJSBlock(
             jsCode,
@@ -2847,7 +2601,6 @@ return { test: test };`
               'data-uid': jsxAttributeValue(BakedInStoryboardUID),
             },
             [],
-            null,
           ),
           null,
         ),
@@ -2856,18 +2609,7 @@ return { test: test };`
     const printedCode = printCode(printCodeOptions(false, true, true), imports, components, null)
     const actualResult = clearParseResultUniqueIDs(testParseCode(printedCode))
     const expectedResult = clearParseResultUniqueIDs(
-      right(
-        parseSuccess(
-          imports,
-          components,
-          right(defaultCanvasMetadata()),
-          false,
-          code,
-          expect.objectContaining({}),
-          null,
-          null,
-        ),
-      ),
+      right(parseSuccess(imports, components, code, expect.objectContaining({}), null, null)),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2913,10 +2655,9 @@ export var App = props => {
               version: 3,
               file: 'code.tsx',
             }),
-            { abc: jsxElement('View', { 'data-uid': jsxAttributeValue('abc') }, [], null) },
+            { abc: jsxElement('View', { 'data-uid': jsxAttributeValue('abc') }, []) },
           ),
         ],
-        null,
       ),
       null,
     )
@@ -2925,8 +2666,6 @@ export var App = props => {
         parseSuccess(
           sampleImportsForTests,
           [component],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -2965,7 +2704,6 @@ export var App = props => {
           'data-uid': jsxAttributeValue('aaa'),
         },
         [jsxTextBlock('cake')],
-        null,
       ),
       null,
     )
@@ -2974,8 +2712,6 @@ export var App = props => {
         parseSuccess(
           sampleImportsForTests,
           [component],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -3032,10 +2768,9 @@ export var App = props => {
               version: 3,
               file: 'code.tsx',
             }),
-            { abc: jsxElement('div', { 'data-uid': jsxAttributeValue('abc') }, [], null) },
+            { abc: jsxElement('div', { 'data-uid': jsxAttributeValue('abc') }, []) },
           ),
         ],
-        null,
       ),
       null,
     )
@@ -3044,8 +2779,6 @@ export var App = props => {
         parseSuccess(
           sampleImportsForTests,
           [component],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -3116,12 +2849,10 @@ export var App = props => {
                   'data-uid': jsxAttributeValue('abc'),
                 },
                 [],
-                null,
               ),
             },
           ),
         ],
-        null,
       ),
       null,
     )
@@ -3137,8 +2868,6 @@ export var App = props => {
         parseSuccess(
           sampleImportsForTests,
           [component],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -3204,7 +2933,6 @@ export var App = props => {
         'data-uid': jsxAttributeValue('bbb'),
       },
       [],
-      null,
     )
     const rectangle = jsxElement(
       'Rectangle',
@@ -3214,7 +2942,6 @@ export var App = props => {
         'data-uid': jsxAttributeValue('ccc'),
       },
       [],
-      null,
     )
     const myCustomCompomnent = jsxElement(
       'MyCustomCompomnent',
@@ -3222,7 +2949,6 @@ export var App = props => {
         'data-uid': jsxAttributeValue('ddd'),
       },
       [ellipse, rectangle],
-      null,
     )
     const view = jsxElement(
       'View',
@@ -3232,7 +2958,6 @@ export var App = props => {
         'data-uid': jsxAttributeValue('ggg'),
       },
       [],
-      null,
     )
     const component = utopiaJSXComponent(
       'App',
@@ -3272,7 +2997,6 @@ export var App = props => {
           'data-uid': jsxAttributeValue('aaa'),
         },
         [myCustomCompomnent, view],
-        null,
       ),
       arbitraryJSBlock(
         `const a = 20;
@@ -3301,8 +3025,6 @@ return { a: a, b: b, MyCustomCompomnent: MyCustomCompomnent };`,
         parseSuccess(
           sampleImportsForTests,
           [component],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -3343,7 +3065,6 @@ export var App = props => {
           booleanProperty: jsxAttributeValue(true),
         },
         [],
-        null,
       ),
       null,
     )
@@ -3352,8 +3073,6 @@ export var App = props => {
         parseSuccess(
           sampleImportsForTests,
           [component],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -3385,7 +3104,6 @@ export var whatever = props => {
       'View',
       { 'data-uid': jsxAttributeValue('aaa'), booleanProperty: jsxAttributeValue(true) },
       [],
-      null,
     )
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const actualResult = printCode(
@@ -3418,7 +3136,6 @@ export var whatever = props => {
       'View',
       { 'data-uid': jsxAttributeValue('aaa'), booleanProperty: jsxAttributeValue(false) },
       [],
-      null,
     )
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const actualResult = printCode(
@@ -3477,7 +3194,7 @@ return {  };`
         file: 'code.tsx',
       }),
     )
-    const view = jsxElement('div', { 'data-uid': jsxAttributeValue('aaa') }, [], null)
+    const view = jsxElement('div', { 'data-uid': jsxAttributeValue('aaa') }, [])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -3491,8 +3208,6 @@ return {  };`
         parseSuccess(
           { react: sampleImportsForTests['react'] },
           [exported],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -3559,7 +3274,7 @@ return { result: result };`
       }),
       {},
     )
-    const view = jsxElement('div', { 'data-uid': jsxAttributeValue('aaa') }, [innerBlock], null)
+    const view = jsxElement('div', { 'data-uid': jsxAttributeValue('aaa') }, [innerBlock])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -3573,8 +3288,6 @@ return { result: result };`
         parseSuccess(
           { react: sampleImportsForTests['react'] },
           [exported],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -3631,7 +3344,6 @@ export var whatever = props => {
         ['data-uid']: jsxAttributeValue('bbb'),
       },
       [],
-      null,
     )
     const arbitraryBlock = jsxArbitraryBlock(
       arbitraryBlockOriginalCode,
@@ -3645,15 +3357,13 @@ export var whatever = props => {
       }),
       { bbb: innerElement },
     )
-    const view = jsxElement('div', { 'data-uid': jsxAttributeValue('aaa') }, [arbitraryBlock], null)
+    const view = jsxElement('div', { 'data-uid': jsxAttributeValue('aaa') }, [arbitraryBlock])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const expectedResult = clearParseResultUniqueIDs(
       right(
         parseSuccess(
           { react: sampleImportsForTests['react'] },
           [exported],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -3712,7 +3422,6 @@ export var whatever = props => {
         ['data-uid']: jsxAttributeValue('bbb'),
       },
       [],
-      null,
     )
     const arbitraryBlock = jsxArbitraryBlock(
       arbitraryBlockOriginalCode,
@@ -3740,7 +3449,7 @@ return { a: a };`,
       }),
     )
 
-    const view = jsxElement('div', { 'data-uid': jsxAttributeValue('aaa') }, [arbitraryBlock], null)
+    const view = jsxElement('div', { 'data-uid': jsxAttributeValue('aaa') }, [arbitraryBlock])
     const exported = utopiaJSXComponent(
       'whatever',
       true,
@@ -3754,8 +3463,6 @@ return { a: a };`,
         parseSuccess(
           { react: sampleImportsForTests['react'] },
           [exported],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -3771,15 +3478,13 @@ export var whatever = props => {
   return <svg data-uid={'abc'}/>
 }`
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
-    const view = jsxElement('svg', { 'data-uid': jsxAttributeValue('abc') }, [], null)
+    const view = jsxElement('svg', { 'data-uid': jsxAttributeValue('abc') }, [])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const expectedResult = clearParseResultUniqueIDs(
       right(
         parseSuccess(
           { react: sampleImportsForTests['react'] },
           [exported],
-          right(defaultCanvasMetadata()),
-          false,
           code,
           expect.objectContaining({}),
           null,
@@ -3870,10 +3575,6 @@ import {
   UtopiaUtils,
   View
 } from "utopia-api";
-export var canvasMetadata = {
-  scenes: [],
-  elementMetadata: {}
-};
 
 console.log('hello!') // line 15 char 9
 
@@ -3917,7 +3618,7 @@ export var App = props => {
 
     const position = consumer.getOriginalPosition(transpiledLine, transpiledCharacter)
 
-    expect(position).toEqual(expect.objectContaining({ line: 16, column: 9 }))
+    expect(position).toEqual(expect.objectContaining({ line: 12, column: 9 }))
   })
 
   it('maps an arbitraryJSBlock inside a utopiaJSXComponent', () => {
@@ -3948,7 +3649,7 @@ export var App = props => {
 
     // TODO BALAZS we should test that the code is in col 9, but I just couldn't make it work :(
     // expect(position).toEqual(expect.objectContaining({ line: 22, column: 9 }))
-    expect(position).toEqual(expect.objectContaining({ line: 20 }))
+    expect(position).toEqual(expect.objectContaining({ line: 16 }))
   })
 
   it('maps a jsxAttributeOtherJavaScript correctly', () => {
@@ -3982,7 +3683,7 @@ export var App = props => {
 
     const position = consumer.getOriginalPosition(transpiledLine, transpiledCharacter)
 
-    expect(position).toEqual(expect.objectContaining({ line: 32, column: 26 }))
+    expect(position).toEqual(expect.objectContaining({ line: 28, column: 26 }))
   })
 })
 
@@ -3999,10 +3700,6 @@ describe('getHighlightBounds', () => {
       Text,
       View
     } from "utopia-api";
-    export var canvasMetadata = {
-      scenes: [],
-      elementMetadata: {}
-    };
     
     console.log('hello!') // line 18 char 9
     
@@ -4043,10 +3740,6 @@ describe('lintAndParse', () => {
       Text,
       View
     } from "utopia-api";
-    export var canvasMetadata = {
-      scenes: [],
-      elementMetadata: {}
-    }
     
     export var App = props => {
       const a = 20
@@ -4069,18 +3762,6 @@ describe('Babel transpile', () => {
     const file = `/** @jsx jsx */
 import * as React from 'react'
 import { View, jsx } from 'utopia-api'
-
-export var canvasMetadata = {
-  scenes: [
-    {
-      component: 'App',
-      frame: { height: 812, left: 0, width: 375, top: 0 },
-      props: { layout: { top: 0, left: 0, bottom: 0, right: 0 } },
-      container: { layoutSystem: 'pinSystem' },
-    },
-  ],
-  elementMetadata: {},
-}
 
 export var App = (props) => {
   return (

--- a/editor/src/core/workers/ts/ts-worker.spec.ts
+++ b/editor/src/core/workers/ts/ts-worker.spec.ts
@@ -186,7 +186,6 @@ const SampleInitTSWorkerMessage: IncomingWorkerMessage = {
                   },
                 },
                 children: [],
-                metadata: null,
               },
               arbitraryJSBlock: null,
             },
@@ -214,11 +213,6 @@ const SampleInitTSWorkerMessage: IncomingWorkerMessage = {
               },
             ]),
           ],
-          canvasMetadata: {
-            type: 'RIGHT',
-            value: {},
-          },
-          projectContainedOldSceneMetadata: true,
           code:
             "/** @jsx jsx */\nimport * as React from 'react'\nimport {\n  Ellipse,\n  HelperFunctions,\n  Image,\n  NodeImplementations,\n  Rectangle,\n  Text,\n  View,\n  jsx,\n} from 'utopia-api'\nimport {\n  colorTheme,\n  Button,\n  Dialog,\n  Icn,\n  Icons,\n  LargerIcons,\n  FunctionIcons,\n  MenuIcons,\n  Isolator,\n  TabComponent,\n  Tooltip,\n  ActionSheet,\n  Avatar,\n  ControlledTextArea,\n  Title,\n  H1,\n  H2,\n  H3,\n  Subdued,\n  InspectorSectionHeader,\n  InspectorSubsectionHeader,\n  FlexColumn,\n  FlexRow,\n  ResizableFlexColumn,\n  PopupList,\n  Section,\n  TitledSection,\n  SectionTitleRow,\n  SectionBodyArea,\n  UtopiaListSelect,\n  UtopiaListItem,\n  CheckboxInput,\n  NumberInput,\n  StringInput,\n  OnClickOutsideHOC,\n} from 'uuiui'\n\nexport var canvasMetadata = {\n  scenes: [\n    {\n      component: 'App',\n      frame: { height: 812, left: 0, width: 375, top: 0 },\n      props: { layout: { top: 0, left: 0, bottom: 0, right: 0 } },\n      container: { layoutSystem: 'pinSystem' },\n    },\n  ],\n  elementMetadata: {},\n}\n\nexport var App = (props) => {\n  return (\n    <View\n      style={{ ...props.style, backgroundColor: colorTheme.white.value }}\n      layout={{ layoutSystem: 'pinSystem' }}\n      data-uid={'aaa'}\n    ></View>\n  )\n}\n\n",
           highlightBounds: {

--- a/editor/src/sample-projects/ui-builder-ui-js-file.ts
+++ b/editor/src/sample-projects/ui-builder-ui-js-file.ts
@@ -73,18 +73,6 @@ import {
   OnClickOutsideHOC,
 } from 'uuiui'
 
-export var canvasMetadata = {
-  scenes: [
-    {
-      component: 'App',
-      frame: { height: 812, left: 0, width: 375, top: 0 },
-      props: { layout: { top: 0, left: 0, bottom: 0, right: 0 } },
-      container: { layoutSystem: 'pinSystem' },
-    },
-  ],
-  elementMetadata: {},
-}
-
 export var App = (props) => {
   return (
     <View

--- a/editor/src/utils/test-utils.ts
+++ b/editor/src/utils/test-utils.ts
@@ -71,18 +71,7 @@ export function createPersistentModel(): PersistentModel {
     ...createEditorState(NO_OP),
     projectContents: contentsToTree({
       '/src/app.js': uiJsFile(
-        right(
-          parseSuccess(
-            sampleImportsForTests,
-            sampleJsxComponentWithScene,
-            right({}),
-            true,
-            '',
-            {},
-            null,
-            null,
-          ),
-        ),
+        right(parseSuccess(sampleImportsForTests, sampleJsxComponentWithScene, '', {}, null, null)),
         null,
         RevisionsState.BothMatch,
         0,
@@ -112,18 +101,7 @@ export function createEditorStates(
     projectContents: contentsToTree({
       '/package.json': codeFile(JSON.stringify(DefaultPackageJson, null, 2), null),
       '/src/app.js': uiJsFile(
-        right(
-          parseSuccess(
-            sampleImportsForTests,
-            sampleJsxComponentWithScene,
-            right({}),
-            true,
-            '',
-            {},
-            null,
-            null,
-          ),
-        ),
+        right(parseSuccess(sampleImportsForTests, sampleJsxComponentWithScene, '', {}, null, null)),
         null,
         RevisionsState.BothMatch,
         0,


### PR DESCRIPTION
**Problem:**
We still had a bunch of unused canvas metadata fields kicking around.

**Fix:**
The unused canvas metadata fields, types and functions were all removed.

**Commit Details:**
- Primarily removed the types `CanvasMetadata`, `ElementCanvasMetadata`,
  `CanvasMetadataParseResult` and `CanvasElementMetadataMap`.
- Removed `metadata` field from `JSXElement`.
- Removed `canvasMetadata` and `projectContainedOldSceneMetadata`
  fields from `ParseSuccess`.
- Renamed `canvas-metadata-parser.ts` to `json-to-expression.ts` to
  represent what it now does.
- Refactored away the fields that used to be passed into functions
  like `jsxElement`.
