### PR TITLE
never generate the same UID twice during a session

### DIFF
--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -20,12 +20,15 @@ import { objectMap } from './object-utils'
 
 export const UtopiaIDPropertyPath = PP.create(['data-uid'])
 
+const GeneratedUIDs: Set<string> = new Set()
+
 export function generateUID(existingIDs: Array<string>): string {
   const fullUid = UUID().replace(/\-/g, '')
   // trying to find a new 3 character substring from the full uid
   for (let i = 0; i < fullUid.length - 3; i++) {
     const id = fullUid.substring(i, i + 3)
-    if (!existingIDs.includes(id)) {
+    if (!existingIDs.includes(id) && !GeneratedUIDs.has(id)) {
+      GeneratedUIDs.add(id)
       return id
     }
   }


### PR DESCRIPTION
**Problem:**
We keep hitting a duplicate uid error which stops the project from loading.

**Fix:**
Without taking the time to investigate the root cause of the problem, I hardened the uid generator. it now compares the generated UID to a global set of already-generated UIDs, meaning it will never generate the same uid during a session. it still respects the array of forbidden uids that can be passed in as parameter.
