### PR TITLE
Perf/dom-walker add mutation and resize observer

### DIFF
--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -20,6 +20,8 @@ import { EditorState, OriginalCanvasAndLocalFrame } from '../editor/store/editor
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import { xor } from '../../core/shared/utils'
 
+export const CanvasContainerID = 'canvas-container'
+
 export const enum CSSCursor {
   Select = "-webkit-image-set( url( '/editor/cursors/cursor-default.png ') 1x, url( '/editor/cursors/cursor-default@2x.png ') 2x ) 4 4, default",
   PhysicsDefault = "-webkit-image-set( url( '/editor/cursors/cursor-default.png ') 1x, url( '/editor/cursors/cursor-default@2x.png ') 2x ) 4 4, default",

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -359,6 +359,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
         validPaths: Array<string>,
       ) {
         if (
+          ObserversAvailable &&
           invalidatedSceneIDsRef.current?.length === 0 &&
           rootMetadataInStateRef.current.length > 0
         ) {

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -386,6 +386,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
         if (
           ObserversAvailable &&
           invalidatedSceneIDsRef.current?.length === 0 &&
+          rootMetadataInStateRef.current.length > 0 &&
           initCompleteRef.current === true
         ) {
           // no mutation happened on the entire canvas, just return the old metadata

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -154,6 +154,9 @@ function globalFrameForElement(element: HTMLElement, path: TemplatePath | null):
     return CanvasRectangleCache[pathAsString]
   } else {
     const elementRect = getCanvasRectangleFromElement(element, scale)
+    if (pathAsString != null) {
+      CanvasRectangleCache[pathAsString] = elementRect
+    }
     return Utils.offsetRect(elementRect, Utils.negate(containerRect))
   }
 }

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -299,7 +299,10 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
             rootMetadataRef.current,
           )
           if (cachedMetadata != null) {
-            rootMetadata.push(cachedMetadata)
+            rootMetadata.push({
+              ...cachedMetadata,
+              children: childMetadata,
+            })
           }
         } else {
           const metadata: ElementInstanceMetadata = elementInstanceMetadata(
@@ -454,7 +457,10 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
             rootMetadataRef.current,
           )
           if (cachedMetadata != null) {
-            return cachedMetadata
+            return {
+              ...cachedMetadata,
+              children: childrenMetadata,
+            }
           }
         }
         const globalFrame = globalFrameForElement(element)

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -12,11 +12,7 @@ import {
   emptyComputedStyle,
 } from '../../core/shared/element-template'
 import { id, TemplatePath, InstancePath } from '../../core/shared/project-file-types'
-import {
-  getCanvasRectangleFromElement,
-  getDOMAttribute,
-  setDOMAttribute,
-} from '../../core/shared/dom-utils'
+import { getCanvasRectangleFromElement, getDOMAttribute } from '../../core/shared/dom-utils'
 import { applicative4Either, isRight, left } from '../../core/shared/either'
 import Utils from '../../utils/utils'
 import {
@@ -359,11 +355,6 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
         scenePath: TemplatePath,
         validPaths: Array<string>,
       ): Array<ElementInstanceMetadata> {
-        setDOMAttribute(
-          scene,
-          UTOPIA_TEMPLATE_PATH,
-          TP.toString(TP.instancePath([], TP.elementPathForPath(scenePath))),
-        )
         const globalFrame: CanvasRectangle = globalFrameForElement(scene)
 
         let metadatas: Array<ElementInstanceMetadata> = []
@@ -430,7 +421,6 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
             uniquePath = TP.appendToPath(uniquePath, parentUIDsAttribute.split('/'))
           }
           uniquePath = TP.appendToPath(uniquePath, pathElement)
-          setDOMAttribute(element, UTOPIA_TEMPLATE_PATH, TP.toString(uniquePath))
 
           const globalFrame = globalFrameForElement(element)
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -137,7 +137,11 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
   const mutationObserver = React.useMemo(() => {
     return new MutationObserver((mutations: MutationRecord[]) => {
       for (let mutation of mutations) {
-        if (mutation.attributeName === 'style') {
+        if (
+          mutation.attributeName === 'style' ||
+          mutation.addedNodes.length > 0 ||
+          mutation.removedNodes.length > 0
+        ) {
           if (mutation.target instanceof HTMLElement) {
             const pathAsString = getDOMAttribute(mutation.target, UTOPIA_TEMPLATE_PATH)
             const path = pathAsString != null ? TP.fromString(pathAsString) : null

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -395,6 +395,23 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
           uniquePath = TP.appendToPath(uniquePath, pathElement)
           setDOMAttribute(element, UTOPIA_TEMPLATE_PATH, TP.toString(uniquePath))
 
+          if (
+            invalidatedTemplatePathsRef.current == null ||
+            invalidatedTemplatePathsRef.current.find((path) => TP.pathsEqual(path, uniquePath))
+          ) {
+            invalidatedTemplatePathsRef.current = invalidatedTemplatePathsRef.current.filter(
+              (path) => !TP.pathsEqual(path, uniquePath),
+            )
+          } else {
+            const elementFromCurrentMetadata = MetadataUtils.findElementMetadata(
+              uniquePath,
+              rootMetadataInStateRef.current,
+            )
+            if (elementFromCurrentMetadata != null) {
+              return [elementFromCurrentMetadata]
+            }
+          }
+
           const globalFrame = globalFrameForElement(element)
 
           // Build the original path for this element.
@@ -447,22 +464,6 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
         parentPoint: CanvasPoint | null,
         childrenMetadata: ElementInstanceMetadata[],
       ): ElementInstanceMetadata {
-        if (
-          invalidatedTemplatePathsRef.current == null ||
-          invalidatedTemplatePathsRef.current.find((path) => TP.pathsEqual(path, instancePath))
-        ) {
-          invalidatedTemplatePathsRef.current = invalidatedTemplatePathsRef.current.filter(
-            (path) => !TP.pathsEqual(path, instancePath),
-          )
-        } else {
-          const elementFromCurrentMetadata = MetadataUtils.findElementMetadata(
-            instancePath,
-            rootMetadataInStateRef.current,
-          )
-          if (elementFromCurrentMetadata != null) {
-            return elementFromCurrentMetadata
-          }
-        }
         const globalFrame = globalFrameForElement(element)
         const localFrame =
           parentPoint != null

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -38,6 +38,7 @@ import {
   UTOPIA_UID_ORIGINAL_PARENTS_KEY,
   UTOPIA_UID_PARENTS_KEY,
 } from '../../core/model/utopia-constants'
+import ResizeObserver from 'resize-observer-polyfill'
 
 function isValidPath(path: TemplatePath | null, validPaths: Array<string>): boolean {
   return path != null && validPaths.indexOf(TP.toString(path)) > -1
@@ -103,7 +104,19 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
   React.useLayoutEffect(() => {
     if (containerRef.current != null) {
       // Get some base values relating to the div this component creates.
+      var resizeObserver = new ResizeObserver((entries: any) => {
+        for (let entry of entries) {
+          const cr = entry.contentRect
+          console.log('Element:', entry.target)
+          console.log(`Element size: ${cr.width}px x ${cr.height}px`)
+          console.log(`Element padding: ${cr.top}px ; ${cr.left}px`)
+        }
+      })
       const refOfContainer = containerRef.current
+      Array.from(document.querySelectorAll('#canvas-container *')).map((elem) =>
+        resizeObserver.observe(elem),
+      )
+      console.log('observer attached')
 
       const containerRect = getCanvasRectangleFromElement(refOfContainer, props.scale)
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -298,7 +298,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
             const sceneID = sceneIndexAttr.value
             if (
               invalidatedSceneIDsRef.current == null ||
-              invalidatedSceneIDsRef.current.indexOf(sceneID) > 0
+              invalidatedSceneIDsRef.current.indexOf(sceneID) > -1
             ) {
               invalidatedSceneIDsRef.current = invalidatedSceneIDsRef.current.filter(
                 (sceneIDref) => sceneIDref !== sceneID,

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -128,7 +128,7 @@ function lazyValue<T>(getter: () => T) {
 }
 
 function useResizeObserver(invalidatedSceneIDsRef: React.MutableRefObject<Array<string>>) {
-  const resizeObserver: ResizeObserver = React.useMemo(() => {
+  const resizeObserver = React.useMemo((): ResizeObserver | null => {
     if (ObserversAvailable) {
       return new ResizeObserver((entries: any) => {
         for (let entry of entries) {
@@ -158,7 +158,7 @@ function useResizeObserver(invalidatedSceneIDsRef: React.MutableRefObject<Array<
 }
 
 function useMutationObserver(invalidatedSceneIDsRef: React.MutableRefObject<Array<string>>) {
-  const mutationObserver = React.useMemo(() => {
+  const mutationObserver = React.useMemo((): MutationObserver | null => {
     if (ObserversAvailable) {
       return new (window as any).MutationObserver((mutations: MutationRecord[]) => {
         for (let mutation of mutations) {
@@ -214,11 +214,11 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
       }
       // Get some base values relating to the div this component creates.
       const refOfContainer = containerRef.current
-      if (ObserversAvailable) {
+      if (ObserversAvailable && resizeObserver != null && mutationObserver != null) {
         Array.from(document.querySelectorAll('#canvas-container *')).map((elem) => {
           resizeObserver.observe(elem)
         })
-        mutationObserver!.observe(refOfContainer, MutationObserverConfig)
+        mutationObserver.observe(refOfContainer, MutationObserverConfig)
       }
 
       // getCanvasRectangleFromElement is costly, so I made it lazy. we only need the value inside globalFrameForElement

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -38,7 +38,6 @@ import {
   UTOPIA_UID_KEY,
   UTOPIA_UID_ORIGINAL_PARENTS_KEY,
   UTOPIA_UID_PARENTS_KEY,
-  UTOPIA_TEMPLATE_PATH,
 } from '../../core/model/utopia-constants'
 import ResizeObserver from 'resize-observer-polyfill'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -47,6 +47,8 @@ import {
 import ResizeObserver from 'resize-observer-polyfill'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 
+const MutationObserverConfig = { attributes: true, childList: true, subtree: true }
+
 function isValidPath(path: TemplatePath | null, validPaths: Array<string>): boolean {
   return path != null && validPaths.indexOf(TP.toString(path)) > -1
 }
@@ -100,8 +102,6 @@ function isScene(node: Node): node is HTMLElement {
     node.attributes.getNamedItemNS(null, 'data-utopia-valid-paths') != null
   )
 }
-
-const mutationObserverConfig = { attributes: true, childList: true, subtree: true }
 
 export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElement> {
   const containerRef = React.useRef<HTMLDivElement>(null)

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -154,7 +154,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
     } else {
       return null
     }
-  }, [invalidatedSceneIDsRef])
+  }, [])
 
   const mutationObserver = React.useMemo(() => {
     if (ObserversAvailable) {
@@ -181,7 +181,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
     } else {
       return null
     }
-  }, [invalidatedSceneIDsRef])
+  }, [])
 
   React.useLayoutEffect(() => {
     if (containerRef.current != null) {

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -153,7 +153,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
     } else {
       return null
     }
-  }, [])
+  }, []) // the dependencies are empty because this should only evaluate once
 
   const mutationObserver = React.useMemo(() => {
     if (ObserversAvailable) {
@@ -180,7 +180,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
     } else {
       return null
     }
-  }, [])
+  }, []) // the dependencies are empty because this should only evaluate once
 
   React.useLayoutEffect(() => {
     if (containerRef.current != null) {

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -42,6 +42,7 @@ import {
 import ResizeObserver from 'resize-observer-polyfill'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { PRODUCTION_ENV } from '../../common/env-vars'
+import { CanvasContainerID } from './canvas-types'
 
 const MutationObserverConfig = { attributes: true, childList: true, subtree: true }
 const ObserversAvailable = (window as any).MutationObserver != null && ResizeObserver != null
@@ -215,7 +216,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
       // Get some base values relating to the div this component creates.
       const refOfContainer = containerRef.current
       if (ObserversAvailable && resizeObserver != null && mutationObserver != null) {
-        Array.from(document.querySelectorAll('#canvas-container *')).map((elem) => {
+        Array.from(document.querySelectorAll(`#${CanvasContainerID} *`)).map((elem) => {
           resizeObserver.observe(elem)
         })
         mutationObserver.observe(refOfContainer, MutationObserverConfig)

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -159,7 +159,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
       Array.from(document.querySelectorAll('#canvas-container *')).map((elem) => {
         resizeObserver.observe(elem)
       })
-      mutationObserver.observe(refOfContainer, mutationObserverConfig)
+      mutationObserver.observe(refOfContainer, MutationObserverConfig)
 
       const containerRect = getCanvasRectangleFromElement(refOfContainer, props.scale)
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -46,6 +46,7 @@ import {
 } from '../../core/model/utopia-constants'
 import ResizeObserver from 'resize-observer-polyfill'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
+import { PRODUCTION_ENV } from '../../common/env-vars'
 
 const MutationObserverConfig = { attributes: true, childList: true, subtree: true }
 
@@ -103,6 +104,8 @@ function isScene(node: Node): node is HTMLElement {
   )
 }
 
+const LogDomWalkerPerformance = !PRODUCTION_ENV && typeof window.performance.mark === 'function'
+
 export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElement> {
   const containerRef = React.useRef<HTMLDivElement>(null)
   const rootMetadataInStateRef = useRefEditorState((store) => store.editor.domMetadataKILLME)
@@ -154,6 +157,9 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
 
   React.useLayoutEffect(() => {
     if (containerRef.current != null) {
+      if (LogDomWalkerPerformance) {
+        performance.mark('DOM_WALKER_START')
+      }
       // Get some base values relating to the div this component creates.
       const refOfContainer = containerRef.current
       Array.from(document.querySelectorAll('#canvas-container *')).map((elem) => {
@@ -508,6 +514,10 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
         props.canvasRootElementTemplatePath,
         props.validRootPaths.map(TP.toString),
       )
+      if (LogDomWalkerPerformance) {
+        performance.mark('DOM_WALKER_END')
+        performance.measure('DOM WALKER', 'DOM_WALKER_START', 'DOM_WALKER_END')
+      }
       props.onDomReport(rootMetadata)
     }
   })

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -131,6 +131,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
   const containerRef = React.useRef<HTMLDivElement>(null)
   const rootMetadataInStateRef = useRefEditorState((store) => store.editor.domMetadataKILLME)
   const invalidatedSceneIDsRef = React.useRef<Array<string>>([])
+  const initCompleteRef = React.useRef<boolean>(false)
   const selectedViews = useEditorState(
     (store) => store.editor.selectedViews,
     'useDomWalker selectedViews',
@@ -360,7 +361,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
         if (
           ObserversAvailable &&
           invalidatedSceneIDsRef.current?.length === 0 &&
-          rootMetadataInStateRef.current.length > 0
+          initCompleteRef.current === true
         ) {
           // no mutation happened on the entire canvas, just return the old metadata
           rootMetadata = rootMetadataInStateRef.current
@@ -555,6 +556,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
         performance.mark('DOM_WALKER_END')
         performance.measure('DOM WALKER', 'DOM_WALKER_START', 'DOM_WALKER_END')
       }
+      initCompleteRef.current = true
       props.onDomReport(rootMetadata)
     }
   })

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -397,7 +397,9 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
 
           if (
             invalidatedTemplatePathsRef.current == null ||
-            invalidatedTemplatePathsRef.current.find((path) => TP.pathsEqual(path, uniquePath))
+            invalidatedTemplatePathsRef.current.find((path) =>
+              TP.isAncestorOf(path, uniquePath, true),
+            )
           ) {
             invalidatedTemplatePathsRef.current = invalidatedTemplatePathsRef.current.filter(
               (path) => !TP.pathsEqual(path, uniquePath),

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -297,7 +297,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
             const validPaths = validPathsAttr.value.split(' ')
             const sceneID = sceneIndexAttr.value
             if (
-              (sceneID != null && invalidatedSceneIDsRef.current == null) ||
+              invalidatedSceneIDsRef.current == null ||
               invalidatedSceneIDsRef.current.indexOf(sceneID) > 0
             ) {
               invalidatedSceneIDsRef.current = invalidatedSceneIDsRef.current.filter(

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -310,6 +310,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
               )
               if (elementFromCurrentMetadata != null) {
                 // early return for cached scenes
+                rootMetadata.push(...elementFromCurrentMetadata.children)
                 rootMetadata.push(elementFromCurrentMetadata)
                 return
               }

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -67,6 +67,7 @@ import {
   updateMutableUtopiaContextWithNewProps,
 } from './ui-jsx-canvas-renderer/ui-jsx-canvas-contexts'
 import { runBlockUpdatingScope } from './ui-jsx-canvas-renderer/ui-jsx-canvas-scope-utils'
+import { CanvasContainerID } from './canvas-types'
 
 const emptyFileBlobs: UIFileBase64Blobs = {}
 
@@ -454,7 +455,7 @@ const CanvasContainer: React.FunctionComponent<React.PropsWithChildren<CanvasCon
   const { scale, offset } = props
   return (
     <div
-      id={'canvas-container'}
+      id={CanvasContainerID}
       key={'canvas-container'}
       ref={containerRef}
       style={{

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -850,7 +850,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     projectVersion: currentEditor.projectVersion,
     isLoaded: currentEditor.isLoaded,
     spyMetadataKILLME: poppedEditor.spyMetadataKILLME,
-    domMetadataKILLME: poppedEditor.domMetadataKILLME,
+    domMetadataKILLME: [],
     jsxMetadataKILLME: poppedEditor.jsxMetadataKILLME,
     projectContents: poppedEditor.projectContents,
     nodeModules: currentEditor.nodeModules,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1355,30 +1355,6 @@ export const MetadataUtils = {
       }
     })
   },
-  removeElementMetadata(
-    target: TemplatePath,
-    rootElements: Array<ElementInstanceMetadata>,
-  ): Array<ElementInstanceMetadata> {
-    const parentPath = TP.parentPath(target) ?? target
-    const transform = (t: ElementInstanceMetadata): ElementInstanceMetadata => {
-      return {
-        ...t,
-        children: [],
-      }
-    }
-    if (TP.isScenePath(parentPath)) {
-      const parentInstancePath = TP.instancePath([], TP.elementPathForPath(parentPath))
-      return rootElements.filter((elem) => !TP.pathsEqual(parentInstancePath, elem.templatePath))
-    } else {
-      return TP.findAndTransformAtPath(
-        rootElements,
-        TP.elementPathForPath(parentPath),
-        MetadataUtils.elementInstanceMetadataGetChildren,
-        getUtopiaID,
-        transform,
-      ).elements
-    }
-  },
   findElementMetadata(
     target: TemplatePath,
     rootElements: Array<ElementInstanceMetadata>,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1355,6 +1355,48 @@ export const MetadataUtils = {
       }
     })
   },
+  removeElementMetadata(
+    target: TemplatePath,
+    rootElements: Array<ElementInstanceMetadata>,
+  ): Array<ElementInstanceMetadata> {
+    const parentPath = TP.parentPath(target) ?? target
+    const transform = (t: ElementInstanceMetadata): ElementInstanceMetadata => {
+      return {
+        ...t,
+        children: [],
+      }
+    }
+    if (TP.isScenePath(parentPath)) {
+      const parentInstancePath = TP.instancePath([], TP.elementPathForPath(parentPath))
+      return rootElements.filter((elem) => !TP.pathsEqual(parentInstancePath, elem.templatePath))
+    } else {
+      return TP.findAndTransformAtPath(
+        rootElements,
+        TP.elementPathForPath(parentPath),
+        MetadataUtils.elementInstanceMetadataGetChildren,
+        getUtopiaID,
+        transform,
+      ).elements
+    }
+  },
+  findElementMetadata(
+    target: TemplatePath,
+    rootElements: Array<ElementInstanceMetadata>,
+  ): ElementInstanceMetadata | null {
+    if (TP.isScenePath(target)) {
+      const sceneInstancePath = TP.instancePath([], TP.elementPathForPath(target))
+      return (
+        rootElements.find((elem) => TP.pathsEqual(sceneInstancePath, elem.templatePath)) ?? null
+      )
+    } else {
+      return TP.findAtElementPath(
+        rootElements,
+        target.element,
+        MetadataUtils.elementInstanceMetadataGetChildren,
+        getUtopiaID,
+      )
+    }
+  },
   getStaticElementName(
     path: TemplatePath,
     rootElements: Array<UtopiaJSXComponent>,

--- a/editor/src/core/model/utopia-constants.ts
+++ b/editor/src/core/model/utopia-constants.ts
@@ -5,7 +5,6 @@ export const UTOPIA_DO_NOT_TRAVERSE_KEY = 'data-utopia-do-not-traverse'
 export const UTOPIA_SCENE_ID_KEY = 'data-utopia-scene-id'
 export const UTOPIA_UID_PARENTS_KEY = 'data-utopia-parents'
 export const UTOPIA_UID_ORIGINAL_PARENTS_KEY = 'data-utopia-original-parents'
-export const UTOPIA_TEMPLATE_PATH = 'data-template-path'
 
 export const UtopiaKeys: Array<string> = [
   UTOPIA_UID_KEY,

--- a/editor/src/core/model/utopia-constants.ts
+++ b/editor/src/core/model/utopia-constants.ts
@@ -5,6 +5,7 @@ export const UTOPIA_DO_NOT_TRAVERSE_KEY = 'data-utopia-do-not-traverse'
 export const UTOPIA_SCENE_ID_KEY = 'data-utopia-scene-id'
 export const UTOPIA_UID_PARENTS_KEY = 'data-utopia-parents'
 export const UTOPIA_UID_ORIGINAL_PARENTS_KEY = 'data-utopia-original-parents'
+export const UTOPIA_TEMPLATE_PATH = 'data-template-path'
 
 export const UtopiaKeys: Array<string> = [
   UTOPIA_UID_KEY,

--- a/editor/src/core/shared/dom-utils.ts
+++ b/editor/src/core/shared/dom-utils.ts
@@ -202,6 +202,21 @@ export const intrinsicHTMLElementNamesThatSupportChildren: Array<string> = [
   'section',
 ]
 
+export function getDOMAttribute(element: HTMLElement, attributeName: string): string | null {
+  const attr = element.attributes.getNamedItemNS(null, attributeName)
+  if (attr == null) {
+    return null
+  } else {
+    return attr.value
+  }
+}
+
+export function setDOMAttribute(element: HTMLElement, attributeName: string, value: string): void {
+  const attr = document.createAttributeNS(null, attributeName)
+  attr.value = value
+  element.attributes.setNamedItemNS(attr)
+}
+
 export function getCanvasRectangleFromElement(
   element: HTMLElement,
   canvasScale: number,


### PR DESCRIPTION
This PR improves the performance of the dom-walker.

It adds the mutation and resize observers, the observer callbacks help tracking which element will need fresh metadata. In `walkElements` the `invalidatedTemplatePathsRef` are checked (with descendants) to return the store value or to recalculate the metadata.
For this `data-template-path` is added to the html elements.