### PR TITLE
fix(Editor) Use rounding and support Maps to improve ref equality

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -20,6 +20,7 @@ import {
   CanvasRectangle,
   LocalPoint,
   localRectangle,
+  roundToNearestHalf,
 } from '../../core/shared/math-utils'
 import {
   CSSNumber,
@@ -119,8 +120,8 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
         const position = getPosition(elementStyle)
 
         const offset = {
-          x: element.offsetLeft,
-          y: element.offsetTop,
+          x: roundToNearestHalf(element.offsetLeft),
+          y: roundToNearestHalf(element.offsetTop),
         } as LocalPoint
 
         const coordinateSystemBounds =
@@ -162,12 +163,12 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
         let naturalWidth: number | null = null
         let naturalHeight: number | null = null
         if (element.tagName === 'IMG') {
-          naturalWidth = (element as HTMLImageElement).naturalWidth
-          naturalHeight = (element as HTMLImageElement).naturalHeight
+          naturalWidth = roundToNearestHalf((element as HTMLImageElement).naturalWidth)
+          naturalHeight = roundToNearestHalf((element as HTMLImageElement).naturalHeight)
         }
 
-        let clientWidth = element.clientWidth
-        let clientHeight = element.clientHeight
+        let clientWidth = roundToNearestHalf(element.clientWidth)
+        let clientHeight = roundToNearestHalf(element.clientHeight)
 
         return specialSizeMeasurements(
           offset,

--- a/editor/src/core/performance/performance-utils.ts
+++ b/editor/src/core/performance/performance-utils.ts
@@ -1,0 +1,10 @@
+export function timeFunction(fnName: string, fn: () => any, iterations: number = 100) {
+  const start = Date.now()
+  for (var i = 0; i < iterations; i++) {
+    fn()
+  }
+  const end = Date.now()
+  const timeTaken = (end - start) / iterations
+  // eslint-disable-next-line no-console
+  console.log(`${fnName} took ${timeTaken}ms`)
+}

--- a/editor/src/core/shared/dom-utils.ts
+++ b/editor/src/core/shared/dom-utils.ts
@@ -1,5 +1,5 @@
 import { ReactDOM } from 'react'
-import { canvasRectangle, CanvasRectangle, scaleRect } from './math-utils'
+import { canvasRectangle, CanvasRectangle, roundToNearestHalf, scaleRect } from './math-utils'
 import { URL_HASH } from '../../common/env-vars'
 
 export const intrinsicHTMLElementNames: Array<keyof ReactDOM> = [
@@ -212,10 +212,10 @@ export function getCanvasRectangleFromElement(
   const scale = canvasScale < 1 ? 1 / canvasScale : 1
   return scaleRect(
     canvasRectangle({
-      x: boundingRect.left,
-      y: boundingRect.top,
-      width: boundingRect.width,
-      height: boundingRect.height,
+      x: roundToNearestHalf(boundingRect.left),
+      y: roundToNearestHalf(boundingRect.top),
+      width: roundToNearestHalf(boundingRect.width),
+      height: roundToNearestHalf(boundingRect.height),
     }),
     scale,
   )

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -191,7 +191,7 @@ export function instancePath(
   elementPath: ElementPath,
 ): InstancePath {
   if (isScenePath(scene as ScenePath)) {
-    return newInstancePath(scene, elementPath)
+    return instancePath((scene as ScenePath).sceneElementPath, elementPath)
   } else {
     const sceneElementPath = scene as StaticElementPath
     if (sceneElementPath.length === 0 && elementPath.length === 0) {

--- a/editor/src/utils/react-performance.ts
+++ b/editor/src/utils/react-performance.ts
@@ -209,6 +209,86 @@ function failSafeMemoEqualityFunction(componentDisplayName: string, severity: 's
   }
 }
 
+function keepDeepReferenceEqualityOfObject(
+  oldObject: any,
+  possibleNewObject: any,
+  stackSizeInner: number,
+  valueStackSoFar: Array<any>,
+): any {
+  const keys = Object.keys(possibleNewObject)
+  const length = keys.length
+
+  let newObjectToReturn: any = {}
+  let canSaveOldObject = true
+
+  const oldKeys = Object.keys(oldObject)
+  if (length !== oldKeys.length) {
+    canSaveOldObject = false
+  }
+
+  for (let i = 0; i < length; i++) {
+    const newKey = keys[i]
+    if (!Object.prototype.hasOwnProperty.call(oldObject, newKey) || newKey !== oldKeys[i]) {
+      canSaveOldObject = false
+    }
+  }
+
+  for (let i = 0; i < length; i++) {
+    const key = keys[i]
+    newObjectToReturn[key] = keepDeepReferenceEqualityInner(
+      oldObject[key],
+      possibleNewObject[key],
+      stackSizeInner + 1,
+      valueStackSoFar,
+    )
+    if (oldObject[key] !== newObjectToReturn[key]) {
+      canSaveOldObject = false
+    }
+  }
+
+  if (canSaveOldObject) {
+    return oldObject
+  } else {
+    return newObjectToReturn
+  }
+}
+
+function keepDeepReferenceEqualityOfMap(
+  oldMap: Map<any, any>,
+  possibleNewMap: Map<any, any>,
+  stackSizeInner: number,
+  valueStackSoFar: Array<any>,
+): Map<any, any> {
+  const length = possibleNewMap.size
+  if (length !== oldMap.size) return possibleNewMap
+
+  let newMapToReturn: Map<any, any> = new Map()
+  let canSaveOldMap = true
+
+  for (let [key, newValue] of possibleNewMap) {
+    if (canSaveOldMap && !oldMap.has(key)) {
+      canSaveOldMap = false
+    }
+    const oldValue = oldMap.get(key)
+    const newValueToReturn = keepDeepReferenceEqualityInner(
+      oldValue,
+      newValue,
+      stackSizeInner + 1,
+      valueStackSoFar,
+    )
+    newMapToReturn.set(key, newValueToReturn)
+    if (oldValue !== newValueToReturn) {
+      canSaveOldMap = false
+    }
+  }
+
+  if (canSaveOldMap) {
+    return oldMap
+  } else {
+    return newMapToReturn
+  }
+}
+
 function keepDeepReferenceEqualityInner(
   oldValueInner: any,
   possibleNewValueInner: any,
@@ -230,8 +310,6 @@ function keepDeepReferenceEqualityInner(
     return possibleNewValueInner
   }
   var isArray = Array.isArray
-  var keyList = Object.keys
-  var hasProp = Object.prototype.hasOwnProperty
 
   if (oldValueInner === possibleNewValueInner) return oldValueInner
 
@@ -302,43 +380,23 @@ function keepDeepReferenceEqualityInner(
         ? oldValueInner
         : possibleNewValueInner
 
-    // for objects we do a deep recursion
-    var keys = keyList(possibleNewValueInner)
-    length = keys.length
-
-    var newObjectToReturn: any = {}
-    var canSaveOldObject = true
-
-    const oldKeys = keyList(oldValueInner)
-    if (length !== oldKeys.length) {
-      canSaveOldObject = false
-    }
-
-    for (i = 0; i < length; i++) {
-      const newKey = keys[i]
-      if (!hasProp.call(oldValueInner, newKey) || newKey !== oldKeys[i]) {
-        canSaveOldObject = false
-      }
-    }
-
-    for (i = 0; i < length; i++) {
-      key = keys[i]
-      newObjectToReturn[key] = keepDeepReferenceEqualityInner(
-        oldValueInner[key],
-        possibleNewValueInner[key],
-        stackSizeInner + 1,
+    var mapA = oldValueInner instanceof Map,
+      mapB = possibleNewValueInner instanceof Map
+    if (mapA && mapB) {
+      return keepDeepReferenceEqualityOfMap(
+        oldValueInner,
+        possibleNewValueInner,
+        stackSizeInner,
         newValueStack,
       )
-      if (oldValueInner[key] !== newObjectToReturn[key]) {
-        canSaveOldObject = false
-      }
     }
 
-    if (canSaveOldObject) {
-      return oldValueInner
-    } else {
-      return newObjectToReturn
-    }
+    return keepDeepReferenceEqualityOfObject(
+      oldValueInner,
+      possibleNewValueInner,
+      stackSizeInner,
+      newValueStack,
+    )
   }
 
   return oldValueInner !== oldValueInner && possibleNewValueInner !== possibleNewValueInner


### PR DESCRIPTION
**Problem:**
DOM element measurements weren't rounding, so ref equality was often lost in the metadata due to floating point precision. Also, `Map`s were completely truncated when run through `keepDeepReferenceEqualityIfPossible`

**Fix:**
Round all DOM element measurements to the nearest 0.5, and extend `keepDeepReferenceEqualityIfPossible` to support `Map`s.
The rounding here has reduced the time to render each frame when scrolling in the Majestic Broker project by roughly 5-8ms!