### PR TITLE
Prevent ReactDOM.render from being usable in the canvas.

### DIFF
--- a/editor/src/core/es-modules/evaluator/evaluator.ts
+++ b/editor/src/core/es-modules/evaluator/evaluator.ts
@@ -21,7 +21,7 @@ function isEsModuleError(error: Error) {
 function transformToCommonJS(filePath: string, moduleCode: string): string {
   const plugins = [BabelTransformCommonJS]
   const result = Babel.transform(moduleCode, {
-    presets: ['es2015'],
+    presets: ['es2015', 'react'],
     plugins: plugins,
     sourceType: 'module',
     sourceFileName: filePath,

--- a/editor/src/core/es-modules/package-manager/built-in-dependencies.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies.ts
@@ -7,6 +7,7 @@ import * as EmotionReact from '@emotion/react'
 
 import * as editorPackageJSON from '../../../../package.json'
 import * as utopiaAPIPackageJSON from '../../../../../utopia-api/package.json'
+import { NO_OP } from '../../shared/utils'
 
 interface BuiltInDependency {
   moduleName: string
@@ -29,12 +30,19 @@ function builtInDependency(
   }
 }
 
+// Prevent ReactDOM.render from running in the canvas/editor because it's
+// entirely likely to cause either havoc or just break.
+export const SafeReactDOM = {
+  ...ReactDOM,
+  render: NO_OP,
+}
+
 const BuiltInDependencies: Array<BuiltInDependency> = [
   builtInDependency('utopia-api', UtopiaAPI, utopiaAPIPackageJSON.version),
   builtInDependency('uuiui', UUIUI, editorPackageJSON.version),
   builtInDependency('uuiui-deps', UUIUIDeps, editorPackageJSON.version),
   builtInDependency('react', React, editorPackageJSON.dependencies.react),
-  builtInDependency('react-dom', ReactDOM, editorPackageJSON.dependencies['react-dom']),
+  builtInDependency('react-dom', SafeReactDOM, editorPackageJSON.dependencies['react-dom']),
   builtInDependency(
     '@emotion/react',
     EmotionReact,

--- a/editor/src/core/workers/parser-printer/parser-printer-transpiling.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-transpiling.ts
@@ -243,7 +243,7 @@ export function transpileJavascriptFromCode(
     plugins.push('proposal-class-properties')
     plugins.push(ReactTransformPlugin)
     const transformResult = Babel.transform(codeToUse, {
-      presets: ['es2015'],
+      presets: ['es2015', 'react'],
       plugins: plugins,
       sourceType: 'script',
       sourceMaps: true,


### PR DESCRIPTION
Fixes #776

**Problem:**
If we allow `ReactDOM.render` to be invoked in the editor a variety of things can happen:
- It fails because the element it expects to render into doesn't exist.
- It potentially rewrites some of the editor if the element does exist.

**Fix:**
`ReactDOM.render` is now effectively disabled and does nothing for code in the canvas. A connected issue with the project being tested has been fixed where code files containing JSX but not with a filename indicating as such are now handled correctly by Babel transpilation.

**Commit Details:**
- Fixes #776.
- `ReactDOM` in `BuiltInDependencies` is now a no-op to prevent any
  breakage that can occur if it is called validly.
- Added more instances of `react` as a preset for Babel because files
  containing JSX but not marked with a filename indicating that will
  otherwise fail.