### PR TITLE
Replace a regex based function with a leaner version.

### DIFF
--- a/editor/src/core/shared/string-utils.ts
+++ b/editor/src/core/shared/string-utils.ts
@@ -19,7 +19,17 @@ export function replaceAll(inString: string, searchFor: string, replaceWith: str
 }
 
 export function camelCaseToDashed(s: string): string {
-  return s.replace(/[A-Z]/g, (l) => `-${l.toLowerCase()}`)
+  let result: string = ''
+  for (let index = 0; index < s.length; index++) {
+    const char = s.charAt(index)
+    if (char >= 'A' && char <= 'Z') {
+      result += '-'
+      result += char.toLowerCase()
+    } else {
+      result += char
+    }
+  }
+  return result
 }
 
 export function splitIntoLines(s: string): Array<string> {


### PR DESCRIPTION
**Problem:**
The function `camelCaseToDashed` uses a regex, but is used potentially hundreds of times per element in the DOM walker which can be quite slow.

**Fix:**
Replaced the function with a handrolled version which just loops over the characters directly.

**Notes:**
Making the DOM walker run for every element and not just the selected one made my Chrome crash until I also included this fix, which possibly indicates there's more going on than the profiler was letting on with just a single element. As with a single element the performance seemed about the same.

**Commit Details:**
- Rewrote `camelCaseToDashed` to not use regexes.