### PR TITLE
Don't include generated `data-uid` values in arbitrary blocks.

### DIFF
--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.ts.snap
@@ -14,16 +14,16 @@ Object {
     ],
     "javascript": "function a(n) {
   if (n <= 0) {
-    return 0;
+    return 0
   } else {
-    return b(n - 1);
+    return b(n - 1)
   }
 }
 function b(n) {
   if (n <= 0) {
-    return 0;
+    return 0
   } else {
-    return a(n - 1);
+    return a(n - 1)
   }
 }",
     "sourceMap": Object {
@@ -201,9 +201,9 @@ return { a: a, b: b };",
       ],
       "javascript": "function a(n) {
   if (n <= 0) {
-    return 0;
+    return 0
   } else {
-    return b(n - 1);
+    return b(n - 1)
   }
 }",
       "sourceMap": Object {
@@ -499,9 +499,9 @@ export var storyboard = (
       ],
       "javascript": "function b(n) {
   if (n <= 0) {
-    return 0;
+    return 0
   } else {
-    return a(n - 1);
+    return a(n - 1)
   }
 }",
       "sourceMap": Object {

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.ts.snap
@@ -152,19 +152,19 @@ export var storyboard = (props) => {
     "definedWithin": Array [
       "storyboard",
     ],
-    "javascript": "export var storyboard = props => {
+    "javascript": "export var storyboard = (props) => {
   return (
     <Storyboard data-uid='utopia-storyboard-uid'>
       <Scene
-      style={{ left: 0, top: 0, width: 400, height: 400 }}
-      component={App}
-      layout={{ layoutSystem: 'pinSystem' }}
-      props={{ layout: { bottom: 0, left: 0, right: 0, top: 0 } }}
-      data-uid='scene-aaa' />
-
-    </Storyboard>);
-
-};",
+        style={{ left: 0, top: 0, width: 400, height: 400 }}
+        component={App}
+        layout={{ layoutSystem: 'pinSystem' }}
+        props={{ layout: { bottom: 0, left: 0, right: 0, top: 0 } }}
+        data-uid='scene-aaa'
+      />
+    </Storyboard>
+  )
+}",
     "sourceMap": Object {
       "file": "code.tsx",
       "mappings": "AAKQA,IAAIC,UAAUC,GAAGC,SAAbF,UAAaE,CAACC,KAADD,EAAWE;AACjCC,SACEC,oBAACC,UAADD;AAAYE,gBAASC;AAArBH,KACEA,oBAACI,KAADJ;AACEK,IAAAA,KAAKC,EAAER;AAAES,MAAAA,IAAIC,EAAEC,CAARX;AAAWY,MAAAA,GAAGF,EAAEC,CAAhBX;AAAmBa,MAAAA,KAAKH,EAAEI,GAA1Bd;AAA+Be,MAAAA,MAAML,EAAEI;AAAvCd,KADTE;AAEEc,IAAAA,SAASR,EAAES,GAFbf;AAGEgB,IAAAA,MAAMV,EAAER;AAAEmB,MAAAA,YAAYT,EAAEL;AAAhBL,KAHVE;AAIEH,IAAAA,KAAKS,EAAER;AAAEkB,MAAAA,MAAMR,EAAEV;AAAEoB,QAAAA,MAAMV,EAAEC,CAAVX;AAAaS,QAAAA,IAAIC,EAAEC,CAAnBX;AAAsBqB,QAAAA,KAAKX,EAAEC,CAA7BX;AAAgCY,QAAAA,GAAGF,EAAEC;AAArCX;AAAVA,KAJTE;AAKEE,gBAASC;AALXH,IADFA,CADFD;AAWFqB,CAZO3B",

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -78,10 +78,10 @@ Object {
       "otherFn",
     ],
     "javascript": "function cakeFn(n) {
-  return n;
+  return n
 }
 function otherFn(n) {
-  return n;
+  return n
 }",
     "sourceMap": Object {
       "file": "code.tsx",
@@ -231,7 +231,7 @@ return { cakeFn: cakeFn, otherFn: otherFn };",
         "cakeFn",
       ],
       "javascript": "function cakeFn(n) {
-  return n;
+  return n
 }",
       "sourceMap": Object {
         "file": "code.tsx",
@@ -285,7 +285,7 @@ return { cakeFn: cakeFn };",
         "otherFn",
       ],
       "javascript": "function otherFn(n) {
-  return n;
+  return n
 }",
       "sourceMap": Object {
         "file": "code.tsx",
@@ -458,8 +458,8 @@ Object {
       "a",
       "b",
     ],
-    "javascript": "const a = n => n > 0 ? n : b(10);
-const b = n => n > 0 ? n : a(10);",
+    "javascript": "const a = (n) => n > 0 ? n : b(10)
+const b = (n) => n > 0 ? n : a(10)",
     "sourceMap": Object {
       "file": "code.tsx",
       "mappings": "AAICA,IAAMC,CAACC,GAAGC,SAAJF,CAAIE,CAACC,CAADD;AAAAA,SAAOC,CAACF,GAAGG,CAAJD,GAAQA,CAARA,GAAYE,CAACH,CAACI,EAADJ,CAApBA;AAAAA,CAAVH;;AAEAA,IAAMM,CAACJ,GAAGC,SAAJG,CAAIH,CAACC,CAADD;AAAAA,SAAOC,CAACF,GAAGG,CAAJD,GAAQA,CAARA,GAAYH,CAACE,CAACI,EAADJ,CAApBA;AAAAA,CAAVH",
@@ -554,7 +554,7 @@ return { a: a, b: b };",
       "definedWithin": Array [
         "a",
       ],
-      "javascript": "const a = n => n > 0 ? n : b(10);",
+      "javascript": "const a = (n) => n > 0 ? n : b(10)",
       "sourceMap": Object {
         "file": "code.tsx",
         "mappings": "AAICA,IAAMC,CAACC,GAAGC,SAAJF,CAAIE,CAACC,CAADD;AAAAA,SAAOC,CAACF,GAAGG,CAAJD,GAAQA,CAARA,GAAYE,CAACH,CAACI,EAADJ,CAApBA;AAAAA,CAAVH",
@@ -648,7 +648,7 @@ return { a: a };",
       "definedWithin": Array [
         "b",
       ],
-      "javascript": "const b = n => n > 0 ? n : a(10);",
+      "javascript": "const b = (n) => n > 0 ? n : a(10)",
       "sourceMap": Object {
         "file": "code.tsx",
         "mappings": "AAMCA,IAAMC,CAACC,GAAGC,SAAJF,CAAIE,CAACC,CAADD;AAAAA,SAAOC,CAACF,GAAGG,CAAJD,GAAQA,CAARA,GAAYE,CAACH,CAACI,EAADJ,CAApBA;AAAAA,CAAVH",
@@ -700,7 +700,7 @@ Object {
     "definedWithin": Array [
       "a",
     ],
-    "javascript": "const a = \\"cake\\";",
+    "javascript": "const a = \\"cake\\"",
     "sourceMap": Object {
       "file": "code.tsx",
       "mappings": "AAUCA,IAAMC,CAACC,GAAGC,MAAVH",
@@ -814,7 +814,7 @@ return { a: a };",
       "definedWithin": Array [
         "a",
       ],
-      "javascript": "const a = \\"cake\\";",
+      "javascript": "const a = \\"cake\\"",
       "sourceMap": Object {
         "file": "code.tsx",
         "mappings": "AAUCA,IAAMC,CAACC,GAAGC,MAAVH",

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
@@ -287,7 +287,7 @@ export var whatever = (props) => {
         ),
       ],
     )
-    const jsCode = `const arr = [{ n: 1 }];`
+    const jsCode = `const arr = [ { n: 1 } ]`
     const transpiledJsCode = `var arr = [{
   n: 1
 }];
@@ -385,7 +385,7 @@ export var whatever = (props) => {
         ),
       ],
     )
-    const jsCode = `const arr = [{ a: { n: 1 } }];`
+    const jsCode = `const arr = [ { a: { n: 1 } } ]`
     const transpiledJsCode = `var arr = [{
   a: {
     n: 1
@@ -490,7 +490,7 @@ export var whatever = (props) => {
         ),
       ],
     )
-    const jsCode = `const arr = [[1]];`
+    const jsCode = `const arr = [ [ 1 ] ]`
     const transpiledJsCode = `var arr = [[1]];
 return { arr: arr };`
     const arbitraryBlock = arbitraryJSBlock(

--- a/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
@@ -72,6 +72,33 @@ describe('Parsing and then printing code', () => {
     expect(parsedThenPrinted).toEqual(code)
   })
 
+  it('does not include data-uid attributes in top level arbitrary blocks', () => {
+    const code = applyPrettier(
+      `
+import { GithubPicker } from "react-color";
+function Picker() {
+  const [color, setColor] = useThemeContext();
+  const [visible, setVisible] = usePickerVisibilityContext();
+  return visible ? (
+    <GithubPicker
+      style={{ position: "absolute" }}
+      triangle="hide"
+      color={color}
+      onChange={(c) => {
+        setColor(c.hex);
+        setVisible(false);
+      }}
+    />
+  ) : null;
+}
+`,
+      false,
+    ).formatted
+
+    const parsedThenPrinted = parseThenPrint(code)
+    expect(parsedThenPrinted).toEqual(code)
+  })
+
   xit('does not remove the braces surrounding a jsx attribute value', () => {
     const code = applyPrettier(
       `export const whatever = (props) => {

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -1975,7 +1975,7 @@ export function parseArbitraryNodes(
         (transpileResult, dataUIDFixResult) => {
           const transpiled = `${transpileResult.code}\n${definedWithCode}`
           return arbitraryJSBlock(
-            dataUIDFixResult.code,
+            code,
             transpiled,
             definedWithin,
             definedElsewhere,

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -889,7 +889,7 @@ export var whatever = (props) => <View data-uid='aaa'>
       emptyComments,
     )
     const jsCode1 = `function getSizing(n) {
-  return 100 + n;
+  return 100 + n
 }`
     const transpiledJsCode1 = `function getSizing(n) {
   return 100 + n;
@@ -907,7 +907,7 @@ return { getSizing: getSizing };`
       }),
       emptyComments,
     )
-    const jsCode2 = `var spacing = 20;`
+    const jsCode2 = `var spacing = 20`
     const transpiledJsCode2 = `var spacing = 20;
 return { spacing: spacing };`
     const arbitraryBlock2 = arbitraryJSBlock(
@@ -923,9 +923,9 @@ return { spacing: spacing };`
       emptyComments,
     )
     const combinedJsCode = `function getSizing(n) {
-  return 100 + n;
+  return 100 + n
 }
-var spacing = 20;`
+var spacing = 20`
     const transpiledcombinedJsCode = `function getSizing(n) {
   return 100 + n;
 }
@@ -1013,7 +1013,7 @@ export var whatever = (props) => <View data-uid='aaa'>
       emptyComments,
     )
     const jsCode = `export default function getSizing(n) {
-  return 100 + n;
+  return 100 + n
 }`
     const transpiledJsCode = `function getSizing(n) {
   return 100 + n;
@@ -1105,10 +1105,10 @@ export var whatever = (props) => <View data-uid='aaa'>
     const jsCode = `export function getSizing(n) {
   switch (n) {
     case 100:
-      return 1;
+      return 1
     default:
-      return 100 + n;}
-
+      return 100 + n
+  }
 }`
     const transpiledJsCode = `function getSizing(n) {
   switch (n) {
@@ -1198,9 +1198,9 @@ export var whatever = (props) => <View data-uid='aaa'>
       emptyComments,
       emptyComments,
     )
-    const jsCode = `export default (n => {
-  return 100 + n;
-});`
+    const jsCode = `export default (n) => {
+  return 100 + n
+}`
     const transpiledJsCode = `(function (n) {
   return 100 + n;
 });
@@ -1288,7 +1288,7 @@ export var whatever = (props) => <View data-uid='aaa'>
     const transpiledJSCode = `var spacing = 20;
 return { spacing: spacing };`
     const jsVariable = arbitraryJSBlock(
-      'var spacing = 20;',
+      'var spacing = 20',
       transpiledJSCode,
       ['spacing'],
       [],
@@ -1351,8 +1351,8 @@ export var whatever = (props) => {
       ),
     }
     const view = jsxElement('View', viewAttributes, [])
-    const jsCode = `const bgs = ['black', 'grey'];
-const bg = bgs[0];`
+    const jsCode = `const bgs = ['black', 'grey']
+const bg = bgs[0]`
     const transpiledJsCode = `var bgs = ['black', 'grey'];
 var bg = bgs[0];
 return { bgs: bgs, bg: bg };`
@@ -1428,7 +1428,7 @@ export var whatever = (props) => {
       ),
     }
     const view = jsxElement('View', viewAttributes, [])
-    const jsCode = `const greys = ['lightGrey', 'grey'];`
+    const jsCode = `const greys = ['lightGrey', 'grey']`
     const transpiledJsCode = `var greys = ['lightGrey', 'grey'];
 return { greys: greys };`
     const arbitraryBlock = arbitraryJSBlock(
@@ -1495,8 +1495,8 @@ export var whatever = (props) => {
       ),
     }
     const view = jsxElement('View', viewAttributes, [])
-    const jsCode = `const a = 10;
-const b = 20;`
+    const jsCode = `const a = 10
+const b = 20`
     const transpiledJsCode = `var a = 10;
 var b = 20;
 return { a: a, b: b };`
@@ -1565,9 +1565,9 @@ export var whatever = (props) => {
       ),
     }
     const view = jsxElement('View', viewAttributes, [])
-    const jsCode = `const a = true;
-const b = 10;
-const c = 20;`
+    const jsCode = `const a = true
+const b = 10
+const c = 20`
     const transpiledJsCode = `var a = true;
 var b = 10;
 var c = 20;
@@ -1645,7 +1645,7 @@ export var whatever = (props) => {
       ),
     }
     const view = jsxElement('View', viewAttributes, [])
-    const jsCode = `let a = 10;`
+    const jsCode = `let a = 10`
     const transpiledJsCode = `var a = 10;
 return { a: a };`
     const arbitraryBlock = arbitraryJSBlock(
@@ -1712,8 +1712,8 @@ export var whatever = (props) => {
       ),
     }
     const view = jsxElement('View', viewAttributes, [])
-    const jsCode = `const a = 10;
-const b = { a: a };`
+    const jsCode = `const a = 10
+const b = { a: a }`
     const transpiledJsCode = `var a = 10;
 var b = {
   a: a
@@ -1790,7 +1790,7 @@ export var whatever = (props) => {
       ),
     }
     const view = jsxElement('View', viewAttributes, [])
-    const jsCode = `const bg = { backgroundColor: 'grey' };`
+    const jsCode = `const bg = { backgroundColor: 'grey' }`
     const transpiledJsCode = `var bg = {
   backgroundColor: 'grey'
 };
@@ -1879,7 +1879,7 @@ export var whatever = (props) => <View data-uid='aaa'>
       emptyComments,
       emptyComments,
     )
-    const jsCode = `var count = 10;`
+    const jsCode = `var count = 10`
     const transpiledJSCode = `var count = 10;
 return { count: count };`
     const jsVariable = arbitraryJSBlock(
@@ -1966,7 +1966,7 @@ export var whatever = (props) => <View data-uid='aaa'>
     const transpiledJSCode = `var use20 = true;
 return { use20: use20 };`
     const jsVariable = arbitraryJSBlock(
-      'var use20 = true;',
+      'var use20 = true',
       transpiledJSCode,
       ['use20'],
       [],
@@ -2030,7 +2030,7 @@ export var whatever = (props) => <View data-uid='aaa'>
     const transpiledJSCode = `var mySet = new Set();
 return { mySet: mySet };`
     const jsVariable = arbitraryJSBlock(
-      'var mySet = new Set();',
+      'var mySet = new Set()',
       transpiledJSCode,
       ['mySet'],
       ['Set'],
@@ -2105,7 +2105,7 @@ export var whatever = (props) => <View data-uid='aaa'>
     const transpiledJSCode = `var spacing = 20;
 return { spacing: spacing };`
     const jsVariable = arbitraryJSBlock(
-      'var spacing = 20;',
+      'var spacing = 20',
       transpiledJSCode,
       ['spacing'],
       [],
@@ -2167,16 +2167,16 @@ export var whatever = (props) => <View data-uid='aaa'>
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
     const jsCode = `var MyComp = props => {
   return React.createElement(
-  "div",
-  {
-    style: {
-      position: "absolute",
-      left: props.layout.left,
-      backgroundColor: "hotpink" } },
-
-
-  "hello");
-
+    "div",
+    {
+      style: {
+        position: "absolute",
+        left: props.layout.left,
+        backgroundColor: "hotpink"
+      }
+    },
+    "hello"
+  );
 };`
     const transpiledJsCode = `var MyComp = function MyComp(props) {
   return React.createElement("div", {
@@ -2710,7 +2710,7 @@ export var App = (props) => <View data-uid='bbb'>
       emptyComments,
     )
     const jsCode1 = `function getSizing(n) {
-  return 100 + n;
+  return 100 + n
 }`
     const transpiledJSCode1 = `function getSizing(n) {
   return 100 + n;
@@ -2728,7 +2728,7 @@ return { getSizing: getSizing };`
       }),
       emptyComments,
     )
-    const jsCode2 = `var spacing = 20;`
+    const jsCode2 = `var spacing = 20`
     const transpiledJSCode2 = `var spacing = 20;
 return { spacing: spacing };`
     const arbitraryBlock2 = arbitraryJSBlock(
@@ -2744,9 +2744,9 @@ return { spacing: spacing };`
       emptyComments,
     )
     const combinedJSCode = `function getSizing(n) {
-  return 100 + n;
+  return 100 + n
 }
-var spacing = 20;`
+var spacing = 20`
     const transpiledcombinedJSCode = `function getSizing(n) {
   return 100 + n;
 }
@@ -3169,8 +3169,8 @@ export var whatever = props => {
 };
 `
     const jsCode = `function test(n) {
-  return n * 2;
-}`
+    return n * 2
+  }`
     const transpiledJSCode = `function test(n) {
   return n * 2;
 }
@@ -3249,8 +3249,8 @@ return { test: test };`
   })
   it('parses arbitrary code in a component back and forth', () => {
     const jsCode = `function test(n) {
-  return n * 2;
-}`
+    return n * 2
+  }`
     const transpiledJSCode = `function test(n) {
   return n * 2;
 }
@@ -3928,7 +3928,7 @@ export var whatever = props => {
     const code = `import * as React from "react"
 export var whatever = props => {
   for (var n = 0; n != -1; n++) {
-    const n2 = n * 2;
+    const n2 = n * 2
   }
   while (true) {
     const a = 1
@@ -3937,11 +3937,11 @@ export var whatever = props => {
 }`
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
     const arbitraryBlockCode = `for (var n = 0; n != -1; n++) {
-  const n2 = n * 2;
-}
+    const n2 = n * 2
+  }
 while (true) {
-  const a = 1;
-}`
+    const a = 1
+  }`
     const arbitraryBlockTranspiledCode = `var _loopIt = 0,
     _loopIt2 = 0;
 
@@ -4004,17 +4004,17 @@ return {  };`
 export var whatever = props => {
   let result = []
   for (var n = 0; n < 5; n++) {
-    const n2 = n * 2;
-    result.push(<div style={{ left: n, top: n2 }} data-uid='bbb' />);
+    const n2 = n * 2
+    result.push(<div style={{ left: n, top: n2 }} data-uid='bbb' />)
   }
   return <div data-uid='aaa'>{result}</div>
 }`
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
-    const arbitraryBlockCode = `let result = [];
+    const arbitraryBlockCode = `let result = []
 for (var n = 0; n < 5; n++) {
-  const n2 = n * 2;
-  result.push(<div style={{ left: n, top: n2 }} data-uid='bbb' />);
-}`
+    const n2 = n * 2
+    result.push(<div style={{ left: n, top: n2 }} data-uid='bbb' />)
+  }`
     const arbitraryBlockTranspiledCode = `var _loopIt = 0;
 var result = [];
 
@@ -4247,7 +4247,7 @@ export var whatever = props => {
     )
 
     const topLevelArbitraryBlock = arbitraryJSBlock(
-      `const a = 30;`,
+      `const a = 30`,
       `var a = 30;
 return { a: a };`,
       ['a'],
@@ -4438,7 +4438,7 @@ export var App = props => {
 
     if (
       !isArbitraryJSBlock(consoleLogBlock) ||
-      consoleLogBlock.javascript !== `console.log('hello!');`
+      consoleLogBlock.javascript !== `console.log('hello!')`
     ) {
       fail('expected the first topLevelElement to be the console logline')
     }


### PR DESCRIPTION
Fixes #822

**Problem:**
For some projects when the code is printed back out, some JSX elements end up with a newly added `data-uid` attribute.

**Fix:**
For a block of code that is treated as an arbitrary one, but has valid JSX elements inside it, the logic to give them `data-uid` attributes ended up also carrying those through into the code. Now the original code is used instead so that printing one back out will produce the same code.

**Commit Details:**
- Fixes #822.
- Uses the original JavaScript before adding the `data-uid` attribute
  so that they don't get printed back out.
