### PR TITLE
Feature/inspector canvas layoutprops

### DIFF
--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1252,7 +1252,7 @@ describe('moveTemplate', () => {
           >
             <View data-uid={'ccc'} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
           </View>
-          <View data-uid={'eee'} layout={{ layoutSystem: 'pinSystem' }} style={{ left: 50, top: 175, width: 80, height: 80 }}/>
+          <View data-uid={'eee'} style={{ position: 'absolute', left: 50, top: 175, width: 80, height: 80 }}/>
         </View>
       `),
     )
@@ -1275,7 +1275,7 @@ describe('moveTemplate', () => {
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
-            <View data-uid={'eee'} layout={{}} style={{ position: 'relative', flexBasis: 80, height: 80 }} />
+            <View data-uid={'eee'} style={{ position: 'relative', flexBasis: 80, height: 80 }} />
           </View>
         </View>
       `),
@@ -1292,7 +1292,7 @@ describe('moveTemplate', () => {
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
           </View>
-          <View data-uid={'eee'} style={{ backgroundColor: '#00ff00', left: 150, top: 250, width: 80, height: 80 }} layout={{ layoutSystem: 'pinSystem' }}/>
+          <View data-uid={'eee'} style={{ position: 'absolute', backgroundColor: '#00ff00', left: 150, top: 250, width: 80, height: 80 }}/>
         </View>
       `),
     )
@@ -1381,7 +1381,7 @@ describe('moveTemplate', () => {
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
-            <View data-uid={'eee'} style={{ backgroundColor: '#00ff00', position: 'relative', flexBasis: 80, height: 80 }} layout={{}} />
+            <View data-uid={'eee'} style={{ backgroundColor: '#00ff00', position: 'relative', flexBasis: 80, height: 80 }} />
           </View>
         </View>
       `),

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1275,7 +1275,7 @@ describe('moveTemplate', () => {
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
-            <View data-uid={'eee'} layout={{ flexBasis: 80, crossBasis: 80 }} style={{ position: 'relative' }} />
+            <View data-uid={'eee'} layout={{}} style={{ position: 'relative', flexBasis: 80, height: 80 }} />
           </View>
         </View>
       `),
@@ -1381,7 +1381,7 @@ describe('moveTemplate', () => {
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
-            <View data-uid={'eee'} style={{ backgroundColor: '#00ff00', position: 'relative' }} layout={{ flexBasis: 80, crossBasis: 80 }} />
+            <View data-uid={'eee'} style={{ backgroundColor: '#00ff00', position: 'relative', flexBasis: 80, height: 80 }} layout={{}} />
           </View>
         </View>
       `),
@@ -1486,9 +1486,8 @@ describe('moveTemplate', () => {
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ flexBasis: 20, crossBasis: 20 }} />
             <View
-              style={{ backgroundColor: '#0091FFAA', position: 'relative' }}
+              style={{ backgroundColor: '#0091FFAA', position: 'relative', flexBasis: 75, height: 75 }}
               data-uid={'${NewUID}'}
-              layout={{ flexBasis: 75, crossBasis: 75 }}
             />
           </View>
         </View>

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -489,17 +489,23 @@ export function updateFramesOfScenesAndComponents(
                   frameAndTarget.edgePosition,
                 )
                 forEachRight(possibleFlexProps, (flexProps) => {
-                  const { flexBasis, crossBasis } = flexProps
+                  const { flexBasis, width, height } = flexProps
                   if (flexBasis != null) {
                     propsToSet.push({
                       path: createLayoutPropertyPath('FlexFlexBasis'),
                       value: jsxAttributeValue(flexBasis),
                     })
                   }
-                  if (crossBasis != null) {
+                  if (width != null) {
                     propsToSet.push({
-                      path: createLayoutPropertyPath('FlexCrossBasis'),
-                      value: jsxAttributeValue(crossBasis),
+                      path: createLayoutPropertyPath('Width'),
+                      value: jsxAttributeValue(width),
+                    })
+                  }
+                  if (height != null) {
+                    propsToSet.push({
+                      path: createLayoutPropertyPath('Height'),
+                      value: jsxAttributeValue(height),
                     })
                   }
                 })

--- a/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
+++ b/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
@@ -24,10 +24,6 @@ Array [
               "type": "ATTRIBUTE_VALUE",
               "value": "bbb",
             },
-            "layout": Object {
-              "content": Array [],
-              "type": "ATTRIBUTE_NESTED_OBJECT",
-            },
             "style": Object {
               "content": Array [
                 Object {
@@ -146,8 +142,16 @@ Array [
               "type": "ATTRIBUTE_VALUE",
               "value": "bbb",
             },
-            "layout": Object {
+            "style": Object {
               "content": Array [
+                Object {
+                  "key": "position",
+                  "type": "PROPERTY_ASSIGNMENT",
+                  "value": Object {
+                    "type": "ATTRIBUTE_VALUE",
+                    "value": "relative",
+                  },
+                },
                 Object {
                   "key": "flexBasis",
                   "type": "PROPERTY_ASSIGNMENT",
@@ -157,24 +161,11 @@ Array [
                   },
                 },
                 Object {
-                  "key": "crossBasis",
+                  "key": "height",
                   "type": "PROPERTY_ASSIGNMENT",
                   "value": Object {
                     "type": "ATTRIBUTE_VALUE",
                     "value": 300,
-                  },
-                },
-              ],
-              "type": "ATTRIBUTE_NESTED_OBJECT",
-            },
-            "style": Object {
-              "content": Array [
-                Object {
-                  "key": "position",
-                  "type": "PROPERTY_ASSIGNMENT",
-                  "value": Object {
-                    "type": "ATTRIBUTE_VALUE",
-                    "value": "relative",
                   },
                 },
               ],

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4491,7 +4491,7 @@ const layoutEmptyValuesNew: LayoutPropertyTypes = {
   Width: undefined,
   Height: undefined,
 
-  FlexGapMain: 0,
+  FlexGap: 0,
   FlexFlexBasis: undefined,
   FlexCrossBasis: undefined,
 
@@ -4513,7 +4513,7 @@ const layoutParsersNew: LayoutParsersNew = {
   Width: parseFramePin,
   Height: parseFramePin,
 
-  FlexGapMain: isNumberParser,
+  FlexGap: isNumberParser,
   FlexFlexBasis: parseFramePin,
   FlexCrossBasis: parseFramePin,
 
@@ -4535,7 +4535,7 @@ const layoutPrintersNew: LayoutPrintersNew = {
   Width: jsxAttributeValue,
   Height: jsxAttributeValue,
 
-  FlexGapMain: jsxAttributeValue,
+  FlexGap: jsxAttributeValue,
   FlexFlexBasis: jsxAttributeValue,
   FlexCrossBasis: jsxAttributeValue,
 

--- a/editor/src/components/inspector/controls/pin-control.tsx
+++ b/editor/src/components/inspector/controls/pin-control.tsx
@@ -204,7 +204,7 @@ export const PinControl = (props: PinControlProps) => {
               id='positioncontrols-pin-centerx-transparent'
               stroke='transparent'
               fill='transparent'
-              onMouseDown={handlePinMouseDown('PinnedCenterX')}
+              onMouseDown={Utils.NO_OP}
             />
             <path
               d={`M 0,0 ${HorizontalDividerWidth},0 0,${VerticalDividerHeight} ${HorizontalDividerWidth},${VerticalDividerHeight} z`}
@@ -212,7 +212,7 @@ export const PinControl = (props: PinControlProps) => {
               id='positioncontrols-pin-centery-transparent'
               stroke='transparent'
               fill='transparent'
-              onMouseDown={handlePinMouseDown('PinnedCenterY')}
+              onMouseDown={Utils.NO_OP}
             />
           </g>
         </g>

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -277,8 +277,6 @@ RenderedLayoutSection.displayName = 'RenderedLayoutSection'
 const nonDefaultPositionPaths: Array<PropertyPath> = [
   createLayoutPropertyPath('PinnedRight'),
   createLayoutPropertyPath('PinnedBottom'),
-  createLayoutPropertyPath('PinnedCenterX'),
-  createLayoutPropertyPath('PinnedCenterY'),
 ]
 
 export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: InspectorProps) => {

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
@@ -17,7 +17,7 @@ import { PropertyLabel } from '../../../widgets/property-label'
 import { createLayoutPropertyPath } from '../../../../../core/layout/layout-helpers-new'
 import { useWrappedEmptyOrUnknownOnSubmitValue } from '../../../../../uuiui'
 
-const flexGapProp = [createLayoutPropertyPath('FlexGapMain')]
+const flexGapProp = [createLayoutPropertyPath('FlexGap')]
 const alignItemsProp = [createLayoutPropertyPath('alignItems')]
 
 export const FlexContainerControls = betterReactMemo<{ seeMoreVisible: boolean }>(
@@ -29,7 +29,7 @@ export const FlexContainerControls = betterReactMemo<{ seeMoreVisible: boolean }
     const alignItems = useInspectorLayoutInfo('alignItems')
     const alignContent = useInspectorLayoutInfo('alignContent')
     const justifyContent = useInspectorLayoutInfo('justifyContent')
-    const flexGapMain = useInspectorLayoutInfo('FlexGapMain')
+    const flexGap = useInspectorLayoutInfo('FlexGap')
 
     const {
       justifyFlexStart,
@@ -47,12 +47,12 @@ export const FlexContainerControls = betterReactMemo<{ seeMoreVisible: boolean }
       flexWrap.value === FlexWrap.NoWrap ? getControlStyles('disabled') : alignItems.controlStyles
 
     const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      flexGapMain.onSubmitValue,
-      flexGapMain.onUnsetValues,
+      flexGap.onSubmitValue,
+      flexGap.onUnsetValues,
     )
     const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      flexGapMain.onSubmitValue,
-      flexGapMain.onUnsetValues,
+      flexGap.onSubmitValue,
+      flexGap.onUnsetValues,
     )
 
     return (
@@ -80,12 +80,12 @@ export const FlexContainerControls = betterReactMemo<{ seeMoreVisible: boolean }
         <GridRow padded={true} type='<---1fr--->|------172px-------|'>
           <PropertyLabel target={flexGapProp}>Gap</PropertyLabel>
           <FlexGapControl
-            value={flexGapMain.value}
+            value={flexGap.value}
             onSubmitValue={wrappedOnSubmitValue}
             onTransientSubmitValue={wrappedOnTransientSubmitValue}
-            onUnset={flexGapMain.onUnsetValues}
-            controlStatus={flexGapMain.controlStatus}
-            controlStyles={flexGapMain.controlStyles}
+            onUnset={flexGap.onUnsetValues}
+            controlStatus={flexGap.controlStatus}
+            controlStyles={flexGap.controlStyles}
           />
         </GridRow>
         <GridRow padded={true} type='<---1fr--->|------172px-------|'>

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -258,7 +258,7 @@ const layoutSystemConfigPropertyPaths = [
   createLayoutPropertyPath('LayoutSystem'),
   PP.create(['style', 'display']),
   createLayoutPropertyPath('flexDirection'),
-  createLayoutPropertyPath('FlexGapMain'),
+  createLayoutPropertyPath('FlexGap'),
   createLayoutPropertyPath('flexWrap'),
   createLayoutPropertyPath('justifyContent'),
   createLayoutPropertyPath('alignItems'),

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -399,37 +399,39 @@ const OtherPinsRow = betterReactMemo('OtherPinsRow', (props: PinControlsProps) =
   let secondXAxisControl: React.ReactElement = <div />
   let firstYAxisControl: React.ReactElement = <div />
   let secondYAxisControl: React.ReactElement = <div />
-  const centerXInfo = useInspectorLayoutInfo('PinnedCenterX')
-  const topInfo = useInspectorLayoutInfo('PinnedTop')
-  if (centerXInfo.value == null) {
-    // No CenterX value, just show top and bottom.
-    firstXAxisControl = pinsLayoutNumberControl(frame, 'PinnedTop')
-    secondXAxisControl = pinsLayoutNumberControl(frame, 'PinnedBottom')
-  } else {
-    // We have a CenterX value, so put that first and then top or bottom after it.
-    firstXAxisControl = pinsLayoutNumberControl(frame, 'PinnedCenterX')
-    if (topInfo.value == null) {
-      secondXAxisControl = pinsLayoutNumberControl(frame, 'PinnedBottom')
-    } else {
-      secondXAxisControl = pinsLayoutNumberControl(frame, 'PinnedTop')
-    }
-  }
+  // TODO LAYOUT update these when there are new ways to set centerX/centerY
+  // const centerXInfo = useInspectorLayoutInfo('PinnedCenterX')
+  // const topInfo = useInspectorLayoutInfo('PinnedTop')
+  // if (centerXInfo.value == null) {
+  // No CenterX value, just show top and bottom.
+  firstXAxisControl = pinsLayoutNumberControl(frame, 'PinnedTop')
+  secondXAxisControl = pinsLayoutNumberControl(frame, 'PinnedBottom')
+  // } else {
+  //   // We have a CenterX value, so put that first and then top or bottom after it.
+  //   firstXAxisControl = pinsLayoutNumberControl(frame, 'PinnedCenterX')
+  //   if (topInfo.value == null) {
+  //     secondXAxisControl = pinsLayoutNumberControl(frame, 'PinnedBottom')
+  //   } else {
+  //     secondXAxisControl = pinsLayoutNumberControl(frame, 'PinnedTop')
+  //   }
+  // }
 
-  const centerYInfo = useInspectorLayoutInfo('PinnedCenterY')
-  const leftInfo = useInspectorLayoutInfo('PinnedLeft')
-  if (centerYInfo.value == null) {
-    // No CenterY value, just show left and right.
-    firstYAxisControl = pinsLayoutNumberControl(frame, 'PinnedLeft')
-    secondYAxisControl = pinsLayoutNumberControl(frame, 'PinnedRight')
-  } else {
-    // We have a CenterY value, so put that first and then left or right after it.
-    firstYAxisControl = pinsLayoutNumberControl(frame, 'PinnedCenterY')
-    if (leftInfo.value == null) {
-      secondYAxisControl = pinsLayoutNumberControl(frame, 'PinnedRight')
-    } else {
-      secondYAxisControl = pinsLayoutNumberControl(frame, 'PinnedLeft')
-    }
-  }
+  // TODO LAYOUT update these when there are new ways to set centerX/centerY
+  // const centerYInfo = useInspectorLayoutInfo('PinnedCenterY')
+  // const leftInfo = useInspectorLayoutInfo('PinnedLeft')
+  // if (centerYInfo.value == null) {
+  // No CenterY value, just show left and right.
+  firstYAxisControl = pinsLayoutNumberControl(frame, 'PinnedLeft')
+  secondYAxisControl = pinsLayoutNumberControl(frame, 'PinnedRight')
+  // } else {
+  //   // We have a CenterY value, so put that first and then left or right after it.
+  //   firstYAxisControl = pinsLayoutNumberControl(frame, 'PinnedCenterY')
+  //   if (leftInfo.value == null) {
+  //     secondYAxisControl = pinsLayoutNumberControl(frame, 'PinnedRight')
+  //   } else {
+  //     secondYAxisControl = pinsLayoutNumberControl(frame, 'PinnedLeft')
+  //   }
+  // }
 
   return (
     <GridRow

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -263,10 +263,8 @@ const WidthHeightRow = betterReactMemo('WidthHeightRow', (props: WidthHeightRowP
       case 'horizontal':
       case null:
         widthControl = flexLayoutNumberControl('W', 'FlexFlexBasis')
-        heightControl = flexLayoutNumberControl('H', 'FlexCrossBasis')
         break
       case 'vertical':
-        widthControl = flexLayoutNumberControl('W', 'FlexCrossBasis')
         heightControl = flexLayoutNumberControl('H', 'FlexFlexBasis')
         break
       default:

--- a/editor/src/components/inspector/sections/scene-inspector/scene-container-section.tsx
+++ b/editor/src/components/inspector/sections/scene-inspector/scene-container-section.tsx
@@ -45,15 +45,15 @@ export const SceneFlexContainerSection = betterReactMemo('SceneFlexContainerSect
   const alignItems = useInspectorLayoutInfo('alignItems')
   const alignContent = useInspectorLayoutInfo('alignContent')
   const justifyContent = useInspectorLayoutInfo('justifyContent')
-  const flexGapMain = useInspectorLayoutInfo('FlexGapMain')
+  const flexGap = useInspectorLayoutInfo('FlexGap')
 
   const wrappedFlexGapOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-    flexGapMain.onSubmitValue,
-    flexGapMain.onUnsetValues,
+    flexGap.onSubmitValue,
+    flexGap.onUnsetValues,
   )
   const wrappedFlexGapOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-    flexGapMain.onSubmitValue,
-    flexGapMain.onUnsetValues,
+    flexGap.onSubmitValue,
+    flexGap.onUnsetValues,
   )
 
   if (styleDisplayMetadata.value === 'flex') {
@@ -67,7 +67,7 @@ export const SceneFlexContainerSection = betterReactMemo('SceneFlexContainerSect
       cssEmptyValues.justifyContent,
       justifyContent.value,
     )
-    const flexGapMainValue = Utils.defaultIfNull(layoutEmptyValues.gapMain, flexGapMain.value)
+    const flexGapValue = Utils.defaultIfNull(layoutEmptyValues.gapMain, flexGap.value)
     const alignContentValue = Utils.defaultIfNull(cssEmptyValues.alignContent, alignContent.value)
 
     const {
@@ -122,10 +122,10 @@ export const SceneFlexContainerSection = betterReactMemo('SceneFlexContainerSect
         <PropertyRow>
           <span>Gap</span>
           <FlexGapControl
-            value={flexGapMainValue}
+            value={flexGapValue}
             onSubmitValue={wrappedFlexGapOnSubmitValue}
             onTransientSubmitValue={wrappedFlexGapOnTransientSubmitValue}
-            onUnset={flexGapMain.onUnsetValues}
+            onUnset={flexGap.onUnsetValues}
             controlStatus={simpleControlStatus}
             controlStyles={simpleControlStyles}
           />

--- a/editor/src/components/inspector/utility-controls/pin-control.tsx
+++ b/editor/src/components/inspector/utility-controls/pin-control.tsx
@@ -204,7 +204,7 @@ export const PinControl = (props: PinControlProps) => {
               id='positioncontrols-pin-centerx-transparent'
               stroke='transparent'
               fill='transparent'
-              onMouseDown={handlePinMouseDown('PinnedCenterX')}
+              onMouseDown={Utils.NO_OP}
             />
             <path
               d={`M 0,0 ${HorizontalDividerWidth},0 0,${VerticalDividerHeight} ${HorizontalDividerWidth},${VerticalDividerHeight} z`}
@@ -212,7 +212,7 @@ export const PinControl = (props: PinControlProps) => {
               id='positioncontrols-pin-centery-transparent'
               stroke='transparent'
               fill='transparent'
-              onMouseDown={handlePinMouseDown('PinnedCenterY')}
+              onMouseDown={Utils.NO_OP}
             />
           </g>
         </g>

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -119,11 +119,11 @@ const LayoutPathMap: { [key in LayoutProp | StyleLayoutProp]: Array<PropertyPath
   LayoutSystem: ['layout', 'layoutSystem'],
   PinnedCenterX: ['layout', 'centerX'],
   PinnedCenterY: ['layout', 'centerY'],
-  FlexFlexBasis: ['layout', 'flexBasis'],
   FlexCrossBasis: ['layout', 'crossBasis'],
 
   // TODO FIXME 'style' here should point to the inspector target selector's current target instead of always pointing to style
   FlexGap: ['style', 'gap'],
+  FlexFlexBasis: ['style', 'flexBasis'],
   PinnedLeft: ['style', 'left'],
   PinnedTop: ['style', 'top'],
   Width: ['style', 'width'],

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -6,7 +6,7 @@ import { ParsedCSSProperties } from '../../components/inspector/common/css-utils
 
 export type LayoutDimension = 'Width' | 'Height'
 
-export type LayoutFlexContainerProp = LayoutDimension | 'FlexGapMain'
+export type LayoutFlexContainerProp = LayoutDimension | 'FlexGap'
 
 export type LayoutFlexElementNumericProp = 'Width' | 'Height' | 'FlexFlexBasis' | 'FlexCrossBasis'
 
@@ -123,7 +123,7 @@ const LayoutPathMap: { [key in LayoutProp | StyleLayoutProp]: Array<PropertyPath
   FlexCrossBasis: ['layout', 'crossBasis'],
 
   // TODO FIXME 'style' here should point to the inspector target selector's current target instead of always pointing to style
-  FlexGapMain: ['style', 'gap'],
+  FlexGap: ['style', 'gap'],
   PinnedLeft: ['style', 'left'],
   PinnedTop: ['style', 'top'],
   Width: ['style', 'width'],
@@ -165,7 +165,7 @@ export interface LayoutPropertyTypes {
   Width: FramePin | undefined
   Height: FramePin | undefined
 
-  FlexGapMain: number
+  FlexGap: number
   FlexFlexBasis: FlexLength
   FlexCrossBasis: FlexLength
 

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -115,15 +115,15 @@ export function pinnedPropForFramePoint(point: FramePoint): LayoutPinnedProp {
 }
 
 const LayoutPathMap: { [key in LayoutProp | StyleLayoutProp]: Array<PropertyPathPart> } = {
+  // TODO LAYOUT remove these once no place uses it
   LayoutSystem: ['layout', 'layoutSystem'],
   PinnedCenterX: ['layout', 'centerX'],
   PinnedCenterY: ['layout', 'centerY'],
-  FlexGapMain: ['layout', 'gapMain'],
-
   FlexFlexBasis: ['layout', 'flexBasis'],
   FlexCrossBasis: ['layout', 'crossBasis'],
 
   // TODO FIXME 'style' here should point to the inspector target selector's current target instead of always pointing to style
+  FlexGapMain: ['style', 'gap'],
   PinnedLeft: ['style', 'left'],
   PinnedTop: ['style', 'top'],
   Width: ['style', 'width'],

--- a/editor/src/core/layout/layout-helpers.ts
+++ b/editor/src/core/layout/layout-helpers.ts
@@ -246,16 +246,10 @@ export const FlexLayoutHelpers = {
       return {
         flexBasis: currentFlexBasis != null || shouldSetFlexBasis ? flexBasis : null,
         width:
-          mainAxis === 'vertical'
-            ? currentWidth != null || shouldSetCrossBasis
-              ? width
-              : null
-            : null,
+          mainAxis === 'vertical' && (currentWidth != null || shouldSetCrossBasis) ? width : null,
         height:
-          mainAxis === 'horizontal'
-            ? currentHeight != null || shouldSetCrossBasis
-              ? height
-              : null
+          mainAxis === 'horizontal' && (currentHeight != null || shouldSetCrossBasis)
+            ? height
             : null,
       }
     }, possibleMainAxis)

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -247,13 +247,9 @@ function getLayoutFunction(
   }
 }
 
-export const PinningAndFlexPoints = [...AllFramePoints, 'FlexFlexBasis', 'FlexCrossBasis']
+export const PinningAndFlexPoints = [...AllFramePoints, 'FlexFlexBasis']
 
-export const PinningAndFlexPointsExceptSize = [
-  ...AllFramePointsExceptSize,
-  'FlexFlexBasis',
-  'FlexCrossBasis',
-]
+export const PinningAndFlexPointsExceptSize = [...AllFramePointsExceptSize, 'FlexFlexBasis']
 
 function keepLayoutProps(
   target: InstancePath,
@@ -333,17 +329,23 @@ export function switchPinnedChildToFlex(
     )
 
     forEachRight(possibleFlexProps, (flexProps) => {
-      const { flexBasis, crossBasis } = flexProps
+      const { flexBasis, width, height } = flexProps
       if (flexBasis != null) {
         propsToAdd.push({
           path: createLayoutPropertyPath('FlexFlexBasis'),
           value: jsxAttributeValue(flexBasis),
         })
       }
-      if (crossBasis != null) {
+      if (width != null) {
         propsToAdd.push({
-          path: createLayoutPropertyPath('FlexCrossBasis'),
-          value: jsxAttributeValue(crossBasis),
+          path: createLayoutPropertyPath('Width'),
+          value: jsxAttributeValue(width),
+        })
+      }
+      if (height != null) {
+        propsToAdd.push({
+          path: createLayoutPropertyPath('Height'),
+          value: jsxAttributeValue(height),
         })
       }
     })

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -304,9 +304,9 @@ export const MetadataUtils = {
           const element = findJSXElementChildAtPath(components, staticTarget)
           if (element != null && isJSXElement(element)) {
             const widthLookupAxis: LayoutProp =
-              flexDirection === 'horizontal' ? 'FlexFlexBasis' : 'FlexCrossBasis'
+              flexDirection === 'horizontal' ? 'FlexFlexBasis' : 'Width'
             const heightLookupAxis: LayoutProp =
-              flexDirection === 'vertical' ? 'FlexFlexBasis' : 'FlexCrossBasis'
+              flexDirection === 'vertical' ? 'FlexFlexBasis' : 'Height'
             let result: Partial<Size> = {}
             const width: Either<string, FlexLength> = alternativeEither(
               getLayoutProperty(widthLookupAxis, right(element.props)),


### PR DESCRIPTION
Closes https://github.com/concrete-utopia/utopia/issues/769

Changed all places where the editor updates something inside the layout properties.
- layout.FlexBasis is now style.flexBasis
- layout.FlexGapMain is using the new browser feature style.gap

Removed:
- CrossBasis, this will change now the width or height depending on the flex direction in the update actions, removed crossBasis from the inspector
- CenterX, CenterY removed it from the inspector, it's still visible on the nice pin control but ignores onMouseDown. Made it into a TODO in the subsection because later we would like to reintroduce them differently.