### PR TITLE
Experiment/components instances highlight

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -360,9 +360,18 @@ const NewCanvasControlsClass = (props: NewCanvasControlsClassProps) => {
           if (frame == null) {
             return null
           }
-          const color = TP.isScenePath(path)
-            ? colorTheme.canvasSelectionSceneOutline.value
-            : colorTheme.canvasSelectionPrimaryOutline.value
+          let color: string
+          if (TP.isScenePath(path)) {
+            color = colorTheme.canvasSelectionSceneOutline.value
+          } else {
+            const element = MetadataUtils.getElementByInstancePathMaybe(
+              componentMetadata.elements,
+              path,
+            )
+            color = element?.internalChildOfComponent
+              ? '#FFA500'
+              : colorTheme.canvasSelectionPrimaryOutline.value
+          }
           return (
             <HighlightControl
               key={`highlight-control-${TP.toComponentId(path)}`}

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -22,6 +22,7 @@ export function getSelectionColor(
   imports: Imports,
   createsYogaLayout: boolean,
   anySelectedElementIsYogaLayouted: boolean,
+  internalChildOfComponent: boolean | undefined,
 ): string {
   if (TP.isScenePath(path)) {
     return colorTheme.canvasSelectionSceneOutline.value
@@ -32,6 +33,8 @@ export function getSelectionColor(
     const originType = MetadataUtils.getElementOriginType(rootElements, path)
     if (originType === 'generated-static-definition-present' || originType === 'unknown-element') {
       return colorTheme.canvasSelectionRandomDOMElementInstanceOutline.value
+    } else if (internalChildOfComponent) {
+      return '#FFA500'
     } else if (createsYogaLayout) {
       return colorTheme.canvasSelectionAlternateOutlineYogaParent.value
     } else if (anySelectedElementIsYogaLayouted) {
@@ -147,6 +150,7 @@ export class OutlineControls extends React.Component<OutlineControlsProps> {
         this.props.imports,
         createsYogaLayout,
         anySelectedElementIsYogaLayouted,
+        instance?.internalChildOfComponent,
       )
 
       if (this.props.dragState == null) {

--- a/editor/src/components/canvas/controls/repositionable-control.tsx
+++ b/editor/src/components/canvas/controls/repositionable-control.tsx
@@ -37,6 +37,7 @@ export class RepositionableControl extends React.Component<ControlProps> {
         this.props.imports,
         createsYogaLayout,
         anySelectedElementIsYogaLayouted,
+        instance?.internalChildOfComponent,
       )
 
       indicators.push(

--- a/editor/src/components/canvas/controls/yoga-control.tsx
+++ b/editor/src/components/canvas/controls/yoga-control.tsx
@@ -138,6 +138,7 @@ export class YogaControls extends React.Component<YogaControlsProps> {
         this.props.imports,
         createsYogaLayout,
         true,
+        instance?.internalChildOfComponent,
       )
     }
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -48,6 +48,7 @@ import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { PRODUCTION_ENV } from '../../common/env-vars'
 import { CanvasContainerID } from './canvas-types'
 import { emptySet } from '../../core/shared/set-utils'
+import { isFeatureEnabled } from '../../utils/feature-switches'
 
 const MutationObserverConfig = { attributes: true, childList: true, subtree: true }
 const ObserversAvailable = (window as any).MutationObserver != null && ResizeObserver != null
@@ -517,7 +518,9 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
           }
 
           // Check this is a path we're interested in, otherwise skip straight to the children
-          const pathIsValid = isValidPath(Utils.defaultIfNull(uniquePath, originalPath), validPaths)
+          const pathIsValid =
+            isValidPath(Utils.defaultIfNull(uniquePath, originalPath), validPaths) ||
+            isFeatureEnabled('Component Children Highlights')
           const pathForChildren = pathIsValid ? uniquePath : uniqueParentPath
 
           // Build the metadata for the children of this DOM node.

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -424,6 +424,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
             null,
             rootElements,
             false,
+            false,
             emptySpecialSizeMeasurements,
             emptyComputedStyle,
           )
@@ -584,6 +585,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
           globalFrame,
           localFrame,
           children,
+          false,
           false,
           getSpecialMeasurements(element),
           getComputedStyle(element, instancePath),

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
@@ -77,6 +77,7 @@ function useRunSpy(
       localFrame: null,
       children: [],
       componentInstance: false,
+      internalChildOfComponent: false,
       specialSizeMeasurements: emptySpecialSizeMeasurements,
       computedStyle: emptyComputedStyle,
     }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -88,7 +88,9 @@ export function createComponentRendererComponent(params: {
         // if this component is used as an instance inside some other component, this template path will be garbage.
         // but! worry not, because in cases this is an instance, we are not running the DOM-walker and we discard the spy results
         // so it is not an issue that we have a false template path
-        const ownTemplatePath = TP.instancePath(scenePath, [getUtopiaID(element)])
+        const realTemplatePath = realPassedProps['data-template-path']
+        const uid = realPassedProps['data-uid'] || getUtopiaID(element)
+        const ownTemplatePath = realTemplatePath ?? TP.instancePath(scenePath, [uid])
 
         return renderCoreElement(
           element,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -213,7 +213,7 @@ function renderJSXElement(
   codeError: Error | null,
   shouldIncludeCanvasRootInTheSpy: boolean,
 ): React.ReactElement {
-  let elementProps = { key: key, ...passthroughProps }
+  let elementProps = { key: key, ...passthroughProps, 'data-template-path': templatePath }
   if (isHidden(hiddenInstances, templatePath)) {
     elementProps = hideElement(elementProps)
   }
@@ -261,7 +261,10 @@ function renderJSXElement(
     Utils.fastForEach(jsx.children, (child) => {
       if (isJSXElement(child)) {
         const childPath = TP.appendToPath(templatePath, getUtopiaID(child))
-        if (TP.containsPath(childPath, validPaths)) {
+        if (
+          TP.containsPath(childPath, validPaths) ||
+          isFeatureEnabled('Component Children Highlights')
+        ) {
           childrenTemplatePaths.push(childPath)
         }
       }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -35,6 +35,7 @@ import { cssValueOnlyContainsComments } from '../../../printer-parsers/css/css-p
 import { filterDataProps } from '../../../utils/canvas-react-utils'
 import { buildSpyWrappedElement } from './ui-jsx-canvas-spy-wrapper'
 import { createIndexedUid } from '../../../core/shared/uid-utils'
+import { isFeatureEnabled } from '../../../utils/feature-switches'
 
 export function renderCoreElement(
   element: JSXElementChild,
@@ -251,7 +252,10 @@ function renderJSXElement(
   const finalProps =
     elementIsIntrinsic && !elementIsBaseHTML ? filterDataProps(elementProps) : elementProps
 
-  if (FinalElement != null && TP.containsPath(templatePath, validPaths)) {
+  if (
+    FinalElement != null &&
+    (TP.containsPath(templatePath, validPaths) || isFeatureEnabled('Component Children Highlights'))
+  ) {
     let childrenTemplatePaths: InstancePath[] = []
 
     Utils.fastForEach(jsx.children, (child) => {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -252,10 +252,8 @@ function renderJSXElement(
   const finalProps =
     elementIsIntrinsic && !elementIsBaseHTML ? filterDataProps(elementProps) : elementProps
 
-  if (
-    FinalElement != null &&
-    (TP.containsPath(templatePath, validPaths) || isFeatureEnabled('Component Children Highlights'))
-  ) {
+  const isValidPath = TP.containsPath(templatePath, validPaths)
+  if (FinalElement != null && (isValidPath || isFeatureEnabled('Component Children Highlights'))) {
     let childrenTemplatePaths: InstancePath[] = []
 
     Utils.fastForEach(jsx.children, (child) => {
@@ -281,6 +279,7 @@ function renderJSXElement(
       inScope,
       jsxFactoryFunctionName,
       shouldIncludeCanvasRootInTheSpy,
+      !isValidPath,
     )
   } else {
     const childrenOrNull = childrenElements.length !== 0 ? childrenElements : null

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -25,6 +25,7 @@ export function buildSpyWrappedElement(
   inScope: MapLike<any>,
   jsxFactoryFunctionName: string | null,
   shouldIncludeCanvasRootInTheSpy: boolean,
+  internalChildOfComponent: boolean,
 ): React.ReactElement {
   const props = {
     ...finalProps,
@@ -40,6 +41,7 @@ export function buildSpyWrappedElement(
       localFrame: null,
       children: childrenTemplatePaths,
       componentInstance: false,
+      internalChildOfComponent: internalChildOfComponent,
       specialSizeMeasurements: emptySpecialSizeMeasurements, // This is not the nicest, but the results from the DOM walker will override this anyways
       computedStyle: emptyComputedStyle,
     }

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -815,6 +815,7 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
     children: [childElementPath],
     componentInstance: false,
+    internalChildOfComponent: false,
     specialSizeMeasurements: emptySpecialSizeMeasurements,
     computedStyle: emptyComputedStyle,
   }
@@ -835,6 +836,7 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     localFrame: localRectangle({ x: 0, y: 0, width: 200, height: 300 }),
     children: [],
     componentInstance: false,
+    internalChildOfComponent: false,
     specialSizeMeasurements: emptySpecialSizeMeasurements,
     computedStyle: emptyComputedStyle,
   }

--- a/editor/src/core/layout/layout-utils.spec.browser.ts
+++ b/editor/src/core/layout/layout-utils.spec.browser.ts
@@ -80,6 +80,7 @@ describe('maybeSwitchLayoutProps', () => {
         localFrame: { x: 0, y: 0, width: 375, height: 812 } as LocalRectangle,
         children: [],
         componentInstance: true,
+        internalChildOfComponent: false,
         specialSizeMeasurements: specialSizeMeasurements(
           { x: 0, y: 0 } as any,
           null,

--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -44,6 +44,7 @@ const testComponentMetadataChild1: ElementInstanceMetadata = {
   element: right(jsxTestElement('View', {}, [])),
   children: [],
   componentInstance: false,
+  internalChildOfComponent: false,
   specialSizeMeasurements: emptySpecialSizeMeasurements,
   computedStyle: emptyComputedStyle,
 }
@@ -55,6 +56,7 @@ const testComponentMetadataChild2: ElementInstanceMetadata = {
   element: right(jsxTestElement('View', {}, [])),
   children: [],
   componentInstance: false,
+  internalChildOfComponent: false,
   specialSizeMeasurements: emptySpecialSizeMeasurements,
   computedStyle: emptyComputedStyle,
 }
@@ -69,6 +71,7 @@ const testComponentMetadataGrandchild: ElementInstanceMetadata = {
   element: right(jsxTestElement('View', {}, [])),
   children: [],
   componentInstance: false,
+  internalChildOfComponent: false,
   specialSizeMeasurements: emptySpecialSizeMeasurements,
   computedStyle: emptyComputedStyle,
 }
@@ -81,6 +84,7 @@ const testComponentMetadataChild3: ElementInstanceMetadata = {
   element: right(jsxTestElement('View', {}, [])),
   children: [testComponentMetadataGrandchild.templatePath],
   componentInstance: false,
+  internalChildOfComponent: false,
   specialSizeMeasurements: emptySpecialSizeMeasurements,
   computedStyle: emptyComputedStyle,
 }
@@ -97,6 +101,7 @@ const testComponentRoot1: ElementInstanceMetadata = {
     testComponentMetadataChild3.templatePath,
   ],
   componentInstance: false,
+  internalChildOfComponent: false,
   specialSizeMeasurements: emptySpecialSizeMeasurements,
   computedStyle: emptyComputedStyle,
 }
@@ -203,6 +208,7 @@ describe('targetElementSupportsChildren', () => {
       element: right(jsxTestElement(elementName, {}, [])),
       children: [],
       componentInstance: false,
+      internalChildOfComponent: false,
       specialSizeMeasurements: emptySpecialSizeMeasurements,
       computedStyle: emptyComputedStyle,
     }
@@ -327,6 +333,7 @@ describe('getElementLabel', () => {
     zeroRectangle as LocalRectangle,
     [],
     false,
+    false,
     emptySpecialSizeMeasurements,
     emptyComputedStyle,
   )
@@ -340,6 +347,7 @@ describe('getElementLabel', () => {
     zeroRectangle as CanvasRectangle,
     zeroRectangle as LocalRectangle,
     [spanElementMetadata.templatePath],
+    false,
     false,
     emptySpecialSizeMeasurements,
     emptyComputedStyle,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1111,6 +1111,8 @@ export const MetadataUtils = {
         newlyFoundElements.push(domElem.templatePath)
       } else {
         let componentInstance = spyElem.componentInstance || domElem.componentInstance
+        let internalChildOfComponent =
+          spyElem.internalChildOfComponent || domElem.internalChildOfComponent
         let jsxElement = alternativeEither(spyElem.element, domElem.element)
 
         const possibleUID: string | null | undefined = Utils.defaultIfNull(
@@ -1139,6 +1141,7 @@ export const MetadataUtils = {
           element: elementToUse,
           children: children,
           componentInstance: componentInstance,
+          internalChildOfComponent: internalChildOfComponent,
         }
         workingElements[TP.toString(domElem.templatePath)] = elem
       }

--- a/editor/src/core/shared/element-template.tsx
+++ b/editor/src/core/shared/element-template.tsx
@@ -942,6 +942,7 @@ export interface ElementInstanceMetadata {
   localFrame: LocalRectangle | null
   children: Array<InstancePath>
   componentInstance: boolean
+  internalChildOfComponent: boolean
   specialSizeMeasurements: SpecialSizeMeasurements
   computedStyle: ComputedStyle | null
 }
@@ -954,6 +955,7 @@ export function elementInstanceMetadata(
   localFrame: LocalRectangle | null,
   children: Array<InstancePath>,
   componentInstance: boolean,
+  internalChildOfComponent: boolean,
   sizeMeasurements: SpecialSizeMeasurements,
   computedStyle: ComputedStyle | null,
 ): ElementInstanceMetadata {
@@ -965,6 +967,7 @@ export function elementInstanceMetadata(
     localFrame: localFrame,
     children: children,
     componentInstance: componentInstance,
+    internalChildOfComponent: internalChildOfComponent,
     specialSizeMeasurements: sizeMeasurements,
     computedStyle: computedStyle,
   }

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -8,6 +8,7 @@ export type FeatureName =
   | 'Advanced Resize Box'
   | 'Re-parse Project Button'
   | 'iFrame Code Editor'
+  | 'Component Children Highlights'
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
   // 'Dragging Shows Overlay', // Removing this option so that we can experiment on this later
@@ -15,6 +16,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Advanced Resize Box',
   'Re-parse Project Button',
   'iFrame Code Editor',
+  'Component Children Highlights',
 ]
 
 let FeatureSwitches: { [feature: string]: boolean } = {
@@ -24,6 +26,7 @@ let FeatureSwitches: { [feature: string]: boolean } = {
   'Advanced Resize Box': false,
   'Re-parse Project Button': false,
   'iFrame Code Editor': false,
+  'Component Children Highlights': true,
 }
 
 function settingKeyForName(featureName: FeatureName): string {

--- a/editor/src/utils/test-utils.ts
+++ b/editor/src/utils/test-utils.ts
@@ -297,6 +297,7 @@ function createFakeMetadataForJSXElement(
       localFrame: Utils.zeroRectangle as LocalRectangle,
       children: childPaths,
       componentInstance: false,
+      internalChildOfComponent: false,
       specialSizeMeasurements: emptySpecialSizeMeasurements,
       computedStyle: emptyComputedStyle,
     })


### PR DESCRIPTION
Component Experiment #706

#### How to try it?
Try highlighting and selecting component children on the canvas. Uses feature flag `Component Children Highlights`.
Editing is not included in this PR, the elements can be only selected.

To try it on a different project please add `?branch_name=experiment/components-instances-highlight` to the end of the URL. 

🍕 https://utopia.pizza/p/4c23662a-hissing-repair/?branch_name=experiment/components-instances-highlight