### PR TITLE
vastly simplify dynamicPathToStaticPath

### DIFF
--- a/editor/src/components/canvas/controls/constraints-control.tsx
+++ b/editor/src/components/canvas/controls/constraints-control.tsx
@@ -17,7 +17,6 @@ export class ConstraintsControls extends React.Component<ConstraintsControlProps
     )
     const anyUnknownElements = MetadataUtils.anyUnknownOrGeneratedElements(
       this.props.rootComponents,
-      this.props.componentMetadata,
       this.props.selectedViews,
     )
     const validResizeDragState =

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -429,10 +429,7 @@ export class InsertModeControlContainer extends React.Component<
     ) {
       const insertionSubject = this.props.mode.subject
       const parent = safeIndex(this.props.highlightedViews, 0) ?? null
-      const staticParent = MetadataUtils.templatePathToStaticTemplatePath(
-        this.props.componentMetadata,
-        parent,
-      )
+      const staticParent = MetadataUtils.templatePathToStaticTemplatePath(parent)
 
       let { element } = this.props.mode.subject
       if (this.isTextInsertion(element, insertionSubject.importsToAdd)) {
@@ -572,10 +569,7 @@ export class InsertModeControlContainer extends React.Component<
         this.props.dragState.start != null
       ) {
         const parent = this.props.highlightedViews[0]
-        const staticParent = MetadataUtils.templatePathToStaticTemplatePath(
-          this.props.componentMetadata,
-          parent,
-        )
+        const staticParent = MetadataUtils.templatePathToStaticTemplatePath(parent)
         let element = this.elementWithDragFrame(insertionSubject.element)
         if (this.isTextInsertion(element, insertionSubject.importsToAdd)) {
           element = this.setTextElementFixedSize(element)

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -249,10 +249,7 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
         componentMetadata,
         selectedView,
       )
-      return (
-        possibleMetadata == null ||
-        MetadataUtils.dynamicPathToStaticPath(componentMetadata, selectedView) == null
-      )
+      return possibleMetadata == null || MetadataUtils.dynamicPathToStaticPath(selectedView) == null
     })
     if (anyIncomprehensibleElementsSelected) {
       return 'disabled'

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -29,7 +29,7 @@ export function getSelectionColor(
     if (MetadataUtils.isComponentInstance(path, rootElements, metadata, imports)) {
       return colorTheme.canvasSelectionInstanceOutline.value
     }
-    const originType = MetadataUtils.getElementOriginType(rootElements, metadata, path)
+    const originType = MetadataUtils.getElementOriginType(rootElements, path)
     if (originType === 'generated-static-definition-present' || originType === 'unknown-element') {
       return colorTheme.canvasSelectionRandomDOMElementInstanceOutline.value
     } else if (createsYogaLayout) {

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -123,11 +123,7 @@ export class SelectModeControlContainer extends React.Component<
     if (
       // Only on left mouse down.
       originalEvent.buttons === 1 &&
-      !MetadataUtils.anyUnknownOrGeneratedElements(
-        this.props.rootComponents,
-        this.props.componentMetadata,
-        selectedViews,
-      )
+      !MetadataUtils.anyUnknownOrGeneratedElements(this.props.rootComponents, selectedViews)
     ) {
       const selection = TP.areAllElementsInSameScene(selectedViews) ? selectedViews : [target]
       const moveTargets = selection.filter(

--- a/editor/src/components/canvas/controls/yoga-control.tsx
+++ b/editor/src/components/canvas/controls/yoga-control.tsx
@@ -116,7 +116,6 @@ export class YogaControls extends React.Component<YogaControlsProps> {
     })
     const unknownElementsSelected = MetadataUtils.anyUnknownOrGeneratedElements(
       this.props.rootComponents,
-      this.props.componentMetadata,
       this.props.selectedViews,
     )
     const showResizeControl =

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -79,13 +79,6 @@ export function renderCoreElement(
       if (originalIDForProps != null) {
         passthroughProps[UTOPIA_ORIGINAL_ID_KEY] = originalIDForProps
       }
-      // const originalParentIDForProps = Utils.defaultIfNull(
-      //   assembledProps[UTOPIA_UID_ORIGINAL_PARENTS_KEY],
-      //   parentComponentInputProps[UTOPIA_UID_ORIGINAL_PARENTS_KEY],
-      // )
-      // if (originalParentIDForProps != null) {
-      //   originalParentIDForProps[UTOPIA_UID_ORIGINAL_PARENTS_KEY] = originalParentIDForProps
-      // }
 
       return renderJSXElement(
         TP.toString(templatePath),

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -34,6 +34,7 @@ import { objectMap } from '../../../core/shared/object-utils'
 import { cssValueOnlyContainsComments } from '../../../printer-parsers/css/css-parser-utils'
 import { filterDataProps } from '../../../utils/canvas-react-utils'
 import { buildSpyWrappedElement } from './ui-jsx-canvas-spy-wrapper'
+import { createIndexedUid } from '../../../core/shared/uid-utils'
 
 export function renderCoreElement(
   element: JSXElementChild,
@@ -78,13 +79,13 @@ export function renderCoreElement(
       if (originalIDForProps != null) {
         passthroughProps[UTOPIA_ORIGINAL_ID_KEY] = originalIDForProps
       }
-      const originalParentIDForProps = Utils.defaultIfNull(
-        assembledProps[UTOPIA_UID_ORIGINAL_PARENTS_KEY],
-        parentComponentInputProps[UTOPIA_UID_ORIGINAL_PARENTS_KEY],
-      )
-      if (originalParentIDForProps != null) {
-        originalParentIDForProps[UTOPIA_UID_ORIGINAL_PARENTS_KEY] = originalParentIDForProps
-      }
+      // const originalParentIDForProps = Utils.defaultIfNull(
+      //   assembledProps[UTOPIA_UID_ORIGINAL_PARENTS_KEY],
+      //   parentComponentInputProps[UTOPIA_UID_ORIGINAL_PARENTS_KEY],
+      // )
+      // if (originalParentIDForProps != null) {
+      //   originalParentIDForProps[UTOPIA_UID_ORIGINAL_PARENTS_KEY] = originalParentIDForProps
+      // }
 
       return renderJSXElement(
         TP.toString(templatePath),
@@ -119,7 +120,7 @@ export function renderCoreElement(
           PP.create([UTOPIA_ORIGINAL_ID_KEY]),
           jsxAttributeValue(innerUID),
         )
-        const generatedUID = `${innerUID}-${innerIndex}`
+        const generatedUID = createIndexedUid(innerUID, innerIndex)
         const withGeneratedUID = flatMapEither(
           (attrs) =>
             setJSXValueAtPath(attrs, PP.create(['data-uid']), jsxAttributeValue(generatedUID)),

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -254,8 +254,8 @@ export const UiJsxCanvas = betterReactMemo(
     } = props
 
     // FIXME This is illegal! The two lines below are triggering a re-render
-    clearConsoleLogs()
-    proxyConsole(console, addToConsoleLogs)
+    // clearConsoleLogs()
+    // proxyConsole(console, addToConsoleLogs)
 
     let metadataContext: UiJsxCanvasContextData = React.useContext(UiJsxCanvasContext)
 

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -254,8 +254,8 @@ export const UiJsxCanvas = betterReactMemo(
     } = props
 
     // FIXME This is illegal! The two lines below are triggering a re-render
-    // clearConsoleLogs()
-    // proxyConsole(console, addToConsoleLogs)
+    clearConsoleLogs()
+    proxyConsole(console, addToConsoleLogs)
 
     let metadataContext: UiJsxCanvasContextData = React.useContext(UiJsxCanvasContext)
 

--- a/editor/src/components/code-editor/script-editor.tsx
+++ b/editor/src/components/code-editor/script-editor.tsx
@@ -106,7 +106,7 @@ function getHighlightBoundsForTemplatePath(path: TemplatePath, store: EditorStor
     if (TP.isInstancePath(path)) {
       const highlightedUID = Utils.optionalMap(
         TP.toUid,
-        MetadataUtils.dynamicPathToStaticPath(store.editor.jsxMetadataKILLME, path),
+        MetadataUtils.dynamicPathToStaticPath(path),
       )
       if (highlightedUID != null) {
         return parseSuccess.highlightBounds[highlightedUID]
@@ -120,7 +120,6 @@ function getTemplatePathsInBounds(
   line: number,
   parsedHighlightBounds: HighlightBoundsForUids | null,
   allTemplatePaths: TemplatePath[],
-  jsxMetadataKILLME: ComponentMetadata[],
 ): TemplatePath[] {
   if (parsedHighlightBounds == null) {
     return []
@@ -139,7 +138,7 @@ function getTemplatePathsInBounds(
     const target = targets[0]
     Utils.fastForEach(allTemplatePaths, (path) => {
       if (TP.isInstancePath(path)) {
-        const staticPath = MetadataUtils.dynamicPathToStaticPath(jsxMetadataKILLME, path)
+        const staticPath = MetadataUtils.dynamicPathToStaticPath(path)
         const uid = staticPath != null ? TP.toUid(staticPath) : null
         if (uid === target) {
           paths.push(path)
@@ -165,14 +164,12 @@ export const ScriptEditor = betterReactMemo('ScriptEditor', (props: ScriptEditor
     openFile,
     cursorPositionFromOpenFile,
     savedCursorPosition,
-    packageJsonFile,
     typeDefinitions,
     lintErrors,
     parserPrinterErrors,
     projectContents,
     parsedHighlightBounds,
     allTemplatePaths,
-    jsxMetadataKILLME,
     focusedPanel,
     codeEditorTheme,
     selectedViews,
@@ -192,7 +189,6 @@ export const ScriptEditor = betterReactMemo('ScriptEditor', (props: ScriptEditor
       cursorPositionFromOpenFile:
         store.editor.selectedFile == null ? null : store.editor.selectedFile.initialCursorPosition,
       savedCursorPosition: openFilePath == null ? null : store.editor.cursorPositions[openFilePath],
-      packageJsonFile: packageJsonFileFromProjectContents(store.editor.projectContents),
       typeDefinitions: getDependencyTypeDefinitions(store.editor.nodeModules.files),
       lintErrors: getAllLintErrors(store.editor),
       parserPrinterErrors: parseFailureAsErrorMessages(openUIJSFileKey, openUIJSFile),
@@ -202,7 +198,6 @@ export const ScriptEditor = betterReactMemo('ScriptEditor', (props: ScriptEditor
           ? openUIJSFile.fileContents.parsed.highlightBounds
           : null,
       allTemplatePaths: store.derived.navigatorTargets,
-      jsxMetadataKILLME: store.editor.jsxMetadataKILLME,
       focusedPanel: store.editor.focusedPanel,
       codeEditorTheme: store.editor.codeEditorTheme,
       selectedViews: store.editor.selectedViews,
@@ -231,33 +226,23 @@ export const ScriptEditor = betterReactMemo('ScriptEditor', (props: ScriptEditor
 
   const onHover = React.useCallback(
     (line: number, column: number) => {
-      const targets = getTemplatePathsInBounds(
-        line,
-        parsedHighlightBounds,
-        allTemplatePaths,
-        jsxMetadataKILLME,
-      )
+      const targets = getTemplatePathsInBounds(line, parsedHighlightBounds, allTemplatePaths)
       if (targets.length > 0) {
         const actions = targets.map((path) => EditorActions.setHighlightedView(path))
         dispatch(actions, 'everyone')
       }
     },
-    [parsedHighlightBounds, allTemplatePaths, jsxMetadataKILLME, dispatch],
+    [parsedHighlightBounds, allTemplatePaths, dispatch],
   )
 
   const onSelect = React.useCallback(
     (line: number, column: number) => {
-      const targets = getTemplatePathsInBounds(
-        line,
-        parsedHighlightBounds,
-        allTemplatePaths,
-        jsxMetadataKILLME,
-      )
+      const targets = getTemplatePathsInBounds(line, parsedHighlightBounds, allTemplatePaths)
       if (targets.length > 0) {
         dispatch([EditorActions.selectComponents(targets, false)], 'everyone')
       }
     },
-    [parsedHighlightBounds, allTemplatePaths, jsxMetadataKILLME, dispatch],
+    [parsedHighlightBounds, allTemplatePaths, dispatch],
   )
 
   const onSave = React.useCallback(

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -1004,14 +1004,13 @@ function deleteElements(targets: TemplatePath[], editor: EditorModel): EditorMod
       } else {
         return modifyOpenParseSuccess((parseSuccess) => {
           const utopiaComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
-          const element = findElementAtPath(target, utopiaComponents, editor.jsxMetadataKILLME)
+          const element = findElementAtPath(target, utopiaComponents)
           if (element == null) {
             return parseSuccess
           } else {
             const withTargetRemoved: Array<UtopiaJSXComponent> = removeElementAtPath(
               target,
               utopiaComponents,
-              editor.jsxMetadataKILLME,
             )
             return modifyParseSuccessWithSimple((success: SimpleParseSuccess) => {
               return {
@@ -1396,7 +1395,7 @@ export const UPDATE_FNS = {
     } else {
       const components = getUtopiaJSXComponentsFromSuccess(openUIJSFile.fileContents.parsed)
       const target = action.element
-      const element = findElementAtPath(target, components, editor.jsxMetadataKILLME)
+      const element = findElementAtPath(target, components)
       if (element == null || !isJSXElement(element)) {
         return editor
       } else {
@@ -1533,7 +1532,6 @@ export const UPDATE_FNS = {
         const components = getOpenUtopiaJSXComponentsFromState(editor)
         const staticSelectedElements = MetadataUtils.staticElementsOnly(
           components,
-          editor.jsxMetadataKILLME,
           editor.selectedViews,
         )
         return deleteElements(staticSelectedElements, editor)
@@ -1571,11 +1569,7 @@ export const UPDATE_FNS = {
       true,
       (editorState) => {
         const components = getOpenUtopiaJSXComponentsFromState(editorState)
-        const staticSelectedElements = MetadataUtils.staticElementsOnly(
-          components,
-          editorState.jsxMetadataKILLME,
-          action.targets,
-        )
+        const staticSelectedElements = MetadataUtils.staticElementsOnly(components, action.targets)
         return deleteElements(staticSelectedElements, editorState)
       },
       dispatch,
@@ -1892,7 +1886,6 @@ export const UPDATE_FNS = {
         action.jsxElement,
         elements,
         null,
-        editor.jsxMetadataKILLME,
       )
 
       const uid = getUtopiaID(action.jsxElement)
@@ -1957,7 +1950,6 @@ export const UPDATE_FNS = {
               elementToInsert,
               utopiaJSXComponents,
               null,
-              editor.jsxMetadataKILLME,
             )
 
             viewPath = TP.appendToPath(parentPath, newUID)
@@ -2335,7 +2327,6 @@ export const UPDATE_FNS = {
     if (targetParent != null) {
       const parentOriginType = MetadataUtils.getElementOriginType(
         getOpenUtopiaJSXComponentsFromState(editor),
-        editor.jsxMetadataKILLME,
         targetParent,
       )
       switch (parentOriginType) {
@@ -2367,13 +2358,7 @@ export const UPDATE_FNS = {
             }
             return addSceneToJSXComponents(accumulator, newSceneElement)
           } else {
-            const components = insertElementAtPath(
-              targetParent,
-              elementToAdd,
-              accumulator,
-              null,
-              editor.jsxMetadataKILLME,
-            )
+            const components = insertElementAtPath(targetParent, elementToAdd, accumulator, null)
             if (targetParent == null || TP.isScenePath(targetParent)) {
               return components
             } else {
@@ -3927,7 +3912,6 @@ export const UPDATE_FNS = {
         const element = findJSXElementAtPath(
           action.target,
           getOpenUtopiaJSXComponentsFromState(editor),
-          editor.jsxMetadataKILLME,
         )
         if (element != null) {
           elementName = getJSXElementNameAsString(element.name)

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -184,7 +184,7 @@ function getTextEditorTarget(editor: EditorState): InstancePath | null {
 
     const components = getOpenUtopiaJSXComponentsFromState(editor)
     const imports = getOpenImportsFromState(editor)
-    const element = findElementAtPath(target, components, editor.jsxMetadataKILLME)
+    const element = findElementAtPath(target, components)
     if (element != null && isUtopiaAPITextElement(element, imports)) {
       return target
     } else {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -725,7 +725,7 @@ export function modifyOpenJsxElementAtPath(
   transform: (element: JSXElement) => JSXElement,
   model: EditorState,
 ): EditorState {
-  const staticPath = MetadataUtils.dynamicPathToStaticPath(model.jsxMetadataKILLME, path)
+  const staticPath = MetadataUtils.dynamicPathToStaticPath(path)
   if (staticPath == null) {
     return model
   } else {
@@ -858,9 +858,8 @@ export function getOpenImportsFromState(model: EditorState): Imports {
 export function removeElementAtPath(
   target: InstancePath,
   components: Array<UtopiaJSXComponent>,
-  metadata: ComponentMetadata[],
 ): Array<UtopiaJSXComponent> {
-  const staticTarget = MetadataUtils.dynamicPathToStaticPath(metadata, target)
+  const staticTarget = MetadataUtils.dynamicPathToStaticPath(target)
   if (staticTarget == null) {
     return components
   } else {
@@ -873,9 +872,8 @@ export function insertElementAtPath(
   elementToInsert: JSXElementChild,
   components: Array<UtopiaJSXComponent>,
   indexPosition: IndexPosition | null,
-  metadata: ComponentMetadata[],
 ): Array<UtopiaJSXComponent> {
-  const staticTarget = MetadataUtils.templatePathToStaticTemplatePath(metadata, targetParent)
+  const staticTarget = MetadataUtils.templatePathToStaticTemplatePath(targetParent)
   return insertJSXElementChild(staticTarget, elementToInsert, components, indexPosition)
 }
 
@@ -883,9 +881,8 @@ export function transformElementAtPath(
   components: Array<UtopiaJSXComponent>,
   target: InstancePath,
   transform: (elem: JSXElement) => JSXElement,
-  metadata: ComponentMetadata[],
 ): Array<UtopiaJSXComponent> {
-  const staticTarget = MetadataUtils.dynamicPathToStaticPath(metadata, target)
+  const staticTarget = MetadataUtils.dynamicPathToStaticPath(target)
   if (staticTarget == null) {
     return components
   } else {
@@ -1286,7 +1283,7 @@ export function deriveState(
         const target = targets[0]
         Utils.fastForEach(componentKeys, (path) => {
           if (isInstancePath(path)) {
-            const staticPath = MetadataUtils.dynamicPathToStaticPath(editor.jsxMetadataKILLME, path)
+            const staticPath = MetadataUtils.dynamicPathToStaticPath(path)
             const uid = staticPath != null ? toUid(staticPath) : null
             if (uid === target) {
               selectedViews.push(path)
@@ -1659,11 +1656,7 @@ export function areGeneratedElementsTargeted(
 ): boolean {
   const components = getOpenUtopiaJSXComponentsFromState(editor)
   return targets.some((target) => {
-    const originType = MetadataUtils.getElementOriginType(
-      components,
-      editor.jsxMetadataKILLME,
-      target,
-    )
+    const originType = MetadataUtils.getElementOriginType(components, target)
     switch (originType) {
       case 'unknown-element':
       case 'generated-static-definition-present':

--- a/editor/src/components/inspector/common/layout-property-path-hooks.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.ts
@@ -295,7 +295,7 @@ export function usePinToggling(): UsePinTogglingResult {
       const rootComponents = getOpenUtopiaJSXComponentsFromState(store.editor)
 
       const jsxElements = TP.filterScenes(selectedViewsRef.current).map((path) =>
-        findElementAtPath(path, rootComponents, store.editor.jsxMetadataKILLME),
+        findElementAtPath(path, rootComponents),
       )
 
       return jsxElements.map((elem) => {

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -842,7 +842,7 @@ export function useIsSubSectionVisible(sectionName: string): boolean {
         return 'scene'
       }
 
-      const element = findElementAtPath(view, rootComponents, store.editor.jsxMetadataKILLME)
+      const element = findElementAtPath(view, rootComponents)
       if (element == null) {
         return null
       } else if (isJSXElement(element)) {
@@ -932,7 +932,7 @@ export function useUsedPropsWithoutControls(): Array<string> {
           forEachOptional(pushComponent, underlyingComponent)
         }
       } else {
-        const element = findElementAtPath(path, rootComponents, jsxMetadataKILLME)
+        const element = findElementAtPath(path, rootComponents)
         if (element != null && isJSXElement(element)) {
           const noPathName = getJSXElementNameNoPathName(element.name)
           const underlyingComponent = rootComponents.find(
@@ -989,7 +989,7 @@ export function useUsedPropsWithoutDefaults(): Array<string> {
           forEachOptional(pushPropsForComponent, underlyingComponent)
         }
       } else {
-        const element = findElementAtPath(path, rootComponents, jsxMetadataKILLME)
+        const element = findElementAtPath(path, rootComponents)
         if (element != null && isJSXElement(element)) {
           const noPathName = getJSXElementNameNoPathName(element.name)
           const underlyingComponent = rootComponents.find(
@@ -1017,7 +1017,7 @@ export function useInspectorWarningStatus(): boolean {
         return
       }
 
-      const element = findElementAtPath(view, rootComponents, store.editor.jsxMetadataKILLME)
+      const element = findElementAtPath(view, rootComponents)
       if (element == null || !isJSXElement(element)) {
         return
       } else {

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -314,11 +314,7 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
         // its own compared to the props.
         aspectRatioLockedInner = aspectRatioLockedInner || isAspectRatioLockedNew(possibleElement)
 
-        const elementOriginType = MetadataUtils.getElementOriginType(
-          rootComponents,
-          rootMetadata,
-          view,
-        )
+        const elementOriginType = MetadataUtils.getElementOriginType(rootComponents, view)
         if (elementOriginType === 'unknown-element') {
           anyUnknownElementsInner = true
         }
@@ -521,11 +517,11 @@ export const SingleInspectorEntryPoint: React.FunctionComponent<{
     // TODO multiselect
     const elementMetadata = MetadataUtils.getElementByInstancePathMaybe(jsxMetadataKILLME, path)
     if (elementMetadata != null) {
-      const jsxElement = findElementAtPath(path, rootComponents, jsxMetadataKILLME)
+      const jsxElement = findElementAtPath(path, rootComponents)
       const parentPath = TP.parentPath(path)
       const parentElement =
         parentPath != null && TP.isInstancePath(parentPath)
-          ? findElementAtPath(parentPath, rootComponents, jsxMetadataKILLME)
+          ? findElementAtPath(parentPath, rootComponents)
           : null
 
       const nonGroupAncestor = MetadataUtils.findNonGroupParent(jsxMetadataKILLME, path)
@@ -815,7 +811,7 @@ export const InspectorContextProvider = betterReactMemo<{
           return
         }
 
-        const jsxElement = findElementAtPath(path, rootComponents, jsxMetadataKILLME)
+        const jsxElement = findElementAtPath(path, rootComponents)
         const jsxAttributes = jsxElement != null && isJSXElement(jsxElement) ? jsxElement.props : {}
         newEditedMultiSelectedProps.push(jsxAttributes)
         newRealValues.push(elementMetadata.props)

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -53,14 +53,9 @@ const navigatorItemWrapperSelectorFactory = (templatePath: TemplatePath) =>
           : fileState.topLevelElementsIncludingScenes.filter(isUtopiaJSXComponent)
       const elementOriginType = MetadataUtils.getElementOriginType(
         componentsIncludingScenes,
-        jsxMetadataKILLME,
         templatePath,
       )
-      const staticName = MetadataUtils.getStaticElementName(
-        templatePath,
-        componentsIncludingScenes,
-        jsxMetadataKILLME,
-      )
+      const staticName = MetadataUtils.getStaticElementName(templatePath, componentsIncludingScenes)
       const labelInner = MetadataUtils.getElementLabel(templatePath, jsxMetadataKILLME, staticName)
       const componentInstanceInner = MetadataUtils.isComponentInstance(
         templatePath,

--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -25,6 +25,12 @@ import {
 import { sampleImportsForTests } from './test-ui-js-file'
 import { BakedInStoryboardUID } from './scene-utils'
 import { TemplatePath } from '../shared/project-file-types'
+import {
+  makeTestProjectCodeWithSnippet,
+  renderTestEditorWithCode,
+  TestScenePath as TestScenePathForTestProject,
+} from '../../components/canvas/ui-jsx-test-utils'
+import { createIndexedUid } from '../shared/uid-utils'
 
 const TestScenePath = 'scene-aaa'
 
@@ -381,5 +387,21 @@ describe('getAllPaths', () => {
       TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View', 'View2', 'View0']),
     ]
     expect(actualResult).toEqual(expectedResult)
+  })
+})
+
+describe('dynamicPathToStaticPath', () => {
+  it('converts a dynamic path to static', async () => {
+    const staticPath = MetadataUtils.dynamicPathToStaticPath(
+      TP.instancePath(TestScenePathForTestProject, ['aaa', createIndexedUid('bbb', 1)]),
+    )
+    expect(staticPath).toEqual(TP.staticInstancePath(TestScenePathForTestProject, ['aaa', 'bbb']))
+  })
+
+  it('finds an already static path all right', async () => {
+    const staticPath = MetadataUtils.dynamicPathToStaticPath(
+      TP.instancePath(TestScenePathForTestProject, ['aaa', 'ccc']),
+    )
+    expect(staticPath).toEqual(TP.staticInstancePath(TestScenePathForTestProject, ['aaa', 'ccc']))
   })
 })

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1061,7 +1061,7 @@ export const MetadataUtils = {
   getJSXElementName(
     path: TemplatePath,
     components: Array<UtopiaJSXComponent>,
-    metadata: ComponentMetadata[], // TODO BEFORE MERGE maybe we could remove metadata as a dependency from here
+    metadata: ComponentMetadata[], // TODO maybe we could remove metadata as a dependency from here if we change findSceneByTemplatePath
   ): JSXElementName | null {
     if (TP.isScenePath(path)) {
       const scene = MetadataUtils.findSceneByTemplatePath(metadata, path)

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -79,6 +79,7 @@ import { isGivenUtopiaAPIElement, isUtopiaAPIComponent } from './project-file-ut
 import { EmptyScenePathForStoryboard } from './scene-utils'
 import { fastForEach } from '../shared/utils'
 import { UTOPIA_ORIGINAL_ID_KEY, UTOPIA_UID_KEY } from './utopia-constants'
+import { extractOriginalUidFromIndexedUid } from '../shared/uid-utils'
 const ObjectPathImmutable: any = OPI
 
 type MergeCandidate = These<ElementInstanceMetadata, ElementInstanceMetadata>
@@ -178,13 +179,12 @@ const ElementsToDrillIntoForTextContent = ['div', 'span']
 export const MetadataUtils = {
   getElementOriginType(
     elements: Array<UtopiaJSXComponent>,
-    metadata: Array<ComponentMetadata>,
     target: TemplatePath,
   ): ElementOriginType {
     if (TP.isScenePath(target)) {
       return 'scene'
     } else {
-      const staticTarget = this.dynamicPathToStaticPath(metadata, target)
+      const staticTarget = this.dynamicPathToStaticPath(target)
       if (staticTarget == null) {
         return 'unknown-element'
       } else {
@@ -203,11 +203,10 @@ export const MetadataUtils = {
   },
   anyUnknownOrGeneratedElements(
     elements: Array<UtopiaJSXComponent>,
-    metadata: Array<ComponentMetadata>,
     targets: Array<TemplatePath>,
   ): boolean {
     return targets.some((target) => {
-      const originType = this.getElementOriginType(elements, metadata, target)
+      const originType = this.getElementOriginType(elements, target)
       return (
         originType === 'unknown-element' || originType === 'generated-static-definition-present'
       )
@@ -412,7 +411,7 @@ export const MetadataUtils = {
       const flexDirection = getReorderDirection(this.getYogaDirection(parentInstance))
 
       if (TP.isInstancePath(target)) {
-        const staticTarget = this.dynamicPathToStaticPath(scenes, target)
+        const staticTarget = this.dynamicPathToStaticPath(target)
         if (staticTarget == null) {
           return {}
         } else {
@@ -551,52 +550,15 @@ export const MetadataUtils = {
       }
     }
   },
-  templatePathToStaticTemplatePath(
-    metadata: Array<ComponentMetadata>,
-    path: TemplatePath | null,
-  ): StaticTemplatePath | null {
+  templatePathToStaticTemplatePath(path: TemplatePath | null): StaticTemplatePath | null {
     if (path == null || TP.isScenePath(path)) {
       return path
     } else {
-      return this.dynamicPathToStaticPath(metadata, path)
+      return this.dynamicPathToStaticPath(path)
     }
   },
-  dynamicPathToStaticPath(
-    metadata: Array<ComponentMetadata>,
-    path: InstancePath,
-  ): StaticInstancePath | null {
-    const metadataAlongPath = this.getElementInstanceMetadataAlongPath(metadata, path)
-    if (metadataAlongPath == null) {
-      return null
-    } else {
-      // FIXME: Not really a fan, but needs must.
-      if (metadataAlongPath.length + 1 === TP.depth(path)) {
-        const scenePath = TP.scenePathForPath(path)
-        const pathElements = traverseEither<ElementInstanceMetadata, id, ElementInstanceMetadata>(
-          (metadataToTransform) => {
-            const staticUID = Utils.defaultIfNull(
-              metadataToTransform.props['data-uid'],
-              metadataToTransform.props[UTOPIA_ORIGINAL_ID_KEY],
-            )
-            // Should really not fall past this case,
-            // but protecting against it nonetheless.
-            if (staticUID == null) {
-              return left(metadataToTransform)
-            } else {
-              return right(staticUID)
-            }
-          },
-          metadataAlongPath,
-        )
-        return eitherToMaybe(
-          mapEither((elems) => {
-            return TP.staticInstancePath(scenePath, elems)
-          }, pathElements),
-        )
-      } else {
-        return TP.asStatic(path)
-      }
-    }
+  dynamicPathToStaticPath(path: InstancePath): StaticInstancePath | null {
+    return TP.staticInstancePath(path.scene, path.element.map(extractOriginalUidFromIndexedUid))
   },
   shiftGroupFrame(
     componentsMetadata: Array<ComponentMetadata>,
@@ -1099,7 +1061,7 @@ export const MetadataUtils = {
   getJSXElementName(
     path: TemplatePath,
     components: Array<UtopiaJSXComponent>,
-    metadata: ComponentMetadata[],
+    metadata: ComponentMetadata[], // TODO BEFORE MERGE maybe we could remove metadata as a dependency from here
   ): JSXElementName | null {
     if (TP.isScenePath(path)) {
       const scene = MetadataUtils.findSceneByTemplatePath(metadata, path)
@@ -1109,7 +1071,7 @@ export const MetadataUtils = {
         return null
       }
     } else {
-      const jsxElement = findElementAtPath(path, components, metadata)
+      const jsxElement = findElementAtPath(path, components)
       if (jsxElement != null) {
         if (isJSXElement(jsxElement)) {
           return jsxElement.name
@@ -1123,7 +1085,7 @@ export const MetadataUtils = {
   getJSXElementBaseName(
     path: TemplatePath,
     components: Array<UtopiaJSXComponent>,
-    metadata: ComponentMetadata[],
+    metadata: ComponentMetadata[], // TODO BEFORE MERGE maybe we could remove metadata as a dependency from here
   ): string | null {
     if (TP.isScenePath(path)) {
       const scene = MetadataUtils.findSceneByTemplatePath(metadata, path)
@@ -1133,7 +1095,7 @@ export const MetadataUtils = {
         return null
       }
     } else {
-      const jsxElement = findElementAtPath(path, components, metadata)
+      const jsxElement = findElementAtPath(path, components)
       if (jsxElement != null) {
         if (isJSXElement(jsxElement)) {
           return jsxElement.name.baseVariable
@@ -1147,7 +1109,7 @@ export const MetadataUtils = {
   getJSXElementTagName(
     path: TemplatePath,
     components: Array<UtopiaJSXComponent>,
-    metadata: ComponentMetadata[],
+    metadata: ComponentMetadata[], // TODO BEFORE MERGE maybe we could remove metadata as a dependency from here
   ): string | null {
     if (TP.isScenePath(path)) {
       const scene = MetadataUtils.findSceneByTemplatePath(metadata, path)
@@ -1157,7 +1119,7 @@ export const MetadataUtils = {
         return null
       }
     } else {
-      const jsxElement = findElementAtPath(path, components, metadata)
+      const jsxElement = findElementAtPath(path, components)
       if (jsxElement != null) {
         if (isJSXElement(jsxElement)) {
           return getJSXElementNameAsString(jsxElement.name)
@@ -1233,11 +1195,10 @@ export const MetadataUtils = {
   },
   staticElementsOnly(
     elements: Array<UtopiaJSXComponent>,
-    rootMetadata: Array<ComponentMetadata>,
     targets: Array<TemplatePath>,
   ): Array<TemplatePath> {
     return targets.filter((target) => {
-      const originType = this.getElementOriginType(elements, rootMetadata, target)
+      const originType = this.getElementOriginType(elements, target)
       return originType === 'statically-defined' || originType === 'scene'
     })
   },
@@ -1397,13 +1358,12 @@ export const MetadataUtils = {
   getStaticElementName(
     path: TemplatePath,
     rootElements: Array<UtopiaJSXComponent>,
-    metadata: ComponentMetadata[],
   ): JSXElementName | null {
     if (TP.isScenePath(path)) {
       return null
     } else {
       // TODO remove dependency on metadata from here
-      const staticPath = MetadataUtils.dynamicPathToStaticPath(metadata, path)
+      const staticPath = MetadataUtils.dynamicPathToStaticPath(path)
       const jsxElement = optionalMap((p) => findJSXElementChildAtPath(rootElements, p), staticPath)
       return optionalMap((element) => (isJSXElement(element) ? element.name : null), jsxElement)
     }
@@ -1417,7 +1377,7 @@ export const MetadataUtils = {
     if (TP.isScenePath(path)) {
       return false
     } else {
-      const elementName = MetadataUtils.getStaticElementName(path, rootElements, metadata)
+      const elementName = MetadataUtils.getStaticElementName(path, rootElements)
       const instanceMetadata = MetadataUtils.getElementByInstancePathMaybe(metadata, path)
       return (
         elementName != null &&
@@ -1511,7 +1471,6 @@ export function convertMetadataMap(
 export function findElementAtPath(
   target: TemplatePath | null,
   components: Array<UtopiaJSXComponent>,
-  metadata: ComponentMetadata[],
 ): JSXElementChild | null {
   if (target == null) {
     return null
@@ -1519,7 +1478,7 @@ export function findElementAtPath(
     if (TP.isScenePath(target)) {
       return null
     } else {
-      const staticTarget = MetadataUtils.dynamicPathToStaticPath(metadata, target)
+      const staticTarget = MetadataUtils.dynamicPathToStaticPath(target)
       if (staticTarget == null) {
         return null
       } else {
@@ -1532,9 +1491,8 @@ export function findElementAtPath(
 export function findJSXElementAtPath(
   target: TemplatePath | null,
   components: Array<UtopiaJSXComponent>,
-  metadata: ComponentMetadata[],
 ): JSXElement | null {
-  const elem = findElementAtPath(target, components, metadata)
+  const elem = findElementAtPath(target, components)
   return Utils.optionalMap((e) => {
     if (isJSXElement(e)) {
       return e

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -59,8 +59,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(595) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(600)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(580) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(585)
   })
 
   it('Changing the selected view', async () => {

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -59,8 +59,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(580) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(585)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(595) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(600)
   })
 
   it('Changing the selected view', async () => {

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -33,6 +33,15 @@ export function generateUID(existingIDs: Array<string>): string {
   return generateUID(existingIDs)
 }
 
+export const GeneratedUIDSeparator = `-`
+export function createIndexedUid(originalUid: string, index: string | number): string {
+  return `${originalUid}${GeneratedUIDSeparator}${index}`
+}
+
+export function extractOriginalUidFromIndexedUid(uid: string): string {
+  return uid.split(GeneratedUIDSeparator)[0]
+}
+
 export function setUtopiaIDOnJSXElement(element: JSXElement, uid: string): JSXElement {
   return {
     ...element,

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -172,7 +172,7 @@ export function createClipboardDataFromSelectionNewWorld(
       const path = createSceneTemplatePath(view)
       return findJSXElementChildAtPath(utopiaComponents, path)
     } else {
-      return findElementAtPath(view, utopiaComponents, editor.jsxMetadataKILLME)
+      return findElementAtPath(view, utopiaComponents)
     }
   })
   return {


### PR DESCRIPTION
**Problem:**
`MetadataUtils.dynamicPathToStaticPath` required the entire jsxMetadataKILLME and performed a fairly costly tree walk to extract the static path for a given dynamic path. This caused `getPropertyControlsForTarget` to take 3ms on the Majestic Broker test project. The problem was mitigated by us keeping the reference equality for jsxMetadataKILLME, but if any change was made on the canvas, this extra 3ms-5ms "penalty" would pile on top of the other necessary extra renders.

**Fix:**
Since the dynamic path element contains the static path element (for example, for the uid `aaa`, the dynamic path element is something like `aaa-1`), this PR uses a string splitting to get the static part of the path.

**Commit Details:**
- Use simple string splitting to get the static path
- `dynamicPathToStaticPath` no longer depends on jsxMetadataKILLME, which means I got to remove jsxMetadataKILLME from a lot of places that only required it to feed it to dynamicPathToStaticPath
