### PR TITLE
perf(dom-walker) move regex out from parseCSSNumericTypeString

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -615,14 +615,16 @@ function unitParseFnForType(
 const LeadingSign = String.raw`(?:-?|\+?)`
 const NumericPart = String.raw`(?:\d*\.?\d+|\d+\.?)`
 const UnitPart = String.raw`[a-zA-Z%]*`
+const NumericTypeStringRegex = new RegExp(
+  String.raw`^\s*(${LeadingSign}${NumericPart})\s*(${UnitPart})\s*$`,
+)
 
 function parseCSSNumericTypeString(
   input: string,
   parseUnit: (i: string) => Either<string, CSSNumberUnit>,
   defaultUnit: CSSNumberUnit | null = null,
 ): Either<string, CSSNumber> {
-  const regex = String.raw`^\s*(${LeadingSign}${NumericPart})\s*(${UnitPart})\s*$`
-  const matches = input.match(regex)
+  const matches = input.match(NumericTypeStringRegex)
   if (matches == null) {
     return left(`Unable to parse ${input}`)
   } else {


### PR DESCRIPTION
**Problem:**
The dom walker is slow in some places, one of those is margin/padding parsing. It creates a new regex each time and for every element it is running for all 4 sides for both margin and padding.

**Fix:**
Move the regex to a const outside of the function and changed it to a faster version.
