### PR TITLE
Dom-based select hooks use canvas control overlay div

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -16,7 +16,6 @@ interface CanvasComponentEntryProps extends CanvasReactErrorCallback {
   clearConsoleLogs: () => void
   addToConsoleLogs: (log: ConsoleLog) => void
   canvasConsoleLogs: Array<ConsoleLog>
-  setSelectedViewsForCanvasControlsOnly: (newSelectedViews: TemplatePath[]) => void
 }
 
 export const CanvasComponentEntry = betterReactMemo(
@@ -39,7 +38,6 @@ export const CanvasComponentEntry = betterReactMemo(
           props.clearConsoleLogs,
           props.addToConsoleLogs,
           store.dispatch,
-          props.setSelectedViewsForCanvasControlsOnly,
         ),
       'CanvasComponentEntry canvasProps',
     )

--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
@@ -17,11 +17,19 @@ import { determineElementsToOperateOnForDragging } from './controls/select-mode/
 import { BakedInStoryboardUID } from '../../core/model/scene-utils'
 import { CanvasControlsContainerID } from './controls/new-canvas-controls'
 
-// we need to set the Electron window to a larger size so document.elementsUnderPoint works correctly!
-const currentWindow = require('electron').remote.getCurrentWindow()
-currentWindow.setSize(2200, 1000)
-
 describe('moving a scene/rootview on the canvas', () => {
+  beforeAll((done) => {
+    // we need to set the Electron window to a larger size so document.elementsUnderPoint works correctly!
+    const currentWindow = require('electron').remote.getCurrentWindow()
+    const size = currentWindow.getSize()
+    if (size.width !== 2200) {
+      currentWindow.once('resize', () => {
+        done()
+      })
+      currentWindow.setSize(2200, 1000)
+    }
+  })
+
   it('dragging a dynamic scene’s root view sets the scene position', async () => {
     const testCode = Prettier.format(
       `

--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
@@ -15,6 +15,11 @@ import { PrettierConfig } from '../../core/workers/parser-printer/prettier-utils
 import { createFakeMetadataForParseSuccess, wait } from '../../utils/test-utils'
 import { determineElementsToOperateOnForDragging } from './controls/select-mode/move-utils'
 import { BakedInStoryboardUID } from '../../core/model/scene-utils'
+import { CanvasControlsContainerID } from './controls/new-canvas-controls'
+
+// we need to set the Electron window to a larger size so document.elementsUnderPoint works correctly!
+const currentWindow = require('electron').remote.getCurrentWindow()
+currentWindow.setSize(2200, 1000)
 
 describe('moving a scene/rootview on the canvas', () => {
   it('dragging a dynamic scene’s root view sets the scene position', async () => {
@@ -64,8 +69,10 @@ describe('moving a scene/rootview on the canvas', () => {
 
     const areaControlBounds = areaControl.getBoundingClientRect()
 
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
     fireEvent(
-      areaControl,
+      canvasControlsLayer,
       new MouseEvent('mousedown', {
         bubbles: true,
         cancelable: true,
@@ -80,7 +87,7 @@ describe('moving a scene/rootview on the canvas', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
-        areaControl,
+        canvasControlsLayer,
         new MouseEvent('mousemove', {
           bubbles: true,
           cancelable: true,
@@ -98,7 +105,7 @@ describe('moving a scene/rootview on the canvas', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
-        areaControl,
+        canvasControlsLayer,
         new MouseEvent('mousemove', {
           bubbles: true,
           cancelable: true,
@@ -333,8 +340,10 @@ describe('moving a scene/rootview on the canvas', () => {
 
     const areaControlBounds = areaControl.getBoundingClientRect()
 
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
     fireEvent(
-      areaControl,
+      canvasControlsLayer,
       new MouseEvent('mousedown', {
         bubbles: true,
         cancelable: true,
@@ -349,7 +358,7 @@ describe('moving a scene/rootview on the canvas', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
-        areaControl,
+        canvasControlsLayer,
         new MouseEvent('mousemove', {
           bubbles: true,
           cancelable: true,
@@ -367,7 +376,7 @@ describe('moving a scene/rootview on the canvas', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
-        areaControl,
+        canvasControlsLayer,
         new MouseEvent('mousemove', {
           bubbles: true,
           cancelable: true,

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -19,8 +19,13 @@ import {
   EdgePosition,
 } from './canvas-types'
 import { wait } from '../../utils/test-utils'
+import { CanvasControlsContainerID } from './controls/new-canvas-controls'
 
 const NewUID = 'catdog'
+
+// we need to set the Electron window to a larger size so document.elementsUnderPoint works correctly!
+const currentWindow = require('electron').remote.getCurrentWindow()
+currentWindow.setSize(2200, 1000)
 
 describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
   it('a simple TLWH pin change works', async () => {
@@ -1307,8 +1312,10 @@ describe('moveTemplate', () => {
 
     const areaControlBounds = areaControl.getBoundingClientRect()
 
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
     fireEvent(
-      areaControl,
+      canvasControlsLayer,
       new MouseEvent('mousedown', {
         bubbles: true,
         cancelable: true,
@@ -1323,7 +1330,7 @@ describe('moveTemplate', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
-        areaControl,
+        canvasControlsLayer,
         new MouseEvent('mousemove', {
           bubbles: true,
           cancelable: true,
@@ -1341,7 +1348,7 @@ describe('moveTemplate', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
-        areaControl,
+        canvasControlsLayer,
         new MouseEvent('mousemove', {
           bubbles: true,
           cancelable: true,
@@ -1517,8 +1524,10 @@ describe('moveTemplate', () => {
 
     const areaControlBounds = areaControl.getBoundingClientRect()
 
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
     fireEvent(
-      areaControl,
+      canvasControlsLayer,
       new MouseEvent('mousedown', {
         bubbles: true,
         cancelable: true,
@@ -1533,7 +1542,7 @@ describe('moveTemplate', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
-        areaControl,
+        window,
         new MouseEvent('mousemove', {
           bubbles: true,
           cancelable: true,
@@ -1551,7 +1560,7 @@ describe('moveTemplate', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
-        areaControl,
+        window,
         new MouseEvent('mousemove', {
           bubbles: true,
           cancelable: true,
@@ -1632,8 +1641,10 @@ describe('moveTemplate', () => {
     const areaControl = renderResult.renderedDOM.getByTestId('ccc')
     const areaControlBounds = areaControl.getBoundingClientRect()
 
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
     fireEvent(
-      areaControl,
+      canvasControlsLayer,
       new MouseEvent('mousedown', {
         bubbles: true,
         cancelable: true,
@@ -1648,7 +1659,7 @@ describe('moveTemplate', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
-        areaControl,
+        canvasControlsLayer,
         new MouseEvent('mousemove', {
           bubbles: true,
           cancelable: true,
@@ -1666,7 +1677,7 @@ describe('moveTemplate', () => {
       const domFinished = renderResult.getDomReportDispatched()
       const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
       fireEvent(
-        areaControl,
+        canvasControlsLayer,
         new MouseEvent('mousemove', {
           bubbles: true,
           cancelable: true,

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -23,11 +23,18 @@ import { CanvasControlsContainerID } from './controls/new-canvas-controls'
 
 const NewUID = 'catdog'
 
-// we need to set the Electron window to a larger size so document.elementsUnderPoint works correctly!
-const currentWindow = require('electron').remote.getCurrentWindow()
-currentWindow.setSize(2200, 1000)
-
 describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
+  beforeAll((done) => {
+    // we need to set the Electron window to a larger size so document.elementsUnderPoint works correctly!
+    const currentWindow = require('electron').remote.getCurrentWindow()
+    const size = currentWindow.getSize()
+    if (size.width !== 2200) {
+      currentWindow.once('resize', () => {
+        done()
+      })
+      currentWindow.setSize(2200, 1000)
+    }
+  })
   it('a simple TLWH pin change works', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`

--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -28,30 +28,6 @@ import { betterReactMemo } from '../../uuiui-deps'
 import { TemplatePath } from '../../core/shared/project-file-types'
 import { usePropControlledStateV2 } from '../inspector/common/inspector-utils'
 
-function useLocalSelectedHighlightedViews(
-  transientCanvasState: TransientCanvasState,
-): {
-  localSelectedViews: TemplatePath[]
-  localHighlightedViews: TemplatePath[]
-  setSelectedViewsLocally: (newSelectedViews: Array<TemplatePath>) => void
-} {
-  const [localSelectedViews, setLocalSelectedViews] = usePropControlledStateV2(
-    transientCanvasState.selectedViews,
-  )
-  const [localHighlightedViews, setLocalHighlightedViews] = usePropControlledStateV2(
-    transientCanvasState.highlightedViews,
-  )
-
-  const setSelectedViewsLocally = React.useCallback(
-    (newSelectedViews: Array<TemplatePath>) => {
-      setLocalSelectedViews(newSelectedViews)
-      setLocalHighlightedViews([])
-    },
-    [setLocalSelectedViews, setLocalHighlightedViews],
-  )
-  return { localSelectedViews, localHighlightedViews, setSelectedViewsLocally }
-}
-
 interface CanvasWrapperComponentProps {
   runtimeErrors: Array<RuntimeErrorInfo>
   onRuntimeError: (editedFile: string, error: FancyError, errorInfo?: React.ErrorInfo) => void
@@ -72,12 +48,6 @@ export const CanvasWrapperComponent = betterReactMemo(
       }),
       'CanvasWrapperComponent',
     )
-
-    const {
-      localSelectedViews,
-      localHighlightedViews,
-      setSelectedViewsLocally,
-    } = useLocalSelectedHighlightedViews(derivedState.canvas.transientState)
 
     const {
       runtimeErrors,
@@ -131,9 +101,6 @@ export const CanvasWrapperComponent = betterReactMemo(
             canvasConsoleLogs={canvasConsoleLogs}
             clearConsoleLogs={clearConsoleLogs}
             addToConsoleLogs={addToConsoleLogs}
-            localSelectedViews={localSelectedViews}
-            localHighlightedViews={localHighlightedViews}
-            setLocalSelectedViews={setSelectedViewsLocally}
           />
         ) : null}
         {safeMode ? (

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -46,7 +46,7 @@ import {
   getSnappedGuidelinesForPoint,
 } from './guideline-helpers'
 import { InsertionControls } from './insertion-control'
-import { ControlProps } from './new-canvas-controls'
+import { CanvasControlsContainerID, ControlProps } from './new-canvas-controls'
 import { getLayoutPropertyOr } from '../../../core/layout/getLayoutProperty'
 import { RightMenuTab } from '../right-menu'
 import { safeIndex } from '../../../core/shared/array-utils'
@@ -644,7 +644,7 @@ export class InsertModeControlContainer extends React.Component<
   }
 
   componentDidMount() {
-    const canvasContainer = document.getElementById(CanvasContainerID)
+    const canvasContainer = document.getElementById(CanvasControlsContainerID)
     if (canvasContainer != null) {
       canvasContainer.addEventListener('mousedown', this.onMouseDown)
       canvasContainer.addEventListener('mousemove', this.onMouseMove)
@@ -653,7 +653,7 @@ export class InsertModeControlContainer extends React.Component<
   }
 
   componentWillUnmount() {
-    const canvasContainer = document.getElementById(CanvasContainerID)
+    const canvasContainer = document.getElementById(CanvasControlsContainerID)
     if (canvasContainer != null) {
       canvasContainer.removeEventListener('mousedown', this.onMouseDown)
       canvasContainer.removeEventListener('mousemove', this.onMouseMove)

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -481,6 +481,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
   return (
     <div
       id={CanvasControlsContainerID}
+      data-testid={CanvasControlsContainerID}
       className='new-canvas-controls-container'
       style={{
         pointerEvents: 'initial',

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -42,8 +42,12 @@ import {
   isResizing,
   pickSelectionEnabled,
   useMaybeHighlightElement,
+  useSelectAndHover,
   useStartDragStateAfterDragExceedsThreshold,
 } from './select-mode/select-mode-hooks'
+import { NO_OP } from '../../../core/shared/utils'
+
+export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
 export type ResizeStatus = 'disabled' | 'noninteractive' | 'enabled'
 
@@ -226,6 +230,8 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
   const selectionEnabled = pickSelectionEnabled(props.editor.canvas, props.editor.keysPressed)
 
   const { maybeHighlightOnHover, maybeClearHighlightsOnHoverEnd } = useMaybeHighlightElement()
+
+  const { onMouseMove, onMouseDown } = useSelectAndHover(setLocalSelectedViews)
 
   const getResizeStatus = () => {
     const selectedViews = localSelectedViews
@@ -445,12 +451,16 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
 
   return (
     <div
+      id={CanvasControlsContainerID}
       className='new-canvas-controls-container'
       style={{
+        pointerEvents: 'initial',
         position: 'relative',
         width: '100%',
         height: '100%',
       }}
+      onMouseDown={onMouseDown}
+      onMouseMove={onMouseMove}
     >
       {renderModeControlContainer()}
       {renderHighlightControls()}

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -46,10 +46,35 @@ import {
   useStartDragStateAfterDragExceedsThreshold,
 } from './select-mode/select-mode-hooks'
 import { NO_OP } from '../../../core/shared/utils'
+import { usePropControlledStateV2 } from '../../inspector/common/inspector-utils'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
 export type ResizeStatus = 'disabled' | 'noninteractive' | 'enabled'
+
+function useLocalSelectedHighlightedViews(
+  transientCanvasState: TransientCanvasState,
+): {
+  localSelectedViews: TemplatePath[]
+  localHighlightedViews: TemplatePath[]
+  setSelectedViewsLocally: (newSelectedViews: Array<TemplatePath>) => void
+} {
+  const [localSelectedViews, setLocalSelectedViews] = usePropControlledStateV2(
+    transientCanvasState.selectedViews,
+  )
+  const [localHighlightedViews, setLocalHighlightedViews] = usePropControlledStateV2(
+    transientCanvasState.highlightedViews,
+  )
+
+  const setSelectedViewsLocally = React.useCallback(
+    (newSelectedViews: Array<TemplatePath>) => {
+      setLocalSelectedViews(newSelectedViews)
+      setLocalHighlightedViews([])
+    },
+    [setLocalSelectedViews, setLocalHighlightedViews],
+  )
+  return { localSelectedViews, localHighlightedViews, setSelectedViewsLocally }
+}
 
 export interface ControlProps {
   selectedViews: Array<TemplatePath>
@@ -74,9 +99,6 @@ export interface ControlProps {
 interface NewCanvasControlsProps {
   windowToCanvasPosition: (event: MouseEvent) => CanvasPositions
   cursor: CSSCursor
-  localSelectedViews: Array<TemplatePath>
-  localHighlightedViews: Array<TemplatePath>
-  setLocalSelectedViews: (newSelectedViews: TemplatePath[]) => void
 }
 
 export const NewCanvasControls = betterReactMemo(
@@ -95,9 +117,16 @@ export const NewCanvasControls = betterReactMemo(
         controls: store.derived.canvas.controls,
         scale: store.editor.canvas.scale,
         focusedPanel: store.editor.focusedPanel,
+        transientCanvasState: store.derived.canvas.transientState,
       }),
       'NewCanvasControls',
     )
+
+    const {
+      localSelectedViews,
+      localHighlightedViews,
+      setSelectedViewsLocally,
+    } = useLocalSelectedHighlightedViews(canvasControlProps.transientCanvasState)
 
     // Somehow this being setup and hooked into the div makes the `onDrop` call
     // work properly in `editor-canvas.ts`. I blame React DnD for this.
@@ -153,9 +182,9 @@ export const NewCanvasControls = betterReactMemo(
           >
             <NewCanvasControlsInner
               windowToCanvasPosition={props.windowToCanvasPosition}
-              localSelectedViews={props.localSelectedViews}
-              localHighlightedViews={props.localHighlightedViews}
-              setLocalSelectedViews={props.setLocalSelectedViews}
+              localSelectedViews={localSelectedViews}
+              localHighlightedViews={localHighlightedViews}
+              setLocalSelectedViews={setSelectedViewsLocally}
               {...canvasControlProps}
             />
           </div>

--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
@@ -43,16 +43,14 @@ function useGetHiglightableViewsForInsertMode() {
 }
 
 export function useInsertModeSelectAndHover(): {
-  onMouseOver: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
-  onMouseOut: () => void
+  onMouseMove: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 } {
   const getHiglightableViewsForInsertMode = useGetHiglightableViewsForInsertMode()
-  const { onMouseOver, onMouseOut } = useHighlightCallbacks(getHiglightableViewsForInsertMode)
+  const { onMouseMove } = useHighlightCallbacks(getHiglightableViewsForInsertMode)
 
   return useKeepShallowReferenceEquality({
-    onMouseOver: onMouseOver,
-    onMouseOut: onMouseOut,
+    onMouseMove: onMouseMove,
     onMouseDown: NO_OP,
   })
 }

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -46,6 +46,27 @@ export function findFirstParentWithValidUID(
   }
 }
 
+export function getValidTargetAtPoint(
+  validTemplatePaths: Array<string>,
+  point: WindowPoint | null,
+): TemplatePath | null {
+  if (point == null) {
+    return null
+  }
+  const elementsUnderPoint = document.elementsFromPoint(point.x, point.y)
+  return (
+    stripNulls(
+      elementsUnderPoint.map((element) => {
+        const foundValidtemplatePath = findFirstParentWithValidUID(validTemplatePaths, element)
+        if (foundValidtemplatePath != null) {
+          return TP.fromString(foundValidtemplatePath)
+        }
+        return null
+      }),
+    )[0] ?? null
+  )
+}
+
 export function getAllTargetsAtPoint(point: WindowPoint | null): Array<TemplatePath> {
   if (point == null) {
     return []

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -54,17 +54,13 @@ export function getValidTargetAtPoint(
     return null
   }
   const elementsUnderPoint = document.elementsFromPoint(point.x, point.y)
-  return (
-    stripNulls(
-      elementsUnderPoint.map((element) => {
-        const foundValidtemplatePath = findFirstParentWithValidUID(validTemplatePaths, element)
-        if (foundValidtemplatePath != null) {
-          return TP.fromString(foundValidtemplatePath)
-        }
-        return null
-      }),
-    )[0] ?? null
-  )
+  for (const element of elementsUnderPoint) {
+    const foundValidtemplatePath = findFirstParentWithValidUID(validTemplatePaths, element)
+    if (foundValidtemplatePath != null) {
+      return TP.fromString(foundValidtemplatePath)
+    }
+  }
+  return null
 }
 
 export function getAllTargetsAtPoint(point: WindowPoint | null): Array<TemplatePath> {

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -155,7 +155,6 @@ export function renderCanvasReturnResultAndError(
       addToConsoleLogs: addToConsoleLogs,
       linkTags: '',
       combinedTopLevelArbitraryBlock: combinedTopLevelArbitraryBlock,
-      setSelectedViewsForCanvasControlsOnly: Utils.NO_OP,
     }
   } else {
     canvasProps = {
@@ -176,7 +175,6 @@ export function renderCanvasReturnResultAndError(
       addToConsoleLogs: addToConsoleLogs,
       linkTags: '',
       combinedTopLevelArbitraryBlock: combinedTopLevelArbitraryBlock,
-      setSelectedViewsForCanvasControlsOnly: Utils.NO_OP,
     }
   }
 

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -453,19 +453,12 @@ const CanvasContainer: React.FunctionComponent<React.PropsWithChildren<CanvasCon
   // eslint-disable-next-line react-hooks/rules-of-hooks
   let containerRef = props.walkDOM ? useDomWalker(props) : React.useRef<HTMLDivElement>(null)
 
-  const { onMouseOver, onMouseOut, onMouseDown } = useSelectAndHover(
-    props.setSelectedViewsForCanvasControlsOnly,
-  )
-
   const { scale, offset } = props
   return (
     <div
       id={CanvasContainerID}
       key={'canvas-container'}
       ref={containerRef}
-      onMouseOver={onMouseOver}
-      onMouseOut={onMouseOut}
-      onMouseDown={onMouseDown}
       style={{
         all: 'initial',
         position: 'absolute',

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -119,7 +119,6 @@ export interface UiJsxCanvasProps {
   addToConsoleLogs: (log: ConsoleLog) => void
   linkTags: string
   combinedTopLevelArbitraryBlock: ArbitraryJSBlock | null
-  setSelectedViewsForCanvasControlsOnly: (newSelectedViews: TemplatePath[]) => void
 }
 
 export interface CanvasReactReportErrorCallback {
@@ -146,7 +145,6 @@ export function pickUiJsxCanvasProps(
   clearConsoleLogs: () => void,
   addToConsoleLogs: (log: ConsoleLog) => void,
   dispatch: EditorDispatch,
-  setSelectedViewsForCanvasControlsOnly: (newSelectedViews: TemplatePath[]) => void,
 ): UiJsxCanvasProps | null {
   const uiFile = getOpenUIJSFile(editor)
   const uiFilePath = getOpenUIJSFileKey(editor)
@@ -217,7 +215,6 @@ export function pickUiJsxCanvasProps(
       shouldIncludeCanvasRootInTheSpy: true,
       linkTags: linkTags,
       combinedTopLevelArbitraryBlock: combinedTopLevelArbitraryBlock,
-      setSelectedViewsForCanvasControlsOnly: setSelectedViewsForCanvasControlsOnly,
     }
   }
 }
@@ -372,7 +369,6 @@ export const UiJsxCanvas = betterReactMemo(
                 onDomReport={onDomReport}
                 validRootPaths={rootValidPaths}
                 canvasRootElementTemplatePath={storyboardRootElementPath}
-                setSelectedViewsForCanvasControlsOnly={props.setSelectedViewsForCanvasControlsOnly}
               >
                 <SceneLevelUtopiaContext.Provider
                   value={{ validPaths: rootValidPaths, scenePath: rootScenePath }}
@@ -444,7 +440,6 @@ export interface CanvasContainerProps {
   canvasRootElementTemplatePath: TemplatePath
   validRootPaths: Array<StaticInstancePath>
   mountCount: number
-  setSelectedViewsForCanvasControlsOnly: (newSelectedViews: TemplatePath[]) => void
 }
 
 const CanvasContainer: React.FunctionComponent<React.PropsWithChildren<CanvasContainerProps>> = (

--- a/editor/src/templates/editor-canvas.ts
+++ b/editor/src/templates/editor-canvas.ts
@@ -506,9 +506,6 @@ interface EditorCanvasProps extends CanvasReactErrorCallback {
   canvasConsoleLogs: Array<ConsoleLog>
   clearConsoleLogs: () => void
   addToConsoleLogs: (log: ConsoleLog) => void
-  localSelectedViews: Array<TemplatePath>
-  localHighlightedViews: Array<TemplatePath>
-  setLocalSelectedViews: (newSelectedViews: TemplatePath[]) => void
 }
 
 export class EditorCanvas extends React.Component<EditorCanvasProps> {
@@ -662,9 +659,6 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
       windowToCanvasPosition: this.getPosition,
       cursor,
       getPositionFromCoordinates: this.getPositionFromCoordinates,
-      localSelectedViews: this.props.localSelectedViews,
-      localHighlightedViews: this.props.localHighlightedViews,
-      setLocalSelectedViews: this.props.setLocalSelectedViews,
     })
 
     const canvasLiveEditingStyle = canvasIsLive
@@ -787,7 +781,6 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         addToConsoleLogs: this.props.addToConsoleLogs,
         getPositionFromCoordinates: this.getPositionFromCoordinates,
         dispatch: this.props.dispatch,
-        setSelectedViewsForCanvasControlsOnly: this.props.setLocalSelectedViews,
       }),
       canvasControls,
     )


### PR DESCRIPTION
**Problem:**
The dom-based select mode hooks removed the canvas control overlay. This meant that they could directly subscribe to mouseDown events on the canvas elements. However, it had the unfortunate side effect that the user's code got every mouse event that was previously conveniently prevented by the canvas controls overlay div.

**Fix:**
This PR reinstates the canvas control overlay div with pointerEvents enabled. The hover and select detection now uses the `document.elementsFromPoint(point.x, point.y)` API instead of relying on mouseDown and mouseOver events.

**Commit Details:**
- Moved the hook entry point to new-canvas-controls
- Changed the hooks to use `getValidTargetAtPoint`
- Moved the `localSelectedViews` performance-hack to new-canvas-controls as now that is the highest point in the tree that needs them. 
- Made `canvas-component-entry` and `ui-jsx-canvas` clean again