### PR TITLE
Introduce caching around TemplatePath creation

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3354,6 +3354,10 @@ export const UPDATE_FNS = {
         break
       }
       case 'Model': {
+        // Clear any cached paths since UIDs will have been regenerated and property paths may no longer exist
+        PP.clearPropertyPathCache()
+        TP.clearTemplatePathCache()
+
         // we use the new highlightBounds coming from the action
         code = existing.fileContents.code
         const highlightBounds = getHighlightBoundsFromParseResult(action.file.fileContents.parsed)

--- a/editor/src/core/shared/property-path.ts
+++ b/editor/src/core/shared/property-path.ts
@@ -27,8 +27,13 @@ function emptyPathCache(): PropertyPathCache {
   }
 }
 
-const globalPathStringToPathCache: { [key: string]: PropertyPath } = {}
-const globalPathCache: PropertyPathCache = emptyPathCache()
+let globalPathStringToPathCache: { [key: string]: PropertyPath } = {}
+let globalPathCache: PropertyPathCache = emptyPathCache()
+
+export function clearPropertyPathCache() {
+  globalPathStringToPathCache = {}
+  globalPathCache = emptyPathCache()
+}
 
 function getPathCache(elements: Array<PropertyPathPart>): PropertyPathCache {
   let workingPathCache: PropertyPathCache = globalPathCache

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -51,8 +51,13 @@ function emptyInstancePathCache(): InstancePathCache {
   }
 }
 
-const globalPathStringToPathCache: { [key: string]: TemplatePath } = {}
-const globalScenePathCache: ScenePathCache = emptyScenePathCache()
+let globalPathStringToPathCache: { [key: string]: TemplatePath } = {}
+let globalScenePathCache: ScenePathCache = emptyScenePathCache()
+
+export function clearTemplatePathCache() {
+  globalPathStringToPathCache = {}
+  globalScenePathCache = emptyScenePathCache()
+}
 
 function getScenePathCache(sceneElementPath: StaticElementPath): ScenePathCache {
   let workingPathCache: ScenePathCache = globalScenePathCache

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -21,11 +21,93 @@ export function toVarSafeComponentId(path: TemplatePath): string {
   return replaceAll(asStr, '-', '_')
 }
 
+interface ScenePathCache {
+  cached: ScenePath | null
+  cachedToString: string | null
+  childSceneCaches: { [key: string]: ScenePathCache }
+  childInstanceCaches: { [key: string]: InstancePathCache }
+}
+
+interface InstancePathCache {
+  cached: InstancePath | null
+  cachedToString: string | null
+  childInstanceCaches: { [key: string]: InstancePathCache }
+}
+
+function emptyScenePathCache(): ScenePathCache {
+  return {
+    cached: null,
+    cachedToString: null,
+    childSceneCaches: {},
+    childInstanceCaches: {},
+  }
+}
+
+function emptyInstancePathCache(): InstancePathCache {
+  return {
+    cached: null,
+    cachedToString: null,
+    childInstanceCaches: {},
+  }
+}
+
+const globalPathStringToPathCache: { [key: string]: TemplatePath } = {}
+const globalScenePathCache: ScenePathCache = emptyScenePathCache()
+
+function getScenePathCache(sceneElementPath: StaticElementPath): ScenePathCache {
+  let workingPathCache: ScenePathCache = globalScenePathCache
+  fastForEach(sceneElementPath, (pathPart) => {
+    if (workingPathCache.childSceneCaches[pathPart] == null) {
+      const newCache = emptyScenePathCache()
+      workingPathCache.childSceneCaches[pathPart] = newCache
+      workingPathCache = newCache
+    } else {
+      workingPathCache = workingPathCache.childSceneCaches[pathPart]
+    }
+  })
+  return workingPathCache
+}
+
+function getInstancePathCacheFromScenePathCache(
+  elementPath: ElementPath,
+  startingPoint: ScenePathCache,
+): InstancePathCache {
+  let workingPathCache: InstancePathCache = emptyInstancePathCache()
+  fastForEach(elementPath, (pathPart, index) => {
+    const cacheToReadFrom =
+      index === 0 ? startingPoint.childInstanceCaches : workingPathCache.childInstanceCaches
+
+    if (cacheToReadFrom[pathPart] == null) {
+      const newCache = emptyInstancePathCache()
+      cacheToReadFrom[pathPart] = newCache
+      workingPathCache = newCache
+    } else {
+      workingPathCache = cacheToReadFrom[pathPart]
+    }
+  })
+  return workingPathCache
+}
+
+function getInstancePathCache(
+  sceneElementPath: StaticElementPath,
+  elementPath: ElementPath,
+): InstancePathCache {
+  const scenePathCache = getScenePathCache(sceneElementPath)
+  return getInstancePathCacheFromScenePathCache(elementPath, scenePathCache)
+}
+
 const SceneSeparator = ':'
 const ElementSeparator = '/'
 
 function scenePathToString(path: ScenePath): string {
-  return elementPathToString(path.sceneElementPath)
+  const pathCache = getScenePathCache(path.sceneElementPath)
+  if (pathCache.cachedToString == null) {
+    const result = elementPathToString(path.sceneElementPath)
+    pathCache.cachedToString = result
+    return result
+  } else {
+    return pathCache.cachedToString
+  }
 }
 
 export function elementPathToString(path: ElementPath): string {
@@ -41,7 +123,16 @@ export function elementPathToString(path: ElementPath): string {
 }
 
 function instancePathToString(path: InstancePath): string {
-  return `${scenePathToString(path.scene)}${SceneSeparator}${elementPathToString(path.element)}`
+  const pathCache = getInstancePathCache(path.scene.sceneElementPath, path.element)
+  if (pathCache.cachedToString == null) {
+    const result = `${scenePathToString(path.scene)}${SceneSeparator}${elementPathToString(
+      path.element,
+    )}`
+    pathCache.cachedToString = result
+    return result
+  } else {
+    return pathCache.cachedToString
+  }
 }
 
 export function toString(target: TemplatePath): string {
@@ -52,10 +143,33 @@ export function toString(target: TemplatePath): string {
   }
 }
 
-export function scenePath(elements: ElementPath): ScenePath {
+function newScenePath(elements: StaticElementPath): ScenePath {
   return {
     type: 'scenepath',
-    sceneElementPath: elements as StaticElementPath,
+    sceneElementPath: elements,
+  }
+}
+
+const emptyScenePath: ScenePath = newScenePath(([] as any) as StaticElementPath)
+
+function newInstancePath(scene: ScenePath | ElementPath, elementPath: ElementPath): InstancePath {
+  return {
+    scene: scenePathFromElementPathOrScenePath(scene),
+    element: elementPath,
+  }
+}
+
+const emptyInstancePath: InstancePath = newInstancePath(emptyScenePath, [])
+
+export function scenePath(elements: ElementPath): ScenePath {
+  const staticElements = elements as StaticElementPath
+  const pathCache = getScenePathCache(staticElements)
+  if (pathCache.cached == null) {
+    const newPath = newScenePath(staticElements)
+    pathCache.cached = newPath
+    return newPath
+  } else {
+    return pathCache.cached
   }
 }
 
@@ -71,9 +185,22 @@ export function instancePath(
   scene: ScenePath | ElementPath,
   elementPath: ElementPath,
 ): InstancePath {
-  return {
-    scene: scenePathFromElementPathOrScenePath(scene),
-    element: elementPath,
+  if (isScenePath(scene as ScenePath)) {
+    return newInstancePath(scene, elementPath)
+  } else {
+    const sceneElementPath = scene as StaticElementPath
+    if (sceneElementPath.length === 0 && elementPath.length === 0) {
+      return emptyInstancePath
+    } else {
+      const pathCache = getInstancePathCache(sceneElementPath, elementPath)
+      if (pathCache.cached == null) {
+        const newPath = newInstancePath(sceneElementPath, elementPath)
+        pathCache.cached = newPath
+        return newPath
+      } else {
+        return pathCache.cached
+      }
+    }
   }
 }
 
@@ -81,17 +208,11 @@ export function staticInstancePath(
   scene: ScenePath | ElementPath,
   elementPath: ElementPath,
 ): StaticInstancePath {
-  return {
-    scene: scenePathFromElementPathOrScenePath(scene),
-    element: elementPath as StaticElementPath,
-  }
+  return instancePath(scene, elementPath) as StaticInstancePath
 }
 
 export function asStatic(path: InstancePath): StaticInstancePath {
-  return {
-    scene: path.scene,
-    element: path.element as StaticElementPath,
-  }
+  return path as StaticInstancePath
 }
 
 export function isScenePath(path: TemplatePath): path is ScenePath {
@@ -134,7 +255,7 @@ export function filterScenes(paths: TemplatePath[]): StaticInstancePath | Instan
 
 // FIXME: This should be retired, it's just plain dangerous.
 // Right now this is only used for SpecialNodes (in CanvasMetaData)
-export function fromString(path: string): TemplatePath {
+function fromStringUncached(path: string): TemplatePath {
   const [sceneStr, elementStr] = path.split(SceneSeparator)
   const scene = sceneStr.split(ElementSeparator).filter((e) => e.length > 0)
 
@@ -148,6 +269,17 @@ export function fromString(path: string): TemplatePath {
     } else {
       return scenePath(scene)
     }
+  }
+}
+
+export function fromString(path: string): TemplatePath {
+  let fromPathStringCache = globalPathStringToPathCache[path]
+  if (fromPathStringCache == null) {
+    const result = fromStringUncached(path)
+    globalPathStringToPathCache[path] = result
+    return result
+  } else {
+    return fromPathStringCache
   }
 }
 
@@ -194,10 +326,7 @@ export function instancePathParent(path: InstancePath): TemplatePath {
   if (parentElementPath.length === 0) {
     return path.scene
   } else {
-    return {
-      scene: path.scene,
-      element: parentElementPath,
-    }
+    return instancePath(path.scene, parentElementPath)
   }
 }
 


### PR DESCRIPTION
**Problem:**
We are repeatedly creating new `TemplatePath` s over and over in our editor.

**Fix:**
I have copied the style set out by [`property-path.ts`](https://github.com/concrete-utopia/utopia/blob/master/editor/src/core/shared/property-path.ts) for caching, but adjusted it to support the more complex nature of `TemplatePath` s.
