### PR TITLE
Fixed incorrect handling of export default statements

### DIFF
--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -135,6 +135,18 @@ export function exportDetailNamed(name: string): ExportDetailNamed {
   }
 }
 
+export interface ExportDefaultDetailModifier {
+  type: 'EXPORT_DEFAULT_DETAIL_MODIFIER'
+  name: string
+}
+
+export function exportDefaultDetailModifier(name: string): ExportDefaultDetailModifier {
+  return {
+    type: 'EXPORT_DEFAULT_DETAIL_MODIFIER',
+    name: name,
+  }
+}
+
 export interface ExportDetailModifier {
   type: 'EXPORT_DETAIL_MODIFIER'
 }
@@ -146,8 +158,11 @@ export function exportDetailModifier(): ExportDetailModifier {
 }
 
 export type ExportDetail = ExportDetailNamed | ExportDetailModifier
+export type ExportDefault = ExportDetailNamed | ExportDefaultDetailModifier
 
-export function isExportDetailNamed(detail: ExportDetail): detail is ExportDetailNamed {
+export function isExportDetailNamed(
+  detail: ExportDetail | ExportDefault,
+): detail is ExportDetailNamed {
   return detail.type === 'EXPORT_DETAIL_NAMED'
 }
 
@@ -155,8 +170,14 @@ export function isExportDetailModifier(detail: ExportDetail): detail is ExportDe
   return detail.type === 'EXPORT_DETAIL_MODIFIER'
 }
 
+export function isExportDefaultDetailModifier(
+  detail: ExportDefault,
+): detail is ExportDefaultDetailModifier {
+  return detail.type === 'EXPORT_DEFAULT_DETAIL_MODIFIER'
+}
+
 export interface ExportsDetail {
-  defaultExport: ExportDetailNamed | null
+  defaultExport: ExportDefault | null
   namedExports: Record<string, ExportDetail>
 }
 
@@ -209,6 +230,16 @@ export function addModifierExportToDetail(detail: ExportsDetail, name: string): 
 export function setNamedDefaultExportInDetail(detail: ExportsDetail, name: string): ExportsDetail {
   return {
     defaultExport: exportDetailNamed(name),
+    namedExports: detail.namedExports,
+  }
+}
+
+export function setModifierDefaultExportInDetail(
+  detail: ExportsDetail,
+  name: string,
+): ExportsDetail {
+  return {
+    defaultExport: exportDefaultDetailModifier(name),
     namedExports: detail.namedExports,
   }
 }

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -126,24 +126,14 @@ export function importsEquals(first: Imports, second: Imports): boolean {
 export interface ExportDetailNamed {
   type: 'EXPORT_DETAIL_NAMED'
   name: string
+  moduleName: string | undefined
 }
 
-export function exportDetailNamed(name: string): ExportDetailNamed {
+export function exportDetailNamed(name: string, moduleName: string | undefined): ExportDetailNamed {
   return {
     type: 'EXPORT_DETAIL_NAMED',
     name: name,
-  }
-}
-
-export interface ExportDefaultDetailModifier {
-  type: 'EXPORT_DEFAULT_DETAIL_MODIFIER'
-  name: string
-}
-
-export function exportDefaultDetailModifier(name: string): ExportDefaultDetailModifier {
-  return {
-    type: 'EXPORT_DEFAULT_DETAIL_MODIFIER',
-    name: name,
+    moduleName: moduleName,
   }
 }
 
@@ -157,12 +147,34 @@ export function exportDetailModifier(): ExportDetailModifier {
   }
 }
 
-export type ExportDetail = ExportDetailNamed | ExportDetailModifier
-export type ExportDefault = ExportDetailNamed | ExportDefaultDetailModifier
+export interface ExportDefaultNamed {
+  type: 'EXPORT_DEFAULT_NAMED'
+  name: string
+}
 
-export function isExportDetailNamed(
-  detail: ExportDetail | ExportDefault,
-): detail is ExportDetailNamed {
+export function exportDefaultNamed(name: string): ExportDefaultNamed {
+  return {
+    type: 'EXPORT_DEFAULT_NAMED',
+    name: name,
+  }
+}
+
+export interface ExportDefaultModifier {
+  type: 'EXPORT_DEFAULT_MODIFIER'
+  name: string
+}
+
+export function exportDefaultModifier(name: string): ExportDefaultModifier {
+  return {
+    type: 'EXPORT_DEFAULT_MODIFIER',
+    name: name,
+  }
+}
+
+export type ExportDetail = ExportDetailNamed | ExportDetailModifier
+export type ExportDefault = ExportDefaultNamed | ExportDefaultModifier
+
+export function isExportDetailNamed(detail: ExportDetail): detail is ExportDetailNamed {
   return detail.type === 'EXPORT_DETAIL_NAMED'
 }
 
@@ -170,10 +182,12 @@ export function isExportDetailModifier(detail: ExportDetail): detail is ExportDe
   return detail.type === 'EXPORT_DETAIL_MODIFIER'
 }
 
-export function isExportDefaultDetailModifier(
-  detail: ExportDefault,
-): detail is ExportDefaultDetailModifier {
-  return detail.type === 'EXPORT_DEFAULT_DETAIL_MODIFIER'
+export function isExportDefaultNamed(detail: ExportDefault): detail is ExportDefaultNamed {
+  return detail.type === 'EXPORT_DEFAULT_NAMED'
+}
+
+export function isExportDefaultModifier(detail: ExportDefault): detail is ExportDefaultModifier {
+  return detail.type === 'EXPORT_DEFAULT_MODIFIER'
 }
 
 export interface ExportsDetail {
@@ -182,7 +196,7 @@ export interface ExportsDetail {
 }
 
 export function exportsDetail(
-  defaultExport: ExportDetailNamed | null,
+  defaultExport: ExportDefault | null,
   namedExports: Record<string, ExportDetail>,
 ): ExportsDetail {
   return {
@@ -207,12 +221,13 @@ export function addNamedExportToDetail(
   detail: ExportsDetail,
   name: string,
   alias: string,
+  moduleName: string | undefined,
 ): ExportsDetail {
   return {
     defaultExport: detail.defaultExport,
     namedExports: {
       ...detail.namedExports,
-      [name]: exportDetailNamed(alias),
+      [name]: exportDetailNamed(alias, moduleName),
     },
   }
 }
@@ -229,7 +244,7 @@ export function addModifierExportToDetail(detail: ExportsDetail, name: string): 
 
 export function setNamedDefaultExportInDetail(detail: ExportsDetail, name: string): ExportsDetail {
   return {
-    defaultExport: exportDetailNamed(name),
+    defaultExport: exportDefaultNamed(name),
     namedExports: detail.namedExports,
   }
 }
@@ -239,7 +254,7 @@ export function setModifierDefaultExportInDetail(
   name: string,
 ): ExportsDetail {
   return {
-    defaultExport: exportDefaultDetailModifier(name),
+    defaultExport: exportDefaultModifier(name),
     namedExports: detail.namedExports,
   }
 }

--- a/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
@@ -100,7 +100,28 @@ describe('Parsing and then printing code', () => {
   it('does not remove a trailing export default statement for anything else', () => {
     const code = applyPrettier(
       `const Thing = 1
-      export default whatever`,
+      export default Thing`,
+      false,
+    ).formatted
+
+    const parsedThenPrinted = parseThenPrint(code)
+    expect(parsedThenPrinted).toEqual(code)
+  })
+
+  it('preserves export statements including those with module specifiers', () => {
+    const code = applyPrettier(
+      `
+      const Thing = 1
+      const OtherThing = 2
+      export { default as Calendar } from './Calendar'
+      export { DateLocalizer } from './localizer'
+      export { Thing, OtherThing as SomethingElse }
+      export { default as momentLocalizer } from './localizers/moment'
+      export { default as globalizeLocalizer } from './localizers/globalize'
+      export { default as dateFnsLocalizer } from './localizers/date-fns'
+      export { default as move } from './utils/move'
+      export { views as Views, navigate as Navigate } from './utils/constants'
+      `,
       false,
     ).formatted
 

--- a/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
@@ -84,12 +84,22 @@ describe('Parsing and then printing code', () => {
     expect(parsedThenPrinted).toEqual(code)
   })
 
-  xit('does not remove a trailing export default statement', () => {
+  it('does not remove a trailing export default statement for a component', () => {
     const code = applyPrettier(
       `const whatever = (props) => {
         return <div data-uid='aaa' />
       }
-      
+      export default whatever`,
+      false,
+    ).formatted
+
+    const parsedThenPrinted = parseThenPrint(code)
+    expect(parsedThenPrinted).toEqual(code)
+  })
+
+  it('does not remove a trailing export default statement for anything else', () => {
+    const code = applyPrettier(
+      `const Thing = 1
       export default whatever`,
       false,
     ).formatted

--- a/editor/src/core/workers/parser-printer/parser-printer-exports.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-exports.spec.ts
@@ -45,6 +45,7 @@ describe('parseCode', () => {
         "defaultExport": null,
         "namedExports": Object {
           "whatever": Object {
+            "moduleName": undefined,
             "name": "whatever",
             "type": "EXPORT_DETAIL_NAMED",
           },
@@ -70,6 +71,7 @@ describe('parseCode', () => {
         "defaultExport": null,
         "namedExports": Object {
           "otherThing": Object {
+            "moduleName": undefined,
             "name": "whatever",
             "type": "EXPORT_DETAIL_NAMED",
           },

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -39,6 +39,7 @@ import {
   EmptyExportsDetail,
   setNamedDefaultExportInDetail,
   addModifierExportToDetail,
+  setModifierDefaultExportInDetail,
 } from '../../shared/project-file-types'
 import {
   lintAndParse,
@@ -380,7 +381,7 @@ export default function whatever(props) {
         expect.objectContaining({}),
         null,
         null,
-        setNamedDefaultExportInDetail(EmptyExportsDetail, 'whatever'),
+        setModifierDefaultExportInDetail(EmptyExportsDetail, 'whatever'),
       ),
     )
     expect(actualResult).toEqual(expectedResult)
@@ -443,7 +444,7 @@ export default function whatever() {
         expect.objectContaining({}),
         null,
         null,
-        setNamedDefaultExportInDetail(EmptyExportsDetail, 'whatever'),
+        setModifierDefaultExportInDetail(EmptyExportsDetail, 'whatever'),
       ),
     )
     expect(actualResult).toEqual(expectedResult)

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -629,7 +629,7 @@ export function topLevelElementArbitrary(): Arbitrary<TopLevelElement> {
 export function exportDetailNamedArbitrary(
   possibleNames: Array<string>,
 ): Arbitrary<ExportDetailNamed> {
-  return FastCheck.constantFrom(...possibleNames).map(exportDetailNamed)
+  return FastCheck.constantFrom(...possibleNames).map((name) => exportDetailNamed(name, undefined))
 }
 
 export function exportDetailModifierArbitrary(): Arbitrary<ExportDetailModifier> {

--- a/editor/src/scripts/github-projects.ts
+++ b/editor/src/scripts/github-projects.ts
@@ -76,7 +76,7 @@ export const githubProjects: Array<GitRepoWithRevision> = [
     username: 'contra',
     repositoryName: 'react-responsive',
     revision: 'b6ffef5c4a4b89c69299c2b04c9196dde59b3ef4',
-    pathsToIgnore: [],
+    pathsToIgnore: ['/samples/sandbox/dist/sample.js'],
   },
   {
     name: 'context-provider-hooks-sample',


### PR DESCRIPTION
Fixes #826 

**Problem:**
`export default` statements were being either (incorrectly) added as modifiers to components defined elsewhere in the file, or removed completely.

**Fix:**
This PR adds a new type for `export default` modifiers (rather than named assignments) so that we can ensure we are only adding those modifiers back on to components that they were originally present on. It also updates the function that produces the export statements to include export default statements.

**Commit Details:**
- Introduced the type `ExportDefaultDetailModifier` for differentiating between `export default` modifiers vs assignments
- Updated `produceExportStatements` to ensure we print `export default` statements
- Added two test cases to capture default exports for a component and a regular constant
