### PR TITLE
Fix broken workflows

### DIFF
--- a/.github/workflows/master-pushes.yml
+++ b/.github/workflows/master-pushes.yml
@@ -45,7 +45,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-website-master-
       - name: Install nix
-        uses: Rheeseyb/install-nix-action@master
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-20.09
       - name: Run the tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-all-ci
@@ -90,7 +92,9 @@ jobs:
           path: server/src
           key: ${{ runner.os }}-server-tests-master-${{ hashFiles('server/src/**') }}-${{ hashFiles('server/test/**') }}-${{ hashFiles('server/cabal.project.freeze') }}
       - name: Install nix
-        uses: Rheeseyb/install-nix-action@master
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-20.09
       - name: Run the tests
         if: steps.cache-server-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeEditorBuildSupport false --arg includeRunLocallySupport false --run test-server-ci

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -43,7 +43,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-website-PRs-
       - name: Install nix
-        uses: Rheeseyb/install-nix-action@master
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-20.09
       - name: Run the tests
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run check-editor-all-ci
@@ -78,7 +80,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-utopia-api-PRs-
       - name: Install nix
-        uses: Rheeseyb/install-nix-action@master
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-20.09
       - name: Build Editor
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
**Problem:**
Workflows are now broken because of a command that has been disabled

**Fix:**
The command was being used by a now very outdated version of one of our actions, so I have updated the version used.
