### PR TITLE
feature(navigator) navigator toggle button

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -99,7 +99,7 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
     [interfaceDesigner, navigatorPosition, props.isUiJsFileOpen],
   )
 
-  const getNavigatorLeft = (): number | undefined => {
+  const getNavigatorLeft = React.useMemo((): number | undefined => {
     let position = undefined
     const codeEditorCurrentWidth =
       codeEditorResizingWidth != null ? codeEditorResizingWidth : interfaceDesigner.codePaneWidth
@@ -119,7 +119,13 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
       }
     }
     return position
-  }
+  }, [
+    codeEditorResizingWidth,
+    interfaceDesigner.codePaneVisible,
+    interfaceDesigner.codePaneWidth,
+    leftMenuExpanded,
+    navigatorPosition,
+  ])
 
   return (
     <SimpleFlexRow
@@ -179,7 +185,7 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
           style={{
             position: 'absolute',
             height: '100%',
-            left: getNavigatorLeft(),
+            left: getNavigatorLeft,
             width: LeftPaneDefaultWidth,
           }}
         />

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -38,9 +38,9 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
     (store) => store.editor.interfaceDesigner,
     'DesignPanelRoot interfaceDesigner',
   )
-  const navigatorVisible = useEditorState(
-    (store) => store.editor.navigator.visible,
-    'DesignPanelRoot navigatorVisible',
+  const navigatorPosition = useEditorState(
+    (store) => store.editor.navigator.position,
+    'DesignPanelRoot navigatorPosition',
   )
 
   const isRightMenuExpanded = useEditorState(
@@ -80,6 +80,26 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
     },
     [updateDeltaWidth, props.isUiJsFileOpen],
   )
+
+  const getNavigatorLeft = (): number | undefined => {
+    let position = undefined
+    switch (navigatorPosition) {
+      case 'left':
+        position = interfaceDesigner.codePaneWidth - LeftPaneDefaultWidth
+        break
+      case 'right':
+        position = interfaceDesigner.codePaneWidth
+        break
+    }
+    if (!interfaceDesigner.codePaneVisible) {
+      if (leftMenuExpanded) {
+        position = LeftPaneDefaultWidth
+      } else {
+        position = undefined
+      }
+    }
+    return position
+  }
 
   return (
     <SimpleFlexRow
@@ -131,33 +151,18 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
         >
           <CodeEditorWrapper />
         </Resizable>
-        {props.isUiJsFileOpen ? (
-          <SimpleFlexRow
-            style={{
-              position: 'relative',
-              overflowX: 'hidden',
-              justifyContent: 'stretch',
-              alignItems: 'stretch',
-              flexGrow: 1,
-            }}
-          >
-            <CanvasWrapperComponent {...props} />
-            {navigatorVisible && (
-              <NavigatorComponent
-                style={{
-                  position: 'absolute',
-                  height: '100%',
-                  left:
-                    leftMenuExpanded && !interfaceDesigner.codePaneVisible
-                      ? LeftPaneDefaultWidth
-                      : undefined,
-                  width: LeftPaneDefaultWidth,
-                }}
-              />
-            )}
-          </SimpleFlexRow>
-        ) : null}
+        {props.isUiJsFileOpen ? <CanvasWrapperComponent {...props} /> : null}
       </SimpleFlexRow>
+      {props.isUiJsFileOpen && navigatorPosition !== 'hidden' ? (
+        <NavigatorComponent
+          style={{
+            position: 'absolute',
+            height: '100%',
+            left: getNavigatorLeft(),
+            width: LeftPaneDefaultWidth,
+          }}
+        />
+      ) : null}
       {props.isUiJsFileOpen ? (
         <>
           <RightMenu visible={true} />

--- a/editor/src/components/canvas/right-menu.tsx
+++ b/editor/src/components/canvas/right-menu.tsx
@@ -117,8 +117,8 @@ export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) =>
     'RightMenu rightMenuSelectedTab',
   )
 
-  const navigatorVisible = useEditorState(
-    (store) => store.editor.navigator.visible,
+  const navigatorPosition = useEditorState(
+    (store) => store.editor.navigator.position,
     'RightMenu navigatorVisible',
   )
 
@@ -306,7 +306,7 @@ export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) =>
         <Tooltip title={'Navigator'} placement={'right'}>
           <span>
             <RightMenuTile
-              selected={navigatorVisible}
+              selected={navigatorPosition !== 'hidden'}
               highlightSelected={false}
               icon={<MenuIcons.Project />}
               onClick={onClickNavigateTab}

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -968,7 +968,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     },
     navigator: {
       minimised: currentEditor.navigator.minimised,
-      visible: currentEditor.navigator.visible,
+      position: currentEditor.navigator.position,
       dropTargetHint: {
         target: null,
         type: null,
@@ -1191,6 +1191,20 @@ function updateNavigatorCollapsedState(
       $set: collapsedWithChildrenSelected,
     },
   })
+}
+
+function getNavigatorPositionNextState(editor: EditorState): 'hidden' | 'left' | 'right' {
+  switch (editor.navigator.position) {
+    case 'hidden':
+      return 'right'
+    case 'left':
+      return 'hidden'
+    case 'right':
+      return editor.interfaceDesigner.codePaneVisible ? 'left' : 'hidden'
+    default:
+      const _exhaustiveCheck: never = editor.navigator.position
+      throw new Error(`Cannot update navigator position to ${editor.navigator.position}`)
+  }
 }
 
 interface ReplaceFilePathSuccess {
@@ -2143,7 +2157,7 @@ export const UPDATE_FNS = {
           ...editor,
           navigator: {
             ...editor.navigator,
-            visible: !action.visible,
+            position: action.visible ? 'left' : 'hidden',
           },
         }
       case 'filebrowser':
@@ -2284,7 +2298,7 @@ export const UPDATE_FNS = {
           ...editor,
           navigator: {
             ...editor.navigator,
-            visible: !editor.navigator.visible,
+            position: getNavigatorPositionNextState(editor),
           },
         }
       case 'inspector':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -2157,7 +2157,7 @@ export const UPDATE_FNS = {
           ...editor,
           navigator: {
             ...editor.navigator,
-            position: action.visible ? 'left' : 'hidden',
+            position: action.visible ? 'right' : 'hidden',
           },
         }
       case 'filebrowser':

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -313,7 +313,7 @@ export interface EditorState {
     dropTargetHint: DropTargetHint
     collapsedViews: TemplatePath[]
     renamingTarget: TemplatePath | null
-    visible: boolean
+    position: 'hidden' | 'left' | 'right'
   }
   preview: {
     visible: boolean
@@ -1103,7 +1103,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     },
     navigator: {
       minimised: false,
-      visible: true,
+      position: 'right',
       dropTargetHint: {
         target: null,
         type: null,
@@ -1367,7 +1367,7 @@ export function editorModelFromPersistentModel(
       collapsedViews: [],
       renamingTarget: null,
       minimised: persistentModel.navigator.minimised,
-      visible: true,
+      position: 'right',
     },
     fileBrowser: {
       renamingTarget: null,


### PR DESCRIPTION
Toggling the right menu navigator button cycles through 3 different navigator positions, one of them is hidden. This is a preparation step for having enough space on the canvas area for the top menu.
The navigator tries to stick to the resizer between the code editor and the canvas, with the toggling you can place it to the right or left side of the resizer (or hide it).

When the code editor is closed it acts as a simple show/hide toggle. I also tried to make it not stuck under the Left Menu when it's open but the code editor is not.