### PR TITLE
Stop the ts-worker pulling in the entire editor

### DIFF
--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -41,7 +41,6 @@ import {
 import { stripNulls } from '../shared/array-utils'
 import { isPercentPin } from 'utopia-api'
 import { UTOPIA_UID_KEY } from './utopia-constants'
-import { MetadataUtils } from './element-metadata-utils'
 
 export const EmptyScenePathForStoryboard = TP.scenePath([])
 
@@ -303,7 +302,9 @@ export function isSceneChildWidthHeightPercentage(
   scene: ComponentMetadata,
   metadata: JSXMetadata,
 ): boolean {
-  const rootElements = MetadataUtils.getImmediateChildren(metadata, scene.scenePath)
+  // FIXME ASAP This is reproducing logic that should stay in MetadataUtils, but importing that
+  // imports the entire editor into the worker threads, including modules that require window and document
+  const rootElements = scene.rootElements.map((path) => metadata.elements[TP.toString(path)])
   const rootElementSizes = rootElements.map((element) => {
     return {
       width: element.props?.style?.width,


### PR DESCRIPTION
**Problem:**
The ts-worker is indirectly pulling in the entire editor, running code that expects `window` and `document` to be defined, causing it to completely blow out and preventing the property controls from being processed.

The problem is caused by the following dependency chain:

- `ts-worker`
- `project-file-utils`
- `scene-utils`
- `element-metadata-utils`
- `element-template-utils`
- `editor-state`
- `canvas-utils`
- `ui-jsx-canvas`

Note that this isn't the only chain, but the key is that the `editor-state` pulls in the canvas (and everything along with it)

**Fix:**
Break the chain at `scene-utils` by duplicating some metadata logic that really shouldn't live there. This is a hot fix to unblock us.