### PR TITLE
Removed repeated keepDeepReferenceEqualityIfPossible calls

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -155,8 +155,6 @@ import { OutgoingWorkerMessage, isJsFile, BuildType } from '../../../core/worker
 import { UtopiaTsWorkers } from '../../../core/workers/common/worker-types'
 import { defaultProject, sampleProjectForId } from '../../../sample-projects/sample-project-utils'
 import { KeysPressed, Key } from '../../../utils/keyboard'
-import { keepDeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
-import RU from '../../../utils/react-utils'
 import Utils, { IndexPosition } from '../../../utils/utils'
 import {
   CanvasPoint,
@@ -3610,14 +3608,11 @@ export const UPDATE_FNS = {
       spyCollector.current.spyValues.scenes,
     )
 
-    return keepDeepReferenceEqualityIfPossible(editor, {
+    return {
       ...editor,
-      domMetadataKILLME: keepDeepReferenceEqualityIfPossible(
-        editor.domMetadataKILLME,
-        action.elementMetadata,
-      ),
-      spyMetadataKILLME: keepDeepReferenceEqualityIfPossible(editor.spyMetadataKILLME, spyResult),
-    })
+      domMetadataKILLME: action.elementMetadata,
+      spyMetadataKILLME: spyResult,
+    }
   },
   SET_PROP: (action: SetProp, editor: EditorModel): EditorModel => {
     return addUtopiaUtilsImportIfUsed(

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -462,6 +462,7 @@ import {
   addStoryboardFileToProject,
   StoryboardFilePath,
 } from '../../../core/model/storyboard-utils'
+import { keepDeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
 
 export function clearSelection(): EditorAction {
   return {
@@ -3610,8 +3611,11 @@ export const UPDATE_FNS = {
 
     return {
       ...editor,
-      domMetadataKILLME: action.elementMetadata,
-      spyMetadataKILLME: spyResult,
+      domMetadataKILLME: keepDeepReferenceEqualityIfPossible(
+        editor.domMetadataKILLME,
+        action.elementMetadata,
+      ),
+      spyMetadataKILLME: keepDeepReferenceEqualityIfPossible(editor.spyMetadataKILLME, spyResult),
     }
   },
   SET_PROP: (action: SetProp, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1252,10 +1252,7 @@ export function deriveState(
       controls: derivedState.canvas.controls,
       transientState: produceCanvasTransientState(editor, true),
     },
-    elementWarnings: keepDeepReferenceEqualityIfPossible(
-      oldDerivedState?.elementWarnings,
-      getElementWarnings(getMetadata(editor)),
-    ),
+    elementWarnings: getElementWarnings(getMetadata(editor)),
   }
 
   const sanitizedDerivedState = keepDeepReferenceEqualityIfPossible(derivedState, derived)


### PR DESCRIPTION
**Problem:**
We call `keepDeepReferenceEqualityIfPossible` at multiple points when recording and merging the metadata, meaning that if we don't keep ref equality we will be recursing the same objects multiple times.

**Fix:**
Only call it at the top level.
