### PR TITLE
Tests/performance resize select

### DIFF
--- a/editor/src/components/menubar/menubar.tsx
+++ b/editor/src/components/menubar/menubar.tsx
@@ -4,7 +4,11 @@ import styled from '@emotion/styled'
 import * as React from 'react'
 import { FLOATING_PREVIEW_BASE_URL } from '../../common/env-vars'
 import { LoginState } from '../../common/user'
-import { useTriggerScrollPerformanceTest } from '../../core/model/performance-scripts'
+import {
+  useTriggerScrollPerformanceTest,
+  useTriggerResizePerformanceTest,
+  useTriggerSelectionPerformanceTest,
+} from '../../core/model/performance-scripts'
 import { useReParseOpenProjectFile } from '../../core/model/project-file-helper-hooks'
 import { shareURLForProject } from '../../core/shared/utils'
 import { isFeatureEnabled } from '../../utils/feature-switches'
@@ -130,6 +134,8 @@ export const Menubar = betterReactMemo('Menubar', () => {
   const onReparseClick = useReParseOpenProjectFile()
 
   const onTriggerScrollTest = useTriggerScrollPerformanceTest()
+  const onTriggerResizeTest = useTriggerResizePerformanceTest()
+  const onTriggerSelectionTest = useTriggerSelectionPerformanceTest()
 
   const previewURL =
     projectId == null ? '' : shareURLForProject(FLOATING_PREVIEW_BASE_URL, projectId, projectName)
@@ -174,9 +180,17 @@ export const Menubar = betterReactMemo('Menubar', () => {
         </Tooltip>
       </FlexColumn>
       {isFeatureEnabled('Performance Test Triggers') ? (
-        <Tile style={{ marginTop: 12, marginBottom: 12 }}>
-          <a onClick={onTriggerScrollTest}>P S</a>
-        </Tile>
+        <React.Fragment>
+          <Tile style={{ marginTop: 12, marginBottom: 12 }}>
+            <a onClick={onTriggerScrollTest}>P S</a>
+          </Tile>
+          <Tile style={{ marginTop: 12, marginBottom: 12 }}>
+            <a onClick={onTriggerResizeTest}>P R</a>
+          </Tile>
+          <Tile style={{ marginTop: 12, marginBottom: 12 }}>
+            <a onClick={onTriggerSelectionTest}>P E</a>
+          </Tile>
+        </React.Fragment>
       ) : null}
       {isFeatureEnabled('Re-parse Project Button') ? (
         <Tile style={{ marginTop: 12, marginBottom: 12 }}>

--- a/editor/src/core/model/performance-scripts.ts
+++ b/editor/src/core/model/performance-scripts.ts
@@ -2,8 +2,20 @@ import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import CanvasActions from '../../components/canvas/canvas-actions'
 import { DebugDispatch } from '../../components/editor/action-types'
+import { clearSelection, selectComponents } from '../../components/editor/actions/action-creators'
 import { useEditorState } from '../../components/editor/store/store-hook'
-import { canvasPoint } from '../shared/math-utils'
+import {
+  canvasPoint,
+  CanvasRectangle,
+  CanvasVector,
+  zeroPoint,
+  zeroRectangle,
+} from '../shared/math-utils'
+import { resizeDragState } from '../../components/canvas/canvas-types'
+import { MetadataUtils } from './element-metadata-utils'
+import { InstancePath } from '../shared/project-file-types'
+import { getOriginalFrames } from '../../components/canvas/canvas-utils'
+import * as TP from '../../core/shared/template-path'
 
 export function useTriggerScrollPerformanceTest(): () => void {
   const dispatch = useEditorState(
@@ -31,5 +43,125 @@ export function useTriggerScrollPerformanceTest(): () => void {
     }
     requestAnimationFrame(step)
   }, [dispatch])
+  return trigger
+}
+
+export function useTriggerResizePerformanceTest(): () => void {
+  const dispatch = useEditorState(
+    (store) => store.dispatch as DebugDispatch,
+    'useTriggerResizePerformanceTest dispatch',
+  )
+  const metadata = useEditorState(
+    (store) => store.editor.jsxMetadataKILLME,
+    'useTriggerResizePerformanceTest metadata',
+  )
+  const selectedViews = useEditorState(
+    (store) => store.editor.selectedViews,
+    'useTriggerResizePerformanceTest selectedViews',
+  )
+  const trigger = React.useCallback(async () => {
+    if (selectedViews.length === 0) {
+      console.info('RESIZE_TEST_MISSING_SELECTEDVIEW')
+      return
+    }
+
+    const target = selectedViews[0]
+    const targetFrame = MetadataUtils.getElementByInstancePathMaybe(
+      metadata.elements,
+      target as InstancePath,
+    )?.globalFrame
+    const targetStartPoint =
+      targetFrame != null
+        ? ({
+            x: targetFrame.x + targetFrame.width,
+            y: targetFrame.y + targetFrame.height,
+          } as CanvasVector)
+        : (zeroPoint as CanvasVector)
+    const originalFrames = getOriginalFrames(selectedViews, metadata)
+
+    let framesPassed = 0
+    async function step() {
+      performance.mark(`resize_step_${framesPassed}`)
+      const dragState = resizeDragState(
+        targetStartPoint,
+        { x: framesPassed / 10, y: framesPassed / 10 } as CanvasVector,
+        true,
+        false,
+        false,
+        targetFrame || (zeroRectangle as CanvasRectangle),
+        originalFrames,
+        { x: 1, y: 1 },
+        { x: 1, y: 1 },
+        metadata,
+        [target],
+        false,
+      )
+      await dispatch([CanvasActions.createDragState(dragState)]).entireUpdateFinished
+      performance.mark(`resize_dispatch_finished_${framesPassed}`)
+      performance.measure(
+        `resize_frame_${framesPassed}`,
+        `resize_step_${framesPassed}`,
+        `resize_dispatch_finished_${framesPassed}`,
+      )
+      framesPassed++
+      if (framesPassed < 600) {
+        requestAnimationFrame(step)
+      } else {
+        await dispatch([CanvasActions.clearDragState(true)]).entireUpdateFinished
+        console.info('RESIZE_TEST_FINISHED')
+      }
+    }
+    requestAnimationFrame(step)
+  }, [dispatch, metadata, selectedViews])
+  return trigger
+}
+
+export function useTriggerSelectionPerformanceTest(): () => void {
+  const dispatch = useEditorState(
+    (store) => store.dispatch as DebugDispatch,
+    'useTriggerSelectionPerformanceTest dispatch',
+  )
+  const allPaths = useEditorState(
+    (store) => store.derived.navigatorTargets,
+    'useTriggerResizePerformanceTest navigatorTargets',
+  )
+  const trigger = React.useCallback(async () => {
+    if (allPaths.length === 0) {
+      console.info('SELECT_TEST_MISSING_ELEMENTS')
+      return
+    }
+
+    const targetPath = [...allPaths].sort(
+      (a, b) => TP.toString(b).length - TP.toString(a).length,
+    )[0]
+    let framesPassed = 0
+    async function step() {
+      performance.mark(`select_step_${framesPassed}`)
+      await dispatch([selectComponents([targetPath!], false)]).entireUpdateFinished
+      performance.mark(`select_dispatch_finished_${framesPassed}`)
+      performance.measure(
+        `select_frame_${framesPassed}`,
+        `select_step_${framesPassed}`,
+        `select_dispatch_finished_${framesPassed}`,
+      )
+
+      performance.mark(`select_deselect_step_${framesPassed}`)
+      await dispatch([clearSelection()]).entireUpdateFinished
+      performance.mark(`select_deselect_dispatch_finished_${framesPassed}`)
+      performance.measure(
+        `select_deselect_frame_${framesPassed}`,
+        `select_deselect_step_${framesPassed}`,
+        `select_deselect_dispatch_finished_${framesPassed}`,
+      )
+
+      framesPassed++
+      if (framesPassed < 5) {
+        requestAnimationFrame(step)
+      } else {
+        console.info('SELECT_TEST_FINISHED')
+      }
+    }
+    requestAnimationFrame(step)
+  }, [dispatch, allPaths])
   return trigger
 }


### PR DESCRIPTION
Created performance 2 test buttons for element resize and selection next to the other performance test button, hidden behind the `Performance Test Triggers` feature flag.

Resizing test uses the selectedview and resizes it from a corner.
Selection test selects a view then deselects a view and measures both performance.

These are not used in a performance tests yet.
