### PR TITLE
Debugging functionality for the parse-print-analysis script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,5 +120,6 @@ server/utopia-web
 utopia-api/index.d.ts
 editor/src/components/editor/npm-dependency/utopia-api-typings.ts
 
-# Parse print analysis results.
+# Cache of projects for scripts.
 .parse-print-analysis
+.github-test-projects

--- a/editor/.dependency-cruiser.js
+++ b/editor/.dependency-cruiser.js
@@ -153,7 +153,7 @@ module.exports = {
       severity: 'error',
       from: {
         pathNot:
-          '\\.(spec|test|spec.browser|test-utils)\\.(js|mjs|cjs|ts|tsx|ls|coffee|litcoffee|coffee\\.md)$',
+          '\\.(spec|test|spec.browser|test-utils)\\.(js|mjs|cjs|ts|tsx|ls|coffee|litcoffee|coffee\\.md)$|(src/scripts/.*$)',
       },
       to: {
         path: '\\.(test-utils)\\.(js|mjs|cjs|ts|tsx|ls|coffee|litcoffee|coffee\\.md)$',

--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -13579,6 +13579,12 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
+    "ignore-styles": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-styles/-/ignore-styles-5.0.1.tgz",
+      "integrity": "sha1-tJ7yJ0va/NikiAqWa/440aC/RnE=",
+      "dev": true
+    },
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",

--- a/editor/package.json
+++ b/editor/package.json
@@ -31,7 +31,8 @@
     "preinstall": "npm run install-utopia-api",
     "postinstall": "patch-package",
     "eslint-check": "eslint --quiet --config .eslintrc.js --ext .ts --ext .tsx src ../utopia-api/src ../website/src",
-    "parse-print-analysis": "npx ts-node --transpile-only ./src/scripts/parse-print-analysis.ts"
+    "parse-print-analysis": "npx -s sh ts-node --require ignore-styles --transpile-only ./src/scripts/parse-print-analysis.ts",
+    "parse-debug": "npx -s sh ts-node --pretty --require ignore-styles --transpile-only ./src/scripts/parse-debug.ts"
   },
   "jest": {
     "testEnvironment": "jest-environment-jsdom-global",
@@ -260,6 +261,7 @@
     "got": "11.8.1",
     "html-webpack-plugin": "4.0.4",
     "husky": "3.1.0",
+    "ignore-styles": "5.0.1",
     "immutable": "3.8.1",
     "jStat": "1.5.3",
     "jest": "26.1.0",

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -120,7 +120,6 @@ import {
   getStoryboardTemplatePathFromEditorState,
   addSceneToJSXComponents,
   getNumberOfScenes,
-  getStoryboardUID,
 } from '../editor/store/editor-state'
 import * as Frame from '../frame'
 import { getImageSizeFromMetadata, MultipliersForImages, scaleImageDimensions } from '../images'
@@ -160,7 +159,11 @@ import {
 } from './guideline'
 import { addImport, mergeImports } from '../../core/workers/common/project-file-utils'
 import { getLayoutProperty } from '../../core/layout/getLayoutProperty'
-import { createSceneTemplatePath, PathForSceneStyle } from '../../core/model/scene-utils'
+import {
+  createSceneTemplatePath,
+  getStoryboardUID,
+  PathForSceneStyle,
+} from '../../core/model/scene-utils'
 import { optionalMap } from '../../core/shared/optional-utils'
 import { fastForEach } from '../../core/shared/utils'
 import { UiJsxCanvasContextData } from './ui-jsx-canvas'

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -50,8 +50,8 @@ import { ControlProps } from './new-canvas-controls'
 import { getLayoutPropertyOr } from '../../../core/layout/getLayoutProperty'
 import { RightMenuTab } from '../right-menu'
 import { safeIndex } from '../../../core/shared/array-utils'
-import { getStoryboardTemplatePath } from '../../editor/store/editor-state'
 import { createLayoutPropertyPath } from '../../../core/layout/layout-helpers-new'
+import { getStoryboardTemplatePath } from '../../../core/model/scene-utils'
 
 // I feel comfortable having this function confined to this file only, since we absolutely shouldn't be trying
 // to set values that would fail whilst inserting elements. If that ever changes, this function should be binned

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -412,7 +412,6 @@ import {
   addNewScene,
   removeScene,
   getNumberOfScenes,
-  getStoryboardTemplatePath,
   addSceneToJSXComponents,
   UserState,
   UserConfiguration,
@@ -428,6 +427,7 @@ import {
   fishOutUtopiaCanvasFromTopLevelElements,
   createSceneFromComponent,
   BakedInStoryboardVariableName,
+  getStoryboardTemplatePath,
 } from '../../../core/model/scene-utils'
 import { addUtopiaUtilsImportIfUsed } from '../import-utils'
 import { getFrameAndMultiplier } from '../../images'

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -116,6 +116,7 @@ import {
   BakedInStoryboardVariableName,
   EmptyScenePathForStoryboard,
   isDynamicSceneChildWidthHeightPercentage,
+  getStoryboardTemplatePath,
 } from '../../../core/model/scene-utils'
 
 import { RightMenuTab } from '../../canvas/right-menu'
@@ -1683,29 +1684,6 @@ export function reconstructJSXMetadata(editor: EditorState): JSXMetadata {
       uiFile.fileContents.parsed,
     )
   }
-}
-
-export function getStoryboardUID(openComponents: UtopiaJSXComponent[]): string | null {
-  const possiblyStoryboard = openComponents.find(
-    (component) => component.name === BakedInStoryboardVariableName,
-  )
-  if (possiblyStoryboard != null) {
-    return getUtopiaID(possiblyStoryboard.rootElement)
-  }
-  return null
-}
-
-export function getStoryboardTemplatePath(
-  openComponents: UtopiaJSXComponent[],
-): StaticInstancePath | null {
-  const possiblyStoryboard = openComponents.find(
-    (component) => component.name === BakedInStoryboardVariableName,
-  )
-  if (possiblyStoryboard != null) {
-    const uid = getUtopiaID(possiblyStoryboard.rootElement)
-    return staticInstancePath(EmptyScenePathForStoryboard, [uid])
-  }
-  return null
 }
 
 export function getStoryboardTemplatePathFromEditorState(

--- a/editor/src/components/editor/store/editor-update.spec.ts
+++ b/editor/src/components/editor/store/editor-update.spec.ts
@@ -21,11 +21,7 @@ import {
 } from '../../../core/shared/project-file-types'
 import { MockUtopiaTsWorkers } from '../../../core/workers/workers'
 import { isRight, right } from '../../../core/shared/either'
-import {
-  createEditorStates,
-  createFakeMetadataForEditor,
-  forceParseSuccessFromFileOrFail,
-} from '../../../utils/test-utils'
+import { createEditorStates, createFakeMetadataForEditor } from '../../../utils/test-utils'
 import Utils from '../../../utils/utils'
 import { renameComponent, reparentComponents } from '../../navigator/actions'
 import * as TP from '../../../core/shared/template-path'
@@ -63,6 +59,7 @@ import { emptyUiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
 import { requestedNpmDependency } from '../../../core/shared/npm-dependency-types'
 import { getContentsTreeFileFromString } from '../../assets'
 import { openFileTab } from './editor-tabs'
+import { forceParseSuccessFromFileOrFail } from '../../../core/workers/parser-printer/parser-printer.test-utils'
 
 const chaiExpect = Chai.expect
 

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -32,7 +32,7 @@ import {
 } from '../shared/uid-utils'
 import { fastForEach } from '../shared/utils'
 import { isUtopiaAPIComponent, getComponentsFromTopLevelElements } from './project-file-utils'
-import { getStoryboardTemplatePath } from '../../components/editor/store/editor-state'
+import { getStoryboardTemplatePath } from './scene-utils'
 
 function getAllUniqueUidsInner(
   components: Array<UtopiaJSXComponent>,

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -40,6 +40,7 @@ import {
 import { stripNulls } from '../shared/array-utils'
 import { isPercentPin } from 'utopia-api'
 import { UTOPIA_UID_KEY } from './utopia-constants'
+import { getUtopiaID } from './element-template-utils'
 
 export const EmptyScenePathForStoryboard = TP.scenePath([])
 
@@ -301,4 +302,27 @@ export function isDynamicSceneChildWidthHeightPercentage(
   const isDynamicScene = scene.sceneResizesContent
 
   return isDynamicScene && isSceneChildWidthHeightPercentage(scene, metadata)
+}
+
+export function getStoryboardUID(openComponents: UtopiaJSXComponent[]): string | null {
+  const possiblyStoryboard = openComponents.find(
+    (component) => component.name === BakedInStoryboardVariableName,
+  )
+  if (possiblyStoryboard != null) {
+    return getUtopiaID(possiblyStoryboard.rootElement)
+  }
+  return null
+}
+
+export function getStoryboardTemplatePath(
+  openComponents: UtopiaJSXComponent[],
+): StaticInstancePath | null {
+  const possiblyStoryboard = openComponents.find(
+    (component) => component.name === BakedInStoryboardVariableName,
+  )
+  if (possiblyStoryboard != null) {
+    const uid = getUtopiaID(possiblyStoryboard.rootElement)
+    return TP.staticInstancePath(EmptyScenePathForStoryboard, [uid])
+  }
+  return null
 }

--- a/editor/src/core/shared/element-template.tsx
+++ b/editor/src/core/shared/element-template.tsx
@@ -1121,28 +1121,29 @@ export type ElementsByUID = { [uid: string]: JSXElement }
 export function walkElement(
   element: JSXElementChild,
   parentPath: StaticElementPath,
-  forEach: (e: JSXElementChild, path: StaticElementPath) => void,
+  depth: number,
+  forEach: (e: JSXElementChild, path: StaticElementPath, depth: number) => void,
 ): void {
   switch (element.type) {
     case 'JSX_ELEMENT':
       const uidAttr = element.props['data-uid']
       if (isJSXAttributeValue(uidAttr) && typeof uidAttr.value === 'string') {
         const path = TP.appendToElementPath(parentPath, uidAttr.value)
-        forEach(element, path)
-        fastForEach(element.children, (child) => walkElement(child, path, forEach))
+        forEach(element, path, depth)
+        fastForEach(element.children, (child) => walkElement(child, path, depth + 1, forEach))
       }
       break
     case 'JSX_FRAGMENT':
-      forEach(element, parentPath)
-      fastForEach(element.children, (child) => walkElement(child, parentPath, forEach))
+      forEach(element, parentPath, depth)
+      fastForEach(element.children, (child) => walkElement(child, parentPath, depth + 1, forEach))
       break
     case 'JSX_TEXT_BLOCK':
-      forEach(element, parentPath)
+      forEach(element, parentPath, depth)
       break
     case 'JSX_ARBITRARY_BLOCK':
-      forEach(element, parentPath)
+      forEach(element, parentPath, depth)
       fastForEach(Object.keys(element.elementsWithin), (childKey) =>
-        walkElement(element.elementsWithin[childKey], parentPath, forEach),
+        walkElement(element.elementsWithin[childKey], parentPath, depth + 1, forEach),
       )
       break
     default:
@@ -1158,7 +1159,7 @@ export function walkElements(
   const emptyPath = ([] as any) as StaticElementPath // Oh my word
   fastForEach(topLevelElements, (rootComponent) => {
     if (isUtopiaJSXComponent(rootComponent)) {
-      walkElement(rootComponent.rootElement, emptyPath, forEach)
+      walkElement(rootComponent.rootElement, emptyPath, 0, forEach)
     }
   })
 }

--- a/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
@@ -1,8 +1,10 @@
 import { printCode, printCodeOptions } from './parser-printer'
 import { applyPrettier } from './prettier-utils'
-import { isRight } from '../../shared/either'
-import { testParseCode, clearParseResultUniqueIDs } from './parser-printer.test-utils'
-import { elementsStructure } from '../../../utils/test-utils'
+import {
+  testParseCode,
+  clearParseResultUniqueIDs,
+  elementsStructure,
+} from './parser-printer.test-utils'
 import { AwkwardFragmentsCode } from './parser-printer-fragments.test-utils'
 import { isParseSuccess } from '../../shared/project-file-types'
 
@@ -12,19 +14,21 @@ describe('JSX parser', () => {
     const parseResult = clearParseResultUniqueIDs(testParseCode(code))
     if (isParseSuccess(parseResult)) {
       expect(elementsStructure(parseResult.topLevelElements)).toMatchInlineSnapshot(`
-        "  JSX_ELEMENT - aaa
+        "UTOPIA_JSX_COMPONENT - App
+          JSX_ELEMENT - View - aaa
             JSX_TEXT_BLOCK
             JSX_FRAGMENT
-            JSX_ELEMENT - bbb
-              JSX_TEXT_BLOCK
-              JSX_FRAGMENT
-              JSX_ELEMENT - ccc
-              JSX_TEXT_BLOCK
+              JSX_ELEMENT - div - bbb
+                JSX_TEXT_BLOCK
+                JSX_FRAGMENT
+                  JSX_ELEMENT - div - ccc
+                JSX_TEXT_BLOCK
             JSX_TEXT_BLOCK
-            JSX_ELEMENT - ddd
+            JSX_ELEMENT - div - ddd
               JSX_TEXT_BLOCK
-          JSX_ELEMENT - eee
-            JSX_ELEMENT - fff"
+        UTOPIA_JSX_COMPONENT - storyboard
+          JSX_ELEMENT - Storyboard - eee
+            JSX_ELEMENT - Scene - fff"
       `)
 
       const printedCode = printCode(

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -1,11 +1,5 @@
 import * as React from 'react'
 import * as TS from 'typescript'
-import {
-  BakedInStoryboardVariableName,
-  convertTopLevelElementsBackToScenesAndTopLevelElements_FOR_PP_ONLY,
-  EmptyUtopiaCanvasComponent,
-  convertUtopiaCanvasComponentToScenes,
-} from '../../model/scene-utils'
 import { addUniquely, flatMapArray, uniq, uniqBy, sortBy } from '../../shared/array-utils'
 import { SafeFunction } from '../../shared/code-exec-utils'
 import {

--- a/editor/src/scripts/github-projects.ts
+++ b/editor/src/scripts/github-projects.ts
@@ -1,0 +1,62 @@
+/* eslint no-console: "off" */
+import * as Path from 'path'
+import * as FS from 'fs'
+import Got from 'got'
+import { extract } from 'tar'
+
+export const localDir = Path.resolve('./.github-test-projects/')
+
+export interface GitRepoWithRevision {
+  name: string
+  username: string
+  repositoryName: string
+  revision: string
+  pathsToIgnore: Array<string>
+}
+
+export const githubProjects: Array<GitRepoWithRevision> = [
+  {
+    name: 'react-three-flex-examples',
+    username: 'utopia-test',
+    repositoryName: 'react-three-flex-examples',
+    revision: 'b4b60193de78a0f50e51028300c29bbdb67b34ab',
+    pathsToIgnore: ['/public/draco-gltf', '/src/utils/three.js'],
+  },
+  {
+    name: 'react-tic-tac-toe-with-hooks',
+    username: 'utopia-test',
+    repositoryName: 'react-tic-tac-toe-with-hooks',
+    revision: 'd3eeb96536d9e7a78435b967a41d656164535528',
+    pathsToIgnore: [],
+  },
+]
+
+export async function downloadAndExtractRepo(gitRepo: GitRepoWithRevision): Promise<string> {
+  if (!FS.existsSync(localDir)) {
+    FS.mkdirSync(localDir, { recursive: true })
+  }
+  // Folder we intend on putting the contents into.
+  const projectLocalDir = Path.join(localDir, gitRepo.revision)
+  // Check if we already have a copy.
+  if (!FS.existsSync(projectLocalDir)) {
+    // If the local dir does not exist, download the tarball.
+    const urlToDownload = `https://github.com/${gitRepo.username}/${gitRepo.repositoryName}/tarball/${gitRepo.revision}`
+    const tarballLocalFile = Path.join(localDir, `${gitRepo.revision}.tgz`)
+    const writeStream = FS.createWriteStream(tarballLocalFile)
+    const writeStreamPromise = new Promise((resolve, reject) => {
+      Got.stream(urlToDownload)
+        .pipe(writeStream)
+        .on('finish', () => resolve())
+        .on('error', (error) => reject(error))
+    })
+    await writeStreamPromise
+    // Expand the tarball.
+    const targetDir = Path.join(localDir, gitRepo.revision)
+    FS.mkdirSync(targetDir)
+    // Extract the tarball into the folder for the revision,
+    // stripping off the path prefix which contains the repo name
+    // that we don't want.
+    await extract({ file: tarballLocalFile, cwd: targetDir, strip: 1 })
+  }
+  return projectLocalDir
+}

--- a/editor/src/scripts/parse-debug.ts
+++ b/editor/src/scripts/parse-debug.ts
@@ -1,0 +1,58 @@
+/* eslint no-console: "off" */
+
+import * as Path from 'path'
+import * as FS from 'fs'
+import { downloadAndExtractRepo, githubProjects } from './github-projects'
+import { applyPrettier } from '../core/workers/parser-printer/prettier-utils'
+import { parseCode } from '../core/workers/parser-printer/parser-printer'
+import { foldParsedTextFile } from '../core/shared/project-file-types'
+import { elementsStructure } from '../core/workers/parser-printer/parser-printer.test-utils'
+
+async function printOutParseResult(
+  command: string,
+  gitRepoName: string,
+  javascriptFilePath: string,
+): Promise<void> {
+  const gitRepo = githubProjects.find((project) => project.name === gitRepoName)
+  if (gitRepo == null) {
+    console.error(`Could not find repo with name ${gitRepoName}`)
+  } else {
+    const repoDir = await downloadAndExtractRepo(gitRepo)
+    const fullFilePath = Path.join(repoDir, javascriptFilePath)
+    if (FS.existsSync(fullFilePath)) {
+      const fileContents = FS.readFileSync(fullFilePath, 'utf8')
+      const initialPrettifiedContents = applyPrettier(fileContents, false).formatted
+      const parsedContents = parseCode(javascriptFilePath, initialPrettifiedContents)
+      switch (command) {
+        case 'print':
+          console.log(JSON.stringify(parsedContents, null, 2))
+          break
+        case 'structure':
+          const result = foldParsedTextFile(
+            (failure) => failure.errorMessage,
+            (success) => elementsStructure(success.topLevelElements),
+            () => 'UNPARSED',
+            parsedContents,
+          )
+          console.log(result)
+          break
+        default:
+          console.error(`Unhandled command ${command}.`)
+      }
+    } else {
+      console.error(`Could not find file ${javascriptFilePath} in ${gitRepoName}`)
+    }
+  }
+}
+
+let processArguments = [...process.argv]
+// Strip away the weird set of process arguments we get because of ts-node.
+if (processArguments.length === 5 && processArguments[0].endsWith('ts-node')) {
+  processArguments = processArguments.slice(2)
+}
+
+if (processArguments.length === 3) {
+  printOutParseResult(processArguments[0], processArguments[1], processArguments[2])
+} else {
+  console.error('Invalid number of parameters. Must be command, repo name and then filename.')
+}

--- a/editor/src/scripts/parse-print-analysis.ts
+++ b/editor/src/scripts/parse-print-analysis.ts
@@ -1,8 +1,6 @@
 /* eslint no-console: "off" */
 import * as Path from 'path'
 import * as FS from 'fs'
-import Got from 'got'
-import { extract } from 'tar'
 import { applyPrettier } from '../core/workers/parser-printer/prettier-utils'
 import {
   parseCode,
@@ -11,33 +9,7 @@ import {
 } from '../core/workers/parser-printer/parser-printer'
 import { foldParsedTextFile } from '../core/shared/project-file-types'
 import * as Diff from 'diff'
-
-const localDir = Path.resolve('./.parse-print-analysis/')
-
-interface GitRepoWithRevision {
-  name: string
-  username: string
-  repositoryName: string
-  revision: string
-  pathsToIgnore: Array<string>
-}
-
-const githubProjects: Array<GitRepoWithRevision> = [
-  {
-    name: 'react-three-flex-examples',
-    username: 'utopia-test',
-    repositoryName: 'react-three-flex-examples',
-    revision: 'b4b60193de78a0f50e51028300c29bbdb67b34ab',
-    pathsToIgnore: ['/public/draco-gltf', '/src/utils/three.js'],
-  },
-  {
-    name: 'react-tic-tac-toe-with-hooks',
-    username: 'utopia-test',
-    repositoryName: 'react-tic-tac-toe-with-hooks',
-    revision: 'd3eeb96536d9e7a78435b967a41d656164535528',
-    pathsToIgnore: [],
-  },
-]
+import { GitRepoWithRevision, downloadAndExtractRepo, githubProjects } from './github-projects'
 
 const javascriptFileEndings = ['.js', '.ts', '.jsx', '.tsx']
 
@@ -113,32 +85,7 @@ async function processProjectCode(
 
 async function processProject(gitRepo: GitRepoWithRevision): Promise<Array<string>> {
   // Create the folder that caches the current copy of the projects.
-  if (!FS.existsSync(localDir)) {
-    FS.mkdirSync(localDir, { recursive: true })
-  }
-  // Folder we intend on putting the contents into.
-  const projectLocalDir = Path.join(localDir, gitRepo.revision)
-  // Check if we already have a copy.
-  if (!FS.existsSync(projectLocalDir)) {
-    // If the local dir does not exist, download the tarball.
-    const urlToDownload = `https://github.com/${gitRepo.username}/${gitRepo.repositoryName}/tarball/${gitRepo.revision}`
-    const tarballLocalFile = Path.join(localDir, `${gitRepo.revision}.tgz`)
-    const writeStream = FS.createWriteStream(tarballLocalFile)
-    const writeStreamPromise = new Promise((resolve, reject) => {
-      Got.stream(urlToDownload)
-        .pipe(writeStream)
-        .on('finish', () => resolve())
-        .on('error', (error) => reject(error))
-    })
-    await writeStreamPromise
-    // Expand the tarball.
-    const targetDir = Path.join(localDir, gitRepo.revision)
-    FS.mkdirSync(targetDir)
-    // Extract the tarball into the folder for the revision,
-    // stripping off the path prefix which contains the repo name
-    // that we don't want.
-    await extract({ file: tarballLocalFile, cwd: targetDir, strip: 1 })
-  }
+  const projectLocalDir = await downloadAndExtractRepo(gitRepo)
 
   return processProjectCode(gitRepo, projectLocalDir, projectLocalDir)
 }

--- a/editor/src/utils/test-utils.ts
+++ b/editor/src/utils/test-utils.ts
@@ -26,6 +26,8 @@ import {
   emptyJsxMetadata,
   ElementInstanceMetadataMap,
   jsxMetadata,
+  getJSXElementNameAsString,
+  walkElement,
 } from '../core/shared/element-template'
 import { getUtopiaID } from '../core/model/element-template-utils'
 import { jsxAttributesToProps, jsxSimpleAttributeToValue } from '../core/shared/jsx-attributes'
@@ -46,6 +48,7 @@ import {
   ProjectFile,
   InstancePath,
   EmptyExportsDetail,
+  StaticElementPath,
 } from '../core/shared/project-file-types'
 import { right, eitherToMaybe, isLeft } from '../core/shared/either'
 import Utils from './utils'
@@ -311,39 +314,4 @@ export function wait(timeout: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, timeout)
   })
-}
-
-export function elementsStructure(elements: Array<TopLevelElement>): string {
-  let structureResults: Array<string> = []
-  walkElements(elements, (element, path) => {
-    const isElement = isJSXElement(element)
-    // Adjustment to cater for things which are not elements
-    // appearing one level too high because they do not modify the
-    // path from walkElements.
-    const depth = path.length + (isElement ? 0 : 1)
-    let elementResult: string = ''
-    for (let index = 0; index < depth; index++) {
-      elementResult += '  '
-    }
-    elementResult += element.type
-    if (isJSXElement(element)) {
-      elementResult += ` - ${getUtopiaID(element)}`
-    }
-    structureResults.push(elementResult)
-  })
-  return structureResults.join('\n')
-}
-
-export function forceParseSuccessFromFileOrFail(
-  file: ProjectFile | null | undefined,
-): ParseSuccess {
-  if (file != null && isTextFile(file)) {
-    if (isParseSuccess(file.fileContents.parsed)) {
-      return file.fileContents.parsed
-    } else {
-      fail(`Not a parse success ${file.fileContents.parsed}`)
-    }
-  } else {
-    fail(`Not a text file ${file}`)
-  }
 }


### PR DESCRIPTION
Fixes #797

**Problem:**
The `parse-print-analysis` script produces a lot of output, but it is not particularly easy to then get some information on what is necessary to improve the results that are seen.

**Fix:**
Created another script which can produce some debug like information about a particular file from those listed that can then be used to work through what needs fixing/improving. There are two types of output the script can produce:

The first command looks like this:
`npm run parse-debug -- print 'react-three-flex-examples' '/src/App.js'`
Which prints out the parsed model in full for that particular file, akin to what is produced by the currently available debugging button in the right hand pane.

The second command is very similar:
`npm run parse-debug -- structure 'react-three-flex-examples' '/src/App.js'`
That prints out a more readable and terse hierarchy from parsing the given file, see the `elementsStructure` function as that is the crux of what is used.

**Commit Details:**
- Fixes #797.
- Generalise the earlier work for grabbing projects from Github.
- Added a `parse-debug.ts` script with `print` and `structure` commands.
- Moved `getStoryboardUID` and `getStoryboardTemplatePath` to `scene-utils.ts`.
- `walkElement` better supports handling the depth.
- `elementsStructure` and `forceParseSuccessFromFileOrFail` moved to
  `parser-printer.test-utils.tsx`.
- `elementsStructure` now includes the top level elements and their types,
  as well as the names of JSX elements.
- Added the `ignore-styles` plugin so that ts-node doesn't attempt to process
  CSS files.
- Reworked the ts-node scripts slightly to ensure that we can get the stack
  trace when something fails.
