### PR TITLE
Make Emotion use globalThis.

### DIFF
--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -26883,6 +26883,11 @@
             "@babel/types": "^7.12.5"
           }
         },
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+        },
         "@babel/helper-validator-identifier": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
@@ -26896,6 +26901,14 @@
             "@babel/helper-validator-identifier": "^7.10.4",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/plugin-syntax-jsx": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz",
+          "integrity": "sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
         "@babel/runtime": {
@@ -26916,6 +26929,25 @@
             "to-fast-properties": "^2.0.0"
           }
         },
+        "@emotion/babel-plugin": {
+          "version": "11.1.2",
+          "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.1.2.tgz",
+          "integrity": "sha512-Nz1k7b11dWw8Nw4Z1R99A9mlB6C6rRsCtZnwNUOj4NsoZdrO2f2A/83ST7htJORD5zpOiLKY59aJN23092949w==",
+          "requires": {
+            "@babel/helper-module-imports": "^7.7.0",
+            "@babel/plugin-syntax-jsx": "^7.12.1",
+            "@babel/runtime": "^7.7.2",
+            "@emotion/hash": "^0.8.0",
+            "@emotion/memoize": "^0.7.5",
+            "@emotion/serialize": "^1.0.0",
+            "babel-plugin-macros": "^2.6.1",
+            "convert-source-map": "^1.5.0",
+            "escape-string-regexp": "^4.0.0",
+            "find-root": "^1.1.0",
+            "source-map": "^0.5.7",
+            "stylis": "^4.0.3"
+          }
+        },
         "@emotion/cache": {
           "version": "10.0.29",
           "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -26923,7 +26955,6 @@
           "requires": {
             "@emotion/sheet": "0.9.4",
             "@emotion/stylis": "0.8.5",
-            "@emotion/utils": "0.11.3",
             "@emotion/weak-memoize": "0.2.5"
           }
         },
@@ -26935,20 +26966,13 @@
             "@babel/runtime": "^7.5.5",
             "@emotion/cache": "^10.0.27",
             "@emotion/css": "^10.0.27",
-            "@emotion/serialize": "^0.11.15",
-            "@emotion/sheet": "0.9.4",
-            "@emotion/utils": "0.11.3"
+            "@emotion/sheet": "0.9.4"
           }
         },
         "@emotion/css": {
           "version": "10.0.27",
           "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
-          "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-          "requires": {
-            "@emotion/serialize": "^0.11.15",
-            "@emotion/utils": "0.11.3",
-            "babel-plugin-emotion": "^10.0.27"
-          }
+          "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw=="
         },
         "@emotion/hash": {
           "version": "0.8.0",
@@ -26956,28 +26980,61 @@
           "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
         },
         "@emotion/is-prop-valid": {
-          "version": "0.8.8",
-          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-          "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.0.0.tgz",
+          "integrity": "sha512-G5X0t7eR9pkhUvAY32QS3lToP9JyNF8It5CcmMvbWjmC9/Yq7IhevaKqxl+me2BKR93iTPiL/h3En1ZX/1G3PQ==",
           "requires": {
-            "@emotion/memoize": "0.7.4"
+            "@emotion/memoize": "^0.7.4"
           }
         },
         "@emotion/memoize": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+          "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+        },
+        "@emotion/react": {
+          "version": "11.1.2",
+          "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.1.2.tgz",
+          "integrity": "sha512-zEpxynUhHm2GqjY556RnA12Ijt0v6rYUwV6WliyGoFbQKJKkXFuTzGHGQx4UY2jKUV1I4yjr66Ajj/qoQMVPeQ==",
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@emotion/cache": "^11.0.0",
+            "@emotion/serialize": "^1.0.0",
+            "@emotion/sheet": "^1.0.1",
+            "@emotion/utils": "^1.0.0",
+            "@emotion/weak-memoize": "^0.2.5",
+            "hoist-non-react-statics": "^3.3.1"
+          },
+          "dependencies": {
+            "@emotion/cache": {
+              "version": "11.0.0",
+              "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.0.0.tgz",
+              "integrity": "sha512-NStfcnLkL5vj3mBILvkR2m/5vFxo3G0QEreYKDGHNHm9IMYoT/t3j6xwjx6lMI/S1LUJfVHQqn0m9wSINttTTQ==",
+              "requires": {
+                "@emotion/memoize": "^0.7.4",
+                "@emotion/sheet": "^1.0.0",
+                "@emotion/utils": "^1.0.0",
+                "@emotion/weak-memoize": "^0.2.5",
+                "stylis": "^4.0.3"
+              }
+            },
+            "@emotion/sheet": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.1.tgz",
+              "integrity": "sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g=="
+            }
+          }
         },
         "@emotion/serialize": {
-          "version": "0.11.16",
-          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-          "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.0.tgz",
+          "integrity": "sha512-zt1gm4rhdo5Sry8QpCOpopIUIKU+mUSpV9WNmFILUraatm5dttNEaYzUWWSboSMUE6PtN2j1cAsuvcugfdI3mw==",
           "requires": {
-            "@emotion/hash": "0.8.0",
-            "@emotion/memoize": "0.7.4",
-            "@emotion/unitless": "0.7.5",
-            "@emotion/utils": "0.11.3",
-            "csstype": "^2.5.7"
+            "@emotion/hash": "^0.8.0",
+            "@emotion/memoize": "^0.7.4",
+            "@emotion/unitless": "^0.7.5",
+            "@emotion/utils": "^1.0.0",
+            "csstype": "^3.0.2"
           }
         },
         "@emotion/sheet": {
@@ -26986,24 +27043,21 @@
           "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
         },
         "@emotion/styled": {
-          "version": "10.0.27",
-          "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
-          "integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.0.0.tgz",
+          "integrity": "sha512-498laccxJlBiJqrr2r/fx9q+Pr55D0URP2UyOkoSGLjevb8LLAFWueqthsQ5XijE66iGo7y3rzzEYdA7CHmZEQ==",
           "requires": {
-            "@emotion/styled-base": "^10.0.27",
-            "babel-plugin-emotion": "^10.0.27"
+            "@babel/runtime": "^7.7.2",
+            "@emotion/babel-plugin": "^11.0.0",
+            "@emotion/is-prop-valid": "^1.0.0",
+            "@emotion/serialize": "^1.0.0",
+            "@emotion/utils": "^1.0.0"
           }
         },
         "@emotion/styled-base": {
-          "version": "10.0.31",
-          "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.31.tgz",
-          "integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
-          "requires": {
-            "@babel/runtime": "^7.5.5",
-            "@emotion/is-prop-valid": "0.8.8",
-            "@emotion/serialize": "^0.11.15",
-            "@emotion/utils": "0.11.3"
-          }
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-11.0.0.tgz",
+          "integrity": "sha512-/NY/PXrQkl/wI0+0E3QWd+m9kMg7h4THmjbPEe0VVnplNtdJC6db0VHDqmaC2tsEDcda6zvy3b8giM9DHa6BLw=="
         },
         "@emotion/stylis": {
           "version": "0.8.5",
@@ -27016,9 +27070,9 @@
           "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
         },
         "@emotion/utils": {
-          "version": "0.11.3",
-          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-          "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+          "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
         },
         "@emotion/weak-memoize": {
           "version": "0.2.5",
@@ -27043,23 +27097,6 @@
           "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
         },
-        "babel-plugin-emotion": {
-          "version": "10.0.33",
-          "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
-          "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@emotion/hash": "0.8.0",
-            "@emotion/memoize": "0.7.4",
-            "@emotion/serialize": "^0.11.16",
-            "babel-plugin-macros": "^2.0.0",
-            "babel-plugin-syntax-jsx": "^6.18.0",
-            "convert-source-map": "^1.5.0",
-            "escape-string-regexp": "^1.0.5",
-            "find-root": "^1.1.0",
-            "source-map": "^0.5.7"
-          }
-        },
         "babel-plugin-macros": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
@@ -27069,11 +27106,6 @@
             "cosmiconfig": "^6.0.0",
             "resolve": "^1.12.0"
           }
-        },
-        "babel-plugin-syntax-jsx": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-          "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
         },
         "callsites": {
           "version": "3.1.0",
@@ -27088,6 +27120,13 @@
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            }
           }
         },
         "color-convert": {
@@ -27129,9 +27168,9 @@
           }
         },
         "csstype": {
-          "version": "2.6.14",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
-          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
         },
         "draft-js": {
           "version": "git://github.com/concrete-utopia/draft-js.git#6b211318785d16f6b8d391cd0eb18f0203afba6b",
@@ -27177,9 +27216,9 @@
           }
         },
         "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         },
         "fbjs": {
           "version": "0.8.17",
@@ -27217,6 +27256,14 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
         },
         "iconv-lite": {
           "version": "0.6.2",
@@ -27356,6 +27403,11 @@
             "asap": "~2.0.3"
           }
         },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -27394,6 +27446,11 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "stylis": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.6.tgz",
+          "integrity": "sha512-1igcUEmYFBEO14uQHAJhCUelTR5jPztfdVKrYxRnDa5D5Dn3w0NxXupJNPr/VV/yRfZYEAco8sTIRZzH3sRYKg=="
         },
         "supports-color": {
           "version": "5.5.0",

--- a/editor/patches/@emotion+react+11.1.2.patch
+++ b/editor/patches/@emotion+react+11.1.2.patch
@@ -1,0 +1,65 @@
+diff --git a/node_modules/@emotion/react/dist/emotion-react.browser.cjs.js b/node_modules/@emotion/react/dist/emotion-react.browser.cjs.js
+index b688583..063ad1a 100644
+--- a/node_modules/@emotion/react/dist/emotion-react.browser.cjs.js
++++ b/node_modules/@emotion/react/dist/emotion-react.browser.cjs.js
+@@ -318,7 +318,7 @@ if (process.env.NODE_ENV !== 'production') {
+   var isJest = typeof jest !== 'undefined';
+ 
+   if (isBrowser && !isJest) {
+-    var globalContext = isBrowser ? window : global;
++    var globalContext = isBrowser ? globalThis : global;
+     var globalKey = "__EMOTION_REACT_" + pkg.version.split('.')[0] + "__";
+ 
+     if (globalContext[globalKey]) {
+diff --git a/node_modules/@emotion/react/dist/emotion-react.browser.esm.js b/node_modules/@emotion/react/dist/emotion-react.browser.esm.js
+index e0382e7..f3b93ff 100644
+--- a/node_modules/@emotion/react/dist/emotion-react.browser.esm.js
++++ b/node_modules/@emotion/react/dist/emotion-react.browser.esm.js
+@@ -315,7 +315,7 @@ if (process.env.NODE_ENV !== 'production') {
+   var isJest = typeof jest !== 'undefined';
+ 
+   if (isBrowser && !isJest) {
+-    var globalContext = isBrowser ? window : global;
++    var globalContext = isBrowser ? globalThis : global;
+     var globalKey = "__EMOTION_REACT_" + pkg.version.split('.')[0] + "__";
+ 
+     if (globalContext[globalKey]) {
+diff --git a/node_modules/@emotion/react/dist/emotion-react.cjs.dev.js b/node_modules/@emotion/react/dist/emotion-react.cjs.dev.js
+index ab7e485..b72e5cb 100644
+--- a/node_modules/@emotion/react/dist/emotion-react.cjs.dev.js
++++ b/node_modules/@emotion/react/dist/emotion-react.cjs.dev.js
+@@ -366,7 +366,7 @@ if (process.env.NODE_ENV !== 'production') {
+   var isJest = typeof jest !== 'undefined';
+ 
+   if (isBrowser && !isJest) {
+-    var globalContext = isBrowser ? window : global;
++    var globalContext = isBrowser ? globalThis : global;
+     var globalKey = "__EMOTION_REACT_" + pkg.version.split('.')[0] + "__";
+ 
+     if (globalContext[globalKey]) {
+diff --git a/node_modules/@emotion/react/dist/emotion-react.esm.js b/node_modules/@emotion/react/dist/emotion-react.esm.js
+index 2fe6811..8d814de 100644
+--- a/node_modules/@emotion/react/dist/emotion-react.esm.js
++++ b/node_modules/@emotion/react/dist/emotion-react.esm.js
+@@ -363,7 +363,7 @@ if (process.env.NODE_ENV !== 'production') {
+   var isJest = typeof jest !== 'undefined';
+ 
+   if (isBrowser && !isJest) {
+-    var globalContext = isBrowser ? window : global;
++    var globalContext = isBrowser ? globalThis : global;
+     var globalKey = "__EMOTION_REACT_" + pkg.version.split('.')[0] + "__";
+ 
+     if (globalContext[globalKey]) {
+diff --git a/node_modules/@emotion/react/src/index.js b/node_modules/@emotion/react/src/index.js
+index 7e472b6..6704bfe 100644
+--- a/node_modules/@emotion/react/src/index.js
++++ b/node_modules/@emotion/react/src/index.js
+@@ -15,7 +15,7 @@ if (process.env.NODE_ENV !== 'production') {
+   const isJest = typeof jest !== 'undefined'
+ 
+   if (isBrowser && !isJest) {
+-    const globalContext = isBrowser ? window : global
++    const globalContext = isBrowser ? globalThis : global
+     const globalKey = `__EMOTION_REACT_${pkg.version.split('.')[0]}__`
+     if (globalContext[globalKey]) {
+       console.warn(

--- a/utopia-api/patches/@emotion+react+11.1.2.patch
+++ b/utopia-api/patches/@emotion+react+11.1.2.patch
@@ -1,0 +1,65 @@
+diff --git a/node_modules/@emotion/react/dist/emotion-react.browser.cjs.js b/node_modules/@emotion/react/dist/emotion-react.browser.cjs.js
+index b688583..063ad1a 100644
+--- a/node_modules/@emotion/react/dist/emotion-react.browser.cjs.js
++++ b/node_modules/@emotion/react/dist/emotion-react.browser.cjs.js
+@@ -318,7 +318,7 @@ if (process.env.NODE_ENV !== 'production') {
+   var isJest = typeof jest !== 'undefined';
+ 
+   if (isBrowser && !isJest) {
+-    var globalContext = isBrowser ? window : global;
++    var globalContext = isBrowser ? globalThis : global;
+     var globalKey = "__EMOTION_REACT_" + pkg.version.split('.')[0] + "__";
+ 
+     if (globalContext[globalKey]) {
+diff --git a/node_modules/@emotion/react/dist/emotion-react.browser.esm.js b/node_modules/@emotion/react/dist/emotion-react.browser.esm.js
+index e0382e7..f3b93ff 100644
+--- a/node_modules/@emotion/react/dist/emotion-react.browser.esm.js
++++ b/node_modules/@emotion/react/dist/emotion-react.browser.esm.js
+@@ -315,7 +315,7 @@ if (process.env.NODE_ENV !== 'production') {
+   var isJest = typeof jest !== 'undefined';
+ 
+   if (isBrowser && !isJest) {
+-    var globalContext = isBrowser ? window : global;
++    var globalContext = isBrowser ? globalThis : global;
+     var globalKey = "__EMOTION_REACT_" + pkg.version.split('.')[0] + "__";
+ 
+     if (globalContext[globalKey]) {
+diff --git a/node_modules/@emotion/react/dist/emotion-react.cjs.dev.js b/node_modules/@emotion/react/dist/emotion-react.cjs.dev.js
+index ab7e485..b72e5cb 100644
+--- a/node_modules/@emotion/react/dist/emotion-react.cjs.dev.js
++++ b/node_modules/@emotion/react/dist/emotion-react.cjs.dev.js
+@@ -366,7 +366,7 @@ if (process.env.NODE_ENV !== 'production') {
+   var isJest = typeof jest !== 'undefined';
+ 
+   if (isBrowser && !isJest) {
+-    var globalContext = isBrowser ? window : global;
++    var globalContext = isBrowser ? globalThis : global;
+     var globalKey = "__EMOTION_REACT_" + pkg.version.split('.')[0] + "__";
+ 
+     if (globalContext[globalKey]) {
+diff --git a/node_modules/@emotion/react/dist/emotion-react.esm.js b/node_modules/@emotion/react/dist/emotion-react.esm.js
+index 2fe6811..8d814de 100644
+--- a/node_modules/@emotion/react/dist/emotion-react.esm.js
++++ b/node_modules/@emotion/react/dist/emotion-react.esm.js
+@@ -363,7 +363,7 @@ if (process.env.NODE_ENV !== 'production') {
+   var isJest = typeof jest !== 'undefined';
+ 
+   if (isBrowser && !isJest) {
+-    var globalContext = isBrowser ? window : global;
++    var globalContext = isBrowser ? globalThis : global;
+     var globalKey = "__EMOTION_REACT_" + pkg.version.split('.')[0] + "__";
+ 
+     if (globalContext[globalKey]) {
+diff --git a/node_modules/@emotion/react/src/index.js b/node_modules/@emotion/react/src/index.js
+index 7e472b6..6704bfe 100644
+--- a/node_modules/@emotion/react/src/index.js
++++ b/node_modules/@emotion/react/src/index.js
+@@ -15,7 +15,7 @@ if (process.env.NODE_ENV !== 'production') {
+   const isJest = typeof jest !== 'undefined'
+ 
+   if (isBrowser && !isJest) {
+-    const globalContext = isBrowser ? window : global
++    const globalContext = isBrowser ? globalThis : global
+     const globalKey = `__EMOTION_REACT_${pkg.version.split('.')[0]}__`
+     if (globalContext[globalKey]) {
+       console.warn(


### PR DESCRIPTION
**Problem:**
The `@emotion/react` library references `window` which detonates the web workers killing them on initialisation.

**Fix:**
Use `patch-package` to "fix" the code so that `globalThis` is used in place of `window`.

**Commit Details:**
- Added in patches for the editor and utopia-api that replaces
  `window` with `globalThis` in the `@emotion/react` code.