### PR TITLE
fix(DragState) only enter dragstate after mouse moved >2 px

### DIFF
--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
@@ -99,6 +99,24 @@ describe('moving a scene/rootview on the canvas', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
+        areaControl,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: areaControlBounds.left + 45,
+          clientY: areaControlBounds.top - 25,
+          buttons: 1,
+        }),
+      )
+      await domFinished
+      await dispatchDone
+    })
+
+    await act(async () => {
+      const domFinished = renderResult.getDomReportDispatched()
+      const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
+      fireEvent(
         window,
         new MouseEvent('mouseup', {
           bubbles: true,
@@ -203,6 +221,24 @@ describe('moving a scene/rootview on the canvas', () => {
         buttons: 1,
       }),
     )
+
+    await act(async () => {
+      const domFinished = renderResult.getDomReportDispatched()
+      const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
+      fireEvent(
+        areaControl,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: areaControlBounds.left + 45,
+          clientY: areaControlBounds.top + 25,
+          buttons: 1,
+        }),
+      )
+      await domFinished
+      await dispatchDone
+    })
 
     await act(async () => {
       const domFinished = renderResult.getDomReportDispatched()
@@ -333,6 +369,24 @@ describe('moving a scene/rootview on the canvas', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
+        areaControl,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: areaControlBounds.left + 45,
+          clientY: areaControlBounds.top - 25,
+          buttons: 1,
+        }),
+      )
+      await domFinished
+      await dispatchDone
+    })
+
+    await act(async () => {
+      const domFinished = renderResult.getDomReportDispatched()
+      const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
+      fireEvent(
         window,
         new MouseEvent('mouseup', {
           bubbles: true,
@@ -416,6 +470,24 @@ describe('moving a scene/rootview on the canvas', () => {
         buttons: 1,
       }),
     )
+
+    await act(async () => {
+      const domFinished = renderResult.getDomReportDispatched()
+      const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
+      fireEvent(
+        areaControl,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: areaControlBounds.left + 45,
+          clientY: areaControlBounds.top - 25,
+          buttons: 1,
+        }),
+      )
+      await domFinished
+      await dispatchDone
+    })
 
     await act(async () => {
       const domFinished = renderResult.getDomReportDispatched()

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1355,6 +1355,24 @@ describe('moveTemplate', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
+        areaControl,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: true,
+          clientX: areaControlBounds.left + 5,
+          clientY: areaControlBounds.top - 25,
+          buttons: 1,
+        }),
+      )
+      await domFinished
+      await dispatchDone
+    })
+
+    await act(async () => {
+      const domFinished = renderResult.getDomReportDispatched()
+      const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
+      fireEvent(
         window,
         new MouseEvent('mouseup', {
           bubbles: true,
@@ -1552,6 +1570,24 @@ describe('moveTemplate', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
+        areaControl,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: true,
+          clientX: areaControlBounds.left + 5,
+          clientY: areaControlBounds.top - 25,
+          buttons: 1,
+        }),
+      )
+      await domFinished
+      await dispatchDone
+    })
+
+    await act(async () => {
+      const domFinished = renderResult.getDomReportDispatched()
+      const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
+      fireEvent(
         window,
         new MouseEvent('mouseup', {
           bubbles: true,
@@ -1626,6 +1662,24 @@ describe('moveTemplate', () => {
         buttons: 1,
       }),
     )
+
+    await act(async () => {
+      const domFinished = renderResult.getDomReportDispatched()
+      const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
+      fireEvent(
+        areaControl,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: areaControlBounds.left + 45,
+          clientY: areaControlBounds.top - 25,
+          buttons: 1,
+        }),
+      )
+      await domFinished
+      await dispatchDone
+    })
 
     await act(async () => {
       const domFinished = renderResult.getDomReportDispatched()

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -151,25 +151,44 @@ export class SelectModeControlContainer extends React.Component<
             )
           : null
 
-        this.props.dispatch([
-          CanvasActions.createDragState(
-            moveDragState(
-              start,
-              null,
-              null,
-              originalFrames,
-              selectionArea,
-              !originalEvent.metaKey,
-              originalEvent.shiftKey,
-              duplicate,
-              originalEvent.metaKey,
-              duplicateNewUIDs,
-              start,
-              this.props.componentMetadata,
-              moveTargets,
-            ),
-          ),
-        ])
+        const onMouseMove = (event: MouseEvent) => {
+          const cursorPosition = this.props.windowToCanvasPosition(event)
+          if (Utils.distance(start, cursorPosition.canvasPositionRaw) > 2) {
+            // actually start the drag state
+            removeMouseListeners()
+            this.props.dispatch([
+              CanvasActions.createDragState(
+                moveDragState(
+                  start,
+                  null,
+                  null,
+                  originalFrames,
+                  selectionArea,
+                  !originalEvent.metaKey,
+                  originalEvent.shiftKey,
+                  duplicate,
+                  originalEvent.metaKey,
+                  duplicateNewUIDs,
+                  start,
+                  this.props.componentMetadata,
+                  moveTargets,
+                ),
+              ),
+            ])
+          }
+        }
+
+        const onMouseUp = () => {
+          removeMouseListeners()
+        }
+
+        const removeMouseListeners = () => {
+          window.removeEventListener('mousemove', onMouseMove)
+          window.removeEventListener('mouseup', onMouseUp)
+        }
+
+        window.addEventListener('mousemove', onMouseMove)
+        window.addEventListener('mouseup', onMouseUp)
       }
     }
   }

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -142,19 +142,19 @@ export class SelectModeControlContainer extends React.Component<
           }),
         )
 
-        const duplicate = originalEvent.altKey
-        const duplicateNewUIDs = duplicate
-          ? createDuplicationNewUIDs(
-              this.props.selectedViews,
-              this.props.componentMetadata,
-              this.props.rootComponents,
-            )
-          : null
-
         const onMouseMove = (event: MouseEvent) => {
           const cursorPosition = this.props.windowToCanvasPosition(event)
           if (Utils.distance(start, cursorPosition.canvasPositionRaw) > 2) {
             // actually start the drag state
+            const duplicate = event.altKey
+            const duplicateNewUIDs = duplicate
+              ? createDuplicationNewUIDs(
+                  this.props.selectedViews,
+                  this.props.componentMetadata,
+                  this.props.rootComponents,
+                )
+              : null
+
             removeMouseListeners()
             this.props.dispatch([
               CanvasActions.createDragState(
@@ -164,10 +164,10 @@ export class SelectModeControlContainer extends React.Component<
                   null,
                   originalFrames,
                   selectionArea,
-                  !originalEvent.metaKey,
-                  originalEvent.shiftKey,
+                  !event.metaKey,
+                  event.shiftKey,
                   duplicate,
-                  originalEvent.metaKey,
+                  event.metaKey,
                   duplicateNewUIDs,
                   start,
                   this.props.componentMetadata,


### PR DESCRIPTION
Part of #719

**Problem:**
When performing click-to-select on any element, we'd immediately dispatch an CREATE_DRAG_STATE on mouse down, and we'd follow up with a CLEAR_DRAG_STATE on mouse up. This caused two problems: it incurred some unnecessary spinning of the editor update functions, and it meant that we wouldn't show the resize rectangles on a selected element until we processed CLEAR_DRAG_STATE, because those are hidden during a drag.

This meant that perceptually click-to-drag could take 100-200 ms to take effect on the screen (an expensive 50-100ms action to change selected view + enter drag state, and a second expensive action to clear drag state). 

**Fix:**
`onControlMouseDown` does not immediately dispatch a CREATE_DRAG_STATE, instead it sets mouse move listeners which wait for a certain treshold to be crossed.

**Commit Details:**
- added mouse move and mouse up listeners inside `onControlMouseDown`
- only dispatch `CREATE_DRAG_STATE` if mouse is further than 2 pixels away from the mouse down point
