### PR TITLE
render the new selection before dispatching a selected view change

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -311,6 +311,7 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
       case 'live': {
         return (
           <SelectModeControlContainer
+            key={props.editor.selectedViews.map(TP.toString).join(';')}
             {...controlProps}
             keysPressed={props.editor.keysPressed}
             windowToCanvasPosition={props.windowToCanvasPosition}


### PR DESCRIPTION
this is a quick and _very_ dirty hack to see how much perceived performance can be if the canvas reacts to the MouseDown event with a priority