### PR TITLE
Rework the handling of inserting data-uid field.

### DIFF
--- a/editor/src/core/shared/set-utils.ts
+++ b/editor/src/core/shared/set-utils.ts
@@ -1,0 +1,5 @@
+// Should allow us to guard against a type being refactored into something
+// which Set allows but gives us nonsense results.
+export function emptySet<T extends string | boolean | number>(): Set<T> {
+  return new Set()
+}

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -20,16 +20,19 @@ import { objectMap } from './object-utils'
 
 export const UtopiaIDPropertyPath = PP.create(['data-uid'])
 
-const GeneratedUIDs: Set<string> = new Set()
-
-export function generateUID(existingIDs: Array<string>): string {
+export function generateUID(existingIDs: Array<string> | Set<string>): string {
   const fullUid = UUID().replace(/\-/g, '')
   // trying to find a new 3 character substring from the full uid
   for (let i = 0; i < fullUid.length - 3; i++) {
     const id = fullUid.substring(i, i + 3)
-    if (!existingIDs.includes(id) && !GeneratedUIDs.has(id)) {
-      GeneratedUIDs.add(id)
-      return id
+    if (Array.isArray(existingIDs)) {
+      if (!existingIDs.includes(id)) {
+        return id
+      }
+    } else {
+      if (!existingIDs.has(id)) {
+        return id
+      }
     }
   }
   // if all the substrings are already used as ids, let's try again with a new full uid

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -122,7 +122,7 @@ function parseArrayLiteralExpression(
   propsObjectName: string | null,
   literal: TS.ArrayLiteralExpression,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
 ): Either<string, WithParserMetadata<JSXAttribute>> {
   let arrayContents: Array<JSXArrayElement> = []
   let simpleArrayContents: Array<any> = []
@@ -204,7 +204,7 @@ function parseObjectLiteralExpression(
   propsObjectName: string | null,
   literal: TS.ObjectLiteralExpression,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
 ): Either<string, WithParserMetadata<JSXAttribute>> {
   let contents: Array<JSXProperty> = []
   let simpleContents: {
@@ -408,7 +408,7 @@ function parseOtherJavaScript<E extends TS.Node, T>(
   topLevelNames: Array<string>,
   initialPropsObjectName: string | null,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
   create: (
     code: string,
     definedWithin: Array<string>,
@@ -857,7 +857,7 @@ export function parseAttributeOtherJavaScript(
   propsObjectName: string | null,
   expression: TS.Expression,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
 ): Either<string, WithParserMetadata<JSXAttributeOtherJavaScript>> {
   return parseOtherJavaScript(
     sourceFile,
@@ -907,7 +907,7 @@ function parseJSXArbitraryBlock(
   propsObjectName: string | null,
   expression: TS.Expression | undefined,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
 ): Either<string, WithParserMetadata<JSXArbitraryBlock>> {
   return parseOtherJavaScript(
     sourceFile,
@@ -986,7 +986,7 @@ function parseAttributeExpression(
   propsObjectName: string | null,
   expression: TS.Expression,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
 ): Either<string, WithParserMetadata<JSXAttribute>> {
   if (TS.isArrayLiteralExpression(expression)) {
     return parseArrayLiteralExpression(
@@ -1153,7 +1153,7 @@ function getAttributeExpression(
   propsObjectName: string | null,
   initializer: TS.StringLiteral | TS.JsxExpression,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
 ): Either<string, WithParserMetadata<JSXAttribute>> {
   if (TS.isStringLiteral(initializer)) {
     return right(
@@ -1194,7 +1194,7 @@ function parseElementProps(
   propsObjectName: string | null,
   attributes: TS.JsxAttributes,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
 ): Either<string, WithParserMetadata<JSXAttributes>> {
   let result: JSXAttributes = {}
   let highlightBounds = existingHighlightBounds
@@ -1386,10 +1386,10 @@ function forciblyUpdateDataUID(
   originatingElement: TS.Node,
   props: JSXAttributes,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
 ): WithParserMetadata<JSXAttributes> {
-  const keysToAvoid = [...alreadyExistingUIDs, ...Object.keys(existingHighlightBounds)]
-  const uid = generateUID(keysToAvoid)
+  const uid = generateUID(alreadyExistingUIDs)
+  alreadyExistingUIDs.add(uid)
   const updatedProps = {
     ...props,
     ['data-uid']: jsxAttributeValue(uid),
@@ -1412,7 +1412,7 @@ function createJSXElementAllocatingUID(
   props: JSXAttributes,
   children: JSXElementChildren,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
 ): WithParserMetadata<SuccessfullyParsedElement> {
   const dataUIDAttribute = parseUID(props)
   const updatedProps = foldEither(
@@ -1472,7 +1472,7 @@ export function parseOutJSXElements(
   topLevelNames: Array<string>,
   propsObjectName: string | null,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
 ): ParseElementsResult {
   let highlightBounds = existingHighlightBounds
   let propsUsed: Array<string> = []
@@ -1817,7 +1817,7 @@ export function parseArbitraryNodes(
   topLevelNames: Array<string>,
   propsObjectName: string | null,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
   rootLevel: boolean,
 ): Either<string, WithParserMetadata<ArbitraryJSBlock>> {
   return parseOtherJavaScript(
@@ -1901,7 +1901,7 @@ export function parseOutFunctionContents(
   propsObjectName: string | null,
   arrowFunctionBody: TS.ConciseBody,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  alreadyExistingUIDs: ReadonlyArray<string>,
+  alreadyExistingUIDs: Set<string>,
 ): Either<string, WithParserMetadata<FunctionContents>> {
   let highlightBounds = existingHighlightBounds
   if (TS.isBlock(arrowFunctionBody)) {

--- a/editor/src/core/workers/parser-printer/parser-printer-test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-test-utils.ts
@@ -557,7 +557,7 @@ export function ensureElementsHaveUID(jsxElementChild: JSXElementChild, uids: Ar
     // Relies on this function blowing out for anything that doesn't have a valid one.
     const uid = getUtopiaIDFromJSXElement(element)
     if (uids.includes(uid)) {
-      throw new Error(`UID ${uid} is duplicated in ${element}`)
+      throw new Error(`UID ${uid} is duplicated in ${JSON.stringify(element)}`)
     } else {
       uids.push(uid)
     }

--- a/editor/src/core/workers/parser-printer/parser-printer-uids.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-uids.spec.ts
@@ -1,0 +1,24 @@
+import { MajesticBrokerTestCaseCode } from '../../../test-cases/majestic-broker'
+import { getAllUniqueUids } from '../../model/element-template-utils'
+import { getComponentsFromTopLevelElements } from '../../model/project-file-utils'
+import { uniq } from '../../shared/array-utils'
+import { foldParsedTextFile } from '../../shared/project-file-types'
+import { testParseCode } from './parser-printer-test-utils'
+
+describe('parseCode', () => {
+  it('produces unique IDs for every element', () => {
+    const parseResult = testParseCode(MajesticBrokerTestCaseCode)
+    foldParsedTextFile(
+      (_) => fail('Is a failure.'),
+      (success) => {
+        const uniqueIDs = getAllUniqueUids(
+          getComponentsFromTopLevelElements(success.topLevelElements),
+          'Unique IDs failure.',
+        )
+        expect(uniq(uniqueIDs).length).toMatchInlineSnapshot(`74`)
+      },
+      (_) => fail('Is unparsed.'),
+      parseResult,
+    )
+  })
+})

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -94,6 +94,7 @@ import { ParserPrinterResultMessage } from './parser-printer-worker'
 import creator from './ts-creator'
 import { applyPrettier } from './prettier-utils'
 import { jsonToExpression } from './json-to-expression'
+import { emptySet } from '../../shared/set-utils'
 
 function buildPropertyCallingFunction(
   functionName: string,
@@ -729,7 +730,7 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
     let imports: Imports = emptyImports()
     // Find the already existing UIDs so that when we generate one it doesn't duplicate one
     // existing further ahead.
-    const alreadyExistingUIDs: ReadonlyArray<string> = collatedUIDs(sourceFile)
+    const alreadyExistingUIDs: Set<string> = emptySet() // collatedUIDs(sourceFile)
     let highlightBounds: HighlightBoundsForUids = {}
 
     // As we hit chunks of arbitrary code, shove them here so we can
@@ -997,7 +998,7 @@ function parseParams(
   imports: Imports,
   topLevelNames: Array<string>,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  existingUIDs: ReadonlyArray<string>,
+  existingUIDs: Set<string>,
 ): Either<string, WithParserMetadata<Array<Param>>> {
   let parsedParams: Array<Param> = []
   let highlightBounds: HighlightBoundsForUids = { ...existingHighlightBounds }
@@ -1034,7 +1035,7 @@ function parseParam(
   imports: Imports,
   topLevelNames: Array<string>,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  existingUIDs: ReadonlyArray<string>,
+  existingUIDs: Set<string>,
 ): Either<string, WithParserMetadata<Param>> {
   const dotDotDotToken = param.dotDotDotToken != null
   const parsedExpression: Either<
@@ -1085,7 +1086,7 @@ function parseBindingName(
   imports: Imports,
   topLevelNames: Array<string>,
   existingHighlightBounds: Readonly<HighlightBoundsForUids>,
-  existingUIDs: ReadonlyArray<string>,
+  existingUIDs: Set<string>,
 ): Either<string, WithParserMetadata<BoundParam>> {
   let highlightBounds: HighlightBoundsForUids = {
     ...existingHighlightBounds,
@@ -1330,11 +1331,11 @@ export function getHighlightBoundsWithoutUID(
   return result
 }
 
-function collatedUIDs(sourceFile: TS.SourceFile): Array<string> {
-  let result: Array<string> = []
+function collatedUIDs(sourceFile: TS.SourceFile): Set<string> {
+  let result: Set<string> = emptySet()
   function addUID(boundingElement: TS.Node, attributes: TS.JsxAttributes): void {
     withUID(undefined, attributes, undefined, (uid) => {
-      result = addUniquely(result, uid)
+      result.add(uid)
     })
   }
   withJSXElementAttributes(sourceFile, addUID)

--- a/editor/src/test-cases/majestic-broker.ts
+++ b/editor/src/test-cases/majestic-broker.ts
@@ -1,0 +1,463 @@
+export const MajesticBrokerTestCaseCode = `
+/** @jsx jsx */
+import * as React from 'react'
+import { Scene, Storyboard, View, jsx } from 'utopia-api'
+export var User = (props) => {
+  return <span style={{ ...props.style, fontWeight: 600 }}>{props.children}</span>
+}
+User.propertyControls = {
+  style: {
+    type: 'styleobject',
+  },
+}
+export var Comment = (props) => {
+  return (
+    <span style={{ ...props.style, fontWeight: 400, color: 'grey', marginLeft: 12 }}>
+      {props.children}
+    </span>
+  )
+}
+Comment.propertyControls = {
+  style: {
+    type: 'styleobject',
+  },
+}
+export var Card = (props) => {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          fontWeight: 500,
+          marginLeft: 20,
+          marginRight: 20,
+        }}
+        layout={{ flexBasis: 58 }}
+      >
+        <div
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: 50,
+            border: '1px solid red',
+            boxShadow: 'inset 0px 0px 0px 2px white',
+            background: \`url(\${props.url})\`,
+            backgroundSize: '32px 32px',
+          }}
+        />
+        <h3
+          style={{ marginLeft: 16, flexGrow: 1, fontSize: 14, fontWeight: 600 }}
+          layout={{ crossBasis: 49 }}
+        >
+          Zeus
+          <View
+            style={{ backgroundColor: '#0091FFAA', left: 46, top: 11, width: 82, height: 62 }}
+            layout={{ layoutSystem: 'pinSystem' }}
+          />
+        </h3>
+        <button style={{ flexGrow: 0, border: 'none', backgroundColor: 'transparent' }}>
+          . . .{' '}
+        </button>
+      </div>
+      .
+      <div
+        data-label={'card'}
+        style={{
+          minWidth: 200,
+          maxWidth: 375,
+          minHeight: 400,
+          boxShadow: '0px 0px 5px 2px rgba(0,0,0,.1)',
+          backgroundRepeat: 'repeat',
+          backgroundSize: '10px 10px',
+          position: 'relative',
+        }}
+      >
+        <img src={props.url} width={375} />
+        <div style={{ width: '100%', marginLeft: 16, marginRight: 16 }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              cursor: 'pointer',
+              gap: 20,
+              height: 40,
+            }}
+          >
+            <div style={{ fontSize: 25 }}>✩</div>
+            <div style={{ fontSize: 25 }}>⌽</div>
+            <div style={{ fontSize: 25 }}>〠</div>
+          </div>
+          <p className={'description'}>
+            <span style={{ fontFamily: 'garamond', fontSize: 15 }}>
+              Quando quegli stati, che si acquistano, sono abituati a vivere con le loro leggi e in
+              libertà, a volerli mantenere, ci sono tre modi: il primo, raderne al suolo le città;
+              l’altro, andarvi ad abitare personalmente; il terzo,{' '}
+              <b>
+                lasciarli vivere con le loro leggi, traendone un tributo e creandovi dentro
+                un’amministrazione fatta di pochi individui che te li conservino amici.
+              </b>
+              <a style={{ color: 'black', textDecoration: 'none' }} href={''}>
+                #macchiavelli
+              </a>
+              &nbsp;
+              <a style={{ color: 'black', textDecoration: 'none' }} href={''}>
+                #goodadvice
+              </a>
+              &nbsp;
+              <a style={{ color: 'black', textDecoration: 'none' }} href={''}>
+                #selfhelp
+              </a>
+              &nbsp;
+            </span>
+          </p>
+          <p>
+            <span style={{ fontWeight: 400 }}>
+              <User>Apollo</User>
+              <Comment>Uva uvam vivendo varia fit?</Comment>
+            </span>
+          </p>
+          <p>
+            <span style={{ fontWeight: 400 }}>
+              <User>Hercules</User>
+              <Comment>Ita est.</Comment>
+            </span>
+          </p>
+          <p>
+            <span style={{ fontWeight: 400 }}>
+              <User>Xena</User>
+              <Comment>In hoc signo vinces.</Comment>
+            </span>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+export var Photo = (props) => {
+  return (
+    <div
+      style={{
+        ...props.style,
+        backgroundSize: 'contain',
+        backgroundSize: '20px 20px',
+        borderRadius: 50,
+        height: 50,
+        width: 50,
+        background: \`url(\${props.url})\`,
+        transition: 'all .2s linear',
+      }}
+    />
+  )
+}
+Photo.propertyControls = {
+  style: {
+    type: 'styleobject',
+  },
+}
+export var ScrollablePhotoGrid = (props) => {
+  return (
+    <div style={{ ...props.style, overflowX: 'scroll', position: 'absolute', left: 0, right: 0 }}>
+      <div
+        style={{
+          display: 'flex',
+          gap: 20,
+          width: 600,
+          marginTop: 20,
+          marginBottom: 20,
+          padding: 8,
+        }}
+      >
+        <div style={{ width: 300, height: 300, display: 'relative' }}>
+          hi
+          <div
+            style={{
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              top: 8,
+              height: 78,
+              width: 122,
+              left: 38,
+            }}
+            layout={{ layoutSystem: 'pinSystem' }}
+          >
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                height: 40,
+                width: 76,
+                left: 6,
+                top: 5,
+                position: 'absolute',
+              }}
+              layout={{ layoutSystem: 'pinSystem' }}
+            />
+          </div>
+        </div>
+        <Photo
+          url={
+            'https://images.generated.photos/F3N3OT3PEQgszg8GLS1dfQf2vRkjoXCwff5cjs_l5Oc/rs:fit:512:512/Z3M6Ly9nZW5lcmF0/ZWQtcGhvdG9zL3Yz/XzAyMDY3NDEuanBn.jpg'
+          }
+        />
+        <Photo
+          url={
+            'https://images.generated.photos/fqisoBYuCsobJnXNh6CAxBLv4ErstueHips0ddRMrD4/rs:fit:512:512/Z3M6Ly9nZW5lcmF0/ZWQtcGhvdG9zL3Yy/XzAzMDk2MjAuanBn.jpg'
+          }
+        />
+        <Photo
+          url={
+            'https://images.generated.photos/GMbjdhAJrCKhDT8C7jMCJVHMjSc0S0A-nXcfNTPvCOo/rs:fit:512:512/Z3M6Ly9nZW5lcmF0/ZWQtcGhvdG9zL3Yy/XzAyNjMwOTEuanBn.jpg'
+          }
+        />
+        <Photo
+          url={
+            'https://images.generated.photos/f0Uen3tXgTUbdKLBhgRC5Vk5m2lNGsUAxMz4Y8yOE9E/rs:fit:512:512/Z3M6Ly9nZW5lcmF0/ZWQtcGhvdG9zL3Yy/XzA1NDI0MTUuanBn.jpg'
+          }
+        />
+        <Photo
+          url={
+            'https://images.generated.photos/gsx5n_96xTlUxl4YjkBFUwgXi3LLH23ifpiwisDoX-Q/rs:fit:512:512/Z3M6Ly9nZW5lcmF0/ZWQtcGhvdG9zL3Yy/XzAwODc5ODYuanBn.jpg'
+          }
+        />
+        <Photo
+          url={
+            'https://images.generated.photos/LCOHlb4KV8SFHypgVUD1qDLn-n1q5eLckMfnVklfIUo/rs:fit:512:512/Z3M6Ly9nZW5lcmF0/ZWQtcGhvdG9zL3Yy/XzA1NDQxMDkuanBn.jpg'
+          }
+        />
+        <Photo
+          url={
+            'https://images.generated.photos/LCOHlb4KV8SFHypgVUD1qDLn-n1q5eLckMfnVklfIUo/rs:fit:512:512/Z3M6Ly9nZW5lcmF0/ZWQtcGhvdG9zL3Yy/XzA1NDQxMDkuanBn.jpg'
+          }
+        />
+        <Photo
+          url={
+            'https://images.generated.photos/LCOHlb4KV8SFHypgVUD1qDLn-n1q5eLckMfnVklfIUo/rs:fit:512:512/Z3M6Ly9nZW5lcmF0/ZWQtcGhvdG9zL3Yy/XzA1NDQxMDkuanBn.jpg'
+          }
+        />
+        <Photo
+          url={
+            'https://images.generated.photos/LCOHlb4KV8SFHypgVUD1qDLn-n1q5eLckMfnVklfIUo/rs:fit:512:512/Z3M6Ly9nZW5lcmF0/ZWQtcGhvdG9zL3Yy/XzA1NDQxMDkuanBn.jpg'
+          }
+        />
+      </div>
+    </div>
+  )
+}
+ScrollablePhotoGrid.propertyControls = {
+  style: {
+    type: 'styleobject',
+  },
+}
+export var Content = (props) => {
+  return (
+    <div
+      style={{
+        ...props.style,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 20,
+        paddingTop: 20,
+        paddingBottom: 40,
+      }}
+    >
+      {props.children}
+    </div>
+  )
+}
+Content.propertyControls = {
+  style: {
+    type: 'styleobject',
+  },
+}
+export var BottomMenu = (props) => {
+  return (
+    <div
+      style={{
+        ...props.style,
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+      }}
+    >
+      {props.children}
+    </div>
+  )
+}
+BottomMenu.propertyControls = {
+  style: {
+    type: 'styleobject',
+  },
+}
+export var App = () => {
+  return (
+    <div
+      id={'sampleBody'}
+      style={{ position: 'relative', background: 'url(./bg.jpg)', width: '100%', height: '100%' }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          bottom: 0,
+          top: 0,
+          background: 'rgba(78,0,0,.3)',
+          backdropFilter: 'blur (23px)',
+        }}
+      />
+      <div
+        data-label={'preview'}
+        style={{
+          position: 'absolute',
+          width: 375,
+          margin: 40,
+          boxShadow: '0px 10px 35px 5px rgba(0,0,0,.5)',
+          borderRadius: 5,
+          background: 'rgb(10,30,50)',
+          color: '#B2943D',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'stretch',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 30,
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            flexGrow: 0.5,
+          }}
+        >
+          <span>␐</span>
+          <span style={{ fontWeight: 'bold' }}>␖</span>
+          <span>␖</span>
+          <span>␖</span>
+          <span>␖</span>
+        </div>
+        <div id={'scrollView'} style={{ minHeight: 100, margin: 'auto', overflowX: 'hidden' }}>
+          <ScrollablePhotoGrid />
+        </div>
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            zIndex: 99999,
+            left: 0,
+            right: 0,
+            backgroundColor: 'rgb(30,60,80)',
+            boxShadow: 'inset 0px 1px 0px 0px grey',
+            display: 'grid',
+            gridTemplateColumns: '60px 60px 120px 60px 60px',
+            height: 40,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              fontSize: 22,
+              fontWeight: 700,
+              color: '#B2943D',
+              justifyContent: 'center',
+            }}
+          >
+            🃈
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              fontSize: 22,
+              fontWeight: 700,
+              color: '#B2943D',
+              justifyContent: 'center',
+            }}
+          >
+            🃌
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              fontSize: 22,
+              fontWeight: 700,
+              color: '#B2943D',
+              justifyContent: 'center',
+            }}
+          >
+            🀑
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              fontSize: 22,
+              fontWeight: 700,
+              color: '#B2943D',
+              justifyContent: 'center',
+            }}
+          >
+            🃈
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              fontSize: 22,
+              fontWeight: 700,
+              color: '#B2943D',
+              justifyContent: 'center',
+            }}
+          >
+            🀚
+          </div>
+        </div>
+        <div
+          id={'scrollView'}
+          style={{ width: 375, height: 400, overflowY: 'scroll', position: 'relative' }}
+        >
+          <Content>
+            {[
+              'https://upload.wikimedia.org/wikipedia/commons/8/88/Bonifacio_bembo%2C_regina_di_spade.jpg',
+              'https://upload.wikimedia.org/wikipedia/en/thumb/0/0d/Wands13.jpg/220px-Wands13.jpg',
+              'https://upload.wikimedia.org/wikipedia/en/c/c3/RWS_Tarot_04_Emperor.jpg',
+              'https://upload.wikimedia.org/wikipedia/en/0/0d/Wands13.jpg',
+              'https://upload.wikimedia.org/wikipedia/en/3/33/Swords14.jpg',
+            ].map((item) => (
+              <Card url={item}>{item}</Card>
+            ))}
+          </Content>
+          <BottomMenu />
+        </div>
+      </div>
+    </div>
+  )
+}
+export var storyboard = (
+  <Storyboard>
+    <Scene
+      component={App}
+      props={{}}
+      style={{ position: 'absolute', left: 0, top: 0, width: 522, height: 652 }}
+    />
+    <Scene
+      data-label={'ScrollablePhotoGrid'}
+      component={ScrollablePhotoGrid}
+      resizeContent
+      style={{ position: 'absolute', left: 561, top: 1, width: 437, height: 96 }}
+    />
+    <Scene
+      data-label={'Card'}
+      component={Card}
+      resizeContent
+      props={{
+        url:
+          'https://upload.wikimedia.org/wikipedia/commons/8/88/Bonifacio_bembo%2C_regina_di_spade.jpg',
+      }}
+      style={{ position: 'absolute', left: 561, top: 123, width: 376, height: 1110 }}
+    />
+  </Storyboard>
+)
+`

--- a/editor/src/utils/utils.ts
+++ b/editor/src/utils/utils.ts
@@ -141,6 +141,7 @@ import {
 } from '../core/shared/code-exec-utils'
 import { memoize } from '../core/shared/memoize'
 import { ValueType, OptionsType, OptionTypeBase } from 'react-select'
+import { emptySet } from '../core/shared/set-utils'
 // TODO Remove re-exported functions
 
 export type FilteredFields<Base, T> = {
@@ -790,12 +791,6 @@ function createThrottler(
       }, timeout)
     }
   }
-}
-
-// Should allow us to guard against a type being refactored into something
-// which Set allows but gives us nonsense results.
-function emptySet<T extends string | boolean | number>(): Set<T> {
-  return new Set()
 }
 
 function path<T>(

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -15496,9 +15496,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
       "dev": true
     },
     "ua-parser-js": {


### PR DESCRIPTION
Fixes #668

**Problem:**
The quick fix done for handling duplicate UIDs had a memory leak which meant it would grow in size effectively infinitely (albeit slowly).

**Fix:**
Slightly reworked the original handling of duplicate UIDs to actually add values as it went to prevent duplicates.

**Commit Details:**
- Fixes #668.
- `alreadyExistingUIDs` passed around the parser functions is now a mutated
  `Set` so that it can be used more effectively to record the UIDs
  seen so far in the parser flow.
- Removed `GeneratedUIDs`.
- Refactored out `emptySet` into a new file.
- Added the "majestic-broker" project code as a full test case.
