### PR TITLE
Fix/use ref editor state

### DIFF
--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -85,6 +85,8 @@ export const useRefEditorState = <U>(
   selectorRef.current = selector // the selector is possibly a new function instance every time this hook is called
 
   const sliceRef = React.useRef(selector(api.getState()))
+  // TODO CONCURRENT MODE: We should avoid mutation during the render phase and follow a pattern similar to
+  // https://github.com/pmndrs/zustand/blob/d82e103cc6702ed10a404a587163e42fc3ac1338/src/index.ts#L161
   sliceRef.current = selector(api.getState()) // ensure that callers of this always have the latest data
   if (explainMe) {
     console.info('reading useEditorState', sliceRef.current)

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -85,6 +85,7 @@ export const useRefEditorState = <U>(
   selectorRef.current = selector // the selector is possibly a new function instance every time this hook is called
 
   const sliceRef = React.useRef(selector(api.getState()))
+  sliceRef.current = selector(api.getState()) // ensure that callers of this always have the latest data
   if (explainMe) {
     console.info('reading useEditorState', sliceRef.current)
   }


### PR DESCRIPTION
**Problem:**
Occasionally the editor would end up in a state where metadata was missing

**Fix:**
The DOM walker relies on a use of `useRefEditorState` to retrieve the previous DOM metadata, and in cases where nothing has been marked as having changed it will return that. However, because of the ordering of notifying subscribers to the zustand store, it would mean that when updating the store the canvas would be notified first, triggering the DOM walker to run, and *then* the current value of the ref would be updated.

To fix this, we now explicitly update the current value of the ref on all calls of `useRefEditorState`.

There is also a potential bug around Concurrent Mode, but that's a problem for another day (and one we'll be dealing with in many places).