### PR TITLE
enhanced zustand selectors that can early return

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -214,20 +214,30 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
     return 'enabled'
   }
 
-  const elementsThatRespectLayout = useEditorState((store) => {
-    return flatMapArray((view) => {
-      if (TP.isScenePath(view)) {
-        const scene = MetadataUtils.findSceneByTemplatePath(store.editor.jsxMetadataKILLME, view)
-        if (scene != null) {
-          return [view, ...scene.rootElements.map((e) => e.templatePath)]
+  const elementsThatRespectLayout = useEditorState<TemplatePath[]>(
+    (store, { previousResult, previousState }) => {
+      if (
+        previousState?.editor.jsxMetadataKILLME === store.editor.jsxMetadataKILLME &&
+        previousResult != null
+      ) {
+        // short circuiting
+        return previousResult
+      }
+      return flatMapArray((view) => {
+        if (TP.isScenePath(view)) {
+          const scene = MetadataUtils.findSceneByTemplatePath(store.editor.jsxMetadataKILLME, view)
+          if (scene != null) {
+            return [view, ...scene.rootElements.map((e) => e.templatePath)]
+          } else {
+            return [view]
+          }
         } else {
           return [view]
         }
-      } else {
-        return [view]
-      }
-    }, store.derived.navigatorTargets).filter((view) => targetRespectsLayout(view, store.editor))
-  })
+      }, store.derived.navigatorTargets).filter((view) => targetRespectsLayout(view, store.editor))
+    },
+    'NewCanvasControlsClass elementsThatRespectLayout',
+  )
 
   const renderModeControlContainer = () => {
     const fallbackTransientState = props.derived.canvas.transientState

--- a/editor/src/components/inspector/common/layout-property-path-hooks.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.ts
@@ -290,32 +290,36 @@ export function usePinToggling(): UsePinTogglingResult {
     ),
   )
 
-  const elementFrames = useEditorState((store): ReadonlyArray<Frame> => {
-    const rootComponents = getOpenUtopiaJSXComponentsFromState(store.editor)
+  const elementFrames = useEditorState(
+    (store): ReadonlyArray<Frame> => {
+      const rootComponents = getOpenUtopiaJSXComponentsFromState(store.editor)
 
-    const jsxElements = TP.filterScenes(selectedViewsRef.current).map((path) =>
-      findElementAtPath(path, rootComponents, store.editor.jsxMetadataKILLME),
-    )
+      const jsxElements = TP.filterScenes(selectedViewsRef.current).map((path) =>
+        findElementAtPath(path, rootComponents, store.editor.jsxMetadataKILLME),
+      )
 
-    return jsxElements.map((elem) => {
-      if (elem != null && isJSXElement(elem)) {
-        return AllFramePoints.reduce<Frame>((working, point) => {
-          const layoutProp = pinnedPropForFramePoint(point)
-          const value = getLayoutProperty(layoutProp, right(elem.props))
-          if (isLeft(value)) {
-            return working
-          } else {
-            return {
-              ...working,
-              [point]: value.value,
+      return jsxElements.map((elem) => {
+        if (elem != null && isJSXElement(elem)) {
+          return AllFramePoints.reduce<Frame>((working, point) => {
+            const layoutProp = pinnedPropForFramePoint(point)
+            const value = getLayoutProperty(layoutProp, right(elem.props))
+            if (isLeft(value)) {
+              return working
+            } else {
+              return {
+                ...working,
+                [point]: value.value,
+              }
             }
-          }
-        }, {})
-      } else {
-        return {}
-      }
-    })
-  }, fastDeepEqual)
+          }, {})
+        } else {
+          return {}
+        }
+      })
+    },
+    'usePinToggling',
+    fastDeepEqual,
+  )
 
   const framePins = React.useMemo((): FramePinsInfo => {
     const allHorizontalPoints = HorizontalFramePoints.filter((p) => allPinsMatch(p, elementFrames))


### PR DESCRIPTION
**Problem:**
Some Zustand selectors can be very expensive (sometimes in the 2-3ms range!!!), but they are still cheaper than re-rendering the components. If only there were a way to memoize the selected results.

**Fix:**
Added a second (optional!) parameter to the selector functions that can be used to compare the previous state to the new state, and bail out from recalculating the selector.

**Commit Details:**
- Selectors are now called with a second paramter containing `{ previousState, previousResult}`. if previousState === state, they can just return previousResult
- useEditorState now takes the name of the selector as an optional argument, used for debugging performance.
