### PR TITLE
Scroll test button

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -910,5 +910,12 @@ export type EditorDispatch = (
   priority?: DispatchPriority,
 ) => void
 
+export type DebugDispatch = (
+  actions: ReadonlyArray<EditorAction>,
+  priority?: DispatchPriority,
+) => {
+  entireUpdateFinished: Promise<any>
+}
+
 export type Alignment = 'left' | 'hcenter' | 'right' | 'top' | 'vcenter' | 'bottom'
 export type Distribution = 'horizontal' | 'vertical'

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -70,7 +70,7 @@ import {
 } from '../../assets'
 import { isSendPreviewModel, restoreDerivedState, UPDATE_FNS } from '../actions/actions'
 
-interface DispatchResult extends EditorStore {
+export interface DispatchResult extends EditorStore {
   nothingChanged: boolean
   entireUpdateFinished: Promise<any>
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -107,7 +107,7 @@ import { FontSettings } from '../../inspector/common/css-utils'
 import { DefaultPackagesList, PackageDetails } from '../../navigator/dependency-list'
 import { LeftMenuTab, LeftPaneDefaultWidth } from '../../navigator/left-pane'
 import { DropTargetHint } from '../../navigator/navigator'
-import { EditorDispatch, LoginState, ProjectListing } from '../action-types'
+import { DebugDispatch, EditorDispatch, LoginState, ProjectListing } from '../action-types'
 import { CURRENT_PROJECT_VERSION } from '../actions/migrations/migrations'
 import { StateHistory } from '../history'
 import {

--- a/editor/src/components/menubar/menubar.tsx
+++ b/editor/src/components/menubar/menubar.tsx
@@ -15,6 +15,7 @@ import {
 import { betterReactMemo } from 'uuiui-deps'
 import { FLOATING_PREVIEW_BASE_URL } from '../../common/env-vars'
 import { LoginState } from '../../common/user'
+import { useTriggerScrollPerformanceTest } from '../../core/model/performance-scripts'
 import { useReParseOpenProjectFile } from '../../core/model/project-file-helper-hooks'
 import { shareURLForProject } from '../../core/shared/utils'
 import { isFeatureEnabled } from '../../utils/feature-switches'
@@ -132,6 +133,8 @@ export const Menubar = betterReactMemo('Menubar', () => {
 
   const onReparseClick = useReParseOpenProjectFile()
 
+  const onTriggerScrollTest = useTriggerScrollPerformanceTest()
+
   const previewURL =
     projectId == null ? '' : shareURLForProject(FLOATING_PREVIEW_BASE_URL, projectId, projectName)
 
@@ -184,6 +187,11 @@ export const Menubar = betterReactMemo('Menubar', () => {
           </span>
         </Tooltip>
       </FlexColumn>
+      {isFeatureEnabled('Performance Test Triggers') ? (
+        <Tile style={{ marginTop: 12, marginBottom: 12 }}>
+          <a onClick={onTriggerScrollTest}>P S</a>
+        </Tile>
+      ) : null}
       {isFeatureEnabled('Re-parse Project Button') ? (
         <Tile style={{ marginTop: 12, marginBottom: 12 }}>
           <a onClick={onReparseClick}>R</a>

--- a/editor/src/core/model/performance-scripts.ts
+++ b/editor/src/core/model/performance-scripts.ts
@@ -25,6 +25,8 @@ export function useTriggerScrollPerformanceTest(): () => void {
       framesPassed++
       if (framesPassed < 100) {
         requestAnimationFrame(step)
+      } else {
+        console.info('SCROLL_TEST_FINISHED')
       }
     }
     requestAnimationFrame(step)

--- a/editor/src/core/model/performance-scripts.ts
+++ b/editor/src/core/model/performance-scripts.ts
@@ -13,9 +13,16 @@ export function useTriggerScrollPerformanceTest(): () => void {
   const trigger = React.useCallback(async () => {
     let framesPassed = 0
     async function step() {
-      framesPassed++
+      performance.mark(`scroll_step_${framesPassed}`)
       await dispatch([CanvasActions.scrollCanvas(canvasPoint({ x: -5, y: -1 }))])
         .entireUpdateFinished
+      performance.mark(`scroll_dispatch_finished_${framesPassed}`)
+      performance.measure(
+        `scroll_frame_${framesPassed}`,
+        `scroll_step_${framesPassed}`,
+        `scroll_dispatch_finished_${framesPassed}`,
+      )
+      framesPassed++
       if (framesPassed < 100) {
         requestAnimationFrame(step)
       }

--- a/editor/src/core/model/performance-scripts.ts
+++ b/editor/src/core/model/performance-scripts.ts
@@ -14,7 +14,7 @@ export function useTriggerScrollPerformanceTest(): () => void {
     let framesPassed = 0
     async function step() {
       framesPassed++
-      await dispatch([CanvasActions.scrollCanvas(canvasPoint({ x: -15, y: -1 }))])
+      await dispatch([CanvasActions.scrollCanvas(canvasPoint({ x: -5, y: -1 }))])
         .entireUpdateFinished
       if (framesPassed < 100) {
         requestAnimationFrame(step)

--- a/editor/src/core/model/performance-scripts.ts
+++ b/editor/src/core/model/performance-scripts.ts
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import CanvasActions from '../../components/canvas/canvas-actions'
+import { DebugDispatch } from '../../components/editor/action-types'
+import { useEditorState } from '../../components/editor/store/store-hook'
+import { canvasPoint } from '../shared/math-utils'
+
+export function useTriggerScrollPerformanceTest(): () => void {
+  const dispatch = useEditorState(
+    (store) => store.dispatch as DebugDispatch,
+    'useTriggerScrollPerformanceTest dispatch',
+  )
+  const trigger = React.useCallback(async () => {
+    let framesPassed = 0
+    async function step() {
+      framesPassed++
+      await dispatch([CanvasActions.scrollCanvas(canvasPoint({ x: -15, y: -1 }))])
+        .entireUpdateFinished
+      if (framesPassed < 100) {
+        requestAnimationFrame(step)
+      }
+    }
+    requestAnimationFrame(step)
+  }, [dispatch])
+  return trigger
+}

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -8,6 +8,7 @@ export type FeatureName =
   | 'Advanced Resize Box'
   | 'Re-parse Project Button'
   | 'iFrame Code Editor'
+  | 'Performance Test Triggers'
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
   // 'Dragging Shows Overlay', // Removing this option so that we can experiment on this later
@@ -15,6 +16,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Advanced Resize Box',
   'Re-parse Project Button',
   'iFrame Code Editor',
+  'Performance Test Triggers',
 ]
 
 let FeatureSwitches: { [feature: string]: boolean } = {
@@ -24,6 +26,7 @@ let FeatureSwitches: { [feature: string]: boolean } = {
   'Advanced Resize Box': false,
   'Re-parse Project Button': false,
   'iFrame Code Editor': false,
+  'Performance Test Triggers': true,
 }
 
 function settingKeyForName(featureName: FeatureName): string {


### PR DESCRIPTION
**Problem:**
We need a way to reproducibly trigger smooth user interactions. This makes manual measurements easier, but also enables automated tests.

**Fix:**
This PR is the easiest and very first of these interactions.
![image](https://user-images.githubusercontent.com/2226774/100906048-06acf080-34c9-11eb-9f44-71d6404b3c6c.png)
if you press the P S button it scrolls the canvas for 100 frames. If you run the performance measurement during this time, you can see it leaves helpful performance marks there too. 

**Commit Details:**
- The dispatch now returns the (internally used) Promise that succeeds if the entire update is done (dom-walker included).
- I made a new hook that triggers a scroll interaction, waits for the dom-walker, then requests an animation frame, and triggers another scroll interaction until the counter reaches 100.

**Note:**
It's actually very powerful to try even in manual mode! It makes jank _so visible_ I am mad at myself for not implementing this sooner.
