### PR TITLE
If the dom report changes nothing, return the original editor model

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3609,13 +3609,26 @@ export const UPDATE_FNS = {
       spyCollector.current.spyValues.scenes,
     )
 
-    return {
-      ...editor,
-      domMetadataKILLME: keepDeepReferenceEqualityIfPossible(
-        editor.domMetadataKILLME,
-        action.elementMetadata,
-      ),
-      spyMetadataKILLME: keepDeepReferenceEqualityIfPossible(editor.spyMetadataKILLME, spyResult),
+    const finalDomMetadata = keepDeepReferenceEqualityIfPossible(
+      editor.domMetadataKILLME,
+      action.elementMetadata,
+    )
+    const finalSpyMetadata = keepDeepReferenceEqualityIfPossible(
+      editor.spyMetadataKILLME,
+      spyResult,
+    )
+
+    const stayedTheSame =
+      editor.domMetadataKILLME === finalDomMetadata && editor.spyMetadataKILLME === finalSpyMetadata
+
+    if (stayedTheSame) {
+      return editor
+    } else {
+      return {
+        ...editor,
+        domMetadataKILLME: finalDomMetadata,
+        spyMetadataKILLME: finalSpyMetadata,
+      }
     }
   },
   SET_PROP: (action: SetProp, editor: EditorModel): EditorModel => {


### PR DESCRIPTION
**Problem:**
Non-changes to the dom report weren't retaining ref equality of the editor after #656 

**Fix:**
If nothing has changed, just return the original editor model
