### PR TITLE
Prevent use of `AutosizeInput` in `react-select`.

### DIFF
--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -28,6 +28,7 @@ import { areYogaChildren } from './select-mode/yoga-utils'
 import { JSXMetadata } from '../../../core/shared/element-template'
 import { BoundingMarks } from './parent-bounding-marks'
 import { RightMenuTab } from '../right-menu'
+import { uniqBy } from '../../../core/shared/array-utils'
 
 export const SnappingThreshold = 5
 
@@ -242,7 +243,7 @@ export class SelectModeControlContainer extends React.Component<
           rootElements != null &&
           rootElements.length > 1
         ) {
-          rootElementsToFilter = [...rootElementsToFilter, ...rootElements]
+          rootElementsToFilter.push(...rootElements)
           dynamicScenesWithFragmentRootViews.push(path)
         }
       })
@@ -264,7 +265,7 @@ export class SelectModeControlContainer extends React.Component<
       })
 
       const selectableViews = [...dynamicScenesWithFragmentRootViews, ...allRoots, ...siblings]
-      const uniqueSelectableViews = R.uniqWith<TemplatePath>(TP.pathsEqual, selectableViews)
+      const uniqueSelectableViews = uniqBy<TemplatePath>(selectableViews, TP.pathsEqual)
 
       const selectableViewsFiltered = uniqueSelectableViews.filter((view) => {
         // I kept the group-like behavior here that the user can't single-click select the parent group, even though it is a view now

--- a/editor/src/components/inspector/controls/select-control.tsx
+++ b/editor/src/components/inspector/controls/select-control.tsx
@@ -1,6 +1,6 @@
 import * as R from 'ramda'
 import * as React from 'react'
-import Select, { components, createFilter } from 'react-select'
+import Select, { components, createFilter, InputProps } from 'react-select'
 import CreatableSelect, { Props as SelectProps } from 'react-select/creatable'
 import { IndicatorProps } from 'react-select/src/components/indicators'
 import Utils from '../../../utils/utils'
@@ -53,6 +53,31 @@ const ControlledDropdownIndicator: React.FunctionComponent<IndicatorProps<Select
         <Icons.ExpansionArrowControlled />
       </components.DropdownIndicator>
     )
+  )
+}
+
+export const CustomReactSelectInput = (props: InputProps) => {
+  const inputStyle = React.useMemo(() => {
+    return {
+      label: 'input',
+      background: 0,
+      border: 0,
+      fontSize: 'inherit',
+      opacity: props.isHidden ? 0 : 1,
+      outline: 0,
+      padding: 0,
+      color: 'inherit',
+    }
+  }, [props.isHidden])
+  return (
+    <div>
+      <input
+        className={props.className}
+        style={inputStyle}
+        disabled={props.isDisabled}
+        {...props}
+      />
+    </div>
   )
 }
 
@@ -112,6 +137,7 @@ export const SelectControl: React.StatelessComponent<DEPRECATEDControlProps<any>
     isDisabled: !props.controlStyles.interactive,
     components: {
       DropdownIndicator: controlledStatus ? ControlledDropdownIndicator : DropdownIndicator,
+      Input: CustomReactSelectInput,
       ...props.reactSelectComponents,
     },
     onChange: createableSelectOnSubmitValue,

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -9,6 +9,7 @@ import { GridRow } from '../../../widgets/grid-row'
 import { useGetSubsectionHeaderStyle } from '../../../common/inspector-utils'
 import { useInspectorElementInfo } from '../../../common/property-path-hooks'
 import { styleFn } from 'react-select/src/styles'
+import { CustomReactSelectInput } from '../../../controls/select-control'
 
 const IndicatorsContainer: React.FunctionComponent<IndicatorContainerProps<SelectOption>> = () =>
   null
@@ -199,6 +200,7 @@ const ClassNameControl = betterReactMemo(
         components={{
           IndicatorsContainer,
           MultiValueRemove,
+          Input: CustomReactSelectInput,
         }}
         className='className-inspector-control'
         styles={{

--- a/editor/src/templates/editor-canvas.ts
+++ b/editor/src/templates/editor-canvas.ts
@@ -567,7 +567,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
     return this.getPositionFromCoordinates(event.clientX, event.clientY)
   }
 
-  handleEvent(event: CanvasMouseEvent) {
+  handleEvent(event: CanvasMouseEvent): void {
     if (
       event.event === 'MOVE' &&
       !this.props.editor.canvas.selectionControlsVisible &&

--- a/editor/src/uuiui/widgets/popup-list/popup-list.tsx
+++ b/editor/src/uuiui/widgets/popup-list/popup-list.tsx
@@ -7,6 +7,7 @@ import * as ReactDOM from 'react-dom'
 import Select, {
   components,
   createFilter,
+  InputProps,
   MenuListComponentProps,
   OptionProps,
   OptionsType,
@@ -465,6 +466,31 @@ const getContainer = (
   }
 }
 
+const Input = (props: InputProps) => {
+  const inputStyle = React.useMemo(() => {
+    return {
+      label: 'input',
+      background: 0,
+      border: 0,
+      fontSize: 'inherit',
+      opacity: props.isHidden ? 0 : 1,
+      outline: 0,
+      padding: 0,
+      color: 'inherit',
+    }
+  }, [props.isHidden])
+  return (
+    <div>
+      <input
+        className={props.className}
+        style={inputStyle}
+        disabled={props.isDisabled}
+        {...props}
+      />
+    </div>
+  )
+}
+
 export const PopupList = betterReactMemo<PopupListProps>(
   'PopupList',
   ({
@@ -497,6 +523,7 @@ export const PopupList = betterReactMemo<PopupListProps>(
           MenuPortal,
           DropdownIndicator,
           SingleValue,
+          Input,
         }}
         value={value}
         onChange={selectOnSubmitValue}


### PR DESCRIPTION
**Problem:**
`react-select` uses `react-input-autosize` internally which puts hooks in for when elements are mounted or updated which trigger reflows during the React render call chain, which needlessly puts strain on various updates like changing selection.

**Fix:**
`react-select` supports replacing the `Input` component, which has been done in all the places it is used.

**Commit Details:**
- Use a custom implementation of the `Input` component wherever
  `react-select` is used.
- Couple of tiny changes in `SelectModeControlContainer` which are
  mostly tiny fine tuning.
