### PR TITLE
Spike: select canvas before dispatch v4

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -311,6 +311,7 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
       case 'live': {
         return (
           <SelectModeControlContainer
+            key={props.editor.selectedViews.map(TP.toString).join(';')}
             {...controlProps}
             keysPressed={props.editor.keysPressed}
             windowToCanvasPosition={props.windowToCanvasPosition}

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -141,6 +141,14 @@ export const NewCanvasControls = betterReactMemo(
             }}
           >
             <NewCanvasControlsClass
+              key={
+                canvasControlProps.derived.canvas.transientState.selectedViews
+                  .map(TP.toString)
+                  .join(';') +
+                canvasControlProps.derived.canvas.transientState.highlightedViews
+                  .map(TP.toString)
+                  .join(';')
+              }
               windowToCanvasPosition={props.windowToCanvasPosition}
               {...canvasControlProps}
             />
@@ -262,6 +270,18 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
     'NewCanvasControls elementsThatRespectLayout',
   )
 
+  const [localSelectedViews, setLocalSelectedViews] = React.useState(
+    props.derived.canvas.transientState.selectedViews,
+  )
+  const [localHighlightedViews, setLocalHighlightedViews] = React.useState(
+    props.derived.canvas.transientState.highlightedViews,
+  )
+
+  const selectViewsWithPriority = React.useCallback((newSelectedViews: Array<TemplatePath>) => {
+    setLocalHighlightedViews([])
+    setLocalSelectedViews(newSelectedViews)
+  }, [])
+
   const renderModeControlContainer = () => {
     const fallbackTransientState = props.derived.canvas.transientState
     const targets = fallbackTransientState.selectedViews
@@ -311,7 +331,6 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
       case 'live': {
         return (
           <SelectModeControlContainer
-            key={props.editor.selectedViews.map(TP.toString).join(';')}
             {...controlProps}
             keysPressed={props.editor.keysPressed}
             windowToCanvasPosition={props.windowToCanvasPosition}
@@ -327,6 +346,9 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
                 : null
             }
             showAdditionalControls={props.editor.interfaceDesigner.additionalControls}
+            selectViewsWithPriority={selectViewsWithPriority}
+            selectedViews={localSelectedViews}
+            highlightedViews={localHighlightedViews}
           />
         )
       }
@@ -354,7 +376,7 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
   }
 
   const renderHighlightControls = () => {
-    const highlightedViews = props.derived.canvas.transientState.highlightedViews
+    const highlightedViews = localHighlightedViews
     return selectionEnabled
       ? highlightedViews.map((path) => {
           const frame = MetadataUtils.getFrameInCanvasCoords(path, componentMetadata)

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -110,15 +110,17 @@ export class SelectModeControlContainer extends React.Component<
         this.setState({ selectedViews: updatedSelection })
       })
       // is this enough?
-      setTimeout(() => {
-        let selectActions = [
-          EditorActions.clearHighlightedViews(),
-          EditorActions.selectComponents(updatedSelection, false),
-          EditorActions.setLeftMenuTab(LeftMenuTab.UINavigate),
-          EditorActions.setRightMenuTab(RightMenuTab.Inspector),
-        ]
-        this.props.dispatch(selectActions, 'canvas')
-      }, 0)
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          let selectActions = [
+            EditorActions.clearHighlightedViews(),
+            EditorActions.selectComponents(updatedSelection, false),
+            EditorActions.setLeftMenuTab(LeftMenuTab.UINavigate),
+            EditorActions.setRightMenuTab(RightMenuTab.Inspector),
+          ]
+          this.props.dispatch(selectActions, 'canvas')
+        })
+      })
       return updatedSelection
     }
   }

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -1,4 +1,5 @@
 import * as R from 'ramda'
+import * as ReactDOM from 'react-dom'
 import * as React from 'react'
 import { KeysPressed } from '../../../utils/keyboard'
 import Utils from '../../../utils/utils'
@@ -105,7 +106,9 @@ export class SelectModeControlContainer extends React.Component<
       if (isMultiselect) {
         updatedSelection = TP.addPathIfMissing(target, this.state.selectedViews)
       }
-      this.setState({ selectedViews: updatedSelection })
+      ;(ReactDOM as any).flushSync(() => {
+        this.setState({ selectedViews: updatedSelection })
+      })
       // is this enough?
       setTimeout(() => {
         let selectActions = [
@@ -115,7 +118,7 @@ export class SelectModeControlContainer extends React.Component<
           EditorActions.setRightMenuTab(RightMenuTab.Inspector),
         ]
         this.props.dispatch(selectActions, 'canvas')
-      }, 1)
+      }, 0)
       return updatedSelection
     }
   }
@@ -156,25 +159,25 @@ export class SelectModeControlContainer extends React.Component<
             )
           : null
 
-        this.props.dispatch([
-          CanvasActions.createDragState(
-            moveDragState(
-              start,
-              null,
-              null,
-              originalFrames,
-              selectionArea,
-              !originalEvent.metaKey,
-              originalEvent.shiftKey,
-              duplicate,
-              originalEvent.metaKey,
-              duplicateNewUIDs,
-              start,
-              this.props.componentMetadata,
-              moveTargets,
-            ),
-          ),
-        ])
+        // this.props.dispatch([
+        //   CanvasActions.createDragState(
+        //     moveDragState(
+        //       start,
+        //       null,
+        //       null,
+        //       originalFrames,
+        //       selectionArea,
+        //       !originalEvent.metaKey,
+        //       originalEvent.shiftKey,
+        //       duplicate,
+        //       originalEvent.metaKey,
+        //       duplicateNewUIDs,
+        //       start,
+        //       this.props.componentMetadata,
+        //       moveTargets,
+        //     ),
+        //   ),
+        // ])
       }
     }
   }
@@ -702,15 +705,16 @@ export class SelectModeControlContainer extends React.Component<
           : null}
         {this.props.selectionEnabled ? (
           <>
-            <OutlineControls {...this.props} />
+            <OutlineControls {...this.props} selectedViews={this.state.selectedViews} />
             {this.canResizeElements() ? (
               repositionOnly ? (
-                <RepositionableControl {...this.props} />
+                <RepositionableControl {...this.props} selectedViews={this.state.selectedViews} />
               ) : (
                 <>
-                  <ConstraintsControls {...this.props} />
+                  <ConstraintsControls {...this.props} selectedViews={this.state.selectedViews} />
                   <YogaControls
                     {...this.props}
+                    selectedViews={this.state.selectedViews}
                     dragState={
                       this.props.dragState != null &&
                       this.props.dragState.type === 'RESIZE_DRAG_STATE'


### PR DESCRIPTION
improvement over #715 

moving the fake selectedViews state up to NewCanvasControlsClass, clearing local highlightedViews on click. this instantly removes the highlighted view, before the rest of the editor renders