### PR TITLE
Use our deep equality handling for element metadata.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { View } from 'utopia-api'
+import { LayoutSystem, View } from 'utopia-api'
 import { useContextSelector } from 'use-context-selector'
 import * as fastDeepEquals from 'fast-deep-equal'
 import { getValidTemplatePaths } from '../../../core/model/element-template-utils'
@@ -36,12 +36,12 @@ import utils from '../../../utils/utils'
 import { PathForResizeContent } from '../../../core/model/scene-utils'
 
 interface SceneProps {
-  component: React.ComponentType | null
-  props: any
-  style: React.CSSProperties
-  layout: ScenePinnedContainer
-  'data-uid': string
-  'data-label': string | undefined
+  component?: React.ComponentType | null
+  props?: any
+  style?: React.CSSProperties
+  layout?: ScenePinnedContainer
+  'data-uid'?: string
+  'data-label'?: string
 }
 
 function useRunSpy(
@@ -66,7 +66,7 @@ function useRunSpy(
     sceneResizesContent: resizesContent,
     globalFrame: null,
     label: props['data-label'],
-    style: props.style,
+    style: props.style ?? {},
   }
   if (shouldIncludeCanvasRootInTheSpy) {
     metadataContext.current.spyValues.metadata[TP.toComponentId(templatePath)] = {
@@ -84,7 +84,7 @@ function useRunSpy(
 }
 
 function getTopLevelElementName(
-  componentRenderer: ComponentRendererComponent | React.ComponentType | null,
+  componentRenderer: ComponentRendererComponent | React.ComponentType | null | undefined,
 ): string | null {
   if (isComponentRendererComponent(componentRenderer)) {
     return componentRenderer.topLevelElementName

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -22,7 +22,7 @@ export type ComponentRendererComponent = React.ComponentType<any> & {
 }
 
 export function isComponentRendererComponent(
-  component: ComponentRendererComponent | React.ComponentType | null,
+  component: ComponentRendererComponent | React.ComponentType | null | undefined,
 ): component is ComponentRendererComponent {
   return (
     component != null &&

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-props-utils.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-props-utils.ts
@@ -22,7 +22,7 @@ export function applyPropsParamToPassedProps(
     defaultExpression: JSXAttributeOtherJavaScript | null,
   ): unknown {
     if (value === undefined && defaultExpression != null) {
-      return jsxAttributeToValue(inScope, requireResult)(defaultExpression)
+      return jsxAttributeToValue(inScope, requireResult, defaultExpression)
     } else {
       return value
     }

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -464,6 +464,11 @@ import {
   StoryboardFilePath,
 } from '../../../core/model/storyboard-utils'
 import { keepDeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
+import { arrayDeepEquality } from '../../../utils/deep-equality'
+import {
+  ElementInstanceMetadataKeepDeepEquality,
+  JSXMetadataKeepDeepEquality,
+} from '../store/store-deep-equality-instances'
 
 export function clearSelection(): EditorAction {
   return {
@@ -3609,14 +3614,12 @@ export const UPDATE_FNS = {
       spyCollector.current.spyValues.scenes,
     )
 
-    const finalDomMetadata = keepDeepReferenceEqualityIfPossible(
+    const finalDomMetadata = arrayDeepEquality(ElementInstanceMetadataKeepDeepEquality())(
       editor.domMetadataKILLME,
       action.elementMetadata,
-    )
-    const finalSpyMetadata = keepDeepReferenceEqualityIfPossible(
-      editor.spyMetadataKILLME,
-      spyResult,
-    )
+    ).value
+    const finalSpyMetadata = JSXMetadataKeepDeepEquality()(editor.spyMetadataKILLME, spyResult)
+      .value
 
     const stayedTheSame =
       editor.domMetadataKILLME === finalDomMetadata && editor.spyMetadataKILLME === finalSpyMetadata

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -140,7 +140,10 @@ import {
 } from '../npm-dependency/npm-dependency'
 import { getControlsForExternalDependencies } from '../../../core/property-controls/property-controls-utils'
 import { parseSuccess } from '../../../core/workers/common/project-file-utils'
-import { DerivedStateKeepDeepEquality } from './store-deep-equality-instances'
+import {
+  DerivedStateKeepDeepEquality,
+  JSXMetadataKeepDeepEquality,
+} from './store-deep-equality-instances'
 
 export interface OriginalPath {
   originalTP: TemplatePath
@@ -1719,7 +1722,7 @@ export function reconstructJSXMetadata(editor: EditorState): JSXMetadata {
           editor.spyMetadataKILLME,
           editor.domMetadataKILLME,
         )
-        return keepDeepReferenceEqualityIfPossible(editor.jsxMetadataKILLME, mergedMetadata)
+        return JSXMetadataKeepDeepEquality()(editor.jsxMetadataKILLME, mergedMetadata).value
       },
       (_) => editor.jsxMetadataKILLME,
       uiFile.fileContents.parsed,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1,13 +1,85 @@
+import { Sides } from 'utopia-api'
+import {
+  ComponentMetadata,
+  ElementInstanceMetadata,
+  elementInstanceMetadata,
+  ElementInstanceMetadataMap,
+  ElementsWithin,
+  isArraySpread,
+  isArrayValue,
+  isJSXArbitraryBlock,
+  isJSXAttributeFunctionCall,
+  isJSXAttributeNestedArray,
+  isJSXAttributeNestedObject,
+  isJSXAttributeOtherJavaScript,
+  isJSXAttributeValue,
+  isJSXElement,
+  isJSXFragment,
+  isJSXTextBlock,
+  isPropertyAssignment,
+  isSpreadAssignment,
+  JSXArbitraryBlock,
+  JSXArrayElement,
+  jsxArraySpread,
+  JSXArraySpread,
+  JSXArrayValue,
+  jsxArrayValue,
+  JSXAttribute,
+  jsxAttributeFunctionCall,
+  JSXAttributeFunctionCall,
+  jsxAttributeNestedArray,
+  JSXAttributeNestedArray,
+  jsxAttributeNestedObject,
+  JSXAttributeNestedObject,
+  JSXAttributeOtherJavaScript,
+  JSXAttributes,
+  jsxAttributeValue,
+  JSXAttributeValue,
+  jsxElement,
+  JSXElement,
+  JSXElementChild,
+  JSXFragment,
+  jsxMetadata,
+  JSXMetadata,
+  JSXProperty,
+  jsxPropertyAssignment,
+  JSXPropertyAssignment,
+  jsxSpreadAssignment,
+  JSXSpreadAssignment,
+  JSXTextBlock,
+  specialSizeMeasurements,
+  SpecialSizeMeasurements,
+} from '../../../core/shared/element-template'
+import { CanvasRectangle, LocalPoint, LocalRectangle } from '../../../core/shared/math-utils'
+import { SceneContainer } from '../../../core/shared/project-file-types'
 import {
   KeepDeepEqualityResult,
   keepDeepEqualityResult,
   KeepDeepEqualityCall,
   combine3EqualityCalls,
   combine6EqualityCalls,
+  nullableDeepEquality,
+  createCallWithTripleEquals,
+  combine9EqualityCalls,
+  objectDeepEquality,
+  mapKeepDeepEqualityResult,
+  combine5EqualityCalls,
+  arrayDeepEquality,
+  combine1EqualityCall,
+  combine2EqualityCalls,
+  combine7EqualityCalls,
+  combine8EqualityCalls,
+  undefinableDeepEquality,
 } from '../../../utils/deep-equality'
 import {
   TemplatePathArrayKeepDeepEquality,
   HigherOrderControlArrayKeepDeepEquality,
+  TemplatePathKeepDeepEquality,
+  EitherKeepDeepEquality,
+  InstancePathKeepDeepEquality,
+  InstancePathArrayKeepDeepEquality,
+  JSXElementNameKeepDeepEqualityCall,
+  ScenePathKeepDeepEquality,
 } from '../../../utils/deep-equality-instances'
 import { createCallFromIntrospectiveKeepDeep } from '../../../utils/react-performance'
 import {
@@ -62,5 +134,510 @@ export function DerivedStateKeepDeepEquality(): KeepDeepEqualityCall<DerivedStat
         elementWarnings: elementWarnings,
       }
     },
+  )
+}
+
+export function JSXAttributeValueKeepDeepEqualityCall<T>(): KeepDeepEqualityCall<
+  JSXAttributeValue<T>
+> {
+  return combine1EqualityCall(
+    (attribute) => attribute.value,
+    createCallFromIntrospectiveKeepDeep<T>(),
+    jsxAttributeValue,
+  )
+}
+
+export function JSXAttributeOtherJavaScriptKeepDeepEqualityCall(): KeepDeepEqualityCall<
+  JSXAttributeOtherJavaScript
+> {
+  return combine5EqualityCalls(
+    (attribute) => attribute.javascript,
+    createCallWithTripleEquals(),
+    (attribute) => attribute.transpiledJavascript,
+    createCallWithTripleEquals(),
+    (attribute) => attribute.definedElsewhere,
+    arrayDeepEquality(createCallWithTripleEquals()),
+    (attribute) => attribute.sourceMap,
+    createCallFromIntrospectiveKeepDeep(),
+    (attribute) => attribute.uniqueID,
+    createCallWithTripleEquals(),
+    (javascript, transpiledJavascript, definedElsewhere, sourceMap, uniqueID) => {
+      return {
+        type: 'ATTRIBUTE_OTHER_JAVASCRIPT',
+        javascript: javascript,
+        transpiledJavascript: transpiledJavascript,
+        definedElsewhere: definedElsewhere,
+        sourceMap: sourceMap,
+        uniqueID: uniqueID,
+      }
+    },
+  )
+}
+
+export function JSXArrayValueKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXArrayValue> {
+  return combine1EqualityCall(
+    (value) => value.value,
+    JSXAttributeKeepDeepEqualityCall(),
+    jsxArrayValue,
+  )
+}
+
+export function JSXArraySpreadKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXArraySpread> {
+  return combine1EqualityCall(
+    (value) => value.value,
+    JSXAttributeKeepDeepEqualityCall(),
+    jsxArraySpread,
+  )
+}
+
+export function JSXArrayElementKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXArrayElement> {
+  return (oldElement, newElement) => {
+    if (isArrayValue(oldElement) && isArrayValue(newElement)) {
+      return JSXArrayValueKeepDeepEqualityCall()(oldElement, newElement)
+    } else if (isArraySpread(oldElement) && isArraySpread(newElement)) {
+      return JSXArraySpreadKeepDeepEqualityCall()(oldElement, newElement)
+    } else {
+      return keepDeepEqualityResult(newElement, false)
+    }
+  }
+}
+
+export function JSXAttributeNestedArrayKeepDeepEqualityCall(): KeepDeepEqualityCall<
+  JSXAttributeNestedArray
+> {
+  return combine1EqualityCall(
+    (attribute) => attribute.content,
+    arrayDeepEquality(JSXArrayElementKeepDeepEqualityCall()),
+    jsxAttributeNestedArray,
+  )
+}
+
+export function JSXSpreadAssignmentKeepDeepEqualityCall(): KeepDeepEqualityCall<
+  JSXSpreadAssignment
+> {
+  return combine1EqualityCall(
+    (value) => value.value,
+    JSXAttributeKeepDeepEqualityCall(),
+    jsxSpreadAssignment,
+  )
+}
+
+export function JSXPropertyAssignmentKeepDeepEqualityCall(): KeepDeepEqualityCall<
+  JSXPropertyAssignment
+> {
+  return combine2EqualityCalls(
+    (value) => value.key,
+    createCallWithTripleEquals(),
+    (value) => value.value,
+    JSXAttributeKeepDeepEqualityCall(),
+    jsxPropertyAssignment,
+  )
+}
+
+export function JSXPropertyKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXProperty> {
+  return (oldProperty, newProperty) => {
+    if (isSpreadAssignment(oldProperty) && isSpreadAssignment(newProperty)) {
+      return JSXSpreadAssignmentKeepDeepEqualityCall()(oldProperty, newProperty)
+    } else if (isPropertyAssignment(oldProperty) && isPropertyAssignment(newProperty)) {
+      return JSXPropertyAssignmentKeepDeepEqualityCall()(oldProperty, newProperty)
+    } else {
+      return keepDeepEqualityResult(newProperty, false)
+    }
+  }
+}
+
+export function JSXAttributeNestedObjectKeepDeepEqualityCall(): KeepDeepEqualityCall<
+  JSXAttributeNestedObject
+> {
+  return combine1EqualityCall(
+    (attribute) => attribute.content,
+    arrayDeepEquality(JSXPropertyKeepDeepEqualityCall()),
+    jsxAttributeNestedObject,
+  )
+}
+
+export function JSXAttributeFunctionCallKeepDeepEqualityCall(): KeepDeepEqualityCall<
+  JSXAttributeFunctionCall
+> {
+  return combine2EqualityCalls(
+    (value) => value.functionName,
+    createCallWithTripleEquals(),
+    (value) => value.parameters,
+    arrayDeepEquality(JSXAttributeKeepDeepEqualityCall()),
+    jsxAttributeFunctionCall,
+  )
+}
+
+export function JSXAttributeKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXAttribute> {
+  return (oldAttribute, newAttribute) => {
+    if (isJSXAttributeValue(oldAttribute) && isJSXAttributeValue(newAttribute)) {
+      return JSXAttributeValueKeepDeepEqualityCall()(oldAttribute, newAttribute)
+    } else if (
+      isJSXAttributeOtherJavaScript(oldAttribute) &&
+      isJSXAttributeOtherJavaScript(newAttribute)
+    ) {
+      return JSXAttributeOtherJavaScriptKeepDeepEqualityCall()(oldAttribute, newAttribute)
+    } else if (isJSXAttributeNestedArray(oldAttribute) && isJSXAttributeNestedArray(newAttribute)) {
+      return JSXAttributeNestedArrayKeepDeepEqualityCall()(oldAttribute, newAttribute)
+    } else if (
+      isJSXAttributeNestedObject(oldAttribute) &&
+      isJSXAttributeNestedObject(newAttribute)
+    ) {
+      return JSXAttributeNestedObjectKeepDeepEqualityCall()(oldAttribute, newAttribute)
+    } else if (
+      isJSXAttributeFunctionCall(oldAttribute) &&
+      isJSXAttributeFunctionCall(newAttribute)
+    ) {
+      return JSXAttributeFunctionCallKeepDeepEqualityCall()(oldAttribute, newAttribute)
+    } else {
+      return keepDeepEqualityResult(newAttribute, false)
+    }
+  }
+}
+
+export function JSXAttributesKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXAttributes> {
+  return objectDeepEquality(JSXAttributeKeepDeepEqualityCall())
+}
+
+export function JSXElementKeepDeepEquality(): KeepDeepEqualityCall<JSXElement> {
+  return combine3EqualityCalls(
+    (element) => element.name,
+    JSXElementNameKeepDeepEqualityCall(),
+    (element) => element.props,
+    JSXAttributesKeepDeepEqualityCall(),
+    (element) => element.children,
+    JSXElementChildArrayKeepDeepEquality(),
+    jsxElement,
+  )
+}
+
+export function ElementsWithinKeepDeepEqualityCall(): KeepDeepEqualityCall<ElementsWithin> {
+  return objectDeepEquality(JSXElementKeepDeepEquality())
+}
+
+export function JSXArbitraryBlockKeepDeepEquality(): KeepDeepEqualityCall<JSXArbitraryBlock> {
+  return combine7EqualityCalls(
+    (block) => block.originalJavascript,
+    createCallWithTripleEquals(),
+    (block) => block.javascript,
+    createCallWithTripleEquals(),
+    (block) => block.transpiledJavascript,
+    createCallWithTripleEquals(),
+    (block) => block.definedElsewhere,
+    arrayDeepEquality(createCallWithTripleEquals()),
+    (block) => block.sourceMap,
+    createCallFromIntrospectiveKeepDeep(),
+    (block) => block.uniqueID,
+    createCallWithTripleEquals(),
+    (block) => block.elementsWithin,
+    ElementsWithinKeepDeepEqualityCall(),
+    (
+      originalJavascript,
+      javascript,
+      transpiledJavascript,
+      definedElsewhere,
+      sourceMap,
+      uniqueID,
+      elementsWithin,
+    ) => {
+      return {
+        type: 'JSX_ARBITRARY_BLOCK',
+        originalJavascript: originalJavascript,
+        javascript: javascript,
+        transpiledJavascript: transpiledJavascript,
+        definedElsewhere: definedElsewhere,
+        sourceMap: sourceMap,
+        uniqueID: uniqueID,
+        elementsWithin: elementsWithin,
+      }
+    },
+  )
+}
+
+export function JSXTextBlockKeepDeepEquality(): KeepDeepEqualityCall<JSXTextBlock> {
+  return combine2EqualityCalls(
+    (block) => block.text,
+    createCallWithTripleEquals(),
+    (block) => block.uniqueID,
+    createCallWithTripleEquals(),
+    (text, uniqueID) => {
+      return {
+        type: 'JSX_TEXT_BLOCK',
+        text: text,
+        uniqueID: uniqueID,
+      }
+    },
+  )
+}
+
+export function JSXFragmentKeepDeepEquality(): KeepDeepEqualityCall<JSXFragment> {
+  return combine3EqualityCalls(
+    (fragment) => fragment.children,
+    JSXElementChildArrayKeepDeepEquality(),
+    (fragment) => fragment.uniqueID,
+    createCallWithTripleEquals(),
+    (fragment) => fragment.longForm,
+    createCallWithTripleEquals(),
+    (children, uniqueID, longForm) => {
+      return {
+        type: 'JSX_FRAGMENT',
+        children: children,
+        uniqueID: uniqueID,
+        longForm: longForm,
+      }
+    },
+  )
+}
+
+export function JSXElementChildKeepDeepEquality(): KeepDeepEqualityCall<JSXElementChild> {
+  return (oldElement, newElement) => {
+    if (isJSXElement(oldElement) && isJSXElement(newElement)) {
+      return JSXElementKeepDeepEquality()(oldElement, newElement)
+    } else if (isJSXArbitraryBlock(oldElement) && isJSXArbitraryBlock(newElement)) {
+      return JSXArbitraryBlockKeepDeepEquality()(oldElement, newElement)
+    } else if (isJSXTextBlock(oldElement) && isJSXTextBlock(newElement)) {
+      return JSXTextBlockKeepDeepEquality()(oldElement, newElement)
+    } else if (isJSXFragment(oldElement) && isJSXFragment(newElement)) {
+      return JSXFragmentKeepDeepEquality()(oldElement, newElement)
+    } else {
+      return keepDeepEqualityResult(newElement, false)
+    }
+  }
+}
+
+export function JSXElementChildArrayKeepDeepEquality(): KeepDeepEqualityCall<
+  Array<JSXElementChild>
+> {
+  return arrayDeepEquality(JSXElementChildKeepDeepEquality())
+}
+
+export function CanvasRectangleKeepDeepEquality(
+  oldRect: CanvasRectangle,
+  newRect: CanvasRectangle,
+): KeepDeepEqualityResult<CanvasRectangle> {
+  if (
+    oldRect.x === newRect.x &&
+    oldRect.y === newRect.y &&
+    oldRect.width === newRect.width &&
+    oldRect.height === newRect.height
+  ) {
+    return keepDeepEqualityResult(oldRect, true)
+  } else {
+    return keepDeepEqualityResult(newRect, false)
+  }
+}
+
+export function LocalRectangleKeepDeepEquality(
+  oldRect: LocalRectangle,
+  newRect: LocalRectangle,
+): KeepDeepEqualityResult<LocalRectangle> {
+  if (
+    oldRect.x === newRect.x &&
+    oldRect.y === newRect.y &&
+    oldRect.width === newRect.width &&
+    oldRect.height === newRect.height
+  ) {
+    return keepDeepEqualityResult(oldRect, true)
+  } else {
+    return keepDeepEqualityResult(newRect, false)
+  }
+}
+
+export function LocalPointKeepDeepEquality(
+  oldPoint: LocalPoint,
+  newPoint: LocalPoint,
+): KeepDeepEqualityResult<LocalPoint> {
+  if (oldPoint.x === newPoint.x && oldPoint.y === newPoint.y) {
+    return keepDeepEqualityResult(oldPoint, true)
+  } else {
+    return keepDeepEqualityResult(newPoint, false)
+  }
+}
+
+export function SidesKeepDeepEquality(
+  oldSides: Sides,
+  newSides: Sides,
+): KeepDeepEqualityResult<Sides> {
+  if (
+    oldSides.top === newSides.top &&
+    oldSides.left === newSides.left &&
+    oldSides.right === newSides.right &&
+    oldSides.bottom === newSides.bottom
+  ) {
+    return keepDeepEqualityResult(oldSides, true)
+  } else {
+    return keepDeepEqualityResult(newSides, false)
+  }
+}
+
+export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
+  SpecialSizeMeasurements
+> {
+  return (oldSize, newSize) => {
+    const offsetResult = LocalPointKeepDeepEquality(oldSize.offset, newSize.offset)
+    const coordinateSystemBoundsResult = nullableDeepEquality(CanvasRectangleKeepDeepEquality)(
+      oldSize.coordinateSystemBounds,
+      newSize.coordinateSystemBounds,
+    )
+    const immediateParentBoundsResult = nullableDeepEquality(CanvasRectangleKeepDeepEquality)(
+      oldSize.immediateParentBounds,
+      newSize.immediateParentBounds,
+    )
+    const immediateParentProvidesLayoutResult =
+      oldSize.immediateParentProvidesLayout === newSize.immediateParentProvidesLayout
+    const usesParentBoundsResult = oldSize.usesParentBounds === newSize.usesParentBounds
+    const parentLayoutSystemResult = oldSize.parentLayoutSystem === newSize.parentLayoutSystem
+    const layoutSystemForChildrenResult =
+      oldSize.layoutSystemForChildren === newSize.layoutSystemForChildren
+    const providesBoundsForChildrenResult =
+      oldSize.providesBoundsForChildren === newSize.providesBoundsForChildren
+    const positionResult = oldSize.position === newSize.position
+    const marginResult = SidesKeepDeepEquality(oldSize.margin, newSize.margin)
+    const paddingResult = SidesKeepDeepEquality(oldSize.padding, newSize.padding)
+    const naturalWidthResult = oldSize.naturalWidth === newSize.naturalWidth
+    const naturalHeightResult = oldSize.naturalHeight === newSize.naturalHeight
+    const clientWidthResult = oldSize.clientWidth === newSize.clientWidth
+    const clientHeightResult = oldSize.clientHeight === newSize.clientHeight
+    const parentFlexDirectionResult = oldSize.parentFlexDirection === newSize.parentFlexDirection
+    const areEqual =
+      offsetResult.areEqual &&
+      coordinateSystemBoundsResult.areEqual &&
+      immediateParentBoundsResult.areEqual &&
+      immediateParentProvidesLayoutResult &&
+      usesParentBoundsResult &&
+      parentLayoutSystemResult &&
+      layoutSystemForChildrenResult &&
+      providesBoundsForChildrenResult &&
+      positionResult &&
+      marginResult.areEqual &&
+      paddingResult.areEqual &&
+      naturalWidthResult &&
+      naturalHeightResult &&
+      clientWidthResult &&
+      clientHeightResult &&
+      parentFlexDirectionResult
+    if (areEqual) {
+      return keepDeepEqualityResult(oldSize, true)
+    } else {
+      const sizeMeasurements = specialSizeMeasurements(
+        offsetResult.value,
+        coordinateSystemBoundsResult.value,
+        immediateParentBoundsResult.value,
+        newSize.immediateParentProvidesLayout,
+        newSize.usesParentBounds,
+        newSize.parentLayoutSystem,
+        newSize.layoutSystemForChildren,
+        newSize.providesBoundsForChildren,
+        newSize.position,
+        marginResult.value,
+        paddingResult.value,
+        newSize.naturalWidth,
+        newSize.naturalHeight,
+        newSize.clientWidth,
+        newSize.clientHeight,
+        newSize.parentFlexDirection,
+      )
+      return keepDeepEqualityResult(sizeMeasurements, false)
+    }
+  }
+}
+
+export function ElementInstanceMetadataKeepDeepEquality(): KeepDeepEqualityCall<
+  ElementInstanceMetadata
+> {
+  return combine9EqualityCalls(
+    (metadata) => metadata.templatePath,
+    InstancePathKeepDeepEquality,
+    (metadata) => metadata.element,
+    EitherKeepDeepEquality(createCallWithTripleEquals(), JSXElementChildKeepDeepEquality()),
+    (metadata) => metadata.props,
+    createCallFromIntrospectiveKeepDeep(),
+    (metadata) => metadata.globalFrame,
+    nullableDeepEquality(CanvasRectangleKeepDeepEquality),
+    (metadata) => metadata.localFrame,
+    nullableDeepEquality(LocalRectangleKeepDeepEquality),
+    (metadata) => metadata.children,
+    InstancePathArrayKeepDeepEquality,
+    (metadata) => metadata.componentInstance,
+    createCallWithTripleEquals(),
+    (metadata) => metadata.specialSizeMeasurements,
+    SpecialSizeMeasurementsKeepDeepEquality(),
+    (metadata) => metadata.computedStyle,
+    nullableDeepEquality(objectDeepEquality(createCallWithTripleEquals())),
+    elementInstanceMetadata,
+  )
+}
+
+export function ElementInstanceMetadataMapKeepDeepEquality(): KeepDeepEqualityCall<
+  ElementInstanceMetadataMap
+> {
+  return objectDeepEquality(ElementInstanceMetadataKeepDeepEquality())
+}
+
+export function SceneContainerKeepDeepEquality(): KeepDeepEqualityCall<SceneContainer> {
+  return combine1EqualityCall(
+    (container) => container.layoutSystem,
+    createCallWithTripleEquals(),
+    (layoutSystem) => {
+      return {
+        layoutSystem: layoutSystem,
+      }
+    },
+  )
+}
+
+export function ComponentMetadataKeepDeepEquality(): KeepDeepEqualityCall<ComponentMetadata> {
+  return combine9EqualityCalls(
+    (metadata) => metadata.scenePath,
+    ScenePathKeepDeepEquality,
+    (metadata) => metadata.templatePath,
+    InstancePathKeepDeepEquality,
+    (metadata) => metadata.rootElements,
+    InstancePathArrayKeepDeepEquality,
+    (metadata) => metadata.component,
+    nullableDeepEquality(createCallWithTripleEquals()),
+    (metadata) => metadata.container,
+    undefinableDeepEquality(SceneContainerKeepDeepEquality()),
+    (metadata) => metadata.globalFrame,
+    nullableDeepEquality(CanvasRectangleKeepDeepEquality),
+    (metadata) => metadata.sceneResizesContent,
+    createCallWithTripleEquals(),
+    (metadata) => metadata.label,
+    undefinableDeepEquality(createCallWithTripleEquals()),
+    (metadata) => metadata.style,
+    createCallFromIntrospectiveKeepDeep(),
+    (
+      scenePath,
+      templatePath,
+      rootElements,
+      component,
+      container,
+      globalFrame,
+      sceneResizesContent,
+      label,
+      style,
+    ) => {
+      return {
+        scenePath: scenePath,
+        templatePath: templatePath,
+        rootElements: rootElements,
+        component: component,
+        container: container,
+        globalFrame: globalFrame,
+        sceneResizesContent: sceneResizesContent,
+        label: label,
+        style: style,
+      }
+    },
+  )
+}
+
+export function JSXMetadataKeepDeepEquality(): KeepDeepEqualityCall<JSXMetadata> {
+  return combine2EqualityCalls(
+    (metadata) => metadata.components,
+    arrayDeepEquality(ComponentMetadataKeepDeepEquality()),
+    (metadata) => metadata.elements,
+    ElementInstanceMetadataMapKeepDeepEquality(),
+    jsxMetadata,
   )
 }

--- a/editor/src/core/shared/element-template.tsx
+++ b/editor/src/core/shared/element-template.tsx
@@ -948,7 +948,7 @@ export interface ElementInstanceMetadata {
 
 export function elementInstanceMetadata(
   templatePath: InstancePath,
-  element: Either<string, JSXElement>,
+  element: Either<string, JSXElementChild>,
   props: { [key: string]: any },
   globalFrame: CanvasRectangle | null,
   localFrame: LocalRectangle | null,
@@ -1059,7 +1059,7 @@ export interface ComponentMetadata {
   templatePath: InstancePath
   rootElements: Array<InstancePath>
   component: string | null
-  container: SceneContainer
+  container?: SceneContainer
   globalFrame: CanvasRectangle | null
   sceneResizesContent: boolean
   label?: string
@@ -1067,9 +1067,9 @@ export interface ComponentMetadata {
 }
 
 export function isComponentMetadata(
-  maybeComponentMetadata: any,
+  maybeComponentMetadata: ComponentMetadata | ElementInstanceMetadata,
 ): maybeComponentMetadata is ComponentMetadata {
-  return maybeComponentMetadata.scenePath != null
+  return (maybeComponentMetadata as ComponentMetadata).scenePath != null
 }
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>> // TODO update typescript!!

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -154,16 +154,18 @@ export function jsxFunctionAttributeToRawValue(
   }
 }
 
-export const jsxAttributeToValue = (inScope: MapLike<any>, requireResult: MapLike<any>) => (
+export function jsxAttributeToValue(
+  inScope: MapLike<any>,
+  requireResult: MapLike<any>,
   attribute: JSXAttribute,
-): any => {
+): any {
   switch (attribute.type) {
     case 'ATTRIBUTE_VALUE':
       return attribute.value
     case 'ATTRIBUTE_NESTED_ARRAY':
       let returnArray: Array<any> = []
       for (const elem of attribute.content) {
-        const value = jsxAttributeToValue(inScope, requireResult)(elem.value)
+        const value = jsxAttributeToValue(inScope, requireResult, elem.value)
 
         // We don't need to explicitly handle spreads because `concat` will take care of it for us
         returnArray = returnArray.concat(value)
@@ -173,7 +175,7 @@ export const jsxAttributeToValue = (inScope: MapLike<any>, requireResult: MapLik
     case 'ATTRIBUTE_NESTED_OBJECT':
       let returnObject: { [key: string]: any } = {}
       fastForEach(attribute.content, (prop) => {
-        const value = jsxAttributeToValue(inScope, requireResult)(prop.value)
+        const value = jsxAttributeToValue(inScope, requireResult, prop.value)
 
         switch (prop.type) {
           case 'PROPERTY_ASSIGNMENT':
@@ -192,8 +194,8 @@ export const jsxAttributeToValue = (inScope: MapLike<any>, requireResult: MapLik
     case 'ATTRIBUTE_FUNCTION_CALL':
       const foundFunction = (UtopiaUtils as any)[attribute.functionName]
       if (foundFunction != null) {
-        const resolvedParameters = attribute.parameters.map(
-          jsxAttributeToValue(inScope, requireResult),
+        const resolvedParameters = attribute.parameters.map((param) =>
+          jsxAttributeToValue(inScope, requireResult, param),
         )
         return foundFunction(...resolvedParameters)
       }
@@ -211,7 +213,7 @@ export function jsxAttributesToProps(
   attributes: JSXAttributes,
   requireResult: MapLike<any>,
 ): any {
-  return objectMap(jsxAttributeToValue(inScope, requireResult), attributes)
+  return objectMap((attrib) => jsxAttributeToValue(inScope, requireResult, attrib), attributes)
 }
 
 export type GetModifiableAttributeResult = Either<string, ModifiableAttribute>

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -401,7 +401,7 @@ export function elementsEqual(l: id | null, r: id | null): boolean {
   return l === r
 }
 
-function scenePathsEqual(l: ScenePath, r: ScenePath): boolean {
+export function scenePathsEqual(l: ScenePath, r: ScenePath): boolean {
   return l === r || elementPathsEqual(l.sceneElementPath, r.sceneElementPath)
 }
 

--- a/editor/src/utils/deep-equality-instances.ts
+++ b/editor/src/utils/deep-equality-instances.ts
@@ -4,13 +4,22 @@ import {
   createCallFromEqualsFunction,
   createCallWithTripleEquals,
   KeepDeepEqualityCall,
+  KeepDeepEqualityResult,
+  keepDeepEqualityResult,
+  mapKeepDeepEqualityResult,
 } from './deep-equality'
 import * as TP from '../core/shared/template-path'
 import * as PP from '../core/shared/property-path'
 import { HigherOrderControl } from '../components/canvas/canvas-types'
 import { JSXElementName } from '../core/shared/element-template'
-import { TemplatePath, PropertyPath } from '../core/shared/project-file-types'
+import {
+  TemplatePath,
+  PropertyPath,
+  InstancePath,
+  ScenePath,
+} from '../core/shared/project-file-types'
 import { createCallFromIntrospectiveKeepDeep } from './react-performance'
+import { Either, foldEither, isLeft, left, right } from '../core/shared/either'
 
 export const TemplatePathKeepDeepEquality: KeepDeepEqualityCall<TemplatePath> = createCallFromEqualsFunction(
   (oldPath: TemplatePath, newPath: TemplatePath) => {
@@ -21,6 +30,20 @@ export const TemplatePathKeepDeepEquality: KeepDeepEqualityCall<TemplatePath> = 
 export const TemplatePathArrayKeepDeepEquality: KeepDeepEqualityCall<Array<
   TemplatePath
 >> = arrayDeepEquality(TemplatePathKeepDeepEquality)
+
+export const InstancePathKeepDeepEquality: KeepDeepEqualityCall<InstancePath> = createCallFromEqualsFunction(
+  (oldPath: InstancePath, newPath: InstancePath) => {
+    return TP.pathsEqual(oldPath, newPath)
+  },
+)
+
+export const InstancePathArrayKeepDeepEquality: KeepDeepEqualityCall<Array<
+  InstancePath
+>> = arrayDeepEquality(InstancePathKeepDeepEquality)
+
+export const ScenePathKeepDeepEquality: KeepDeepEqualityCall<ScenePath> = createCallFromEqualsFunction(
+  TP.scenePathsEqual,
+)
 
 export const PropertyPathKeepDeepEquality: KeepDeepEqualityCall<PropertyPath> = createCallFromEqualsFunction(
   (oldPath: PropertyPath, newPath: PropertyPath) => {
@@ -45,4 +68,40 @@ export function JSXElementNameKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXEl
       }
     },
   )
+}
+
+export function EitherKeepDeepEquality<L, R>(
+  leftDeep: KeepDeepEqualityCall<L>,
+  rightDeep: KeepDeepEqualityCall<R>,
+): KeepDeepEqualityCall<Either<L, R>> {
+  type Result = KeepDeepEqualityResult<Either<L, R>>
+  return (oldEither: Either<L, R>, newEither: Either<L, R>) => {
+    return foldEither<L, R, Result>(
+      (oldLeftValue) => {
+        return foldEither<L, R, Result>(
+          (newLeftValue) => {
+            const leftDeepResult = leftDeep(oldLeftValue, newLeftValue)
+            return mapKeepDeepEqualityResult<L, Either<L, R>>(left, leftDeepResult)
+          },
+          (_) => {
+            return keepDeepEqualityResult(newEither, false)
+          },
+          newEither,
+        )
+      },
+      (oldRightValue) => {
+        return foldEither<L, R, Result>(
+          (_) => {
+            return keepDeepEqualityResult(newEither, false)
+          },
+          (newRightValue) => {
+            const rightDeepResult = rightDeep(oldRightValue, newRightValue)
+            return mapKeepDeepEqualityResult<R, Either<L, R>>(right, rightDeepResult)
+          },
+          newEither,
+        )
+      },
+      oldEither,
+    )
+  }
 }

--- a/editor/src/utils/deep-equality.ts
+++ b/editor/src/utils/deep-equality.ts
@@ -1,3 +1,5 @@
+import { fastForEach } from '../core/shared/utils'
+
 export interface KeepDeepEqualityResult<T> {
   value: T
   areEqual: boolean
@@ -10,9 +12,33 @@ export function keepDeepEqualityResult<T>(value: T, areEqual: boolean): KeepDeep
   }
 }
 
+export function mapKeepDeepEqualityResult<T, U>(
+  transform: (t: T) => U,
+  result: KeepDeepEqualityResult<T>,
+): KeepDeepEqualityResult<U> {
+  return keepDeepEqualityResult(transform(result.value), result.areEqual)
+}
+
 export type EqualityCheck<T> = (oldValue: T, newValue: T) => boolean
 
 export type KeepDeepEqualityCall<T> = (oldValue: T, newValue: T) => KeepDeepEqualityResult<T>
+
+export function combine1EqualityCall<A, X>(
+  getAValue: (x: X) => A,
+  callA: KeepDeepEqualityCall<A>,
+  combine: (a: A) => X,
+): KeepDeepEqualityCall<X> {
+  return (oldValue, newValue) => {
+    const resultA = callA(getAValue(oldValue), getAValue(newValue))
+    const areEqual = resultA.areEqual
+    if (areEqual) {
+      return keepDeepEqualityResult(oldValue, true)
+    } else {
+      const value = combine(resultA.value)
+      return keepDeepEqualityResult(value, false)
+    }
+  }
+}
 
 export function combine2EqualityCalls<A, B, X>(
   getAValue: (x: X) => A,
@@ -273,6 +299,65 @@ export function combine8EqualityCalls<A, B, C, D, E, F, G, H, X>(
   }
 }
 
+export function combine9EqualityCalls<A, B, C, D, E, F, G, H, I, X>(
+  getAValue: (x: X) => A,
+  callA: KeepDeepEqualityCall<A>,
+  getBValue: (x: X) => B,
+  callB: KeepDeepEqualityCall<B>,
+  getCValue: (x: X) => C,
+  callC: KeepDeepEqualityCall<C>,
+  getDValue: (x: X) => D,
+  callD: KeepDeepEqualityCall<D>,
+  getEValue: (x: X) => E,
+  callE: KeepDeepEqualityCall<E>,
+  getFValue: (x: X) => F,
+  callF: KeepDeepEqualityCall<F>,
+  getGValue: (x: X) => G,
+  callG: KeepDeepEqualityCall<G>,
+  getHValue: (x: X) => H,
+  callH: KeepDeepEqualityCall<H>,
+  getIValue: (x: X) => I,
+  callI: KeepDeepEqualityCall<I>,
+  combine: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => X,
+): KeepDeepEqualityCall<X> {
+  return (oldValue, newValue) => {
+    const resultA = callA(getAValue(oldValue), getAValue(newValue))
+    const resultB = callB(getBValue(oldValue), getBValue(newValue))
+    const resultC = callC(getCValue(oldValue), getCValue(newValue))
+    const resultD = callD(getDValue(oldValue), getDValue(newValue))
+    const resultE = callE(getEValue(oldValue), getEValue(newValue))
+    const resultF = callF(getFValue(oldValue), getFValue(newValue))
+    const resultG = callG(getGValue(oldValue), getGValue(newValue))
+    const resultH = callH(getHValue(oldValue), getHValue(newValue))
+    const resultI = callI(getIValue(oldValue), getIValue(newValue))
+    const areEqual =
+      resultA.areEqual &&
+      resultB.areEqual &&
+      resultC.areEqual &&
+      resultD.areEqual &&
+      resultE.areEqual &&
+      resultF.areEqual &&
+      resultG.areEqual &&
+      resultH.areEqual &&
+      resultI.areEqual
+    if (areEqual) {
+      return keepDeepEqualityResult(oldValue, true)
+    } else {
+      const value = combine(
+        resultA.value,
+        resultB.value,
+        resultC.value,
+        resultD.value,
+        resultE.value,
+        resultF.value,
+        resultG.value,
+        resultH.value,
+        resultI.value,
+      )
+      return keepDeepEqualityResult(value, false)
+    }
+  }
+}
 export function createCallWithTripleEquals<T>(): KeepDeepEqualityCall<T> {
   return (oldValue, newValue) => {
     const areEqual = oldValue === newValue
@@ -291,22 +376,67 @@ export function arrayDeepEquality<T>(
   elementCall: KeepDeepEqualityCall<T>,
 ): KeepDeepEqualityCall<Array<T>> {
   return (oldArray, newArray) => {
-    let areEquals: boolean = true
-    let workingResult: Array<T> = []
     if (oldArray === newArray) {
       return keepDeepEqualityResult(oldArray, true)
     } else {
+      let areEquals: boolean = true
+      let workingResult: Array<T> = []
       const length = newArray.length
+      const oldLength = oldArray.length
       for (let arrayIndex = 0; arrayIndex < length; arrayIndex++) {
-        const oldArrayElement = oldArray[arrayIndex]
         const newArrayElement = newArray[arrayIndex]
-        const equalityResult = elementCall(oldArrayElement, newArrayElement)
-        areEquals = areEquals && equalityResult.areEqual
-        workingResult.push(equalityResult.value)
+        if (arrayIndex < oldLength) {
+          const oldArrayElement = oldArray[arrayIndex]
+          const equalityResult = elementCall(oldArrayElement, newArrayElement)
+          areEquals = areEquals && equalityResult.areEqual
+          workingResult.push(equalityResult.value)
+        } else {
+          areEquals = false
+          workingResult.push(newArrayElement)
+        }
       }
 
       if (length === oldArray.length && areEquals) {
         return keepDeepEqualityResult(oldArray, true)
+      } else {
+        return keepDeepEqualityResult(workingResult, false)
+      }
+    }
+  }
+}
+
+export function objectDeepEquality<T>(
+  valueCall: KeepDeepEqualityCall<T>,
+): KeepDeepEqualityCall<Record<string, T>> {
+  return (oldObject, newObject) => {
+    if (oldObject === newObject) {
+      return keepDeepEqualityResult(oldObject, true)
+    } else {
+      let areEquals: boolean = true
+      let workingResult: Record<string, T> = {}
+      const newObjectKeys = Object.keys(newObject)
+      fastForEach(newObjectKeys, (newObjectKey) => {
+        const newObjectValue = newObject[newObjectKey]
+        if (newObjectKey in oldObject) {
+          const oldObjectValue = oldObject[newObjectKey]
+          const valueResult = valueCall(oldObjectValue, newObjectValue)
+          workingResult[newObjectKey] = valueResult.value
+          areEquals = areEquals && valueResult.areEqual
+        } else {
+          workingResult[newObjectKey] = newObjectValue
+          areEquals = false
+        }
+      })
+      // Check if keys have been removed.
+      if (areEquals) {
+        const oldObjectKeys = Object.keys(oldObject)
+        if (oldObjectKeys.length !== newObjectKeys.length) {
+          areEquals = false
+        }
+      }
+
+      if (areEquals) {
+        return keepDeepEqualityResult(oldObject, true)
       } else {
         return keepDeepEqualityResult(workingResult, false)
       }


### PR DESCRIPTION
**Problem:**
There's a lot of deep equality checks that happen every frame, which are currently handled by introspective code.

**Fix:**
Mostly attempt to reduce the introspection by building more manual deep equality checking.

**Results:**
This appears to be upper bounded to be as good as the existing introspective calls or in a best case scenario was twice as fast.

**Commit Details:**
- Created `KeepDeepEqualityCall` instances for everything up to `JSXMetadata`.
- Added some more utility functions for deep equality.
- Fixed a bug in `arrayDeepEquality`.
- Used the new deep equality functions when reconstructing the metadata
  and when the DOM report is pushed.
- Fixed some typing issues around `SceneProps` that were uncovered when
  running the deep equality checker.
