### PR TITLE
Don't wrap JSX string literals in braces

### DIFF
--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
@@ -28,24 +28,24 @@ describe('moving a scene/rootview on the canvas', () => {
             <View
               style={{ width: 375, height: 812 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'aaa'}
-              data-testid={'aaa'}
+              data-uid='aaa'
+              data-testid='aaa'
             >
               <View
                 style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
                 layout={{ layoutSystem: 'pinSystem' }}
-                data-uid={'bbb'}
+                data-uid='bbb'
               />
             </View>
           )
         }
         export var storyboard = (props) => {
           return (
-            <Storyboard data-uid={'utopia-storyboard-uid'}>
+            <Storyboard data-uid='utopia-storyboard-uid'>
               <Scene
                 style={{ position: 'absolute' }}
                 component={App}
-                data-uid={'scene-aaa'}
+                data-uid='scene-aaa'
                 resizeContent
               />
             </Storyboard>
@@ -137,24 +137,24 @@ describe('moving a scene/rootview on the canvas', () => {
           <View
             style={{ width: 375, height: 812 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'aaa'}
-            data-testid={'aaa'}
+            data-uid='aaa'
+            data-testid='aaa'
           >
             <View
               style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'bbb'}
+              data-uid='bbb'
             />
           </View>
         )
       }
       export var storyboard = (props) => {
         return (
-          <Storyboard data-uid={'utopia-storyboard-uid'}>
+          <Storyboard data-uid='utopia-storyboard-uid'>
             <Scene
               style={{ position: 'absolute', top: -30, left: 40 }}
               component={App}
-              data-uid={'scene-aaa'}
+              data-uid='scene-aaa'
               resizeContent
             />
           </Storyboard>
@@ -176,23 +176,23 @@ describe('moving a scene/rootview on the canvas', () => {
             <View
               style={{ width: 375, height: 812 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'aaa'}
+              data-uid='aaa'
             >
               <View
                 style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
                 layout={{ layoutSystem: 'pinSystem' }}
-                data-uid={'bbb'}
+                data-uid='bbb'
               />
             </View>
           )
         }
         export var storyboard = (props) => {
           return (
-            <Storyboard data-uid={'utopia-storyboard-uid'}>
+            <Storyboard data-uid='utopia-storyboard-uid'>
               <Scene
                 style={{ position: 'absolute' }}
                 component={App}
-                data-uid={'scene-aaa'}
+                data-uid='scene-aaa'
                 resizeContent
               />
             </Storyboard>
@@ -283,23 +283,23 @@ describe('moving a scene/rootview on the canvas', () => {
           <View
             style={{ width: 375, height: 812 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'aaa'}
+            data-uid='aaa'
           >
             <View
               style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'bbb'}
+              data-uid='bbb'
             />
           </View>
         )
       }
       export var storyboard = (props) => {
         return (
-          <Storyboard data-uid={'utopia-storyboard-uid'}>
+          <Storyboard data-uid='utopia-storyboard-uid'>
             <Scene
               style={{ position: 'absolute', top: 20, left: 40 }}
               component={App}
-              data-uid={'scene-aaa'}
+              data-uid='scene-aaa'
               resizeContent
             />
           </Storyboard>
@@ -314,11 +314,11 @@ describe('moving a scene/rootview on the canvas', () => {
   it('dragging a static scene’s root view sets the root view position', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ width: '100%', height: '100%' }} layout={{ layoutSystem: 'pinSystem' }} data-testid={'aaa'} data-uid={'aaa'}>
+        <View style={{ width: '100%', height: '100%' }} layout={{ layoutSystem: 'pinSystem' }} data-testid='aaa' data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       `),
@@ -403,13 +403,13 @@ describe('moving a scene/rootview on the canvas', () => {
       <View
           style={{ width: '100%', height: '100%', left: 40, top: -30 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-testid={'aaa'}
-          data-uid={'aaa'}
+          data-testid='aaa'
+          data-uid='aaa'
         >
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       `),
@@ -425,23 +425,23 @@ describe('moving a scene/rootview on the canvas', () => {
             <View
               style={{ width: '100%', height: '100%' }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'aaa'}
+              data-uid='aaa'
             >
               <View
                 style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
                 layout={{ layoutSystem: 'pinSystem' }}
-                data-uid={'bbb'}
+                data-uid='bbb'
               />
             </View>
           )
         }
         export var storyboard = (props) => {
           return (
-            <Storyboard data-uid={'utopia-storyboard-uid'}>
+            <Storyboard data-uid='utopia-storyboard-uid'>
               <Scene
                 style={{ position: 'absolute', left: 0, top: 0, width: 400, height: 400 }}
                 component={App}
-                data-uid={'scene-aaa'}
+                data-uid='scene-aaa'
               />
             </Storyboard>
           )
@@ -531,23 +531,23 @@ describe('moving a scene/rootview on the canvas', () => {
         <View
           style={{ width: '100%', height: '100%' }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'aaa'}
+          data-uid='aaa'
         >
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       )
     }
     export var storyboard = (props) => {
       return (
-        <Storyboard data-uid={'utopia-storyboard-uid'}>
+        <Storyboard data-uid='utopia-storyboard-uid'>
           <Scene
             style={{ position: 'absolute', width: 400, height: 400, top: -30, left: 40 }}
             component={App}
-            data-uid={'scene-aaa'}
+            data-uid='scene-aaa'
           />
         </Storyboard>
       )
@@ -570,24 +570,24 @@ describe('resizing a scene/rootview on the canvas', () => {
             <View
               style={{ width: 200, height: 400 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'aaa'}
-              data-testid={'aaa'}
+              data-uid='aaa'
+              data-testid='aaa'
             >
               <View
                 style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
                 layout={{ layoutSystem: 'pinSystem' }}
-                data-uid={'bbb'}
+                data-uid='bbb'
               />
             </View>
           )
         }
         export var storyboard = (props) => {
           return (
-            <Storyboard data-uid={'utopia-storyboard-uid'}>
+            <Storyboard data-uid='utopia-storyboard-uid'>
               <Scene
                 style={{ position: 'absolute' }}
                 component={App}
-                data-uid={'scene-aaa'}
+                data-uid='scene-aaa'
                 resizeContent
               />
             </Storyboard>
@@ -663,24 +663,24 @@ describe('resizing a scene/rootview on the canvas', () => {
           <View
             style={{ height: 370, width: 240 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'aaa'}
-            data-testid={'aaa'}
+            data-uid='aaa'
+            data-testid='aaa'
           >
             <View
               style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'bbb'}
+              data-uid='bbb'
             />
           </View>
         )
       }
       export var storyboard = (props) => {
         return (
-          <Storyboard data-uid={'utopia-storyboard-uid'}>
+          <Storyboard data-uid='utopia-storyboard-uid'>
             <Scene
               style={{ position: 'absolute' }}
               component={App}
-              data-uid={'scene-aaa'}
+              data-uid='scene-aaa'
               resizeContent
             />
           </Storyboard>
@@ -701,23 +701,23 @@ describe('resizing a scene/rootview on the canvas', () => {
             <View
               style={{ width: 200, height: 400 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'aaa'}
+              data-uid='aaa'
             >
               <View
                 style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
                 layout={{ layoutSystem: 'pinSystem' }}
-                data-uid={'bbb'}
+                data-uid='bbb'
               />
             </View>
           )
         }
         export var storyboard = (props) => {
           return (
-            <Storyboard data-uid={'utopia-storyboard-uid'}>
+            <Storyboard data-uid='utopia-storyboard-uid'>
               <Scene
                 style={{ position: 'absolute' }}
                 component={App}
-                data-uid={'scene-aaa'}
+                data-uid='scene-aaa'
                 resizeContent
               />
             </Storyboard>
@@ -790,23 +790,23 @@ describe('resizing a scene/rootview on the canvas', () => {
           <View
             style={{ height: 370, width: 240 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'aaa'}
+            data-uid='aaa'
           >
             <View
               style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'bbb'}
+              data-uid='bbb'
             />
           </View>
         )
       }
       export var storyboard = (props) => {
         return (
-          <Storyboard data-uid={'utopia-storyboard-uid'}>
+          <Storyboard data-uid='utopia-storyboard-uid'>
             <Scene
               style={{ position: 'absolute' }}
               component={App}
-              data-uid={'scene-aaa'}
+              data-uid='scene-aaa'
               resizeContent
             />
           </Storyboard>
@@ -827,23 +827,23 @@ describe('resizing a scene/rootview on the canvas', () => {
             <View
               style={{ width: 200, height: 400 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'aaa'}
+              data-uid='aaa'
             >
               <View
                 style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
                 layout={{ layoutSystem: 'pinSystem' }}
-                data-uid={'bbb'}
+                data-uid='bbb'
               />
             </View>
           )
         }
         export var storyboard = (props) => {
           return (
-            <Storyboard data-uid={'utopia-storyboard-uid'}>
+            <Storyboard data-uid='utopia-storyboard-uid'>
               <Scene
                 style={{ position: 'absolute', width: 200, height: 200 }}
                 component={App}
-                data-uid={'scene-aaa'}
+                data-uid='scene-aaa'
                 resizeContent
               />
             </Storyboard>
@@ -916,23 +916,23 @@ describe('resizing a scene/rootview on the canvas', () => {
           <View
             style={{ height: 170, width: 240 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'aaa'}
+            data-uid='aaa'
           >
             <View
               style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'bbb'}
+              data-uid='bbb'
             />
           </View>
         )
       }
       export var storyboard = (props) => {
         return (
-          <Storyboard data-uid={'utopia-storyboard-uid'}>
+          <Storyboard data-uid='utopia-storyboard-uid'>
             <Scene
               style={{ position: 'absolute', width: 200, height: 200 }}
               component={App}
-              data-uid={'scene-aaa'}
+              data-uid='scene-aaa'
               resizeContent
             />
           </Storyboard>
@@ -953,23 +953,23 @@ describe('resizing a scene/rootview on the canvas', () => {
             <View
               style={{ width: '100%', height: '100%' }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'aaa'}
+              data-uid='aaa'
             >
               <View
                 style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
                 layout={{ layoutSystem: 'pinSystem' }}
-                data-uid={'bbb'}
+                data-uid='bbb'
               />
             </View>
           )
         }
         export var storyboard = (props) => {
           return (
-            <Storyboard data-uid={'utopia-storyboard-uid'}>
+            <Storyboard data-uid='utopia-storyboard-uid'>
               <Scene
                 style={{ position: 'absolute', top: 0, left: 0, width: 200, height: 400 }}
                 component={App}
-                data-uid={'scene-aaa'}
+                data-uid='scene-aaa'
               />
             </Storyboard>
           )
@@ -1044,23 +1044,23 @@ describe('resizing a scene/rootview on the canvas', () => {
         <View
           style={{ height: '92.5%', width: '120%' }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'aaa'}
+          data-uid='aaa'
         >
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       )
     }
     export var storyboard = (props) => {
       return (
-        <Storyboard data-uid={'utopia-storyboard-uid'}>
+        <Storyboard data-uid='utopia-storyboard-uid'>
           <Scene
             style={{ position: 'absolute', top: 0, left: 0, width: 200, height: 400 }}
             component={App}
-            data-uid={'scene-aaa'}
+            data-uid='scene-aaa'
           />
         </Storyboard>
       )
@@ -1080,23 +1080,23 @@ describe('resizing a scene/rootview on the canvas', () => {
           <View
             style={{ width: '100%', height: '100%' }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'aaa'}
+            data-uid='aaa'
           >
             <View
               style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'bbb'}
+              data-uid='bbb'
             />
           </View>
         )
       }
       export var storyboard = (props) => {
         return (
-          <Storyboard data-uid={'utopia-storyboard-uid'}>
+          <Storyboard data-uid='utopia-storyboard-uid'>
             <Scene
               style={{ position: 'absolute', top: 0, left: 0, width: 200, height: 400 }}
               component={App}
-              data-uid={'scene-aaa'}
+              data-uid='scene-aaa'
             />
           </Storyboard>
         )
@@ -1168,23 +1168,23 @@ describe('resizing a scene/rootview on the canvas', () => {
           <View
             style={{ width: '100%', height: '100%' }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'aaa'}
+            data-uid='aaa'
           >
             <View
               style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'bbb'}
+              data-uid='bbb'
             />
           </View>
         )
       }
       export var storyboard = (props) => {
         return (
-          <Storyboard data-uid={'utopia-storyboard-uid'}>
+          <Storyboard data-uid='utopia-storyboard-uid'>
             <Scene
               style={{ position: 'absolute', top: 0, left: 0, width: 240, height: 370 }}
               component={App}
-              data-uid={'scene-aaa'}
+              data-uid='scene-aaa'
             />
           </Storyboard>
         )

--- a/editor/src/components/canvas/canvas-utils-unit-tests.spec.ts
+++ b/editor/src/components/canvas/canvas-utils-unit-tests.spec.ts
@@ -16,11 +16,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   it('a simple TLWH pin change works', async () => {
     const testProject = getTestParseSuccess(
       makeTestProjectCodeWithSnippet(`
-    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
         style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 250, height: 300 }}
         layout={{ layoutSystem: 'pinSystem' }}
-        data-uid={'bbb'}
+        data-uid='bbb'
       />
     </View>
     `),
@@ -46,11 +46,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     expect(testPrintCode(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, height: 340, width: 310 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -59,11 +59,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   it('TLW, missing H resizing from bottom right edge adds height', async () => {
     const testProject = getTestParseSuccess(
       makeTestProjectCodeWithSnippet(`
-    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
         style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256 }}
         layout={{ layoutSystem: 'pinSystem' }}
-        data-uid={'bbb'}
+        data-uid='bbb'
       />
     </View>
     `),
@@ -89,11 +89,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     expect(testPrintCode(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, height: 30, width: 296 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -102,11 +102,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   it('TLWHBR, too many frame points work', async () => {
     const testProject = getTestParseSuccess(
       makeTestProjectCodeWithSnippet(`
-    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
         style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202, bottom: 137, right: 93 }}
         layout={{ layoutSystem: 'pinSystem' }}
-        data-uid={'bbb'}
+        data-uid='bbb'
       />
     </View>
     `),
@@ -132,7 +132,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     expect(testPrintCode(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{
             backgroundColor: '#0091FFAA',
@@ -144,7 +144,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
             right: 43,
           }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -154,11 +154,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   it('TLRB pin change works, dragged from topleft point', async () => {
     const testProject = getTestParseSuccess(
       makeTestProjectCodeWithSnippet(`
-    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
         style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, right: 50, bottom: 20 }}
         layout={{ layoutSystem: 'pinSystem' }}
-        data-uid={'bbb'}
+        data-uid='bbb'
       />
     </View>
     `),
@@ -184,11 +184,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     expect(testPrintCode(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', right: 50, bottom: 20, top: 41, left: 2 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -197,11 +197,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   it('TLRB pin change works, dragged from bottom right point', async () => {
     const testProject = getTestParseSuccess(
       makeTestProjectCodeWithSnippet(`
-    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
         style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, right: 50, bottom: 20 }}
         layout={{ layoutSystem: 'pinSystem' }}
-        data-uid={'bbb'}
+        data-uid='bbb'
       />
     </View>
     `),
@@ -227,11 +227,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     expect(testPrintCode(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, bottom: 30, right: -30 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -241,11 +241,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   it('TLCxCy pin change works, dragged from topleft point', async () => {
     const testProject = getTestParseSuccess(
       makeTestProjectCodeWithSnippet(`
-    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
         style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
         layout={{ layoutSystem: 'pinSystem', centerX: 100, centerY: 100 }}
-        data-uid={'bbb'}
+        data-uid='bbb'
       />
     </View>
     `),
@@ -271,11 +271,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     expect(testPrintCode(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', top: 31, left: 12 }}
           layout={{ layoutSystem: 'pinSystem', centerY: 85, centerX: 80 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -284,11 +284,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   it('TLCxCy pin change works, dragged from bottomright point', async () => {
     const testProject = getTestParseSuccess(
       makeTestProjectCodeWithSnippet(`
-    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+    <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
         style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
         layout={{ layoutSystem: 'pinSystem', centerX: 100, centerY: 100 }}
-        data-uid={'bbb'}
+        data-uid='bbb'
       />
     </View>
     `),
@@ -314,11 +314,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     expect(testPrintCode(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
           layout={{ layoutSystem: 'pinSystem', centerY: 115, centerX: 120 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -26,11 +26,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
   it('a simple TLWH pin change works', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -45,11 +45,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', width: 100, height: 100, left: 20, top: 20 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -59,11 +59,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
   it('a simple TLWH pin change works with old CanvasMetadata format as well', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -78,11 +78,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', width: 100, height: 100, left: 20, top: 20 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -92,11 +92,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
   it('TLWH, but W and H are percentage works', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: '50%', height: '20%'  }}
           layout={{ layoutSystem: 'pinSystem'}}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -111,11 +111,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', width: '25%', height: '25%', left: 20, top: 20 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -125,11 +125,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
   it('TLW, missing H pin change works', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -144,11 +144,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, width: 100, height: 100 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -158,11 +158,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
   it('TLWHBR, too many frame points work', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202, bottom: 137, right: 93 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -177,12 +177,12 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, width: 100, height: 100 }}
           ${/** notice how the extraneous pins were removed automatically */ ''}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -192,11 +192,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
   it('TLRB pin change works', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, right: 50, bottom: 20 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -211,11 +211,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, right: 280, bottom: 280 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -225,11 +225,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
   it('TLCxCy pin change works', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
           layout={{ layoutSystem: 'pinSystem', centerX: 100, centerY: 100 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -244,11 +244,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 20, top: 20 }}
           layout={{ layoutSystem: 'pinSystem', centerX: -130, centerY: -130 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -258,10 +258,10 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
   it('no layout prop on child', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -276,11 +276,11 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           ${/** pins are magically created */ ''}
           style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, width: 100, height: 100 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -292,11 +292,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('only TL pins work', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -311,11 +311,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 20, top: 20 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -325,11 +325,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('only TL pins work with old CanvasMetadata as well', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -344,11 +344,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 20, top: 20 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -358,11 +358,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('only RB pins work', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', right: 50, bottom: 50 }}
             layout={{ layoutSystem: 'pinSystem'  }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -377,11 +377,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', right: 30, bottom: 30 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -391,11 +391,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('just R pin gets turned into T,R', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', right: 50 }}
             layout={{ layoutSystem: 'pinSystem'  }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -410,11 +410,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', right: 30, top: 20 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -424,11 +424,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('just B pin gets turned into L,B', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', bottom: 50 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -443,11 +443,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', bottom: 30, left: 20 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -457,11 +457,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('just B pin doesn`t turn into L,B with deltaX=0', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', bottom: 50 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -476,11 +476,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', bottom: 30 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -490,11 +490,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('TLWH, but W and H are left alone', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', width: '50%', height: 25, left: 52, top: 61 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -509,11 +509,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', width: '50%', height: 25, left: 20, top: 20  }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -523,11 +523,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('TLWH, but W and H are left alone, T, L are % values', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', width: '50%', height: 25, left: '10%', top: '5%' }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -542,11 +542,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', width: '50%', height: 25, left: '2%', top: '16.3%' }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -556,11 +556,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('TLRB pin change works', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, right: 50, bottom: 20 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -575,11 +575,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, right: 82, bottom: 61 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -589,11 +589,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('TLRB pin change works, with % values', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: '10%', top: '15%', right: '10%', bottom: '25%' }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -608,7 +608,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{
             backgroundColor: '#0091FFAA',
@@ -618,7 +618,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
             bottom: '8.8%',
           }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -628,11 +628,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('TLCxCy pin change works', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
           layout={{ layoutSystem: 'pinSystem', centerX: 100, centerY: 100 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -647,11 +647,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 20, top: 20 }}
           layout={{ layoutSystem: 'pinSystem', centerX: 68, centerY: 59 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -661,11 +661,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('RBCxCy pin change works', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', right: 52, bottom: 61 }}
           layout={{ layoutSystem: 'pinSystem', centerX: 100, centerY: 100 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -680,11 +680,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', right: 84, bottom: 102 }}
           layout={{ layoutSystem: 'pinSystem', centerX: 68, centerY: 59 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -694,11 +694,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('TLWHBR, too many frame points work', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202, bottom: 137, right: 93 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -713,7 +713,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             ${
               /**
@@ -731,7 +731,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
               bottom: 178,
             }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
       </View>`,
       ),
@@ -741,11 +741,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
   it('TLR, no B pin change?', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, right: 50 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -760,11 +760,11 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, right: 82 }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -776,11 +776,11 @@ describe('updateFramesOfScenesAndComponents - pinSizeChange -', () => {
   it('only TL pins work', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -796,11 +796,11 @@ describe('updateFramesOfScenesAndComponents - pinSizeChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 20, width: 100, top: 20, height: 100 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -810,11 +810,11 @@ describe('updateFramesOfScenesAndComponents - pinSizeChange -', () => {
   it('only TW pins work', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 52, width: 100 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -832,11 +832,11 @@ describe('updateFramesOfScenesAndComponents - pinSizeChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', width: 100, left: 20, height: 100 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -846,11 +846,11 @@ describe('updateFramesOfScenesAndComponents - pinSizeChange -', () => {
   it('TLRB pins work', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, right: 150, bottom: 150 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -866,11 +866,11 @@ describe('updateFramesOfScenesAndComponents - pinSizeChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 20, right: 280, top: 20, bottom: 280 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>`,
       ),
@@ -882,11 +882,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   it('TLWH, but W and H are percentage works', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 40, top: 40, width: '50%', height: '20%'  }}
           layout={{ layoutSystem: 'pinSystem'}}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -902,11 +902,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 40, top: 40, height: '17.5%', width: '45%' }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -915,10 +915,10 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   it('no layout prop on child', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -934,11 +934,11 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           ${/** pins are magically created */ ''}
           style={{ backgroundColor: '#0091FFAA', top: -60, height: 60, left: -50, width: 50 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -950,10 +950,10 @@ describe('moveTemplate', () => {
   it('wraps in 1 element', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} data-uid='aaa'>
         <View
           style={{ position: 'absolute', backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -966,14 +966,14 @@ describe('moveTemplate', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} data-uid='aaa'>
         <View
           style={{ position: 'absolute', left: 52, top: 61, width: 256, height: 202 }}
-          data-uid={'${NewUID}'}
+          data-uid='${NewUID}'
         >
           <View
             style={{ backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202, position: 'absolute' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       </View>
@@ -983,29 +983,29 @@ describe('moveTemplate', () => {
   it('wraps multiselected elements', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style, width: '100%', height: '100%', position: 'relative' }} data-uid={'aaa'}>
+      <View style={{ ...props.style, width: '100%', height: '100%', position: 'relative' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202, position: 'absolute' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         >
           <View
             style={{ left: 10, top: 10, width: 100, height: 100, position: 'absolute' }}
-            data-uid={'ccc'}
+            data-uid='ccc'
           >
-            <View data-uid={'ddd'} />
+            <View data-uid='ddd' />
           </View>
         </View>
-        <View data-uid={'eee'}/>
+        <View data-uid='eee'/>
         <View
           style={{ left: 10, top: 10, width: 256, height: 150, position: 'absolute' }}
-          data-uid={'fff'}
+          data-uid='fff'
         >
             <View
               style={{ left: 5, top: 0, width: 246, height: 150, position: 'absolute'  }}
-              data-uid={'ggg'}
+              data-uid='ggg'
             />
           </View>
-        <View data-uid={'hhh'}/>
+        <View data-uid='hhh'/>
       </View>
       `),
     )
@@ -1020,30 +1020,30 @@ describe('moveTemplate', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style, width: '100%', height: '100%', position: 'relative' }} data-uid={'aaa'}>
+      <View style={{ ...props.style, width: '100%', height: '100%', position: 'relative' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202, position: 'absolute' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
-        <View data-uid={'eee'} />
+        <View data-uid='eee' />
         <View
           style={{ left: 10, top: 10, width: 256, height: 150, position: 'absolute' }}
-          data-uid={'fff'}
+          data-uid='fff'
         />
-        <View data-uid={'hhh'} />
+        <View data-uid='hhh' />
         <View
           style={{ position: 'absolute', left: 15, top: 10, width: 246, height: 161 }}
-          data-uid={'${NewUID}'}
+          data-uid='${NewUID}'
         >
           <View
             style={{ left: 47, top: 61, width: 100, height: 100, position: 'absolute' }}
-            data-uid={'ccc'}
+            data-uid='ccc'
           >
-            <View data-uid={'ddd'} />
+            <View data-uid='ddd' />
           </View>
           <View
             style={{ left: 0, top: 0, width: 246, height: 150, position: 'absolute' }}
-            data-uid={'ggg'}
+            data-uid='ggg'
           />
         </View>
       </View>
@@ -1053,16 +1053,16 @@ describe('moveTemplate', () => {
   it('wraps in multiselected element and children, moves only the element, keeps children', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} data-uid='aaa'>
         <View
           style={{ position: 'absolute', backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         >
-          <View data-uid={'ccc'}>
-            <View data-uid={'ddd'} />
+          <View data-uid='ccc'>
+            <View data-uid='ddd' />
           </View>
         </View>
-        <View data-uid={'eee'}/>
+        <View data-uid='eee'/>
       </View>
       `),
     )
@@ -1077,18 +1077,18 @@ describe('moveTemplate', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} data-uid={'aaa'}>
-        <View data-uid={'eee'} />
+      <View style={{ ...props.style }} data-uid='aaa'>
+        <View data-uid='eee' />
         <View
           style={{ position: 'absolute', left: 52, top: 61, width: 256, height: 202 }}
-          data-uid={'${NewUID}'}
+          data-uid='${NewUID}'
         >
           <View
             style={{ backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202, position: 'absolute' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           >
-            <View data-uid={'ccc'}>
-              <View data-uid={'ddd'} />
+            <View data-uid='ccc'>
+              <View data-uid='ddd' />
             </View>
           </View>
         </View>
@@ -1099,21 +1099,21 @@ describe('moveTemplate', () => {
   it('reparents multiselected elements', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
             layout={{ layoutSystem: 'pinSystem'}}
-            data-uid={'bbb'}
+            data-uid='bbb'
           >
-            <View data-uid={'ccc'}>
-              <View data-uid={'ddd'} />
+            <View data-uid='ccc'>
+              <View data-uid='ddd' />
             </View>
           </View>
-          <View data-uid={'eee'}/>
-          <View data-uid={'fff'}>
-              <View data-uid={'ggg'} />
+          <View data-uid='eee'/>
+          <View data-uid='fff'>
+              <View data-uid='ggg' />
             </View>
-          <View data-uid={'hhh'}/>
+          <View data-uid='hhh'/>
         </View>
       `),
     )
@@ -1131,21 +1131,21 @@ describe('moveTemplate', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
-          <View data-uid={'eee'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
+          <View data-uid='eee'>
             <View
               style={{ backgroundColor: '#0091FFAA', left: 52, width: 256, height: 202, top: -141 }}
               layout={{ layoutSystem: 'pinSystem'  }}
-              data-uid={'bbb'}
+              data-uid='bbb'
             >
-              <View data-uid={'ccc'}>
-                <View data-uid={'ddd'} />
+              <View data-uid='ccc'>
+                <View data-uid='ddd' />
               </View>
             </View>
-            <View data-uid={'ggg'} />
-            <View data-uid={'hhh'} style={{ top: 0 }} />
+            <View data-uid='ggg' />
+            <View data-uid='hhh' style={{ top: 0 }} />
           </View>
-          <View data-uid={'fff'} />
+          <View data-uid='fff' />
         </View>
       `),
     )
@@ -1153,17 +1153,17 @@ describe('moveTemplate', () => {
   it('reparents multiselected element and children, moves only the element, keeps children', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           >
-            <View data-uid={'ccc'}>
-              <View data-uid={'ddd'} />
+            <View data-uid='ccc'>
+              <View data-uid='ddd' />
             </View>
           </View>
-          <View data-uid={'eee'}/>
+          <View data-uid='eee'/>
         </View>
       `),
     )
@@ -1180,15 +1180,15 @@ describe('moveTemplate', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
-          <View data-uid={'eee'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
+          <View data-uid='eee'>
             <View
               style={{ backgroundColor: '#0091FFAA', left: 52, width: 256, height: 202, top: -141 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'bbb'}
+              data-uid='bbb'
             >
-              <View data-uid={'ccc'}>
-                <View data-uid={'ddd'} />
+              <View data-uid='ccc'>
+                <View data-uid='ddd' />
               </View>
             </View>
           </View>
@@ -1199,17 +1199,17 @@ describe('moveTemplate', () => {
   it('reparents multiselected element and descendant which are not direct children, moves both of the elements', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 256, height: 202 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           >
-            <View data-uid={'ccc'}>
-              <View data-uid={'ddd'} />
+            <View data-uid='ccc'>
+              <View data-uid='ddd' />
             </View>
           </View>
-          <View data-uid={'eee'}/>
+          <View data-uid='eee'/>
         </View>
       `),
     )
@@ -1226,15 +1226,15 @@ describe('moveTemplate', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} data-uid={'aaa'}>
-          <View data-uid={'eee'}>
-            <View data-uid={'ddd'} style={{ left: 52, top: -141 }} />
+        `<View style={{ ...props.style }} data-uid='aaa'>
+          <View data-uid='eee'>
+            <View data-uid='ddd' style={{ left: 52, top: -141 }} />
             <View
               style={{ backgroundColor: '#0091FFAA', left: 52, width: 256, height: 202, top: -141 }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'bbb'}
+              data-uid='bbb'
             >
-              <View data-uid={'ccc'} />
+              <View data-uid='ccc' />
             </View>
           </View>
         </View>
@@ -1246,14 +1246,14 @@ describe('moveTemplate', () => {
   it('reparents a pinned element to flex', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           >
-            <View data-uid={'ccc'} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
+            <View data-uid='ccc' layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
           </View>
-          <View data-uid={'eee'} style={{ position: 'absolute', left: 50, top: 175, width: 80, height: 80 }}/>
+          <View data-uid='eee' style={{ position: 'absolute', left: 50, top: 175, width: 80, height: 80 }}/>
         </View>
       `),
     )
@@ -1270,13 +1270,13 @@ describe('moveTemplate', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           >
-            <View data-uid={'ccc'} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
-            <View data-uid={'eee'} style={{ position: 'relative', flexBasis: 80, height: 80 }} />
+            <View data-uid='ccc' layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
+            <View data-uid='eee' style={{ position: 'relative', flexBasis: 80, height: 80 }} />
           </View>
         </View>
       `),
@@ -1286,14 +1286,14 @@ describe('moveTemplate', () => {
   it('reparents a pinned element to flex using magic?', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           >
-            <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
+            <View data-uid='ccc' style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
           </View>
-          <View data-testid={'eee'} data-uid={'eee'} style={{ position: 'absolute', backgroundColor: '#00ff00', left: 150, top: 250, width: 80, height: 80 }}/>
+          <View data-testid='eee' data-uid='eee' style={{ position: 'absolute', backgroundColor: '#00ff00', left: 150, top: 250, width: 80, height: 80 }}/>
         </View>
       `),
     )
@@ -1374,13 +1374,13 @@ describe('moveTemplate', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           >
-            <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
-            <View data-testid={'eee'}  data-uid={'eee'} style={{ backgroundColor: '#00ff00', position: 'relative', flexBasis: 80, height: 80 }} />
+            <View data-uid='ccc' style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', flexBasis: 70, crossBasis: 50 }} />
+            <View data-testid='eee'  data-uid='eee' style={{ backgroundColor: '#00ff00', position: 'relative', flexBasis: 80, height: 80 }} />
           </View>
         </View>
       `),
@@ -1390,12 +1390,12 @@ describe('moveTemplate', () => {
   it('inserting a new element', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex', position: 'absolute' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           >
-            <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ flexBasis: 20, crossBasis: 20 }} />
+            <View data-uid='ccc' style={{ backgroundColor: '#ff00ff' }} layout={{ flexBasis: 20, crossBasis: 20 }} />
           </View>
         </View>
       `),
@@ -1476,15 +1476,15 @@ describe('moveTemplate', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, display: 'flex', position: 'absolute' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           >
-            <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ flexBasis: 20, crossBasis: 20 }} />
+            <View data-uid='ccc' style={{ backgroundColor: '#ff00ff' }} layout={{ flexBasis: 20, crossBasis: 20 }} />
             <View
               style={{ backgroundColor: '#0091FFAA', position: 'relative', flexBasis: 75, height: 75 }}
-              data-uid={'${NewUID}'}
+              data-uid='${NewUID}'
             />
           </View>
         </View>
@@ -1495,15 +1495,15 @@ describe('moveTemplate', () => {
   it('reparents an element while dragging', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           >
-            <View data-uid={'ccc'} style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', top: 10, left: 15, width: 50, height: 60 }} />
+            <View data-uid='ccc' style={{ backgroundColor: '#ff00ff' }} layout={{ layoutSystem: 'pinSystem', top: 10, left: 15, width: 50, height: 60 }} />
           </View>
-          <View data-testid={'eee'} data-uid={'eee'} style={{ backgroundColor: '#00ff00', left: 150, top: 250, width: 80, height: 80 }} layout={{ layoutSystem: 'pinSystem' }}/>
+          <View data-testid='eee' data-uid='eee' style={{ backgroundColor: '#00ff00', left: 150, top: 250, width: 80, height: 80 }} layout={{ layoutSystem: 'pinSystem' }}/>
         </View>
       `),
     )
@@ -1584,20 +1584,20 @@ describe('moveTemplate', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
         style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
         layout={{ layoutSystem: 'pinSystem' }}
-        data-uid={'bbb'}
+        data-uid='bbb'
       >
         <View
-          data-uid={'ccc'}
+          data-uid='ccc'
           style={{ backgroundColor: '#ff00ff' }}
           layout={{ layoutSystem: 'pinSystem', top: 10, left: 15, width: 50, height: 60 }}
         />
         <View
-          data-testid={'eee'}
-          data-uid={'eee'}
+          data-testid='eee'
+          data-uid='eee'
           style={{ backgroundColor: '#00ff00', width: 80, height: 80, left: 100, top: 170 }}
           layout={{ layoutSystem: 'pinSystem' }}
         />
@@ -1609,15 +1609,15 @@ describe('moveTemplate', () => {
   it('canvas select a sibling and drag immediately', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ width: '100%', height: '100%' }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        <View style={{ width: '100%', height: '100%' }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200, }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
           <View
             style={{ backgroundColor: '#0091FFAA', left: 55, top: 275, width: 200, height: 105 }}
-            data-uid={'ccc'}
-            data-testid={'ccc'}
+            data-uid='ccc'
+            data-testid='ccc'
           />
         </View>
       `),
@@ -1702,16 +1702,16 @@ describe('moveTemplate', () => {
       <View
           style={{ width: '100%', height: '100%' }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'aaa'}
+          data-uid='aaa'
         >
           <View
             style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 200, height: 200 }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
           <View
             style={{ backgroundColor: '#0091FFAA', width: 200, height: 105, left: 95, top: 245 }}
-            data-uid={'ccc'}
-            data-testid={'ccc'}
+            data-uid='ccc'
+            data-testid='ccc'
           />
         </View>
       `),

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -227,13 +227,13 @@ ${snippet}
   }
   export var ${BakedInStoryboardVariableName} = (props) => {
     return (
-      <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+      <Storyboard data-uid='${BakedInStoryboardUID}'>
         <Scene
           style={{ left: 0, top: 0, width: 400, height: 400 }}
           component={App}
           static
           props={{ style: { position: 'absolute', bottom: 0, left: 0, right: 0, top: 0 } }}
-          data-uid={'${TestSceneUID}'}
+          data-uid='${TestSceneUID}'
         />
       </Storyboard>
     )

--- a/editor/src/components/inspector/common/css-utils.spec.browser.ts
+++ b/editor/src/components/inspector/common/css-utils.spec.browser.ts
@@ -13,11 +13,11 @@ describe('toggle style prop', () => {
   it('disables border, sets border to none from solid', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
           style={{ backgroundColor: '#DDDDDD', border: '1px solid #000' }}
           layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       `),
@@ -35,11 +35,11 @@ describe('toggle style prop', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
           style={{ backgroundColor: '#DDDDDD', border: '1px #000' }}
           layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       `),
@@ -49,11 +49,11 @@ describe('toggle style prop', () => {
   it('enables border, sets it to solid from none', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
           style={{ backgroundColor: '#DDDDDD', border: '1px #000' }}
           layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       `),
@@ -71,11 +71,11 @@ describe('toggle style prop', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
           style={{ backgroundColor: '#DDDDDD', border: '1px solid #000' }}
           layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       `),
@@ -84,10 +84,10 @@ describe('toggle style prop', () => {
   it('adds border when style prop is missing', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} data-uid='aaa'>
         <View
           layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -105,10 +105,10 @@ describe('toggle style prop', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
             layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-            data-uid={'bbb'}
+            data-uid='bbb'
             style={{ border: '1px solid #000' }}
           />
         </View>
@@ -119,11 +119,11 @@ describe('toggle style prop', () => {
   it('toggles shadow, comments out boxshadow property values', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#DDDDDD', boxShadow: '0px 0px #000, 0px 0px #000' }}
             layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       `),
@@ -141,11 +141,11 @@ describe('toggle style prop', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#DDDDDD', boxShadow: '/*0px 0px #000*/ /*0px 0px #000*/' }}
             layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       `),
@@ -154,11 +154,11 @@ describe('toggle style prop', () => {
   it('toggles shadow, after toggle shadow is visible', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#DDDDDD', boxShadow: '/*0px 0px #000*/ /*0px 0px #000*/' }}
             layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       `),
@@ -176,11 +176,11 @@ describe('toggle style prop', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
-        <View style={{ ...props.style }} data-uid={'aaa'}>
+        <View style={{ ...props.style }} data-uid='aaa'>
           <View
             style={{ backgroundColor: '#DDDDDD', boxShadow: '0px 0px #000, 0px 0px #000' }}
             layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           />
         </View>
       `),

--- a/editor/src/core/layout/layout-utils.spec.browser.ts
+++ b/editor/src/core/layout/layout-utils.spec.browser.ts
@@ -36,10 +36,10 @@ describe('maybeSwitchLayoutProps', () => {
     //await wait(20000)
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202, display: 'flex' }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -126,13 +126,13 @@ describe('maybeSwitchLayoutProps', () => {
         `<View
           style={{ ...props.style }}
           layout={{ layoutSystem: 'pinSystem' }}
-          data-uid={'aaa'}
+          data-uid='aaa'
         >
           <View
             style={{ backgroundColor: '#DDDDDD', left: 52, top: 61, width: 256, height: 202, display: 'flex' }}
-            data-uid={'bbb'}
+            data-uid='bbb'
           >
-            <View style={{ position: 'relative' }} data-uid={'catdog'} />
+            <View style={{ position: 'relative' }} data-uid='catdog' />
           </View>
         </View>`,
       ),

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -13,11 +13,11 @@ describe('React Render Count Tests - ', () => {
   it('Clicking on opacity slider', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#DDDDDD', opacity: 1 }}
           layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>
       `),
@@ -48,11 +48,11 @@ describe('React Render Count Tests - ', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#DDDDDD', opacity: 0.3 }}
           layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
       </View>`,
       ),
@@ -66,16 +66,16 @@ describe('React Render Count Tests - ', () => {
   it('Changing the selected view', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
-      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+      <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#DDDDDD', opacity: 1 }}
           layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
         <View
           style={{ backgroundColor: '#DDDDDD', opacity: 1 }}
           layout={{ layoutSystem: 'pinSystem', left: 152, top: 161, width: 256, height: 202 }}
-          data-uid={'ccc'}
+          data-uid='ccc'
         />
       </View>
       `),
@@ -100,16 +100,16 @@ describe('React Render Count Tests - ', () => {
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(
-        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid={'aaa'}>
+        `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#DDDDDD', opacity: 1 }}
           layout={{ layoutSystem: 'pinSystem', left: 52, top: 61, width: 256, height: 202 }}
-          data-uid={'bbb'}
+          data-uid='bbb'
         />
         <View
           style={{ backgroundColor: '#DDDDDD', opacity: 1 }}
           layout={{ layoutSystem: 'pinSystem', left: 152, top: 161, width: 256, height: 202 }}
-          data-uid={'ccc'}
+          data-uid='ccc'
         />
       </View>`,
       ),

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.ts.snap
@@ -64,7 +64,7 @@ function a(n) {
 export var App = (props) => {
   return (
     <div
-      data-uid={'aaa'}
+      data-uid='aaa'
       style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
       layout={{ layoutSystem: 'pinSystem' }}
     >{b(5)} - {a(5)}</div>
@@ -80,9 +80,9 @@ function b(n) {
 }
 
 export var storyboard = (
-  <Storyboard data-uid={'bbb'} layout={{ layoutSystem: 'pinSystem' }}>
+  <Storyboard data-uid='bbb' layout={{ layoutSystem: 'pinSystem' }}>
     <Scene
-      data-uid={'ccc'}
+      data-uid='ccc'
       component={App}
       props={{}}
       style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
@@ -243,7 +243,7 @@ function a(n) {
 export var App = (props) => {
   return (
     <div
-      data-uid={'aaa'}
+      data-uid='aaa'
       style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
       layout={{ layoutSystem: 'pinSystem' }}
     >{b(5)} - {a(5)}</div>
@@ -259,9 +259,9 @@ function b(n) {
 }
 
 export var storyboard = (
-  <Storyboard data-uid={'bbb'} layout={{ layoutSystem: 'pinSystem' }}>
+  <Storyboard data-uid='bbb' layout={{ layoutSystem: 'pinSystem' }}>
     <Scene
-      data-uid={'ccc'}
+      data-uid='ccc'
       component={App}
       props={{}}
       style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
@@ -340,7 +340,7 @@ function a(n) {
 export var App = (props) => {
   return (
     <div
-      data-uid={'aaa'}
+      data-uid='aaa'
       style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
       layout={{ layoutSystem: 'pinSystem' }}
     >{b(5)} - {a(5)}</div>
@@ -356,9 +356,9 @@ function b(n) {
 }
 
 export var storyboard = (
-  <Storyboard data-uid={'bbb'} layout={{ layoutSystem: 'pinSystem' }}>
+  <Storyboard data-uid='bbb' layout={{ layoutSystem: 'pinSystem' }}>
     <Scene
-      data-uid={'ccc'}
+      data-uid='ccc'
       component={App}
       props={{}}
       style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
@@ -409,7 +409,7 @@ function a(n) {
 export var App = (props) => {
   return (
     <div
-      data-uid={'aaa'}
+      data-uid='aaa'
       style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
       layout={{ layoutSystem: 'pinSystem' }}
     >{b(5)} - {a(5)}</div>
@@ -425,9 +425,9 @@ function b(n) {
 }
 
 export var storyboard = (
-  <Storyboard data-uid={'bbb'} layout={{ layoutSystem: 'pinSystem' }}>
+  <Storyboard data-uid='bbb' layout={{ layoutSystem: 'pinSystem' }}>
     <Scene
-      data-uid={'ccc'}
+      data-uid='ccc'
       component={App}
       props={{}}
       style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
@@ -529,7 +529,7 @@ function a(n) {
 export var App = (props) => {
   return (
     <div
-      data-uid={'aaa'}
+      data-uid='aaa'
       style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
       layout={{ layoutSystem: 'pinSystem' }}
     >{b(5)} - {a(5)}</div>
@@ -545,9 +545,9 @@ function b(n) {
 }
 
 export var storyboard = (
-  <Storyboard data-uid={'bbb'} layout={{ layoutSystem: 'pinSystem' }}>
+  <Storyboard data-uid='bbb' layout={{ layoutSystem: 'pinSystem' }}>
     <Scene
-      data-uid={'ccc'}
+      data-uid='ccc'
       component={App}
       props={{}}
       style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
@@ -625,7 +625,7 @@ function a(n) {
 export var App = (props) => {
   return (
     <div
-      data-uid={'aaa'}
+      data-uid='aaa'
       style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
       layout={{ layoutSystem: 'pinSystem' }}
     >{b(5)} - {a(5)}</div>
@@ -641,9 +641,9 @@ function b(n) {
 }
 
 export var storyboard = (
-  <Storyboard data-uid={'bbb'} layout={{ layoutSystem: 'pinSystem' }}>
+  <Storyboard data-uid='bbb' layout={{ layoutSystem: 'pinSystem' }}>
     <Scene
-      data-uid={'ccc'}
+      data-uid='ccc'
       component={App}
       props={{}}
       style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.ts.snap
@@ -74,8 +74,8 @@ Array [
               "type": "JSX_ELEMENT",
             },
           },
-          "javascript": "<div data-uid={'bbb'} />;",
-          "originalJavascript": "<div data-uid={'bbb'} />",
+          "javascript": "<div data-uid='bbb' />;",
+          "originalJavascript": "<div data-uid='bbb' />",
           "sourceMap": Object {
             "file": "code.tsx",
             "mappings": "OAAA",
@@ -87,17 +87,17 @@ Array [
               "import * as React from 'react'
 import * as Utopia from 'utopia-api'
 export var App = (props) => {
-  return <Utopia.View data-uid={'aaa'}>{<div data-uid={'bbb'} />}</Utopia.View>
+  return <Utopia.View data-uid='aaa'>{<div data-uid='bbb' />}</Utopia.View>
 }
 export var storyboard = (props) => {
   return (
-    <Storyboard data-uid={'utopia-storyboard-uid'}>
+    <Storyboard data-uid='utopia-storyboard-uid'>
       <Scene
         style={{ left: 0, top: 0, width: 400, height: 400 }}
         component={App}
         layout={{ layoutSystem: 'pinSystem' }}
         props={{ layout: { bottom: 0, left: 0, right: 0, top: 0 } }}
-        data-uid={'scene-aaa'}
+        data-uid='scene-aaa'
       />
     </Storyboard>
   )
@@ -146,20 +146,20 @@ export var storyboard = (props) => {
     ],
     "javascript": "export var storyboard = props => {
   return (
-    <Storyboard data-uid={'utopia-storyboard-uid'}>
+    <Storyboard data-uid='utopia-storyboard-uid'>
       <Scene
       style={{ left: 0, top: 0, width: 400, height: 400 }}
       component={App}
       layout={{ layoutSystem: 'pinSystem' }}
       props={{ layout: { bottom: 0, left: 0, right: 0, top: 0 } }}
-      data-uid={'scene-aaa'} />
+      data-uid='scene-aaa' />
 
     </Storyboard>);
 
 };",
     "sourceMap": Object {
       "file": "code.tsx",
-      "mappings": "AAKQA,IAAIC,UAAUC,GAAGC,SAAbF,UAAaE,CAACC,KAADD,EAAWE;AACjCC,SACEC,oBAACC,UAADD;AAAYE,gBAAUC;AAAtBH,KACEA,oBAACI,KAADJ;AACEK,IAAAA,KAAKC,EAAER;AAAES,MAAAA,IAAIC,EAAEC,CAARX;AAAWY,MAAAA,GAAGF,EAAEC,CAAhBX;AAAmBa,MAAAA,KAAKH,EAAEI,GAA1Bd;AAA+Be,MAAAA,MAAML,EAAEI;AAAvCd,KADTE;AAEEc,IAAAA,SAASR,EAAES,GAFbf;AAGEgB,IAAAA,MAAMV,EAAER;AAAEmB,MAAAA,YAAYT,EAAEL;AAAhBL,KAHVE;AAIEH,IAAAA,KAAKS,EAAER;AAAEkB,MAAAA,MAAMR,EAAEV;AAAEoB,QAAAA,MAAMV,EAAEC,CAAVX;AAAaS,QAAAA,IAAIC,EAAEC,CAAnBX;AAAsBqB,QAAAA,KAAKX,EAAEC,CAA7BX;AAAgCY,QAAAA,GAAGF,EAAEC;AAArCX;AAAVA,KAJTE;AAKEE,gBAAUC;AALZH,IADFA,CADFD;AAWFqB,CAZO3B",
+      "mappings": "AAKQA,IAAIC,UAAUC,GAAGC,SAAbF,UAAaE,CAACC,KAADD,EAAWE;AACjCC,SACEC,oBAACC,UAADD;AAAYE,gBAASC;AAArBH,KACEA,oBAACI,KAADJ;AACEK,IAAAA,KAAKC,EAAER;AAAES,MAAAA,IAAIC,EAAEC,CAARX;AAAWY,MAAAA,GAAGF,EAAEC,CAAhBX;AAAmBa,MAAAA,KAAKH,EAAEI,GAA1Bd;AAA+Be,MAAAA,MAAML,EAAEI;AAAvCd,KADTE;AAEEc,IAAAA,SAASR,EAAES,GAFbf;AAGEgB,IAAAA,MAAMV,EAAER;AAAEmB,MAAAA,YAAYT,EAAEL;AAAhBL,KAHVE;AAIEH,IAAAA,KAAKS,EAAER;AAAEkB,MAAAA,MAAMR,EAAEV;AAAEoB,QAAAA,MAAMV,EAAEC,CAAVX;AAAaS,QAAAA,IAAIC,EAAEC,CAAnBX;AAAsBqB,QAAAA,KAAKX,EAAEC,CAA7BX;AAAgCY,QAAAA,GAAGF,EAAEC;AAArCX;AAAVA,KAJTE;AAKEE,gBAASC;AALXH,IADFA,CADFD;AAWFqB,CAZO3B",
       "names": Array [
         "var",
         "storyboard",
@@ -197,17 +197,17 @@ export var storyboard = (props) => {
         "import * as React from 'react'
 import * as Utopia from 'utopia-api'
 export var App = (props) => {
-  return <Utopia.View data-uid={'aaa'}>{<div data-uid={'bbb'} />}</Utopia.View>
+  return <Utopia.View data-uid='aaa'>{<div data-uid='bbb' />}</Utopia.View>
 }
 export var storyboard = (props) => {
   return (
-    <Storyboard data-uid={'utopia-storyboard-uid'}>
+    <Storyboard data-uid='utopia-storyboard-uid'>
       <Scene
         style={{ left: 0, top: 0, width: 400, height: 400 }}
         component={App}
         layout={{ layoutSystem: 'pinSystem' }}
         props={{ layout: { bottom: 0, left: 0, right: 0, top: 0 } }}
-        data-uid={'scene-aaa'}
+        data-uid='scene-aaa'
       />
     </Storyboard>
   )
@@ -218,7 +218,7 @@ export var storyboard = (props) => {
     },
     "transpiledJavascript": "var storyboard = function storyboard(props) {
   return React.createElement(Storyboard, {
-    \\"data-uid\\": 'utopia-storyboard-uid'
+    \\"data-uid\\": \\"utopia-storyboard-uid\\"
   }, React.createElement(Scene, {
     style: {
       left: 0,
@@ -238,7 +238,7 @@ export var storyboard = (props) => {
         top: 0
       }
     },
-    \\"data-uid\\": 'scene-aaa'
+    \\"data-uid\\": \\"scene-aaa\\"
   }));
 };
 return { storyboard: storyboard };",

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -12,7 +12,7 @@ Object {
     layout: {
       layoutSystem: 'pinSystem'
     },
-    \\"data-uid\\": 'aaa'
+    \\"data-uid\\": \\"aaa\\"
   }));
 };",
     "sourceMap": Object {
@@ -52,7 +52,7 @@ export var App = (props) => {
       <View
         style={{ ...props.style, backgroundColor: '#FFFFFF' }}
         layout={{ layoutSystem: 'pinSystem' }}
-        data-uid={'aaa'}
+        data-uid='aaa'
       ></View>
     </>
   )
@@ -112,8 +112,8 @@ function otherFn(n) {
 }
 export var whatever = (props) => {
   return (
-    <View data-uid={'aaa'}>
-      <cake data-uid={'aab'} left={cakeFn(otherFn('b') + 2)} />
+    <View data-uid='aaa'>
+      <cake data-uid='aab' left={cakeFn(otherFn('b') + 2)} />
     </View>
   )
 }
@@ -149,7 +149,7 @@ return { cakeFn: cakeFn, otherFn: otherFn };",
       "uid": "aaa",
     },
     "aab": Object {
-      "endCol": 63,
+      "endCol": 61,
       "endLine": 12,
       "startCol": 6,
       "startLine": 12,
@@ -259,8 +259,8 @@ function otherFn(n) {
 }
 export var whatever = (props) => {
   return (
-    <View data-uid={'aaa'}>
-      <cake data-uid={'aab'} left={cakeFn(otherFn('b') + 2)} />
+    <View data-uid='aaa'>
+      <cake data-uid='aab' left={cakeFn(otherFn('b') + 2)} />
     </View>
   )
 }
@@ -313,8 +313,8 @@ function otherFn(n) {
 }
 export var whatever = (props) => {
   return (
-    <View data-uid={'aaa'}>
-      <cake data-uid={'aab'} left={cakeFn(otherFn('b') + 2)} />
+    <View data-uid='aaa'>
+      <cake data-uid='aab' left={cakeFn(otherFn('b') + 2)} />
     </View>
   )
 }
@@ -376,7 +376,7 @@ return { otherFn: otherFn };",
                 "javascript": "cakeFn(otherFn('b') + 2)",
                 "sourceMap": Object {
                   "file": "code.tsx",
-                  "mappings": "OAYoCA,MAAOC,QAAQC,CAACC,GAADD,CAARD,GAAgBG,CAAhBH,CAAPD",
+                  "mappings": "OAYkCA,MAAOC,QAAQC,CAACC,GAADD,CAARD,GAAgBG,CAAhBH,CAAPD",
                   "names": Array [
                     "cakeFn",
                     "otherFn",
@@ -399,8 +399,8 @@ function otherFn(n) {
 }
 export var whatever = (props) => {
   return (
-    <View data-uid={'aaa'}>
-      <cake data-uid={'aab'} left={cakeFn(otherFn('b') + 2)} />
+    <View data-uid='aaa'>
+      <cake data-uid='aab' left={cakeFn(otherFn('b') + 2)} />
     </View>
   )
 }
@@ -474,7 +474,7 @@ import {
   View
 } from \\"utopia-api\\";
 const a = (n) => n > 0 ? n : b(10)
-export var whatever = (props) => <View data-uid={'aaa'} />
+export var whatever = (props) => <View data-uid='aaa' />
 const b = (n) => n > 0 ? n : a(10)
 ",
       ],
@@ -501,7 +501,7 @@ return { a: a, b: b };",
   },
   "highlightBounds": Object {
     "aaa": Object {
-      "endCol": 58,
+      "endCol": 56,
       "endLine": 5,
       "startCol": 33,
       "startLine": 5,
@@ -569,7 +569,7 @@ import {
   View
 } from \\"utopia-api\\";
 const a = (n) => n > 0 ? n : b(10)
-export var whatever = (props) => <View data-uid={'aaa'} />
+export var whatever = (props) => <View data-uid='aaa' />
 const b = (n) => n > 0 ? n : a(10)
 ",
         ],
@@ -659,7 +659,7 @@ import {
   View
 } from \\"utopia-api\\";
 const a = (n) => n > 0 ? n : b(10)
-export var whatever = (props) => <View data-uid={'aaa'} />
+export var whatever = (props) => <View data-uid='aaa' />
 const b = (n) => n > 0 ? n : a(10)
 ",
         ],
@@ -713,7 +713,7 @@ import {
   View
 } from \\"utopia-api\\";
 const a = \\"cake\\"
-export var App = (props) => <View data-uid={'bbb'}>
+export var App = (props) => <View data-uid='bbb'>
   {{a: a}}
 </View>
 ",
@@ -827,7 +827,7 @@ import {
   View
 } from \\"utopia-api\\";
 const a = \\"cake\\"
-export var App = (props) => <View data-uid={'bbb'}>
+export var App = (props) => <View data-uid='bbb'>
   {{a: a}}
 </View>
 ",
@@ -889,7 +889,7 @@ import {
   View
 } from \\"utopia-api\\";
 const a = \\"cake\\"
-export var App = (props) => <View data-uid={'bbb'}>
+export var App = (props) => <View data-uid='bbb'>
   {{a: a}}
 </View>
 ",

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
@@ -46,13 +46,13 @@ export var App = props => {
 }
 export var ${BakedInStoryboardVariableName} = (props) => {
   return (
-    <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+    <Storyboard data-uid='${BakedInStoryboardUID}'>
       <Scene
         style={{ height: 200, left: 59, width: 200, top: 79 }}
         component={App}
         layout={{ layoutSystem: 'pinSystem' }}
         props={{ style: { height: '100%', width: '100%' }, title: 'Hi there!' }}
-        data-uid={'scene-0'}
+        data-uid='scene-0'
       />
     </Storyboard>
   )
@@ -93,20 +93,20 @@ export var ${BakedInStoryboardVariableName} = (props) => {
 import { View, Storyboard, Scene } from 'utopia-api';
 export var App = props => {
   return (
-    <View data-uid={'aaa'}>
-      {<div data-uid={'bbb'} />}
+    <View data-uid='aaa'>
+      {<div data-uid='bbb' />}
     </View>
   )
 }
 export var ${BakedInStoryboardVariableName} = (props) => {
   return (
-    <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+    <Storyboard data-uid='${BakedInStoryboardUID}'>
       <Scene
         style={{ height: 200, left: 59, width: 200, top: 79 }}
         component={App}
         layout={{ layoutSystem: 'pinSystem' }}
         props={{ style: { height: '100%', width: '100%' }, title: 'Hi there!' }}
-        data-uid={'scene-0'}
+        data-uid='scene-0'
       />
     </Storyboard>
   )
@@ -120,20 +120,20 @@ export var ${BakedInStoryboardVariableName} = (props) => {
 import { Scene, Storyboard, View } from 'utopia-api';
 export var App = props => {
   return (
-    <View data-uid={"aaa"}>
-      {<div data-uid={"bbb"} style={{ left: 20, top: 300 }} />}
+    <View data-uid="aaa">
+      {<div data-uid="bbb" style={{ left: 20, top: 300 }} />}
     </View>
   );
 };
 export var ${BakedInStoryboardVariableName} = (props) => {
   return (
-    <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+    <Storyboard data-uid='${BakedInStoryboardUID}'>
       <Scene
         style={{ height: 200, left: 59, width: 200, top: 79 }}
         component={App}
         layout={{ layoutSystem: 'pinSystem' }}
         props={{ style: { height: '100%', width: '100%' }, title: 'Hi there!' }}
-        data-uid={'scene-0'}
+        data-uid='scene-0'
       />
     </Storyboard>
   )
@@ -168,10 +168,10 @@ export var ${BakedInStoryboardVariableName} = (props) => {
   it('Supports using top level components inside an arbitrary block', () => {
     const code = `import React from "react";
 import { View } from "utopia-api";
-var MyComp = (props) => <div data-uid={'abc'}/>
+var MyComp = (props) => <div data-uid='abc'/>
 export var whatever = props => (
-<View data-uid={'aaa'}>
-  {<MyComp data-uid={'aab'}/>}
+<View data-uid='aaa'>
+  {<MyComp data-uid='aab'/>}
 </View>
 )
 `
@@ -192,8 +192,8 @@ export var whatever = props => (
     )
 
     const codeBlock = jsxArbitraryBlock(
-      `<MyComp data-uid={'aab'}/>`,
-      `<MyComp data-uid={'aab'} />;`,
+      `<MyComp data-uid='aab'/>`,
+      `<MyComp data-uid='aab' />;`,
       `return utopiaCanvasJSXLookup("aab", {});`,
       ['React', 'MyComp', 'utopiaCanvasJSXLookup'],
       expect.objectContaining({
@@ -235,8 +235,8 @@ import { View } from "utopia-api";
 export var whatever = (props) => {
   const arr = [ { n: 1 } ]
   return (
-    <View data-uid={'aaa'}>
-      { arr.map(({ n }) => <View data-uid={'aab'} thing={n} /> ) }
+    <View data-uid='aaa'>
+      { arr.map(({ n }) => <View data-uid='aab' thing={n} /> ) }
     </View>
   )
 }
@@ -249,8 +249,8 @@ export var whatever = (props) => {
       },
       [
         jsxArbitraryBlock(
-          `arr.map(({ n }) => <View data-uid={'aab'} thing={n} /> )`,
-          `arr.map(({ n }) => <View data-uid={'aab'} thing={n} />);`,
+          `arr.map(({ n }) => <View data-uid='aab' thing={n} /> )`,
+          `arr.map(({ n }) => <View data-uid='aab' thing={n} />);`,
           `return arr.map(function (_ref) {
   var n = _ref.n;
   return utopiaCanvasJSXLookup("aab", {
@@ -333,8 +333,8 @@ import { View } from "utopia-api";
 export var whatever = (props) => {
   const arr = [ { a: { n: 1 } } ]
   return (
-    <View data-uid={'aaa'}>
-      { arr.map(({ a: { n } }) => <View data-uid={'aab'} thing={n} /> ) }
+    <View data-uid='aaa'>
+      { arr.map(({ a: { n } }) => <View data-uid='aab' thing={n} /> ) }
     </View>
   )
 }
@@ -347,8 +347,8 @@ export var whatever = (props) => {
       },
       [
         jsxArbitraryBlock(
-          `arr.map(({ a: { n } }) => <View data-uid={'aab'} thing={n} /> )`,
-          `arr.map(({ a: { n } }) => <View data-uid={'aab'} thing={n} />);`,
+          `arr.map(({ a: { n } }) => <View data-uid='aab' thing={n} /> )`,
+          `arr.map(({ a: { n } }) => <View data-uid='aab' thing={n} />);`,
           `return arr.map(function (_ref) {
   var n = _ref.a.n;
   return utopiaCanvasJSXLookup("aab", {
@@ -433,15 +433,15 @@ import { View } from "utopia-api";
 export var whatever = (props) => {
   const arr = [ [ 1 ] ]
   return (
-    <View data-uid={'aaa'}>
-      { arr.map(([ n ]) => <View data-uid={'aab'} thing={n} /> ) }
+    <View data-uid='aaa'>
+      { arr.map(([ n ]) => <View data-uid='aab' thing={n} /> ) }
     </View>
   )
 }
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
-    const originalMapJsCode = `arr.map(([ n ]) => <View data-uid={'aab'} thing={n} /> )`
-    const mapJsCode = `arr.map(([n]) => <View data-uid={'aab'} thing={n} />);`
+    const originalMapJsCode = `arr.map(([ n ]) => <View data-uid='aab' thing={n} /> )`
+    const mapJsCode = `arr.map(([n]) => <View data-uid='aab' thing={n} />);`
     const transpiledMapJsCode = `return arr.map(function (_ref) {
   var _ref2 = babelHelpers.slicedToArray(_ref, 1),
       n = _ref2[0];
@@ -532,8 +532,8 @@ return { arr: arr };`
 import { View } from "utopia-api";
 export var whatever = (props) => {
   return (
-    <View data-uid={'aaa'}>
-      { [1].map((n) => <div data-uid={'aab'}><div data-uid={'aac'}>{n}</div></div> ) }
+    <View data-uid='aaa'>
+      { [1].map((n) => <div data-uid='aab'><div data-uid='aac'>{n}</div></div> ) }
     </View>
   )
 }
@@ -546,8 +546,8 @@ export var whatever = (props) => {
       },
       [
         jsxArbitraryBlock(
-          `[1].map((n) => <div data-uid={'aab'}><div data-uid={'aac'}>{n}</div></div> )`,
-          `[1].map(n => <div data-uid={'aab'}><div data-uid={'aac'}>{n}</div></div>);`,
+          `[1].map((n) => <div data-uid='aab'><div data-uid='aac'>{n}</div></div> )`,
+          `[1].map(n => <div data-uid='aab'><div data-uid='aac'>{n}</div></div>);`,
           `return [1].map(function (n) {
   return utopiaCanvasJSXLookup("aab", {
     n: n
@@ -623,14 +623,14 @@ import { View } from "utopia-api";
 export var whatever = (props) => {
   const arr = [ [ [ 1 ] ] ]
   return (
-    <View data-uid={'aaa'}>
-      { arr.map(([[ n ]]) => <View data-uid={'aab'} thing={n} /> ) }
+    <View data-uid='aaa'>
+      { arr.map(([[ n ]]) => <View data-uid='aab' thing={n} /> ) }
     </View>
   )
 }
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
-    const mapJsCode = `arr.map(([[ n ]]) => <View data-uid={'aab'} thing={n} /> )`
+    const mapJsCode = `arr.map(([[ n ]]) => <View data-uid='aab' thing={n} /> )`
     const transpiledMapJsCode = `return arr.map(function (_ref) {
   var _ref2 = babelHelpers.slicedToArray(_ref, 1),
       _ref2$ = babelHelpers.slicedToArray(_ref2[0], 1),
@@ -722,8 +722,8 @@ return { arr: arr };`
 import { View } from "utopia-api";
 export var whatever = (props) => {
   return (
-    <View data-uid={'aaa'}>
-      { [1].map((n) => <div data-uid={'aab'}><div data-uid={'aac'}>{n}</div></div> ) }
+    <View data-uid='aaa'>
+      { [1].map((n) => <div data-uid='aab'><div data-uid='aac'>{n}</div></div> ) }
     </View>
   )
 }
@@ -736,8 +736,8 @@ export var whatever = (props) => {
       },
       [
         jsxArbitraryBlock(
-          `[1].map((n) => <div data-uid={'aab'}><div data-uid={'aac'}>{n}</div></div> )`,
-          `[1].map(n => <div data-uid={'aab'}><div data-uid={'aac'}>{n}</div></div>);`,
+          `[1].map((n) => <div data-uid='aab'><div data-uid='aac'>{n}</div></div> )`,
+          `[1].map(n => <div data-uid='aab'><div data-uid='aac'>{n}</div></div>);`,
           `return [1].map(function (n) {
   return utopiaCanvasJSXLookup("aab", {
     n: n
@@ -813,14 +813,14 @@ import { View } from "utopia-api";
 export var whatever = (props) => {
   const arr = [ [ [ 1 ] ] ]
   return (
-    <View data-uid={'aaa'}>
-      { arr.map(([[ n ]]) => <View data-uid={'aab'} thing={n} /> ) }
+    <View data-uid='aaa'>
+      { arr.map(([[ n ]]) => <View data-uid='aab' thing={n} /> ) }
     </View>
   )
 }
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
-    const mapJsCode = `arr.map(([[ n ]]) => <View data-uid={'aab'} thing={n} /> )`
+    const mapJsCode = `arr.map(([[ n ]]) => <View data-uid='aab' thing={n} /> )`
     const transpiledMapJsCode = `return arr.map(function (_ref) {
   var _ref2 = babelHelpers.slicedToArray(_ref, 1),
       _ref2$ = babelHelpers.slicedToArray(_ref2[0], 1),
@@ -924,7 +924,7 @@ function a(n) {
 export var App = (props) => {
   return (
     <div
-      data-uid={'aaa'}
+      data-uid='aaa'
       style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
       layout={{ layoutSystem: 'pinSystem' }}
     >{b(5)} - {a(5)}</div>
@@ -940,9 +940,9 @@ function b(n) {
 }
 
 export var storyboard = (
-  <Storyboard data-uid={'bbb'} layout={{ layoutSystem: 'pinSystem' }}>
+  <Storyboard data-uid='bbb' layout={{ layoutSystem: 'pinSystem' }}>
     <Scene
-      data-uid={'ccc'}
+      data-uid='ccc'
       component={App}
       props={{}}
       style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}

--- a/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
@@ -37,7 +37,7 @@ describe('JSX parser', () => {
     const code = `import * as React from "react";
 import { Ellipse, UtopiaUtils, Image, Rectangle, Text, View } from "utopia-api";
 export var App = props => {
-  return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid={"xxx"}>
+  return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid="xxx">
     {[1, 2, 3].map(n => {
       return <div>{n}</div>
     })}
@@ -53,7 +53,7 @@ export var App = props => {
     import * as React from "react";
     import { Ellipse, UtopiaUtils, Image, Rectangle, Text, View } from "utopia-api";
     export var App = props => {
-        return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid={"xxx"} />
+        return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid="xxx" />
     };`
     const parsedPlainCode = testParseCode(code)
     if (isParseSuccess(parsedPlainCode)) {
@@ -86,9 +86,9 @@ describe('JSX printer', () => {
 import { Storyboard, View } from 'utopia-api'
 const myCoolTheme = {}
 export var App = (props) => {
-  return <View data-uid={'xxx'} style={{ ...myCoolTheme, backgroundColor: 'purple' }} />
+  return <View data-uid='xxx' style={{ ...myCoolTheme, backgroundColor: 'purple' }} />
 }
-export var ${BakedInStoryboardVariableName} = <Storyboard data-uid={'${BakedInStoryboardUID}'} />
+export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInStoryboardUID}' />
 `
     testParseThenPrint(code, code)
   })
@@ -96,12 +96,12 @@ export var ${BakedInStoryboardVariableName} = <Storyboard data-uid={'${BakedInSt
     const code = `import * as React from 'react'
 import { Storyboard, View } from 'utopia-api'
 export var App = (props) => {
-  return <Widget data-uid={'bbb'} />
+  return <Widget data-uid='bbb' />
 }
 export var Widget = (props) => {
-  return <View data-uid={'aaa'} />
+  return <View data-uid='aaa' />
 }
-export var ${BakedInStoryboardVariableName} = <Storyboard data-uid={'${BakedInStoryboardUID}'} />
+export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInStoryboardUID}' />
 `
     testParseThenPrint(code, code)
   })
@@ -113,12 +113,12 @@ const color = 'white'
 export var App = (props) => {
   return (
     <View
-      data-uid={'aaa'}
+      data-uid='aaa'
       css={{ backgroundColor: 'regular propety, without quotes', '& :hover': { color: color } }}
     />
   )
 }
-export var ${BakedInStoryboardVariableName} = <Storyboard data-uid={'${BakedInStoryboardUID}'} />
+export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInStoryboardUID}' />
 `
     testParseThenPrint(code, code)
   })
@@ -128,13 +128,13 @@ export var ${BakedInStoryboardVariableName} = <Storyboard data-uid={'${BakedInSt
 import { Storyboard, View } from 'utopia-api'
 export var App = (props) => {
   return (
-    <View data-uid={'aaa'} css={{ backgroundColor: 'red' }}>
-      <View data-uid={'bbb'}>{elements.map((e) => null)}</View>
+    <View data-uid='aaa' css={{ backgroundColor: 'red' }}>
+      <View data-uid='bbb'>{elements.map((e) => null)}</View>
     </View>
   )
 }
 const elements = []
-export var ${BakedInStoryboardVariableName} = <Storyboard data-uid={'${BakedInStoryboardUID}'} />
+export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInStoryboardUID}' />
 `
     testParseThenPrint(code, code)
   })
@@ -147,13 +147,13 @@ import * as React from 'react'
 import { Storyboard, View } from 'utopia-api'
 export var App = (props) => {
   return (
-    <View data-uid={'aaa'} css={{ backgroundColor: 'red' }}>
-      <View data-uid={'bbb'}>{elements.map((e) => null)}</View>
+    <View data-uid='aaa' css={{ backgroundColor: 'red' }}>
+      <View data-uid='bbb'>{elements.map((e) => null)}</View>
     </View>
   )
 }
 const elements = []
-export var ${BakedInStoryboardVariableName} = <Storyboard data-uid={'${BakedInStoryboardUID}'} />
+export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInStoryboardUID}' />
 `
     testParseThenPrint(code, code)
   })

--- a/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
@@ -6,7 +6,7 @@ describe('Parsing and then printing code', () => {
     it(`retains the variable declaration keyword ${varLetOrConst}`, () => {
       const code = applyPrettier(
         `export ${varLetOrConst} whatever = (props) => {
-          return <div data-uid={'aaa'} />
+          return <div data-uid='aaa' />
         }`,
         false,
       ).formatted
@@ -19,7 +19,7 @@ describe('Parsing and then printing code', () => {
   it('does not replace a function with a const', () => {
     const code = applyPrettier(
       `export default function whatever(props) {
-        return <div data-uid={'aaa'} />
+        return <div data-uid='aaa' />
       }`,
       false,
     ).formatted
@@ -31,7 +31,7 @@ describe('Parsing and then printing code', () => {
   it('retains a parenthesized expression body on an arrow function component', () => {
     const code = applyPrettier(
       `export const whatever = (props) => (
-        <div data-uid={'aaa'} />
+        <div data-uid='aaa' />
       )`,
       false,
     ).formatted
@@ -41,7 +41,7 @@ describe('Parsing and then printing code', () => {
   })
 
   it('retains a non-parenthesized expression body on an arrow function component', () => {
-    const code = applyPrettier(`export const whatever = (props) => <div data-uid={'aaa'} />`, false)
+    const code = applyPrettier(`export const whatever = (props) => <div data-uid='aaa' />`, false)
       .formatted
 
     const parsedThenPrinted = parseThenPrint(code)
@@ -51,7 +51,7 @@ describe('Parsing and then printing code', () => {
   it('retains a block expression body on an arrow function component', () => {
     const code = applyPrettier(
       `export const whatever = (props) => {
-        return <div data-uid={'aaa'} />
+        return <div data-uid='aaa' />
       }`,
       false,
     ).formatted
@@ -60,10 +60,22 @@ describe('Parsing and then printing code', () => {
     expect(parsedThenPrinted).toEqual(code)
   })
 
-  xit('does not surround a literal in braces when it was not previously surrounded in braces', () => {
+  it('does not surround a jsx attribute value in braces when it was not previously surrounded in braces', () => {
     const code = applyPrettier(
       `export const whatever = (props) => {
-        return <div data-something='something' data-uid={'aaa'} />
+        return <div data-something='something' data-uid='aaa' />
+      }`,
+      false,
+    ).formatted
+
+    const parsedThenPrinted = parseThenPrint(code)
+    expect(parsedThenPrinted).toEqual(code)
+  })
+
+  xit('does not remove the braces surrounding a jsx attribute value', () => {
+    const code = applyPrettier(
+      `export const whatever = (props) => {
+        return <div data-something={'something'} data-uid='aaa' />
       }`,
       false,
     ).formatted
@@ -75,7 +87,7 @@ describe('Parsing and then printing code', () => {
   xit('does not remove a trailing export default statement', () => {
     const code = applyPrettier(
       `const whatever = (props) => {
-        return <div data-something='something' data-uid={'aaa'} />
+        return <div data-uid='aaa' />
       }
       
       export default whatever`,

--- a/editor/src/core/workers/parser-printer/parser-printer-component-based-canvas.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-component-based-canvas.spec.ts
@@ -11,28 +11,28 @@ export var App = (props) => {
     <View
       style={{ ...props.style, backgroundColor: '#FFFFFF' }}
       layout={{ layoutSystem: 'pinSystem' }}
-      data-uid={'aaa'}
+      data-uid='aaa'
     >
-      <View data-uid={'9ec'}>hi</View>
+      <View data-uid='9ec'>hi</View>
     </View>
   )
 }
 export var ${BakedInStoryboardVariableName} = (props) => {
   return (
-    <Canvas data-uid={'${BakedInStoryboardUID}'}>
+    <Canvas data-uid='${BakedInStoryboardUID}'>
       <Scene
         style={{ height: 200, left: 59, width: 200, top: 79 }}
         component={App}
         layout={{ layoutSystem: 'pinSystem' }}
         props={{ style: { height: '100%', width: '100%' }, title: 'Hi there!' }}
-        data-uid={'scene-0'}
+        data-uid='scene-0'
       />
       <Scene
         style={{ height: 400, left: 459, width: 400, top: 79 }}
         component={App}
         layout={{ layoutSystem: 'pinSystem' }}
         props={{ style: { height: '100%', width: '100%' }, title: 'woo there!' }}
-        data-uid={'scene-1'}
+        data-uid='scene-1'
       />
     </Canvas>
   )

--- a/editor/src/core/workers/parser-printer/parser-printer-dot-notation.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-dot-notation.spec.ts
@@ -15,20 +15,20 @@ import * as React from "react";
 import * as Utopia from "utopia-api";
 export var App = props => {
   return (
-    <Utopia.View data-uid={"aaa"}>
-      {<div data-uid={"bbb"} />}
+    <Utopia.View data-uid="aaa">
+      {<div data-uid="bbb" />}
     </Utopia.View>
   )
 }
 export var storyboard = (props) => {
   return (
-    <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+    <Storyboard data-uid='${BakedInStoryboardUID}'>
       <Scene
         style={{ left: 0, top: 0, width: 400, height: 400 }}
         component={App}
         layout={{ layoutSystem: 'pinSystem' }}
         props={{ layout: { bottom: 0, left: 0, right: 0, top: 0 } }}
-        data-uid={'scene-aaa'}
+        data-uid='scene-aaa'
       />
     </Storyboard>
   )
@@ -58,20 +58,20 @@ import * as Utopia from "utopia-api";
 import { Scene, Storyboard, View } from "utopia-api";
 export var App = props => {
   return (
-    <Utopia.View data-uid={"aaa"}>
-      <View data-uid={'bbb'} />
+    <Utopia.View data-uid="aaa">
+      <View data-uid='bbb' />
     </Utopia.View>
   )
 }
 export var storyboard = (props) => {
   return (
-    <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+    <Storyboard data-uid='${BakedInStoryboardUID}'>
       <Scene
         style={{ left: 0, top: 0, width: 400, height: 400 }}
         component={App}
         layout={{ layoutSystem: 'pinSystem' }}
         props={{ layout: { bottom: 0, left: 0, right: 0, top: 0 } }}
-        data-uid={'scene-aaa'}
+        data-uid='scene-aaa'
       />
     </Storyboard>
   )
@@ -81,20 +81,20 @@ import { Scene, Storyboard, View } from 'utopia-api'
 import * as Utopia from 'utopia-api'
 export var App = (props) => {
   return (
-    <Utopia.View data-uid={'aaa'}>
-      <View data-uid={'bbb'} />
+    <Utopia.View data-uid='aaa'>
+      <View data-uid='bbb' />
     </Utopia.View>
   )
 }
 export var storyboard = (props) => {
   return (
-    <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+    <Storyboard data-uid='${BakedInStoryboardUID}'>
       <Scene
         style={{ left: 0, top: 0, width: 400, height: 400 }}
         component={App}
         layout={{ layoutSystem: 'pinSystem' }}
         props={{ layout: { bottom: 0, left: 0, right: 0, top: 0 } }}
-        data-uid={'scene-aaa'}
+        data-uid='scene-aaa'
       />
     </Storyboard>
   )

--- a/editor/src/core/workers/parser-printer/parser-printer-event-handlers.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-event-handlers.spec.ts
@@ -22,18 +22,18 @@ import {
 } from "utopia-api";
 export var App = props => {
   return (
-    <View data-uid={'aaa'} onClick={() => {console.log('hat')}}/>
+    <View data-uid='aaa' onClick={() => {console.log('hat')}}/>
   )
 }
 export var ${BakedInStoryboardVariableName} = (props) => {
   return (
-    <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+    <Storyboard data-uid='${BakedInStoryboardUID}'>
       <Scene
         style={{ left: 0, top: 0, width: 400, height: 400 }}
         component={App}
         layout={{ layoutSystem: 'pinSystem' }}
         props={{ layout: { bottom: 0, left: 0, right: 0, top: 0 } }}
-        data-uid={'scene-aaa'}
+        data-uid='scene-aaa'
       />
     </Storyboard>
   )
@@ -65,7 +65,7 @@ import {
 export var App = props => {
   return (
     <View
-      data-uid={"aaa"}
+      data-uid='aaa'
       onClick={() => {
         console.log("hat");
       }}
@@ -74,13 +74,13 @@ export var App = props => {
 };
 export var ${BakedInStoryboardVariableName} = (props) => {
   return (
-    <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+    <Storyboard data-uid='${BakedInStoryboardUID}'>
       <Scene
         style={{ left: 0, top: 0, width: 400, height: 400 }}
         component={App}
         layout={{ layoutSystem: 'pinSystem' }}
         props={{ layout: { bottom: 0, left: 0, right: 0, top: 0 } }}
-        data-uid={'scene-aaa'}
+        data-uid='scene-aaa'
       />
     </Storyboard>
   )

--- a/editor/src/core/workers/parser-printer/parser-printer-exports.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-exports.spec.ts
@@ -8,7 +8,7 @@ describe('parseCode', () => {
     const code = applyPrettier(
       `
     export var whatever = (props) => {
-      return <div data-uid={'aaa'} />
+      return <div data-uid='aaa' />
     }
 `,
       false,
@@ -31,7 +31,7 @@ describe('parseCode', () => {
     const code = applyPrettier(
       `
     var whatever = (props) => {
-      return <div data-uid={'aaa'} />
+      return <div data-uid='aaa' />
     }
     export { whatever }
 `,
@@ -56,7 +56,7 @@ describe('parseCode', () => {
     const code = applyPrettier(
       `
     var whatever = (props) => {
-      return <div data-uid={'aaa'} />
+      return <div data-uid='aaa' />
     }
     export { whatever as otherThing }
 `,

--- a/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
@@ -48,31 +48,27 @@ describe('JSX parser', () => {
             <View
               style={{ ...props.style, backgroundColor: '#FFFFFF' }}
               layout={{ layoutSystem: 'pinSystem' }}
-              data-uid={'aaa'}
+              data-uid='aaa'
             >
               <React.Fragment>
-                <div data-label={'random-div'} style={{ width: 100, height: 100 }} data-uid={'bbb'}>
+                <div data-label='random-div' style={{ width: 100, height: 100 }} data-uid='bbb'>
                   Hello
                   <>
-                    <div
-                      data-label={'some-other-div'}
-                      style={{ width: 100, height: 100 }}
-                      data-uid={'ccc'}
-                    />
+                    <div data-label='some-other-div' style={{ width: 100, height: 100 }} data-uid='ccc' />
                   </>
                 </div>
               </React.Fragment>
-              <div data-uid={'ddd'}>World</div>
+              <div data-uid='ddd'>World</div>
             </View>
           )
         }
         export var storyboard = (
-          <Storyboard data-uid={'eee'}>
+          <Storyboard data-uid='eee'>
             <Scene
               style={{ position: 'absolute', height: 812, left: 0, width: 375, top: 0 }}
               component={App}
               props={{ style: { position: 'absolute', bottom: 0, left: 0, right: 0, top: 0 } }}
-              data-uid={'fff'}
+              data-uid='fff'
             />
           </Storyboard>
         )

--- a/editor/src/core/workers/parser-printer/parser-printer-pragma.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-pragma.spec.ts
@@ -10,7 +10,7 @@ describe('Parsing JSX Pragma:', () => {
     import * as React from "react";
     import { Ellipse, Image, Rectangle, Text, UtopiaUtils, View } from "utopia-api";
     export var App = props => {
-        return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid={"xxx"} />
+        return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid="xxx" />
     };`
     const parsedPlainCode = testParseCode(code)
     if (isParseSuccess(parsedPlainCode)) {
@@ -26,7 +26,7 @@ describe('Parsing JSX Pragma:', () => {
     import * as React from "react";
     import { Ellipse, Image, Rectangle, Text, UtopiaUtils, View, jsx } from "utopia-api";
     export var App = props => {
-        return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid={"xxx"} />
+        return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid="xxx" />
     };`
     const parsedPlainCode = testParseCode(code)
     if (isParseSuccess(parsedPlainCode)) {
@@ -43,17 +43,17 @@ describe('Parsing JSX Pragma:', () => {
     import * as React from "react";
     import { Ellipse, Image, Rectangle, Scene, Storyboard, Text, UtopiaUtils, View, jsx } from "utopia-api";
     export var App = props => {
-        return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid={"xxx"} />
+        return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid="xxx" />
     };
     export var storyboard = (props) => {
       return (
-        <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+        <Storyboard data-uid='${BakedInStoryboardUID}'>
           <Scene
             style={{ left: 0, top: 0, width: 400, height: 400 }}
             component={App}
             layout={{ layoutSystem: 'pinSystem' }}
             props={{ layout: { bottom: 0, left: 0, right: 0, top: 0 } }}
-            data-uid={'scene-aaa'}
+            data-uid='scene-aaa'
           />
         </Storyboard>
       )
@@ -70,7 +70,7 @@ describe('Parsing JSX Pragma:', () => {
     import * as React from "react";
     import { Ellipse, Image, Rectangle, Text, UtopiaUtils, View } from "utopia-api";
     export var App = props => {
-        return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid={"xxx"} />
+        return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid="xxx" />
     };`
     const parsedPlainCode = testParseCode(code)
     if (isParseSuccess(parsedPlainCode)) {
@@ -88,7 +88,7 @@ describe('Parsing JSX Pragma:', () => {
     import * as React from "react";
     import { Ellipse, Image, Rectangle, Text, UtopiaUtils, View } from "utopia-api";
     export var App = props => {
-        return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid={"xxx"} />
+        return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid="xxx" />
     };`
     const parsedPlainCode = testParseCode(code)
     if (isParseSuccess(parsedPlainCode)) {

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -75,8 +75,8 @@ import {
   View
 } from "utopia-api";
 import { cake } from 'cake'
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -139,8 +139,8 @@ import {
   View
 } from "utopia-api";
 import { cake } from 'cake'
-export var whatever = () => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={20} right={20} top={-20} />
+export var whatever = () => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red'}} left={20} right={20} top={-20} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -200,8 +200,8 @@ import {
 import { cake } from 'cake'
 export function whatever(props) {
   return (
-    <View data-uid={'aaa'}>
-      <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
+    <View data-uid='aaa'>
+      <cake data-uid='aab' style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
     </View>
   )
 }
@@ -268,8 +268,8 @@ import {
 import { cake } from 'cake'
 export function whatever() {
   return (
-    <View data-uid={'aaa'}>
-      <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={20} right={20} top={-20} />
+    <View data-uid='aaa'>
+      <cake data-uid='aab' style={{backgroundColor: 'red'}} left={20} right={20} top={-20} />
     </View>
   )
 }
@@ -331,8 +331,8 @@ import {
 import { cake } from 'cake'
 export default function whatever(props) {
   return (
-    <View data-uid={'aaa'}>
-      <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
+    <View data-uid='aaa'>
+      <cake data-uid='aab' style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
     </View>
   )
 }
@@ -399,8 +399,8 @@ import {
 import { cake } from 'cake'
 export default function whatever() {
   return (
-    <View data-uid={'aaa'}>
-      <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={20} right={20} top={-20} />
+    <View data-uid='aaa'>
+      <cake data-uid='aab' style={{backgroundColor: 'red'}} left={20} right={20} top={-20} />
     </View>
   )
 }
@@ -461,8 +461,8 @@ import {
 } from "utopia-api";
 import cake from 'cake'
 import './style.css'
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -533,9 +533,9 @@ import {
   View
 } from "utopia-api";
 import cake, { cake2 } from 'cake'
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
-  <cake2 data-uid={'aac'} style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
+  <cake2 data-uid='aac' style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -611,8 +611,8 @@ import {
   View
 } from "utopia-api";
 import { cake as cake2 } from 'cake'
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake2 data-uid={'aac'} style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake2 data-uid='aac' style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
 </View>
 `
       const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -675,9 +675,9 @@ import {
   View
 } from "utopia-api";
 import { cake } from 'cake'
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} data-label={'First cake'} style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
-  <cake data-uid={'111'} data-label={'Second cake'} style={{backgroundColor: 'blue'}} left={props.rightOfTheCake[0].hat} right={10} top={-10} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' data-label='First cake' style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
+  <cake data-uid='111' data-label='Second cake' style={{backgroundColor: 'blue'}} left={props.rightOfTheCake[0].hat} right={10} top={-10} />
 </View>
 `
       const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -758,8 +758,8 @@ import {
   View
 } from "utopia-api";
 import { cake } from 'cake'
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red' }} left={props.leftOfTheCake[0].hat} right={20} top={-20} nullProp={null} undefinedProp={undefined} trueProp={true} falseProp={false} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red' }} left={props.leftOfTheCake[0].hat} right={20} top={-20} nullProp={null} undefinedProp={undefined} trueProp={true} falseProp={false} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -832,8 +832,8 @@ function getSizing(n) {
   return 100 + n
 }
 var spacing = 20
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={getSizing(spacing)} right={20} top={-20} onClick={function(){console.log('click')}} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red'}} left={getSizing(spacing)} right={20} top={-20} onClick={function(){console.log('click')}} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -972,8 +972,8 @@ import { cake } from 'cake'
 export default function getSizing(n) {
   return 100 + n
 }
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -1062,8 +1062,8 @@ export function getSizing(n) {
       return 100 + n
   }
 }
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -1158,8 +1158,8 @@ import { cake } from 'cake'
 export default (n) => {
   return 100 + n
 }
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red'}} left={props.leftOfTheCake[0].hat} right={20} top={-20} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -1241,8 +1241,8 @@ import {
 } from "utopia-api";
 import { cake } from 'cake'
 var spacing = 20
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={spacing} right={20} top={-20} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red'}} left={spacing} right={20} top={-20} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -1319,7 +1319,7 @@ export var whatever = (props) => {
   const bgs = ['black', 'grey']
   const bg = bgs[0]
   return (
-    <View data-uid={'aaa'} style={{ backgroundColor: bgs[0] }} />
+    <View data-uid='aaa' style={{ backgroundColor: bgs[0] }} />
   )
 }
 `
@@ -1389,7 +1389,7 @@ import { View } from "utopia-api";
 export var whatever = (props) => {
   const greys = ['lightGrey', 'grey']
   return (
-    <View data-uid={'aaa'} colors={['black', ...greys]}/>
+    <View data-uid='aaa' colors={['black', ...greys]}/>
   )
 }
 `
@@ -1461,7 +1461,7 @@ export var whatever = (props) => {
   const a = 10
   const b = 20
   return (
-    <View data-uid={'aaa'} left={a + b} />
+    <View data-uid='aaa' left={a + b} />
   )
 }
 `
@@ -1531,7 +1531,7 @@ export var whatever = (props) => {
   const b = 10
   const c = 20
   return (
-    <View data-uid={'aaa'} left={a ? b : c} />
+    <View data-uid='aaa' left={a ? b : c} />
   )
 }
 `
@@ -1601,7 +1601,7 @@ import { View } from "utopia-api";
 export var whatever = (props) => {
   let a = 10
   return (
-    <View data-uid={'aaa'} left={a++} right={++a} />
+    <View data-uid='aaa' left={a++} right={++a} />
   )
 }
 `
@@ -1678,7 +1678,7 @@ export var whatever = (props) => {
   const a = 10
   const b = { a: a }
   return (
-    <View data-uid={'aaa'} left={b.a} />
+    <View data-uid='aaa' left={b.a} />
   )
 }
 `
@@ -1748,7 +1748,7 @@ import { View } from "utopia-api";
 export var whatever = (props) => {
   const bg = { backgroundColor: 'grey' }
   return (
-    <View data-uid={'aaa'} style={{...bg}} />
+    <View data-uid='aaa' style={{...bg}} />
   )
 }
 `
@@ -1826,8 +1826,8 @@ import {
 } from "utopia-api";
 import { cake } from 'cake'
 var count = 10
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red'}} text={\`Count \${count}\`} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red'}} text={\`Count \${count}\`} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -1908,8 +1908,8 @@ import {
 } from "utopia-api";
 import { cake } from 'cake'
 var use20 = true
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={use20 ? 20 : 10} right={20} top={-20} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red'}} left={use20 ? 20 : 10} right={20} top={-20} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -1990,7 +1990,7 @@ import {
   View
 } from "utopia-api";
 var mySet = new Set()
-export var whatever = (props) => <View data-uid={'aaa'}>
+export var whatever = (props) => <View data-uid='aaa'>
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -2047,8 +2047,8 @@ import {
 } from "utopia-api";
 import { cake } from 'cake'
 var spacing = 20
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <cake data-uid={'aab'} style={{backgroundColor: 'red'}} left={props.left + spacing} right={20} top={-20} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <cake data-uid='aab' style={{backgroundColor: 'red'}} left={props.left + spacing} right={20} top={-20} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -2141,8 +2141,8 @@ var MyComp = props => {
     "hello"
   );
 };
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <MyComp data-uid={'aab'} layout={{left: 100}} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <MyComp data-uid='aab' layout={{left: 100}} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -2227,7 +2227,7 @@ import {
 var MyComp = (props) => {
   return (
     <div
-      data-uid={"abc"}
+      data-uid='abc'
       style={{
         position: "absolute",
         left: props.layout.left,
@@ -2240,8 +2240,8 @@ var MyComp = (props) => {
   );
 };
 export var whatever = props => (
-  <View data-uid={'aaa'}>
-    <MyComp data-uid={'aab'} layout={{left: 100}} />
+  <View data-uid='aaa'>
+    <MyComp data-uid='aab' layout={{left: 100}} />
   </View>
 )
 `
@@ -2356,8 +2356,8 @@ export var Whatever = (props) => <View>
     const code = `import * as React from "react";
 import { View } from "utopia-api";
 import { cake } from 'cake'
-export var whatever = (props) => <View data-uid={'aaa'}>
-<cake data-uid={'aab'} left={2 + 2} />
+export var whatever = (props) => <View data-uid='aaa'>
+<cake data-uid='aab' left={2 + 2} />
 </View>
 `
     const actualResult = testParseCode(code)
@@ -2404,8 +2404,8 @@ import {
   View
 } from "utopia-api";
 import { cake } from 'cake'
-export var whatever = (props) => <View data-uid={'aaa'}>
-<cake data-uid={'aab'} style={{backgroundColor: 'red', color: [props.color, -200]}} />
+export var whatever = (props) => <View data-uid='aaa'>
+<cake data-uid='aab' style={{backgroundColor: 'red', color: [props.color, -200]}} />
 </View>
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -2474,8 +2474,8 @@ import {
   View
 } from "utopia-api";
 import { cake } from 'cake'
-export var whatever = <View data-uid={'aaa'}>
-<cake data-uid={'aab'} style={{backgroundColor: 'red'}} />
+export var whatever = <View data-uid='aaa'>
+<cake data-uid='aab' style={{backgroundColor: 'red'}} />
 </View>
 `
     const actualResult = testParseCode(code)
@@ -2530,7 +2530,7 @@ import {
   UtopiaUtils,
   View
 } from "utopia-api";
-export var App = (props) => <View data-uid={'bbb'}>
+export var App = (props) => <View data-uid='bbb'>
   {}
 </View>
 `
@@ -2575,7 +2575,7 @@ import {
   View
 } from "utopia-api";
 const a = "cake"
-export var App = (props) => <View data-uid={'bbb'}>
+export var App = (props) => <View data-uid='bbb'>
   {{a: a}}
 </View>
 `
@@ -2826,8 +2826,8 @@ function otherFn(n) {
 }
 export var whatever = props => {
   return (
-    <View data-uid={"aaa"}>
-      <cake data-uid={"aab"} left={cakeFn(otherFn("b") + 2)} />
+    <View data-uid="aaa">
+      <cake data-uid="aab" left={cakeFn(otherFn("b") + 2)} />
     </View>
   );
 };
@@ -2851,7 +2851,7 @@ import {
 } from 'utopia-api'
 export var whatever = props => {
   return (
-    <View data-uid={"aaa"}>
+    <View data-uid="aaa">
       {}
     </View>
   );
@@ -3075,7 +3075,7 @@ export var whatever = props => {
     const code = applyPrettier(
       `const first = 100
 let second = 'cake'
-export var ${BakedInStoryboardVariableName} = <Storyboard data-uid={'${BakedInStoryboardUID}'} />
+export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInStoryboardUID}' />
 `,
       false,
     ).formatted
@@ -3083,7 +3083,7 @@ export var ${BakedInStoryboardVariableName} = <Storyboard data-uid={'${BakedInSt
       `
 const first = 100;
 let second = "cake";
-export var ${BakedInStoryboardVariableName} = <Storyboard data-uid={'${BakedInStoryboardUID}'} />
+export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInStoryboardUID}' />
 `,
       false,
     ).formatted
@@ -3118,8 +3118,8 @@ export var whatever = props => {
     return n * 2
   }
   return (
-    <View data-uid={"aaa"}>
-      <cake data-uid={"aab"} left={test(100)} />
+    <View data-uid="aaa">
+      <cake data-uid="aab" left={test(100)} />
     </View>
   );
 };
@@ -3322,8 +3322,8 @@ import {
 } from "utopia-api";
 export var App = props => {
   return (
-    <View data-uid={'aaa'}>
-      {[1,2,3].map(x=> <View data-uid={'abc'} />)}
+    <View data-uid='aaa'>
+      {[1,2,3].map(x=> <View data-uid='abc' />)}
     </View>
   );
 };`
@@ -3342,8 +3342,8 @@ export var App = props => {
         },
         [
           jsxArbitraryBlock(
-            `[1,2,3].map(x=> <View data-uid={'abc'} />)`,
-            `[1, 2, 3].map(x => <View data-uid={'abc'} />);`,
+            `[1,2,3].map(x=> <View data-uid='abc' />)`,
+            `[1, 2, 3].map(x => <View data-uid='abc' />);`,
             `return [1, 2, 3].map(function (x) {
   return utopiaCanvasJSXLookup("abc", {});
 });`,
@@ -3388,7 +3388,7 @@ import {
 } from "utopia-api";
 export var App = props => {
   return (
-    <View data-uid={'aaa'}>cake</View>
+    <View data-uid='aaa'>cake</View>
   );
 };`
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -3436,9 +3436,9 @@ import {
 } from "utopia-api";
 export var App = props => {
   return (
-    <View data-uid={'aaa'}>
+    <View data-uid='aaa'>
       {[1, 2, 3].map(n => (
-        <div data-uid={"abc"} />
+        <div data-uid="abc" />
       ))}
     </View>
   );
@@ -3459,10 +3459,10 @@ export var App = props => {
         [
           jsxArbitraryBlock(
             `[1, 2, 3].map(n => (
-        <div data-uid={"abc"} />
+        <div data-uid="abc" />
       ))`,
             `[1, 2, 3].map((n) =>
-<div data-uid={"abc"} />);`,
+<div data-uid="abc" />);`,
             `return [1, 2, 3].map(function (n) {
   return utopiaCanvasJSXLookup("abc", {});
 });`,
@@ -3513,10 +3513,10 @@ export var App = props => {
         [
           jsxArbitraryBlock(
             `[1, 2, 3].map((n) => (
-      <div data-uid={'abc'} />
+      <div data-uid='abc' />
     ))`,
             `[1, 2, 3].map((n) =>
-<div data-uid={'abc'} />);`,
+<div data-uid='abc' />);`,
             `return [1, 2, 3].map(function (n) {
   return utopiaCanvasJSXLookup("abc", {});
 });`,
@@ -3578,7 +3578,7 @@ import {
 export var App = props => {
   const a = 20;
   const b = 40;
-  const MyCustomCompomnent = props => <View data-uid={"abc"}>{props.children}</View>;
+  const MyCustomCompomnent = props => <View data-uid="abc">{props.children}</View>;
 
   return (
     <View
@@ -3589,24 +3589,24 @@ export var App = props => {
         width: props.layout.width,
         top: props.layout.top
       }}
-      data-uid={"aaa"}
+      data-uid="aaa"
     >
-      <MyCustomCompomnent data-uid={"ddd"}>
+      <MyCustomCompomnent data-uid="ddd">
         <Ellipse
           style={{ backgroundColor: "lightgreen" }}
           layout={{ height: 100, left: 150, width: 100, top: 540 }}
-          data-uid={"bbb"}
+          data-uid="bbb"
         />
         <Rectangle
           style={{ backgroundColor: "orange" }}
           layout={{ height: 100, left: 150, width: 100, top: 540 }}
-          data-uid={"ccc"}
+          data-uid="ccc"
         />
       </MyCustomCompomnent>
       <View
         style={{ backgroundColor: "blue", position: "absolute" }}
         layout={{ height: 200, left: 80, width: 100, top: 145 }}
-        data-uid={"ggg"}
+        data-uid="ggg"
       />
     </View>
   );
@@ -3690,7 +3690,7 @@ export var App = props => {
       arbitraryJSBlock(
         `const a = 20;
 const b = 40;
-const MyCustomCompomnent = props => <View data-uid={"abc"}>{props.children}</View>;`,
+const MyCustomCompomnent = props => <View data-uid="abc">{props.children}</View>;`,
         `var a = 20;
 var b = 40;
 
@@ -3740,7 +3740,7 @@ import {
 } from "utopia-api";
 export var App = props => {
   return (
-    <View data-uid={'aaa'} booleanProperty />
+    <View data-uid='aaa' booleanProperty />
   )
 }`
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -3789,7 +3789,7 @@ import {
   View
 } from "utopia-api";
 export var whatever = props => {
-  return <View data-uid={"aaa"} booleanProperty />;
+  return <View data-uid="aaa" booleanProperty />;
 };
 `,
       false,
@@ -3834,7 +3834,7 @@ import {
   View
 } from "utopia-api";
 export var whatever = props => {
-  return <View data-uid={"aaa"} />;
+  return <View data-uid="aaa" />;
 };
 `,
       false,
@@ -3875,7 +3875,7 @@ export var whatever = props => {
   while (true) {
     const a = 1
   }
-  return <div data-uid={'aaa'}></div>
+  return <div data-uid='aaa'></div>
 }`
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
     const arbitraryBlockCode = `for (var n = 0; n != -1; n++) {
@@ -3947,15 +3947,15 @@ export var whatever = props => {
   let result = []
   for (var n = 0; n < 5; n++) {
     const n2 = n * 2;
-    result.push(<div style={{ left: n, top: n2 }} data-uid={'bbb'} />);
+    result.push(<div style={{ left: n, top: n2 }} data-uid='bbb' />);
   }
-  return <div data-uid={'aaa'}>{result}</div>
+  return <div data-uid='aaa'>{result}</div>
 }`
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
     const arbitraryBlockCode = `let result = [];
 for (var n = 0; n < 5; n++) {
   const n2 = n * 2;
-  result.push(<div style={{ left: n, top: n2 }} data-uid={'bbb'} />);
+  result.push(<div style={{ left: n, top: n2 }} data-uid='bbb' />);
 }`
     const arbitraryBlockTranspiledCode = `var _loopIt = 0;
 var result = [];
@@ -3971,7 +3971,7 @@ for (var n = 0; n < 5; n++) {
       left: n,
       top: n2
     },
-    "data-uid": 'bbb'
+    "data-uid": "bbb"
   }));
 }
 return { result: result };`
@@ -4028,18 +4028,18 @@ return { result: result };`
   it('defined elsewhere values are assigned for elements inside arbitrary blocks', () => {
     const code = `import * as React from "react"
 export var whatever = props => {
-  return <div data-uid={'aaa'}>
+  return <div data-uid='aaa'>
     {[1, 2, 3].map(n => {
-      return <div style={{left: n * 30, top: n * 30}} data-uid={'bbb'} />
+      return <div style={{left: n * 30, top: n * 30}} data-uid='bbb' />
     })}
   </div>
 }`
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
     const arbitraryBlockOriginalCode = `[1, 2, 3].map(n => {
-      return <div style={{left: n * 30, top: n * 30}} data-uid={'bbb'} />
+      return <div style={{left: n * 30, top: n * 30}} data-uid='bbb' />
     })`
     const arbitraryBlockCode = `[1, 2, 3].map(n => {
-  return <div style={{ left: n * 30, top: n * 30 }} data-uid={'bbb'} />;
+  return <div style={{ left: n * 30, top: n * 30 }} data-uid='bbb' />;
 });`
     const arbitraryBlockTranspiledCode = `return [1, 2, 3].map(function (n) {
   return utopiaCanvasJSXLookup("bbb", {
@@ -4115,18 +4115,18 @@ export var whatever = props => {
     const code = `import * as React from "react"
 export var whatever = props => {
   const a = 30
-  return <div data-uid={'aaa'}>
+  return <div data-uid='aaa'>
     {[1, 2, 3].map(n => {
-      return <div style={{left: n * a, top: n * a}} data-uid={'bbb'} />
+      return <div style={{left: n * a, top: n * a}} data-uid='bbb' />
     })}
   </div>
 }`
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
     const arbitraryBlockOriginalCode = `[1, 2, 3].map(n => {
-      return <div style={{left: n * a, top: n * a}} data-uid={'bbb'} />
+      return <div style={{left: n * a, top: n * a}} data-uid='bbb' />
     })`
     const arbitraryBlockCode = `[1, 2, 3].map(n => {
-  return <div style={{ left: n * a, top: n * a }} data-uid={'bbb'} />;
+  return <div style={{ left: n * a, top: n * a }} data-uid='bbb' />;
 });`
     const arbitraryBlockTranspiledCode = `return [1, 2, 3].map(function (n) {
   return utopiaCanvasJSXLookup("bbb", {
@@ -4217,7 +4217,7 @@ return { a: a };`,
   it('svg elements are accepted', () => {
     const code = `import * as React from "react"
 export var whatever = props => {
-  return <svg data-uid={'abc'}/>
+  return <svg data-uid='abc'/>
 }`
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
     const view = jsxElement('svg', { 'data-uid': jsxAttributeValue('abc') }, [])
@@ -4252,7 +4252,7 @@ import {
   View
 } from "utopia-api";
 const a = (n) => n > 0 ? n : b(10)
-export var whatever = (props) => <View data-uid={'aaa'} />
+export var whatever = (props) => <View data-uid='aaa' />
 const b = (n) => n > 0 ? n : a(10)
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
@@ -4263,11 +4263,11 @@ const b = (n) => n > 0 ? n : a(10)
 import {
   View
 } from "utopia-api";
-export var whatever = (props) => <View data-uid={'aaa'}>
-  <View data-uid={'aaa'} />
+export var whatever = (props) => <View data-uid='aaa'>
+  <View data-uid='aaa' />
 </View>
-export var whatever2 = (props) => <View data-uid={'aaa'}>
-  <View data-uid={'aaa'} />
+export var whatever2 = (props) => <View data-uid='aaa'>
+  <View data-uid='aaa' />
 </View>
 `
     const actualResult = testParseCode(code)
@@ -4349,7 +4349,7 @@ export var App = props => {
         width: props.layout.width,
         top: props.layout.top,
       }}
-      data-uid={"aaa"}
+      data-uid="aaa"
       arbitrary={console.log('hi')} // line 31, char 26
     >
     </View>
@@ -4467,7 +4467,7 @@ describe('getHighlightBounds', () => {
             width: props.layout.width,
             top: props.layout.top,
           }}
-          data-uid={"aaa"}
+          data-uid="aaa"
           arbitrary={console.log('hi')} // line 34, char 26
         >
         </View>
@@ -4520,7 +4520,7 @@ export var App = (props) => {
       <View
         style={{ ...props.style, backgroundColor: '#FFFFFF' }}
         layout={{ layoutSystem: 'pinSystem' }}
-        data-uid={'aaa'}
+        data-uid='aaa'
       ></View>
     </>
   )
@@ -4531,7 +4531,7 @@ export var App = (props) => {
           <View
             style={{ ...props.style, backgroundColor: '#FFFFFF' }}
             layout={{ layoutSystem: 'pinSystem' }}
-            data-uid={'aaa'}
+            data-uid='aaa'
           ></View>
         </>
       )
@@ -4577,7 +4577,7 @@ export var App = (props) => {
         'AAcEA;AACDA;AACMC,CAACC,GAAGD,CAACE,GAAGF,CAACG,CAACH,CAACI,CAACC,KAAKC,CAACN,CAACG,CAACI,CAACP,CAACQ,CAACT;AAC7BC,CAACA,CAACS,MAAMT,CAACI,CAACL;AACVC,CAACA,CAACA,CAACA,CAACU,CAACH,CAACR;AACNC,CAACA,CAACA,CAACA,CAACA,CAACA,CAACU,CAACC,IAAIZ;AACXC,CAACA,CAACA,CAACA,CAACA,CAACA,CAACA,CAACA,CAACY,KAAKT,CAACK,CAACA,CAACR,CAACa,CAACA,CAACA,CAACT,CAACC,KAAKQ,CAACD,KAAKZ,CAACc,CAACA,CAACd,CAACQ,CAACO,CAACT,CAACU,CAAChB,CAACiB,eAAeC,CAAClB,CAACmB,CAACC,CAACC,MAAMF,CAACnB,CAACe,CAACA,CAAChB;AACtEC,CAACA,CAACA,CAACA,CAACA,CAACA,CAACA,CAACA,CAACsB,MAAMnB,CAACK,CAACA,CAACR,CAACuB,YAAYL,CAAClB,CAACmB,CAACK,SAASL,CAACnB,CAACe,CAACA,CAAChB;AAC9CC,CAACA,CAACA,CAACA,CAACA,CAACA,CAACA,CAACA,CAACyB,IAAIC,CAACC,GAAGxB,CAACK,CAACW,CAACS,GAAGT,CAACJ,CAAChB;AACxBC,CAACA,CAACA,CAACA,CAACA,CAACA,CAACO,CAACG,CAACmB,CAAClB,IAAIJ,CAACR;AACdC,CAACA,CAACA,CAACA,CAACU,CAACmB,CAACtB,CAACR;AACPC,CAACA,CAACM,CAACP;AACHgB',
       file: '/src/app.js',
       sourcesContent: [
-        "/** @jsx jsx */\nimport * as React from 'react'\nimport { View, jsx } from 'utopia-api'\n\nexport var canvasMetadata = {\n  scenes: [\n    {\n      component: 'App',\n      frame: { height: 812, left: 0, width: 375, top: 0 },\n      props: { layout: { top: 0, left: 0, bottom: 0, right: 0 } },\n      container: { layoutSystem: 'pinSystem' },\n    },\n  ],\n  elementMetadata: {},\n}\n\nexport var App = (props) => {\n  return (\n    <>\n      <View\n        style={{ ...props.style, backgroundColor: '#FFFFFF' }}\n        layout={{ layoutSystem: 'pinSystem' }}\n        data-uid={'aaa'}\n      ></View>\n    </>\n  )\n}\n",
+        "/** @jsx jsx */\nimport * as React from 'react'\nimport { View, jsx } from 'utopia-api'\n\nexport var canvasMetadata = {\n  scenes: [\n    {\n      component: 'App',\n      frame: { height: 812, left: 0, width: 375, top: 0 },\n      props: { layout: { top: 0, left: 0, bottom: 0, right: 0 } },\n      container: { layoutSystem: 'pinSystem' },\n    },\n  ],\n  elementMetadata: {},\n}\n\nexport var App = (props) => {\n  return (\n    <>\n      <View\n        style={{ ...props.style, backgroundColor: '#FFFFFF' }}\n        layout={{ layoutSystem: 'pinSystem' }}\n        data-uid='aaa'\n      ></View>\n    </>\n  )\n}\n",
       ],
     }
     expect(

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -124,10 +124,11 @@ function buildPropertyCallingFunction(
 function jsxAttributeToExpression(attribute: JSXAttribute): TS.Expression {
   switch (attribute.type) {
     case 'ATTRIBUTE_VALUE':
-      if (typeof attribute.value === 'string') {
-        return TS.createLiteral(attribute.value)
+      const value = attribute.value
+      if (typeof value === 'string') {
+        return TS.createLiteral(value)
       } else {
-        return jsonToExpression(attribute.value)
+        return jsonToExpression(value)
       }
     case 'ATTRIBUTE_NESTED_OBJECT':
       const contents = attribute.content
@@ -322,10 +323,11 @@ function jsxElementToExpression(
             // No else case here as a boolean false value means it gets omitted.
           } else {
             const attributeExpression = jsxAttributeToExpression(prop)
-            const initializer: TS.StringLiteral | TS.JsxExpression = TS.createJsxExpression(
-              undefined,
+            const initializer: TS.StringLiteral | TS.JsxExpression = TS.isStringLiteral(
               attributeExpression,
             )
+              ? attributeExpression
+              : TS.createJsxExpression(undefined, attributeExpression)
             attribsArray.push(TS.createJsxAttribute(identifier, initializer))
           }
         }


### PR DESCRIPTION
Fixes #816 

**Problem:**
When printing a JSX attribute that is a string literal we were always wrapping it in braces.

**Fix:**
When printing the attribute, if the value is a string literal we don't wrap in braces. The ideal fix would be to track whether the value was or wasn't originally wrapped in braces, but doing so would require a huge chunk of refactoring for a very little gain (especially since the braces could be added again via https://github.com/yannickcr/eslint-plugin-react/blob/HEAD/docs/rules/jsx-curly-brace-presence.md)

**Commit Details:**
- The actual functional change is in `editor/src/core/workers/parser-printer/parser-printer.ts`, where we now check if the value is a string literal, and in that case don't wrap it in a JSX expression
- Fixed a bajillion tests that were using `data-uid={'blah'}` since the braces are now removed :upside_down_face: 