### PR TITLE
Clear staging bundles.

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -101,7 +101,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_BUNDLE_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_BUNDLE_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
-      - name: Flush Editor Bundle
+      - name: Flush Staging Editor Bundle
         shell: bash
         run: |
-          curl -i -X DELETE 'https://${{ secrets.STAGING_SERVER }}/internal/branch?branch_name=${{ steps.extract_branch.outputs.branch }}'
+          curl -s -o /dev/null -w "FLUSH STAGING HTTP RESPONSE CODE: %{http_code}" -X DELETE 'https://${{ secrets.STAGING_SERVER }}/internal/branch?branch_name=${{ steps.extract_branch.outputs.branch }}'

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -101,3 +101,9 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_BUNDLE_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_BUNDLE_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
+      - name: Flush Editor Bundle
+        shell: bash
+        run: |
+          curl -i -X DELETE 'https://$STAGING_SERVER/internal/branch?branch_name=${{ steps.extract_branch.outputs.branch }}'
+        env:
+          STAGING_SERVER: ${{ secrets.STAGING_SERVER }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -104,6 +104,4 @@ jobs:
       - name: Flush Editor Bundle
         shell: bash
         run: |
-          curl -i -X DELETE 'https://$STAGING_SERVER/internal/branch?branch_name=${{ steps.extract_branch.outputs.branch }}'
-        env:
-          STAGING_SERVER: ${{ secrets.STAGING_SERVER }}
+          curl -i -X DELETE 'https://${{ secrets.STAGING_SERVER }}/internal/branch?branch_name=${{ steps.extract_branch.outputs.branch }}'

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -42,6 +42,7 @@ dependencies:
   - monad-logger
   - mtl
   - network-uri
+  - path
   - path-pieces
   - pathwalk
   - persistent <2.10.0

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -352,6 +352,11 @@ downloadGithubProjectEndpoint cookie owner repo = requireUser cookie $ \_ -> do
 monitoringEndpoint :: ServerMonad Value
 monitoringEndpoint = getMetrics
 
+clearBranchCacheEndpoint :: Text -> ServerMonad NoContent
+clearBranchCacheEndpoint branchName = do
+  clearBranchCache branchName
+  pure NoContent
+
 websiteAssetsEndpoint :: FilePath -> ServerMonad Application
 websiteAssetsEndpoint notProxiedPath = do
   possibleProxyManager <- getProxyManager
@@ -462,6 +467,7 @@ unprotected = authenticate
          :<|> loadProjectAssetEndpoint
          :<|> loadProjectThumbnailEndpoint
          :<|> monitoringEndpoint
+         :<|> clearBranchCacheEndpoint
          :<|> packagePackagerEndpoint
          :<|> getPackageJSONEndpoint
          :<|> getPackageVersionJSONEndpoint

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -270,7 +270,7 @@ innerServerExecutor (GetSiteRoot action) = do
 innerServerExecutor (GetPathToServe defaultPathToServe possibleBranchName action) = do
   possibleDownloads <- fmap _branchDownloads ask
   pathToServe <- case (defaultPathToServe, possibleBranchName, possibleDownloads) of
-                   ("./editor", (Just branchName), (Just downloads))  -> liftIO $ downloadBranchBundle downloads branchName
+                   ("./editor", (Just branchName), (Just downloads))  -> liftIO $ getBranchBundleFolder downloads branchName
                    _                                                  -> return defaultPathToServe
   return $ action pathToServe
 innerServerExecutor (GetUserConfiguration user action) = do
@@ -281,6 +281,10 @@ innerServerExecutor (SaveUserConfiguration user possibleShortcutConfig action) =
   pool <- fmap _projectPool ask
   metrics <- fmap _databaseMetrics ask
   saveUserConfigurationWithPool metrics pool user possibleShortcutConfig
+  return action
+innerServerExecutor (ClearBranchCache branchName action) = do
+  possibleDownloads <- fmap _branchDownloads ask
+  liftIO $ traverse_ (\d -> deleteBranchCache d branchName) possibleDownloads
   return action
 
 {-|

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -204,7 +204,7 @@ innerServerExecutor (GetSiteRoot action) = do
 innerServerExecutor (GetPathToServe defaultPathToServe possibleBranchName action) = do
   possibleDownloads <- fmap _branchDownloads ask
   pathToServe <- case (defaultPathToServe, possibleBranchName, possibleDownloads) of
-                   ("./editor", (Just branchName), (Just downloads))  -> liftIO $ downloadBranchBundle downloads branchName
+                   ("./editor", (Just branchName), (Just downloads))  -> liftIO $ getBranchBundleFolder downloads branchName
                    _                                                  -> return defaultPathToServe
   return $ action pathToServe
 innerServerExecutor (GetUserConfiguration user action) = do
@@ -216,7 +216,10 @@ innerServerExecutor (SaveUserConfiguration user possibleShortcutConfig action) =
   metrics <- fmap _databaseMetrics ask
   saveUserConfigurationWithPool metrics pool user possibleShortcutConfig
   return action
-
+innerServerExecutor (ClearBranchCache branchName action) = do
+  possibleDownloads <- fmap _branchDownloads ask
+  liftIO $ traverse_ (\d -> deleteBranchCache d branchName) possibleDownloads
+  return action
 
 readEditorContentFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text
 readEditorContentFromDisk (Just downloads) (Just branchName) fileName = do

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -118,6 +118,7 @@ data ServiceCallsF a = NotFound
                      | GetPathToServe FilePath (Maybe Text) (FilePath -> a)
                      | GetUserConfiguration Text (Maybe DecodedUserConfiguration -> a)
                      | SaveUserConfiguration Text (Maybe Value) a
+                     | ClearBranchCache Text a
                      deriving Functor
 
 {-

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -135,6 +135,8 @@ type GetPackageVersionsAPI = "v1" :> "javascript" :> "package" :> "versions" :> 
 
 type MonitoringAPI = "monitoring" :> "secret" :> "location" :> Get '[JSON] Value
 
+type ClearBranchAPI = "internal" :> "branch" :> QueryParam' '[Required, Strict] "branch_name" Text :> Delete '[JSON] NoContent
+
 type HashedAssetPathsAPI = "hashed-assets.json" :> Get '[JSON] Value
 
 type EditorAssetsAPI = "editor" :> BranchNameParam :> RawM
@@ -180,6 +182,7 @@ type Unprotected = AuthenticateAPI
               :<|> PreviewProjectAssetAPI
               :<|> LoadProjectThumbnailAPI
               :<|> MonitoringAPI
+              :<|> ClearBranchAPI
               :<|> PackagePackagerAPI
               :<|> GetPackageJSONAPI
               :<|> GetPackageVersionJSONAPI

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 59365a7cae4d2a726cdca15fd8fc3bfbf56f429e927cc5fe7295c4498d64fec9
+-- hash: 58ab737db13887effbbb6f5660ddeffb97c44ed4e7cd966f51c5a969460b52b7
 
 name:           utopia-web
 version:        0.1.0.4
@@ -88,6 +88,7 @@ executable utopia-web
     , monad-logger
     , mtl
     , network-uri
+    , path
     , path-pieces
     , pathwalk
     , persistent <2.10.0
@@ -201,6 +202,7 @@ test-suite utopia-web-test
     , monad-logger
     , mtl
     , network-uri
+    , path
     , path-pieces
     , pathwalk
     , persistent <2.10.0


### PR DESCRIPTION
Fixes #511

**Problem:**
If a staging bundle is updated, the server holding the staging branch bundles continues to serve the old bundle.

**Fix:**
Provide an endpoint that flushes the cache for a given branch name.

**Commit Details:**
- Fixes #511.
- Branch downloading now uses a simplistic read/write like lock using
  a semaphore where a read waits for 1 from the semaphore and a write
  waits for the entire value of the semaphore.
- Status of the branch download is also stored next to the semaphore.
- Added `getLocalFolder` to validate the path to avoid bulldozing the
  entire machine by a malicious entry.
- Added `deleteBranchCache` to delete the branch content and mark the
  branch as not having been downloaded.
- Added endpoint to trigger deletion of the branch cache.
