### PR TITLE
Experiment/Component Isolation Mode 2nd Pass

### DIFF
--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -50,7 +50,7 @@ import { ControlProps } from './new-canvas-controls'
 import { getLayoutPropertyOr } from '../../../core/layout/getLayoutProperty'
 import { RightMenuTab } from '../right-menu'
 import { safeIndex } from '../../../core/shared/array-utils'
-import { getStoryboardTemplatePath } from '../../editor/store/editor-state'
+import { getStoryboardTemplatePath, IsolatedComponent } from '../../editor/store/editor-state'
 
 // I feel comfortable having this function confined to this file only, since we absolutely shouldn't be trying
 // to set values that would fail whilst inserting elements. If that ever changes, this function should be binned
@@ -75,6 +75,7 @@ interface InsertModeControlContainerProps extends ControlProps {
   dragState: InsertDragState | null
   canvasOffset: CanvasVector
   scale: number
+  isolatedComponent: IsolatedComponent | null
 }
 
 interface InsertModeControlContainerState {
@@ -223,6 +224,7 @@ export class InsertModeControlContainer extends React.Component<
         imports={this.props.imports}
         testID={`insert-target-${TP.toComponentId(target)}`}
         showAdditionalControls={this.props.showAdditionalControls}
+        isolatedComponent={null}
       />
     )
   }
@@ -255,6 +257,7 @@ export class InsertModeControlContainer extends React.Component<
         selectedViews={this.props.selectedViews}
         imports={this.props.imports}
         showAdditionalControls={this.props.showAdditionalControls}
+        isolatedComponent={null}
       />
     )
   }
@@ -662,9 +665,20 @@ export class InsertModeControlContainer extends React.Component<
   }
 
   render() {
-    const roots = MetadataUtils.getAllScenePaths(this.props.componentMetadata.components)
+    const roots =
+      this.props.isolatedComponent == null
+        ? MetadataUtils.getAllScenePaths(this.props.componentMetadata.components)
+        : [this.props.isolatedComponent.scenePath]
+
     const allPaths = MetadataUtils.getAllPaths(this.props.componentMetadata)
     const insertTargets = allPaths.filter((path) => {
+      if (
+        this.props.isolatedComponent != null &&
+        !TP.isAncestorOf(path, this.props.isolatedComponent.scenePath)
+      ) {
+        return false
+      }
+
       if (TP.isScenePath(path)) {
         // TODO Scene Implementation
         return false

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -12,7 +12,12 @@ import {
   EditorStore,
   getOpenUIJSFileKey,
 } from '../../editor/store/editor-state'
-import { TemplatePath, InstancePath, Imports } from '../../../core/shared/project-file-types'
+import {
+  TemplatePath,
+  InstancePath,
+  Imports,
+  ScenePath,
+} from '../../../core/shared/project-file-types'
 import { CanvasPositions } from '../canvas-types'
 import { SelectModeControlContainer } from './select-mode-control-container'
 import { InsertModeControlContainer } from './insert-mode-control-container'
@@ -326,6 +331,7 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
                 : null
             }
             showAdditionalControls={props.editor.interfaceDesigner.additionalControls}
+            isolatedComponentScenePath={props.editor.isolatedComponent?.scenePath ?? null}
           />
         )
       }

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -331,7 +331,7 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
                 : null
             }
             showAdditionalControls={props.editor.interfaceDesigner.additionalControls}
-            isolatedComponentScenePath={props.editor.isolatedComponent?.scenePath ?? null}
+            isolatedComponent={props.editor.isolatedComponent}
           />
         )
       }
@@ -348,6 +348,7 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
             }
             canvasOffset={props.editor.canvas.realCanvasOffset /* maybe roundedCanvasOffset? */}
             scale={props.editor.canvas.scale}
+            isolatedComponent={props.editor.isolatedComponent}
           />
         )
       }

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -6,7 +6,7 @@ import { CanvasPoint, CanvasRectangle, CanvasVector } from '../../../core/shared
 import { TemplatePath, ScenePath } from '../../../core/shared/project-file-types'
 import { EditorAction } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/actions'
-import { DuplicationState } from '../../editor/store/editor-state'
+import { DuplicationState, IsolatedComponent } from '../../editor/store/editor-state'
 import * as TP from '../../../core/shared/template-path'
 import { CanvasPositions, MoveDragState, ResizeDragState, moveDragState } from '../canvas-types'
 import { Guidelines, Guideline } from '../guideline'
@@ -53,7 +53,7 @@ interface SelectModeControlContainerProps extends ControlProps {
   maybeClearHighlightsOnHoverEnd: () => void
   duplicationState: DuplicationState | null
   dragState: MoveDragState | ResizeDragState | null
-  isolatedComponentScenePath: ScenePath | null
+  isolatedComponent: IsolatedComponent | null
 }
 
 interface SelectModeControlContainerState {
@@ -239,9 +239,9 @@ export class SelectModeControlContainer extends React.Component<
       candidateViews = MetadataUtils.getAllPaths(this.props.componentMetadata)
     } else {
       const scenes =
-        this.props.isolatedComponentScenePath == null
+        this.props.isolatedComponent == null
           ? MetadataUtils.getAllScenePaths(this.props.componentMetadata.components)
-          : [this.props.isolatedComponentScenePath]
+          : [this.props.isolatedComponent.scenePath]
       let dynamicScenesWithFragmentRootViews: ScenePath[] = []
       let allRoots: TemplatePath[] = []
       let rootElementsToFilter: TemplatePath[] = []
@@ -262,10 +262,10 @@ export class SelectModeControlContainer extends React.Component<
       })
       allRoots = MetadataUtils.getAllCanvasRootPaths(this.props.componentMetadata).filter(
         (rootPath) => {
-          if (this.props.isolatedComponentScenePath == null) {
+          if (this.props.isolatedComponent == null) {
             return !rootElementsToFilter.some((path) => TP.pathsEqual(rootPath, path))
           } else {
-            return TP.isAncestorOf(rootPath, this.props.isolatedComponentScenePath)
+            return TP.isAncestorOf(rootPath, this.props.isolatedComponent.scenePath)
           }
         },
       )
@@ -365,6 +365,7 @@ export class SelectModeControlContainer extends React.Component<
           selectedViews={this.props.selectedViews}
           imports={this.props.imports}
           showAdditionalControls={this.props.showAdditionalControls}
+          isolatedComponent={this.props.isolatedComponent}
         />
       )
     } else {
@@ -399,6 +400,7 @@ export class SelectModeControlContainer extends React.Component<
         selectedViews={this.props.selectedViews}
         imports={this.props.imports}
         showAdditionalControls={this.props.showAdditionalControls}
+        isolatedComponent={this.props.isolatedComponent}
       />
     )
   }
@@ -435,6 +437,7 @@ export class SelectModeControlContainer extends React.Component<
         selectedViews={this.props.selectedViews}
         imports={this.props.imports}
         showAdditionalControls={this.props.showAdditionalControls}
+        isolatedComponent={this.props.isolatedComponent}
       />
     )
   }
@@ -663,10 +666,10 @@ export class SelectModeControlContainer extends React.Component<
     const cmdPressed = this.props.keysPressed['cmd'] || false
     const allElementsDirectlySelectable = cmdPressed && !this.props.isDragging
     const roots =
-      this.props.isolatedComponentScenePath == null
+      this.props.isolatedComponent == null
         ? MetadataUtils.getAllScenePaths(this.props.componentMetadata.components)
-        : [this.props.isolatedComponentScenePath]
-    let labelDirectlySelectable = this.props.isolatedComponentScenePath == null
+        : [this.props.isolatedComponent.scenePath]
+    let labelDirectlySelectable = this.props.isolatedComponent == null
     let draggableViews = this.getSelectableViews(allElementsDirectlySelectable)
     if (!this.props.highlightsEnabled) {
       draggableViews = []

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -37,6 +37,7 @@ import {
 } from '../editor/store/store-hook'
 import {
   UTOPIA_DO_NOT_TRAVERSE_KEY,
+  UTOPIA_EXCLUDE_FROM_REPORT,
   UTOPIA_LABEL_KEY,
   UTOPIA_ORIGINAL_ID_KEY,
   UTOPIA_UID_KEY,
@@ -473,6 +474,12 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
           return []
         }
         if (element instanceof HTMLElement) {
+          const excludeFromReportAttribute = getDOMAttribute(element, UTOPIA_EXCLUDE_FROM_REPORT)
+          if (excludeFromReportAttribute === 'true') {
+            // An element inserted during component isolation
+            return []
+          }
+
           // Determine the uid of this element if it has one.
           const uidAttribute = getDOMAttribute(element, UTOPIA_UID_KEY)
           const parentUIDsAttribute = getDOMAttribute(element, UTOPIA_UID_PARENTS_KEY)

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
@@ -107,6 +107,7 @@ function useGetValidTemplatePaths(
 }
 
 interface SceneRootRendererProps {
+  isIsolatedComponent: boolean
   sceneElement: JSXElement
   style?: React.CSSProperties
 }
@@ -161,6 +162,19 @@ export const SceneRootRenderer = betterReactMemo(
 
     return (
       <SceneLevelUtopiaContext.Provider value={{ validPaths: validPaths, scenePath: scenePath }}>
+        {props.isIsolatedComponent ? (
+          <div
+            style={{
+              width: '300vw',
+              height: '300vh',
+              left: '-100vw',
+              top: '-100vh',
+              position: 'fixed',
+              backgroundColor: '#E6E6E6AB',
+            }}
+            data-utopia-exclude-from-report={true}
+          />
+        ) : null}
         <View
           data-utopia-scene-id={TP.toString(scenePath)}
           data-utopia-valid-paths={validPaths.map(TP.toString).join(' ')}

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -44,6 +44,10 @@ export function createComponentRendererComponent(params: {
       (c) => c.shouldIncludeCanvasRootInTheSpy,
     )
     const hiddenInstances = useContextSelector(RerenderUtopiaContext, (c) => c.hiddenInstances)
+    const isolatedComponentScenePath = useContextSelector(
+      RerenderUtopiaContext,
+      (c) => c.isolatedComponentScenePath,
+    )
     const sceneContext = React.useContext(SceneLevelUtopiaContext)
 
     let metadataContext: UiJsxCanvasContextData = React.useContext(UiJsxCanvasContext)
@@ -98,6 +102,7 @@ export function createComponentRendererComponent(params: {
           realPassedProps,
           mutableContext.requireResult,
           hiddenInstances,
+          isolatedComponentScenePath,
           mutableContext.fileBlobs,
           sceneContext.validPaths,
           realPassedProps['data-uid'],

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
@@ -33,6 +33,7 @@ export function updateMutableUtopiaContextWithNewProps(
 interface RerenderUtopiaContextProps {
   topLevelElements: ReadonlyMap<string, UtopiaJSXComponent>
   hiddenInstances: Array<TemplatePath>
+  isolatedComponentScenePath: ScenePath | null
   canvasIsLive: boolean
   shouldIncludeCanvasRootInTheSpy: boolean
 }
@@ -40,6 +41,7 @@ interface RerenderUtopiaContextProps {
 export const RerenderUtopiaContext = createContext<RerenderUtopiaContextProps>({
   topLevelElements: new Map(),
   hiddenInstances: [],
+  isolatedComponentScenePath: null,
   canvasIsLive: false,
   shouldIncludeCanvasRootInTheSpy: false,
 })

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -19,8 +19,8 @@ import {
   JSXArbitraryBlock,
 } from '../../../core/shared/element-template'
 import { jsxAttributesToProps, setJSXValueAtPath } from '../../../core/shared/jsx-attributes'
-import { InstancePath, TemplatePath } from '../../../core/shared/project-file-types'
-import { fastForEach } from '../../../core/shared/utils'
+import { InstancePath, ScenePath, TemplatePath } from '../../../core/shared/project-file-types'
+import { arrayEquals, fastForEach } from '../../../core/shared/utils'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/workers/parser-printer/parser-printer-utils'
 import { Utils } from '../../../uuiui-deps'
 import { UIFileBase64Blobs } from '../../editor/store/editor-state'
@@ -44,6 +44,7 @@ export function renderCoreElement(
   parentComponentInputProps: MapLike<any>,
   requireResult: MapLike<any>,
   hiddenInstances: Array<TemplatePath>,
+  isolatedComponentScenePath: ScenePath | null,
   fileBlobs: UIFileBase64Blobs,
   validPaths: Array<InstancePath>,
   uid: string | undefined,
@@ -57,7 +58,11 @@ export function renderCoreElement(
     throw codeError
   }
   if (isJSXElement(element) && isSceneElement(element)) {
-    return <SceneRootRenderer sceneElement={element} />
+    const isIsolatedComponent =
+      isolatedComponentScenePath == null
+        ? false
+        : arrayEquals(isolatedComponentScenePath.sceneElementPath, templatePath.element)
+    return <SceneRootRenderer sceneElement={element} isIsolatedComponent={isIsolatedComponent} />
   }
   switch (element.type) {
     case 'JSX_ELEMENT': {
@@ -89,6 +94,7 @@ export function renderCoreElement(
         rootScope,
         inScope,
         hiddenInstances,
+        isolatedComponentScenePath,
         fileBlobs,
         validPaths,
         passthroughProps,
@@ -135,6 +141,7 @@ export function renderCoreElement(
           parentComponentInputProps,
           requireResult,
           hiddenInstances,
+          isolatedComponentScenePath,
           fileBlobs,
           validPaths,
           generatedUID,
@@ -166,6 +173,7 @@ export function renderCoreElement(
           parentComponentInputProps,
           requireResult,
           hiddenInstances,
+          isolatedComponentScenePath,
           fileBlobs,
           validPaths,
           uid,
@@ -204,6 +212,7 @@ function renderJSXElement(
   rootScope: MapLike<any>,
   inScope: MapLike<any>,
   hiddenInstances: Array<TemplatePath>,
+  isolatedComponentScenePath: ScenePath | null,
   fileBlobs: UIFileBase64Blobs,
   validPaths: Array<InstancePath>,
   passthroughProps: MapLike<any>,
@@ -230,6 +239,7 @@ function renderJSXElement(
       parentComponentInputProps,
       requireResult,
       hiddenInstances,
+      isolatedComponentScenePath,
       fileBlobs,
       validPaths,
       undefined,

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -138,6 +138,7 @@ function renderCanvasReturnResultAndError(possibleProps: PartialCanvasProps | nu
       offset: canvasPoint({ x: 0, y: 0 }),
       scale: 1,
       hiddenInstances: [],
+      isolatedComponentScenePath: null,
       editedTextElement: null,
       mountCount: 0,
       walkDOM: false,
@@ -170,6 +171,7 @@ function renderCanvasReturnResultAndError(possibleProps: PartialCanvasProps | nu
       addToConsoleLogs: addToConsoleLogs,
       linkTags: '',
       combinedTopLevelArbitraryBlock: combinedTopLevelArbitraryBlock,
+      isolatedComponentScenePath: null,
     }
   }
 

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -105,6 +105,7 @@ export interface UiJsxCanvasProps {
   uiFilePath: string
   requireFn: UtopiaRequireFn | null
   hiddenInstances: TemplatePath[]
+  isolatedComponentScenePath: ScenePath | null
   editedTextElement: InstancePath | null
   fileBlobs: UIFileBase64Blobs
   mountCount: number
@@ -201,6 +202,7 @@ export function pickUiJsxCanvasProps(
       uiFilePath: uiFilePath,
       requireFn: requireFn,
       hiddenInstances: hiddenInstances,
+      isolatedComponentScenePath: editor.isolatedComponent?.scenePath ?? null,
       editedTextElement: editedTextElement,
       fileBlobs: defaultedFileBlobs,
       mountCount: editor.canvas.mountCount,
@@ -240,6 +242,7 @@ export const UiJsxCanvas = betterReactMemo(
       uiFilePath,
       requireFn,
       hiddenInstances,
+      isolatedComponentScenePath,
       fileBlobs,
       walkDOM,
       onDomReport,
@@ -361,6 +364,7 @@ export const UiJsxCanvas = betterReactMemo(
             <RerenderUtopiaContext.Provider
               value={{
                 hiddenInstances: hiddenInstances,
+                isolatedComponentScenePath: isolatedComponentScenePath,
                 topLevelElements: topLevelElementsMap,
                 canvasIsLive: canvasIsLive,
                 shouldIncludeCanvasRootInTheSpy: props.shouldIncludeCanvasRootInTheSpy,

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -70,7 +70,7 @@ export function isolatedComponentSceneElement(
     [PP.toString(PathForResizeContent)]: jsxAttributeValue(true),
     style: jsxAttributeValue({
       position: 'absolute',
-      boxShadow: '0px 0px 6px 4px rgb(0, 0, 0, 0.29)',
+      boxShadow: '0px 0px 0px 1px rgba(255, 255, 255, 0.3), 0px 0px 6px 4px rgb(0, 0, 0, 0.29)',
       ...frame,
     }),
   }

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -58,7 +58,7 @@ export function isolatedComponentSceneElement(
 
   const props = {
     'data-uid': jsxAttributeValue('TRANSIENT_SCENE'),
-    'data-label': jsxAttributeValue(''),
+    'data-label': jsxAttributeValue(`Isolated ${componentName}`),
     component: jsxAttributeOtherJavaScript(
       componentName,
       `return ${componentName}`,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -270,6 +270,7 @@ export interface ConsoleLog {
 export interface IsolatedComponent {
   componentName: string
   instance: InstancePath
+  scenePath: ScenePath
 }
 
 // FIXME We need to pull out ProjectState from here

--- a/editor/src/core/model/utopia-constants.ts
+++ b/editor/src/core/model/utopia-constants.ts
@@ -1,6 +1,7 @@
 export const UTOPIA_UID_KEY = 'data-uid'
 export const UTOPIA_LABEL_KEY = 'data-label'
 export const UTOPIA_ORIGINAL_ID_KEY = 'data-utopia-original-uid'
+export const UTOPIA_EXCLUDE_FROM_REPORT = 'data-utopia-exclude-from-report'
 export const UTOPIA_DO_NOT_TRAVERSE_KEY = 'data-utopia-do-not-traverse'
 export const UTOPIA_SCENE_ID_KEY = 'data-utopia-scene-id'
 export const UTOPIA_UID_PARENTS_KEY = 'data-utopia-parents'
@@ -10,6 +11,7 @@ export const UtopiaKeys: Array<string> = [
   UTOPIA_UID_KEY,
   UTOPIA_LABEL_KEY,
   UTOPIA_ORIGINAL_ID_KEY,
+  UTOPIA_EXCLUDE_FROM_REPORT,
   UTOPIA_DO_NOT_TRAVERSE_KEY,
   UTOPIA_SCENE_ID_KEY,
   UTOPIA_UID_PARENTS_KEY,


### PR DESCRIPTION
Covers #701 - Further improvements to the previous component isolation mode experiment from #696 

The following changes have been made:
- Overlay displayed over everything else when in isolation mode
- Prevent selection of other elements via the canvas when in isolation mode
- Selection of other elements elsewhere (e.g. navigator) exits isolation mode
- `Isolated ${componentName}` label (there's a bug in clearing this, so after exiting isolation mode you might need to scroll for it to disappear)
- Dragging the root element or scene updates the instance that was isolated
- Support insert mode when component is isolated

Try it out at https://utopia.pizza/p/2d8b43ad-pitch-ankle/?branch_name=experiment/component-isolation-mode-pt2
