### PR TITLE
Look for components rendered by ReactDOM.

### DIFF
--- a/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
+++ b/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
@@ -109,6 +109,7 @@ Array [
       "type": "JSX_ELEMENT",
     },
     "type": "UTOPIA_JSX_COMPONENT",
+    "usedInReactDOMRender": false,
   },
 ]
 `;
@@ -205,6 +206,7 @@ Array [
       "type": "JSX_ELEMENT",
     },
     "type": "UTOPIA_JSX_COMPONENT",
+    "usedInReactDOMRender": false,
   },
 ]
 `;

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -102,6 +102,7 @@ describe('SET_PROP', () => {
             ],
           ),
           null,
+          false,
         ),
       ],
       {},
@@ -192,6 +193,7 @@ describe('SET_CANVAS_FRAMES', () => {
         ],
       ),
       null,
+      false,
     ),
   ]
 
@@ -265,7 +267,7 @@ describe('moveTemplate', () => {
       parseSuccess(
         emptyImports(),
         rootElements.map((element, index) =>
-          utopiaJSXComponent(`MyView${index}`, true, defaultPropsParam, [], element, null),
+          utopiaJSXComponent(`MyView${index}`, true, defaultPropsParam, [], element, null, false),
         ),
         {},
         null,
@@ -764,7 +766,7 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     },
     [childElement],
   )
-  const firstTopLevelElement = utopiaJSXComponent('App', true, null, [], rootElement, null)
+  const firstTopLevelElement = utopiaJSXComponent('App', true, null, [], rootElement, null, false)
   const fileForUI = textFile(
     textFileContents(
       '',

--- a/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
@@ -20,7 +20,7 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
       [TP.instancePath(['scene'], ['aaa', 'bbb'])],
       [TP.instancePath(['scene'], ['aaa', 'ccc'])],
       transientFileState(
-        [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null)],
+        [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null, false)],
         emptyImports(),
       ),
     )
@@ -34,7 +34,7 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
       [TP.instancePath(['scene'], ['aaa', 'bbb'])],
       [TP.instancePath(['scene'], ['aaa', 'ccc'])],
       transientFileState(
-        [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null)],
+        [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null, false)],
         emptyImports(),
       ),
     )
@@ -42,7 +42,7 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
       [TP.instancePath(['scene'], ['aaa', 'bbb'])],
       [TP.instancePath(['scene'], ['aaa', 'ccc'])],
       transientFileState(
-        [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null)],
+        [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null, false)],
         emptyImports(),
       ),
     )
@@ -56,7 +56,7 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
       [TP.instancePath(['scene'], ['aaa', 'bbb'])],
       [TP.instancePath(['scene'], ['aaa', 'ccc'])],
       transientFileState(
-        [utopiaJSXComponent('App', false, null, [], jsxElement('span', {}, []), null)],
+        [utopiaJSXComponent('App', false, null, [], jsxElement('span', {}, []), null, false)],
         emptyImports(),
       ),
     )
@@ -64,7 +64,7 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
       [TP.instancePath(['scene'], ['aaa', 'ddd'])],
       [TP.instancePath(['scene'], ['aaa', 'ccc'])],
       transientFileState(
-        [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null)],
+        [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null, false)],
         emptyImports(),
       ),
     )
@@ -90,7 +90,7 @@ describe('DerivedStateKeepDeepEquality', () => {
           [TP.instancePath(['scene'], ['aaa', 'bbb'])],
           [TP.instancePath(['scene'], ['aaa', 'ccc'])],
           transientFileState(
-            [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null)],
+            [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null, false)],
             emptyImports(),
           ),
         ),
@@ -117,7 +117,7 @@ describe('DerivedStateKeepDeepEquality', () => {
           [TP.instancePath(['scene'], ['aaa', 'bbb'])],
           [TP.instancePath(['scene'], ['aaa', 'ccc'])],
           transientFileState(
-            [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null)],
+            [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null, false)],
             emptyImports(),
           ),
         ),
@@ -139,7 +139,7 @@ describe('DerivedStateKeepDeepEquality', () => {
           [TP.instancePath(['scene'], ['aaa', 'bbb'])],
           [TP.instancePath(['scene'], ['aaa', 'ccc'])],
           transientFileState(
-            [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null)],
+            [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null, false)],
             emptyImports(),
           ),
         ),
@@ -166,7 +166,7 @@ describe('DerivedStateKeepDeepEquality', () => {
           [TP.instancePath(['scene'], ['aaa', 'bbb'])],
           [TP.instancePath(['scene'], ['aaa', 'ccc'])],
           transientFileState(
-            [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null)],
+            [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null, false)],
             emptyImports(),
           ),
         ),
@@ -188,7 +188,7 @@ describe('DerivedStateKeepDeepEquality', () => {
           [TP.instancePath(['scene'], ['aaa', 'ddd'])],
           [TP.instancePath(['scene'], ['aaa', 'ccc'])],
           transientFileState(
-            [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null)],
+            [utopiaJSXComponent('App', false, null, [], jsxElement('div', {}, []), null, false)],
             emptyImports(),
           ),
         ),

--- a/editor/src/core/model/__snapshots__/storyboard-utils.spec.ts.snap
+++ b/editor/src/core/model/__snapshots__/storyboard-utils.spec.ts.snap
@@ -72,6 +72,7 @@ Array [
       "type": "JSX_ELEMENT",
     },
     "type": "UTOPIA_JSX_COMPONENT",
+    "usedInReactDOMRender": false,
   },
 ]
 `;

--- a/editor/src/core/model/element-template-utils.spec.ts
+++ b/editor/src/core/model/element-template-utils.spec.ts
@@ -92,6 +92,7 @@ describe('removeJSXElementChild', () => {
       [],
       jsxElement('View', { 'data-uid': jsxAttributeValue('aaa'), prop1: jsxAttributeValue(5) }, []),
       null,
+      false,
     ),
     utopiaJSXComponent(
       'test2WithChildren',
@@ -108,6 +109,7 @@ describe('removeJSXElementChild', () => {
         jsxElement('View', { 'data-uid': jsxAttributeValue('aae') }, []),
       ]),
       null,
+      false,
     ),
   ]
   xit('removes a root element', () => {

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -152,6 +152,7 @@ export function convertScenesToUtopiaCanvasComponent(
       scenes.map(mapScene),
     ),
     null,
+    false,
   )
 }
 

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -1,10 +1,20 @@
 import {
   addFileToProjectContents,
   getContentsTreeFileFromString,
+  ProjectContentTreeRoot,
   walkContentsTree,
 } from '../../components/assets'
 import { EditorModel } from '../../components/editor/action-types'
+import { updateFile } from '../../components/editor/actions/action-creators'
 import { EditorState } from '../../components/editor/store/editor-state'
+import {
+  Compare,
+  compareCompose,
+  compareField,
+  compareIfIs,
+  compareOn,
+  comparePrimitive,
+} from '../../utils/compare'
 import {
   isUtopiaJSXComponent,
   JSXElement,
@@ -12,18 +22,23 @@ import {
   utopiaJSXComponent,
 } from '../shared/element-template'
 import { forEachValue } from '../shared/object-utils'
+import { forceNotNull } from '../shared/optional-utils'
 import {
   addModifierExportToDetail,
+  addNamedExportToDetail,
   EmptyExportsDetail,
   ExportDetail,
   forEachParseSuccess,
   importAlias,
   isParsedTextFile,
+  isParseSuccess,
   isTextFile,
+  ParseSuccess,
   RevisionsState,
   textFile,
   textFileContents,
 } from '../shared/project-file-types'
+import { fastForEach } from '../shared/utils'
 import { addImport, parseSuccess } from '../workers/common/project-file-utils'
 import {
   BakedInStoryboardUID,
@@ -48,6 +63,12 @@ interface NamedComponentToImport {
   toImport: string
 }
 
+interface UnexportedRenderedComponent {
+  type: 'UNEXPORTED_RENDERED_COMPONENT'
+  path: string
+  elementName: string
+}
+
 function defaultComponentToImport(path: string): DefaultComponentToImport {
   return {
     type: 'DEFAULT_COMPONENT_TO_IMPORT',
@@ -68,32 +89,73 @@ function namedComponentToImport(
   }
 }
 
-type ComponentToImport = DefaultComponentToImport | NamedComponentToImport
-
-function betterImportCandidate(
+function unexportedRenderedComponent(
   path: string,
-  isDefaultImport: boolean,
-  name: string | null,
-  current: ComponentToImport | null,
-): boolean {
-  if (current == null) {
-    return true
-  } else {
-    if (path.split('/').length < current.path.split('/').length) {
-      return true
-    } else {
-      if (name != null && current.type === 'NAMED_COMPONENT_TO_IMPORT') {
-        const candidatePossibleMainComponentName = PossiblyMainComponentNames.includes(name)
-        return candidatePossibleMainComponentName > current.possibleMainComponentName
-      }
-      if (isDefaultImport && current.type === 'NAMED_COMPONENT_TO_IMPORT') {
-        return true
-      }
-    }
+  elementName: string,
+): UnexportedRenderedComponent {
+  return {
+    type: 'UNEXPORTED_RENDERED_COMPONENT',
+    path: path,
+    elementName: elementName,
   }
-
-  return false
 }
+
+type ComponentToImport =
+  | DefaultComponentToImport
+  | NamedComponentToImport
+  | UnexportedRenderedComponent
+
+function isDefaultComponentToImport(
+  toImport: ComponentToImport,
+): toImport is DefaultComponentToImport {
+  return toImport.type === 'DEFAULT_COMPONENT_TO_IMPORT'
+}
+
+function isNamedComponentToImport(toImport: ComponentToImport): toImport is NamedComponentToImport {
+  return toImport.type === 'NAMED_COMPONENT_TO_IMPORT'
+}
+
+function isUnexportedRenderedComponent(
+  toImport: ComponentToImport,
+): toImport is UnexportedRenderedComponent {
+  return toImport.type === 'UNEXPORTED_RENDERED_COMPONENT'
+}
+
+const compareDefaultComponentToImport: Compare<DefaultComponentToImport> = compareCompose(
+  compareOn((toImport) => toImport.path.split('/').length, comparePrimitive),
+)
+
+const compareNamedComponentToImport: Compare<NamedComponentToImport> = compareCompose(
+  compareOn((toImport) => toImport.path.split('/').length, comparePrimitive),
+  compareField('possibleMainComponentName', comparePrimitive),
+  compareField('toImport', comparePrimitive),
+)
+
+const compareUnexportedRenderedComponent: Compare<UnexportedRenderedComponent> = compareCompose(
+  compareOn((toImport) => toImport.path.split('/').length, comparePrimitive),
+  compareOn(
+    (toImport) => PossiblyMainComponentNames.includes(toImport.elementName),
+    comparePrimitive,
+  ),
+)
+
+// Highest priority last.
+const componentToImportTypesInPriorityOrder: Array<ComponentToImport['type']> = [
+  'NAMED_COMPONENT_TO_IMPORT',
+  'DEFAULT_COMPONENT_TO_IMPORT',
+  'UNEXPORTED_RENDERED_COMPONENT',
+]
+
+const compareComponentToImport: Compare<ComponentToImport> = compareCompose(
+  compareOn((toImport) => toImport.path.split('/').length, comparePrimitive),
+  compareIfIs(isDefaultComponentToImport, compareDefaultComponentToImport),
+  compareIfIs(isNamedComponentToImport, compareNamedComponentToImport),
+  compareIfIs(isUnexportedRenderedComponent, compareUnexportedRenderedComponent),
+  compareOn(
+    (toImport) => componentToImportTypesInPriorityOrder.indexOf(toImport.type),
+    comparePrimitive,
+  ),
+)
 
 export function addStoryboardFileToProject(editorModel: EditorModel): EditorModel | null {
   const storyboardFile = getContentsTreeFileFromString(
@@ -102,26 +164,47 @@ export function addStoryboardFileToProject(editorModel: EditorModel): EditorMode
   )
   if (storyboardFile == null) {
     let currentImportCandidate: ComponentToImport | null = null
+    function updateCandidate(importCandidate: ComponentToImport): void {
+      if (currentImportCandidate == null) {
+        currentImportCandidate = importCandidate
+      } else {
+        if (compareComponentToImport(importCandidate, currentImportCandidate) > 0) {
+          currentImportCandidate = importCandidate
+        }
+      }
+    }
     walkContentsTree(editorModel.projectContents, (fullPath, file) => {
       if (isParsedTextFile(file)) {
         // For those successfully parsed files, we want to search all of the components.
         forEachParseSuccess((success) => {
           if (success.exportsDetail.defaultExport != null) {
-            if (betterImportCandidate(fullPath, true, null, currentImportCandidate)) {
-              currentImportCandidate = defaultComponentToImport(fullPath)
-            }
+            updateCandidate(defaultComponentToImport(fullPath))
           }
 
           forEachValue((exportDetail, exportName) => {
-            if (betterImportCandidate(fullPath, false, exportName, currentImportCandidate)) {
-              const possibleMainComponentName = PossiblyMainComponentNames.includes(exportName)
-              currentImportCandidate = namedComponentToImport(
-                fullPath,
-                possibleMainComponentName,
-                exportName,
-              )
-            }
+            const possibleMainComponentName = PossiblyMainComponentNames.includes(exportName)
+            updateCandidate(namedComponentToImport(fullPath, possibleMainComponentName, exportName))
           }, success.exportsDetail.namedExports)
+
+          const namedExportKeys = Object.keys(success.exportsDetail.namedExports)
+          for (const topLevelElement of success.topLevelElements) {
+            if (isUtopiaJSXComponent(topLevelElement) && topLevelElement.usedInReactDOMRender) {
+              // Exported as the default, so exclude it.
+              if (
+                success.exportsDetail.defaultExport != null &&
+                success.exportsDetail.defaultExport.name === topLevelElement.name
+              ) {
+                continue
+              }
+
+              // Exported by name, so exclude it.
+              if (namedExportKeys.includes(topLevelElement.name)) {
+                continue
+              }
+
+              updateCandidate(unexportedRenderedComponent(fullPath, topLevelElement.name))
+            }
+          }
         }, file.fileContents.parsed)
       }
     })
@@ -139,7 +222,7 @@ export function addStoryboardFileToProject(editorModel: EditorModel): EditorMode
 function addStoryboardFileForComponent(
   createFileWithComponent: ComponentToImport,
   editorModel: EditorState,
-) {
+): EditorState {
   // Add import of storyboard and scene components.
   let imports = addImport(
     'utopia-api',
@@ -150,6 +233,7 @@ function addStoryboardFileForComponent(
   )
   // Create the storyboard variable.
   let sceneElement: JSXElement
+  let updatedProjectContents: ProjectContentTreeRoot = editorModel.projectContents
   switch (createFileWithComponent.type) {
     case 'NAMED_COMPONENT_TO_IMPORT':
       sceneElement = createSceneFromComponent(createFileWithComponent.toImport, 'scene-1')
@@ -165,6 +249,57 @@ function addStoryboardFileForComponent(
       sceneElement = createSceneFromComponent('StoryboardComponent', 'scene-1')
       imports = addImport(createFileWithComponent.path, 'StoryboardComponent', [], null, imports)
       break
+    case 'UNEXPORTED_RENDERED_COMPONENT':
+      sceneElement = createSceneFromComponent(createFileWithComponent.elementName, 'scene-1')
+      imports = addImport(
+        createFileWithComponent.path,
+        null,
+        [importAlias(createFileWithComponent.elementName)],
+        null,
+        imports,
+      )
+      // Modify the targeted file to export the component we're interested in.
+      const fileToModify = forceNotNull(
+        `Unable to find file at ${createFileWithComponent.path}`,
+        getContentsTreeFileFromString(updatedProjectContents, createFileWithComponent.path),
+      )
+      if (isTextFile(fileToModify)) {
+        if (isParseSuccess(fileToModify.fileContents.parsed)) {
+          const currentSuccess: ParseSuccess = fileToModify.fileContents.parsed
+          const updatedExports = addModifierExportToDetail(
+            currentSuccess.exportsDetail,
+            createFileWithComponent.elementName,
+          )
+          const updatedParseSuccess = parseSuccess(
+            currentSuccess.imports,
+            currentSuccess.topLevelElements,
+            currentSuccess.highlightBounds,
+            currentSuccess.jsxFactoryFunction,
+            currentSuccess.combinedTopLevelArbitraryBlock,
+            updatedExports,
+          )
+          const updatedContents = textFileContents(
+            fileToModify.fileContents.code,
+            updatedParseSuccess,
+            RevisionsState.ParsedAhead,
+          )
+          const updatedTextFile = textFile(
+            updatedContents,
+            fileToModify.lastSavedContents,
+            fileToModify.lastRevisedTime,
+          )
+          updatedProjectContents = addFileToProjectContents(
+            updatedProjectContents,
+            createFileWithComponent.path,
+            updatedTextFile,
+          )
+        } else {
+          throw new Error(`Unexpectedly ${createFileWithComponent.path} is not a parse success.`)
+        }
+      } else {
+        throw new Error(`${createFileWithComponent.path} was not a text file as expected.`)
+      }
+      break
     default:
       const _exhaustiveCheck: never = createFileWithComponent
       throw new Error(`Unhandled type ${JSON.stringify(createFileWithComponent)}`)
@@ -177,6 +312,7 @@ function addStoryboardFileForComponent(
     [],
     storyboardElement,
     null,
+    false,
   )
   // Add the component import.
   // Create the file.
@@ -195,8 +331,8 @@ function addStoryboardFileForComponent(
   )
 
   // Update the model.
-  const updatedProjectContents = addFileToProjectContents(
-    editorModel.projectContents,
+  updatedProjectContents = addFileToProjectContents(
+    updatedProjectContents,
     StoryboardFilePath,
     storyboardFileContents,
   )

--- a/editor/src/core/model/test-ui-js-file.ts
+++ b/editor/src/core/model/test-ui-js-file.ts
@@ -237,6 +237,7 @@ const mainComponentForTests = utopiaJSXComponent(
     ],
   ),
   null,
+  false,
 )
 
 const scene = utopiaJSXComponent(
@@ -253,6 +254,7 @@ const scene = utopiaJSXComponent(
     [],
   ),
   null,
+  false,
 )
 
 const Scene0UID = 'scene-0'
@@ -283,6 +285,7 @@ const TestStoryboard = utopiaJSXComponent(
     Scene2,
   ]),
   null,
+  false,
 )
 
 export const sampleJsxComponentWithScene = [mainComponentForTests, scene, TestStoryboard]

--- a/editor/src/core/shared/element-template.tsx
+++ b/editor/src/core/shared/element-template.tsx
@@ -634,6 +634,7 @@ export function utopiaJSXComponent(
   propsUsed: Array<string>,
   rootElement: JSXElementChild,
   jsBlock: ArbitraryJSBlock | null,
+  usedInReactDOMRender: boolean,
 ): UtopiaJSXComponent {
   return {
     type: 'UTOPIA_JSX_COMPONENT',
@@ -643,6 +644,7 @@ export function utopiaJSXComponent(
     propsUsed: propsUsed,
     rootElement: rootElement,
     arbitraryJSBlock: jsBlock,
+    usedInReactDOMRender: usedInReactDOMRender,
   }
 }
 
@@ -803,6 +805,7 @@ export interface UtopiaJSXComponent {
   propsUsed: Array<string>
   rootElement: JSXElementChild
   arbitraryJSBlock: ArbitraryJSBlock | null
+  usedInReactDOMRender: boolean
 }
 
 export interface ArbitraryJSBlock {

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.ts.snap
@@ -438,6 +438,7 @@ export var storyboard = (
         "type": "JSX_ELEMENT",
       },
       "type": "UTOPIA_JSX_COMPONENT",
+      "usedInReactDOMRender": false,
     },
     Object {
       "definedElsewhere": Array [
@@ -652,6 +653,7 @@ export var storyboard = (
         "type": "JSX_ELEMENT",
       },
       "type": "UTOPIA_JSX_COMPONENT",
+      "usedInReactDOMRender": false,
     },
   ],
   "type": "PARSE_SUCCESS",

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.ts.snap
@@ -110,6 +110,7 @@ export var storyboard = (props) => {
       "type": "JSX_ELEMENT",
     },
     "type": "UTOPIA_JSX_COMPONENT",
+    "usedInReactDOMRender": false,
   },
   Object {
     "definedElsewhere": Array [

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -358,6 +358,7 @@ export var whatever = (props) => {
         "type": "JSX_ELEMENT",
       },
       "type": "UTOPIA_JSX_COMPONENT",
+      "usedInReactDOMRender": false,
     },
   ],
   "type": "PARSE_SUCCESS",
@@ -523,6 +524,7 @@ return { a: a };",
         "type": "JSX_ELEMENT",
       },
       "type": "UTOPIA_JSX_COMPONENT",
+      "usedInReactDOMRender": false,
     },
     Object {
       "definedElsewhere": Array [
@@ -787,6 +789,7 @@ export var App = (props) => <View data-uid={'bbb'}>
         "type": "JSX_ELEMENT",
       },
       "type": "UTOPIA_JSX_COMPONENT",
+      "usedInReactDOMRender": false,
     },
   ],
   "type": "PARSE_SUCCESS",

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
@@ -183,6 +183,7 @@ export var whatever = props => (
       [],
       jsxElement('div', { 'data-uid': jsxAttributeValue('abc') }, []),
       null,
+      false,
     )
 
     const codeBlock = jsxArbitraryBlock(
@@ -198,7 +199,7 @@ export var whatever = props => (
       { aab: jsxElement('MyComp', { 'data-uid': jsxAttributeValue('aab') }, []) },
     )
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [codeBlock])
-    const whatever = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const whatever = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const topLevelElements = [myComp, whatever].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -290,6 +291,7 @@ return { arr: arr };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
@@ -384,6 +386,7 @@ return { arr: arr };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
@@ -479,6 +482,7 @@ return { arr: arr };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
@@ -556,7 +560,7 @@ export var whatever = (props) => {
         ),
       ],
     )
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -651,6 +655,7 @@ return { arr: arr };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
@@ -728,7 +733,7 @@ export var whatever = (props) => {
         ),
       ],
     )
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -823,6 +828,7 @@ return { arr: arr };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(

--- a/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
@@ -152,7 +152,7 @@ describe('Parsing a function component with props', () => {
       },
       [],
     )
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -190,7 +190,7 @@ describe('Parsing a function component with props', () => {
         ),
       ),
     )
-    const exported = utopiaJSXComponent('whatever', true, propsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, propsParam, [], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -213,7 +213,7 @@ describe('Parsing a function component with props', () => {
       [],
     )
     const propsParam = functionParam(false, regularParam('myProps', null))
-    const exported = utopiaJSXComponent('whatever', true, propsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, propsParam, [], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -240,7 +240,7 @@ describe('Parsing a function component with props', () => {
       false,
       destructuredObject([destructuredParamPart(undefined, destructuredParam, null)]),
     )
-    const exported = utopiaJSXComponent('whatever', true, propsParam, ['prop'], view, null)
+    const exported = utopiaJSXComponent('whatever', true, propsParam, ['prop'], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -275,7 +275,7 @@ describe('Parsing a function component with props', () => {
       false,
       destructuredObject([destructuredParamPart(undefined, destructuredParam, null)]),
     )
-    const exported = utopiaJSXComponent('whatever', true, propsParam, ['prop'], view, null)
+    const exported = utopiaJSXComponent('whatever', true, propsParam, ['prop'], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -305,7 +305,7 @@ describe('Parsing a function component with props', () => {
       false,
       destructuredObject([destructuredParamPart('prop', destructuredParam, null)]),
     )
-    const exported = utopiaJSXComponent('whatever', true, propsParam, ['prop'], view, null)
+    const exported = utopiaJSXComponent('whatever', true, propsParam, ['prop'], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -340,7 +340,7 @@ describe('Parsing a function component with props', () => {
       false,
       destructuredObject([destructuredParamPart('prop', destructuredParam, null)]),
     )
-    const exported = utopiaJSXComponent('whatever', true, propsParam, ['prop'], view, null)
+    const exported = utopiaJSXComponent('whatever', true, propsParam, ['prop'], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -371,7 +371,7 @@ describe('Parsing a function component with props', () => {
       destructuredParamPart(undefined, destructuredRestParam, null),
     ]
     const propsParam = functionParam(false, destructuredObject(destructuredParams))
-    const exported = utopiaJSXComponent('whatever', true, propsParam, ['prop'], view, null)
+    const exported = utopiaJSXComponent('whatever', true, propsParam, ['prop'], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -395,7 +395,7 @@ describe('Parsing a function component with props', () => {
     )
     const destructuredParam = functionParam(false, regularParam('prop', null))
     const propsParam = functionParam(false, destructuredArray([destructuredParam]))
-    const exported = utopiaJSXComponent('whatever', true, propsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, propsParam, [], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -427,7 +427,7 @@ describe('Parsing a function component with props', () => {
       ),
     )
     const propsParam = functionParam(false, destructuredArray([destructuredParam]))
-    const exported = utopiaJSXComponent('whatever', true, propsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, propsParam, [], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -457,7 +457,7 @@ describe('Parsing a function component with props', () => {
       false,
       destructuredArray([destructuredParam1, omittedParam(), destructuredParam2]),
     )
-    const exported = utopiaJSXComponent('whatever', true, propsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, propsParam, [], view, null, false)
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       JustImportViewAndReact,
@@ -507,6 +507,7 @@ describe('Parsing a function component with props', () => {
       ['arrayPart'],
       view,
       null,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
@@ -576,6 +577,7 @@ describe('Parsing a function component with props', () => {
       ['arrayPart'],
       view,
       null,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(

--- a/editor/src/core/workers/parser-printer/parser-printer-utils.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-utils.spec.ts
@@ -21,6 +21,7 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
       [],
       jsxElement('View', { 'data-uid': jsxAttributeValue('aa') }, []),
       null,
+      false,
     )
     const fixedComponent = guaranteeUniqueUidsFromTopLevel([exampleComponent])[0]
     expect(Utils.path(['rootElement', 'props', 'data-uid'], fixedComponent)).toBeDefined()
@@ -37,6 +38,7 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
         jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, []),
       ]),
       null,
+      false,
     )
     const fixedComponent = guaranteeUniqueUidsFromTopLevel([exampleComponent])[0]
     const child0UID = Utils.path(
@@ -59,6 +61,7 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
       [],
       jsxElement('View', { 'data-uid': jsxAttributeFunctionCall('someFunction', []) }, []),
       null,
+      false,
     )
     const fixedComponent = guaranteeUniqueUidsFromTopLevel([exampleComponent])[0]
 
@@ -81,6 +84,7 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
         jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, []),
       ]),
       null,
+      false,
     )
     const fixedComponent = guaranteeUniqueUidsFromTopLevel([exampleComponent])[0]
     expect(
@@ -99,6 +103,7 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
         jsxElement('View', {} as any, []),
       ]),
       null,
+      false,
     )
     const fixedComponent = guaranteeUniqueUidsFromTopLevel([exampleComponent])[0]
     expect(
@@ -120,6 +125,7 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
         jsxElement('View', {}, []),
       ]),
       null,
+      false,
     )
     const fixedComponent = guaranteeUniqueUidsFromTopLevel([exampleComponent])[0]
     expect(exampleComponent === fixedComponent).toBeFalsy()

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -100,6 +100,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       ['leftOfTheCake'],
       view,
       null,
+      false,
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
@@ -140,7 +141,7 @@ export var whatever = () => <View data-uid={'aaa'}>
     }
     const cake = jsxElement('cake', cakeAttributes, [])
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', true, null, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, null, [], view, null, false)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -196,6 +197,7 @@ export function whatever(props) {
       ['leftOfTheCake'],
       view,
       null,
+      false,
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
@@ -240,7 +242,7 @@ export function whatever() {
     }
     const cake = jsxElement('cake', cakeAttributes, [])
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', true, null, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, null, [], view, null, false)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -296,6 +298,7 @@ export default function whatever(props) {
       ['leftOfTheCake'],
       view,
       null,
+      false,
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
@@ -340,7 +343,7 @@ export default function whatever() {
     }
     const cake = jsxElement('cake', cakeAttributes, [])
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', true, null, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, null, [], view, null, false)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -393,6 +396,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       ['leftOfTheCake'],
       view,
       null,
+      false,
     )
     const importsWithCake = addImport('cake', 'cake', [], null, sampleImportsForTests)
     const importsWithStylecss = addImport('./style.css', null, [], null, importsWithCake)
@@ -460,6 +464,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       ['leftOfTheCake'],
       view,
       null,
+      false,
     )
     const imports = addImport('cake', 'cake', [importAlias('cake2')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
@@ -512,6 +517,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         ['leftOfTheCake'],
         view,
         null,
+        false,
       )
       const imports = addImport(
         'cake',
@@ -589,6 +595,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
         ['leftOfTheCake', 'rightOfTheCake'],
         view,
         null,
+        false,
       )
       const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
       const expectedResult = clearParseResultUniqueIDs(
@@ -647,6 +654,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       ['leftOfTheCake'],
       view,
       null,
+      false,
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
@@ -712,7 +720,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     }
     const cake = jsxElement('cake', cakeAttributes, [])
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const jsCode = `function getSizing(n) {
   return 100 + n;
 }
@@ -787,6 +795,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       ['leftOfTheCake'],
       view,
       null,
+      false,
     )
     const jsCode = `export default function getSizing(n) {
   return 100 + n;
@@ -864,6 +873,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       ['leftOfTheCake'],
       view,
       null,
+      false,
     )
     const jsCode = `export function getSizing(n) {
   switch (n) {
@@ -947,6 +957,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       ['leftOfTheCake'],
       view,
       null,
+      false,
     )
     const jsCode = `export default (n => {
   return 100 + n;
@@ -1014,7 +1025,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     }
     const cake = jsxElement('cake', cakeAttributes, [])
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const transpiledJSCode = `var spacing = 20;
 return { spacing: spacing };`
     const jsVariable = arbitraryJSBlock(
@@ -1093,6 +1104,7 @@ return { bgs: bgs, bg: bg };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
@@ -1158,6 +1170,7 @@ return { greys: greys };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
@@ -1221,6 +1234,7 @@ return { a: a, b: b };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
@@ -1287,6 +1301,7 @@ return { a: a, b: b, c: c };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
@@ -1357,6 +1372,7 @@ return { a: a };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
@@ -1422,6 +1438,7 @@ return { a: a, b: b };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
@@ -1488,6 +1505,7 @@ return { bg: bg };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const topLevelElements = [exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
@@ -1535,7 +1553,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     }
     const cake = jsxElement('cake', cakeAttributes, [])
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const jsCode = `var count = 10;`
     const transpiledJSCode = `var count = 10;
 return { count: count };`
@@ -1599,7 +1617,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     }
     const cake = jsxElement('cake', cakeAttributes, [])
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const transpiledJSCode = `var use20 = true;
 return { use20: use20 };`
     const jsVariable = arbitraryJSBlock(
@@ -1643,7 +1661,7 @@ export var whatever = (props) => <View data-uid={'aaa'}>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const transpiledJSCode = `var mySet = new Set();
 return { mySet: mySet };`
     const jsVariable = arbitraryJSBlock(
@@ -1705,7 +1723,15 @@ export var whatever = (props) => <View data-uid={'aaa'}>
     }
     const cake = jsxElement('cake', cakeAttributes, [])
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, ['left'], view, null)
+    const exported = utopiaJSXComponent(
+      'whatever',
+      true,
+      defaultPropsParam,
+      ['left'],
+      view,
+      null,
+      false,
+    )
     const transpiledJSCode = `var spacing = 20;
 return { spacing: spacing };`
     const jsVariable = arbitraryJSBlock(
@@ -1802,7 +1828,7 @@ return { MyComp: MyComp };`
     }
     const myCompElement = jsxElement('MyComp', myCompAttributes, [])
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [myCompElement])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const topLevelElements = [MyComp, exported].map(clearTopLevelElementUniqueIDs)
     const expectedResult = parseSuccess(
       sampleImportsForTests,
@@ -1879,7 +1905,15 @@ export var whatever = props => (
 
     const rootDiv = jsxElement('div', rootDivAttributes, [jsxTextBlock('hello')])
 
-    const myComp = utopiaJSXComponent('MyComp', true, defaultPropsParam, ['layout'], rootDiv, null)
+    const myComp = utopiaJSXComponent(
+      'MyComp',
+      true,
+      defaultPropsParam,
+      ['layout'],
+      rootDiv,
+      null,
+      false,
+    )
 
     const myCompAttributes: JSXAttributes = {
       'data-uid': jsxAttributeValue('aab'),
@@ -1887,7 +1921,7 @@ export var whatever = props => (
     }
     const myCompElement = jsxElement('MyComp', myCompAttributes, [])
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [myCompElement])
-    const whatever = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const whatever = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const topLevelElements = [myComp, whatever].map(clearTopLevelElementUniqueIDs)
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -2007,7 +2041,15 @@ export var whatever = (props) => <View data-uid={'aaa'}>
       [],
     )
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, ['color'], view, null)
+    const exported = utopiaJSXComponent(
+      'whatever',
+      true,
+      defaultPropsParam,
+      ['color'],
+      view,
+      null,
+      false,
+    )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -2047,7 +2089,7 @@ export var whatever = <View data-uid={'aaa'}>
       [],
     )
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', false, null, [], view, null)
+    const exported = utopiaJSXComponent('whatever', false, null, [], view, null, false)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const expectedResult = parseSuccess(
       imports,
@@ -2080,7 +2122,7 @@ export var App = (props) => <View data-uid={'bbb'}>
       uniqueID: expect.any(String),
     }
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('bbb') }, [emptyBrackets])
-    const exported = utopiaJSXComponent('App', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('App', true, defaultPropsParam, [], view, null, false)
     const expectedResult = parseSuccess(
       sampleImportsForTests,
       [exported],
@@ -2123,7 +2165,7 @@ export var App = (props) => <View data-uid={'bbb'}>
       [],
     )
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', false, null, [], view, null)
+    const exported = utopiaJSXComponent('whatever', false, null, [], view, null, false)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
@@ -2164,7 +2206,7 @@ export var App = (props) => <View data-uid={'bbb'}>
     }
     const cake = jsxElement('cake', cakeAttributes, [])
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const jsCode = `function getSizing(n) {
   return 100 + n;
 }
@@ -2217,7 +2259,7 @@ return { getSizing: getSizing, spacing: spacing };`
       [],
     )
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aaa') }, [cake])
-    const exported = utopiaJSXComponent('whatever', false, null, [], view, null)
+    const exported = utopiaJSXComponent('whatever', false, null, [], view, null, false)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
@@ -2317,7 +2359,7 @@ export var whatever = props => {
       [],
     )
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [cake])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
@@ -2352,7 +2394,7 @@ export var whatever = props => {
       [],
     )
     const view = jsxElement('View', { 'data-uid': jsxAttributeValue('aab') }, [cake])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
@@ -2439,6 +2481,7 @@ export var whatever = props => {
       ['color', 'shadowValue', 'there'],
       view,
       null,
+      false,
     )
     const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
@@ -2563,6 +2606,7 @@ return { test: test };`
               ],
             ),
             clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
+            false,
           ),
         ],
         expect.objectContaining({}),
@@ -2626,6 +2670,7 @@ return { test: test };`
               file: 'code.tsx',
             }),
           ),
+          false,
         ),
       ),
       clearTopLevelElementUniqueIDs(
@@ -2642,6 +2687,7 @@ return { test: test };`
             [],
           ),
           null,
+          false,
         ),
       ),
     ]
@@ -2709,6 +2755,7 @@ export var App = props => {
         ],
       ),
       null,
+      false,
     )
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -2753,6 +2800,7 @@ export var App = props => {
         [jsxTextBlock('cake')],
       ),
       null,
+      false,
     )
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -2818,6 +2866,7 @@ export var App = props => {
         ],
       ),
       null,
+      false,
     )
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -2875,6 +2924,7 @@ export var App = props => {
         ],
       ),
       null,
+      false,
     )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'App')
     const printedCode = printCode(
@@ -3039,6 +3089,7 @@ return { a: a, b: b, MyCustomCompomnent: MyCustomCompomnent };`,
           file: 'code.tsx',
         }),
       ),
+      false,
     )
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -3085,6 +3136,7 @@ export var App = props => {
         [],
       ),
       null,
+      false,
     )
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -3121,7 +3173,7 @@ export var whatever = props => {
       { 'data-uid': jsxAttributeValue('aaa'), booleanProperty: jsxAttributeValue(true) },
       [],
     )
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const actualResult = printCode(
       printCodeOptions(false, true, true),
       sampleImportsForTests,
@@ -3154,7 +3206,7 @@ export var whatever = props => {
       { 'data-uid': jsxAttributeValue('aaa'), booleanProperty: jsxAttributeValue(false) },
       [],
     )
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const actualResult = printCode(
       printCodeOptions(false, true, true),
       sampleImportsForTests,
@@ -3220,6 +3272,7 @@ return {  };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -3298,6 +3351,7 @@ return { result: result };`
       [],
       view,
       arbitraryBlock,
+      false,
     )
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -3372,7 +3426,7 @@ export var whatever = props => {
       { bbb: innerElement },
     )
     const view = jsxElement('div', { 'data-uid': jsxAttributeValue('aaa') }, [arbitraryBlock])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
         { react: sampleImportsForTests['react'] },
@@ -3469,6 +3523,7 @@ return { a: a };`,
       [],
       view,
       topLevelArbitraryBlock,
+      false,
     )
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
@@ -3489,7 +3544,7 @@ export var whatever = props => {
 }`
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
     const view = jsxElement('svg', { 'data-uid': jsxAttributeValue('abc') }, [])
-    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null)
+    const exported = utopiaJSXComponent('whatever', true, defaultPropsParam, [], view, null, false)
     const expectedResult = clearParseResultUniqueIDs(
       parseSuccess(
         { react: sampleImportsForTests['react'] },

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -474,7 +474,15 @@ export function utopiaJSXComponentArbitrary(): Arbitrary<UtopiaJSXComponent> {
     arbitraryJSBlockArbitrary(),
   )
     .map(([name, isFunction, rootElement, jsBlock]) => {
-      return utopiaJSXComponent(name, isFunction, defaultPropsParam, [], rootElement, jsBlock)
+      return utopiaJSXComponent(
+        name,
+        isFunction,
+        defaultPropsParam,
+        [],
+        rootElement,
+        jsBlock,
+        false,
+      )
     })
     .filter((component) => {
       // Prevent creating a component that depends on itself.

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -856,6 +856,53 @@ function detailsFromExportDeclaration(
   }
 }
 
+export function getComponentsRenderedWithReactDOM(
+  sourceFile: TS.SourceFile,
+  node: TS.Node,
+): Array<string> {
+  if (TS.isExpressionStatement(node)) {
+    const expressionStatement: TS.ExpressionStatement = node
+    if (TS.isCallExpression(expressionStatement.expression)) {
+      const callExpression: TS.CallExpression = expressionStatement.expression
+      if (TS.isPropertyAccessExpression(callExpression.expression)) {
+        const propertyAccessExpression = callExpression.expression
+        if (
+          TS.isIdentifier(propertyAccessExpression.expression) &&
+          TS.isIdentifier(propertyAccessExpression.name)
+        ) {
+          const propertyExpressionIdentifier: TS.Identifier = propertyAccessExpression.expression
+          const propertyNameIdentifier: TS.Identifier = propertyAccessExpression.name
+          // Checks if this starts as ReactDOM.render(...).
+          if (
+            propertyExpressionIdentifier.getText(sourceFile) === 'ReactDOM' &&
+            propertyNameIdentifier.getText(sourceFile) === 'render'
+          ) {
+            const firstArgument = callExpression.arguments[0]
+            if (firstArgument != null) {
+              if (TS.isJsxSelfClosingElement(firstArgument)) {
+                const selfClosingElement: TS.JsxSelfClosingElement = firstArgument
+                if (TS.isIdentifier(selfClosingElement.tagName)) {
+                  const tagName: TS.Identifier = selfClosingElement.tagName
+                  return [tagName.getText(sourceFile)]
+                }
+              }
+              if (TS.isJsxElement(firstArgument)) {
+                const jsxElement: TS.JsxElement = firstArgument
+                if (TS.isIdentifier(jsxElement.openingElement.tagName)) {
+                  const tagName: TS.Identifier = jsxElement.openingElement.tagName
+                  return [tagName.getText(sourceFile)]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return []
+}
+
 export function parseCode(filename: string, sourceText: string): ParsedTextFile {
   const sourceFile = TS.createSourceFile(filename, sourceText, TS.ScriptTarget.ES3)
 
@@ -1086,6 +1133,7 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
                 propsUsed,
                 contents.elements[0].value,
                 contents.arbitraryJSBlock,
+                false,
               )
 
               const defaultExport = isDefaultExport(topLevelElement)
@@ -1116,7 +1164,7 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
     }
     const realTopLevelElements = sequencedTopLevelElements.value
 
-    const topLevelElementsWithFixedUIDs = guaranteeUniqueUidsFromTopLevel(realTopLevelElements)
+    let topLevelElementsWithFixedUIDs = guaranteeUniqueUidsFromTopLevel(realTopLevelElements)
 
     let combinedTopLevelArbitraryBlock: ArbitraryJSBlock | null = null
     if (allArbitraryNodes.length > 0) {
@@ -1133,6 +1181,29 @@ export function parseCode(filename: string, sourceText: string): ParsedTextFile 
       )
       forEachRight(nodeParseResult, (nodeParseSuccess) => {
         combinedTopLevelArbitraryBlock = nodeParseSuccess.value
+      })
+
+      const componentsRenderedByReactDOM = flatMapArray(
+        (node) => getComponentsRenderedWithReactDOM(sourceFile, node),
+        allArbitraryNodes,
+      )
+      topLevelElementsWithFixedUIDs = topLevelElementsWithFixedUIDs.map((topLevelElement) => {
+        if (
+          isUtopiaJSXComponent(topLevelElement) &&
+          componentsRenderedByReactDOM.includes(topLevelElement.name)
+        ) {
+          return utopiaJSXComponent(
+            topLevelElement.name,
+            topLevelElement.isFunction,
+            topLevelElement.param,
+            topLevelElement.propsUsed,
+            topLevelElement.rootElement,
+            topLevelElement.arbitraryJSBlock,
+            true,
+          )
+        } else {
+          return topLevelElement
+        }
       })
     }
 

--- a/editor/src/core/workers/ts/ts-worker.spec.ts
+++ b/editor/src/core/workers/ts/ts-worker.spec.ts
@@ -223,6 +223,7 @@ const SampleInitTSWorkerMessage: IncomingWorkerMessage = {
                 children: [],
               },
               arbitraryJSBlock: null,
+              usedInReactDOMRender: false,
             },
             convertScenesToUtopiaCanvasComponent([
               {

--- a/editor/src/utils/compare.ts
+++ b/editor/src/utils/compare.ts
@@ -91,3 +91,16 @@ export function compareCompose<T>(...comparisons: Array<Compare<T>>): Compare<T>
     return 0
   }
 }
+
+export function compareIfIs<T, U extends T>(
+  isCheck: (t: T) => t is U,
+  compare: Compare<U>,
+): Compare<T> {
+  return (first: T, second: T) => {
+    if (isCheck(first) && isCheck(second)) {
+      return compare(first, second)
+    } else {
+      return 0
+    }
+  }
+}


### PR DESCRIPTION
**Problem:**
Often projects render their topmost component with a call to `ReactDOM.render`, which is likely what our editor should target, but that component is often not exported which means it can't be reached from another file.

**Fix:**
Parse out the calls to `ReactDOM.render` and the component they render and when creating the storyboard file, mark the component as exported.

**Limitations:**
- Making a change to something that isn't the actively open file appears to not work as well as it should, causing it to not render the component until the storyboard file is re-opened.
- As the `ReactDOM.render` call is at the root of the file being imported it gets executed and causes an error (potentially the cause of the above problem). I suspect the only solution to this is to wrap that call in some kind of conditional that succeeds only if the code isn't being run inside the editor.

**Commit Details:**
- Partly implements #630.
- Changed `ComponentToImport` to include a `UnexportedRenderedComponent` case.
- Replaced `betterImportCandidate` with a `Compare` based function.
- For `UnexportedRenderedComponent` applying that to a project results in
  the component being marked with `exported` as well as the creation of the
  storyboard file.
- Implemented `getComponentsRenderedWithReactDOM` to identify components
  that have been invoked with `ReactDOM.render` at the top level of
  a file.
- Added `compareIfIs` utility function.