### PR TITLE
Dom-based Selection and Highlights

### DIFF
--- a/editor/.eslintrc.js
+++ b/editor/.eslintrc.js
@@ -39,7 +39,6 @@ module.exports = {
       'confirm',
       'defaultStatus',
       'defaultstatus',
-      'Element',
       'event',
       'external',
       'find',

--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
@@ -12,7 +12,7 @@ import * as Prettier from 'prettier'
 import * as TP from '../../core/shared/template-path'
 
 import { PrettierConfig } from '../../core/workers/parser-printer/prettier-utils'
-import { createFakeMetadataForParseSuccess } from '../../utils/test-utils'
+import { createFakeMetadataForParseSuccess, wait } from '../../utils/test-utils'
 import { determineElementsToOperateOnForDragging } from './controls/select-mode/move-utils'
 import { BakedInStoryboardUID } from '../../core/model/scene-utils'
 
@@ -29,6 +29,7 @@ describe('moving a scene/rootview on the canvas', () => {
               style={{ width: 375, height: 812 }}
               layout={{ layoutSystem: 'pinSystem' }}
               data-uid={'aaa'}
+              data-testid={'aaa'}
             >
               <View
                 style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
@@ -59,9 +60,7 @@ describe('moving a scene/rootview on the canvas', () => {
       false,
     )
 
-    const areaControl = renderResult.renderedDOM.getByTestId(
-      'component-area-control-utopia-storyboard-uid/scene-aaa:aaa-0',
-    )
+    const areaControl = renderResult.renderedDOM.getByTestId('aaa')
 
     const areaControlBounds = areaControl.getBoundingClientRect()
 
@@ -139,6 +138,7 @@ describe('moving a scene/rootview on the canvas', () => {
             style={{ width: 375, height: 812 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'aaa'}
+            data-testid={'aaa'}
           >
             <View
               style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
@@ -205,7 +205,7 @@ describe('moving a scene/rootview on the canvas', () => {
     await renderResult.dispatch([selectComponents([TestScenePath], false)], false)
 
     const areaControl = renderResult.renderedDOM.getByTestId(
-      'component-area-control-utopia-storyboard-uid/scene-aaa:aaa-0',
+      'label-control-utopia-storyboard-uid/scene-aaa',
     )
 
     const areaControlBounds = areaControl.getBoundingClientRect()
@@ -314,7 +314,7 @@ describe('moving a scene/rootview on the canvas', () => {
   it('dragging a static scene’s root view sets the root view position', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ width: '100%', height: '100%' }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        <View style={{ width: '100%', height: '100%' }} layout={{ layoutSystem: 'pinSystem' }} data-testid={'aaa'} data-uid={'aaa'}>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
             layout={{ layoutSystem: 'pinSystem' }}
@@ -329,9 +329,7 @@ describe('moving a scene/rootview on the canvas', () => {
       false,
     )
 
-    const areaControl = renderResult.renderedDOM.getByTestId(
-      'component-area-control-utopia-storyboard-uid/scene-aaa:aaa-0',
-    )
+    const areaControl = renderResult.renderedDOM.getByTestId('aaa')
 
     const areaControlBounds = areaControl.getBoundingClientRect()
 
@@ -405,6 +403,7 @@ describe('moving a scene/rootview on the canvas', () => {
       <View
           style={{ width: '100%', height: '100%', left: 40, top: -30 }}
           layout={{ layoutSystem: 'pinSystem' }}
+          data-testid={'aaa'}
           data-uid={'aaa'}
         >
           <View
@@ -454,7 +453,7 @@ describe('moving a scene/rootview on the canvas', () => {
     await renderResult.dispatch([selectComponents([TestScenePath], false)], false)
 
     const areaControl = renderResult.renderedDOM.getByTestId(
-      'component-area-control-utopia-storyboard-uid/scene-aaa:aaa-0',
+      'label-control-utopia-storyboard-uid/scene-aaa',
     )
 
     const areaControlBounds = areaControl.getBoundingClientRect()
@@ -572,6 +571,7 @@ describe('resizing a scene/rootview on the canvas', () => {
               style={{ width: 200, height: 400 }}
               layout={{ layoutSystem: 'pinSystem' }}
               data-uid={'aaa'}
+              data-testid={'aaa'}
             >
               <View
                 style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
@@ -664,6 +664,7 @@ describe('resizing a scene/rootview on the canvas', () => {
             style={{ height: 370, width: 240 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid={'aaa'}
+            data-testid={'aaa'}
           >
             <View
               style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -18,6 +18,7 @@ import {
   singleResizeChange,
   EdgePosition,
 } from './canvas-types'
+import { wait } from '../../utils/test-utils'
 
 const NewUID = 'catdog'
 
@@ -1292,7 +1293,7 @@ describe('moveTemplate', () => {
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
           </View>
-          <View data-uid={'eee'} style={{ position: 'absolute', backgroundColor: '#00ff00', left: 150, top: 250, width: 80, height: 80 }}/>
+          <View data-testid={'eee'} data-uid={'eee'} style={{ position: 'absolute', backgroundColor: '#00ff00', left: 150, top: 250, width: 80, height: 80 }}/>
         </View>
       `),
     )
@@ -1302,9 +1303,7 @@ describe('moveTemplate', () => {
       false,
     )
 
-    const areaControl = renderResult.renderedDOM.getByTestId(
-      'component-area-control-utopia-storyboard-uid/scene-aaa:aaa/eee-2',
-    )
+    const areaControl = renderResult.renderedDOM.getByTestId('eee')
 
     const areaControlBounds = areaControl.getBoundingClientRect()
 
@@ -1381,7 +1380,7 @@ describe('moveTemplate', () => {
             data-uid={'bbb'}
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
-            <View data-uid={'eee'} style={{ backgroundColor: '#00ff00', position: 'relative', flexBasis: 80, height: 80 }} />
+            <View data-testid={'eee'}  data-uid={'eee'} style={{ backgroundColor: '#00ff00', position: 'relative', flexBasis: 80, height: 80 }} />
           </View>
         </View>
       `),
@@ -1506,7 +1505,7 @@ describe('moveTemplate', () => {
           >
             <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', top: 10, left: 15, width: 50, height: 60 }} />
           </View>
-          <View data-uid={'eee'} style={{ backgroundColor: '#00ff00', left: 150, top: 250, width: 80, height: 80 }} layout={{ layoutSystem: 'pinSystem' }}/>
+          <View data-testid={'eee'} data-uid={'eee'} style={{ backgroundColor: '#00ff00', left: 150, top: 250, width: 80, height: 80 }} layout={{ layoutSystem: 'pinSystem' }}/>
         </View>
       `),
     )
@@ -1516,9 +1515,7 @@ describe('moveTemplate', () => {
       false,
     )
 
-    const areaControl = renderResult.renderedDOM.getByTestId(
-      'component-area-control-utopia-storyboard-uid/scene-aaa:aaa/eee-2',
-    )
+    const areaControl = renderResult.renderedDOM.getByTestId('eee')
 
     const areaControlBounds = areaControl.getBoundingClientRect()
 
@@ -1601,6 +1598,7 @@ describe('moveTemplate', () => {
           layout={{ layoutSystem: 'pinSystem', top: 10, left: 15, width: 50, height: 60 }}
         />
         <View
+          data-testid={'eee'}
           data-uid={'eee'}
           style={{ backgroundColor: '#00ff00', width: 80, height: 80, left: 100, top: 170 }}
           layout={{ layoutSystem: 'pinSystem' }}

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1407,20 +1407,18 @@ describe('moveTemplate', () => {
       false,
     )
 
-    const areaControl = renderResult.renderedDOM.getByTestId(
-      'component-area-control-utopia-storyboard-uid/scene-aaa:aaa/bbb-1',
-    )
-    const areaControlBounds = areaControl.getBoundingClientRect()
+    const canvasRoot = renderResult.renderedDOM.getByTestId('canvas-root')
 
     await act(async () => {
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
-      fireEvent.keyDown(areaControl, { key: 'v', keyCode: 86 })
+      fireEvent.keyDown(canvasRoot, { key: 'v', keyCode: 86 })
       await dispatchDone
     })
 
     const insertModeMouseCatcher = renderResult.renderedDOM.getByTestId(
       'insert-target-utopia-storyboard-uid/scene-aaa:aaa/bbb',
     )
+    const areaControlBounds = insertModeMouseCatcher.getBoundingClientRect()
 
     await act(async () => {
       fireEvent(
@@ -1619,6 +1617,7 @@ describe('moveTemplate', () => {
           <View
             style={{ backgroundColor: '#0091FFAA', left: 55, top: 275, width: 200, height: 105 }}
             data-uid={'ccc'}
+            data-testid={'ccc'}
           />
         </View>
       `),
@@ -1630,9 +1629,7 @@ describe('moveTemplate', () => {
       false,
     )
 
-    const areaControl = renderResult.renderedDOM.getByTestId(
-      'component-area-control-utopia-storyboard-uid/scene-aaa:aaa/ccc-2',
-    )
+    const areaControl = renderResult.renderedDOM.getByTestId('ccc')
     const areaControlBounds = areaControl.getBoundingClientRect()
 
     fireEvent(
@@ -1714,6 +1711,7 @@ describe('moveTemplate', () => {
           <View
             style={{ backgroundColor: '#0091FFAA', width: 200, height: 105, left: 95, top: 245 }}
             data-uid={'ccc'}
+            data-testid={'ccc'}
           />
         </View>
       `),

--- a/editor/src/components/canvas/controls/component-area-control.tsx
+++ b/editor/src/components/canvas/controls/component-area-control.tsx
@@ -198,7 +198,7 @@ class ComponentAreaControlInner extends React.Component<ComponentAreaControlProp
             borderWidth: 0.5 / this.props.scale,
             borderRadius: showInvisibleIndicator ? borderRadius : 0,
           }}
-          data-testid={this.props.testID}
+          data-testid={this.props.mouseEnabled ? this.props.testID : undefined}
         />
       </React.Fragment>
     )
@@ -222,6 +222,7 @@ class ComponentAreaControlInner extends React.Component<ComponentAreaControlProp
           onMouseDown={labelSelectable ? this.onMouseDown : utils.NO_OP}
           onDragEnter={labelSelectable ? this.onDragEnter : utils.NO_OP}
           onDragLeave={labelSelectable ? this.onDragLeave : utils.NO_OP}
+          data-testid={this.props.mouseEnabled && labelSelectable ? this.props.testID : undefined}
           className='roleComponentName'
           style={{
             pointerEvents: this.props.mouseEnabled ? 'initial' : 'none',

--- a/editor/src/components/canvas/controls/component-area-control.tsx
+++ b/editor/src/components/canvas/controls/component-area-control.tsx
@@ -179,13 +179,14 @@ class ComponentAreaControlInner extends React.Component<ComponentAreaControlProp
       <React.Fragment>
         <div
           className='role-component-selection-highlight'
-          onMouseOver={this.onMouseOver}
-          onMouseLeave={this.onMouseLeave}
-          onMouseDown={this.onMouseDown}
+          // onMouseOver={this.onMouseOver}
+          // onMouseLeave={this.onMouseLeave}
+          // onMouseDown={this.onMouseDown}
           onClick={this.onClick}
           onDragEnter={this.onDragEnter}
           onDragLeave={this.onDragLeave}
           style={{
+            pointerEvents: 'none',
             position: 'absolute',
             left: this.props.canvasOffset.x + this.props.frame.x - extraWidth / 2,
             top: this.props.canvasOffset.y + this.props.frame.y - extraHeight / 2,

--- a/editor/src/components/canvas/controls/component-area-control.tsx
+++ b/editor/src/components/canvas/controls/component-area-control.tsx
@@ -14,6 +14,7 @@ import { calculateExtraSizeForZeroSizedElement } from './outline-utils'
 import { UtopiaTheme, colorTheme } from '../../../uuiui'
 
 interface ComponentAreaControlProps {
+  mouseEnabled: boolean
   target: TemplatePath
   frame: CanvasRectangle
   highlighted: boolean
@@ -179,14 +180,14 @@ class ComponentAreaControlInner extends React.Component<ComponentAreaControlProp
       <React.Fragment>
         <div
           className='role-component-selection-highlight'
-          // onMouseOver={this.onMouseOver}
-          // onMouseLeave={this.onMouseLeave}
-          // onMouseDown={this.onMouseDown}
+          onMouseOver={this.onMouseOver}
+          onMouseLeave={this.onMouseLeave}
+          onMouseDown={this.onMouseDown}
           onClick={this.onClick}
           onDragEnter={this.onDragEnter}
           onDragLeave={this.onDragLeave}
           style={{
-            pointerEvents: 'none',
+            pointerEvents: this.props.mouseEnabled ? 'initial' : 'none',
             position: 'absolute',
             left: this.props.canvasOffset.x + this.props.frame.x - extraWidth / 2,
             top: this.props.canvasOffset.y + this.props.frame.y - extraHeight / 2,
@@ -223,6 +224,7 @@ class ComponentAreaControlInner extends React.Component<ComponentAreaControlProp
           onDragLeave={labelSelectable ? this.onDragLeave : utils.NO_OP}
           className='roleComponentName'
           style={{
+            pointerEvents: this.props.mouseEnabled ? 'initial' : 'none',
             color: isInternalComponent
               ? colorTheme.component.value
               : colorTheme.subduedForeground.value,

--- a/editor/src/components/canvas/controls/deselect-control.tsx
+++ b/editor/src/components/canvas/controls/deselect-control.tsx
@@ -2,32 +2,37 @@ import * as React from 'react'
 import * as EditorActions from '../../editor/actions/action-creators'
 import { Mode } from '../../editor/editor-modes'
 import { EditorDispatch } from '../../editor/action-types'
+import { betterReactMemo } from '../../../uuiui-deps'
+import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
+import { pickSelectionEnabled } from './select-mode/select-mode-hooks'
 
-interface DeselectControlProps {
-  mode: Mode
-  dispatch: EditorDispatch
-}
+interface DeselectControlProps {}
 
-export class DeselectControl extends React.Component<DeselectControlProps> {
-  onMouseDown = () => {
-    if (this.props.mode.type !== 'insert') {
-      this.props.dispatch([EditorActions.clearSelection()], 'canvas')
-    }
-  }
+export const DeselectControl = betterReactMemo<DeselectControlProps>('DeselectControl', (props) => {
+  const editorStateRef = useRefEditorState((store) => store.editor)
+  const dispatch = useEditorState((store) => store.dispatch, 'DeselectControl dispatch')
 
-  render() {
-    return (
-      <div
-        className='deselect-control'
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-        }}
-        onMouseDown={this.onMouseDown}
-      />
+  const onMouseDown = React.useCallback(() => {
+    const selectionEnabled = pickSelectionEnabled(
+      editorStateRef.current.canvas,
+      editorStateRef.current.keysPressed,
     )
-  }
-}
+    if (selectionEnabled && editorStateRef.current.mode.type !== 'insert') {
+      dispatch([EditorActions.clearSelection()], 'canvas')
+    }
+  }, [dispatch, editorStateRef])
+
+  return (
+    <div
+      data-testid='deselect-control'
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+      }}
+      onMouseDown={onMouseDown}
+    />
+  )
+})

--- a/editor/src/components/canvas/controls/deselect-control.tsx
+++ b/editor/src/components/canvas/controls/deselect-control.tsx
@@ -6,9 +6,7 @@ import { betterReactMemo } from '../../../uuiui-deps'
 import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 import { pickSelectionEnabled } from './select-mode/select-mode-hooks'
 
-interface DeselectControlProps {}
-
-export const DeselectControl = betterReactMemo<DeselectControlProps>('DeselectControl', (props) => {
+export const DeselectControl = betterReactMemo('DeselectControl', () => {
   const editorStateRef = useRefEditorState((store) => store.editor)
   const dispatch = useEditorState((store) => store.dispatch, 'DeselectControl dispatch')
 

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -204,6 +204,7 @@ export class InsertModeControlContainer extends React.Component<
 
     return (
       <ComponentAreaControl
+        mouseEnabled={true}
         key={TP.toComponentId(target)}
         componentMetadata={this.props.componentMetadata}
         target={target}
@@ -238,6 +239,7 @@ export class InsertModeControlContainer extends React.Component<
     return (
       <ComponentLabelControl
         key={TP.toComponentId(target)}
+        mouseEnabled={true}
         componentMetadata={this.props.componentMetadata}
         target={target}
         frame={frame}

--- a/editor/src/components/canvas/controls/multiselect-resize-control.tsx
+++ b/editor/src/components/canvas/controls/multiselect-resize-control.tsx
@@ -181,6 +181,7 @@ export class MultiselectResizeControl extends React.Component<
           <>
             <SingleSelectResizeControls
               {...this.props}
+              key='resize-controls'
               obtainOriginalFrames={this.obtainOriginalFrames}
               onResizeStart={this.onResizeStart}
             />
@@ -224,6 +225,7 @@ export class SingleSelectResizeControls extends React.Component<SingleselectResi
               metadata={this.props.componentMetadata}
               onResizeStart={this.props.onResizeStart}
               testID={`component-resize-control-${TP.toComponentId(view)}-${index}`}
+              key={`component-resize-control-${TP.toComponentId(view)}-${index}`}
             />
           </>
         )

--- a/editor/src/components/canvas/controls/multiselect-resize-control.tsx
+++ b/editor/src/components/canvas/controls/multiselect-resize-control.tsx
@@ -181,7 +181,6 @@ export class MultiselectResizeControl extends React.Component<
           <>
             <SingleSelectResizeControls
               {...this.props}
-              key='resize-controls'
               obtainOriginalFrames={this.obtainOriginalFrames}
               onResizeStart={this.onResizeStart}
             />
@@ -225,7 +224,6 @@ export class SingleSelectResizeControls extends React.Component<SingleselectResi
               metadata={this.props.componentMetadata}
               onResizeStart={this.props.onResizeStart}
               testID={`component-resize-control-${TP.toComponentId(view)}-${index}`}
-              key={`component-resize-control-${TP.toComponentId(view)}-${index}`}
             />
           </>
         )

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -19,14 +19,7 @@ import { CanvasPositions, CSSCursor } from '../canvas-types'
 import { SelectModeControlContainer } from './select-mode-control-container'
 import { InsertModeControlContainer } from './insert-mode-control-container'
 import { HighlightControl } from './highlight-control'
-import { DeselectControl } from './deselect-control'
 import { TextEditor } from '../../editor/text-editor'
-import {
-  setHighlightedView,
-  clearHighlightedViews,
-  insertDroppedImage,
-  switchEditorMode,
-} from '../../editor/actions/action-creators'
 import { useEditorState } from '../../editor/store/store-hook'
 import { JSXMetadata, UtopiaJSXComponent } from '../../../core/shared/element-template'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
@@ -445,10 +438,6 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
     }
   }
 
-  const renderDeselectControl = () => {
-    return selectionEnabled ? <DeselectControl /> : null
-  }
-
   const textEditor =
     props.editor.canvas.textEditor != null
       ? renderTextEditor(props.editor.canvas.textEditor.templatePath)
@@ -463,7 +452,6 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
         height: '100%',
       }}
     >
-      {renderDeselectControl()}
       {renderModeControlContainer()}
       {renderHighlightControls()}
       {textEditor}

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -446,9 +446,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
   }
 
   const renderDeselectControl = () => {
-    return selectionEnabled ? (
-      <DeselectControl mode={props.editor.mode} dispatch={props.dispatch} />
-    ) : null
+    return selectionEnabled ? <DeselectControl /> : null
   }
 
   const textEditor =

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -38,8 +38,8 @@ import { usePropControlledStateV2 } from '../../inspector/common/inspector-utils
 import { colorTheme } from '../../../uuiui'
 import { betterReactMemo } from '../../../uuiui-deps'
 import {
-  pickIsDragging,
-  pickIsResizing,
+  isDragging,
+  isResizing,
   pickSelectionEnabled,
   useMaybeHighlightElement,
 } from './select-mode/select-mode-hooks'
@@ -222,8 +222,8 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
 
   const componentMetadata = getMetadata(props.editor)
 
-  const isResizing = pickIsResizing(props.editor.canvas.dragState)
-  const isDragging = pickIsDragging(props.editor.canvas.dragState)
+  const resizing = isResizing(props.editor.canvas.dragState)
+  const dragging = isDragging(props.editor.canvas.dragState)
   const selectionEnabled = pickSelectionEnabled(props.editor.canvas, props.editor.keysPressed)
 
   const { maybeHighlightOnHover, maybeClearHighlightsOnHoverEnd } = useMaybeHighlightElement()
@@ -309,8 +309,8 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
             setSelectedViewsLocally={setSelectedViewsLocally}
             keysPressed={props.editor.keysPressed}
             windowToCanvasPosition={props.windowToCanvasPosition}
-            isDragging={isDragging}
-            isResizing={isResizing}
+            isDragging={dragging}
+            isResizing={resizing}
             selectionEnabled={selectionEnabled}
             maybeHighlightOnHover={maybeHighlightOnHover}
             maybeClearHighlightsOnHoverEnd={maybeClearHighlightsOnHoverEnd}

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -172,7 +172,7 @@ interface NewCanvasControlsInnerProps {
   windowToCanvasPosition: (event: MouseEvent) => CanvasPositions
 }
 
-const selectElementsThatRespectLayout = createSelector(
+export const selectElementsThatRespectLayout = createSelector(
   (store: EditorStore) => store.derived.navigatorTargets,
   (store) => store.editor.propertyControlsInfo,
   (store) => getOpenImportsFromState(store.editor),

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -288,6 +288,7 @@ export class SelectModeControlContainer extends React.Component<
       return (
         <ComponentAreaControl
           key={`${TP.toComponentId(target)}-${index}-control`}
+          mouseEnabled={false}
           testID={`component-area-control-${TP.toComponentId(target)}-${index}`}
           componentMetadata={this.props.componentMetadata}
           target={target}
@@ -323,6 +324,7 @@ export class SelectModeControlContainer extends React.Component<
     return (
       <ComponentLabelControl
         key={`${TP.toComponentId(target)}-label`}
+        mouseEnabled={true}
         componentMetadata={this.props.componentMetadata}
         target={target}
         frame={frame}
@@ -359,6 +361,7 @@ export class SelectModeControlContainer extends React.Component<
     }
     return (
       <ComponentAreaControl
+        mouseEnabled={false}
         key={`${TP.toComponentId(target)}-non-selectable`}
         componentMetadata={this.props.componentMetadata}
         target={target}

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -98,6 +98,7 @@ export class SelectModeControlContainer extends React.Component<
   }
 
   selectComponent = (target: TemplatePath, isMultiselect: boolean): Array<TemplatePath> => {
+    // TODO BALAZS Remove this and unify with select-mode-hooks
     if (this.props.selectedViews.some((view) => TP.pathsEqual(target, view))) {
       return this.props.selectedViews
     } else {
@@ -134,6 +135,7 @@ export class SelectModeControlContainer extends React.Component<
     start: CanvasPoint,
     originalEvent: React.MouseEvent<HTMLDivElement>,
   ) => {
+    // TODO BALAZS Remove this and unify with select-mode-hooks
     if (
       // Only on left mouse down.
       originalEvent.buttons === 1 &&

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -324,6 +324,7 @@ export class SelectModeControlContainer extends React.Component<
     return (
       <ComponentLabelControl
         key={`${TP.toComponentId(target)}-label`}
+        testID={`label-control-${TP.toComponentId(target)}`}
         mouseEnabled={true}
         componentMetadata={this.props.componentMetadata}
         target={target}

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -36,11 +36,11 @@ import { selectElementsThatRespectLayout } from '../new-canvas-controls'
 
 const DRAG_START_TRESHOLD = 2
 
-export function pickIsResizing(dragState: DragState | null): boolean {
+export function isResizing(dragState: DragState | null): boolean {
   return dragState != null && dragState.type === 'RESIZE_DRAG_STATE' && dragState.drag != null
 }
 
-export function pickIsDragging(dragState: DragState | null): boolean {
+export function isDragging(dragState: DragState | null): boolean {
   return dragState != null && dragState.type === 'MOVE_DRAG_STATE' && dragState.drag != null
 }
 
@@ -61,16 +61,16 @@ export function useMaybeHighlightElement(): {
   const stateRef = useRefEditorState((store) => {
     return {
       dispatch: store.dispatch,
-      isResizing: pickIsResizing(store.editor.canvas.dragState),
-      isDragging: pickIsDragging(store.editor.canvas.dragState),
+      resizing: isResizing(store.editor.canvas.dragState),
+      dragging: isDragging(store.editor.canvas.dragState),
       selectionEnabled: pickSelectionEnabled(store.editor.canvas, store.editor.keysPressed),
     }
   })
 
   const maybeHighlightOnHover = React.useCallback(
     (target: TemplatePath): void => {
-      const { dispatch, isDragging, isResizing, selectionEnabled } = stateRef.current
-      if (selectionEnabled && !isDragging && !isResizing) {
+      const { dispatch, dragging, resizing, selectionEnabled } = stateRef.current
+      if (selectionEnabled && !dragging && !resizing) {
         dispatch([setHighlightedView(target)], 'canvas')
       }
     },
@@ -78,8 +78,8 @@ export function useMaybeHighlightElement(): {
   )
 
   const maybeClearHighlightsOnHoverEnd = React.useCallback((): void => {
-    const { dispatch, isDragging, isResizing, selectionEnabled } = stateRef.current
-    if (selectionEnabled && !isDragging && !isResizing) {
+    const { dispatch, dragging, resizing, selectionEnabled } = stateRef.current
+    if (selectionEnabled && !dragging && !resizing) {
       dispatch([clearHighlightedViews()], 'canvas')
     }
   }, [stateRef])

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -349,6 +349,7 @@ export function useSelectModeSelectAndHover(): {
           const doubleClick = event.detail > 1 // we interpret a triple click as two double clicks, a quadruple click as three double clicks, etc  // TODO TEST ME
           if (foundTarget.selectionMode === 'singleclick' || doubleClick) {
             dispatch([selectComponents([foundTarget.templatePath], event.shiftKey)])
+            // TODO BALAZS repeat the hack from select-mode-control-container which sets the selected views with a priority on the canvas controls first
           }
         }
       }

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -15,7 +15,7 @@ import * as TP from '../../../../core/shared/template-path'
 import { NO_OP } from '../../../../core/shared/utils'
 import { KeysPressed } from '../../../../utils/keyboard'
 import { useKeepShallowReferenceEquality } from '../../../../utils/react-performance'
-import utils from '../../../../utils/utils'
+import Utils from '../../../../utils/utils'
 import {
   clearHighlightedViews,
   clearSelection,
@@ -111,7 +111,7 @@ export function getSelectableViews(
     const scenes = MetadataUtils.getAllScenePaths(componentMetadata.components)
     let rootElementsToFilter: TemplatePath[] = []
     let dynamicScenesWithFragmentRootViews: ScenePath[] = []
-    utils.fastForEach(scenes, (path) => {
+    Utils.fastForEach(scenes, (path) => {
       const scene = MetadataUtils.findSceneByTemplatePath(componentMetadata.components, path)
       const rootElements = scene?.rootElements
       if (
@@ -127,8 +127,8 @@ export function getSelectableViews(
       return !rootElementsToFilter.some((path) => TP.pathsEqual(rootPath, path))
     })
     let siblings: Array<TemplatePath> = []
-    utils.fastForEach(selectedViews, (view) => {
-      utils.fastForEach(TP.allPaths(view), (ancestor) => {
+    Utils.fastForEach(selectedViews, (view) => {
+      Utils.fastForEach(TP.allPaths(view), (ancestor) => {
         const ancestorChildren = MetadataUtils.getImmediateChildren(componentMetadata, ancestor)
 
         siblings.push(...ancestorChildren.map((child) => child.templatePath))

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -1,0 +1,241 @@
+import * as React from 'react'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { uniqBy } from '../../../../core/shared/array-utils'
+import { JSXMetadata } from '../../../../core/shared/element-template'
+import { ScenePath, TemplatePath } from '../../../../core/shared/project-file-types'
+import * as TP from '../../../../core/shared/template-path'
+import { KeysPressed } from '../../../../utils/keyboard'
+import utils from '../../../../utils/utils'
+import {
+  clearHighlightedViews,
+  clearSelection,
+  selectComponents,
+  setHighlightedView,
+} from '../../../editor/actions/action-creators'
+import { EditorState } from '../../../editor/store/editor-state'
+import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
+import { DragState } from '../../canvas-types'
+import { findFirstParentWithValidUID } from '../../dom-lookup'
+
+export function pickIsResizing(dragState: DragState | null): boolean {
+  return dragState != null && dragState.type === 'RESIZE_DRAG_STATE' && dragState.drag != null
+}
+
+export function pickIsDragging(dragState: DragState | null): boolean {
+  return dragState != null && dragState.type === 'MOVE_DRAG_STATE' && dragState.drag != null
+}
+
+export function pickSelectionEnabled(
+  canvas: EditorState['canvas'],
+  keysPressed: KeysPressed,
+): boolean {
+  return canvas.selectionControlsVisible && !keysPressed['z'] && canvas.textEditor == null
+}
+
+/**
+ * maybeHighlightOnHover and maybeClearHighlightsOnHoverEnd are moved here from new-canvas-controls, kept as-is for continuity
+ */
+export function useMaybeHighlightElement(): {
+  maybeHighlightOnHover: (target: TemplatePath) => void
+  maybeClearHighlightsOnHoverEnd: () => void
+} {
+  const stateRef = useRefEditorState((store) => {
+    return {
+      dispatch: store.dispatch,
+      isResizing: pickIsResizing(store.editor.canvas.dragState),
+      isDragging: pickIsDragging(store.editor.canvas.dragState),
+      selectionEnabled: pickSelectionEnabled(store.editor.canvas, store.editor.keysPressed),
+    }
+  })
+
+  const maybeHighlightOnHover = React.useCallback(
+    (target: TemplatePath): void => {
+      const { dispatch, isDragging, isResizing, selectionEnabled } = stateRef.current
+      if (selectionEnabled && !isDragging && !isResizing) {
+        dispatch([setHighlightedView(target)], 'canvas')
+      }
+    },
+    [stateRef],
+  )
+
+  const maybeClearHighlightsOnHoverEnd = React.useCallback((): void => {
+    const { dispatch, isDragging, isResizing, selectionEnabled } = stateRef.current
+    if (selectionEnabled && !isDragging && !isResizing) {
+      dispatch([clearHighlightedViews()], 'canvas')
+    }
+  }, [stateRef])
+
+  return {
+    maybeHighlightOnHover: maybeHighlightOnHover,
+    maybeClearHighlightsOnHoverEnd: maybeClearHighlightsOnHoverEnd,
+  }
+}
+
+function filterHiddenInstances(
+  hiddenInstances: Array<TemplatePath>,
+  paths: Array<TemplatePath>,
+): Array<TemplatePath> {
+  return paths.filter((path) => hiddenInstances.every((hidden) => !TP.pathsEqual(path, hidden)))
+}
+
+export function getSelectableViews(
+  componentMetadata: JSXMetadata,
+  selectedViews: Array<TemplatePath>,
+  hiddenInstances: Array<TemplatePath>,
+  allElementsDirectlySelectable: boolean,
+): TemplatePath[] {
+  let candidateViews: Array<TemplatePath>
+
+  if (allElementsDirectlySelectable) {
+    candidateViews = MetadataUtils.getAllPaths(componentMetadata)
+  } else {
+    const scenes = MetadataUtils.getAllScenePaths(componentMetadata.components)
+    let rootElementsToFilter: TemplatePath[] = []
+    let dynamicScenesWithFragmentRootViews: ScenePath[] = []
+    utils.fastForEach(scenes, (path) => {
+      const scene = MetadataUtils.findSceneByTemplatePath(componentMetadata.components, path)
+      const rootElements = scene?.rootElements
+      if (
+        MetadataUtils.isSceneTreatedAsGroup(scene) &&
+        rootElements != null &&
+        rootElements.length > 1
+      ) {
+        rootElementsToFilter.push(...rootElements)
+        dynamicScenesWithFragmentRootViews.push(path)
+      }
+    })
+    const allRoots = MetadataUtils.getAllCanvasRootPaths(componentMetadata).filter((rootPath) => {
+      return !rootElementsToFilter.some((path) => TP.pathsEqual(rootPath, path))
+    })
+    let siblings: Array<TemplatePath> = []
+    utils.fastForEach(selectedViews, (view) => {
+      utils.fastForEach(TP.allPaths(view), (ancestor) => {
+        const ancestorChildren = MetadataUtils.getImmediateChildren(componentMetadata, ancestor)
+
+        siblings.push(...ancestorChildren.map((child) => child.templatePath))
+      })
+    })
+
+    const selectableViews = [...dynamicScenesWithFragmentRootViews, ...allRoots, ...siblings]
+    const uniqueSelectableViews = uniqBy<TemplatePath>(selectableViews, TP.pathsEqual)
+
+    const selectableViewsFiltered = uniqueSelectableViews.filter((view) => {
+      // I kept the group-like behavior here that the user can't single-click select the parent group, even though it is a view now
+      const isGroup = MetadataUtils.isAutoSizingViewFromComponents(componentMetadata, view)
+      const isAncestorOfSelected = selectedViews.some((selectedView) =>
+        TP.isAncestorOf(selectedView, view, false),
+      )
+      if (isGroup && isAncestorOfSelected) {
+        return false
+      } else {
+        return true
+      }
+    })
+    candidateViews = selectableViewsFiltered
+  }
+
+  return filterHiddenInstances(hiddenInstances, candidateViews)
+}
+
+function useFindValidTarget(): (
+  targetHtmlElement: HTMLElement,
+) => {
+  templatePath: TemplatePath
+  selectionMode: 'singleclick' | 'doubleclick'
+  isSelected: boolean
+} | null {
+  const storeRef = useRefEditorState((store) => {
+    return {
+      componentMetadata: store.editor.jsxMetadataKILLME,
+      selectedViews: store.editor.selectedViews,
+      hiddenInstances: store.editor.hiddenInstances,
+      allElementsDirectlySelectable: store.editor.keysPressed.cmd ?? false,
+    }
+  })
+
+  return React.useCallback(
+    (targetHtmlElement: HTMLElement) => {
+      const {
+        componentMetadata,
+        selectedViews,
+        hiddenInstances,
+        allElementsDirectlySelectable,
+      } = storeRef.current
+      const selectableViews = getSelectableViews(
+        componentMetadata,
+        selectedViews,
+        hiddenInstances,
+        allElementsDirectlySelectable,
+      )
+      const validElementMouseOver: string | null = findFirstParentWithValidUID(
+        selectableViews.map(TP.toString),
+        targetHtmlElement as HTMLElement,
+      )
+      const validTemplatePath: TemplatePath | null =
+        validElementMouseOver != null ? TP.fromString(validElementMouseOver) : null
+      if (validTemplatePath != null) {
+        const isSelected = selectedViews.some((selectedView) =>
+          TP.pathsEqual(validTemplatePath, selectedView),
+        )
+        const isChild = selectedViews.some((selectedView) =>
+          TP.isChildOf(validTemplatePath, selectedView),
+        )
+        return {
+          templatePath: validTemplatePath,
+          selectionMode: isChild ? 'doubleclick' : 'singleclick',
+          isSelected: isSelected,
+        }
+      } else {
+        return null
+      }
+    },
+    [storeRef],
+  )
+}
+
+export function useSelectAndHover(): {
+  onMouseOver: (event: React.MouseEvent<HTMLDivElement>) => void
+  onMouseOut: () => void
+  onMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void
+} {
+  const dispatch = useEditorState((store) => store.dispatch, 'useSelectAndHover dispatch')
+  const { maybeHighlightOnHover, maybeClearHighlightsOnHoverEnd } = useMaybeHighlightElement()
+  const findValidTarget = useFindValidTarget()
+
+  const onMouseOver = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      const validTemplatePath = findValidTarget(event.target as HTMLDivElement)
+      if (
+        validTemplatePath != null &&
+        validTemplatePath.selectionMode === 'singleclick' && // we only show highlights for single-click selectable elements
+        !validTemplatePath.isSelected // do not highlight selected elements
+      ) {
+        maybeHighlightOnHover(validTemplatePath.templatePath)
+      }
+    },
+    [maybeHighlightOnHover, findValidTarget],
+  )
+
+  const onMouseOut = React.useCallback(() => {
+    maybeClearHighlightsOnHoverEnd()
+  }, [maybeClearHighlightsOnHoverEnd])
+
+  const onMouseDown = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      const foundTarget = findValidTarget(event.target as HTMLDivElement)
+      if (foundTarget != null) {
+        if (!foundTarget.isSelected) {
+          const doubleClick = event.detail > 1 // we interpret a triple click as two double clicks, a quadruple click as three double clicks, etc  // TODO TEST ME
+          if (foundTarget.selectionMode === 'singleclick' || doubleClick) {
+            dispatch([selectComponents([foundTarget.templatePath], false)])
+          }
+        }
+      }
+    },
+    [dispatch, findValidTarget],
+  )
+
+  // TODO if mouse moves, enter drag mode
+
+  return { onMouseOver, onMouseOut, onMouseDown }
+}

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../../core/shared/math-utils'
 import { ScenePath, TemplatePath } from '../../../../core/shared/project-file-types'
 import * as TP from '../../../../core/shared/template-path'
-import { NO_OP } from '../../../../core/shared/utils'
+import { fastForEach, NO_OP } from '../../../../core/shared/utils'
 import { KeysPressed } from '../../../../utils/keyboard'
 import { useKeepShallowReferenceEquality } from '../../../../utils/react-performance'
 import Utils from '../../../../utils/utils'
@@ -130,8 +130,7 @@ export function getSelectableViews(
     Utils.fastForEach(selectedViews, (view) => {
       Utils.fastForEach(TP.allPaths(view), (ancestor) => {
         const ancestorChildren = MetadataUtils.getImmediateChildren(componentMetadata, ancestor)
-
-        siblings.push(...ancestorChildren.map((child) => child.templatePath))
+        fastForEach(ancestorChildren, (child) => siblings.push(child.templatePath))
       })
     })
 

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -156,7 +156,7 @@ export function getSelectableViews(
 }
 
 function useFindValidTarget(): (
-  targetHtmlElement: HTMLElement,
+  targetHtmlElement: Element,
   allElementsDirectlySelectable: boolean,
 ) => {
   templatePath: TemplatePath
@@ -172,7 +172,7 @@ function useFindValidTarget(): (
   })
 
   return React.useCallback(
-    (targetHtmlElement: HTMLElement, allElementsDirectlySelectable: boolean) => {
+    (targetHtmlElement: Element, allElementsDirectlySelectable: boolean) => {
       const { componentMetadata, selectedViews, hiddenInstances } = storeRef.current
       const selectableViews = getSelectableViews(
         componentMetadata,
@@ -182,7 +182,7 @@ function useFindValidTarget(): (
       )
       const validElementMouseOver: string | null = findFirstParentWithValidUID(
         selectableViews.map(TP.toString),
-        targetHtmlElement as HTMLElement,
+        targetHtmlElement,
       )
       const validTemplatePath: TemplatePath | null =
         validElementMouseOver != null ? TP.fromString(validElementMouseOver) : null
@@ -314,7 +314,7 @@ export function useSelectModeSelectAndHover(): {
 
   const onMouseOver = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      const validTemplatePath = findValidTarget(event.target as HTMLElement, event.metaKey)
+      const validTemplatePath = findValidTarget(event.target as Element, event.metaKey)
       if (
         validTemplatePath != null &&
         validTemplatePath.selectionMode === 'singleclick' && // we only show highlights for single-click selectable elements
@@ -332,7 +332,7 @@ export function useSelectModeSelectAndHover(): {
 
   const onMouseDown = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      const foundTarget = findValidTarget(event.target as HTMLElement, event.metaKey)
+      const foundTarget = findValidTarget(event.target as Element, event.metaKey)
       if (foundTarget != null) {
         callbackAfterDragExceedsThreshold(
           event.nativeEvent,

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -314,7 +314,7 @@ export function useSelectModeSelectAndHover(): {
 
   const onMouseOver = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      const validTemplatePath = findValidTarget(event.target as HTMLDivElement, event.metaKey)
+      const validTemplatePath = findValidTarget(event.target as HTMLElement, event.metaKey)
       if (
         validTemplatePath != null &&
         validTemplatePath.selectionMode === 'singleclick' && // we only show highlights for single-click selectable elements
@@ -332,7 +332,7 @@ export function useSelectModeSelectAndHover(): {
 
   const onMouseDown = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      const foundTarget = findValidTarget(event.target as HTMLDivElement, event.metaKey)
+      const foundTarget = findValidTarget(event.target as HTMLElement, event.metaKey)
       if (foundTarget != null) {
         callbackAfterDragExceedsThreshold(
           event.nativeEvent,

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -356,8 +356,6 @@ export function useSelectModeSelectAndHover(): {
     [dispatch, findValidTarget, startDragState, windowToCanvasCoordinates],
   )
 
-  // TODO deselect control under the canvas
-
   return { onMouseOver, onMouseOut, onMouseDown }
 }
 

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -46,6 +46,7 @@ class ResizeControl extends React.Component<ResizeControlProps> {
   }
 
   onMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation()
     if (event.buttons === 1) {
       const centerBasedResize = event.altKey
       const keepAspectRatio = event.shiftKey || this.props.elementAspectRatioLocked
@@ -157,6 +158,7 @@ class ResizeEdge extends React.Component<ResizeEdgeProps> {
       <div
         ref={this.reference}
         style={{
+          pointerEvents: 'initial',
           position: 'absolute',
           left: left,
           top: top,
@@ -201,6 +203,7 @@ const ResizeLines = (props: ResizeLinesProps) => {
       <div
         ref={reference}
         style={{
+          pointerEvents: 'initial',
           position: 'absolute',
           width: catchmentSize,
           height: catchmentSize,
@@ -337,6 +340,7 @@ class ResizePoint extends React.Component<ResizePointProps> {
       <React.Fragment>
         <div
           style={{
+            pointerEvents: 'initial',
             position: 'absolute',
             width: size,
             height: size,

--- a/editor/src/components/canvas/dom-lookup-hooks.ts
+++ b/editor/src/components/canvas/dom-lookup-hooks.ts
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import { WindowPoint } from '../../core/shared/math-utils'
+import { useRefEditorState } from '../editor/store/store-hook'
+import { CanvasPositions } from './canvas-types'
+import { windowToCanvasCoordinates } from './dom-lookup'
+
+export function useWindowToCanvasCoordinates(): (screenPoint: WindowPoint) => CanvasPositions {
+  const canvasStateRef = useRefEditorState((store) => store.editor.canvas)
+  return React.useCallback(
+    (screenPoint: WindowPoint) => {
+      return windowToCanvasCoordinates(
+        canvasStateRef.current.scale,
+        canvasStateRef.current.roundedCanvasOffset,
+        screenPoint,
+      )
+    },
+    [canvasStateRef],
+  )
+}

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -1,0 +1,58 @@
+import { last, stripNulls } from '../../core/shared/array-utils'
+import { getDOMAttribute } from '../../core/shared/dom-utils'
+import { WindowPoint } from '../../core/shared/math-utils'
+import { TemplatePath } from '../../core/shared/project-file-types'
+import * as TP from '../../core/shared/template-path'
+
+// eslint-disable-next-line no-restricted-globals
+export function findParentSceneValidPaths(target: Element): Array<string> | null {
+  const validPaths = getDOMAttribute(target, 'data-utopia-valid-paths')
+  if (validPaths != null) {
+    return validPaths.split(' ')
+  } else {
+    if (target.parentElement != null) {
+      return findParentSceneValidPaths(target.parentElement)
+    } else {
+      return null
+    }
+  }
+}
+
+export function findFirstParentWithValidUID(
+  validTemplatePaths: Array<string>,
+  // eslint-disable-next-line no-restricted-globals
+  target: Element,
+): string | null {
+  const uid = getDOMAttribute(target, 'data-uid')
+  const originalUid = getDOMAttribute(target, 'data-utopia-original-uid')
+  if (originalUid != null && validTemplatePaths.find((tp) => tp.endsWith(originalUid))) {
+    return last(validTemplatePaths.filter((tp) => tp.endsWith(originalUid))) ?? null
+  } else if (uid != null && validTemplatePaths.find((tp) => tp.endsWith(uid))) {
+    return last(validTemplatePaths.filter((tp) => tp.endsWith(uid))) ?? null
+  } else {
+    if (target.parentElement != null) {
+      return findFirstParentWithValidUID(validTemplatePaths, target.parentElement)
+    } else {
+      return null
+    }
+  }
+}
+
+export function getAllTargetsAtPoint(point: WindowPoint | null): Array<TemplatePath> {
+  if (point == null) {
+    return []
+  }
+  const elementsUnderPoint = document.elementsFromPoint(point.x, point.y)
+  return stripNulls(
+    elementsUnderPoint.map((element) => {
+      const validTPs = findParentSceneValidPaths(element)
+      if (validTPs != null) {
+        const foundValidtemplatePath = findFirstParentWithValidUID(validTPs, element)
+        if (foundValidtemplatePath != null) {
+          return TP.fromString(foundValidtemplatePath)
+        }
+      }
+      return null
+    }),
+  )
+}

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -1,10 +1,10 @@
 import { last, stripNulls } from '../../core/shared/array-utils'
 import { getDOMAttribute } from '../../core/shared/dom-utils'
 import {
+  canvasPoint,
   CanvasVector,
   negate,
   offsetPoint,
-  RawPoint,
   roundPointToNearestHalf,
   scaleVector,
   windowPoint,
@@ -79,11 +79,11 @@ export function windowToCanvasCoordinates(
     const canvasDivCoords = {
       x: screenPoint.x - canvasWrapperRect.left,
       y: screenPoint.y - canvasWrapperRect.top,
-    } as RawPoint
+    } as WindowPoint
     const inverseOffset = negate(canvasOffset)
     const inverseScale = 1 / canvasScale
-    const pagePosition = scaleVector(canvasDivCoords, inverseScale)
-    const canvasPositionRaw = offsetPoint(pagePosition as any, inverseOffset)
+    const pagePosition = canvasPoint(scaleVector(canvasDivCoords, inverseScale))
+    const canvasPositionRaw = offsetPoint(pagePosition, inverseOffset)
     return {
       windowPosition: windowPoint({ x: screenPoint.x, y: screenPoint.y }),
       canvasPositionRaw: canvasPositionRaw,

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -14,7 +14,6 @@ import { TemplatePath } from '../../core/shared/project-file-types'
 import * as TP from '../../core/shared/template-path'
 import { CanvasPositions } from './canvas-types'
 
-// eslint-disable-next-line no-restricted-globals
 export function findParentSceneValidPaths(target: Element): Array<string> | null {
   const validPaths = getDOMAttribute(target, 'data-utopia-valid-paths')
   if (validPaths != null) {
@@ -30,7 +29,6 @@ export function findParentSceneValidPaths(target: Element): Array<string> | null
 
 export function findFirstParentWithValidUID(
   validTemplatePaths: Array<string>,
-  // eslint-disable-next-line no-restricted-globals
   target: Element,
 ): string | null {
   const uid = getDOMAttribute(target, 'data-uid')

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -34,6 +34,9 @@ import {
   UiJsxCanvas,
 } from './ui-jsx-canvas'
 import { CanvasErrorBoundary } from './canvas-component-entry'
+import { EditorStateContext } from '../editor/store/store-hook'
+import { getStoreHook } from '../inspector/common/inspector.test-utils'
+import { NO_OP } from '../../core/shared/utils'
 
 export interface PartialCanvasProps {
   offset: UiJsxCanvasProps['offset']
@@ -180,20 +183,24 @@ export function renderCanvasReturnResultAndError(
     spyEnabled: false,
   }
 
+  const storeHookForTest = getStoreHook(NO_OP)
+
   let formattedSpyEnabled
   let errorsReportedSpyEnabled = []
   try {
     const flatFormat = ReactDOMServer.renderToStaticMarkup(
-      <UiJsxCanvasContext.Provider value={spyCollector}>
-        <CanvasErrorBoundary
-          fileCode={code}
-          filePath={uiFilePath}
-          reportError={reportError}
-          requireFn={canvasProps.requireFn}
-        >
-          <UiJsxCanvas {...canvasProps} />
-        </CanvasErrorBoundary>
-      </UiJsxCanvasContext.Provider>,
+      <EditorStateContext.Provider value={storeHookForTest}>
+        <UiJsxCanvasContext.Provider value={spyCollector}>
+          <CanvasErrorBoundary
+            fileCode={code}
+            filePath={uiFilePath}
+            reportError={reportError}
+            requireFn={canvasProps.requireFn}
+          >
+            <UiJsxCanvas {...canvasProps} />
+          </CanvasErrorBoundary>
+        </UiJsxCanvasContext.Provider>
+      </EditorStateContext.Provider>,
     )
     formattedSpyEnabled = Prettier.format(flatFormat, { parser: 'html' })
     errorsReportedSpyEnabled = errorsReported
@@ -207,9 +214,11 @@ export function renderCanvasReturnResultAndError(
 
   try {
     const flatFormatSpyDisabled = ReactDOMServer.renderToStaticMarkup(
-      <UiJsxCanvasContext.Provider value={emptyUiJsxCanvasContextData()}>
-        <UiJsxCanvas {...canvasPropsSpyDisabled} />
-      </UiJsxCanvasContext.Provider>,
+      <EditorStateContext.Provider value={storeHookForTest}>
+        <UiJsxCanvasContext.Provider value={emptyUiJsxCanvasContextData()}>
+          <UiJsxCanvas {...canvasPropsSpyDisabled} />
+        </UiJsxCanvasContext.Provider>
+      </EditorStateContext.Provider>,
     )
     formattedSpyDisabled = Prettier.format(flatFormatSpyDisabled, { parser: 'html' })
     errorsReportedSpyDisabled = errorsReported

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -67,6 +67,7 @@ import { runBlockUpdatingScope } from './ui-jsx-canvas-renderer/ui-jsx-canvas-sc
 import { CanvasContainerID } from './canvas-types'
 import { betterReactMemo, useKeepReferenceEqualityIfPossible } from '../../utils/react-performance'
 import { unimportAllButTheseCSSFiles } from '../../core/webpack-loaders/css-loader'
+import { useSelectAndHover } from './controls/select-mode/select-mode-hooks'
 
 const emptyFileBlobs: UIFileBase64Blobs = {}
 
@@ -447,12 +448,17 @@ const CanvasContainer: React.FunctionComponent<React.PropsWithChildren<CanvasCon
   // eslint-disable-next-line react-hooks/rules-of-hooks
   let containerRef = props.walkDOM ? useDomWalker(props) : React.useRef<HTMLDivElement>(null)
 
+  const { onMouseOver, onMouseOut, onMouseDown } = useSelectAndHover()
+
   const { scale, offset } = props
   return (
     <div
       id={CanvasContainerID}
       key={'canvas-container'}
       ref={containerRef}
+      onMouseOver={onMouseOver}
+      onMouseOut={onMouseOut}
+      onMouseDown={onMouseDown}
       style={{
         all: 'initial',
         position: 'absolute',

--- a/editor/src/core/shared/dom-utils.ts
+++ b/editor/src/core/shared/dom-utils.ts
@@ -202,7 +202,8 @@ export const intrinsicHTMLElementNamesThatSupportChildren: Array<string> = [
   'section',
 ]
 
-export function getDOMAttribute(element: HTMLElement, attributeName: string): string | null {
+// eslint-disable-next-line no-restricted-globals
+export function getDOMAttribute(element: Element, attributeName: string): string | null {
   const attr = element.attributes.getNamedItemNS(null, attributeName)
   if (attr == null) {
     return null
@@ -211,7 +212,8 @@ export function getDOMAttribute(element: HTMLElement, attributeName: string): st
   }
 }
 
-export function setDOMAttribute(element: HTMLElement, attributeName: string, value: string): void {
+// eslint-disable-next-line no-restricted-globals
+export function setDOMAttribute(element: Element, attributeName: string, value: string): void {
   const attr = document.createAttributeNS(null, attributeName)
   attr.value = value
   element.attributes.setNamedItemNS(attr)

--- a/editor/src/core/shared/dom-utils.ts
+++ b/editor/src/core/shared/dom-utils.ts
@@ -202,7 +202,6 @@ export const intrinsicHTMLElementNamesThatSupportChildren: Array<string> = [
   'section',
 ]
 
-// eslint-disable-next-line no-restricted-globals
 export function getDOMAttribute(element: Element, attributeName: string): string | null {
   const attr = element.attributes.getNamedItemNS(null, attributeName)
   if (attr == null) {
@@ -212,7 +211,6 @@ export function getDOMAttribute(element: Element, attributeName: string): string
   }
 }
 
-// eslint-disable-next-line no-restricted-globals
 export function setDOMAttribute(element: Element, attributeName: string, value: string): void {
   const attr = document.createAttributeNS(null, attributeName)
   attr.value = value

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -24,6 +24,9 @@ export type CanvasPoint = CanvasModifier & PointInner
 export function canvasPoint(p: PointInner): CanvasPoint {
   return p as CanvasPoint
 }
+export function windowPoint(p: PointInner): WindowPoint {
+  return p as WindowPoint
+}
 
 export type LocalPoint = LocalModifier & PointInner
 export type NodeGraphPoint = NodeGraphModifier & PointInner

--- a/editor/src/core/webpack-loaders/css-loader.ts
+++ b/editor/src/core/webpack-loaders/css-loader.ts
@@ -51,7 +51,6 @@ export function unimportAllButTheseCSSFiles(filesToKeep: Array<string>): void {
     elemId.startsWith(InjectedCSSFilePrefix) &&
     !filesToKeep.some((filename) => elemId.endsWith(filename))
   if (head != null) {
-    // eslint-disable-next-line no-restricted-globals
     let inlinedCSSImportsToRemove: Array<Element> = []
     for (let index = 0; index < head.children.length; index++) {
       const child = head.children[index]

--- a/editor/src/templates/editor-canvas.ts
+++ b/editor/src/templates/editor-canvas.ts
@@ -670,6 +670,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
       {
         id: 'canvas-root',
         key: 'canvas-root',
+        'data-testid': 'canvas-root',
         style: {
           ...canvasLiveEditingStyle,
           transition: 'all .2s linear',

--- a/editor/src/templates/editor-canvas.ts
+++ b/editor/src/templates/editor-canvas.ts
@@ -77,6 +77,7 @@ import { ImageResult } from '../core/shared/file-utils'
 import { fastForEach } from '../core/shared/utils'
 import { arrayToMaybe } from '../core/shared/optional-utils'
 import { UtopiaStyles } from '../uuiui'
+import { DeselectControl } from '../components/canvas/controls/deselect-control'
 
 const webFrame = PROBABLY_ELECTRON ? requireElectron().webFrame : null
 
@@ -769,6 +770,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
           }
         },
       },
+      React.createElement(DeselectControl, {}),
       nodeConnectorsDiv,
       React.createElement(CanvasComponentEntry, {
         reportError: this.props.reportError,


### PR DESCRIPTION
**Problem:**
The selection and highlight system uses AABB (axis-aligned bounding box) bounds to determine where the user clicked. This is an issue with elements that are rotated or otherwise not rectangular. This makes selection feel unreliable/unpredictable.

**Fix:**
This PR fixes the click-to select and mouse-based highlight for elements. It *does not* fix the following, these will be fixed in follow up PRs:
- the actual drawn highlights still use the old AABB
- the spacebar-based selection still uses the old AABB
- insert mode still uses the old AABBs
- on master, when the user clicks to select something, we first dispatch that as a local action (effectively giving it a priority to render) and then in the next animation frame we dispatch the select action. This behavior is not yet working with the new selection hooks.
- if the user has event listeners in the user code, those are *not yet disabled!*

**Commit Details:**
- Created a new family of hooks in `select-mode-hooks`
- useSelectAndHover returns mouse event handlers that the `CanvasContainer` attaches to the canvas root
- the hover and mouseDown detection relies on bubbling events
- fixed a bunch of tests that relied on the old canvas controls