### PR TITLE
feature(editor) remove layoutsystem from defaults for insertion, default project, updating frames

### DIFF
--- a/editor/src/bundled-dependencies/codeBundle.ts
+++ b/editor/src/bundled-dependencies/codeBundle.ts
@@ -6,16 +6,16 @@ import { ExportsInfo } from '../core/workers/ts/ts-worker'
 export const SampleFileBuildResult = JSON.parse(`{
   "/src/app.js": {
     "errors": [],
-    "transpiledCode": "\\"use strict\\";\\n\\nObject.defineProperty(exports, \\"__esModule\\", {\\n  value: true\\n});\\nexports.storyboard = exports.App = void 0;\\n\\nvar utopia_api_1 = require(\\"utopia-api\\");\\n\\nexports.App = function (props) {\\n  return utopia_api_1.jsx(\\"div\\", {\\n    style: {\\n      width: '100%',\\n      height: '100%',\\n      backgroundColor: '#FFFFFF'\\n    },\\n    layout: {\\n      layoutSystem: 'pinSystem'\\n    }\\n  });\\n};\\n\\nexports.storyboard = utopia_api_1.jsx(utopia_api_1.Storyboard, {\\n  layout: {\\n    layoutSystem: 'pinSystem'\\n  }\\n}, utopia_api_1.jsx(utopia_api_1.Scene, {\\n  component: exports.App,\\n  props: {},\\n  style: {\\n    position: 'absolute',\\n    left: 0,\\n    top: 0,\\n    width: 375,\\n    height: 812\\n  }\\n})); //# sourceMappingURL=app.js.map",
+    "transpiledCode": "\\"use strict\\";\\n\\nObject.defineProperty(exports, \\"__esModule\\", {\\n  value: true\\n});\\nexports.storyboard = exports.App = void 0;\\n\\nvar utopia_api_1 = require(\\"utopia-api\\");\\n\\nexports.App = function (props) {\\n  return utopia_api_1.jsx(\\"div\\", {\\n    style: {\\n      width: '100%',\\n      height: '100%',\\n      backgroundColor: '#FFFFFF',\\n      position: 'relative'\\n    }\\n  });\\n};\\n\\nexports.storyboard = utopia_api_1.jsx(utopia_api_1.Storyboard, null, utopia_api_1.jsx(utopia_api_1.Scene, {\\n  component: exports.App,\\n  props: {},\\n  style: {\\n    position: 'absolute',\\n    left: 0,\\n    top: 0,\\n    width: 375,\\n    height: 812\\n  }\\n})); //# sourceMappingURL=app.js.map",
     "sourceMap": {
       "version": 3,
       "sources": [
         "../src/app.js"
       ],
       "names": [],
-      "mappings": ";;;;;;;AAEA,IAAA,YAAA,GAAA,OAAA,CAAA,YAAA,CAAA;;AACW,OAAA,CAAA,GAAA,GAAM,UAAC,KAAD,EAAU;AACzB,SACE,YAAA,CAAA,GAAA,CAAA,KAAA,EAAA;AACE,IAAA,KAAK,EAAE;AAAE,MAAA,KAAK,EAAE,MAAT;AAAiB,MAAA,MAAM,EAAE,MAAzB;AAAiC,MAAA,eAAe,EAAE;AAAlD,KADT;AAEE,IAAA,MAAM,EAAE;AAAE,MAAA,YAAY,EAAE;AAAhB;AAFV,GAAA,CADF;AAMD,CAPU;;AAQA,OAAA,CAAA,UAAA,GACT,YAAA,CAAA,GAAA,CAAC,YAAA,CAAA,UAAD,EAAW;AAAC,EAAA,MAAM,EAAE;AAAE,IAAA,YAAY,EAAE;AAAhB;AAAT,CAAX,EACE,YAAA,CAAA,GAAA,CAAC,YAAA,CAAA,KAAD,EAAM;AACJ,EAAA,SAAS,EAAE,OAAA,CAAA,GADP;AAEJ,EAAA,KAAK,EAAE,EAFH;AAGJ,EAAA,KAAK,EAAE;AAAE,IAAA,QAAQ,EAAE,UAAZ;AAAwB,IAAA,IAAI,EAAE,CAA9B;AAAiC,IAAA,GAAG,EAAE,CAAtC;AAAyC,IAAA,KAAK,EAAE,GAAhD;AAAqD,IAAA,MAAM,EAAE;AAA7D;AAHH,CAAN,CADF,CADS,C",
+      "mappings": ";;;;;;;AAEA,IAAA,YAAA,GAAA,OAAA,CAAA,YAAA,CAAA;;AACW,OAAA,CAAA,GAAA,GAAM,UAAC,KAAD,EAAU;AACzB,SACE,YAAA,CAAA,GAAA,CAAA,KAAA,EAAA;AACE,IAAA,KAAK,EAAE;AAAE,MAAA,KAAK,EAAE,MAAT;AAAiB,MAAA,MAAM,EAAE,MAAzB;AAAiC,MAAA,eAAe,EAAE,SAAlD;AAA6D,MAAA,QAAQ,EAAE;AAAvE;AADT,GAAA,CADF;AAKD,CANU;;AAOA,OAAA,CAAA,UAAA,GACT,YAAA,CAAA,GAAA,CAAC,YAAA,CAAA,UAAD,EAAW,IAAX,EACE,YAAA,CAAA,GAAA,CAAC,YAAA,CAAA,KAAD,EAAM;AACJ,EAAA,SAAS,EAAE,OAAA,CAAA,GADP;AAEJ,EAAA,KAAK,EAAE,EAFH;AAGJ,EAAA,KAAK,EAAE;AAAE,IAAA,QAAQ,EAAE,UAAZ;AAAwB,IAAA,IAAI,EAAE,CAA9B;AAAiC,IAAA,GAAG,EAAE,CAAtC;AAAyC,IAAA,KAAK,EAAE,GAAhD;AAAqD,IAAA,MAAM,EAAE;AAA7D;AAHH,CAAN,CADF,CADS,C",
       "sourcesContent": [
-        "/** @jsx jsx */\\nimport * as React from 'react'\\nimport { Scene, Storyboard, jsx } from 'utopia-api'\\nexport var App = (props) => {\\n  return (\\n    <div\\n      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}\\n      layout={{ layoutSystem: 'pinSystem' }}\\n    />\\n  )\\n}\\nexport var storyboard = (\\n  <Storyboard layout={{ layoutSystem: 'pinSystem' }}>\\n    <Scene\\n      component={App}\\n      props={{}}\\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\\n    />\\n  </Storyboard>\\n)\\n\\n"
+        "/** @jsx jsx */\\nimport * as React from 'react'\\nimport { Scene, Storyboard, jsx } from 'utopia-api'\\nexport var App = (props) => {\\n  return (\\n    <div\\n      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}\\n    />\\n  )\\n}\\nexport var storyboard = (\\n  <Storyboard>\\n    <Scene\\n      component={App}\\n      props={{}}\\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\\n    />\\n  </Storyboard>\\n)\\n\\n"
       ],
       "sourceRoot": "",
       "file": "app.js"
@@ -43,7 +43,7 @@ export const SampleFileBuildResult = JSON.parse(`{
 export const SampleFileBundledExportsInfo: Array<ExportsInfo> = JSON.parse(`[
   {
     "filename": "/src/app.js",
-    "code": "/** @jsx jsx */\\nimport * as React from 'react'\\nimport { Scene, Storyboard, jsx } from 'utopia-api'\\nexport var App = (props) => {\\n  return (\\n    <div\\n      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}\\n      layout={{ layoutSystem: 'pinSystem' }}\\n    />\\n  )\\n}\\nexport var storyboard = (\\n  <Storyboard layout={{ layoutSystem: 'pinSystem' }}>\\n    <Scene\\n      component={App}\\n      props={{}}\\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\\n    />\\n  </Storyboard>\\n)\\n\\n",
+    "code": "/** @jsx jsx */\\nimport * as React from 'react'\\nimport { Scene, Storyboard, jsx } from 'utopia-api'\\nexport var App = (props) => {\\n  return (\\n    <div\\n      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}\\n    />\\n  )\\n}\\nexport var storyboard = (\\n  <Storyboard>\\n    <Scene\\n      component={App}\\n      props={{}}\\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\\n    />\\n  </Storyboard>\\n)\\n\\n",
     "exportTypes": {
       "App": {
         "type": "(props: any) => Element",

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -951,8 +951,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...props.style }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
-          layout={{ layoutSystem: 'pinSystem' }}
+          style={{ position: 'absolute', backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
           data-uid={'bbb'}
         />
       </View>
@@ -968,13 +967,11 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...props.style }} data-uid={'aaa'}>
         <View
-          layout={{ layoutSystem: 'pinSystem' }}
-          style={{ left: 52, top: 61, width: 256, height: 202 }}
+          style={{ position: 'absolute', left: 52, top: 61, width: 256, height: 202 }}
           data-uid={'${NewUID}'}
         >
           <View
-            style={{ backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202 }}
-            layout={{ layoutSystem: 'pinSystem' }}
+            style={{ backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202, position: 'absolute' }}
             data-uid={'bbb'}
           />
         </View>
@@ -985,15 +982,13 @@ describe('moveTemplate', () => {
   it('wraps multiselected elements', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} data-uid={'aaa'}>
+      <View style={{ ...props.style, width: '100%', height: '100%', position: 'relative' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
-          layout={{ layoutSystem: 'pinSystem' }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202, position: 'absolute' }}
           data-uid={'bbb'}
         >
           <View
-            style={{ left: 10, top: 10, width: 100, height: 100 }}
-            layout={{ layoutSystem: 'pinSystem' }}
+            style={{ left: 10, top: 10, width: 100, height: 100, position: 'absolute' }}
             data-uid={'ccc'}
           >
             <View data-uid={'ddd'} />
@@ -1001,12 +996,11 @@ describe('moveTemplate', () => {
         </View>
         <View data-uid={'eee'}/>
         <View
-          style={{ left: 10, top: 10, width: 256, height: 150 }}
-          layout={{ layoutSystem: 'pinSystem' }}
+          style={{ left: 10, top: 10, width: 256, height: 150, position: 'absolute' }}
           data-uid={'fff'}
         >
             <View
-              style={{ left: 5, top: 0, width: 246, height: 150 }}
+              style={{ left: 5, top: 0, width: 246, height: 150, position: 'absolute'  }}
               data-uid={'ggg'}
             />
           </View>
@@ -1025,33 +1019,29 @@ describe('moveTemplate', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} data-uid={'aaa'}>
+      <View style={{ ...props.style, width: '100%', height: '100%', position: 'relative' }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
-          layout={{ layoutSystem: 'pinSystem' }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202, position: 'absolute' }}
           data-uid={'bbb'}
         />
         <View data-uid={'eee'} />
         <View
-          style={{ left: 10, top: 10, width: 256, height: 150 }}
-          layout={{ layoutSystem: 'pinSystem' }}
+          style={{ left: 10, top: 10, width: 256, height: 150, position: 'absolute' }}
           data-uid={'fff'}
         />
         <View data-uid={'hhh'} />
         <View
-          layout={{ layoutSystem: 'pinSystem' }}
-          style={{  left: 15, top: 71, width: 246, height: 291  }}
+          style={{ position: 'absolute', left: 15, top: 10, width: 246, height: 161 }}
           data-uid={'${NewUID}'}
         >
           <View
-            style={{ left: 47, top: 0, width: 100, height: 100 }}
-            layout={{ layoutSystem: 'pinSystem' }}
+            style={{ left: 47, top: 61, width: 100, height: 100, position: 'absolute' }}
             data-uid={'ccc'}
           >
             <View data-uid={'ddd'} />
           </View>
           <View
-            style={{ left: 0, top: 141, width: 246, height: 150 }}
+            style={{ left: 0, top: 0, width: 246, height: 150, position: 'absolute' }}
             data-uid={'ggg'}
           />
         </View>
@@ -1064,8 +1054,7 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...props.style }} data-uid={'aaa'}>
         <View
-          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
-          layout={{ layoutSystem: 'pinSystem' }}
+          style={{ position: 'absolute', backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
           data-uid={'bbb'}
         >
           <View data-uid={'ccc'}>
@@ -1090,13 +1079,11 @@ describe('moveTemplate', () => {
       <View style={{ ...props.style }} data-uid={'aaa'}>
         <View data-uid={'eee'} />
         <View
-          layout={{ layoutSystem: 'pinSystem' }}
-          style={{ left: 52, top: 61, width: 256, height: 202 }}
+          style={{ position: 'absolute', left: 52, top: 61, width: 256, height: 202 }}
           data-uid={'${NewUID}'}
         >
           <View
-            style={{ backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202 }}
-            layout={{ layoutSystem: 'pinSystem' }}
+            style={{ backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202, position: 'absolute' }}
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'}>
@@ -1404,12 +1391,12 @@ describe('moveTemplate', () => {
   it('inserting a new element', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
+            style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex', position: 'absolute' }}
             data-uid={'bbb'}
           >
-            <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 20, crossBasis: 20 }} />
+            <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ flexBasis: 20, crossBasis: 20 }} />
           </View>
         </View>
       `),
@@ -1492,16 +1479,16 @@ describe('moveTemplate', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid={'aaa'}>
           <View
-            style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
+            style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex', position: 'absolute' }}
             data-uid={'bbb'}
           >
-            <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 20, crossBasis: 20 }} />
+            <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ flexBasis: 20, crossBasis: 20 }} />
             <View
               style={{ backgroundColor: '#0091FFAA' }}
               data-uid={'${NewUID}'}
-              layout={{ layoutSystem: 'pinSystem', flexBasis: 75, crossBasis: 75 }}
+              layout={{ flexBasis: 75, crossBasis: 75 }}
             />
           </View>
         </View>

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1275,7 +1275,7 @@ describe('moveTemplate', () => {
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
-            <View data-uid={'eee'} layout={{ layoutSystem: 'pinSystem', flexBasis: 80, crossBasis: 80 }} style={{}} />
+            <View data-uid={'eee'} layout={{ flexBasis: 80, crossBasis: 80 }} style={{ position: 'relative' }} />
           </View>
         </View>
       `),
@@ -1381,7 +1381,7 @@ describe('moveTemplate', () => {
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
-            <View data-uid={'eee'} style={{ backgroundColor: '#00ff00' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 80, crossBasis: 80 }} />
+            <View data-uid={'eee'} style={{ backgroundColor: '#00ff00', position: 'relative' }} layout={{ flexBasis: 80, crossBasis: 80 }} />
           </View>
         </View>
       `),
@@ -1486,7 +1486,7 @@ describe('moveTemplate', () => {
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ flexBasis: 20, crossBasis: 20 }} />
             <View
-              style={{ backgroundColor: '#0091FFAA' }}
+              style={{ backgroundColor: '#0091FFAA', position: 'relative' }}
               data-uid={'${NewUID}'}
               layout={{ flexBasis: 75, crossBasis: 75 }}
             />

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -13,7 +13,7 @@ import {
   JSXElement,
   JSXElementChild,
 } from '../../../core/shared/element-template'
-import { setJSXValueAtPath, unsetJSXValueAtPath } from '../../../core/shared/jsx-attributes'
+import { setJSXValueAtPath } from '../../../core/shared/jsx-attributes'
 import { PropertyPath, TemplatePath, Imports } from '../../../core/shared/project-file-types'
 import { Either, eitherToMaybe, isLeft, right } from '../../../core/shared/either'
 import { KeysPressed } from '../../../utils/keyboard'
@@ -443,7 +443,11 @@ export class InsertModeControlContainer extends React.Component<
           ...element,
           props:
             eitherToMaybe(
-              unsetJSXValueAtPath(element.props, createLayoutPropertyPath('position')),
+              setJSXValueAtPath(
+                element.props,
+                createLayoutPropertyPath('position'),
+                jsxAttributeValue('relative'),
+              ),
             ) ?? element.props,
         }
       }

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -13,9 +13,9 @@ import {
   JSXElement,
   JSXElementChild,
 } from '../../../core/shared/element-template'
-import { setJSXValueAtPath } from '../../../core/shared/jsx-attributes'
+import { setJSXValueAtPath, unsetJSXValueAtPath } from '../../../core/shared/jsx-attributes'
 import { PropertyPath, TemplatePath, Imports } from '../../../core/shared/project-file-types'
-import { Either, isLeft, right } from '../../../core/shared/either'
+import { Either, eitherToMaybe, isLeft, right } from '../../../core/shared/either'
 import { KeysPressed } from '../../../utils/keyboard'
 import Utils from '../../../utils/utils'
 import { CanvasPoint, CanvasRectangle, CanvasVector } from '../../../core/shared/math-utils'
@@ -51,6 +51,7 @@ import { getLayoutPropertyOr } from '../../../core/layout/getLayoutProperty'
 import { RightMenuTab } from '../right-menu'
 import { safeIndex } from '../../../core/shared/array-utils'
 import { getStoryboardTemplatePath } from '../../editor/store/editor-state'
+import { createLayoutPropertyPath } from '../../../core/layout/layout-helpers-new'
 
 // I feel comfortable having this function confined to this file only, since we absolutely shouldn't be trying
 // to set values that would fail whilst inserting elements. If that ever changes, this function should be binned
@@ -437,7 +438,16 @@ export class InsertModeControlContainer extends React.Component<
       let { element } = this.props.mode.subject
       if (this.isTextInsertion(element, insertionSubject.importsToAdd)) {
         element = this.getTextElementAutoSizeWithPosition(element, snappedMousePoint)
+      } else if (this.parentIsFlex(this.props.highlightedViews[0])) {
+        element = {
+          ...element,
+          props:
+            eitherToMaybe(
+              unsetJSXValueAtPath(element.props, createLayoutPropertyPath('position')),
+            ) ?? element.props,
+        }
       }
+
       this.props.dispatch(
         [
           EditorActions.updateEditorMode(

--- a/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
+++ b/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
@@ -61,6 +61,14 @@ Array [
                     "value": 300,
                   },
                 },
+                Object {
+                  "key": "position",
+                  "type": "PROPERTY_ASSIGNMENT",
+                  "value": Object {
+                    "type": "ATTRIBUTE_VALUE",
+                    "value": "absolute",
+                  },
+                },
               ],
               "type": "ATTRIBUTE_NESTED_OBJECT",
             },
@@ -80,17 +88,8 @@ Array [
           "value": "aaa",
         },
         "layout": Object {
-          "content": Array [
-            Object {
-              "key": "layoutSystem",
-              "type": "PROPERTY_ASSIGNMENT",
-              "value": Object {
-                "type": "ATTRIBUTE_VALUE",
-                "value": "pinSystem",
-              },
-            },
-          ],
-          "type": "ATTRIBUTE_NESTED_OBJECT",
+          "type": "ATTRIBUTE_VALUE",
+          "value": Object {},
         },
         "style": Object {
           "content": Array [
@@ -100,6 +99,14 @@ Array [
               "value": Object {
                 "type": "ATTRIBUTE_VALUE",
                 "value": "#FFFFFF",
+              },
+            },
+            Object {
+              "key": "position",
+              "type": "PROPERTY_ASSIGNMENT",
+              "value": Object {
+                "type": "ATTRIBUTE_VALUE",
+                "value": "absolute",
               },
             },
           ],

--- a/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
+++ b/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
@@ -165,8 +165,17 @@ Array [
               "type": "ATTRIBUTE_NESTED_OBJECT",
             },
             "style": Object {
-              "type": "ATTRIBUTE_VALUE",
-              "value": Object {},
+              "content": Array [
+                Object {
+                  "key": "position",
+                  "type": "PROPERTY_ASSIGNMENT",
+                  "value": Object {
+                    "type": "ATTRIBUTE_VALUE",
+                    "value": "relative",
+                  },
+                },
+              ],
+              "type": "ATTRIBUTE_NESTED_OBJECT",
             },
           },
           "type": "JSX_ELEMENT",

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -2039,7 +2039,7 @@ export const UPDATE_FNS = {
             viewPath,
             parentBounds,
             withWrapperViewAdded,
-            null,
+            action.layoutSystem,
           ).editor
 
           return {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -602,7 +602,13 @@ function switchAndUpdateFrames(
       withUpdatedLayoutSystem = setPropertyOnTarget(
         withUpdatedLayoutSystem,
         target,
-        LayoutHelpers.setLayoutAttribute(layoutSystem),
+        (attributes) => {
+          return setJSXValueAtPath(
+            attributes,
+            createLayoutPropertyPath('position'),
+            jsxAttributeValue('absolute'),
+          )
+        },
       )
   }
 

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -627,6 +627,15 @@ function switchAndUpdateFrames(
           'flex',
         ),
       }
+      withUpdatedLayoutSystem = {
+        ...withUpdatedLayoutSystem,
+        jsxMetadataKILLME: MetadataUtils.setPropertyDirectlyIntoMetadata(
+          withUpdatedLayoutSystem.jsxMetadataKILLME,
+          target,
+          createLayoutPropertyPath('position'), // TODO LAYOUT investigate if we should use also update the DOM walker specialSizeMeasurements
+          'relative',
+        ),
+      }
       break
     case 'flow':
       withUpdatedLayoutSystem = {
@@ -639,6 +648,24 @@ function switchAndUpdateFrames(
       }
       break
     case LayoutSystem.PinSystem:
+      withUpdatedLayoutSystem = {
+        ...withUpdatedLayoutSystem,
+        jsxMetadataKILLME: MetadataUtils.unsetPropertyDirectlyIntoMetadata(
+          withUpdatedLayoutSystem.jsxMetadataKILLME,
+          target,
+          layoutSystemPath,
+        ),
+      }
+      withUpdatedLayoutSystem = {
+        ...withUpdatedLayoutSystem,
+        jsxMetadataKILLME: MetadataUtils.setPropertyDirectlyIntoMetadata(
+          withUpdatedLayoutSystem.jsxMetadataKILLME,
+          target,
+          createLayoutPropertyPath('position'), // TODO LAYOUT investigate if we should use also update the DOM walker specialSizeMeasurements
+          'absolute',
+        ),
+      }
+      break
     case LayoutSystem.Group:
     default:
       withUpdatedLayoutSystem = {
@@ -1957,10 +1984,7 @@ export const UPDATE_FNS = {
 
           let viewPath: TemplatePath | null = null
           const withWrapperViewAddedNoFrame = modifyOpenParseSuccess((parseSuccess) => {
-            const elementToInsert: JSXElement = defaultTransparentViewElement(
-              newUID,
-              action.layoutSystem,
-            )
+            const elementToInsert: JSXElement = defaultTransparentViewElement(newUID)
             const utopiaJSXComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
             const withTargetAdded: Array<UtopiaJSXComponent> = insertElementAtPath(
               parentPath,
@@ -2015,7 +2039,7 @@ export const UPDATE_FNS = {
             viewPath,
             parentBounds,
             withWrapperViewAdded,
-            action.layoutSystem,
+            null,
           ).editor
 
           return {

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -61,7 +61,9 @@ export function defaultTransparentViewElement(uid: string): JSXElement {
   return jsxElement(
     jsxElementName('View', []),
     {
-      style: jsxAttributeValue({}),
+      style: jsxAttributeValue({
+        position: 'absolute',
+      }),
       'data-uid': jsxAttributeValue(uid),
     },
     [],

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -5,7 +5,7 @@ import {
   jsxElementName,
   jsxAttributeOtherJavaScript,
 } from '../../core/shared/element-template'
-import { LayoutSystem, NormalisedFrame } from 'utopia-api'
+import { NormalisedFrame } from 'utopia-api'
 import { PathForResizeContent } from '../../core/model/scene-utils'
 import * as PP from '../../core/shared/property-path'
 
@@ -36,11 +36,9 @@ export function defaultViewElement(uid: string): JSXElement {
     {
       style: jsxAttributeValue({
         backgroundColor: '#0091FFAA',
+        position: 'absolute',
       }),
       'data-uid': jsxAttributeValue(uid),
-      layout: jsxAttributeValue({
-        layoutSystem: 'pinSystem',
-      }),
     },
     [],
   )
@@ -59,13 +57,10 @@ export function defaultAnimatedDivElement(uid: string): JSXElement {
   )
 }
 
-export function defaultTransparentViewElement(uid: string, layoutSystem: LayoutSystem): JSXElement {
+export function defaultTransparentViewElement(uid: string): JSXElement {
   return jsxElement(
     jsxElementName('View', []),
     {
-      layout: jsxAttributeValue({
-        layoutSystem: layoutSystem,
-      }),
       style: jsxAttributeValue({}),
       'data-uid': jsxAttributeValue(uid),
     },
@@ -119,11 +114,9 @@ export function defaultDivElement(uid: string): JSXElement {
     {
       style: jsxAttributeValue({
         backgroundColor: '#0091FFAA',
+        position: 'absolute',
       }),
       'data-uid': jsxAttributeValue(uid),
-      layout: jsxAttributeValue({
-        layoutSystem: 'pinSystem',
-      }),
     },
     [],
   )

--- a/editor/src/core/layout/layout-helpers.ts
+++ b/editor/src/core/layout/layout-helpers.ts
@@ -275,23 +275,6 @@ export const LayoutHelpers = {
     const parsedLayoutSystem = this.getLayoutSystemFromAttributes(props)
     return isRight(parsedLayoutSystem) ? parsedLayoutSystem.value : LayoutSystem.PinSystem
   },
-  setLayoutAttribute: (newValue: LayoutSystem) => (
-    props: JSXAttributes,
-  ): Either<string, JSXAttributes> => {
-    if (newValue === LayoutSystem.PinSystem) {
-      return setJSXValueAtPath(
-        props,
-        createLayoutPropertyPath('position'),
-        jsxAttributeValue('absolute'),
-      )
-    } else {
-      return setJSXValueAtPath(
-        props,
-        createLayoutPropertyPath('LayoutSystem'),
-        jsxAttributeValue(newValue),
-      )
-    }
-  },
   stretchesChild(
     parentProps: PropsOrJSXAttributes,
     childProps: JSXAttributes,

--- a/editor/src/core/layout/layout-helpers.ts
+++ b/editor/src/core/layout/layout-helpers.ts
@@ -278,11 +278,19 @@ export const LayoutHelpers = {
   setLayoutAttribute: (newValue: LayoutSystem) => (
     props: JSXAttributes,
   ): Either<string, JSXAttributes> => {
-    return setJSXValueAtPath(
-      props,
-      createLayoutPropertyPath('LayoutSystem'),
-      jsxAttributeValue(newValue),
-    )
+    if (newValue === LayoutSystem.PinSystem) {
+      return setJSXValueAtPath(
+        props,
+        createLayoutPropertyPath('position'),
+        jsxAttributeValue('absolute'),
+      )
+    } else {
+      return setJSXValueAtPath(
+        props,
+        createLayoutPropertyPath('LayoutSystem'),
+        jsxAttributeValue(newValue),
+      )
+    }
   },
   stretchesChild(
     parentProps: PropsOrJSXAttributes,

--- a/editor/src/core/layout/layout-utils.spec.browser.ts
+++ b/editor/src/core/layout/layout-utils.spec.browser.ts
@@ -135,7 +135,7 @@ describe('maybeSwitchLayoutProps', () => {
             style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202, display: 'flex' }}
             data-uid={'bbb'}
           >
-            <View style={{}} data-uid={'catdog'} />
+            <View style={{ position: 'relative' }} data-uid={'catdog'} />
           </View>
         </View>`,
       ),

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -315,7 +315,12 @@ export function switchPinnedChildToFlex(
   const newParent = findJSXElementAtPath(newParentPath, components)
   const element = findJSXElementAtPath(target, components)
 
-  let propsToAdd: Array<ValueAtPath> = []
+  let propsToAdd: Array<ValueAtPath> = [
+    {
+      path: createLayoutPropertyPath('position'),
+      value: jsxAttributeValue('relative'),
+    },
+  ]
 
   if (currentFrame != null && newParent != null && element != null) {
     // When moving pinned to flex, use width and height to set basis values
@@ -349,6 +354,7 @@ export function switchPinnedChildToFlex(
     const pinnedPropsRemoved = unsetJSXValuesAtPaths(e.props, [
       ...AllFramePoints.map((p) => createLayoutPropertyPath(pinnedPropForFramePoint(p))),
       createLayoutPropertyPath('position'),
+      createLayoutPropertyPath('LayoutSystem'),
     ])
     // ...Add in the flex properties.
     const flexPropsAdded = flatMapEither(

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -346,10 +346,10 @@ export function switchPinnedChildToFlex(
 
   const updatedComponents = transformElementAtPath(components, target, (e: JSXElement) => {
     // Remove the pinning props first...
-    const pinnedPropsRemoved = unsetJSXValuesAtPaths(
-      e.props,
-      AllFramePoints.map((p) => createLayoutPropertyPath(pinnedPropForFramePoint(p))),
-    )
+    const pinnedPropsRemoved = unsetJSXValuesAtPaths(e.props, [
+      ...AllFramePoints.map((p) => createLayoutPropertyPath(pinnedPropForFramePoint(p))),
+      createLayoutPropertyPath('position'),
+    ])
     // ...Add in the flex properties.
     const flexPropsAdded = flatMapEither(
       (props) => setJSXValuesAtPaths(props, propsToAdd),
@@ -729,6 +729,7 @@ function removeFlexAndAddPinnedPropsToComponent(
     { path: createLayoutPropertyPath('PinnedTop'), value: jsxAttributeValue(top) },
     { path: createLayoutPropertyPath('Width'), value: jsxAttributeValue(width) },
     { path: createLayoutPropertyPath('Height'), value: jsxAttributeValue(height) },
+    { path: createLayoutPropertyPath('position'), value: jsxAttributeValue('absolute') },
   ]
   const propsToRemove: Array<LayoutProp | StyleLayoutProp> = ['FlexFlexBasis', 'FlexCrossBasis']
 

--- a/editor/src/core/model/new-project-files.ts
+++ b/editor/src/core/model/new-project-files.ts
@@ -18,13 +18,12 @@ import { Scene, Storyboard, jsx } from 'utopia-api'
 export var App = (props) => {
   return (
     <div
-      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
-      layout={{ layoutSystem: 'pinSystem' }}
+      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}
     />
   )
 }
 export var storyboard = (
-  <Storyboard layout={{ layoutSystem: 'pinSystem' }}>
+  <Storyboard>
     <Scene
       component={App}
       props={{}}


### PR DESCRIPTION
Fixes #750 

It is the first step to removing the layout property, this PR removes layoutSystem: pinSystem from:
- the default project
- for inserted elements it's replaced with `position: absolute` for non-flex elements. because the defaults give style properties, this changes depending on the parent target while in insertion mode.
- reparenting adds or removes `position: absolute` depending on flex or non-flex parent
