### PR TITLE
experiment(Canvas) Enable second canvas experiment

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -1753,16 +1753,29 @@ export const UPDATE_FNS = {
           componentsByName,
         )
         if (nearestComponentResult != null) {
-          const { element, component: componentToIsolate } = nearestComponentResult
+          const { element, component: componentToIsolate, path } = nearestComponentResult
+
           const elementName = componentToIsolate.name
           const components = getOpenUtopiaJSXComponentsFromState(editor)
           const storyBoardPath = getStoryboardTemplatePath(components)
           if (elementName !== newIsolatedComponent?.componentName && storyBoardPath != null) {
+            const instanceFrame = MetadataUtils.getFrameInCanvasCoords(
+              path,
+              editor.jsxMetadataKILLME,
+            )
+            const normalisedInstanceFrame =
+              instanceFrame == null
+                ? {
+                    left: 0,
+                    top: 0,
+                    width: 375,
+                    height: 812,
+                  }
+                : canvasFrameToNormalisedFrame(instanceFrame)
+
             const normalisedFrame: NormalisedFrame = {
-              left: 430,
-              top: 0,
-              width: 375,
-              height: 812,
+              ...normalisedInstanceFrame,
+              left: normalisedInstanceFrame.left + 430,
             }
 
             const rootElementUIDProp = isJSXElement(componentToIsolate.rootElement)

--- a/editor/src/core/model/experiment-utils.ts
+++ b/editor/src/core/model/experiment-utils.ts
@@ -13,6 +13,7 @@ import { MetadataUtils } from './element-metadata-utils'
 import { UtopiaJSXComponentsByName } from './project-file-utils'
 
 interface MatchingComponentResult {
+  path: TemplatePath
   element: JSXElement
   component: UtopiaJSXComponent
 }
@@ -31,6 +32,7 @@ export function getMatchingComponentForInstancePath(
       return component == null
         ? null
         : {
+            path: path,
             element: element.value,
             component: component,
           }
@@ -55,6 +57,7 @@ export function getMatchingComponentForScenePath(
   return maybeMatchingComponent == null || maybeMatchingRootElement == null
     ? null
     : {
+        path: path,
         element: maybeMatchingRootElement,
         component: maybeMatchingComponent,
       }

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -35,11 +35,11 @@ let FeatureSwitches: { [feature: string]: boolean } = {
   'Invisible Element Controls': false,
   'Advanced Resize Box': false,
   'Component Children Highlights': true,
-  'Component Isolation Mode': true,
+  'Component Isolation Mode': false,
   'Component Navigator': true,
   'Component Navigator Component Title': true,
   'Component Navigator Nearest Ancestor': true,
-  'Component Second Canvas': false,
+  'Component Second Canvas': true,
   'Re-parse Project Button': false,
   'iFrame Code Editor': false,
 }


### PR DESCRIPTION
A very very hacky attempt at simulating the "Second Canvas" proposal, whereby we always show a second canvas for isolating the currently selected component. This is built using the existing isolation mode, with the second canvas just being a new scene that's always rendered in the same place.

When selecting anything in the left "Canvas", we update the isolated component used to feed the right "Canvas". I've added a divider `div` to the actual example project to separate the canvii.

:pizza: https://utopia.pizza/p/119ab8a6-auspicious-bergamot/?branch_name=experiment/second-canvas