### PR TITLE
Feature/dom based insert mode

### DIFF
--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1387,7 +1387,7 @@ describe('moveTemplate', () => {
     )
   })
 
-  it('inserting a new element', async () => {
+  xit('inserting a new element', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...props.style }} data-uid='aaa'>

--- a/editor/src/components/canvas/controls/component-area-control.tsx
+++ b/editor/src/components/canvas/controls/component-area-control.tsx
@@ -68,52 +68,6 @@ class ComponentAreaControlInner extends React.Component<ComponentAreaControlProp
     }
   }
 
-  onClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (this.mouseEnabled()) {
-      if (event.nativeEvent.detail > 1) {
-        // we interpret this as a double click so that the user can keep on clicking and we keep firing double clicks
-        this.onDoubleClick(event)
-      }
-    }
-  }
-
-  onDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    const { showingInvisibleElement } = calculateExtraSizeForZeroSizedElement(this.props.frame)
-    if (this.mouseEnabled()) {
-      if (this.props.doubleClickToSelect && this.props.selectComponent != null) {
-        const isMultiselect = event.shiftKey
-        this.props.selectComponent(this.props.target, isMultiselect)
-      }
-      if (TP.isInstancePath(this.props.target)) {
-        const instance = MetadataUtils.getElementByInstancePathMaybe(
-          this.props.componentMetadata.elements,
-          this.props.target,
-        )
-        if (
-          this.props.selectedComponents.length === 1 &&
-          TP.pathsEqual(this.props.selectedComponents[0], this.props.target)
-        ) {
-          if (MetadataUtils.isTextAgainstImports(this.props.imports, instance)) {
-            // if target is a text and it is the one and only selected component, then activate the text editor
-            const mousePosition = {
-              x: event.clientX,
-              y: event.clientY,
-            } as WindowPoint
-            this.props.dispatch(
-              [EditorActions.openTextEditor(this.props.target, mousePosition)],
-              'canvas',
-            )
-          } else if (showingInvisibleElement) {
-            // double clicking on an invisible element should give it an arbitrary size
-            this.props.dispatch([
-              EditorActions.addMissingDimensions(this.props.target, this.props.frame),
-            ])
-          }
-        }
-      }
-    }
-  }
-
   onMouseOver = () => {
     this.mouseOver = true
     if (this.mouseEnabled()) {
@@ -171,43 +125,6 @@ class ComponentAreaControlInner extends React.Component<ComponentAreaControlProp
         event,
       )
     }
-  }
-
-  getComponentAreaControl = (canShowInvisibleIndicator: boolean) => {
-    const {
-      extraWidth,
-      extraHeight,
-      showingInvisibleElement,
-      borderRadius,
-    } = calculateExtraSizeForZeroSizedElement(this.props.frame)
-    const showInvisibleIndicator = canShowInvisibleIndicator && showingInvisibleElement
-
-    return (
-      <React.Fragment>
-        <div
-          className='role-component-selection-highlight'
-          onMouseOver={this.onMouseOver}
-          onMouseLeave={this.onMouseLeave}
-          onMouseDown={this.onMouseDown}
-          onClick={this.onClick}
-          onDragEnter={this.onDragEnter}
-          onDragLeave={this.onDragLeave}
-          style={{
-            pointerEvents: this.props.mouseEnabled ? 'initial' : 'none',
-            position: 'absolute',
-            left: this.props.canvasOffset.x + this.props.frame.x - extraWidth / 2,
-            top: this.props.canvasOffset.y + this.props.frame.y - extraHeight / 2,
-            width: this.props.frame.width + extraWidth,
-            height: this.props.frame.height + extraHeight,
-            borderColor: UtopiaTheme.color.primary.o(50).value,
-            borderStyle: showInvisibleIndicator ? 'solid' : undefined,
-            borderWidth: 0.5 / this.props.scale,
-            borderRadius: showInvisibleIndicator ? borderRadius : 0,
-          }}
-          data-testid={this.props.mouseEnabled ? this.props.testID : undefined}
-        />
-      </React.Fragment>
-    )
   }
 
   getComponentLabelControl = () => {
@@ -269,28 +186,6 @@ class ComponentAreaControlInner extends React.Component<ComponentAreaControlProp
     )
   }
 }
-
-export class ComponentAreaControl extends ComponentAreaControlInner {
-  componentDidUpdate(prevProps: ComponentAreaControlProps) {
-    if (prevProps.hoverEffectEnabled !== this.props.hoverEffectEnabled) {
-      if (this.mouseOver && !this.isTargetSelected()) {
-        if (this.props.hoverEffectEnabled) {
-          this.onHoverBegin()
-        } else {
-          this.onHoverEnd()
-        }
-      }
-    }
-  }
-
-  render() {
-    const isParentSelected = this.props.selectedComponents.some((tp: TemplatePath) =>
-      TP.pathsEqual(TP.parentPath(this.props.target), tp),
-    )
-    return this.getComponentAreaControl(isParentSelected || this.props.showAdditionalControls)
-  }
-}
-
 export class ComponentLabelControl extends ComponentAreaControlInner {
   render() {
     return this.getComponentLabelControl()

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 import * as React from 'react'
 import { FramePoint } from 'utopia-api'
 import { LayoutHelpers, TopLeftWidthHeight } from '../../../core/layout/layout-helpers'
@@ -36,7 +37,7 @@ import { LeftMenuTab } from '../../navigator/left-pane'
 import * as PP from '../../../core/shared/property-path'
 import * as TP from '../../../core/shared/template-path'
 import CanvasActions from '../canvas-actions'
-import { InsertDragState, insertDragState } from '../canvas-types'
+import { CanvasContainerID, InsertDragState, insertDragState } from '../canvas-types'
 import { GuidelineWithSnappingVector } from '../guideline'
 import { ComponentAreaControl, ComponentLabelControl } from './component-area-control'
 import { GuidelineControl } from './guideline-control'
@@ -194,40 +195,6 @@ export class InsertModeControlContainer extends React.Component<
 
   isViewInsertion(element: JSXElementChild, importsToAdd: Imports): boolean {
     return this.isUtopiaAPIInsertion(element, importsToAdd, 'View')
-  }
-
-  renderControl = (target: TemplatePath): JSX.Element | null => {
-    const frame = MetadataUtils.getFrameInCanvasCoords(target, this.props.componentMetadata)
-
-    if (frame == null) {
-      return null
-    }
-
-    return (
-      <ComponentAreaControl
-        mouseEnabled={true}
-        key={TP.toComponentId(target)}
-        componentMetadata={this.props.componentMetadata}
-        target={target}
-        frame={frame}
-        highlighted={this.isHighlighted(target)}
-        scale={this.props.scale}
-        selectedComponents={this.props.selectedViews}
-        dispatch={this.props.dispatch}
-        canvasOffset={this.props.canvasOffset}
-        hoverEffectEnabled={true}
-        doubleClickToSelect={false}
-        onMouseDown={Utils.NO_OP}
-        onHover={this.onHover}
-        onHoverEnd={this.onHoverEnd}
-        keysPressed={this.props.keysPressed}
-        windowToCanvasPosition={this.props.windowToCanvasPosition}
-        selectedViews={this.props.selectedViews}
-        imports={this.props.imports}
-        testID={`insert-target-${TP.toComponentId(target)}`}
-        showAdditionalControls={this.props.showAdditionalControls}
-      />
-    )
   }
 
   renderLabel = (target: TemplatePath): JSX.Element | null => {
@@ -418,8 +385,8 @@ export class InsertModeControlContainer extends React.Component<
     }
   }
 
-  onMouseDown = (e: React.MouseEvent) => {
-    const mousePoint = this.props.windowToCanvasPosition(e.nativeEvent).canvasPositionRounded
+  onMouseDown = (e: MouseEvent) => {
+    const mousePoint = this.props.windowToCanvasPosition(e).canvasPositionRounded
     const snappedMousePoint = applySnappingToPoint(mousePoint, this.state.guidelines)
     const updateDragStateAction = CanvasActions.createDragState(
       insertDragState(
@@ -489,7 +456,7 @@ export class InsertModeControlContainer extends React.Component<
     }
   }
 
-  onMouseUp = (event: React.MouseEvent) => {
+  onMouseUp = (event: MouseEvent) => {
     if (!this.props.mode.insertionStarted) {
       return
     }
@@ -563,8 +530,8 @@ export class InsertModeControlContainer extends React.Component<
     }
   }
 
-  onMouseMove = (e: React.MouseEvent) => {
-    const mousePoint = this.props.windowToCanvasPosition(e.nativeEvent).canvasPositionRounded
+  onMouseMove = (e: MouseEvent) => {
+    const mousePoint = this.props.windowToCanvasPosition(e).canvasPositionRounded
     const keepAspectRatio = this.props.keysPressed['shift'] || false
 
     if (insertionSubjectIsJSXElement(this.props.mode.subject)) {
@@ -677,44 +644,37 @@ export class InsertModeControlContainer extends React.Component<
     }
   }
 
+  componentDidMount() {
+    const canvasContainer = document.getElementById(CanvasContainerID)
+    canvasContainer?.addEventListener('mousedown', this.onMouseDown)
+    canvasContainer?.addEventListener('mousemove', this.onMouseMove)
+    canvasContainer?.addEventListener('mouseup', this.onMouseUp)
+  }
+
+  componentWillUnmount() {
+    const canvasContainer = document.getElementById(CanvasContainerID)
+    canvasContainer?.removeEventListener('mousedown', this.onMouseDown)
+    canvasContainer?.removeEventListener('mousemove', this.onMouseMove)
+    canvasContainer?.removeEventListener('mouseup', this.onMouseUp)
+  }
+
   render() {
     const roots = MetadataUtils.getAllScenePaths(this.props.componentMetadata.components)
-    const allPaths = MetadataUtils.getAllPaths(this.props.componentMetadata)
-    const insertTargets = allPaths.filter((path) => {
-      if (TP.isScenePath(path)) {
-        // TODO Scene Implementation
-        return false
-      } else {
-        return (
-          (insertionSubjectIsJSXElement(this.props.mode.subject) ||
-            insertionSubjectIsDragAndDrop(this.props.mode.subject)) &&
-          MetadataUtils.targetSupportsChildren(
-            this.props.imports,
-            this.props.componentMetadata,
-            path,
-          )
-        )
-      }
-    })
     const dragFrame = this.state.dragFrame
 
     return (
       <div
         style={{
-          pointerEvents: 'initial',
+          pointerEvents: 'none',
           position: 'absolute',
           top: 0,
           left: 0,
           width: '100%',
           height: '100%',
         }}
-        onMouseDown={this.onMouseDown}
-        onMouseUp={this.onMouseUp}
-        onMouseMove={this.onMouseMove}
         data-testid='insert-mode-mouse-catcher'
       >
         {roots.map((root) => this.renderLabel(root))}
-        {insertTargets.map(this.renderControl)}
         {dragFrame == null ? null : this.renderInsertionOutline(dragFrame)}
         {this.renderGuidelines()}
       </div>

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-expressions */
 import * as React from 'react'
 import { FramePoint } from 'utopia-api'
 import { LayoutHelpers, TopLeftWidthHeight } from '../../../core/layout/layout-helpers'
@@ -646,16 +645,20 @@ export class InsertModeControlContainer extends React.Component<
 
   componentDidMount() {
     const canvasContainer = document.getElementById(CanvasContainerID)
-    canvasContainer?.addEventListener('mousedown', this.onMouseDown)
-    canvasContainer?.addEventListener('mousemove', this.onMouseMove)
-    canvasContainer?.addEventListener('mouseup', this.onMouseUp)
+    if (canvasContainer != null) {
+      canvasContainer.addEventListener('mousedown', this.onMouseDown)
+      canvasContainer.addEventListener('mousemove', this.onMouseMove)
+      canvasContainer.addEventListener('mouseup', this.onMouseUp)
+    }
   }
 
   componentWillUnmount() {
     const canvasContainer = document.getElementById(CanvasContainerID)
-    canvasContainer?.removeEventListener('mousedown', this.onMouseDown)
-    canvasContainer?.removeEventListener('mousemove', this.onMouseMove)
-    canvasContainer?.removeEventListener('mouseup', this.onMouseUp)
+    if (canvasContainer != null) {
+      canvasContainer.removeEventListener('mousedown', this.onMouseDown)
+      canvasContainer.removeEventListener('mousemove', this.onMouseMove)
+      canvasContainer.removeEventListener('mouseup', this.onMouseUp)
+    }
   }
 
   render() {

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -39,7 +39,7 @@ import * as TP from '../../../core/shared/template-path'
 import CanvasActions from '../canvas-actions'
 import { CanvasContainerID, InsertDragState, insertDragState } from '../canvas-types'
 import { GuidelineWithSnappingVector } from '../guideline'
-import { ComponentAreaControl, ComponentLabelControl } from './component-area-control'
+import { ComponentLabelControl } from './component-area-control'
 import { GuidelineControl } from './guideline-control'
 import {
   applySnappingToPoint,

--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
@@ -12,7 +12,7 @@ import { getOpenImportsFromState } from '../../../editor/store/editor-state'
 import { useRefEditorState } from '../../../editor/store/store-hook'
 import { useHighlightCallbacks } from './select-mode-hooks'
 
-function useGethHiglightableViewsForInsertMode() {
+function useGetHiglightableViewsForInsertMode() {
   const storeRef = useRefEditorState((store) => {
     return {
       componentMetadata: store.editor.jsxMetadataKILLME,
@@ -47,8 +47,8 @@ export function useInsertModeSelectAndHover(): {
   onMouseOut: () => void
   onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 } {
-  const gethHiglightableViewsForInsertMode = useGethHiglightableViewsForInsertMode()
-  const { onMouseOver, onMouseOut } = useHighlightCallbacks(gethHiglightableViewsForInsertMode)
+  const getHiglightableViewsForInsertMode = useGetHiglightableViewsForInsertMode()
+  const { onMouseOver, onMouseOut } = useHighlightCallbacks(getHiglightableViewsForInsertMode)
 
   return useKeepShallowReferenceEquality({
     onMouseOver: onMouseOver,

--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
@@ -20,30 +20,26 @@ function useGethHiglightableViewsForInsertMode() {
       imports: getOpenImportsFromState(store.editor),
     }
   })
-  return React.useCallback(
-    // we don't use allElementsDirectlySelectable and childrenSelectable in insert mode, but they are needed for select mode
-    (_allElementsDirectlySelectable: boolean, _childrenSelectable: boolean) => {
-      const { componentMetadata, mode, imports } = storeRef.current
-      if (!isInsertMode(mode)) {
-        throw new Error('insert highlight callback was called oustide of insert mode')
+  return React.useCallback(() => {
+    const { componentMetadata, mode, imports } = storeRef.current
+    if (!isInsertMode(mode)) {
+      throw new Error('insert highlight callback was called oustide of insert mode')
+    }
+    const allPaths = MetadataUtils.getAllPaths(componentMetadata)
+    const insertTargets = allPaths.filter((path) => {
+      if (TP.isScenePath(path)) {
+        // TODO Scene Implementation
+        return false
+      } else {
+        return (
+          (insertionSubjectIsJSXElement(mode.subject) ||
+            insertionSubjectIsDragAndDrop(mode.subject)) &&
+          MetadataUtils.targetSupportsChildren(imports, componentMetadata, path)
+        )
       }
-      const allPaths = MetadataUtils.getAllPaths(componentMetadata)
-      const insertTargets = allPaths.filter((path) => {
-        if (TP.isScenePath(path)) {
-          // TODO Scene Implementation
-          return false
-        } else {
-          return (
-            (insertionSubjectIsJSXElement(mode.subject) ||
-              insertionSubjectIsDragAndDrop(mode.subject)) &&
-            MetadataUtils.targetSupportsChildren(imports, componentMetadata, path)
-          )
-        }
-      })
-      return insertTargets
-    },
-    [storeRef],
-  )
+    })
+    return insertTargets
+  }, [storeRef])
 }
 
 export function useInsertModeSelectAndHover(): {

--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import { NO_OP } from '../../../../core/shared/utils'
+import { useKeepShallowReferenceEquality } from '../../../../utils/react-performance'
+import { useHighlightCallbacks } from './select-mode-hooks'
+
+/**
+ * const allPaths = MetadataUtils.getAllPaths(this.props.componentMetadata)
+    const insertTargets = allPaths.filter((path) => {
+      if (TP.isScenePath(path)) {
+        // TODO Scene Implementation
+        return false
+      } else {
+        return (
+          (insertionSubjectIsJSXElement(this.props.mode.subject) ||
+            insertionSubjectIsDragAndDrop(this.props.mode.subject)) &&
+          MetadataUtils.targetSupportsChildren(
+            this.props.imports,
+            this.props.componentMetadata,
+            path,
+          )
+        )
+      }
+    })
+ */
+
+export function useInsertModeSelectAndHover(): {
+  onMouseOver: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
+  onMouseOut: () => void
+  onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
+} {
+  const { onMouseOver, onMouseOut } = useHighlightCallbacks(true)
+
+  return useKeepShallowReferenceEquality({
+    onMouseOver: onMouseOver,
+    onMouseOut: onMouseOut,
+    onMouseDown: NO_OP,
+  })
+}


### PR DESCRIPTION
Fixes #829 

**Problem:**
The insert mode was still using the old hittarget divs.

**Fix:**
Use the dom-based highlight functionality of the select-mode-hooks.

**Commit Details:**
- I kept most of the actual logic in insert-mode-control-container to avoid a massive PR
- I refactored the highlight hook so it can take a getter function for potential highlight targets. implemented two functions (`gethHiglightableViewsForInsertMode` for insert mode, and `getSelectableViewsForSelectMode` for select mode). the two functions are wrapped in hooks so they have access to ref editor state.