### PR TITLE
experiment/text-editing-for-simple-text

### DIFF
--- a/editor/src/components/canvas/controls/insertion-plus-button.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.tsx
@@ -23,7 +23,7 @@ interface ButtonControlProps {
   indexPosition: IndexPosition
 }
 
-export const InsertionControls = (props: ControlProps): (JSX.Element | null)[] | null => {
+export const InsertionControls = (props: ControlProps): JSX.Element | null => {
   if (props.selectedViews.length !== 1) {
     return null
   }
@@ -51,77 +51,77 @@ export const InsertionControls = (props: ControlProps): (JSX.Element | null)[] |
       child.templatePath,
       props.componentMetadata,
     )
-    if (child.specialSizeMeasurements.position === 'absolute' || childFrame == null) {
-      return
-    }
-    let direction: 'row' | 'column' =
-      child.specialSizeMeasurements.parentLayoutSystem === 'flex'
-        ? parentElement.props?.style?.flexDirection || 'row'
-        : 'column'
-    const positionX =
-      direction == 'column'
-        ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
-        : childFrame.x + childFrame.width + props.canvasOffset.x
-    const positionY =
-      direction == 'column'
-        ? childFrame.y + childFrame.height + props.canvasOffset.y
-        : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
-
-    const lineEndX =
-      direction == 'column'
-        ? parentFrame.x + parentFrame.width + props.canvasOffset.x
-        : childFrame.x + childFrame.width + props.canvasOffset.x
-    const lineEndY =
-      direction == 'column'
-        ? childFrame.y + childFrame.height + props.canvasOffset.y
-        : parentFrame.y + parentFrame.height + props.canvasOffset.y
-    controlProps.push({
-      key: TP.toString(child.templatePath),
-      positionX: positionX,
-      positionY: positionY,
-      lineEndX: lineEndX,
-      lineEndY: lineEndY,
-      isHorizontalLine: direction === 'column',
-      parentPath: parentPath,
-      indexPosition: {
-        type: 'absolute',
-        index: index + 1,
-      },
-    })
-    // first element has a plus button before the element too
-    if (index === 0) {
-      const beforeX =
+    if (child.specialSizeMeasurements.position !== 'absolute' && childFrame != null) {
+      let direction: 'row' | 'column' =
+        child.specialSizeMeasurements.parentLayoutSystem === 'flex'
+          ? parentElement.props?.style?.flexDirection || 'row'
+          : 'column'
+      const positionX =
         direction == 'column'
           ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
-          : childFrame.x + props.canvasOffset.x
-      const beforeY =
+          : childFrame.x + childFrame.width + props.canvasOffset.x
+      const positionY =
         direction == 'column'
-          ? childFrame.y + props.canvasOffset.y
+          ? childFrame.y + childFrame.height + props.canvasOffset.y
           : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
-      const beforeLineEndX =
+
+      const lineEndX =
         direction == 'column'
           ? parentFrame.x + parentFrame.width + props.canvasOffset.x
-          : childFrame.x + props.canvasOffset.x
-      const beforeLineEndY =
+          : childFrame.x + childFrame.width + props.canvasOffset.x
+      const lineEndY =
         direction == 'column'
-          ? childFrame.y + props.canvasOffset.y
+          ? childFrame.y + childFrame.height + props.canvasOffset.y
           : parentFrame.y + parentFrame.height + props.canvasOffset.y
       controlProps.push({
-        key: TP.toString(child.templatePath) + '0',
-        positionX: beforeX,
-        positionY: beforeY,
-        lineEndX: beforeLineEndX,
-        lineEndY: beforeLineEndY,
+        key: TP.toString(child.templatePath),
+        positionX: positionX,
+        positionY: positionY,
+        lineEndX: lineEndX,
+        lineEndY: lineEndY,
         isHorizontalLine: direction === 'column',
         parentPath: parentPath,
         indexPosition: {
           type: 'absolute',
-          index: 0,
+          index: index + 1,
         },
       })
+    
+      // first element has a plus button before the element too
+      if (index === 0) {
+        const beforeX =
+          direction == 'column'
+            ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
+            : childFrame.x + props.canvasOffset.x
+        const beforeY =
+          direction == 'column'
+            ? childFrame.y + props.canvasOffset.y
+            : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
+        const beforeLineEndX =
+          direction == 'column'
+            ? parentFrame.x + parentFrame.width + props.canvasOffset.x
+            : childFrame.x + props.canvasOffset.x
+        const beforeLineEndY =
+          direction == 'column'
+            ? childFrame.y + props.canvasOffset.y
+            : parentFrame.y + parentFrame.height + props.canvasOffset.y
+        controlProps.push({
+          key: TP.toString(child.templatePath) + '0',
+          positionX: beforeX,
+          positionY: beforeY,
+          lineEndX: beforeLineEndX,
+          lineEndY: beforeLineEndY,
+          isHorizontalLine: direction === 'column',
+          parentPath: parentPath,
+          indexPosition: {
+            type: 'absolute',
+            index: 0,
+          },
+        })
+      }
     }
   })
-  return controlProps.map((control) => <InsertionButtonContainer {...control} key={control.key} />)
+  return <>{controlProps.map((control) => <InsertionButtonContainer {...control} key={control.key} />)}</>
 }
 
 const InsertionButtonContainer = (props: ButtonControlProps) => {

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -52,6 +52,7 @@ import { KeysPressed } from '../../../utils/keyboard'
 import { LayoutTargetableProp } from '../../../core/layout/layout-helpers-new'
 import utils from '../../../utils/utils'
 import useSize from '@react-hook/size'
+import { TextEditingArea } from './text-editing-input-area'
 
 export type ResizeStatus = 'disabled' | 'noninteractive' | 'enabled'
 
@@ -684,6 +685,7 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
       {renderHighlightControls()}
       {textEditor}
       {isFeatureEnabled('Toolbar For Controls') ? renderToolbar() : null}
+      {isFeatureEnabled('Edit Simple Text') ? <TextEditingArea /> : null}
     </div>
   )
 }

--- a/editor/src/components/canvas/controls/text-editing-input-area.tsx
+++ b/editor/src/components/canvas/controls/text-editing-input-area.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react'
+import { colorTheme } from '../../../uuiui'
+import { EditorDispatch } from '../../editor/action-types'
+import { useEditorState } from '../../editor/store/store-hook'
+import * as TP from '../../../core/shared/template-path'
+import { TemplatePath } from '../../../core/shared/project-file-types'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { isRight } from '../../../core/shared/either'
+import { isJSXElement, JSXTextBlock } from '../../../core/shared/element-template'
+import { updateSimpleTextChild } from '../../editor/actions/actions'
+
+interface TextInputProps {
+  dispatch: EditorDispatch
+  simpleText: string
+  disabled: boolean
+  target: TemplatePath | null
+}
+
+export const TextEditingArea = () => {
+  const { selectedViews, componentMetadata } = useEditorState((store) => ({
+    selectedViews: store.editor.selectedViews,
+    componentMetadata: store.editor.jsxMetadataKILLME,
+  }))
+  const dispatch = useEditorState((store) => store.dispatch)
+  let textBlock: JSXTextBlock | null = null
+  let target: TemplatePath | null = null
+  let disabled = false
+  if (selectedViews.length === 1) {
+    target = selectedViews[0]
+    const element = MetadataUtils.getElementByTemplatePathMaybe(componentMetadata, target)
+    if (element != null && isRight(element.element) && isJSXElement(element.element.value)) {
+      if (element.element.value.children.length === 1) {
+        if (element.element.value.children[0].type === 'JSX_TEXT_BLOCK') {
+          textBlock = element.element.value.children[0]
+        }
+      }
+      if (element.element.value.children.length > 1) {
+        target = null
+        disabled = true
+      }
+    }
+  } else {
+    disabled = true
+  }
+  const simpleText = (textBlock as any)?.text ?? ''
+  return (
+    <TextEditingInputArea
+      key={(target && TP.toString(target)) ?? 'simpletext'}
+      target={target}
+      simpleText={simpleText}
+      disabled={disabled}
+      dispatch={dispatch}
+    />
+  )
+}
+
+const TextEditingInputArea = (props: TextInputProps) => {
+  const { dispatch, target } = props
+  const onChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (target != null && TP.isInstancePath(target)) {
+        dispatch([updateSimpleTextChild(target, event.target.value)], 'canvas')
+      }
+    },
+    [dispatch, target],
+  )
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        width: '100%',
+        height: 20,
+        backgroundColor: colorTheme.inspectorBackground.value,
+      }}
+    >
+      <input
+        type='text'
+        style={{
+          padding: '0px',
+          border: '0px',
+          width: '100%',
+          height: '100%',
+          backgroundColor: 'white',
+        }}
+        onChange={onChange}
+        value={props.simpleText}
+        disabled={props.disabled}
+      />
+    </div>
+  )
+}

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -132,6 +132,12 @@ export interface InsertJSXElement {
   indexPosition?: IndexPosition | null
 }
 
+export interface UpdateSimpleTextChild {
+  action: 'UPDATE_SIMPLE_TEXT_CHILD'
+  target: InstancePath
+  value: string
+}
+
 export type DeleteSelected = {
   action: 'DELETE_SELECTED'
 }
@@ -897,6 +903,7 @@ export type EditorAction =
   | SetShortcut
   | UpdatePropertyControlsInfo
   | PropertyControlsIFrameReady
+  | UpdateSimpleTextChild
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -138,6 +138,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_PACKAGE_JSON':
     case 'FINISH_CHECKPOINT_TIMER':
     case 'ADD_MISSING_DIMENSIONS':
+    case 'UPDATE_SIMPLE_TEXT_CHILD':
       return false
     case 'SAVE_ASSET':
       return (

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -60,6 +60,7 @@ import {
   isJSXAttributeOtherJavaScript,
   SettableLayoutSystem,
   walkElements,
+  jsxTextBlock,
 } from '../../../core/shared/element-template'
 import {
   generateUidWithExistingComponents,
@@ -346,6 +347,7 @@ import {
   SetShortcut,
   UpdatePropertyControlsInfo,
   PropertyControlsIFrameReady,
+  UpdateSimpleTextChild,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -4098,6 +4100,29 @@ export const UPDATE_FNS = {
     setPropertyControlsIFrameReady(true)
     return editor
   },
+  UPDATE_SIMPLE_TEXT_CHILD: (action: UpdateSimpleTextChild, editor: EditorModel): EditorModel => {
+    return modifyOpenJsxElementAtPath(
+      action.target,
+      (element) => {
+        if (element.children.length === 0 || element.children.length === 1) {
+          if (action.value.trim() === '') {
+            return {
+              ...element,
+              children: [],
+            }
+          } else {
+            return {
+              ...element,
+              children: [jsxTextBlock(action.value)],
+            }
+          }
+        } else {
+          return element
+        }
+      },
+      editor,
+    )
+  },
 }
 
 /** DO NOT USE outside of actions.ts, only exported for testing purposes */
@@ -4309,6 +4334,14 @@ export function insertJSXElement(
     parent: parent,
     importsToAdd: importsToAdd,
     indexPosition: indexPosition,
+  }
+}
+
+export function updateSimpleTextChild(target: InstancePath, value: string): UpdateSimpleTextChild {
+  return {
+    action: 'UPDATE_SIMPLE_TEXT_CHILD',
+    target: target,
+    value: value,
   }
 }
 

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -286,6 +286,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_PROPERTY_CONTROLS_INFO(action, state)
     case 'PROPERTY_CONTROLS_IFRAME_READY':
       return UPDATE_FNS.PROPERTY_CONTROLS_IFRAME_READY(action, state)
+    case 'UPDATE_SIMPLE_TEXT_CHILD':
+      return UPDATE_FNS.UPDATE_SIMPLE_TEXT_CHILD(action, state)
     default:
       return state
   }

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -26,6 +26,7 @@ export type FeatureName =
   | 'Floating Menu Warning'
   | 'Mouse Pointer For Layouttype'
   | 'Insertion Plus Button'
+  | 'Edit Simple Text'
 
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
@@ -52,6 +53,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Floating Menu Warning',
   'Mouse Pointer For Layouttype',
   'Insertion Plus Button',
+  'Edit Simple Text',
 ]
 
 let FeatureSwitches: { [feature: string]: boolean } = {
@@ -79,6 +81,7 @@ let FeatureSwitches: { [feature: string]: boolean } = {
   'Floating Menu Warning': true,
   'Mouse Pointer For Layouttype': true,
   'Insertion Plus Button': true,
+  'Edit Simple Text': true,
 }
 
 function settingKeyForName(featureName: FeatureName): string {


### PR DESCRIPTION
Canvas Experiment

#### How to try it?
With this experiment you should see an input box on the top area of the canvas. When having a span/div element selected that has a simple text OR it's empty you can type text into the input field. If a div has multiple child elements it is non-interactive. Doesn't work with expressions or more complex things.
Uses the feature flag `Edit Simple Text`.

⚠️ It has horrible performance, please type slowly ⚠️

https://utopia.pizza/project/57c20d14/?branch_name=experiment/text-editing-for-simple-text