### PR TITLE
Add storyboard file now uses parsed exports.

### DIFF
--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -155,12 +155,12 @@ export function convertScenesToUtopiaCanvasComponent(
   )
 }
 
-export function createSceneFromComponent(component: UtopiaJSXComponent, uid: string): JSXElement {
+export function createSceneFromComponent(componentImportedAs: string, uid: string): JSXElement {
   const sceneProps = {
     component: jsxAttributeOtherJavaScript(
-      component.name,
-      `return ${component.name}`,
-      [component.name],
+      componentImportedAs,
+      `return ${componentImportedAs}`,
+      [componentImportedAs],
       null,
     ),
     [UTOPIA_UID_KEY]: jsxAttributeValue(uid),

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -122,13 +122,13 @@ export function importsEquals(first: Imports, second: Imports): boolean {
 
 export interface ExportDetailNamed {
   type: 'EXPORT_DETAIL_NAMED'
-  propertyName: string
+  name: string
 }
 
-export function exportDetailNamed(propertyName: string): ExportDetailNamed {
+export function exportDetailNamed(name: string): ExportDetailNamed {
   return {
     type: 'EXPORT_DETAIL_NAMED',
-    propertyName: propertyName,
+    name: name,
   }
 }
 

--- a/editor/src/core/workers/parser-printer/parser-printer-exports.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-exports.spec.ts
@@ -45,7 +45,7 @@ describe('parseCode', () => {
         "defaultExport": null,
         "namedExports": Object {
           "whatever": Object {
-            "propertyName": "whatever",
+            "name": "whatever",
             "type": "EXPORT_DETAIL_NAMED",
           },
         },
@@ -70,7 +70,7 @@ describe('parseCode', () => {
         "defaultExport": null,
         "namedExports": Object {
           "otherThing": Object {
-            "propertyName": "whatever",
+            "name": "whatever",
             "type": "EXPORT_DETAIL_NAMED",
           },
         },


### PR DESCRIPTION
Fixes #629

**Problem:**
The add storyboard for file functionality looked at components directly marked as exported which appears to be a less commonly used approach in projects we have been testing the Github import with.

**Fix:**
Building on top of some recently added export parsing, the above functionality has been modified to use that to form the way the storyboard file imports from the component it picks.

**Commit Details:**
- `createSceneFromComponent` now uses a text component name.
- Reworked the type `ComponentToImport` to be a union type to
  represent the two cases that would be imported.
- Implemented `betterImportCandidate` as a heuristic way of
  determining what should be put into the storyboard.
- `addStoryboardFileToProject` now rewritten to work with the heuristic
  and the new types.
- `addStoryboardFileForComponent` more correctly does the right
  kind of imports and handles the new type of the import candidate.
- Added `detailsFromExportAssignment` to handle the `export default App`
  type of exports.
- Removed the slightly faulty way of handling named exports exported
  in an object named `default`.
