### PR TITLE
Trying to reduce the amount of work the DOM walker does.

### DIFF
--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -452,7 +452,7 @@ export function sendPropertyControlsInfoRequest(
   let nodeModulesUpdate: NodeModulesUpdate
   if (onlyProjectFiles) {
     let notNodeModulesFiles: NodeModules = {}
-    forEachValue<NodeModules>((value, key) => {
+    forEachValue<NodeModules, string>((value, key) => {
       if (typeof key === 'string' && !key.startsWith('/node_modules')) {
         notNodeModulesFiles[key] = value
       }

--- a/editor/src/core/shared/object-utils.ts
+++ b/editor/src/core/shared/object-utils.ts
@@ -124,8 +124,11 @@ export function objectMap<T, K extends keyof T, U>(
   return mappedObj
 }
 
-export function forEachValue<T>(fn: (val: ValueOf<T>, key: keyof T) => void, obj: T): void {
-  const keys = Object.keys(obj) as Array<keyof T>
+export function forEachValue<T, K extends keyof T>(
+  fn: (val: ValueOf<T>, key: keyof T) => void,
+  obj: T,
+): void {
+  const keys = Object.keys(obj) as Array<K>
   fastForEach(keys, (key) => {
     const value = obj[key]
     fn(value, key)

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -54,7 +54,7 @@ function emptyInstancePathCache(): InstancePathCache {
 let globalPathStringToPathCache: { [key: string]: TemplatePath } = {}
 let globalScenePathCache: ScenePathCache = emptyScenePathCache()
 
-export function clearTemplatePathCache() {
+export function clearTemplatePathCache(): void {
   globalPathStringToPathCache = {}
   globalScenePathCache = emptyScenePathCache()
 }


### PR DESCRIPTION
**Problem:**
The DOM walker has to walk the DOM of the canvas elements and as that's currently linear to the number of elements anything that can be shaved off is beneficial.

**Fix:**
Mostly this has attempted to avoid the costly calls into the browser DOM, by either caching or sharing values. As well as avoiding a regex that was run many times.

**Commit Details:**
- Created a cache that `globalFrameForElement` consults to reduce the number of calls to `getCanvasRectangleFromElement`.
- Moved around calls to `window.getComputedStyle` such that the results are shared with the result for a parent being passed down into a child.
- `getComputedStyle` (our function) now only collects a limited number of values and doesn't invoke `camelCaseToDashed` while doing it, which was particularly slow.
- More fully fleshed out the types of `forEachValue` and `clearTemplatePathCache`.