### PR TITLE
experiment/insertion-plus-button-1

### DIFF
--- a/editor/src/components/canvas/controls/insertion-plus-button.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.tsx
@@ -1,0 +1,239 @@
+import { ControlProps } from './new-canvas-controls'
+import * as React from 'react'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import * as TP from '../../../core/shared/template-path'
+import { colorTheme } from '../../../uuiui'
+import { useEditorState } from '../../editor/store/store-hook'
+import { insertJSXElement } from '../../editor/actions/actions'
+import { TemplatePath } from '../../../core/shared/project-file-types'
+import { defaultInsertableDivElement } from '../../editor/defaults'
+import uuid = require('uuid')
+import { IndexPosition } from '../../../utils/utils'
+
+const InsertionButtonOffset = 10
+
+interface ButtonControlProps {
+  key: string
+  positionX: number
+  positionY: number
+  lineEndX: number
+  lineEndY: number
+  isHorizontalLine: boolean
+  parentPath: TemplatePath
+  indexPosition: IndexPosition
+}
+
+export const InsertionControls = (props: ControlProps): (JSX.Element | null)[] | null => {
+  if (props.selectedViews.length !== 1) {
+    return null
+  }
+  const selectedView = props.selectedViews[0]
+  const parentPath = TP.parentPath(selectedView)
+  const parentFrame =
+    parentPath != null
+      ? MetadataUtils.getFrameInCanvasCoords(parentPath, props.componentMetadata)
+      : null
+  const parentElement =
+    parentPath != null
+      ? MetadataUtils.getElementByTemplatePathMaybe(props.componentMetadata, parentPath)
+      : null
+  if (parentPath == null || parentFrame == null || parentElement == null) {
+    return null
+  }
+  const children = MetadataUtils.getChildrenHandlingGroups(
+    props.componentMetadata,
+    parentPath,
+    false,
+  )
+  let controlProps: ButtonControlProps[] = []
+  children.forEach((child, index) => {
+    const childFrame = MetadataUtils.getFrameInCanvasCoords(
+      child.templatePath,
+      props.componentMetadata,
+    )
+    if (child.specialSizeMeasurements.position === 'absolute' || childFrame == null) {
+      return
+    }
+    let direction: 'row' | 'column' =
+      child.specialSizeMeasurements.parentLayoutSystem === 'flex'
+        ? parentElement.props?.style?.flexDirection || 'row'
+        : 'column'
+    const positionX =
+      direction == 'column'
+        ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
+        : childFrame.x + childFrame.width + props.canvasOffset.x
+    const positionY =
+      direction == 'column'
+        ? childFrame.y + childFrame.height + props.canvasOffset.y
+        : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
+
+    const lineEndX =
+      direction == 'column'
+        ? parentFrame.x + parentFrame.width + props.canvasOffset.x
+        : childFrame.x + childFrame.width + props.canvasOffset.x
+    const lineEndY =
+      direction == 'column'
+        ? childFrame.y + childFrame.height + props.canvasOffset.y
+        : parentFrame.y + parentFrame.height + props.canvasOffset.y
+    controlProps.push({
+      key: TP.toString(child.templatePath),
+      positionX: positionX,
+      positionY: positionY,
+      lineEndX: lineEndX,
+      lineEndY: lineEndY,
+      isHorizontalLine: direction === 'column',
+      parentPath: parentPath,
+      indexPosition: {
+        type: 'absolute',
+        index: index + 1,
+      },
+    })
+    // first element has a plus button before the element too
+    if (index === 0) {
+      const beforeX =
+        direction == 'column'
+          ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
+          : childFrame.x + props.canvasOffset.x
+      const beforeY =
+        direction == 'column'
+          ? childFrame.y + props.canvasOffset.y
+          : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
+      const beforeLineEndX =
+        direction == 'column'
+          ? parentFrame.x + parentFrame.width + props.canvasOffset.x
+          : childFrame.x + props.canvasOffset.x
+      const beforeLineEndY =
+        direction == 'column'
+          ? childFrame.y + props.canvasOffset.y
+          : parentFrame.y + parentFrame.height + props.canvasOffset.y
+      controlProps.push({
+        key: TP.toString(child.templatePath) + '0',
+        positionX: beforeX,
+        positionY: beforeY,
+        lineEndX: beforeLineEndX,
+        lineEndY: beforeLineEndY,
+        isHorizontalLine: direction === 'column',
+        parentPath: parentPath,
+        indexPosition: {
+          type: 'absolute',
+          index: 0,
+        },
+      })
+    }
+  })
+  return controlProps.map((control) => <InsertionButtonContainer {...control} key={control.key} />)
+}
+
+const InsertionButtonContainer = (props: ButtonControlProps) => {
+  const [plusVisible, setPlusVisible] = React.useState(false)
+
+  const onMouseEnter = () => setPlusVisible(true)
+  const onMouseLeave = () => setPlusVisible(false)
+
+  return (
+    <div
+      key={props.key}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={{
+        position: 'absolute',
+        left: props.positionX,
+        top: props.positionY,
+      }}
+    >
+      {plusVisible ? (
+        <>
+          <Line {...props} />
+          <PlusButton {...props} />
+        </>
+      ) : (
+        <BlueDot {...props} />
+      )}
+    </div>
+  )
+}
+const BlueDotSize = 7
+const BlueDot = (props: ButtonControlProps) => {
+  return (
+    <div
+      style={{
+        marginLeft: -BlueDotSize / 2,
+        marginTop: -BlueDotSize / 2,
+        backgroundColor: 'white',
+        width: BlueDotSize,
+        height: BlueDotSize,
+        borderRadius: '50%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div
+        style={{
+          width: BlueDotSize - 2,
+          height: BlueDotSize - 2,
+          backgroundColor: colorTheme.canvasSelectionPrimaryOutline.value,
+          borderRadius: '50%',
+        }}
+      />
+    </div>
+  )
+}
+
+const ButtonSize = 12
+const PlusButton = (props: ButtonControlProps) => {
+  const dispatch = useEditorState((store) => store.dispatch)
+  const { parentPath, indexPosition } = props
+  const insertElement = React.useCallback(() => {
+    dispatch(
+      [insertJSXElement(defaultInsertableDivElement(uuid()), parentPath, {}, indexPosition)],
+      'canvas',
+    )
+  }, [dispatch, parentPath, indexPosition])
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: -ButtonSize / 2,
+        left: -ButtonSize / 2,
+        backgroundColor: 'white',
+        width: ButtonSize,
+        height: ButtonSize,
+        borderRadius: '50%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      onMouseDown={insertElement}
+    >
+      <div
+        style={{
+          width: ButtonSize - 2,
+          height: ButtonSize - 2,
+          backgroundColor: colorTheme.canvasSelectionPrimaryOutline.value,
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <div style={{ color: 'white', fontSize: 10, marginBottom: 2 }}>+</div>
+      </div>
+    </div>
+  )
+}
+
+const Line = (props: ButtonControlProps) => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: -1,
+        left: -1,
+        width: props.isHorizontalLine ? props.lineEndX - props.positionX : 1,
+        height: props.isHorizontalLine ? 1 : props.lineEndY - props.positionY,
+        backgroundColor: colorTheme.canvasSelectionPrimaryOutline.value,
+      }}
+    />
+  )
+}

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -45,6 +45,7 @@ import { fastForEach } from '../../../core/shared/utils'
 import { flatMapArray, uniqBy } from '../../../core/shared/array-utils'
 import { ReorderInsertIndicator } from './reorder-insert-indicator'
 import { FloatingMenu } from './floating-menu'
+import { InsertionControls } from './insertion-plus-button'
 
 export const SnappingThreshold = 5
 
@@ -947,6 +948,10 @@ export class SelectModeControlContainer extends React.Component<
       )
     }
 
+    const insertionControls = isFeatureEnabled('Insertion Plus Button') && (
+      <InsertionControls {...this.props} />
+    )
+
     return (
       <div
         style={{
@@ -989,6 +994,7 @@ export class SelectModeControlContainer extends React.Component<
               }
             })
           : null}
+        {insertionControls}
         {this.props.selectionEnabled ? (
           <>
             <OutlineControls {...this.props} />

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -129,6 +129,7 @@ export interface InsertJSXElement {
   jsxElement: JSXElement
   parent: TemplatePath | null
   importsToAdd: Imports
+  indexPosition?: IndexPosition | null
 }
 
 export type DeleteSelected = {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -1868,7 +1868,7 @@ export const UPDATE_FNS = {
         targetParent,
         action.jsxElement,
         elements,
-        null,
+        action.indexPosition ?? null,
         editor.jsxMetadataKILLME,
       )
 
@@ -4301,12 +4301,14 @@ export function insertJSXElement(
   element: JSXElement,
   parent: TemplatePath | null,
   importsToAdd: Imports,
+  indexPosition?: IndexPosition | null,
 ): InsertJSXElement {
   return {
     action: 'INSERT_JSX_ELEMENT',
     jsxElement: element,
     parent: parent,
     importsToAdd: importsToAdd,
+    indexPosition: indexPosition,
   }
 }
 

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -148,3 +148,19 @@ export function defaultDivElement(uid: string): JSXElement {
     null,
   )
 }
+
+export function defaultInsertableDivElement(uid: string): JSXElement {
+  return jsxElement(
+    jsxElementName('div', []),
+    {
+      style: jsxAttributeValue({
+        backgroundColor: '#0091FFAA',
+        width: 50,
+        height: 50,
+      }),
+      'data-uid': jsxAttributeValue(uid),
+    },
+    [],
+    null,
+  )
+}

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -25,6 +25,7 @@ export type FeatureName =
   | 'Layouttype Outline'
   | 'Floating Menu Warning'
   | 'Mouse Pointer For Layouttype'
+  | 'Insertion Plus Button'
 
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
@@ -50,6 +51,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Layouttype Outline',
   'Floating Menu Warning',
   'Mouse Pointer For Layouttype',
+  'Insertion Plus Button',
 ]
 
 let FeatureSwitches: { [feature: string]: boolean } = {
@@ -76,6 +78,7 @@ let FeatureSwitches: { [feature: string]: boolean } = {
   'Layouttype Outline': true,
   'Floating Menu Warning': true,
   'Mouse Pointer For Layouttype': true,
+  'Insertion Plus Button': true,
 }
 
 function settingKeyForName(featureName: FeatureName): string {


### PR DESCRIPTION
Canvas Experiment

#### How to try it?

Select flex children or flow children, you should see markers on the side of the parent element. On hover the marker becomes a plus sign, clicking on it inserts a new element with a fixed 50x50 size.
The insert controls are not shown for absolute elements and doesn't work well with inline siblings (it works with only 1 span element between divs for example)

Make sure the feature flag `Insertion Plus Button` is enabled.

pizza: https://utopia.pizza/project/57c20d14/?branch_name=experiment/insertion-plus-button-1