### PR TITLE
Component isolation mode 3rd pass

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -53,6 +53,7 @@ import {
   setUtopiaID,
   transformJSXComponentAtPath,
   findJSXElementChildAtPath,
+  getElementChildren,
 } from '../../core/model/element-template-utils'
 import { generateUID } from '../../core/shared/uid-utils'
 import {
@@ -1563,10 +1564,15 @@ function createTransientSceneForSelectedComponent(
         instanceMetadata.globalFrame ??
         (({ left: 0, top: 0, width: 0, height: 0 } as any) as CanvasRectangle)
 
+      const children = isRight(instanceMetadata.element)
+        ? getElementChildren(instanceMetadata.element.value)
+        : []
+
       const newScene: JSXElement = isolatedComponentSceneElement(
         isolatedComponent.componentName,
         canvasFrameToNormalisedFrame(instanceFrame),
         instanceMetadata.props,
+        children,
       )
 
       const oldUtopiaJSXComponents = getUtopiaJSXComponentsFromSuccess(openFile)

--- a/editor/src/components/canvas/controls/component-area-control.tsx
+++ b/editor/src/components/canvas/controls/component-area-control.tsx
@@ -165,17 +165,17 @@ class ComponentAreaControlInner extends React.Component<ComponentAreaControlProp
     // If operating on the isolated scene itself we should apply that change to the original target
     let targets = selectedViews
     let actualTarget = this.props.target
-    if (this.props.isolatedComponent != null) {
-      const { instance: isolatedTarget, scenePath: isolatedScene } = this.props.isolatedComponent
-      const willActOnIsolatedScene = (path: TemplatePath) =>
-        TP.pathsEqual(path, isolatedScene) || TP.isChildOf(path, isolatedScene)
-      if (selectedViews.length === 1 && willActOnIsolatedScene(selectedViews[0])) {
-        targets = [isolatedTarget]
-      }
-      if (willActOnIsolatedScene(this.props.target)) {
-        actualTarget = isolatedTarget
-      }
-    }
+    // if (this.props.isolatedComponent != null) {
+    //   const { instance: isolatedTarget, scenePath: isolatedScene } = this.props.isolatedComponent
+    //   const willActOnIsolatedScene = (path: TemplatePath) =>
+    //     TP.pathsEqual(path, isolatedScene) || TP.isChildOf(path, isolatedScene)
+    //   if (selectedViews.length === 1 && willActOnIsolatedScene(selectedViews[0])) {
+    //     targets = [isolatedTarget]
+    //   }
+    //   if (willActOnIsolatedScene(this.props.target)) {
+    //     actualTarget = isolatedTarget
+    //   }
+    // }
 
     const cursorPosition = this.props.windowToCanvasPosition(event.nativeEvent)
     this.props.onMouseDown(targets, actualTarget, cursorPosition.canvasPositionRaw, event)

--- a/editor/src/components/canvas/controls/component-area-control.tsx
+++ b/editor/src/components/canvas/controls/component-area-control.tsx
@@ -162,23 +162,26 @@ class ComponentAreaControlInner extends React.Component<ComponentAreaControlProp
     selectedViews: Array<TemplatePath>,
     event: React.MouseEvent<HTMLDivElement>,
   ): void {
-    // If operating on the isolated scene itself we should apply that change to the original target
-    let targets = selectedViews
-    let actualTarget = this.props.target
-    // if (this.props.isolatedComponent != null) {
-    //   const { instance: isolatedTarget, scenePath: isolatedScene } = this.props.isolatedComponent
-    //   const willActOnIsolatedScene = (path: TemplatePath) =>
-    //     TP.pathsEqual(path, isolatedScene) || TP.isChildOf(path, isolatedScene)
-    //   if (selectedViews.length === 1 && willActOnIsolatedScene(selectedViews[0])) {
-    //     targets = [isolatedTarget]
-    //   }
-    //   if (willActOnIsolatedScene(this.props.target)) {
-    //     actualTarget = isolatedTarget
-    //   }
-    // }
+    // If operating on the isolated scene itself or its root view, prevent dragging
+    let draggingEnabled: boolean = true
+    if (this.props.isolatedComponent != null) {
+      const { scenePath: isolatedScene } = this.props.isolatedComponent
+      const willActOnIsolatedScene = (path: TemplatePath) =>
+        TP.pathsEqual(path, isolatedScene) || TP.isChildOf(path, isolatedScene)
+      const isolatedSceneSelected = selectedViews.some(willActOnIsolatedScene)
+      const isolatedSceneTargeted = willActOnIsolatedScene(this.props.target)
+      draggingEnabled = !isolatedSceneSelected && !isolatedSceneTargeted
+    }
 
-    const cursorPosition = this.props.windowToCanvasPosition(event.nativeEvent)
-    this.props.onMouseDown(targets, actualTarget, cursorPosition.canvasPositionRaw, event)
+    if (draggingEnabled) {
+      const cursorPosition = this.props.windowToCanvasPosition(event.nativeEvent)
+      this.props.onMouseDown(
+        selectedViews,
+        this.props.target,
+        cursorPosition.canvasPositionRaw,
+        event,
+      )
+    }
   }
 
   getComponentAreaControl = (canShowInvisibleIndicator: boolean) => {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
@@ -38,6 +38,7 @@ import { jsxAttributesToProps } from '../../../core/shared/jsx-attributes'
 import { getUtopiaIDFromJSXElement } from '../../../core/shared/uid-utils'
 import utils from '../../../utils/utils'
 import { PathForResizeContent } from '../../../core/model/scene-utils'
+import { fastForEach } from '../../../core/shared/utils'
 
 interface SceneProps {
   component: React.ComponentType | null
@@ -145,7 +146,15 @@ export const SceneRootRenderer = betterReactMemo(
 
     const topLevelElementName = getTopLevelElementName(sceneProps.component)
 
-    const validPaths = useGetValidTemplatePaths(topLevelElementName, scenePath)
+    const baseValidPaths = useGetValidTemplatePaths(topLevelElementName, scenePath)
+    let validPaths: InstancePath[] = []
+
+    // Append the children uids to the end of all paths because we don't know where it has been rendered
+    const childrenUIDs = props.sceneElement.children.map(getUtopiaID)
+    fastForEach(baseValidPaths, (path) => {
+      validPaths.push(path)
+      fastForEach(childrenUIDs, (childUID) => validPaths.push(TP.appendToPath(path, childUID)))
+    })
 
     const createChildrenElement = (
       child: JSXElementChild,

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -6,6 +6,7 @@ import {
   jsxAttributeOtherJavaScript,
   JSXElementChild,
   JSXElementChildren,
+  JSXAttribute,
 } from '../../core/shared/element-template'
 import { LayoutSystem, NormalisedFrame } from 'utopia-api'
 import { PathForResizeContent } from '../../core/model/scene-utils'
@@ -43,21 +44,10 @@ export function defaultSceneElement(
 export function isolatedComponentSceneElement(
   componentName: string,
   frame: NormalisedFrame,
-  componentProps: any,
+  componentProps: JSXAttribute,
   children: JSXElementChildren,
 ): JSXElement {
   const definedElsewhere = [componentName]
-  let componentPropsToUse: any = {}
-  fastForEach(Object.keys(componentProps), (key) => {
-    if (!['data-uid', 'skipDeepFreeze'].includes(key)) {
-      if (key === 'style') {
-        const styleToUse = omit(['left', 'top', 'right', 'bottom'], componentProps[key])
-        componentPropsToUse[key] = styleToUse
-      } else {
-        componentPropsToUse[key] = componentProps[key]
-      }
-    }
-  })
 
   const props = {
     'data-uid': jsxAttributeValue('TRANSIENT_SCENE'),
@@ -69,7 +59,7 @@ export function isolatedComponentSceneElement(
       null,
       'TRANSIENT_SCENE_COMPONENT',
     ),
-    props: jsxAttributeValue(componentPropsToUse),
+    props: componentProps,
     [PP.toString(PathForResizeContent)]: jsxAttributeValue(true),
     style: jsxAttributeValue({
       position: 'absolute',

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -42,6 +42,7 @@ export function defaultSceneElement(
 }
 
 export function isolatedComponentSceneElement(
+  uid: string,
   componentName: string,
   frame: NormalisedFrame,
   componentProps: JSXAttribute,
@@ -50,14 +51,14 @@ export function isolatedComponentSceneElement(
   const definedElsewhere = [componentName]
 
   const props = {
-    'data-uid': jsxAttributeValue('TRANSIENT_SCENE'),
+    'data-uid': jsxAttributeValue(uid),
     'data-label': jsxAttributeValue(`Isolated ${componentName}`),
     component: jsxAttributeOtherJavaScript(
       componentName,
       `return ${componentName}`,
       definedElsewhere,
       null,
-      'TRANSIENT_SCENE_COMPONENT',
+      `${uid}_COMPONENT`,
     ),
     props: componentProps,
     [PP.toString(PathForResizeContent)]: jsxAttributeValue(true),

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -4,6 +4,8 @@ import {
   jsxAttributeValue,
   jsxElementName,
   jsxAttributeOtherJavaScript,
+  JSXElementChild,
+  JSXElementChildren,
 } from '../../core/shared/element-template'
 import { LayoutSystem, NormalisedFrame } from 'utopia-api'
 import { PathForResizeContent } from '../../core/model/scene-utils'
@@ -42,6 +44,7 @@ export function isolatedComponentSceneElement(
   componentName: string,
   frame: NormalisedFrame,
   componentProps: any,
+  children: JSXElementChildren,
 ): JSXElement {
   const definedElsewhere = [componentName]
   let componentPropsToUse: any = {}
@@ -75,7 +78,7 @@ export function isolatedComponentSceneElement(
     }),
   }
 
-  return jsxElement(jsxElementName('Scene', []), props, [])
+  return jsxElement(jsxElementName('Scene', []), props, children)
 }
 
 export function defaultViewElement(uid: string): JSXElement {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -146,6 +146,7 @@ import { getControlsForExternalDependencies } from '../../../core/property-contr
 import { parseSuccess } from '../../../core/workers/common/project-file-utils'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { DerivedStateKeepDeepEquality } from './store-deep-equality-instances'
+import { NormalisedFrame } from 'utopia-api'
 
 export interface OriginalPath {
   originalTP: TemplatePath
@@ -270,7 +271,8 @@ export interface ConsoleLog {
 
 export interface IsolatedComponent {
   componentName: string
-  instance: InstancePath
+  frame: NormalisedFrame
+  element: JSXElement
   scenePath: ScenePath
 }
 

--- a/editor/src/components/inspector/sections/scene-inspector/scene-container-section.tsx
+++ b/editor/src/components/inspector/sections/scene-inspector/scene-container-section.tsx
@@ -186,11 +186,11 @@ function useIsSceneChildWidthHeightPercentage() {
     }
   }, 'useIsSceneChildWidthHeightPercentage')
 
-  const selectedScenePath = Utils.forceNotNull(
-    'missing scene from scene section',
-    selectedViews.find(TP.isScenePath),
-  )
-  const scene = MetadataUtils.findSceneByTemplatePath(metadata.components, selectedScenePath)
+  const selectedScenePath = selectedViews.find(TP.isScenePath)
+  const scene =
+    selectedScenePath == null
+      ? null
+      : MetadataUtils.findSceneByTemplatePath(metadata.components, selectedScenePath)
   if (scene != null) {
     return isSceneChildWidthHeightPercentage(scene, metadata)
   } else {
@@ -210,11 +210,11 @@ export const SceneContainerSections = betterReactMemo('SceneContainerSections', 
     (store) => store.editor.selectedViews,
     'SceneContainerSections selectedViews',
   )
-  const selectedScene = Utils.forceNotNull(
-    'Scene cannot be null in SceneContainerSection',
-    React.useMemo(() => selectedViews.find(TP.isScenePath), [selectedViews]),
-  )
-  const scene = MetadataUtils.findSceneByTemplatePath(metadata.components, selectedScene)
+  const selectedScene = React.useMemo(() => selectedViews.find(TP.isScenePath), [selectedViews])
+  const scene =
+    selectedScene == null
+      ? null
+      : MetadataUtils.findSceneByTemplatePath(metadata.components, selectedScene)
 
   const sceneResizesContentInfo = useSceneType()
   let controlStatus: ControlStatus = simpleControlStatus
@@ -224,30 +224,32 @@ export const SceneContainerSections = betterReactMemo('SceneContainerSections', 
   }
   const onSubmitValue = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const newSceneResizesContentValue = event.target.checked
-      sceneResizesContentInfo.onSubmitValue(newSceneResizesContentValue)
-      if (newSceneResizesContentValue === true) {
-        dispatch(
-          [
-            unsetSceneProp(selectedScene, createLayoutPropertyPath('Width')),
-            unsetSceneProp(selectedScene, createLayoutPropertyPath('Height')),
-          ],
-          'inspector',
-        )
-      } else if (scene != null) {
-        const actions = [
-          setSceneProp(
-            selectedScene,
-            createLayoutPropertyPath('Width'),
-            jsxAttributeValue(scene.globalFrame?.width),
-          ),
-          setSceneProp(
-            selectedScene,
-            createLayoutPropertyPath('Height'),
-            jsxAttributeValue(scene.globalFrame?.height),
-          ),
-        ]
-        dispatch(actions, 'inspector')
+      if (selectedScene != null) {
+        const newSceneResizesContentValue = event.target.checked
+        sceneResizesContentInfo.onSubmitValue(newSceneResizesContentValue)
+        if (newSceneResizesContentValue === true) {
+          dispatch(
+            [
+              unsetSceneProp(selectedScene, createLayoutPropertyPath('Width')),
+              unsetSceneProp(selectedScene, createLayoutPropertyPath('Height')),
+            ],
+            'inspector',
+          )
+        } else if (scene != null) {
+          const actions = [
+            setSceneProp(
+              selectedScene,
+              createLayoutPropertyPath('Width'),
+              jsxAttributeValue(scene.globalFrame?.width),
+            ),
+            setSceneProp(
+              selectedScene,
+              createLayoutPropertyPath('Height'),
+              jsxAttributeValue(scene.globalFrame?.height),
+            ),
+          ]
+          dispatch(actions, 'inspector')
+        }
       }
     },
     [dispatch, sceneResizesContentInfo, selectedScene, scene],

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -15,6 +15,7 @@ import {
   TopLevelElement,
   UtopiaJSXComponent,
   isJSXFragment,
+  JSXElementChildren,
 } from '../shared/element-template'
 import {
   Imports,
@@ -289,6 +290,14 @@ function transformAtPathOptionally(
   return {
     elements: transformedElements,
     transformedElement: transformedElement,
+  }
+}
+
+export function getElementChildren(element: JSXElementChild): JSXElementChildren {
+  if (isJSXElement(element) || isJSXFragment(element)) {
+    return element.children
+  } else {
+    return []
   }
 }
 

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -355,8 +355,12 @@ function elementPathToUID(path: ElementPath): id {
 export function toTemplateId(path: InstancePath): id {
   return elementPathToUID(path.element)
 }
-export function toUid(path: InstancePath): id {
-  return elementPathToUID(path.element)
+export function toUid(path: TemplatePath): id {
+  if (isInstancePath(path)) {
+    return elementPathToUID(path.element)
+  } else {
+    return elementPathToUID(path.sceneElementPath)
+  }
 }
 
 export function allTemplateIds(path: InstancePath): Array<id> {

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -30,7 +30,7 @@ let FeatureSwitches: { [feature: string]: boolean } = {
   'Dragging Shows Overlay': false,
   'Invisible Element Controls': false,
   'Advanced Resize Box': false,
-  'Component Isolation Mode': false,
+  'Component Isolation Mode': true,
   'Component Navigator': true,
   'Component Navigator Component Title': true,
   'Component Navigator Nearest Ancestor': true,


### PR DESCRIPTION
**What this adds**:

- Scenes pass children to the components they render
- Component Isolation mode now correctly renders children and props that are components
- Children can now be selected in scenes
- Isolation mode supports drilling deeper (e.g. isolating `ComponentA` which renders `ComponentB` would now support double clicking `ComponentB` to isolate that)

**What this doesn't include**:

The intented behaviour was that double clicking a child passed in from the parent when isolating a component would pop back out of isolation mode and select the child in the original context. However, I'm cutting this experiment now because even hacking that together became extremely complicated based on the current hacks to get to this stage, mainly because of some issues around selection of children in general, how we determine the target of a selection, nested isolations would then require maintaining a stack of previously isolated scenes, and metadata would be lost unless we render all isolated scenes in the stack. I'm fully confident we could solve all of these issues with a full implementation of the feature, but for an experiment it feels like we've reached the point of diminishing returns here.

:pizza: https://utopia.pizza/p/119ab8a6-auspicious-bergamot/?branch_name=experiment/component-isolation-mode-pt3
or (Majestic broker, which isn't really a great project for testing this feature): https://utopia.pizza/p/6f386199-glowing-homburg/?branch_name=experiment/component-isolation-mode-pt3