### PR TITLE
Fix/changing selected view invalidates scene

### DIFF
--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -129,7 +129,7 @@ export function useSelectorWithCallback<U>(
   selector: StateSelector<EditorStore, U>,
   callback: (newValue: U) => void,
   equalityFn: (oldSlice: U, newSlice: U) => boolean = utils.shallowEqual,
-  explainMe = false,
+  explainMe: boolean = false,
 ): void {
   const context = React.useContext(EditorStateContext)
   if (context == null) {

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -124,3 +124,52 @@ export type EditorStateContextData = {
 
 export const EditorStateContext = React.createContext<EditorStateContextData | null>(null)
 EditorStateContext.displayName = 'EditorStateContext'
+
+export function useSelectorWithCallback<U>(
+  selector: StateSelector<EditorStore, U>,
+  callback: (newValue: U) => void,
+  equalityFn: (oldSlice: U, newSlice: U) => boolean = utils.shallowEqual,
+  explainMe = false,
+): void {
+  const context = React.useContext(EditorStateContext)
+  if (context == null) {
+    throw new Error('useStore is missing from editor context')
+  }
+  const api = context.api
+
+  const selectorRef = React.useRef(selector)
+  selectorRef.current = selector // the selector is possibly a new function instance every time this hook is called
+
+  const equalityFnRef = React.useRef(equalityFn)
+  equalityFnRef.current = equalityFn // the equality function is possibly a new function instance every time this hook is called, but we don't want to re-subscribe because of that
+
+  const callbackRef = React.useRef(callback)
+  callbackRef.current = callback // the callback function is possibly a new function instance every time this hook is called, but we don't want to re-subscribe because of that
+
+  React.useEffect(() => {
+    if (explainMe) {
+      console.info('subscribing to the api')
+    }
+    const unsubscribe = api.subscribe(
+      (newSlice) => {
+        if (newSlice) {
+          if (explainMe) {
+            console.info(
+              'selected state has a new value according to the provided equalityFn, notifying callback',
+              newSlice,
+            )
+          }
+          callbackRef.current(newSlice)
+        }
+      },
+      (store: EditorStore) => selectorRef.current(store),
+      (oldValue: any, newValue: any) => equalityFnRef.current(oldValue, newValue),
+    )
+    return function cleanup() {
+      if (explainMe) {
+        console.info('unsubscribing from the api')
+      }
+      unsubscribe()
+    }
+  }, [api, explainMe])
+}


### PR DESCRIPTION
**Problem:**
ComputedStyles is only computed for the selected element, but it is stored in the metadata tree. For every non-selected element, we store a null. When you change selection, the lazy dom-walker did not repeat the walk, returning the previous walk result, which contained the non-null computed style for the previous selection. This meant that selecting an element would show an empty inspector. (If you dragged/resized the selected element, then the navigator would suddenly show values, because the DOM-walker's mutation observer would invalidate the edited scene.)

**Fix:**
When changing the selected view, invalidate the scene of the new selection. This triggers the dom walker to repeat the walk, and produce a correct ComputedStyles.

**Commit Details:**
- `useSelectorWithCallback` which introduces a subscriber-based hook to interact with the editor state.
Usage: 
```typescript
useSelectorWithCallback(
    (store) => store.editor.selectedViews, // this is a regular selector
    (newSelectedViews) => {
      console.log('New selected views detected!!!!!') // this callback is only fired if the selected value changed
      })
    },
  )
```
- using `useSelectorWithCallback` in the DOM-walker to listen to selected view changes, and invalidate the scene which contains the new selected view
- changed `invalidatedSceneIDsRef` from an Array<string> to Set<string> because we were already using it like a Set, but with lots of manual filtering, indexof and `[...oldArray, newValue]` style pushing.

**Notes:**
This means selection time will be slower than on master, because we re-walk that entire scene, and loose reference equality on the metadata. A more fine grained solution would be if the lazy dom walker would decide on a subtree basis, however that's out of the scope of this PR.
