### PR TITLE
fix(Dom walker) re-run dom-walker if the canvas mount count increases

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -390,7 +390,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
               }
             }
 
-            if (cachedMetadata == null || initComplete === false) {
+            if (cachedMetadata == null || !initComplete) {
               const rootElements = walkSceneInner(scene, index, scenePath, validPaths)
 
               const sceneMetadata = collectMetadata(
@@ -423,7 +423,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
           ObserversAvailable &&
           invalidatedSceneIDsRef.current.size === 0 &&
           rootMetadataInStateRef.current.length > 0 &&
-          initComplete === true
+          initComplete
         ) {
           // no mutation happened on the entire canvas, just return the old metadata
           rootMetadata = rootMetadataInStateRef.current

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -367,6 +367,7 @@ export const UiJsxCanvas = betterReactMemo(
               }}
             >
               <CanvasContainer
+                mountCount={props.mountCount}
                 walkDOM={walkDOM}
                 scale={scale}
                 offset={offset}
@@ -444,6 +445,7 @@ export interface CanvasContainerProps {
   onDomReport: (elementMetadata: Array<ElementInstanceMetadata>) => void
   canvasRootElementTemplatePath: TemplatePath
   validRootPaths: Array<StaticInstancePath>
+  mountCount: number
 }
 
 const CanvasContainer: React.FunctionComponent<React.PropsWithChildren<CanvasContainerProps>> = (


### PR DESCRIPTION
Fixes #718

**Problem:**
Changing the code did not immediately re-run the DOM walker, leaving traces of old highlights behind.

**Fix:**
The DOM walker now obeys the canvas mount counter, which we use to forcibly update the canvas in situations like a code update.

**Commit Details:**
- Added mount count to dom walker props
- replaced the `initCompleteRef` with a hook that resets initComplete to false if the mount count increases