### PR TITLE
giving a debug name to every useEditorState selector

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -20,24 +20,27 @@ interface CanvasComponentEntryProps extends CanvasReactErrorCallback {
 export const CanvasComponentEntry = betterReactMemo(
   'CanvasComponentEntry',
   (props: CanvasComponentEntryProps) => {
-    const dispatch = useEditorState((store) => store.dispatch)
+    const dispatch = useEditorState((store) => store.dispatch, 'CanvasComponentEntry dispatch')
     const onDomReport = React.useCallback(
       (elementMetadata: Array<ElementInstanceMetadata>) => {
         dispatch([saveDOMReport(elementMetadata)])
       },
       [dispatch],
     )
-    const { canvasProps } = useEditorState((store) => ({
-      canvasProps: pickUiJsxCanvasProps(
-        store.editor,
-        store.derived,
-        true,
-        onDomReport,
-        props.clearConsoleLogs,
-        props.addToConsoleLogs,
-        store.dispatch,
-      ),
-    }))
+    const { canvasProps } = useEditorState(
+      (store) => ({
+        canvasProps: pickUiJsxCanvasProps(
+          store.editor,
+          store.derived,
+          true,
+          onDomReport,
+          props.clearConsoleLogs,
+          props.addToConsoleLogs,
+          store.dispatch,
+        ),
+      }),
+      'CanvasComponentEntry canvasProps',
+    )
 
     if (canvasProps == null) {
       return null

--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -37,11 +37,14 @@ interface CanvasWrapperComponentProps {
 export const CanvasWrapperComponent = betterReactMemo(
   'CanvasWrapperComponent',
   (props: CanvasWrapperComponentProps) => {
-    const { dispatch, editorState, derivedState } = useEditorState((store) => ({
-      dispatch: store.dispatch,
-      editorState: store.editor,
-      derivedState: store.derived,
-    }))
+    const { dispatch, editorState, derivedState } = useEditorState(
+      (store) => ({
+        dispatch: store.dispatch,
+        editorState: store.editor,
+        derivedState: store.derived,
+      }),
+      'CanvasWrapperComponent',
+    )
 
     const {
       runtimeErrors,
@@ -71,7 +74,7 @@ export const CanvasWrapperComponent = betterReactMemo(
 
     const safeMode = useEditorState((store) => {
       return store.editor.safeMode
-    })
+    }, 'CanvasWrapperComponent safeMode')
 
     return (
       <FlexColumn
@@ -114,16 +117,16 @@ interface ErrorOverlayComponentProps {
 const ErrorOverlayComponent = betterReactMemo(
   'ErrorOverlayComponent',
   (props: ErrorOverlayComponentProps) => {
-    const dispatch = useEditorState((store) => store.dispatch)
+    const dispatch = useEditorState((store) => store.dispatch, 'ErrorOverlayComponent dispatch')
     const utopiaParserErrors = useEditorState((store) => {
       return parseFailureAsErrorMessages(
         getOpenUIJSFileKey(store.editor),
         getOpenUIJSFile(store.editor),
       )
-    })
+    }, 'ErrorOverlayComponent utopiaParserErrors')
     const fatalCodeEditorErrors = useEditorState((store) => {
       return getAllCodeEditorErrors(store.editor, true, true)
-    })
+    }, 'ErrorOverlayComponent fatalCodeEditorErrors')
 
     const lintErrors = fatalCodeEditorErrors.filter((e) => e.source === 'eslint')
     // we start with the lint errors, since those show up the fastest. any subsequent error will go below in the error screen
@@ -147,7 +150,7 @@ const ErrorOverlayComponent = betterReactMemo(
 )
 
 export const SafeModeErrorOverlay = betterReactMemo('SafeModeErrorOverlay', () => {
-  const dispatch = useEditorState((store) => store.dispatch)
+  const dispatch = useEditorState((store) => store.dispatch, 'SafeModeErrorOverlay dispatch')
   const onTryAgain = React.useCallback(() => {
     dispatch([setSafeMode(false)], 'everyone')
   }, [dispatch])

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -72,19 +72,22 @@ interface NewCanvasControlsProps {
 export const NewCanvasControls = betterReactMemo(
   'NewCanvasControls',
   (props: NewCanvasControlsProps) => {
-    const canvasControlProps = useEditorState((store) => ({
-      dispatch: store.dispatch,
-      editor: store.editor,
-      derived: store.derived,
-      canvasOffset: store.editor.canvas.roundedCanvasOffset,
-      animationEnabled:
-        (store.editor.canvas.dragState == null || store.editor.canvas.dragState.start == null) &&
-        store.editor.canvas.animationsEnabled,
+    const canvasControlProps = useEditorState(
+      (store) => ({
+        dispatch: store.dispatch,
+        editor: store.editor,
+        derived: store.derived,
+        canvasOffset: store.editor.canvas.roundedCanvasOffset,
+        animationEnabled:
+          (store.editor.canvas.dragState == null || store.editor.canvas.dragState.start == null) &&
+          store.editor.canvas.animationsEnabled,
 
-      controls: store.derived.canvas.controls,
-      scale: store.editor.canvas.scale,
-      focusedPanel: store.editor.focusedPanel,
-    }))
+        controls: store.derived.canvas.controls,
+        scale: store.editor.canvas.scale,
+        focusedPanel: store.editor.focusedPanel,
+      }),
+      'NewCanvasControls',
+    )
 
     // Somehow this being setup and hooked into the div makes the `onDrop` call
     // work properly in `editor-canvas.ts`. I blame React DnD for this.

--- a/editor/src/components/canvas/controls/size-box-label.tsx
+++ b/editor/src/components/canvas/controls/size-box-label.tsx
@@ -57,7 +57,10 @@ export const SizeBoxLabel = React.memo((props: SizeBoxLabelProps) => {
 })
 
 const ResizeLabel = (props: SizeBoxLabelProps) => {
-  const metadata = useEditorState((state) => state.editor.jsxMetadataKILLME)
+  const metadata = useEditorState(
+    (state) => state.editor.jsxMetadataKILLME,
+    'ResizeLabel jsxMetadataKILLME',
+  )
   const isWidthResize = props.dragState?.edgePosition.x !== 0.5
   const isHeightResize = props.dragState?.edgePosition.y !== 0.5
   const padding = 2 / props.scale

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -95,7 +95,10 @@ function isScene(node: Node): node is HTMLElement {
 
 export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElement> {
   const containerRef = React.useRef<HTMLDivElement>(null)
-  const selectedViews = useEditorState((store) => store.editor.selectedViews)
+  const selectedViews = useEditorState(
+    (store) => store.editor.selectedViews,
+    'useDomWalker selectedViews',
+  )
 
   React.useLayoutEffect(() => {
     if (containerRef.current != null) {

--- a/editor/src/components/canvas/right-menu.tsx
+++ b/editor/src/components/canvas/right-menu.tsx
@@ -101,11 +101,20 @@ interface RightMenuProps {
 }
 
 export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) => {
-  const dispatch = useEditorState((store) => store.dispatch)
-  const interfaceDesigner = useEditorState((store) => store.editor.interfaceDesigner)
+  const dispatch = useEditorState((store) => store.dispatch, 'RightMenu dispatch')
+  const interfaceDesigner = useEditorState(
+    (store) => store.editor.interfaceDesigner,
+    'RightMenu interfaceDesigner',
+  )
 
-  const isRightMenuExpanded = useEditorState((store) => store.editor.rightMenu.expanded)
-  const rightMenuSelectedTab = useEditorState((store) => store.editor.rightMenu.selectedTab)
+  const isRightMenuExpanded = useEditorState(
+    (store) => store.editor.rightMenu.expanded,
+    'RightMenu isRightMenuExpanded',
+  )
+  const rightMenuSelectedTab = useEditorState(
+    (store) => store.editor.rightMenu.selectedTab,
+    'RightMenu rightMenuSelectedTab',
+  )
 
   const isInsertMenuSelected = rightMenuSelectedTab === RightMenuTab.Insert
   const isInspectorSelected = rightMenuSelectedTab === RightMenuTab.Inspector
@@ -116,12 +125,18 @@ export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) =>
     [dispatch],
   )
 
-  const isCanvasLive = useEditorState((store) => isLiveMode(store.editor.mode))
+  const isCanvasLive = useEditorState(
+    (store) => isLiveMode(store.editor.mode),
+    'RightMenu isCanvasLive',
+  )
   const toggleLiveCanvas = React.useCallback(() => dispatch([EditorActions.toggleCanvasIsLive()]), [
     dispatch,
   ])
 
-  const isPreviewPaneVisible = useEditorState((store) => store.editor.preview.visible)
+  const isPreviewPaneVisible = useEditorState(
+    (store) => store.editor.preview.visible,
+    'RightMenu isPreviewPaneVisible',
+  )
   const togglePreviewPaneVisible = React.useCallback(
     () => dispatch([EditorActions.setPanelVisibility('preview', !isPreviewPaneVisible)]),
     [dispatch, isPreviewPaneVisible],
@@ -129,6 +144,7 @@ export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) =>
 
   const isAdditionalControlsVisible = useEditorState(
     (store) => store.editor.interfaceDesigner.additionalControls,
+    'RightMenu isAdditionalControlsVisible',
   )
   const toggleAdditionalControlsVisible = React.useCallback(() => {
     dispatch([EditorActions.toggleInterfaceDesignerAdditionalControls()])
@@ -156,7 +172,7 @@ export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) =>
     onShow(RightMenuTab.Inspector)
   }, [onShow])
 
-  const zoomLevel = useEditorState((store) => store.editor.canvas.scale)
+  const zoomLevel = useEditorState((store) => store.editor.canvas.scale, 'RightMenu zoomLevel')
   const zoomIn = React.useCallback(
     () => dispatch([CanvasActions.zoom(Utils.increaseScale(zoomLevel))]),
     [dispatch, zoomLevel],

--- a/editor/src/components/canvas/split-view-canvas-root.tsx
+++ b/editor/src/components/canvas/split-view-canvas-root.tsx
@@ -33,13 +33,22 @@ interface NumberSize {
 export const SplitViewCanvasRoot = betterReactMemo(
   'SplitViewCanvasRoot',
   (props: SplitViewCanvasRootProps) => {
-    const dispatch = useEditorState((store) => store.dispatch)
-    const interfaceDesigner = useEditorState((store) => store.editor.interfaceDesigner)
+    const dispatch = useEditorState((store) => store.dispatch, 'SplitViewCanvasRoot dispatch')
+    const interfaceDesigner = useEditorState(
+      (store) => store.editor.interfaceDesigner,
+      'SplitViewCanvasRoot interfaceDesigner',
+    )
     const layoutReversed = interfaceDesigner.layoutReversed
 
-    const isRightMenuExpanded = useEditorState((store) => store.editor.rightMenu.expanded)
+    const isRightMenuExpanded = useEditorState(
+      (store) => store.editor.rightMenu.expanded,
+      'SplitViewCanvasRoot isRightMenuExpanded',
+    )
 
-    const rightMenuSelectedTab = useEditorState((store) => store.editor.rightMenu.selectedTab)
+    const rightMenuSelectedTab = useEditorState(
+      (store) => store.editor.rightMenu.selectedTab,
+      'SplitViewCanvasRoot rightMenuSelectedTab',
+    )
     const isInsertMenuSelected = rightMenuSelectedTab === RightMenuTab.Insert
 
     const updateDeltaWidth = React.useCallback(

--- a/editor/src/components/code-editor/script-editor.tsx
+++ b/editor/src/components/code-editor/script-editor.tsx
@@ -230,7 +230,7 @@ export const ScriptEditor = betterReactMemo('ScriptEditor', (props: ScriptEditor
       codeEditorTheme: store.editor.codeEditorTheme,
       selectedViews: store.editor.selectedViews,
     }
-  })
+  }, 'ScriptEditor')
 
   const selectedViewBounds = useKeepReferenceEqualityIfPossible(
     useEditorState((store) => {
@@ -239,7 +239,7 @@ export const ScriptEditor = betterReactMemo('ScriptEditor', (props: ScriptEditor
           getHighlightBoundsForTemplatePath(selectedView, store),
         ),
       )
-    }),
+    }, 'ScriptEditor selectedViewBounds'),
   )
 
   const highlightBounds = useKeepReferenceEqualityIfPossible(
@@ -249,7 +249,7 @@ export const ScriptEditor = betterReactMemo('ScriptEditor', (props: ScriptEditor
           getHighlightBoundsForTemplatePath(highlightedView, store),
         ),
       )
-    }),
+    }, 'ScriptEditor highlightBounds'),
   )
 
   const onHover = React.useCallback(

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -157,12 +157,27 @@ export const EditorComponentInner = betterReactMemo(
       }
     }, [onWindowMouseDown, onWindowKeyDown, onWindowKeyUp, preventDefault])
 
-    const dispatch = useEditorState((store) => store.dispatch)
-    const projectName = useEditorState((store) => store.editor.projectName)
-    const previewVisible = useEditorState((store) => store.editor.preview.visible)
-    const leftMenuExpanded = useEditorState((store) => store.editor.leftMenu.expanded)
-    const leftMenuWidth = useEditorState((store) => store.editor.leftMenu.paneWidth)
-    const saveError = useEditorState((store) => store.editor.saveError)
+    const dispatch = useEditorState((store) => store.dispatch, 'EditorComponentInner dispatch')
+    const projectName = useEditorState(
+      (store) => store.editor.projectName,
+      'EditorComponentInner projectName',
+    )
+    const previewVisible = useEditorState(
+      (store) => store.editor.preview.visible,
+      'EditorComponentInner previewVisible',
+    )
+    const leftMenuExpanded = useEditorState(
+      (store) => store.editor.leftMenu.expanded,
+      'EditorComponentInner leftMenuExpanded',
+    )
+    const leftMenuWidth = useEditorState(
+      (store) => store.editor.leftMenu.paneWidth,
+      'EditorComponentInner leftMenuWidth',
+    )
+    const saveError = useEditorState(
+      (store) => store.editor.saveError,
+      'EditorComponentInner saveError',
+    )
 
     React.useEffect(() => {
       document.title = projectName + ' - Utopia'
@@ -191,8 +206,6 @@ export const EditorComponentInner = betterReactMemo(
       },
       [updateDeltaWidth],
     )
-
-    const canvasIsLive = useEditorState((store) => isLiveMode(store.editor.mode))
 
     const toggleLiveCanvas = React.useCallback(
       () => dispatch([EditorActions.toggleCanvasIsLive()]),
@@ -386,7 +399,7 @@ const ModalComponent = betterReactMemo('ModalComponent', (): React.ReactElement<
       dispatch: store.dispatch,
       modal: store.editor.modal,
     }
-  })
+  }, 'ModalComponent')
   if (modal != null) {
     if (modal.type === 'file-delete') {
       return <ConfirmDeleteDialog dispatch={dispatch} filePath={modal.filePath} />
@@ -509,7 +522,7 @@ const OpenFileEditor = betterReactMemo('OpenFileEditor', () => {
       areReleaseNotesOpen: openEditorTab != null && isReleaseNotesTab(openEditorTab),
       isUserConfigurationOpen: openEditorTab != null && isUserConfigurationTab(openEditorTab),
     }
-  })
+  }, 'OpenFileEditor')
 
   const { runtimeErrors, onRuntimeError, clearRuntimeErrors } = useRuntimeErrors()
   const { consoleLogs, addToConsoleLogs, clearConsoleLogs } = useConsoleLogs()
@@ -546,7 +559,7 @@ OpenFileEditor.displayName = 'OpenFileEditor'
 const CanvasCursorComponent = betterReactMemo('CanvasCursorComponent', () => {
   const cursor = useEditorState((store) => {
     return Utils.defaultIfNull(store.editor.canvas.cursor, getCursorFromDragState(store.editor))
-  })
+  }, 'CanvasCursorComponent')
   return cursor == null ? null : (
     <div
       key='cursor-area'
@@ -563,7 +576,7 @@ const CanvasCursorComponent = betterReactMemo('CanvasCursorComponent', () => {
 })
 
 const ToastRenderer = betterReactMemo('ToastRenderer', () => {
-  const toasts = useEditorState((store) => store.editor.toasts)
+  const toasts = useEditorState((store) => store.editor.toasts, 'ToastRenderer')
 
   return (
     <FlexColumn

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -134,7 +134,7 @@ export const InsertMenu = betterReactMemo('InsertMenu', () => {
       packageStatus: store.editor.nodeModules.packageStatus,
       propertyControlsInfo: store.editor.propertyControlsInfo,
     }
-  })
+  }, 'InsertMenu')
 
   const dependencies = usePossiblyResolvedPackageDependencies()
 

--- a/editor/src/components/editor/notification-bar.tsx
+++ b/editor/src/components/editor/notification-bar.tsx
@@ -24,7 +24,7 @@ export const EditorOfflineBar = betterReactMemo('EditorOfflineBar', () => {
 })
 
 export const LoginStatusBar = betterReactMemo('LoginStatusBar', () => {
-  const loginState = useEditorState((store) => store.userState.loginState)
+  const loginState = useEditorState((store) => store.userState.loginState, 'LoginStatusBar')
 
   const onClickCallback = React.useCallback(() => {
     setRedirectUrl(window.top.location.pathname).then(() => window.top.location.replace(auth0Url))

--- a/editor/src/components/editor/npm-dependency/npm-dependency.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.ts
@@ -353,7 +353,7 @@ export function immediatelyResolvableDependenciesWithEditorRequirements(
 export function usePackageDependencies(): Array<RequestedNpmDependency> {
   const packageJsonFile = useEditorState((store) => {
     return packageJsonFileFromProjectContents(store.editor.projectContents)
-  })
+  }, 'usePackageDependencies')
 
   return React.useMemo(() => {
     if (isCodeFile(packageJsonFile)) {
@@ -368,7 +368,7 @@ export function usePossiblyResolvedPackageDependencies(): Array<PossiblyUnversio
   const basePackageDependencies = usePackageDependencies()
   const files = useEditorState((store) => {
     return store.editor.nodeModules.files
-  })
+  }, 'usePossiblyResolvedPackageDependencies')
   return React.useMemo(() => {
     return resolvedDependencyVersions(basePackageDependencies, files)
   }, [basePackageDependencies, files])

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -18,7 +18,7 @@ type StateSelector<T, U> = (state: T) => U
  */
 export const useEditorState = <U>(
   selector: StateSelector<EditorStore, U>,
-  selectorName?: string,
+  selectorName: string,
   equalityFn = utils.shallowEqual,
 ): U => {
   const context = React.useContext(EditorStateContext)
@@ -35,7 +35,7 @@ const LogSelectorPerformance = !PRODUCTION_ENV && typeof window.performance.mark
 
 function useWrapSelectorInPerformanceMeasureBlock<U>(
   selector: StateSelector<EditorStore, U>,
-  selectorName?: string,
+  selectorName: string,
 ): StateSelector<EditorStore, U> {
   const previousSelectorRef = React.useRef<StateSelector<EditorStore, U>>()
   const previousWrappedSelectorRef = React.useRef<StateSelector<EditorStore, U>>()
@@ -53,7 +53,7 @@ function useWrapSelectorInPerformanceMeasureBlock<U>(
       if (LogSelectorPerformance) {
         window.performance.mark('selector_end')
         window.performance.measure(
-          `Zustand Selector ${selectorName ?? ''}`,
+          `Zustand Selector ${selectorName}`,
           'selector_begin',
           'selector_end',
         )

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -62,7 +62,7 @@ export const ElementContextMenu = betterReactMemo(
   ({ contextMenuInstance }: ElementContextMenuProps) => {
     const { dispatch } = useEditorState((store) => {
       return { dispatch: store.dispatch }
-    })
+    }, 'ElementContextMenu dispatch')
 
     const editorSliceRef = useRefEditorState((store) => {
       return {

--- a/editor/src/components/filebrowser/file-tabs.tsx
+++ b/editor/src/components/filebrowser/file-tabs.tsx
@@ -97,6 +97,7 @@ export const FileTabs = betterReactMemo('FileTabs', () => {
         projectContents: store.editor.projectContents,
       }
     },
+    'FileTabs',
   )
 
   const openFileTypes = useEditorState((store) => {
@@ -117,7 +118,7 @@ export const FileTabs = betterReactMemo('FileTabs', () => {
         return 'ui'
       }
     })
-  })
+  }, 'FileTabs openFileTypes')
 
   const onTabClose = React.useCallback(
     (editorTab: EditorTab) => {

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -130,7 +130,7 @@ export const FileBrowser = betterReactMemo('FileBrowser', () => {
       minimised: store.editor.fileBrowser.minimised,
       focusedPanel: store.editor.focusedPanel,
     }
-  })
+  }, 'FileBrowser')
 
   const toggleMinimised = React.useCallback(() => {
     dispatch([EditorActions.togglePanel('filebrowser')], 'leftpane')
@@ -199,7 +199,7 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
       renamingTarget: store.editor.fileBrowser.renamingTarget,
       openUiFileName: getOpenUIJSFileKey(store.editor),
     }
-  })
+  }, 'FileBrowserItems')
 
   // since useEditorState uses a shallow equality check, we use a separate one to return the entire (string) array of componentUIDs
   // because the generated array keept loosing its reference equality
@@ -208,7 +208,7 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
     return uiFile != null && isParseSuccess(uiFile.fileContents)
       ? getAllUniqueUids(getUtopiaJSXComponentsFromSuccess(uiFile.fileContents.value))
       : []
-  })
+  }, 'FileBrowserItems componentUIDs')
   const componentUIDsWithStableRef = useKeepReferenceEqualityIfPossible(componentUIDs)
 
   const [selectedPath, setSelectedPath] = React.useState(editorSelectedFile)
@@ -318,7 +318,10 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
 const FileBrowserActionSheet = betterReactMemo(
   'FileBrowserActionSheet',
   (props: FileBrowserActionSheetProps) => {
-    const { dispatch } = useEditorState((store) => ({ dispatch: store.dispatch }))
+    const { dispatch } = useEditorState(
+      (store) => ({ dispatch: store.dispatch }),
+      'FileBrowserActionSheet dispatch',
+    )
     const addFolderClick = React.useCallback(
       () => dispatch([EditorActions.addFolder('')], 'everyone'),
       [dispatch],

--- a/editor/src/components/inspector/common/instance-context-menu.tsx
+++ b/editor/src/components/inspector/common/instance-context-menu.tsx
@@ -71,7 +71,7 @@ export const InstanceContextMenu = betterReactMemo(
   ({ contextMenuInstance, propNames }: InstanceContextMenuProps) => {
     const { dispatch } = useEditorState((store) => {
       return { dispatch: store.dispatch }
-    })
+    }, 'InstanceContextMenu')
 
     const { selectedViewsRef } = useInspectorContext()
 

--- a/editor/src/components/inspector/common/layout-property-path-hooks.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.ts
@@ -274,7 +274,7 @@ export interface UsePinTogglingResult {
 }
 
 export function usePinToggling(): UsePinTogglingResult {
-  const dispatch = useEditorState((store) => store.dispatch)
+  const dispatch = useEditorState((store) => store.dispatch, 'usePinToggling dispatch')
   const selectedViewsRef = useRefSelectedViews()
   const jsxMetadataRef = useRefEditorState((store) => {
     return store.editor.jsxMetadataKILLME

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -869,7 +869,7 @@ export function useIsSubSectionVisible(sectionName: string): boolean {
         }
       }
     })
-  })
+  }, 'useIsSubSectionVisible')
 }
 
 const StyleSubSectionForType: { [key: string]: string[] | boolean } = {
@@ -901,7 +901,7 @@ export function useSelectedPropertyControls(
     }
 
     return selectedPropertyControls
-  })
+  }, 'useSelectedPropertyControls')
 
   // Strip ignored property controls here.
   const parsed = parsePropertyControls(propertyControls)
@@ -944,7 +944,7 @@ export function useUsedPropsWithoutControls(): Array<string> {
     })
 
     return components
-  })
+  }, 'useUsedPropsWithoutControls')
 
   return foldEither(
     (_) => [],
@@ -1000,7 +1000,7 @@ export function useUsedPropsWithoutDefaults(): Array<string> {
       }
     })
     return propsUsed
-  })
+  }, 'useUsedPropsWithoutDefaults')
 
   const defaultProps = getDefaultPropsFromParsedControls(parsedPropertyControls)
   return findMissingDefaults(selectedComponentProps, defaultProps)
@@ -1034,7 +1034,7 @@ export function useInspectorWarningStatus(): boolean {
       }
     })
     return hasLayoutInCSSProp
-  })
+  }, 'useInspectorWarningStatus')
 }
 
 export function useSelectedViews() {

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -152,7 +152,7 @@ AlignDistributeButton.displayName = 'AlignDistributeButton'
 const AlignmentButtons = betterReactMemo(
   'AlignmentButtons',
   (props: { numberOfTargets: number }) => {
-    const dispatch = useEditorState((store) => store.dispatch)
+    const dispatch = useEditorState((store) => store.dispatch, 'AlignmentButtons dispatch')
     const alignSelected = React.useCallback(
       (alignment: Alignment) => {
         dispatch([alignSelectedViews(alignment)], 'everyone')
@@ -349,7 +349,7 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
       hasNonDefaultPositionAttributes: hasNonDefaultPositionAttributesInner,
       aspectRatioLocked: aspectRatioLockedInner,
     }
-  })
+  }, 'Inspector')
   const instancePaths = useKeepReferenceEqualityIfPossible(
     selectedViews.filter((view) => !TP.isScenePath(view)) as InstancePath[],
   )
@@ -457,7 +457,7 @@ export const InspectorEntryPoint: React.FunctionComponent = betterReactMemo(
         selectedViews: store.editor.selectedViews,
         jsxMetadataKILLME: store.editor.jsxMetadataKILLME,
       }
-    })
+    }, 'InspectorEntryPoint')
 
     const showSceneInspector =
       selectedViews[0] != null &&
@@ -502,6 +502,7 @@ export const SingleInspectorEntryPoint: React.FunctionComponent<{
         imports: getOpenImportsFromState(store.editor),
       }
     },
+    'SingleInspectorEntryPoint',
   )
 
   let inspectorModel: InspectorModel = {
@@ -789,7 +790,7 @@ export const InspectorContextProvider = betterReactMemo<{
       jsxMetadataKILLME: store.editor.jsxMetadataKILLME,
       rootComponents: getOpenUtopiaJSXComponentsFromState(store.editor),
     }
-  })
+  }, 'InspectorContextProvider')
 
   let newEditedMultiSelectedProps: JSXAttributes[] = []
   let newRealValues: Array<{ [key: string]: any }> = []

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -496,7 +496,7 @@ export const ComponentSectionInner = betterReactMemo(
     const propsUsedWithoutControls = useKeepReferenceEqualityIfPossible(
       useUsedPropsWithoutControls(),
     )
-    const dispatch = useEditorState((state) => state.dispatch)
+    const dispatch = useEditorState((state) => state.dispatch, 'ComponentSectionInner')
     const onResetClicked = React.useCallback(
       (event: React.MouseEvent<HTMLElement>) => {
         dispatch(

--- a/editor/src/components/inspector/sections/header-section/target-selector.tsx
+++ b/editor/src/components/inspector/sections/header-section/target-selector.tsx
@@ -243,9 +243,12 @@ const TargetListItem = betterReactMemo('TargetListItem', (props: TargetListItemP
   const [itemBeingRenamedId, setItemBeingRenamedId] = React.useState<number | null>(null)
   const [renameValue, setRenameValue] = React.useState<string | null>(null)
 
-  const { dispatch } = useEditorState((store) => ({
-    dispatch: store.dispatch,
-  }))
+  const { dispatch } = useEditorState(
+    (store) => ({
+      dispatch: store.dispatch,
+    }),
+    'TargetListItem',
+  )
 
   const startRename = React.useCallback(() => {
     setItemBeingRenamedId(fixedItemIndex)

--- a/editor/src/components/inspector/sections/image-section/image-section.tsx
+++ b/editor/src/components/inspector/sections/image-section/image-section.tsx
@@ -40,7 +40,7 @@ export const ImgSection = betterReactMemo('ImgSection', () => {
         selectedNonSceneViews[0],
       ),
     }
-  })
+  }, 'ImgSection')
   const { naturalWidth, naturalHeight, clientWidth, clientHeight } =
     zerothElementInstanceMetadata?.specialSizeMeasurements ?? emptySpecialSizeMeasurements
   const {

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -67,7 +67,7 @@ function useDefaultedLayoutSystemInfo(): {
 }
 
 function useLayoutSystemData() {
-  const dispatch = useEditorState((store) => store.dispatch)
+  const dispatch = useEditorState((store) => store.dispatch, 'useLayoutSystemData dispatch')
 
   const onLayoutSystemChange = React.useCallback(
     (layoutSystem: SettableLayoutSystem) => {

--- a/editor/src/components/inspector/sections/scene-inspector/scene-container-section.tsx
+++ b/editor/src/components/inspector/sections/scene-inspector/scene-container-section.tsx
@@ -179,13 +179,13 @@ function useSceneType(): InspectorInfo<boolean> {
   )
 }
 
-export function useIsSceneChildWidthHeightPercentage() {
+function useIsSceneChildWidthHeightPercentage() {
   const { selectedViews, metadata } = useEditorState((state) => {
     return {
       selectedViews: state.editor.selectedViews,
       metadata: state.editor.jsxMetadataKILLME,
     }
-  })
+  }, 'useIsSceneChildWidthHeightPercentage')
 
   const selectedScenePath = Utils.forceNotNull(
     'missing scene from scene section',
@@ -200,11 +200,17 @@ export function useIsSceneChildWidthHeightPercentage() {
 }
 
 export const SceneContainerSections = betterReactMemo('SceneContainerSections', () => {
-  const { dispatch, metadata } = useEditorState((store) => ({
-    dispatch: store.dispatch,
-    metadata: store.editor.jsxMetadataKILLME,
-  }))
-  const selectedViews = useEditorState((store) => store.editor.selectedViews)
+  const { dispatch, metadata } = useEditorState(
+    (store) => ({
+      dispatch: store.dispatch,
+      metadata: store.editor.jsxMetadataKILLME,
+    }),
+    'SceneContainerSections',
+  )
+  const selectedViews = useEditorState(
+    (store) => store.editor.selectedViews,
+    'SceneContainerSections selectedViews',
+  )
   const selectedScene = Utils.forceNotNull(
     'Scene cannot be null in SceneContainerSection',
     React.useMemo(() => selectedViews.find(TP.isScenePath), [selectedViews]),

--- a/editor/src/components/inspector/sections/scene-inspector/scene-section.tsx
+++ b/editor/src/components/inspector/sections/scene-inspector/scene-section.tsx
@@ -68,6 +68,7 @@ export const SceneSection = betterReactMemo('SceneSection', () => {
   const frameHeight = useInspectorLayoutInfo('Height')
 
   const sceneTarget = useSceneTarget()
+  // TODO FIXME investigate this useKeepReferenceEqualityIfPossible here, might be expensive!
   const { propertyControlsInfo, components, openFileFullPath } = useKeepReferenceEqualityIfPossible(
     useEditorState((store) => {
       return {
@@ -75,7 +76,7 @@ export const SceneSection = betterReactMemo('SceneSection', () => {
         components: getOpenUtopiaJSXComponentsFromState(store.editor),
         openFileFullPath: getOpenFilename(store.editor),
       }
-    }),
+    }, 'SceneSection'),
   )
 
   const filteredComponents = components.filter(

--- a/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
+++ b/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
@@ -62,16 +62,19 @@ const FeatureSwitchRow = betterReactMemo('Feature Switch Row', (props: { name: F
 })
 
 export const SettingsPanel = (props: any) => {
-  const dispatch = useEditorState((store) => store.dispatch)
-  const interfaceDesigner = useEditorState((store) => store.editor.interfaceDesigner)
+  const dispatch = useEditorState((store) => store.dispatch, 'SettingsPanel dispatch')
+  const interfaceDesigner = useEditorState(
+    (store) => store.editor.interfaceDesigner,
+    'SettingsPanel interfaceDesigner',
+  )
 
   const openUiJsFile = useEditorState((store) => {
     return getOpenUIJSFile(store.editor)
-  })
+  }, 'SettingsPanel openUiJsFile')
 
   const jsxMetadata = useEditorState((store) => {
     return store.editor.jsxMetadataKILLME
-  })
+  }, 'SettingsPanel jsxMetadata')
 
   const toggleCodeEditorVisible = React.useCallback(() => {
     dispatch([EditorActions.toggleInterfaceDesignerCodeEditor()])

--- a/editor/src/components/menubar/menubar.tsx
+++ b/editor/src/components/menubar/menubar.tsx
@@ -95,7 +95,7 @@ export const Menubar = betterReactMemo('Menubar', () => {
       projectName: store.editor.projectName,
       isPreviewPaneVisible: store.editor.preview.visible,
     }
-  })
+  }, 'Menubar')
 
   const onClickTab = React.useCallback(
     (menuTab: LeftMenuTab) => {

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -120,7 +120,7 @@ export const DependencyList = betterReactMemo('DependencyList', () => {
       packageJsonFile: packageJsonFileFromProjectContents(store.editor.projectContents),
       packageStatus: store.editor.nodeModules.packageStatus,
     }
-  })
+  }, 'DependencyList')
 
   const dispatch = props.editorDispatch
 

--- a/editor/src/components/navigator/external-resources/generic-external-resources-list.tsx
+++ b/editor/src/components/navigator/external-resources/generic-external-resources-list.tsx
@@ -66,7 +66,7 @@ export const GenericExternalResourcesList = betterReactMemo('GenericExternalReso
       minimised: store.editor.genericExternalResources.minimised,
       focusedPanel: store.editor.focusedPanel,
     }
-  })
+  }, 'GenericExternalResourcesList')
 
   const toggleMinimised = React.useCallback(() => {
     dispatch([togglePanel('genericExternalResources')], 'leftpane')

--- a/editor/src/components/navigator/external-resources/google-fonts-resources-list.tsx
+++ b/editor/src/components/navigator/external-resources/google-fonts-resources-list.tsx
@@ -16,7 +16,7 @@ export const GoogleFontsResourcesList = betterReactMemo('GoogleFontsResourcesLis
       minimised: store.editor.googleFontsResources.minimised,
       focusedPanel: store.editor.focusedPanel,
     }
-  })
+  }, 'GoogleFontsResourcesList')
 
   const toggleMinimised = React.useCallback(() => {
     dispatch([togglePanel('googleFontsResources')], 'leftpane')

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -267,9 +267,15 @@ export const LeftPaneComponentId = 'left-pane'
 export const LeftPaneOverflowScrollId = 'left-pane-overflow-scroll'
 
 export const LeftPaneComponent = betterReactMemo('LeftPaneComponent', () => {
-  const selectedTab = useEditorState((store) => store.editor.leftMenu.selectedTab)
-  const isValidToShowNavigator = useEditorState((store) => validToShowNavigator(store.editor))
-  const dispatch = useEditorState((store) => store.dispatch)
+  const selectedTab = useEditorState(
+    (store) => store.editor.leftMenu.selectedTab,
+    'LeftPaneComponent selectedTab',
+  )
+  const isValidToShowNavigator = useEditorState(
+    (store) => validToShowNavigator(store.editor),
+    'LeftPaneComponent isValidToShowNavigator',
+  )
+  const dispatch = useEditorState((store) => store.dispatch, 'LeftPaneComponent dispatch')
 
   return (
     <div
@@ -365,7 +371,7 @@ export const InsertMenuPane = betterReactMemo('InsertMenuPane', () => {
       dispatch: store.dispatch,
       focusedPanel: store.editor.focusedPanel,
     }
-  })
+  }, 'InsertMenuPane')
 
   const onFocus = React.useCallback(
     (event: React.FocusEvent<HTMLElement>) => {
@@ -434,7 +440,7 @@ const ProjectSettingsPanel = betterReactMemo('ProjectSettingsPanel', () => {
       minimised: store.editor.projectSettings.minimised,
       codeEditorTheme: store.editor.codeEditorTheme,
     }
-  })
+  }, 'ProjectSettingsPanel')
 
   const toggleMinimised = React.useCallback(() => {
     dispatch([EditorActions.togglePanel('projectsettings')], 'leftpane')

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -130,7 +130,7 @@ export const NavigatorItemWrapper: React.FunctionComponent<NavigatorItemWrapperP
         isElementVisible: !TP.containsPath(props.templatePath, store.editor.hiddenInstances),
         elementWarnings: elementWarningsInner ?? defaultElementWarnings,
       }
-    })
+    }, 'NavigatorItemWrapper')
 
     const childrenOfCollapsedViews = getChildrenOfCollapsedViews(navigatorTargets, collapsedViews)
     const isCollapsed = TP.containsPath(props.templatePath, collapsedViews)

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -63,7 +63,7 @@ export const NavigatorComponent = betterReactMemo('NavigatorComponent', () => {
       minimised: store.editor.navigator.minimised,
       navigatorTargets: store.derived.navigatorTargets,
     }
-  })
+  }, 'NavigatorComponent')
 
   const onFocus = React.useCallback(
     (e: React.FocusEvent<HTMLElement>) => {

--- a/editor/src/components/preview/preview-pane.tsx
+++ b/editor/src/components/preview/preview-pane.tsx
@@ -87,7 +87,7 @@ export const PreviewColumn = betterReactMemo('PreviewColumn', () => {
       connected: store.editor.preview.connected,
       mainJSFilename: getMainJSFilename(store.editor.projectContents),
     }
-  })
+  }, 'PreviewColumn')
   return (
     <PreviewColumnContent
       id={id}

--- a/editor/src/components/user-configuration.tsx
+++ b/editor/src/components/user-configuration.tsx
@@ -31,7 +31,7 @@ export function UserConfiguration() {
       dispatch: store.dispatch,
       shortcutConfig: store.userState.shortcutConfig,
     }
-  })
+  }, 'UserConfiguration')
 
   const [editingIndex, setEditingIndex] = React.useState<number | null>(null)
 

--- a/editor/src/printer-parsers/html/external-resources-parser.tsx
+++ b/editor/src/printer-parsers/html/external-resources-parser.tsx
@@ -446,10 +446,13 @@ export function useExternalResources(): {
   onSubmitValue: OnSubmitValue<ExternalResources>
   useSubmitValueFactory: UseSubmitValueFactory<ExternalResources>
 } {
-  const { dispatch, editorState } = useEditorState((store) => ({
-    editorState: store.editor,
-    dispatch: store.dispatch,
-  }))
+  const { dispatch, editorState } = useEditorState(
+    (store) => ({
+      editorState: store.editor,
+      dispatch: store.dispatch,
+    }),
+    'useExternalResources',
+  )
   const externalResourcesInfo = getExternalResourcesInfo(editorState, dispatch)
   const values: Either<DescriptionParseError, ExternalResources> = isRight(externalResourcesInfo)
     ? right(externalResourcesInfo.value.externalResources)


### PR DESCRIPTION
This PR takes the optional `selectorName` in `useEditorState` and makes it non-optional. This makes debugging selector performance easier, because you don't need to dig into the stack trace to catch a glimpse of the call site (which is both inconvenient, and surprisingly unreliable (I get a lot of `anonymous@anonymous` functions which is not helpful))