### PR TITLE
Handle exports similar to imports in the parser.

### DIFF
--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1059,7 +1059,7 @@ describe('moveTemplate', () => {
       `),
     )
   })
-  it('wraps in multiselected element + children, moves only the element, keeps children', async () => {
+  it('wraps in multiselected element and children, moves only the element, keeps children', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...props.style }} data-uid={'aaa'}>
@@ -1162,7 +1162,7 @@ describe('moveTemplate', () => {
       `),
     )
   })
-  it('reparents multiselected element + children, moves only the element, keeps children', async () => {
+  it('reparents multiselected element and children, moves only the element, keeps children', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...props.style }} data-uid={'aaa'}>
@@ -1208,7 +1208,7 @@ describe('moveTemplate', () => {
       `),
     )
   })
-  it('reparents multiselected element + descendant (not direct children), moves both of the elements', async () => {
+  it('reparents multiselected element and descendant which are not direct children, moves both of the elements', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...props.style }} data-uid={'aaa'}>

--- a/editor/src/components/canvas/ui-jsx-test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-test-utils.tsx
@@ -32,10 +32,12 @@ import {
   TopLevelElement,
 } from '../../core/shared/element-template'
 import {
+  foldParsedTextFile,
   isParseFailure,
   isParseSuccess,
   isTextFile,
   isUnparsed,
+  ParsedTextFile,
   ParseSuccess,
   TextFile,
 } from '../../core/shared/project-file-types'
@@ -268,5 +270,15 @@ export function testPrintCode(parseSuccess: ParseSuccess): string {
     parseSuccess.imports,
     parseSuccess.topLevelElements,
     parseSuccess.jsxFactoryFunction,
+    parseSuccess.exportsDetail,
+  )
+}
+
+export function testPrintParsedTextFile(parsedTextFile: ParsedTextFile): string {
+  return foldParsedTextFile(
+    (_) => 'FAILURE',
+    testPrintCode,
+    (_) => 'UNPARSED',
+    parsedTextFile,
   )
 }

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -27,6 +27,8 @@ import {
   textFile,
   TextFileContents,
   unparsed,
+  addModifierExportToDetail,
+  EmptyExportsDetail,
 } from '../../../core/shared/project-file-types'
 import { emptyImports, parseSuccess } from '../../../core/workers/common/project-file-utils'
 import { deepFreeze } from '../../../utils/deep-freeze'
@@ -106,6 +108,7 @@ describe('SET_PROP', () => {
       {},
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     ),
   )
   const testEditor: EditorState = deepFreeze({
@@ -193,7 +196,16 @@ describe('SET_CANVAS_FRAMES', () => {
     ),
   ]
 
-  const originalModel = deepFreeze(parseSuccess(emptyImports(), components, {}, null, null))
+  const originalModel = deepFreeze(
+    parseSuccess(
+      emptyImports(),
+      components,
+      {},
+      null,
+      null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+    ),
+  )
   const testEditor: EditorState = deepFreeze({
     ...createEditorState(NO_OP),
     projectContents: contentsToTree({
@@ -259,6 +271,7 @@ describe('moveTemplate', () => {
         {},
         null,
         null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
       ),
     )
   }
@@ -756,7 +769,14 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
   const fileForUI = textFile(
     textFileContents(
       '',
-      parseSuccess(sampleDefaultImports, [firstTopLevelElement], {}, null, null),
+      parseSuccess(
+        sampleDefaultImports,
+        [firstTopLevelElement],
+        {},
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      ),
       RevisionsState.BothMatch,
     ),
     null,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -50,6 +50,7 @@ import {
   codeFile,
   isParseFailure,
   isParsedTextFile,
+  EmptyExportsDetail,
 } from '../../../core/shared/project-file-types'
 import { diagnosticToErrorMessage } from '../../../core/workers/ts/ts-utils'
 import { ExportsInfo, MultiFileBuildResult } from '../../../core/workers/ts/ts-worker'
@@ -533,6 +534,7 @@ export function modifyParseSuccessWithSimple(
     {},
     success.jsxFactoryFunction,
     success.combinedTopLevelArbitraryBlock,
+    success.exportsDetail,
   )
 }
 

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -5,13 +5,14 @@ import {
 } from '../../components/assets'
 import { EditorModel } from '../../components/editor/action-types'
 import { EditorState } from '../../components/editor/store/editor-state'
-import { forEachRight, left, right } from '../shared/either'
 import {
   isUtopiaJSXComponent,
   UtopiaJSXComponent,
   utopiaJSXComponent,
 } from '../shared/element-template'
 import {
+  addModifierExportToDetail,
+  EmptyExportsDetail,
   forEachParseSuccess,
   importAlias,
   isTextFile,
@@ -19,7 +20,6 @@ import {
   textFile,
   textFileContents,
 } from '../shared/project-file-types'
-import { generateUID } from '../shared/uid-utils'
 import { addImport, parseSuccess } from '../workers/common/project-file-utils'
 import {
   BakedInStoryboardUID,
@@ -119,7 +119,14 @@ function addStoryboardFileForComponent(
     baseImports,
   )
   // Create the file.
-  const success = parseSuccess(imports, [storyboardComponent], {}, 'jsx', null)
+  const success = parseSuccess(
+    imports,
+    [storyboardComponent],
+    {},
+    'jsx',
+    null,
+    addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+  )
   const storyboardFileContents = textFile(
     textFileContents('', success, RevisionsState.ParsedAhead),
     null,

--- a/editor/src/core/workers/common/project-file-utils.ts
+++ b/editor/src/core/workers/common/project-file-utils.ts
@@ -11,6 +11,7 @@ import {
   ParsedJSONSuccess,
   ImportAlias,
   isParseSuccess,
+  ExportsDetail,
 } from '../../shared/project-file-types'
 import { fastForEach } from '../../shared/utils'
 import { defaultIfNull } from '../../shared/optional-utils'
@@ -42,6 +43,7 @@ export function getTextFileContents(
       file.fileContents.parsed.imports,
       file.fileContents.parsed.topLevelElements,
       file.fileContents.parsed.jsxFactoryFunction,
+      file.fileContents.parsed.exportsDetail,
     )
   } else {
     return file.fileContents.code
@@ -129,6 +131,7 @@ export function parseSuccess(
   highlightBounds: HighlightBoundsForUids,
   jsxFactoryFunction: string | null,
   combinedTopLevelArbitraryBlock: ArbitraryJSBlock | null,
+  exportsDetail: ExportsDetail,
 ): ParseSuccess {
   return {
     type: 'PARSE_SUCCESS',
@@ -137,6 +140,7 @@ export function parseSuccess(
     highlightBounds: highlightBounds,
     jsxFactoryFunction: jsxFactoryFunction,
     combinedTopLevelArbitraryBlock: combinedTopLevelArbitraryBlock,
+    exportsDetail: exportsDetail,
   }
 }
 

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.ts.snap
@@ -107,6 +107,17 @@ return { a: a, b: b };",
     "type": "ARBITRARY_JS_BLOCK",
     "uniqueID": "",
   },
+  "exportsDetail": Object {
+    "defaultExport": null,
+    "namedExports": Object {
+      "App": Object {
+        "type": "EXPORT_DETAIL_MODIFIER",
+      },
+      "storyboard": Object {
+        "type": "EXPORT_DETAIL_MODIFIER",
+      },
+    },
+  },
   "highlightBounds": Object {
     "aaa": Object {
       "endCol": 26,

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -128,6 +128,14 @@ return { cakeFn: cakeFn, otherFn: otherFn };",
     "type": "ARBITRARY_JS_BLOCK",
     "uniqueID": "",
   },
+  "exportsDetail": Object {
+    "defaultExport": null,
+    "namedExports": Object {
+      "whatever": Object {
+        "type": "EXPORT_DETAIL_MODIFIER",
+      },
+    },
+  },
   "highlightBounds": Object {
     "aaa": Object {
       "endCol": 11,
@@ -405,6 +413,14 @@ return { a: a, b: b };",
     "type": "ARBITRARY_JS_BLOCK",
     "uniqueID": "",
   },
+  "exportsDetail": Object {
+    "defaultExport": null,
+    "namedExports": Object {
+      "whatever": Object {
+        "type": "EXPORT_DETAIL_MODIFIER",
+      },
+    },
+  },
   "highlightBounds": Object {
     "aaa": Object {
       "endCol": 58,
@@ -599,6 +615,14 @@ export var App = (props) => <View data-uid={'bbb'}>
 return { a: a };",
     "type": "ARBITRARY_JS_BLOCK",
     "uniqueID": "",
+  },
+  "exportsDetail": Object {
+    "defaultExport": null,
+    "namedExports": Object {
+      "App": Object {
+        "type": "EXPORT_DETAIL_MODIFIER",
+      },
+    },
   },
   "highlightBounds": Object {
     "bbb": Object {

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
@@ -13,8 +13,14 @@ import {
   defaultPropsParam,
 } from '../../shared/element-template'
 import { setJSXValueAtPath } from '../../shared/jsx-attributes'
-import { foldEither, forEachRight, right } from '../../shared/either'
-import { foldParsedTextFile, ParseSuccess } from '../../shared/project-file-types'
+import { forEachRight } from '../../shared/either'
+import {
+  addModifierExportToDetail,
+  addNamedExportToDetail,
+  EmptyExportsDetail,
+  foldParsedTextFile,
+  ParseSuccess,
+} from '../../shared/project-file-types'
 import { parseSuccess } from '../common/project-file-utils'
 import { applyPrettier } from './prettier-utils'
 import {
@@ -200,6 +206,7 @@ export var whatever = props => (
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -291,6 +298,7 @@ return { arr: arr };`
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -384,6 +392,7 @@ return { arr: arr };`
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -478,6 +487,7 @@ return { arr: arr };`
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -554,6 +564,7 @@ export var whatever = (props) => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -648,6 +659,7 @@ return { arr: arr };`
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -724,6 +736,7 @@ export var whatever = (props) => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -818,6 +831,7 @@ return { arr: arr };`
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })

--- a/editor/src/core/workers/parser-printer/parser-printer-event-handlers.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-event-handlers.spec.ts
@@ -47,6 +47,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
         parseResult.imports,
         parseResult.topLevelElements,
         parseResult.jsxFactoryFunction,
+        parseResult.exportsDetail,
       )
 
       const expectedCode = applyPrettier(

--- a/editor/src/core/workers/parser-printer/parser-printer-exports.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-exports.spec.ts
@@ -1,0 +1,80 @@
+import { clearParseResultUniqueIDs, testParseCode } from './parser-printer-test-utils'
+import Utils from '../../../utils/utils'
+import { applyPrettier } from './prettier-utils'
+import { testPrintParsedTextFile } from '../../../components/canvas/ui-jsx-test-utils'
+
+describe('parseCode', () => {
+  it('should parse a directly exported component', () => {
+    const code = applyPrettier(
+      `
+    export var whatever = (props) => {
+      return <div data-uid={'aaa'} />
+    }
+`,
+      false,
+    ).formatted
+    const actualResult = clearParseResultUniqueIDs(testParseCode(code))
+    expect(testPrintParsedTextFile(actualResult)).toEqual(code)
+    const exports = Utils.path(['exportsDetail'], actualResult)
+    expect(exports).toMatchInlineSnapshot(`
+      Object {
+        "defaultExport": null,
+        "namedExports": Object {
+          "whatever": Object {
+            "type": "EXPORT_DETAIL_MODIFIER",
+          },
+        },
+      }
+    `)
+  })
+  it('should parse a component exported handled with an external export clause', () => {
+    const code = applyPrettier(
+      `
+    var whatever = (props) => {
+      return <div data-uid={'aaa'} />
+    }
+    export { whatever }
+`,
+      false,
+    ).formatted
+    const actualResult = clearParseResultUniqueIDs(testParseCode(code))
+    expect(testPrintParsedTextFile(actualResult)).toEqual(code)
+    const exports = Utils.path(['exportsDetail'], actualResult)
+    expect(exports).toMatchInlineSnapshot(`
+      Object {
+        "defaultExport": null,
+        "namedExports": Object {
+          "whatever": Object {
+            "propertyName": "whatever",
+            "type": "EXPORT_DETAIL_NAMED",
+          },
+        },
+      }
+    `)
+  })
+  it('should parse a component exported handled with an external export clause, with a different name', () => {
+    const code = applyPrettier(
+      `
+    var whatever = (props) => {
+      return <div data-uid={'aaa'} />
+    }
+    export { whatever as otherThing }
+`,
+      false,
+    ).formatted
+    const actualResult = clearParseResultUniqueIDs(testParseCode(code))
+    expect(testPrintParsedTextFile(actualResult)).toEqual(code)
+    const exports = Utils.path(['exportsDetail'], actualResult)
+    expect(exports).toMatchInlineSnapshot(`
+      Object {
+        "defaultExport": null,
+        "namedExports": Object {
+          "otherThing": Object {
+            "propertyName": "whatever",
+            "type": "EXPORT_DETAIL_NAMED",
+          },
+        },
+      }
+    `)
+  })
+})

--- a/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
@@ -32,6 +32,7 @@ describe('JSX parser', () => {
         parseResult.imports,
         parseResult.topLevelElements,
         parseResult.jsxFactoryFunction,
+        parseResult.exportsDetail,
       )
 
       expect(printedCode).toMatchInlineSnapshot(`

--- a/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
@@ -17,10 +17,14 @@ import {
   omittedParam,
   jsxAttributeOtherJavaScript,
 } from '../../shared/element-template'
-import { right, isRight } from '../../shared/either'
 import { parseSuccess } from '../common/project-file-utils'
 import { printCode, printCodeOptions } from './parser-printer'
-import { isParseSuccess, ParseSuccess } from '../../shared/project-file-types'
+import {
+  addModifierExportToDetail,
+  addNamedExportToDetail,
+  EmptyExportsDetail,
+  isParseSuccess,
+} from '../../shared/project-file-types'
 
 const codeWithBasicPropsObject = `import React from "react";
 import { View } from "utopia-api";
@@ -156,6 +160,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -193,6 +198,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -215,6 +221,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -241,6 +248,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -275,6 +283,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
 
     expect(actualResult).toEqual(expectedResult)
@@ -304,6 +313,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -338,6 +348,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -368,6 +379,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -391,6 +403,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -422,6 +435,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -451,6 +465,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -500,6 +515,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -568,6 +584,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -591,6 +608,7 @@ describe('Parsing, printing, reparsing a function component with props', () => {
       firstAsParseSuccess.imports,
       firstAsParseSuccess.topLevelElements,
       firstAsParseSuccess.jsxFactoryFunction,
+      firstAsParseSuccess.exportsDetail,
     )
 
     const secondParse = clearParseResultUniqueIDs(testParseCode(printed))

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -114,6 +114,14 @@ export function isExported(node: TS.Node): boolean {
   }
 }
 
+export function isDefaultExport(node: TS.Node): boolean {
+  if (node.modifiers == null) {
+    return false
+  } else {
+    return node.modifiers.some((modifier) => modifier.kind === TS.SyntaxKind.DefaultKeyword)
+  }
+}
+
 function parseArrayLiteralExpression(
   sourceFile: TS.SourceFile,
   filename: string,

--- a/editor/src/core/workers/parser-printer/parser-printer-utils.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-utils.spec.ts
@@ -9,27 +9,8 @@ import {
   isJSXAttributeValue,
   defaultPropsParam,
 } from '../../shared/element-template'
-import {
-  guaranteeUniqueUidsFromTopLevel,
-  TopLevelElementAndCodeContext,
-} from './parser-printer-utils'
+import { guaranteeUniqueUidsFromTopLevel } from './parser-printer-utils'
 import Utils from '../../../utils/utils'
-
-function withBounds(topLevelElement: TopLevelElement): TopLevelElementAndCodeContext {
-  return {
-    element: topLevelElement,
-    bounds: {
-      start: {
-        line: 20,
-        character: 10,
-      },
-      end: {
-        line: 21,
-        character: 11,
-      },
-    },
-  }
-}
 
 describe('guaranteeUniqueUidsFromTopLevel', () => {
   it('creates an ID where there was none', () => {
@@ -41,10 +22,8 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
       jsxElement('View', { 'data-uid': jsxAttributeValue('aa') }, []),
       null,
     )
-    const fixedComponent = guaranteeUniqueUidsFromTopLevel([withBounds(exampleComponent)])[0]
-    expect(
-      Utils.path(['element', 'rootElement', 'props', 'data-uid'], fixedComponent),
-    ).toBeDefined()
+    const fixedComponent = guaranteeUniqueUidsFromTopLevel([exampleComponent])[0]
+    expect(Utils.path(['rootElement', 'props', 'data-uid'], fixedComponent)).toBeDefined()
   })
 
   it('if two siblings have the same ID, one will be replaced', () => {
@@ -59,14 +38,14 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
       ]),
       null,
     )
-    const fixedComponent = guaranteeUniqueUidsFromTopLevel([withBounds(exampleComponent)])[0]
+    const fixedComponent = guaranteeUniqueUidsFromTopLevel([exampleComponent])[0]
     const child0UID = Utils.path(
-      ['element', 'rootElement', 'children', 0, 'props', 'data-uid'],
+      ['rootElement', 'children', 0, 'props', 'data-uid'],
       fixedComponent,
     )
     expect(child0UID).toEqual(jsxAttributeValue('aaa'))
     const child1UID = Utils.path(
-      ['element', 'rootElement', 'children', 1, 'props', 'data-uid'],
+      ['rootElement', 'children', 1, 'props', 'data-uid'],
       fixedComponent,
     )
     expect(child1UID).not.toEqual(jsxAttributeValue('aaa'))
@@ -81,12 +60,9 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
       jsxElement('View', { 'data-uid': jsxAttributeFunctionCall('someFunction', []) }, []),
       null,
     )
-    const fixedComponent = guaranteeUniqueUidsFromTopLevel([withBounds(exampleComponent)])[0]
+    const fixedComponent = guaranteeUniqueUidsFromTopLevel([exampleComponent])[0]
 
-    const uidProp = Utils.path<JSXAttribute>(
-      ['element', 'rootElement', 'props', 'data-uid'],
-      fixedComponent,
-    )
+    const uidProp = Utils.path<JSXAttribute>(['rootElement', 'props', 'data-uid'], fixedComponent)
     if (uidProp == null) {
       fail('uid prop does not exist')
     } else {
@@ -106,58 +82,52 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
       ]),
       null,
     )
-    const fixedComponent = guaranteeUniqueUidsFromTopLevel([withBounds(exampleComponent)])[0]
+    const fixedComponent = guaranteeUniqueUidsFromTopLevel([exampleComponent])[0]
     expect(
-      Utils.path(['rootElement'], exampleComponent) ===
-        Utils.path(['element', 'rootElement'], fixedComponent),
+      Utils.path(['rootElement'], exampleComponent) === Utils.path(['rootElement'], fixedComponent),
     ).toBeTruthy()
   })
 
   it('if we had to apply a fix, of course we loose references', () => {
-    const exampleComponent = withBounds(
-      utopiaJSXComponent(
-        'Output',
-        true,
-        defaultPropsParam,
-        [],
-        jsxElement('View', { 'data-uid': jsxAttributeValue('baa') }, [
-          jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, []),
-          jsxElement('View', {} as any, []),
-        ]),
-        null,
-      ),
+    const exampleComponent = utopiaJSXComponent(
+      'Output',
+      true,
+      defaultPropsParam,
+      [],
+      jsxElement('View', { 'data-uid': jsxAttributeValue('baa') }, [
+        jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, []),
+        jsxElement('View', {} as any, []),
+      ]),
+      null,
     )
     const fixedComponent = guaranteeUniqueUidsFromTopLevel([exampleComponent])[0]
     expect(
-      Utils.path(['rootElement'], exampleComponent) ===
-        Utils.path(['element', 'rootElement'], fixedComponent),
+      Utils.path(['rootElement'], exampleComponent) === Utils.path(['rootElement'], fixedComponent),
     ).toBeFalsy()
   })
 
   it('for subtrees which needed no fix, we keep references', () => {
-    const exampleComponent = withBounds(
-      utopiaJSXComponent(
-        'Output',
-        true,
-        defaultPropsParam,
-        [],
-        jsxElement('View', { 'data-uid': jsxAttributeValue('baa') }, [
-          jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [
-            jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, []),
-            jsxElement('View', { 'data-uid': jsxAttributeValue('aac') }, []),
-          ]),
-          jsxElement('View', {}, []),
+    const exampleComponent = utopiaJSXComponent(
+      'Output',
+      true,
+      defaultPropsParam,
+      [],
+      jsxElement('View', { 'data-uid': jsxAttributeValue('baa') }, [
+        jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [
+          jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, []),
+          jsxElement('View', { 'data-uid': jsxAttributeValue('aac') }, []),
         ]),
-        null,
-      ),
+        jsxElement('View', {}, []),
+      ]),
+      null,
     )
     const fixedComponent = guaranteeUniqueUidsFromTopLevel([exampleComponent])[0]
     expect(exampleComponent === fixedComponent).toBeFalsy()
-    expect(Utils.path(['element', 'rootElement', 'children', 0], exampleComponent)).toBe(
-      Utils.path(['element', 'rootElement', 'children', 0], fixedComponent),
+    expect(Utils.path(['rootElement', 'children', 0], exampleComponent)).toBe(
+      Utils.path(['rootElement', 'children', 0], fixedComponent),
     )
-    expect(Utils.path(['element', 'rootElement', 'children', 1], exampleComponent)).not.toBe(
-      Utils.path(['element', 'rootElement', 'children', 1], fixedComponent),
+    expect(Utils.path(['rootElement', 'children', 1], exampleComponent)).not.toBe(
+      Utils.path(['rootElement', 'children', 1], fixedComponent),
     )
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-utils.ts
@@ -1,14 +1,9 @@
 import * as TS from 'typescript'
-import { TopLevelElement, JSXElement } from '../../shared/element-template'
+import { JSXElement, TopLevelElement } from '../../shared/element-template'
 import { fixUtopiaElement } from '../../shared/uid-utils'
 import { fastForEach } from '../../shared/utils'
 import { RawSourceMap } from '../ts/ts-typings/RawSourceMap'
 import { SourceMapConsumer, SourceNode } from 'source-map'
-
-export interface TopLevelElementAndCodeContext {
-  element: TopLevelElement
-  bounds: NodesBounds
-}
 
 // Checks if the first value is greater than the second one.
 export function lineAndCharacterGreaterThan(
@@ -66,16 +61,13 @@ export function getBoundsOfNodes(
 }
 
 export function guaranteeUniqueUidsFromTopLevel(
-  topLevelElements: Array<TopLevelElementAndCodeContext>,
-): Array<TopLevelElementAndCodeContext> {
+  topLevelElements: Array<TopLevelElement>,
+): Array<TopLevelElement> {
   return topLevelElements.map((tle) => {
-    if (tle.element.type === 'UTOPIA_JSX_COMPONENT') {
+    if (tle.type === 'UTOPIA_JSX_COMPONENT') {
       return {
         ...tle,
-        element: {
-          ...tle.element,
-          rootElement: fixUtopiaElement(tle.element.rootElement, []),
-        },
+        rootElement: fixUtopiaElement(tle.rootElement, []),
       }
     } else {
       return tle

--- a/editor/src/core/workers/parser-printer/parser-printer-worker.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-worker.ts
@@ -133,6 +133,7 @@ function printCodeAsync(
     parseSuccess.imports,
     parseSuccess.topLevelElements,
     parseSuccess.jsxFactoryFunction,
+    parseSuccess.exportsDetail,
   )
   const highlightBoundsWithUID = getHighlightBoundsWithUID('with-uids', withUIDs)
 
@@ -141,6 +142,7 @@ function printCodeAsync(
     parseSuccess.imports,
     parseSuccess.topLevelElements,
     parseSuccess.jsxFactoryFunction,
+    parseSuccess.exportsDetail,
   )
   const highlightBoundsWithoutUID = getHighlightBoundsWithoutUID('without-uids', withoutUIDs)
 

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -1,6 +1,5 @@
 import * as FastCheck from 'fast-check'
 import { getSourceMapConsumer } from '../../../third-party/react-error-overlay/utils/getSourceMap'
-import { foldEither, isRight, right } from '../../shared/either'
 import {
   arbitraryJSBlock,
   clearTopLevelElementUniqueIDs,
@@ -31,7 +30,16 @@ import {
 import { sampleCode } from '../../model/new-project-files'
 import { addImport, emptyImports, parseSuccess } from '../common/project-file-utils'
 import { sampleImportsForTests } from '../../model/test-ui-js-file'
-import { isParseSuccess, importAlias, foldParsedTextFile } from '../../shared/project-file-types'
+import {
+  isParseSuccess,
+  importAlias,
+  foldParsedTextFile,
+  exportsDetail,
+  addNamedExportToDetail,
+  EmptyExportsDetail,
+  setNamedDefaultExportInDetail,
+  addModifierExportToDetail,
+} from '../../shared/project-file-types'
 import {
   lintAndParse,
   parseCode,
@@ -95,7 +103,14 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(imports, [exported], expect.objectContaining({}), null, null),
+      parseSuccess(
+        imports,
+        [exported],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -128,7 +143,14 @@ export var whatever = () => <View data-uid={'aaa'}>
     const exported = utopiaJSXComponent('whatever', true, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(imports, [exported], expect.objectContaining({}), null, null),
+      parseSuccess(
+        imports,
+        [exported],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -177,7 +199,14 @@ export function whatever(props) {
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(imports, [exported], expect.objectContaining({}), null, null),
+      parseSuccess(
+        imports,
+        [exported],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -214,7 +243,14 @@ export function whatever() {
     const exported = utopiaJSXComponent('whatever', true, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(imports, [exported], expect.objectContaining({}), null, null),
+      parseSuccess(
+        imports,
+        [exported],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -263,7 +299,14 @@ export default function whatever(props) {
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(imports, [exported], expect.objectContaining({}), null, null),
+      parseSuccess(
+        imports,
+        [exported],
+        expect.objectContaining({}),
+        null,
+        null,
+        setNamedDefaultExportInDetail(EmptyExportsDetail, 'whatever'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -300,7 +343,14 @@ export default function whatever() {
     const exported = utopiaJSXComponent('whatever', true, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(imports, [exported], expect.objectContaining({}), null, null),
+      parseSuccess(
+        imports,
+        [exported],
+        expect.objectContaining({}),
+        null,
+        null,
+        setNamedDefaultExportInDetail(EmptyExportsDetail, 'whatever'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -347,7 +397,14 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     const importsWithCake = addImport('cake', 'cake', [], null, sampleImportsForTests)
     const importsWithStylecss = addImport('./style.css', null, [], null, importsWithCake)
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(importsWithStylecss, [exported], expect.objectContaining({}), null, null),
+      parseSuccess(
+        importsWithStylecss,
+        [exported],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -406,7 +463,14 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     )
     const imports = addImport('cake', 'cake', [importAlias('cake2')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(imports, [exported], expect.objectContaining({}), null, null),
+      parseSuccess(
+        imports,
+        [exported],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   }),
@@ -457,7 +521,14 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         sampleImportsForTests,
       )
       const expectedResult = clearParseResultUniqueIDs(
-        parseSuccess(imports, [exported], expect.objectContaining({}), null, null),
+        parseSuccess(
+          imports,
+          [exported],
+          expect.objectContaining({}),
+          null,
+          null,
+          addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+        ),
       )
       expect(actualResult).toEqual(expectedResult)
     }),
@@ -521,7 +592,14 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       )
       const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
       const expectedResult = clearParseResultUniqueIDs(
-        parseSuccess(imports, [exported], expect.objectContaining({}), null, null),
+        parseSuccess(
+          imports,
+          [exported],
+          expect.objectContaining({}),
+          null,
+          null,
+          addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+        ),
       )
       expect(actualResult).toEqual(expectedResult)
     })
@@ -572,7 +650,14 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(imports, [exported], expect.objectContaining({}), null, null),
+      parseSuccess(
+        imports,
+        [exported],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -657,6 +742,7 @@ return { getSizing: getSizing, spacing: spacing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -728,6 +814,7 @@ return { getSizing: getSizing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -815,6 +902,7 @@ return { getSizing: getSizing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -886,6 +974,7 @@ return {  };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -947,6 +1036,7 @@ return { spacing: spacing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(jsVariable),
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1011,6 +1101,7 @@ return { bgs: bgs, bg: bg };`
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1075,6 +1166,7 @@ return { greys: greys };`
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1137,6 +1229,7 @@ return { a: a, b: b };`
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1202,6 +1295,7 @@ return { a: a, b: b, c: c };`
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1271,6 +1365,7 @@ return { a: a };`
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1335,6 +1430,7 @@ return { a: a, b: b };`
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1400,6 +1496,7 @@ return { bg: bg };`
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1461,6 +1558,7 @@ return { count: count };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(jsVariable),
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1523,6 +1621,7 @@ return { use20: use20 };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(jsVariable),
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1565,6 +1664,7 @@ return { mySet: mySet };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(jsVariable),
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1627,6 +1727,7 @@ return { spacing: spacing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(jsVariable),
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1709,6 +1810,7 @@ return { MyComp: MyComp };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(MyComp),
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1794,6 +1896,7 @@ export var whatever = props => (
         expect.objectContaining({}),
         null,
         null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
       ),
     )
     expect(actualResult).toEqual(expectedResult)
@@ -1907,7 +2010,14 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, ['color'], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(imports, [exported], expect.objectContaining({}), null, null),
+      parseSuccess(
+        imports,
+        [exported],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1945,43 +2055,7 @@ export var whatever = <View data-uid={'aaa'}>
       expect.objectContaining({}),
       null,
       null,
-    )
-    expect(actualResult).toEqual(expectedResult)
-  })
-  it('parses the code when it is a var', () => {
-    const code = `import * as React from "react";
-import {
-  Ellipse,
-  Image,
-  Rectangle,
-  Storyboard,
-  Text,
-  UtopiaUtils,
-  View
-} from "utopia-api";
-import { cake } from 'cake'
-export var whatever = <View data-uid={'aaa'}>
-<cake data-uid={'aab'} style={{backgroundColor: 'red'}} />
-</View>
-`
-    const actualResult = testParseCode(code)
-    const cake = jsxElement(
-      'cake',
-      {
-        'data-uid': jsxAttributeValue('aab'),
-        style: jsxAttributeValue({ backgroundColor: 'red' }),
-      },
-      [],
-    )
-    const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', false, null, [], view, null)
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
-    const expectedResult = parseSuccess(
-      imports,
-      [exported],
-      expect.objectContaining({}),
-      null,
-      null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2013,6 +2087,7 @@ export var App = (props) => <View data-uid={'bbb'}>
       expect.objectContaining({}),
       null,
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'App'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2035,6 +2110,7 @@ export var App = (props) => <View data-uid={'bbb'}>
     const actualResult = testParseCode(code)
     expect(clearParseResultUniqueIDs(actualResult)).toMatchSnapshot()
   })
+
   it('parses back and forth as a var', () => {
     const cake = jsxElement(
       'cake',
@@ -2049,7 +2125,14 @@ export var App = (props) => <View data-uid={'bbb'}>
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', false, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
-    const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
+    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
+    const printedCode = printCode(
+      printCodeOptions(false, true, true),
+      imports,
+      [exported],
+      null,
+      detailOfExports,
+    )
     const actualResult = testParseCode(printedCode)
     const expectedResult = parseSuccess(
       imports,
@@ -2057,9 +2140,11 @@ export var App = (props) => <View data-uid={'bbb'}>
       expect.objectContaining({}),
       null,
       null,
+      detailOfExports,
     )
     expect(actualResult).toEqual(expectedResult)
   })
+
   it('parses back and forth as a var, with some arbitrary javascript', () => {
     const cakeAttributes: JSXAttributes = {
       'data-uid': jsxAttributeValue('aab'),
@@ -2103,11 +2188,13 @@ return { getSizing: getSizing, spacing: spacing };`
     )
     const topLevelElements = [arbitraryBlock, exported].map(clearTopLevelElementUniqueIDs)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
       printCodeOptions(false, true, true),
       imports,
       [...topLevelElements],
       null,
+      detailOfExports,
     )
     const actualResult = clearParseResultUniqueIDs(testParseCode(printedCode))
     const expectedResult = parseSuccess(
@@ -2116,6 +2203,7 @@ return { getSizing: getSizing, spacing: spacing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
+      detailOfExports,
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2131,7 +2219,14 @@ return { getSizing: getSizing, spacing: spacing };`
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
     const exported = utopiaJSXComponent('whatever', false, null, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
-    const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
+    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
+    const printedCode = printCode(
+      printCodeOptions(false, true, true),
+      imports,
+      [exported],
+      null,
+      detailOfExports,
+    )
     const actualResult = testParseCode(printedCode)
     const expectedResult = parseSuccess(
       imports,
@@ -2139,6 +2234,7 @@ return { getSizing: getSizing, spacing: spacing };`
       expect.objectContaining({}),
       null,
       null,
+      detailOfExports,
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2204,6 +2300,7 @@ export var whatever = props => {
         sampleImportsForTests,
         parsedCode.topLevelElements,
         null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
       )
       expect(printedCode).toEqual(code)
     } else {
@@ -2222,7 +2319,14 @@ export var whatever = props => {
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
-    const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
+    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
+    const printedCode = printCode(
+      printCodeOptions(false, true, true),
+      imports,
+      [exported],
+      null,
+      detailOfExports,
+    )
     const actualResult = testParseCode(printedCode)
     const expectedResult = parseSuccess(
       imports,
@@ -2230,6 +2334,7 @@ export var whatever = props => {
       expect.objectContaining({}),
       null,
       null,
+      detailOfExports,
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2249,7 +2354,14 @@ export var whatever = props => {
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [cake])
     const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
-    const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
+    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
+    const printedCode = printCode(
+      printCodeOptions(false, true, true),
+      imports,
+      [exported],
+      null,
+      detailOfExports,
+    )
     const actualResult = clearParseResultUniqueIDs(testParseCode(printedCode))
     // As false properties are eliminated from the output,
     // create a copy of the original and snip that value out.
@@ -2270,7 +2382,14 @@ export var whatever = props => {
       },
     }
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(imports, [withoutFalseProp], expect.objectContaining({}), null, null),
+      parseSuccess(
+        imports,
+        [withoutFalseProp],
+        expect.objectContaining({}),
+        null,
+        null,
+        detailOfExports,
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2322,10 +2441,17 @@ export var whatever = props => {
       null,
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
-    const printedCode = printCode(printCodeOptions(false, true, true), imports, [exported], null)
+    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
+    const printedCode = printCode(
+      printCodeOptions(false, true, true),
+      imports,
+      [exported],
+      null,
+      detailOfExports,
+    )
     const actualResult = clearParseResultUniqueIDs(testParseCode(printedCode))
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(imports, [exported], expect.objectContaining({}), null, null),
+      parseSuccess(imports, [exported], expect.objectContaining({}), null, null, detailOfExports),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2352,6 +2478,7 @@ export var ${BakedInStoryboardVariableName} = <Storyboard data-uid={'${BakedInSt
         emptyImports(),
         parsedCode.topLevelElements,
         null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
       )
       expect(printedCode).toEqual(expectedCode)
     } else {
@@ -2441,38 +2568,13 @@ return { test: test };`
         expect.objectContaining({}),
         null,
         null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
       ),
     )
 
     expect(actualResult).toEqual(expectedResult)
   })
   it('parses arbitrary code in a component back and forth', () => {
-    const code = applyPrettier(
-      `import { cake } from "cake";
-import * as React from "react";
-import {
-  Ellipse,
-  Image,
-  Rectangle,
-  Storyboard,
-  Text,
-  UtopiaUtils,
-  View
-} from "utopia-api";
-export var whatever = props => {
-  function test(n) {
-    return n * 2;
-  }
-  return (
-    <View data-uid={"aaa"}>
-      <cake data-uid={"aab"} left={test(100)} />
-    </View>
-  );
-};
-export var storyboard = <Storyboard data-uid={'utopia-storyboard-uid'} />
-`,
-      false,
-    ).formatted
     const jsCode = `function test(n) {
   return n * 2;
 }`
@@ -2543,10 +2645,20 @@ return { test: test };`
         ),
       ),
     ]
-    const printedCode = printCode(printCodeOptions(false, true, true), imports, components, null)
+    const detailOfExports = addModifierExportToDetail(
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      'storyboard',
+    )
+    const printedCode = printCode(
+      printCodeOptions(false, true, true),
+      imports,
+      components,
+      null,
+      detailOfExports,
+    )
     const actualResult = clearParseResultUniqueIDs(testParseCode(printedCode))
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(imports, components, expect.objectContaining({}), null, null),
+      parseSuccess(imports, components, expect.objectContaining({}), null, null, detailOfExports),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2599,7 +2711,14 @@ export var App = props => {
       null,
     )
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(sampleImportsForTests, [component], expect.objectContaining({}), null, null),
+      parseSuccess(
+        sampleImportsForTests,
+        [component],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'App'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2636,7 +2755,14 @@ export var App = props => {
       null,
     )
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(sampleImportsForTests, [component], expect.objectContaining({}), null, null),
+      parseSuccess(
+        sampleImportsForTests,
+        [component],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'App'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2694,7 +2820,14 @@ export var App = props => {
       null,
     )
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(sampleImportsForTests, [component], expect.objectContaining({}), null, null),
+      parseSuccess(
+        sampleImportsForTests,
+        [component],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'App'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2703,29 +2836,6 @@ export var App = props => {
     expect(isParseSuccess(parseResult)).toBe(true)
   })
   it('parses expressions in JSX back and forth', () => {
-    const code = applyPrettier(
-      `import * as React from "react";
-import {
-  Ellipse,
-  Image,
-  Rectangle,
-  Storyboard,
-  Text,
-  UtopiaUtils,
-  View,
-} from "utopia-api";
-export var App = props => {
-  return (
-    <View data-uid={"aaa"}>
-      {[1, 2, 3].map(n => (
-        <div data-uid={"abc"} />
-      ))}
-    </View>
-  );
-};
-`,
-      false,
-    ).formatted
     const component = utopiaJSXComponent(
       'App',
       true,
@@ -2766,15 +2876,24 @@ export var App = props => {
       ),
       null,
     )
+    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'App')
     const printedCode = printCode(
       printCodeOptions(false, true, true),
       sampleImportsForTests,
       [component],
       null,
+      detailOfExports,
     )
     const actualResult = clearParseResultUniqueIDs(testParseCode(printedCode))
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(sampleImportsForTests, [component], expect.objectContaining({}), null, null),
+      parseSuccess(
+        sampleImportsForTests,
+        [component],
+        expect.objectContaining({}),
+        null,
+        null,
+        detailOfExports,
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2922,7 +3041,14 @@ return { a: a, b: b, MyCustomCompomnent: MyCustomCompomnent };`,
       ),
     )
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(sampleImportsForTests, [component], expect.objectContaining({}), null, null),
+      parseSuccess(
+        sampleImportsForTests,
+        [component],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'App'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2961,7 +3087,14 @@ export var App = props => {
       null,
     )
     const expectedResult = clearParseResultUniqueIDs(
-      parseSuccess(sampleImportsForTests, [component], expect.objectContaining({}), null, null),
+      parseSuccess(
+        sampleImportsForTests,
+        [component],
+        expect.objectContaining({}),
+        null,
+        null,
+        addModifierExportToDetail(EmptyExportsDetail, 'App'),
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2994,6 +3127,7 @@ export var whatever = props => {
       sampleImportsForTests,
       [exported],
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -3026,6 +3160,7 @@ export var whatever = props => {
       sampleImportsForTests,
       [exported],
       null,
+      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -3093,6 +3228,7 @@ return {  };`
         expect.objectContaining({}),
         null,
         null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
       ),
     )
     expect(actualResult).toEqual(expectedResult)
@@ -3170,6 +3306,7 @@ return { result: result };`
         expect.objectContaining({}),
         null,
         null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
       ),
     )
     expect(actualResult).toEqual(expectedResult)
@@ -3243,6 +3380,7 @@ export var whatever = props => {
         expect.objectContaining({}),
         null,
         null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
       ),
     )
     expect(actualResult).toEqual(expectedResult)
@@ -3339,6 +3477,7 @@ return { a: a };`,
         expect.objectContaining({}),
         null,
         null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
       ),
     )
     expect(actualResult).toEqual(expectedResult)
@@ -3358,6 +3497,7 @@ export var whatever = props => {
         expect.objectContaining({}),
         null,
         null,
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
       ),
     )
     expect(actualResult).toEqual(expectedResult)
@@ -3408,6 +3548,7 @@ export var whatever2 = (props) => <View data-uid={'aaa'}>
         printableProjectContent.imports,
         printableProjectContent.topLevelElements,
         printableProjectContent.jsxFactoryFunction,
+        printableProjectContent.exportsDetail,
       )
       const parseResult = testParseCode(printedCode)
       return foldParsedTextFile(
@@ -3498,19 +3639,16 @@ export var App = props => {
     const parseResult = testParseCode(code)
     if (!isParseSuccess(parseResult)) {
       fail('expected parseResult to be Right')
-      return
     }
     const appComponent = parseResult.topLevelElements[1]
     if (!isUtopiaJSXComponent(appComponent) || appComponent.name !== `App`) {
       fail('expected the second topLevelElement to be the App component')
-      return
     }
 
     const arbitraryBlock = appComponent.arbitraryJSBlock
 
     if (arbitraryBlock == null) {
       fail(`expected the App component's arbitraryJSBlock to be defined`)
-      return
     }
 
     const transpiledCharacter = 1 + arbitraryBlock.transpiledJavascript.split('\n')[1].indexOf('b')
@@ -3529,23 +3667,19 @@ export var App = props => {
     const parseResult = testParseCode(code)
     if (!isParseSuccess(parseResult)) {
       fail('expected parseResult to be a success')
-      return
     }
     const appComponent = parseResult.topLevelElements[1]
     if (!isUtopiaJSXComponent(appComponent) || appComponent.name !== `App`) {
       fail('expected the second topLevelElement to be the App component')
-      return
     }
     if (!isJSXElement(appComponent.rootElement)) {
       fail(`expected the App component's root element to be a JSXElement`)
-      return
     }
 
     const arbitraryProp = appComponent.rootElement.props.arbitrary
 
     if (!isJSXAttributeOtherJavaScript(arbitraryProp)) {
       fail(`expected <View /> to have an arbitrary js prop called props.arbitrary`)
-      return
     }
 
     const transpiledCharacter = 1 + arbitraryProp.transpiledJavascript.indexOf('log')

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -23,6 +23,7 @@ import {
   forEachLeft,
   bimapEither,
   forEachRight,
+  traverseEither,
 } from '../../shared/either'
 import {
   ArbitraryJSBlock,
@@ -63,8 +64,15 @@ import {
   ParsedTextFile,
   ParseSuccess,
   PropertyPathPart,
-  isParsedJSONSuccess,
   HighlightBounds,
+  exportsDetail,
+  ExportsDetail,
+  addNamedExportToDetail,
+  setNamedDefaultExportInDetail,
+  mergeExportsDetail,
+  addModifierExportToDetail,
+  isExportDetailNamed,
+  EmptyExportsDetail,
 } from '../../shared/project-file-types'
 import * as PP from '../../shared/property-path'
 import { fastForEach, NO_OP } from '../../shared/utils'
@@ -76,7 +84,6 @@ import {
   flattenOutAnnoyingContainers,
   FunctionContents,
   getPropertyNameText,
-  isExported,
   liftParsedElementsIntoFunctionContents,
   parseArbitraryNodes,
   parseOutFunctionContents,
@@ -84,16 +91,15 @@ import {
   WithParserMetadata,
   parseAttributeOtherJavaScript,
   withParserMetadata,
+  isExported,
+  isDefaultExport,
 } from './parser-printer-parsing'
-import {
-  getBoundsOfNodes,
-  guaranteeUniqueUidsFromTopLevel,
-  TopLevelElementAndCodeContext,
-} from './parser-printer-utils'
+import { getBoundsOfNodes, guaranteeUniqueUidsFromTopLevel } from './parser-printer-utils'
 import { ParserPrinterResultMessage } from './parser-printer-worker'
 import creator from './ts-creator'
 import { applyPrettier } from './prettier-utils'
 import { jsonToExpression } from './json-to-expression'
+import { compareOn, comparePrimitive } from '../../../utils/compare'
 
 function buildPropertyCallingFunction(
   functionName: string,
@@ -412,13 +418,42 @@ export function printCodeOptions(
   }
 }
 
+function getModifersForComponent(
+  element: UtopiaJSXComponent,
+  detailOfExports: ExportsDetail,
+): Array<TS.Modifier> {
+  let result: Array<TS.Modifier> = []
+  let isExportedDirectly: boolean = false
+  let isExportedAsDefault: boolean = false
+  if (detailOfExports.defaultExport?.propertyName === element.name) {
+    isExportedAsDefault = true
+    isExportedDirectly = true
+  } else {
+    const componentExport = detailOfExports.namedExports[element.name]
+    if (componentExport != null && componentExport.type === 'EXPORT_DETAIL_MODIFIER') {
+      isExportedDirectly = true
+    }
+  }
+
+  if (isExportedDirectly) {
+    result.push(TS.createToken(TS.SyntaxKind.ExportKeyword))
+  }
+  if (isExportedAsDefault) {
+    result.push(TS.createToken(TS.SyntaxKind.DefaultKeyword))
+  }
+
+  return result
+}
+
 function printUtopiaJSXComponent(
   printOptions: PrintCodeOptions,
   imports: Imports,
   element: UtopiaJSXComponent,
+  detailOfExports: ExportsDetail,
 ): TS.Node {
   const asJSX = jsxElementToExpression(element.rootElement, imports, printOptions.stripUIDs)
   if (TS.isJsxElement(asJSX) || TS.isJsxSelfClosingElement(asJSX)) {
+    const modifiers = getModifersForComponent(element, detailOfExports)
     if (element.isFunction) {
       const arrowParams = maybeToArray(element.param).map(printParam)
       let statements: Array<TS.Statement> = []
@@ -439,10 +474,10 @@ function printUtopiaJSXComponent(
         bodyBlock,
       )
       const varDec = TS.createVariableDeclaration(element.name, undefined, arrowFunction)
-      return TS.createVariableStatement([TS.createToken(TS.SyntaxKind.ExportKeyword)], [varDec])
+      return TS.createVariableStatement(modifiers, [varDec])
     } else {
       const varDec = TS.createVariableDeclaration(element.name, undefined, asJSX)
-      return TS.createVariableStatement([TS.createToken(TS.SyntaxKind.ExportKeyword)], [varDec])
+      return TS.createVariableStatement(modifiers, [varDec])
     }
   } else {
     throw new Error(
@@ -558,11 +593,38 @@ function createJsxPragma(jsxFactoryFunction: string | null): string {
   }
 }
 
+function produceExportDeclaration(detailOfExports: ExportsDetail) {
+  let possibleExports: Array<TS.ExportSpecifier> = []
+  for (const componentName of Object.keys(detailOfExports.namedExports)) {
+    const exportForComponent = detailOfExports.namedExports[componentName]
+    if (isExportDetailNamed(exportForComponent)) {
+      if (componentName === exportForComponent.propertyName) {
+        possibleExports.push(
+          TS.createExportSpecifier(undefined, TS.createIdentifier(componentName)),
+        )
+      } else {
+        possibleExports.push(
+          TS.createExportSpecifier(
+            TS.createIdentifier(exportForComponent.propertyName),
+            TS.createIdentifier(componentName),
+          ),
+        )
+      }
+    }
+  }
+  if (possibleExports.length === 0) {
+    return null
+  } else {
+    return TS.createExportDeclaration(undefined, undefined, TS.createNamedExports(possibleExports))
+  }
+}
+
 function printCodeImpl(
   printOptions: PrintCodeOptions,
   imports: Imports,
   topLevelElementsIncludingScenes: Array<TopLevelElement>,
   jsxFactoryFunction: string | null,
+  detailOfExports: ExportsDetail,
 ): string {
   // if the project used the old SceneMetadata notation, strip out the Storyboard component here
   const topLevelElements = topLevelElementsIncludingScenes
@@ -639,7 +701,7 @@ function printCodeImpl(
   const topLevelStatements = topLevelElements.map((e) => {
     switch (e.type) {
       case 'UTOPIA_JSX_COMPONENT':
-        return printUtopiaJSXComponent(printOptions, imports, e)
+        return printUtopiaJSXComponent(printOptions, imports, e, detailOfExports)
       case 'ARBITRARY_JS_BLOCK':
         return printArbitraryJSBlock(e)
       default:
@@ -648,10 +710,15 @@ function printCodeImpl(
     }
   })
 
+  const exportDeclaration: TS.ExportDeclaration | null = produceExportDeclaration(detailOfExports)
+
   let statementsToPrint: Array<TS.Node> = []
   statementsToPrint.push(...importDeclarations)
-
   statementsToPrint.push(...topLevelStatements)
+  if (exportDeclaration != null) {
+    statementsToPrint.push(exportDeclaration)
+  }
+
   const printedCode = printStatements(statementsToPrint, printOptions.pretty)
   const jsxPragma = createJsxPragma(jsxFactoryFunction)
   // we just dumbly append the parsed jsx pragma to the top of the file, no matter where it was originally
@@ -660,14 +727,40 @@ function printCodeImpl(
 }
 
 interface PossibleCanvasContentsExpression {
+  type: 'POSSIBLE_CANVAS_CONTENTS_EXPRESSION'
   name: string
   initializer: TS.Expression
 }
 
+function possibleCanvasContentsExpression(
+  name: string,
+  initializer: TS.Expression,
+): PossibleCanvasContentsExpression {
+  return {
+    type: 'POSSIBLE_CANVAS_CONTENTS_EXPRESSION',
+    name: name,
+    initializer: initializer,
+  }
+}
+
 interface PossibleCanvasContentsFunction {
+  type: 'POSSIBLE_CANVAS_CONTENTS_FUNCTION'
   name: string
   parameters: TS.NodeArray<TS.ParameterDeclaration>
   body: TS.ConciseBody
+}
+
+function possibleCanvasContentsFunction(
+  name: string,
+  parameters: TS.NodeArray<TS.ParameterDeclaration>,
+  body: TS.ConciseBody,
+): PossibleCanvasContentsFunction {
+  return {
+    type: 'POSSIBLE_CANVAS_CONTENTS_FUNCTION',
+    name: name,
+    parameters: parameters,
+    body: body,
+  }
 }
 
 type PossibleCanvasContents = PossibleCanvasContentsExpression | PossibleCanvasContentsFunction
@@ -675,7 +768,7 @@ type PossibleCanvasContents = PossibleCanvasContentsExpression | PossibleCanvasC
 function isPossibleCanvasContentsFunction(
   canvasContents: PossibleCanvasContents,
 ): canvasContents is PossibleCanvasContentsFunction {
-  return (canvasContents as PossibleCanvasContentsFunction).body != null
+  return canvasContents.type === 'POSSIBLE_CANVAS_CONTENTS_FUNCTION'
 }
 
 export function looksLikeCanvasElements(
@@ -689,16 +782,18 @@ export function looksLikeCanvasElements(
         const name = variableDeclaration.name.getText(sourceFile)
         const initializer = variableDeclaration.initializer
         if (TS.isArrowFunction(initializer)) {
-          return right({ name: name, parameters: initializer.parameters, body: initializer.body })
+          return right(
+            possibleCanvasContentsFunction(name, initializer.parameters, initializer.body),
+          )
         } else {
-          return right({ name: name, initializer: variableDeclaration.initializer })
+          return right(possibleCanvasContentsExpression(name, variableDeclaration.initializer))
         }
       }
     }
   } else if (TS.isFunctionDeclaration(node)) {
     if (node.name != null && node.body != null) {
       const name = node.name.getText(sourceFile)
-      return right({ name: name, parameters: node.parameters, body: node.body })
+      return right(possibleCanvasContentsFunction(name, node.parameters, node.body))
     }
   }
 
@@ -716,6 +811,37 @@ function getJsxFactoryFunction(sourceFile: TS.SourceFile): string | null {
   }
 }
 
+function getNameFromImportAlias(alias: ImportAlias): string {
+  return alias.name
+}
+
+const compareImportAliasByName = compareOn(getNameFromImportAlias, comparePrimitive)
+
+function detailsFromExportDeclaration(
+  sourceFile: TS.SourceFile,
+  declaration: TS.ExportDeclaration,
+): Either<TS.ExportDeclaration, ExportsDetail> {
+  const exportClause = declaration.exportClause
+  if (exportClause != null && TS.isNamedExports(exportClause)) {
+    const result = exportClause.elements.reduce((workingResult, specifier) => {
+      const specifierName = specifier.name.getText(sourceFile)
+      if (specifier.propertyName == null) {
+        return addNamedExportToDetail(workingResult, specifierName, specifierName)
+      } else {
+        const specifierPropertyName = specifier.propertyName.getText(sourceFile)
+        if (specifierPropertyName === 'default') {
+          return setNamedDefaultExportInDetail(workingResult, specifierName)
+        } else {
+          return addNamedExportToDetail(workingResult, specifierName, specifierPropertyName)
+        }
+      }
+    }, exportsDetail(null, {}))
+    return right(result)
+  } else {
+    return left(declaration)
+  }
+}
+
 export function parseCode(filename: string, sourceText: string): ParsedTextFile {
   const sourceFile = TS.createSourceFile(filename, sourceText, TS.ScriptTarget.ES3)
 
@@ -724,8 +850,7 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
   if (sourceFile == null) {
     return parseFailure([], null, `File ${filename} not found.`, [])
   } else {
-    const code = sourceFile.text
-    let topLevelElements: Array<Either<string, TopLevelElementAndCodeContext>> = []
+    let topLevelElements: Array<Either<string, TopLevelElement>> = []
     let imports: Imports = emptyImports()
     // Find the already existing UIDs so that when we generate one it doesn't duplicate one
     // existing further ahead.
@@ -736,6 +861,9 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
     // handle them as a block of code.
     let arbitraryNodes: Array<TS.Node> = []
     let allArbitraryNodes: Array<TS.Node> = []
+
+    // Account for exported components.
+    let detailOfExports: ExportsDetail = EmptyExportsDetail
 
     function applyAndResetArbitraryNodes(): void {
       const filteredArbitraryNodes = arbitraryNodes.filter(
@@ -756,11 +884,7 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
         topLevelElements.push(
           mapEither((parsed) => {
             highlightBounds = parsed.highlightBounds
-            const bounds = getBoundsOfNodes(sourceFile, filteredArbitraryNodes)
-            return {
-              element: parsed.value,
-              bounds: bounds,
-            }
+            return parsed.value
           }, nodeParseResult),
         )
         allArbitraryNodes = [...allArbitraryNodes, ...filteredArbitraryNodes]
@@ -794,8 +918,19 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
     }, topLevelNodes)
 
     for (const topLevelElement of topLevelNodes) {
-      // Handle imports.
-      if (TS.isImportDeclaration(topLevelElement)) {
+      // Handle export declarations.
+      if (TS.isExportDeclaration(topLevelElement)) {
+        const fromDeclaration = detailsFromExportDeclaration(sourceFile, topLevelElement)
+        // Parsed it fully, so it can be incorporated.
+        forEachRight(fromDeclaration, (toMerge) => {
+          detailOfExports = mergeExportsDetail(detailOfExports, toMerge)
+        })
+        // Unable to parse it so treat it as an arbitrary node.
+        forEachLeft(fromDeclaration, (exportDeclaration) => {
+          arbitraryNodes.push(exportDeclaration)
+        })
+        // Handle imports.
+      } else if (TS.isImportDeclaration(topLevelElement)) {
         if (TS.isStringLiteral(topLevelElement.moduleSpecifier)) {
           const importClause: TS.ImportClause | undefined = topLevelElement.importClause
           const importFrom: string = topLevelElement.moduleSpecifier.text
@@ -830,15 +965,7 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
             const importBindings = importClause.namedBindings
             importedAs = importBindings.name.getText(sourceFile)
           }
-          importedFromWithin.sort((i1, i2) => {
-            if (i1.name < i2.name) {
-              return -1
-            }
-            if (i1.name > i2.name) {
-              return 1
-            }
-            return 0
-          })
+          importedFromWithin.sort(compareImportAliasByName)
           imports = addImport(importFrom, importedWithName, importedFromWithin, importedAs, imports)
         }
       } else {
@@ -921,6 +1048,8 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
             propsUsed = propsUsed.length > 0 ? propsUsed : uniq(parsedContents.value.propsUsed)
             if (contents.elements.length === 1) {
               applyAndResetArbitraryNodes()
+              const exported = isExported(topLevelElement)
+
               const utopiaComponent = utopiaJSXComponent(
                 name,
                 isFunction,
@@ -933,13 +1062,17 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
                 contents.elements[0].value,
                 contents.arbitraryJSBlock,
               )
-              const bounds = getBoundsOfNodes(sourceFile, topLevelElement)
-              topLevelElements.push(
-                right({
-                  element: utopiaComponent,
-                  bounds: bounds,
-                }),
-              )
+
+              const defaultExport = isDefaultExport(topLevelElement)
+              if (exported) {
+                if (defaultExport) {
+                  detailOfExports = setNamedDefaultExportInDetail(detailOfExports, name)
+                } else {
+                  detailOfExports = addModifierExportToDetail(detailOfExports, name)
+                }
+              }
+
+              topLevelElements.push(right(utopiaComponent))
             } else {
               arbitraryNodes.push(topLevelElement)
             }
@@ -959,8 +1092,6 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
     const realTopLevelElements = sequencedTopLevelElements.value
 
     const topLevelElementsWithFixedUIDs = guaranteeUniqueUidsFromTopLevel(realTopLevelElements)
-
-    const topLevelElementsIncludingScenes = topLevelElementsWithFixedUIDs.map((e) => e.element)
 
     let combinedTopLevelArbitraryBlock: ArbitraryJSBlock | null = null
     if (allArbitraryNodes.length > 0) {
@@ -982,10 +1113,11 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
 
     return parseSuccess(
       imports,
-      topLevelElementsIncludingScenes,
+      topLevelElementsWithFixedUIDs,
       highlightBounds,
       jsxFactoryFunction,
       combinedTopLevelArbitraryBlock,
+      detailOfExports,
     )
   }
 }

--- a/editor/src/core/workers/ts/ts-worker.spec.ts
+++ b/editor/src/core/workers/ts/ts-worker.spec.ts
@@ -1,6 +1,7 @@
 import { handleMessage, IncomingWorkerMessage } from './ts-worker'
 import { LayoutSystem } from 'utopia-api'
 import {
+  EmptyExportsDetail,
   RevisionsState,
   textFile,
   textFileContents,
@@ -75,6 +76,7 @@ const SampleInitTSWorkerMessage: IncomingWorkerMessage = {
         "/** @jsx jsx */\nimport * as React from 'react'\nimport {\n  Ellipse,\n  HelperFunctions,\n  Image,\n  NodeImplementations,\n  Rectangle,\n  Text,\n  View,\n  jsx,\n} from 'utopia-api'\nimport {\n  colorTheme,\n  Button,\n  Dialog,\n  Icn,\n  Icons,\n  LargerIcons,\n  FunctionIcons,\n  MenuIcons,\n  Isolator,\n  TabComponent,\n  Tooltip,\n  ActionSheet,\n  Avatar,\n  ControlledTextArea,\n  Title,\n  H1,\n  H2,\n  H3,\n  Subdued,\n  InspectorSectionHeader,\n  InspectorSubsectionHeader,\n  FlexColumn,\n  FlexRow,\n  ResizableFlexColumn,\n  PopupList,\n  Section,\n  TitledSection,\n  SectionTitleRow,\n  SectionBodyArea,\n  UtopiaListSelect,\n  UtopiaListItem,\n  CheckboxInput,\n  NumberInput,\n  StringInput,\n  OnClickOutsideHOC,\n} from 'uuiui'\n\nexport var canvasMetadata = {\n  scenes: [\n    {\n      component: 'App',\n      frame: { height: 812, left: 0, width: 375, top: 0 },\n      props: { layout: { top: 0, left: 0, bottom: 0, right: 0 } },\n      container: { layoutSystem: 'pinSystem' },\n    },\n  ],\n  elementMetadata: {},\n}\n\nexport var App = (props) => {\n  return (\n    <View\n      style={{ ...props.style, backgroundColor: colorTheme.white.value }}\n      layout={{ layoutSystem: 'pinSystem' }}\n      data-uid={'aaa'}\n    ></View>\n  )\n}\n\n",
         {
           type: 'PARSE_SUCCESS',
+          exportsDetail: EmptyExportsDetail,
           imports: {
             react: {
               importedWithName: null,

--- a/editor/src/utils/test-utils.ts
+++ b/editor/src/utils/test-utils.ts
@@ -44,6 +44,7 @@ import {
   isTextFile,
   isParseSuccess,
   ProjectFile,
+  EmptyExportsDetail,
 } from '../core/shared/project-file-types'
 import { right, eitherToMaybe, isLeft } from '../core/shared/either'
 import Utils from './utils'
@@ -76,7 +77,14 @@ export function createPersistentModel(): PersistentModel {
       '/src/app.js': textFile(
         textFileContents(
           '',
-          parseSuccess(sampleImportsForTests, sampleJsxComponentWithScene, {}, null, null),
+          parseSuccess(
+            sampleImportsForTests,
+            sampleJsxComponentWithScene,
+            {},
+            null,
+            null,
+            EmptyExportsDetail,
+          ),
           RevisionsState.ParsedAhead,
         ),
         null,
@@ -117,7 +125,14 @@ export function createEditorStates(
       '/src/app.js': textFile(
         textFileContents(
           '',
-          parseSuccess(sampleImportsForTests, sampleJsxComponentWithScene, {}, null, null),
+          parseSuccess(
+            sampleImportsForTests,
+            sampleJsxComponentWithScene,
+            {},
+            null,
+            null,
+            EmptyExportsDetail,
+          ),
           RevisionsState.ParsedAhead,
         ),
         null,

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -15496,9 +15496,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
       "dev": true
     },
     "ua-parser-js": {


### PR DESCRIPTION
**Problem:**
Currently we don't handle exports in any way and exposing those to the storyboard creation would mean we could handle React components that aren't straight exposed with the `export` modifier.

**Fix:**
Have the parser process and handle exports similarly to exports conglomerating the various ways something can be exported.

**Limitations:**
This does not currently handle things like inline anonymous components that are exposed with `export default` and the `export default Thing` style which can expose an existing constant or variable. Thought it better to checkpoint this work here for now as it covers the overall flow.

**Commit Details:**
- Created `ExportsDetail` along with associated types to represent
  the detail of what is exported, attempting to pull together the
  individual representations of the exports.
- Added `exportsDetail` to `ParseSuccess`.
- Implemented `isDefaultExport`.
- Removed `TopLevelElementAndCodeContext` as it wasn't really used.
- Printer now applies modifiers to elements based on the export detail.
- Printer adds in an export expression as appropriate if values are
  exported that way.
- Parser now also processes export declarations and includes the values
  from those along with the modifiers from JSX components parsed.
- Changed some import sorting to use our comparison code instead of
  a hand rolled function.
