### PR TITLE
feature(canvas) update hierarchy shortcut to use new selection

### DIFF
--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -10,7 +10,7 @@ import {
 import * as PP from '../../core/shared/property-path'
 import * as TP from '../../core/shared/template-path'
 import { emptyComments } from '../../core/workers/parser-printer/parser-printer-comments'
-import { CanvasMousePositionRaw } from '../../templates/editor-canvas'
+import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../templates/editor-canvas'
 import Keyboard, {
   KeyCharacter,
   KeysPressed,
@@ -23,6 +23,7 @@ import Utils from '../../utils/utils'
 import Canvas, { TargetSearchType } from '../canvas/canvas'
 import CanvasActions from '../canvas/canvas-actions'
 import { adjustAllSelectedFrames } from '../canvas/controls/select-mode/move-utils'
+import { getAllTargetsAtPoint } from '../canvas/dom-lookup'
 import {
   toggleBackgroundLayers,
   toggleBorder,
@@ -461,13 +462,7 @@ export function handleKeyDown(
           if (CanvasMousePositionRaw == null) {
             return [EditorActions.clearSelection()]
           }
-          const targetStack = Canvas.getAllTargetsAtPoint(
-            editor,
-            CanvasMousePositionRaw,
-            [TargetSearchType.All],
-            true,
-            'strict', // _IF_ we want to enable loose targeting for selection, it means we also need to change component-area-control
-          )
+          const targetStack = getAllTargetsAtPoint(WindowMousePositionRaw)
           const nextTarget = Canvas.getNextTarget(editor.selectedViews, targetStack)
           if (targetStack.length === 0 || nextTarget === null) {
             return [EditorActions.clearSelection()]


### PR DESCRIPTION
Fixes #828 

Updating how the hierarchy shortcut finds target elements, the new version is using `document.elementsFromPoint`
