### PR TITLE
spike: a separate canvas iframe

### DIFF
--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -307,6 +307,7 @@ describe('Generating codeResultCache', () => {
       'incremental',
       null,
       false,
+      null,
     )
 
     expect(codeResultCache).toMatchSnapshot()
@@ -323,6 +324,7 @@ describe('Generating codeResultCache', () => {
       'incremental',
       null,
       false,
+      null,
     )
 
     expect(codeResultCache).toMatchSnapshot()
@@ -338,6 +340,7 @@ describe('Generating codeResultCache', () => {
       'incremental',
       null,
       false,
+      null,
     )
 
     expect(codeResultCache).toMatchSnapshot()
@@ -356,6 +359,7 @@ describe('Creating require function', () => {
       'incremental',
       null,
       false,
+      null,
     )
 
     expect(codeResultCache.requireFn('/', './app', false)).toMatchSnapshot()
@@ -371,6 +375,7 @@ describe('Creating require function', () => {
       'incremental',
       null,
       false,
+      null,
     )
 
     expect(codeResultCache.requireFn('/', './app', false)).toMatchSnapshot()
@@ -387,6 +392,7 @@ describe('Creating require function', () => {
       'incremental',
       null,
       false,
+      null,
     )
 
     expect(() => codeResultCache.requireFn('/', './src/code', false)).toThrowErrorMatchingSnapshot()
@@ -402,6 +408,7 @@ describe('Creating require function', () => {
       'incremental',
       null,
       false,
+      null,
     )
 
     expect(() => codeResultCache.requireFn('/', 'foo', false)).toThrowErrorMatchingSnapshot()

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -10,6 +10,7 @@ import { PropertyControls } from 'utopia-api'
 import { RawSourceMap } from '../../core/workers/ts/ts-typings/RawSourceMap'
 import { SafeFunction } from '../../core/shared/code-exec-utils'
 import {
+  CanvasRelatedProps,
   getControlsForExternalDependencies,
   NodeModulesUpdate,
   sendPropertyControlsInfoRequest,
@@ -180,6 +181,7 @@ export function generateCodeResultCache(
   buildType: BuildType,
   mainUiFileName: string | null,
   onlyProjectFiles: boolean,
+  canvasRelatedProps: CanvasRelatedProps | null,
 ): CodeResultCache {
   // Makes the assumption that `fullBuild` and `updatedModules` are in line
   // with each other.
@@ -216,7 +218,13 @@ export function generateCodeResultCache(
   }
 
   // Trigger async call to build the property controls info.
-  sendPropertyControlsInfoRequest(exportsInfo, nodeModules, projectContents, onlyProjectFiles)
+  sendPropertyControlsInfoRequest(
+    exportsInfo,
+    nodeModules,
+    projectContents,
+    onlyProjectFiles,
+    canvasRelatedProps,
+  )
 
   const requireFn = getEditorRequireFn(projectContents, nodeModules, dispatch)
 

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -221,7 +221,7 @@ describe('SET_CANVAS_FRAMES', () => {
       ],
       false,
     )
-    const newEditor = UPDATE_FNS.SET_CANVAS_FRAMES(action, testEditor, derivedState)
+    const newEditor = UPDATE_FNS.SET_CANVAS_FRAMES(action, testEditor, derivedState, NO_OP)
     const newUiJsFile = getContentsTreeFileFromString(
       newEditor.projectContents,
       '/src/app.js',
@@ -827,16 +827,26 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
   })
   it('switches from pins to flex correctly', () => {
     const switchActionToFlex = switchLayoutSystem('flex')
-    const result = UPDATE_FNS.SWITCH_LAYOUT_SYSTEM(switchActionToFlex, testEditorWithPins)
+    const result = UPDATE_FNS.SWITCH_LAYOUT_SYSTEM(
+      switchActionToFlex,
+      testEditorWithPins,
+      null as any,
+      NO_OP as any,
+    )
     expect(
       getOpenUtopiaJSXComponentsFromState(result).map(clearTopLevelElementUniqueIDs),
     ).toMatchSnapshot()
   })
   it('switches from flex to pins correctly', () => {
     const switchActionToFlex = switchLayoutSystem('flex')
-    let result = UPDATE_FNS.SWITCH_LAYOUT_SYSTEM(switchActionToFlex, testEditorWithPins)
+    let result = UPDATE_FNS.SWITCH_LAYOUT_SYSTEM(
+      switchActionToFlex,
+      testEditorWithPins,
+      null as any,
+      NO_OP as any,
+    )
     const switchActionToPins = switchLayoutSystem(LayoutSystem.PinSystem)
-    result = UPDATE_FNS.SWITCH_LAYOUT_SYSTEM(switchActionToPins, result)
+    result = UPDATE_FNS.SWITCH_LAYOUT_SYSTEM(switchActionToPins, result, null as any, NO_OP as any)
     expect(
       getOpenUtopiaJSXComponentsFromState(result).map(clearTopLevelElementUniqueIDs),
     ).toMatchSnapshot()
@@ -898,6 +908,7 @@ describe('LOAD', () => {
         'full-build',
         null,
         false,
+        null,
       ),
       title: '',
       projectId: '',

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -625,8 +625,8 @@ const PropertyControlsInfoComponent = betterReactMemo('PropertyControlsInfoCompo
       allow='autoplay'
       style={{
         backgroundColor: 'transparent',
-        width: '0px',
-        height: '0px',
+        width: '300px',
+        height: '600px',
         borderWidth: 0,
       }}
     />

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -131,6 +131,7 @@ function processAction(
     const editorAfterCanvas = runLocalCanvasAction(
       editorAfterUpdateFunction,
       working.derived,
+      dispatchEvent,
       action as CanvasAction,
     )
     let editorAfterNavigator = runLocalNavigatorAction(

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1066,6 +1066,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
       'full-build',
       null,
       true,
+      null,
     ),
     propertyControlsInfo: {},
     nodeModules: {
@@ -1348,6 +1349,7 @@ export function editorModelFromPersistentModel(
       'full-build',
       null,
       true,
+      null,
     ),
     projectContents: persistentModel.projectContents,
     propertyControlsInfo: getControlsForExternalDependencies(npmDependencies),

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -22,11 +22,11 @@ export function runLocalEditorAction(
 ): EditorState {
   switch (action.action) {
     case 'SET_CANVAS_FRAMES':
-      return UPDATE_FNS.SET_CANVAS_FRAMES(action, state, derivedState)
+      return UPDATE_FNS.SET_CANVAS_FRAMES(action, state, derivedState, dispatch)
     case 'ALIGN_SELECTED_VIEWS':
-      return UPDATE_FNS.ALIGN_SELECTED_VIEWS(action, state, derivedState)
+      return UPDATE_FNS.ALIGN_SELECTED_VIEWS(action, state, derivedState, dispatch)
     case 'DISTRIBUTE_SELECTED_VIEWS':
-      return UPDATE_FNS.DISTRIBUTE_SELECTED_VIEWS(action, state, derivedState)
+      return UPDATE_FNS.DISTRIBUTE_SELECTED_VIEWS(action, state, derivedState, dispatch)
     case 'SAVE_ASSET':
       return UPDATE_FNS.SAVE_ASSET(action, state, derivedState, dispatch, userState)
     default:
@@ -155,7 +155,7 @@ export function runSimpleLocalEditorAction(
     case 'SET_Z_INDEX':
       return UPDATE_FNS.SET_Z_INDEX(action, state, derivedState)
     case 'UPDATE_FRAME_DIMENSIONS':
-      return UPDATE_FNS.UPDATE_FRAME_DIMENSIONS(action, state, derivedState)
+      return UPDATE_FNS.UPDATE_FRAME_DIMENSIONS(action, state, derivedState, dispatch)
     case 'SET_NAVIGATOR_RENAMING_TARGET':
       return UPDATE_FNS.SET_NAVIGATOR_RENAMING_TARGET(action, state)
     case 'SET_STORED_FONT_SETTINGS':
@@ -223,7 +223,7 @@ export function runSimpleLocalEditorAction(
     case 'TOGGLE_PROPERTY':
       return UPDATE_FNS.TOGGLE_PROPERTY(action, state)
     case 'SWITCH_LAYOUT_SYSTEM':
-      return UPDATE_FNS.SWITCH_LAYOUT_SYSTEM(action, state)
+      return UPDATE_FNS.SWITCH_LAYOUT_SYSTEM(action, state, derivedState, dispatch)
     case 'CLEAR_IMAGE_FILE_BLOB':
       return UPDATE_FNS.CLEAR_IMAGE_FILE_BLOB(action, state)
     case 'SAVE_CURRENT_FILE':
@@ -269,7 +269,7 @@ export function runSimpleLocalEditorAction(
     case 'RESET_PROP_TO_DEFAULT':
       return UPDATE_FNS.RESET_PROP_TO_DEFAULT(action, state)
     case 'UPDATE_NODE_MODULES_CONTENTS':
-      return UPDATE_FNS.UPDATE_NODE_MODULES_CONTENTS(action, state, dispatch)
+      return UPDATE_FNS.UPDATE_NODE_MODULES_CONTENTS(action, state, derivedState, dispatch)
     case 'UPDATE_PACKAGE_JSON':
       return UPDATE_FNS.UPDATE_PACKAGE_JSON(action, state)
     case 'START_CHECKPOINT_TIMER':
@@ -277,7 +277,7 @@ export function runSimpleLocalEditorAction(
     case 'FINISH_CHECKPOINT_TIMER':
       return UPDATE_FNS.FINISH_CHECKPOINT_TIMER(action, state)
     case 'ADD_MISSING_DIMENSIONS':
-      return UPDATE_FNS.ADD_MISSING_DIMENSIONS(action, state)
+      return UPDATE_FNS.ADD_MISSING_DIMENSIONS(action, state, derivedState, dispatch)
     case 'SET_PACKAGE_STATUS':
       return UPDATE_FNS.SET_PACKAGE_STATUS(action, state)
     case 'UPDATE_PROPERTY_CONTROLS_INFO':

--- a/editor/src/core/property-controls/property-controls-processor.spec.ts
+++ b/editor/src/core/property-controls/property-controls-processor.spec.ts
@@ -7,6 +7,8 @@ import {
 import { mangleNodeModulePaths } from '../es-modules/package-manager/merge-modules'
 import { getJsDelivrFileUrl } from '../es-modules/package-manager/packager-url'
 import * as antdPackagerResponse from '../es-modules/test-cases/antd-packager-response.json'
+import { left } from '../shared/either'
+import { canvasPoint } from '../shared/math-utils'
 import { PackagerServerResponse, requestedNpmDependency } from '../shared/npm-dependency-types'
 import { initPropertyControlsProcessor } from './property-controls-processor'
 import { fullNodeModulesUpdate, getThirdPartyPropertyControls } from './property-controls-utils'
@@ -56,6 +58,18 @@ describe('Property Controls Processor', () => {
       {},
       {},
       [],
+      {
+        base64Blobs: {},
+        canvasIsLive: false,
+        hiddenInstances: [],
+        indexHtmlFile: left('no'),
+        mountCount: 0,
+        roundedCanvasOffset: canvasPoint({ x: 0, y: 0 }),
+        scale: 1,
+        textEditor: null,
+        transientFileState: null,
+        uiFilePath: 'src/app.js',
+      },
     )
   })
 
@@ -107,6 +121,18 @@ describe('Property Controls Processor', () => {
         },
       },
       [],
+      {
+        base64Blobs: {},
+        canvasIsLive: false,
+        hiddenInstances: [],
+        indexHtmlFile: left('no'),
+        mountCount: 0,
+        roundedCanvasOffset: canvasPoint({ x: 0, y: 0 }),
+        scale: 1,
+        textEditor: null,
+        transientFileState: null,
+        uiFilePath: 'src/app.js',
+      },
     )
   })
 })

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -609,53 +609,21 @@ export function sendPropertyControlsInfoRequest(
       ? nodeModulesUpdate
       : combineUpdates(queuedNodeModulesUpdate, nodeModulesUpdate)
 
-  function scheduleSend(): void {
-    if (propertyControlsIFrameAvailable) {
-      window.clearTimeout(lastPropertyControlsInfoSendID)
-      lastPropertyControlsInfoSendID = window.setTimeout(async () => sendToIFrame(), 0)
-    }
-  }
-
-  function sendToIFrame(): void {
-    // Prevent a scheduled send from firing.
-    window.clearTimeout(lastPropertyControlsInfoSendID)
-
-    if (propertyControlsIFrameReady) {
-      const propertyControlsInfoElement = document.getElementById(PropertyControlsInfoIFrameID)
-      if (propertyControlsInfoElement == null) {
-        scheduleSend()
-      } else {
-        const iFramePropertyControlsInfoElement = (propertyControlsInfoElement as any) as HTMLIFrameElement
-        const contentWindow = iFramePropertyControlsInfoElement.contentWindow
-        if (contentWindow == null) {
-          scheduleSend()
-        } else {
-          try {
-            if (queuedNodeModulesUpdate != null) {
-              // console.log('actually sending message!!!')
-              contentWindow.postMessage(
-                createGetPropertyControlsInfoMessage(
-                  exportsInfo,
-                  queuedNodeModulesUpdate,
-                  projectContents,
-                  canvasRelatedProps,
-                ),
-                '*',
-              )
-              queuedNodeModulesUpdate = null
-            }
-          } catch (exception) {
-            // Don't nuke the editor if there's an exception posting the message.
-            // This can happen if a value can't be cloned when posted.
-            console.error('Error sending message for property controls info.', exception)
-          }
-        }
-      }
-    } else {
-      scheduleSend()
-    }
-  }
+  const propertyControlsInfoElement = document.getElementById(PropertyControlsInfoIFrameID)
+  const iFramePropertyControlsInfoElement = (propertyControlsInfoElement as any) as HTMLIFrameElement
+  const contentWindow = iFramePropertyControlsInfoElement?.contentWindow
+  // eslint-disable-next-line no-unused-expressions
+  contentWindow?.postMessage(
+    createGetPropertyControlsInfoMessage(
+      exportsInfo,
+      queuedNodeModulesUpdate,
+      projectContents,
+      canvasRelatedProps,
+    ),
+    '*',
+  )
+  queuedNodeModulesUpdate = null
 
   // Initialise the first call.
-  sendToIFrame()
+  // sendToIFrame()
 }

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -612,7 +612,7 @@ export function sendPropertyControlsInfoRequest(
   function scheduleSend(): void {
     if (propertyControlsIFrameAvailable) {
       window.clearTimeout(lastPropertyControlsInfoSendID)
-      lastPropertyControlsInfoSendID = window.setTimeout(async () => sendToIFrame(), 500)
+      lastPropertyControlsInfoSendID = window.setTimeout(async () => sendToIFrame(), 0)
     }
   }
 

--- a/editor/src/core/workers/common/worker-types.ts
+++ b/editor/src/core/workers/common/worker-types.ts
@@ -1,4 +1,5 @@
 import { ProjectContentTreeRoot } from '../../../components/assets'
+import type { EditorAction } from '../../../components/editor/action-types'
 import { TypeDefinitions } from '../../shared/npm-dependency-types'
 import { TextFile, ParseSuccess } from '../../shared/project-file-types'
 
@@ -22,4 +23,6 @@ export interface UtopiaTsWorkers {
   initWatchdogWorker(projectID: string): void
   addHeartbeatRequestEventListener(handler: (e: MessageEvent) => void): void
   sendHeartbeatResponseMessage: (id: NodeJS.Timer, projectId: string, safeMode: boolean) => void
+  sendActionToDispatcher(actions: ReadonlyArray<EditorAction>): void
+  addActionDispatchEventListener(listener: (actions: ReadonlyArray<EditorAction>) => void): void
 }

--- a/editor/src/core/workers/test-workers.ts
+++ b/editor/src/core/workers/test-workers.ts
@@ -13,6 +13,7 @@ import {
 } from './parser-printer/parser-printer-worker'
 import { handleMessage as handleTSWorkerMessage } from './ts/ts-worker'
 import { BundlerWorker } from './bundler-bridge'
+import type { EditorAction } from '../../components/editor/action-types'
 
 export class FakeBundlerWorker implements BundlerWorker {
   messageListeners: Array<(ev: MessageEvent) => any> = []
@@ -98,6 +99,13 @@ export class FakeWatchdogWorker implements WatchdogWorker {
   }
 
   sendHeartbeatResponseMessage(_id: NodeJS.Timer, _projectId: string): void {
+    // empty
+  }
+
+  sendActionToDispatcher(actions: ReadonlyArray<EditorAction>): void {
+    // empty
+  }
+  addActionDispatchEventListener(listener: (actions: ReadonlyArray<EditorAction>) => void): void {
     // empty
   }
 }

--- a/editor/src/templates/editor-canvas.ts
+++ b/editor/src/templates/editor-canvas.ts
@@ -43,6 +43,7 @@ import {
   getOpenImportsFromState,
   isOpenFileUiJs,
   getOpenUtopiaJSXComponentsFromState,
+  getMainUIFromModel,
 } from '../components/editor/store/editor-state'
 import {
   didWeHandleMouseMoveForThisFrame,
@@ -77,6 +78,11 @@ import {
 import { ImageResult } from '../core/shared/file-utils'
 import { fastForEach } from '../core/shared/utils'
 import { arrayToMaybe } from '../core/shared/optional-utils'
+import {
+  codeCacheToBuildResult,
+  generateCodeResultCache,
+} from '../components/custom-code/code-file'
+import { pickCanvasRelatedProps } from '../core/property-controls/property-controls-utils'
 
 const webFrame = PROBABLY_ELECTRON ? requireElectron().webFrame : null
 
@@ -264,6 +270,7 @@ function on(
 export function runLocalCanvasAction(
   model: EditorState,
   derivedState: DerivedState,
+  dispatch: EditorDispatch,
   action: CanvasAction,
 ): EditorState {
   // TODO BB horrorshow performance
@@ -285,6 +292,18 @@ export function runLocalCanvasAction(
     case 'CLEAR_DRAG_STATE':
       return clearDragState(model, derivedState, action.applyChanges)
     case 'CREATE_DRAG_STATE':
+      generateCodeResultCache(
+        model.projectContents,
+        model.codeResultCache.projectModules,
+        codeCacheToBuildResult(model.codeResultCache.cache),
+        model.codeResultCache.exportsInfo,
+        model.nodeModules.files,
+        dispatch,
+        'incremental',
+        getMainUIFromModel(model),
+        true,
+        pickCanvasRelatedProps(model, derivedState),
+      )
       return {
         ...model,
         canvas: {

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -81,6 +81,7 @@ import {
 import { isLeft } from '../core/shared/either'
 import { importZippedGitProject, isProjectImportSuccess } from '../core/model/project-import'
 import { UtopiaTsWorkers } from '../core/workers/common/worker-types'
+import { pickCanvasRelatedProps } from '../core/property-controls/property-controls-utils'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
@@ -159,6 +160,7 @@ export class Editor {
               msg.buildType,
               getMainUIFromModel(this.storedState.editor),
               true,
+              pickCanvasRelatedProps(this.storedState.editor, this.storedState.derived),
             )
 
             if (codeResultCache != null) {

--- a/editor/src/templates/property-controls-info.html
+++ b/editor/src/templates/property-controls-info.html
@@ -5,5 +5,6 @@
     <!-- End Generated Utopia External Links -->
   </head>
   <body>
+    <div id="canvas-root" />
   </body>
 </html>

--- a/editor/src/templates/property-controls-info.tsx
+++ b/editor/src/templates/property-controls-info.tsx
@@ -10,18 +10,19 @@ import {
   createGetPropertyControlsInfoMessage,
   GetPropertyControlsInfoMessage,
 } from '../core/property-controls/property-controls-utils'
-import { applicative3Either, forEachRight } from '../core/shared/either'
+import { applicative3Either, applicative4Either, forEachRight } from '../core/shared/either'
 import { NewBundlerWorker, RealBundlerWorker } from '../core/workers/bundler-bridge'
 import { createBundle } from '../core/workers/bundler-promise'
 import { objectKeyParser, parseAny, ParseResult } from '../utils/value-parser-utils'
 
 // Not a full parse, just checks the primary fields are there.
 function fastPropertyControlsParse(value: unknown): ParseResult<GetPropertyControlsInfoMessage> {
-  return applicative3Either(
+  return applicative4Either(
     createGetPropertyControlsInfoMessage,
     objectKeyParser(parseAny, 'exportsInfo')(value),
     objectKeyParser(parseAny, 'nodeModulesUpdate')(value),
     objectKeyParser(parseAny, 'projectContents')(value),
+    objectKeyParser(parseAny, 'canvasRelatedProps')(value),
   )
 }
 
@@ -47,17 +48,20 @@ const initPropertyControlsWorker = () => {
        * for the bundler to process it, basically with no upside
        */
       const emptyTypeDefinitions = {}
-      const bundledProjectFiles = (
-        await createBundle(bundlerWorker, emptyTypeDefinitions, projectContents)
-      ).buildResult
+      // console.log('got message GetPropertyControlsInfoMessage now updating createBundle')
+      // const bundledProjectFiles = (
+      //   await createBundle(bundlerWorker, emptyTypeDefinitions, projectContents)
+      // ).buildResult
 
+      // console.log('bundle done')
       const npmDependencies = dependenciesWithEditorRequirements(projectContents)
       propertyControlsProcessor(
         npmDependencies,
         model.nodeModulesUpdate,
         projectContents,
-        bundledProjectFiles,
+        {},
         model.exportsInfo,
+        model.canvasRelatedProps,
       )
     }
   }


### PR DESCRIPTION
this spike repurposes the property controls iframe to render a Canvas.

at the current stage, the biggest issue seems to be that there's a delay between sending an update message from the editor until the iframe receives it.

probably I made a mistake by piggybacking on the (special-cased) `sendPropertyControlsInfoRequest` function which does some form of throttling.

I'll pick this up today and try to make a more responsive version!

so far the spike seems promising, I think a few more hours of trial and error and I will have an answer whether canvas in a separate iframe is a viable performance improvement.

-------

**Note:**
Even if this is not good enough for the canvas, this is definitely a viable direction to improve the Preview which now takes _seconds_ to respond to user actions.