### PR TITLE
experiment/canvas-component-to-scene

### DIFF
--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -11,6 +11,7 @@ import {
   deleteView,
   duplicateSelected,
   toggleHidden,
+  extractSceneFromComponent,
 } from './editor/actions/actions'
 import {
   toggleBackgroundLayers,
@@ -36,6 +37,15 @@ export interface CanvasData {
 
 export function requireDispatch(dispatch: EditorDispatch | null | undefined): EditorDispatch {
   return Utils.forceNotNull('Dispatch not supplied.', dispatch)
+}
+
+export const extractScene: ContextMenuItem<CanvasData> = {
+  name: 'Extract Scene',
+  enabled: true,
+  shortcut: '',
+  action: (data, dispatch?: EditorDispatch) => {
+    requireDispatch(dispatch)([extractSceneFromComponent(data.selectedViews)] as any, 'everyone')
+  },
 }
 
 export const duplicateElement: ContextMenuItem<CanvasData> = {

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -768,6 +768,11 @@ export interface AddStoryboardFile {
   action: 'ADD_STORYBOARD_FILE'
 }
 
+export interface ExtractSceneFromComponent {
+  action: 'EXTRACT_SCENE_FROM_COMPONENT'
+  targets: InstancePath[]
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -896,6 +901,7 @@ export type EditorAction =
   | UpdatePropertyControlsInfo
   | PropertyControlsIFrameReady
   | AddStoryboardFile
+  | ExtractSceneFromComponent
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -138,6 +138,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'FINISH_CHECKPOINT_TIMER':
     case 'ADD_MISSING_DIMENSIONS':
     case 'ADD_STORYBOARD_FILE':
+    case 'EXTRACT_SCENE_FROM_COMPONENT':
       return false
     case 'SAVE_ASSET':
       return (

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4152,12 +4152,18 @@ export const UPDATE_FNS = {
         updatedStyleProps['left'] = 400
         updatedStyleProps['top'] = 0
 
+        let filteredProps = { ...element.props }
+        delete filteredProps['style']
+        delete filteredProps['className']
+        delete filteredProps['data-uid']
+        delete filteredProps['skipDeepFreeze']
         const newScene: JSXElement = defaultSceneElement(
           sceneUID,
           elementName ?? null,
           updatedStyleProps,
           newSceneLabel,
           false,
+          filteredProps,
         )
         const storyBoardPath = getStoryboardTemplatePath(components)
         const newSelection =

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -18,10 +18,16 @@ export function defaultSceneElement(
   componentProps: any = null,
 ): JSXElement {
   const component = componentName == null ? 'null' : componentName
+  const definedElsewhere = [component]
   const props = {
     'data-uid': jsxAttributeValue(uid),
     'data-label': jsxAttributeValue(label),
-    component: jsxAttributeOtherJavaScript(component, `return ${componentName}`, [], null),
+    component: jsxAttributeOtherJavaScript(
+      component,
+      `return ${componentName}`,
+      definedElsewhere,
+      null,
+    ),
     [PP.toString(PathForResizeContent)]: jsxAttributeValue(resizeContent),
     style: jsxAttributeValue({
       position: 'absolute',

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -15,6 +15,7 @@ export function defaultSceneElement(
   frame: NormalisedFrame | any,
   label: string,
   resizeContent: boolean = true,
+  componentProps: any = null,
 ): JSXElement {
   const component = componentName == null ? 'null' : componentName
   const props = {
@@ -26,6 +27,9 @@ export function defaultSceneElement(
       position: 'absolute',
       ...frame,
     }),
+  }
+  if (componentProps != null) {
+    props['props'] = jsxAttributeValue(componentProps)
   }
 
   return jsxElement(jsxElementName('Scene', []), props, [])

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -12,15 +12,16 @@ import * as PP from '../../core/shared/property-path'
 export function defaultSceneElement(
   uid: string,
   componentName: string | null,
-  frame: NormalisedFrame,
+  frame: NormalisedFrame | any,
   label: string,
+  resizeContent: boolean = true,
 ): JSXElement {
   const component = componentName == null ? 'null' : componentName
   const props = {
     'data-uid': jsxAttributeValue(uid),
     'data-label': jsxAttributeValue(label),
     component: jsxAttributeOtherJavaScript(component, `return ${componentName}`, [], null),
-    [PP.toString(PathForResizeContent)]: jsxAttributeValue(true),
+    [PP.toString(PathForResizeContent)]: jsxAttributeValue(resizeContent),
     style: jsxAttributeValue({
       position: 'absolute',
       ...frame,

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -286,6 +286,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.PROPERTY_CONTROLS_IFRAME_READY(action, state)
     case 'ADD_STORYBOARD_FILE':
       return UPDATE_FNS.ADD_STORYBOARD_FILE(action, state)
+    case 'EXTRACT_SCENE_FROM_COMPONENT':
+      return UPDATE_FNS.EXTRACT_SCENE_FROM_COMPONENT(action, state)
     default:
       return state
   }

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -18,6 +18,7 @@ import {
   toggleShadowItem,
   ContextMenuItem,
   CanvasData,
+  extractScene,
 } from './context-menu-items'
 import { MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState } from './editor/store/store-hook'
@@ -34,6 +35,7 @@ interface ElementContextMenuProps {
 }
 
 const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
+  extractScene,
   cutElements,
   copyElements,
   duplicateElement,

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -24,6 +24,8 @@ import { MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState } from './editor/store/store-hook'
 import { filterScenes } from '../core/shared/template-path'
 import { betterReactMemo } from 'uuiui-deps'
+import { isFeatureEnabled } from '../utils/feature-switches'
+import { stripNulls } from '../core/shared/array-utils'
 
 export type ElementContextMenuInstance =
   | 'context-menu-navigator'
@@ -34,8 +36,8 @@ interface ElementContextMenuProps {
   contextMenuInstance: ElementContextMenuInstance
 }
 
-const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
-  extractScene,
+const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = stripNulls([
+  isFeatureEnabled('Extract Scene') ? extractScene : null,
   cutElements,
   copyElements,
   duplicateElement,
@@ -56,7 +58,7 @@ const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
   toggleBackgroundLayersItem,
   toggleBorderItem,
   toggleShadowItem,
-]
+])
 
 // TODO Scene Implementation - seems we should have a different context menu for scenes
 export const ElementContextMenu = betterReactMemo(

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -8,6 +8,7 @@ export type FeatureName =
   | 'Advanced Resize Box'
   | 'Re-parse Project Button'
   | 'iFrame Code Editor'
+  | 'Extract Scene'
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
   // 'Dragging Shows Overlay', // Removing this option so that we can experiment on this later
@@ -15,6 +16,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Advanced Resize Box',
   'Re-parse Project Button',
   'iFrame Code Editor',
+  'Extract Scene',
 ]
 
 let FeatureSwitches: { [feature: string]: boolean } = {
@@ -24,6 +26,7 @@ let FeatureSwitches: { [feature: string]: boolean } = {
   'Advanced Resize Box': false,
   'Re-parse Project Button': false,
   'iFrame Code Editor': false,
+  'Extract Scene': true,
 }
 
 function settingKeyForName(featureName: FeatureName): string {


### PR DESCRIPTION
Component Experiment #698 

#### How to try it?
Select a Component, open the right click menu. The first item should be `Extract Scene`. Clicking it will create a Scene using the current component and runtime properties from the metadata. The Scene positioning is not so smart, it's hardcoded to appear at (400, 0).
Please note that it doesn't work with component as props, like props.icon.

🍕 https://utopia.pizza/p/ddab49af-clumsy-license/?branch_name=experiment/canvas-component-to-scene