### PR TITLE
fix small alignment issues

### DIFF
--- a/editor/src/uuiui/icn.tsx
+++ b/editor/src/uuiui/icn.tsx
@@ -82,6 +82,7 @@ export const Icn = betterReactMemo(
       <img
         style={{
           userSelect: 'none',
+          display: 'block',
           ...props.style,
           ...disabledStyle,
         }}

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -641,8 +641,9 @@ export const NumberInput = betterReactMemo<NumberInputProps>(
                 style={{
                   position: 'absolute',
                   pointerEvents: 'none',
-                  left: 2,
+                  right: 0,
                   top: 5,
+                  textAlign: 'center',
                   fontWeight: 'bold',
                   fontSize: '9px',
                   width: '100%',


### PR DESCRIPTION
fixes two small bugs:
1. inspector number increment arrows were misaligned, this adds a `display: block` for all Icns, which I am not sure why we didn't have that before? Possibly was removed CSS somewhere else?
2. Inspector inner labels were misaligned, moved them to attach to the right, and centre align their text.