### PR TITLE
Parser Printer blank line insertion

### DIFF
--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
@@ -23,6 +23,7 @@ describe('moving a scene/rootview on the canvas', () => {
       /** @jsx jsx */
         import * as React from 'react'
         import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
         export var App = (props) => {
           return (
             <View
@@ -39,6 +40,7 @@ describe('moving a scene/rootview on the canvas', () => {
             </View>
           )
         }
+
         export var storyboard = (props) => {
           return (
             <Storyboard data-uid='utopia-storyboard-uid'>
@@ -132,6 +134,7 @@ describe('moving a scene/rootview on the canvas', () => {
     const expectedCode = `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
       export var App = (props) => {
         return (
           <View
@@ -148,6 +151,7 @@ describe('moving a scene/rootview on the canvas', () => {
           </View>
         )
       }
+
       export var storyboard = (props) => {
         return (
           <Storyboard data-uid='utopia-storyboard-uid'>
@@ -171,6 +175,7 @@ describe('moving a scene/rootview on the canvas', () => {
       /** @jsx jsx */
         import * as React from 'react'
         import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
         export var App = (props) => {
           return (
             <View
@@ -186,6 +191,7 @@ describe('moving a scene/rootview on the canvas', () => {
             </View>
           )
         }
+
         export var storyboard = (props) => {
           return (
             <Storyboard data-uid='utopia-storyboard-uid'>
@@ -278,6 +284,7 @@ describe('moving a scene/rootview on the canvas', () => {
     const expectedCode = `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
       export var App = (props) => {
         return (
           <View
@@ -293,6 +300,7 @@ describe('moving a scene/rootview on the canvas', () => {
           </View>
         )
       }
+
       export var storyboard = (props) => {
         return (
           <Storyboard data-uid='utopia-storyboard-uid'>
@@ -420,6 +428,7 @@ describe('moving a scene/rootview on the canvas', () => {
       `/** @jsx jsx */
         import * as React from 'react'
         import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
         export var App = (props) => {
           return (
             <View
@@ -435,6 +444,7 @@ describe('moving a scene/rootview on the canvas', () => {
             </View>
           )
         }
+
         export var storyboard = (props) => {
           return (
             <Storyboard data-uid='utopia-storyboard-uid'>
@@ -526,6 +536,7 @@ describe('moving a scene/rootview on the canvas', () => {
     const expectedCode = `/** @jsx jsx */
     import * as React from 'react'
     import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
     export var App = (props) => {
       return (
         <View
@@ -541,6 +552,7 @@ describe('moving a scene/rootview on the canvas', () => {
         </View>
       )
     }
+
     export var storyboard = (props) => {
       return (
         <Storyboard data-uid='utopia-storyboard-uid'>
@@ -565,6 +577,7 @@ describe('resizing a scene/rootview on the canvas', () => {
       `/** @jsx jsx */
         import * as React from 'react'
         import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
         export var App = (props) => {
           return (
             <View
@@ -581,6 +594,7 @@ describe('resizing a scene/rootview on the canvas', () => {
             </View>
           )
         }
+
         export var storyboard = (props) => {
           return (
             <Storyboard data-uid='utopia-storyboard-uid'>
@@ -658,6 +672,7 @@ describe('resizing a scene/rootview on the canvas', () => {
     const expectedCode = `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
       export var App = (props) => {
         return (
           <View
@@ -674,6 +689,7 @@ describe('resizing a scene/rootview on the canvas', () => {
           </View>
         )
       }
+
       export var storyboard = (props) => {
         return (
           <Storyboard data-uid='utopia-storyboard-uid'>
@@ -696,6 +712,7 @@ describe('resizing a scene/rootview on the canvas', () => {
       `/** @jsx jsx */
         import * as React from 'react'
         import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
         export var App = (props) => {
           return (
             <View
@@ -711,6 +728,7 @@ describe('resizing a scene/rootview on the canvas', () => {
             </View>
           )
         }
+
         export var storyboard = (props) => {
           return (
             <Storyboard data-uid='utopia-storyboard-uid'>
@@ -785,6 +803,7 @@ describe('resizing a scene/rootview on the canvas', () => {
     const expectedCode = `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
       export var App = (props) => {
         return (
           <View
@@ -800,6 +819,7 @@ describe('resizing a scene/rootview on the canvas', () => {
           </View>
         )
       }
+
       export var storyboard = (props) => {
         return (
           <Storyboard data-uid='utopia-storyboard-uid'>
@@ -822,6 +842,7 @@ describe('resizing a scene/rootview on the canvas', () => {
       `/** @jsx jsx */
         import * as React from 'react'
         import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
         export var App = (props) => {
           return (
             <View
@@ -837,6 +858,7 @@ describe('resizing a scene/rootview on the canvas', () => {
             </View>
           )
         }
+
         export var storyboard = (props) => {
           return (
             <Storyboard data-uid='utopia-storyboard-uid'>
@@ -911,6 +933,7 @@ describe('resizing a scene/rootview on the canvas', () => {
     const expectedCode = `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
       export var App = (props) => {
         return (
           <View
@@ -926,6 +949,7 @@ describe('resizing a scene/rootview on the canvas', () => {
           </View>
         )
       }
+
       export var storyboard = (props) => {
         return (
           <Storyboard data-uid='utopia-storyboard-uid'>
@@ -948,6 +972,7 @@ describe('resizing a scene/rootview on the canvas', () => {
       `/** @jsx jsx */
         import * as React from 'react'
         import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
         export var App = (props) => {
           return (
             <View
@@ -963,6 +988,7 @@ describe('resizing a scene/rootview on the canvas', () => {
             </View>
           )
         }
+
         export var storyboard = (props) => {
           return (
             <Storyboard data-uid='utopia-storyboard-uid'>
@@ -1039,6 +1065,7 @@ describe('resizing a scene/rootview on the canvas', () => {
     const expectedCode = `/** @jsx jsx */
     import * as React from 'react'
     import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
     export var App = (props) => {
       return (
         <View
@@ -1054,6 +1081,7 @@ describe('resizing a scene/rootview on the canvas', () => {
         </View>
       )
     }
+
     export var storyboard = (props) => {
       return (
         <Storyboard data-uid='utopia-storyboard-uid'>
@@ -1075,6 +1103,7 @@ describe('resizing a scene/rootview on the canvas', () => {
       `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
       export var App = (props) => {
         return (
           <View
@@ -1090,6 +1119,7 @@ describe('resizing a scene/rootview on the canvas', () => {
           </View>
         )
       }
+
       export var storyboard = (props) => {
         return (
           <Storyboard data-uid='utopia-storyboard-uid'>
@@ -1163,6 +1193,7 @@ describe('resizing a scene/rootview on the canvas', () => {
     const expectedCode = `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
       export var App = (props) => {
         return (
           <View
@@ -1178,6 +1209,7 @@ describe('resizing a scene/rootview on the canvas', () => {
           </View>
         )
       }
+      
       export var storyboard = (props) => {
         return (
           <Storyboard data-uid='utopia-storyboard-uid'>

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -220,11 +220,13 @@ export function makeTestProjectCodeWithSnippet(snippet: string): string {
   const code = `/** @jsx jsx */
   import * as React from 'react'
   import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
   export var App = (props) => {
     return (
 ${snippet}
     )
   }
+
   export var ${BakedInStoryboardVariableName} = (props) => {
     return (
       <Storyboard data-uid='${BakedInStoryboardUID}'>

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.ts.snap
@@ -90,9 +90,11 @@ Array [
             "sourcesContent": Array [
               "import * as React from 'react'
 import * as Utopia from 'utopia-api'
+
 export var App = (props) => {
   return <Utopia.View data-uid='aaa'>{<div data-uid='bbb' />}</Utopia.View>
 }
+
 export var storyboard = (props) => {
   return (
     <Storyboard data-uid='utopia-storyboard-uid'>
@@ -167,7 +169,7 @@ export var storyboard = (props) => {
 }",
     "sourceMap": Object {
       "file": "code.tsx",
-      "mappings": "AAKQA,IAAIC,UAAUC,GAAGC,SAAbF,UAAaE,CAACC,KAADD,EAAWE;AACjCC,SACEC,oBAACC,UAADD;AAAYE,gBAASC;AAArBH,KACEA,oBAACI,KAADJ;AACEK,IAAAA,KAAKC,EAAER;AAAES,MAAAA,IAAIC,EAAEC,CAARX;AAAWY,MAAAA,GAAGF,EAAEC,CAAhBX;AAAmBa,MAAAA,KAAKH,EAAEI,GAA1Bd;AAA+Be,MAAAA,MAAML,EAAEI;AAAvCd,KADTE;AAEEc,IAAAA,SAASR,EAAES,GAFbf;AAGEgB,IAAAA,MAAMV,EAAER;AAAEmB,MAAAA,YAAYT,EAAEL;AAAhBL,KAHVE;AAIEH,IAAAA,KAAKS,EAAER;AAAEkB,MAAAA,MAAMR,EAAEV;AAAEoB,QAAAA,MAAMV,EAAEC,CAAVX;AAAaS,QAAAA,IAAIC,EAAEC,CAAnBX;AAAsBqB,QAAAA,KAAKX,EAAEC,CAA7BX;AAAgCY,QAAAA,GAAGF,EAAEC;AAArCX;AAAVA,KAJTE;AAKEE,gBAASC;AALXH,IADFA,CADFD;AAWFqB,CAZO3B",
+      "mappings": "AAOQA,IAAIC,UAAUC,GAAGC,SAAbF,UAAaE,CAACC,KAADD,EAAWE;AACjCC,SACEC,oBAACC,UAADD;AAAYE,gBAASC;AAArBH,KACEA,oBAACI,KAADJ;AACEK,IAAAA,KAAKC,EAAER;AAAES,MAAAA,IAAIC,EAAEC,CAARX;AAAWY,MAAAA,GAAGF,EAAEC,CAAhBX;AAAmBa,MAAAA,KAAKH,EAAEI,GAA1Bd;AAA+Be,MAAAA,MAAML,EAAEI;AAAvCd,KADTE;AAEEc,IAAAA,SAASR,EAAES,GAFbf;AAGEgB,IAAAA,MAAMV,EAAER;AAAEmB,MAAAA,YAAYT,EAAEL;AAAhBL,KAHVE;AAIEH,IAAAA,KAAKS,EAAER;AAAEkB,MAAAA,MAAMR,EAAEV;AAAEoB,QAAAA,MAAMV,EAAEC,CAAVX;AAAaS,QAAAA,IAAIC,EAAEC,CAAnBX;AAAsBqB,QAAAA,KAAKX,EAAEC,CAA7BX;AAAgCY,QAAAA,GAAGF,EAAEC;AAArCX;AAAVA,KAJTE;AAKEE,gBAASC;AALXH,IADFA,CADFD;AAWFqB,CAZO3B",
       "names": Array [
         "var",
         "storyboard",
@@ -204,9 +206,11 @@ export var storyboard = (props) => {
       "sourcesContent": Array [
         "import * as React from 'react'
 import * as Utopia from 'utopia-api'
+
 export var App = (props) => {
   return <Utopia.View data-uid='aaa'>{<div data-uid='bbb' />}</Utopia.View>
 }
+
 export var storyboard = (props) => {
   return (
     <Storyboard data-uid='utopia-storyboard-uid'>

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
@@ -118,6 +118,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
     const expectedCode = applyPrettier(
       `import * as React from "react";
 import { View, Storyboard, Scene } from 'utopia-api';
+
 export var App = props => {
   return (
     <View data-uid="aaa">
@@ -125,6 +126,7 @@ export var App = props => {
     </View>
   );
 };
+
 export var ${BakedInStoryboardVariableName} = (props) => {
   return (
     <Storyboard data-uid='${BakedInStoryboardUID}'>

--- a/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
@@ -37,6 +37,7 @@ describe('JSX parser', () => {
   it('adds in data-uid attributes for elements in arbitrary code', () => {
     const code = `import * as React from "react";
 import { Ellipse, UtopiaUtils, Image, Rectangle, Text, View } from "utopia-api";
+
 export var App = props => {
   return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid="xxx">
     {[1, 2, 3].map(n => {
@@ -53,6 +54,7 @@ export var App = props => {
     const code = `import Button, { LABEL } from "./src/components";
     import * as React from "react";
     import { Ellipse, UtopiaUtils, Image, Rectangle, Text, View } from "utopia-api";
+
     export var App = props => {
         return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid="xxx" />
     };`
@@ -88,10 +90,13 @@ describe('JSX printer', () => {
   it('reprints spread object values correctly', () => {
     const code = `import * as React from 'react'
 import { Storyboard, View } from 'utopia-api'
+
 const myCoolTheme = {}
+
 export var App = (props) => {
   return <View data-uid='xxx' style={{ ...myCoolTheme, backgroundColor: 'purple' }} />
 }
+
 export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInStoryboardUID}' />
 `
     testParseThenPrint(code, code)
@@ -99,12 +104,15 @@ export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInSto
   it('components are not reordered when printing', () => {
     const code = `import * as React from 'react'
 import { Storyboard, View } from 'utopia-api'
+
 export var App = (props) => {
   return <Widget data-uid='bbb' />
 }
+
 export var Widget = (props) => {
   return <View data-uid='aaa' />
 }
+
 export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInStoryboardUID}' />
 `
     testParseThenPrint(code, code)
@@ -113,7 +121,9 @@ export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInSto
   it('object property names with special characters should be printed in string quotes', () => {
     const code = `import * as React from 'react'
 import { Storyboard, View } from 'utopia-api'
+
 const color = 'white'
+
 export var App = (props) => {
   return (
     <View
@@ -122,6 +132,7 @@ export var App = (props) => {
     />
   )
 }
+
 export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInStoryboardUID}' />
 `
     testParseThenPrint(code, code)
@@ -130,6 +141,7 @@ export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInSto
   it('definedWithin and definedElsewhere are mutually exclusive properties', () => {
     const code = `import * as React from 'react'
 import { Storyboard, View } from 'utopia-api'
+
 export var App = (props) => {
   return (
     <View data-uid='aaa' css={{ backgroundColor: 'red' }}>
@@ -137,6 +149,7 @@ export var App = (props) => {
     </View>
   )
 }
+
 const elements = []
 export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInStoryboardUID}' />
 `
@@ -149,6 +162,7 @@ describe('Imports', () => {
     const code = `import './style.css'
 import * as React from 'react'
 import { Storyboard, View } from 'utopia-api'
+
 export var App = (props) => {
   return (
     <View data-uid='aaa' css={{ backgroundColor: 'red' }}>
@@ -156,6 +170,7 @@ export var App = (props) => {
     </View>
   )
 }
+
 const elements = []
 export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInStoryboardUID}' />
 `

--- a/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
@@ -191,4 +191,55 @@ function Picker() {
     const parsedThenPrinted = parseThenPrint(code)
     expect(parsedThenPrinted).toEqual(code)
   })
+
+  it('inserts newlines based on heuristics', () => {
+    const code = applyPrettier(
+      `/** @jsx jsx */
+      import * as React from 'react'
+      import { Scene, Storyboard, View, jsx } from 'utopia-api'
+      
+      const { m } = require('./thing')
+      const { n } = require('./thing')
+      const { o } = require('./thing')
+      
+      export function doThing() {
+        return 1
+      }
+      
+      export default function App(props) {
+        return <div data-uid='aaa' />
+      }
+      
+      const a = 1
+      const b = 10
+      const c = 100
+      
+      const thing1 = {
+        a: 10,
+      }
+      
+      const thing2 = {
+        b: 100,
+      }
+      
+      export var storyboard = (
+        <Storyboard data-uid='bbb'>
+          <Scene
+            component={App}
+            props={{}}
+            style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+            data-uid='ccc'
+          />
+        </Storyboard>
+      )
+      
+      export { thing1, thing2 }
+      export { default as p } from './thing'
+      `,
+      false,
+    ).formatted
+
+    const parsedThenPrinted = parseThenPrint(code)
+    expect(parsedThenPrinted).toEqual(code)
+  })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
@@ -76,6 +76,7 @@ describe('Parsing and then printing code', () => {
     const code = applyPrettier(
       `
 import { GithubPicker } from "react-color";
+
 function Picker() {
   const [color, setColor] = useThemeContext();
   const [visible, setVisible] = usePickerVisibilityContext();
@@ -116,6 +117,7 @@ function Picker() {
       `const whatever = (props) => {
         return <div data-uid='aaa' />
       }
+
       export default whatever`,
       false,
     ).formatted
@@ -140,6 +142,7 @@ function Picker() {
       `
       const Thing = 1
       const OtherThing = 2
+
       export { default as Calendar } from './Calendar'
       export { DateLocalizer } from './localizer'
       export { Thing, OtherThing as SomethingElse }
@@ -168,6 +171,7 @@ function Picker() {
       import { GammaCorrectionShader } from 'three/examples/jsm/shaders/GammaCorrectionShader'
       import { WaterPass } from './shaders/WaterPass'
       import state from '../state'
+
       export const whatever = (props) => {
         return <div data-uid='aaa' />
       }`,
@@ -196,6 +200,22 @@ function Picker() {
     const code = applyPrettier(
       `/** @jsx jsx */
       import * as React from 'react'
+      import { 
+        Loads,
+        AndLoads,
+        AndMore,
+        Just,
+        So,
+        Many,
+        Different,
+        Things,
+        Enough,
+        To,
+        Force,
+        Onto,
+        Multiple,
+        Lines
+      } from 'some-library'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
       
       const { m } = require('./thing')
@@ -210,6 +230,21 @@ function Picker() {
         return <div data-uid='aaa' />
       }
       
+      export const whatever = (props) => {
+        return <div data-uid='aab' />
+      }
+
+      export var storyboard = (
+        <Storyboard data-uid='bbb'>
+          <Scene
+            component={App}
+            props={{}}
+            style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+            data-uid='ccc'
+          />
+        </Storyboard>
+      )
+      
       const a = 1
       const b = 10
       const c = 100
@@ -221,17 +256,6 @@ function Picker() {
       const thing2 = {
         b: 100,
       }
-      
-      export var storyboard = (
-        <Storyboard data-uid='bbb'>
-          <Scene
-            component={App}
-            props={{}}
-            style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
-            data-uid='ccc'
-          />
-        </Storyboard>
-      )
       
       export { thing1, thing2 }
       export { default as p } from './thing'

--- a/editor/src/core/workers/parser-printer/parser-printer-component-based-canvas.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-component-based-canvas.spec.ts
@@ -6,6 +6,7 @@ describe('Storyboard project files', () => {
     const originalCode = `/** @jsx jsx */
 import * as React from 'react'
 import { Canvas, Scene, View, jsx } from 'utopia-api'
+
 export var App = (props) => {
   return (
     <View
@@ -17,6 +18,7 @@ export var App = (props) => {
     </View>
   )
 }
+
 export var ${BakedInStoryboardVariableName} = (props) => {
   return (
     <Canvas data-uid='${BakedInStoryboardUID}'>

--- a/editor/src/core/workers/parser-printer/parser-printer-dot-notation.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-dot-notation.spec.ts
@@ -13,6 +13,7 @@ describe('JSX parser', () => {
       `
 import * as React from "react";
 import * as Utopia from "utopia-api";
+
 export var App = props => {
   return (
     <Utopia.View data-uid="aaa">
@@ -20,6 +21,7 @@ export var App = props => {
     </Utopia.View>
   )
 }
+
 export var storyboard = (props) => {
   return (
     <Storyboard data-uid='${BakedInStoryboardUID}'>
@@ -56,6 +58,7 @@ export var storyboard = (props) => {
 import * as React from "react";
 import * as Utopia from "utopia-api";
 import { Scene, Storyboard, View } from "utopia-api";
+
 export var App = props => {
   return (
     <Utopia.View data-uid="aaa">
@@ -63,6 +66,7 @@ export var App = props => {
     </Utopia.View>
   )
 }
+
 export var storyboard = (props) => {
   return (
     <Storyboard data-uid='${BakedInStoryboardUID}'>
@@ -79,6 +83,7 @@ export var storyboard = (props) => {
     const printedCode = `import * as React from 'react'
 import { Scene, Storyboard, View } from 'utopia-api'
 import * as Utopia from 'utopia-api'
+
 export var App = (props) => {
   return (
     <Utopia.View data-uid='aaa'>
@@ -86,6 +91,7 @@ export var App = (props) => {
     </Utopia.View>
   )
 }
+
 export var storyboard = (props) => {
   return (
     <Storyboard data-uid='${BakedInStoryboardUID}'>

--- a/editor/src/core/workers/parser-printer/parser-printer-event-handlers.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-event-handlers.spec.ts
@@ -20,11 +20,13 @@ import {
   UtopiaUtils,
   View
 } from "utopia-api";
+
 export var App = props => {
   return (
     <View data-uid='aaa' onClick={() => {console.log('hat')}}/>
   )
 }
+
 export var ${BakedInStoryboardVariableName} = (props) => {
   return (
     <Storyboard data-uid='${BakedInStoryboardUID}'>
@@ -62,6 +64,7 @@ import {
   UtopiaUtils,
   View
 } from "utopia-api";
+
 export var App = props => {
   return (
     <View
@@ -72,6 +75,7 @@ export var App = props => {
     />
   );
 };
+
 export var ${BakedInStoryboardVariableName} = (props) => {
   return (
     <Storyboard data-uid='${BakedInStoryboardUID}'>

--- a/editor/src/core/workers/parser-printer/parser-printer-exports.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-exports.spec.ts
@@ -33,6 +33,7 @@ describe('parseCode', () => {
     var whatever = (props) => {
       return <div data-uid='aaa' />
     }
+
     export { whatever }
 `,
       false,
@@ -59,6 +60,7 @@ describe('parseCode', () => {
     var whatever = (props) => {
       return <div data-uid='aaa' />
     }
+    
     export { whatever as otherThing }
 `,
       false,

--- a/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
@@ -43,6 +43,7 @@ describe('JSX parser', () => {
         "/** @jsx jsx */
         import * as React from 'react'
         import { Scene, Storyboard, View, jsx } from 'utopia-api'
+
         export var App = (props) => {
           return (
             <View
@@ -62,6 +63,7 @@ describe('JSX parser', () => {
             </View>
           )
         }
+
         export var storyboard = (
           <Storyboard data-uid='eee'>
             <Scene

--- a/editor/src/core/workers/parser-printer/parser-printer-pragma.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-pragma.spec.ts
@@ -42,9 +42,11 @@ describe('Parsing JSX Pragma:', () => {
     import Button, { LABEL } from "./src/components";
     import * as React from "react";
     import { Ellipse, Image, Rectangle, Scene, Storyboard, Text, UtopiaUtils, View, jsx } from "utopia-api";
+
     export var App = props => {
         return <View style={{ "backgroundColor": "green", "position": "absolute" }} data-uid="xxx" />
     };
+    
     export var storyboard = (props) => {
       return (
         <Storyboard data-uid='${BakedInStoryboardUID}'>

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -2891,6 +2891,7 @@ import {
   Text,
   View,
 } from 'utopia-api'
+
 export var whatever = props => {
   return (
     <View data-uid="aaa">
@@ -3816,6 +3817,7 @@ import {
   Text,
   View
 } from "utopia-api";
+
 export var whatever = props => {
   return <View data-uid="aaa" booleanProperty />;
 };
@@ -3864,6 +3866,7 @@ import {
   Text,
   View
 } from "utopia-api";
+
 export var whatever = props => {
   return <View data-uid="aaa" booleanProperty={false} />;
 };

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -672,7 +672,7 @@ function isFunctionDeclaration(line: string): boolean {
   return withoutDefault.startsWith('function')
 }
 
-function createBlanklineTracker() {
+function createBlanklineTracker(): (statement: TS.Node, printedCode: string) => boolean {
   // When inserting blank lines we apply the following series of rules
   // 1) we shouldn't insert blank lines in amongst import statements or exports declarations (not the modifier keyword)
   // 2) variable declarations shouldn't insert a blank line unless a single declaration is spread over separate lines

--- a/editor/src/scripts/parse-print-analysis.ts
+++ b/editor/src/scripts/parse-print-analysis.ts
@@ -75,7 +75,10 @@ async function processProjectCode(
       // Handle
       if (dirEntry.isFile() && javascriptFileEndings.some((ending) => fullPath.endsWith(ending))) {
         const fileResult = await processFile(repo, rootProjectPath, fullPath)
-        result.push(fileResult)
+        if (fileResult.split('\n').length > 4) {
+          // Skip empty patches
+          result.push(fileResult)
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #843 

**Problem:**
We print code without any blank lines between top level statements because we're unable to track their existence during parsing.

**Fix:**
Apply a series of rules to determine when to insert them

**Commit Details:**
- Updated the printing logic in `parser-printer.ts` to apply rules and optionally insert a blank line
- Added a test and fixed all existing tests that were broken by this
