### PR TITLE
Still support modifying elements in arbitrary blocks.

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -11960,14 +11960,14 @@ Object {
                <div data-uid={'ccc'}>{n}</div>
              </div>;
 });",
-            "originalJavascript": "[1, 2, 3].map(n => {
+            "originalJavascript": " [1, 2, 3].map(n => {
              return <div data-uid={'bbb'}>
                <div data-uid={'ccc'}>{n}</div>
              </div>
            })",
             "sourceMap": Object {
               "file": "code.tsx",
-              "mappings": "OAAE,CAAD,CAAC,EAAD,CAAC,EAAD,CAAC,EAAD,GAAC,CAAc,aAAI;AACP;AAAA;AAAA;AADb,CAAE,CAAD",
+              "mappings": "OAAG,CAAD,CAAC,EAAD,CAAC,EAAD,CAAC,EAAD,GAAC,CAAc,aAAI;AACR;AAAA;AAAA;AADb,CAAG,CAAD",
               "names": Array [],
               "sources": Array [
                 "code.tsx",

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
@@ -251,7 +251,7 @@ export var whatever = (props) => {
       },
       [
         jsxArbitraryBlock(
-          `arr.map(({ n }) => <View data-uid='aab' thing={n} /> )`,
+          ` arr.map(({ n }) => <View data-uid='aab' thing={n} /> ) `,
           `arr.map(({ n }) => <View data-uid='aab' thing={n} />);`,
           `return arr.map(function (_ref) {
   var n = _ref.n;
@@ -349,7 +349,7 @@ export var whatever = (props) => {
       },
       [
         jsxArbitraryBlock(
-          `arr.map(({ a: { n } }) => <View data-uid='aab' thing={n} /> )`,
+          ` arr.map(({ a: { n } }) => <View data-uid='aab' thing={n} /> ) `,
           `arr.map(({ a: { n } }) => <View data-uid='aab' thing={n} />);`,
           `return arr.map(function (_ref) {
   var n = _ref.a.n;
@@ -442,7 +442,7 @@ export var whatever = (props) => {
 }
 `
     const actualResult = clearParseResultUniqueIDs(testParseCode(code))
-    const originalMapJsCode = `arr.map(([ n ]) => <View data-uid='aab' thing={n} /> )`
+    const originalMapJsCode = ` arr.map(([ n ]) => <View data-uid='aab' thing={n} /> ) `
     const mapJsCode = `arr.map(([n]) => <View data-uid='aab' thing={n} />);`
     const transpiledMapJsCode = `return arr.map(function (_ref) {
   var _ref2 = babelHelpers.slicedToArray(_ref, 1),
@@ -548,7 +548,7 @@ export var whatever = (props) => {
       },
       [
         jsxArbitraryBlock(
-          `[1].map((n) => <div data-uid='aab'><div data-uid='aac'>{n}</div></div> )`,
+          ` [1].map((n) => <div data-uid='aab'><div data-uid='aac'>{n}</div></div> ) `,
           `[1].map(n => <div data-uid='aab'><div data-uid='aac'>{n}</div></div>);`,
           `return [1].map(function (n) {
   return utopiaCanvasJSXLookup("aab", {
@@ -738,7 +738,7 @@ export var whatever = (props) => {
       },
       [
         jsxArbitraryBlock(
-          `[1].map((n) => <div data-uid='aab'><div data-uid='aac'>{n}</div></div> )`,
+          ` [1].map((n) => <div data-uid='aab'><div data-uid='aac'>{n}</div></div> ) `,
           `[1].map(n => <div data-uid='aab'><div data-uid='aac'>{n}</div></div>);`,
           `return [1].map(function (n) {
   return utopiaCanvasJSXLookup("aab", {

--- a/editor/src/core/workers/parser-printer/parser-printer-uids.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-uids.spec.ts
@@ -2,8 +2,21 @@ import { MajesticBrokerTestCaseCode } from '../../../test-cases/majestic-broker'
 import { getAllUniqueUids } from '../../model/element-template-utils'
 import { getComponentsFromTopLevelElements } from '../../model/project-file-utils'
 import { uniq } from '../../shared/array-utils'
+import {
+  isJSXArbitraryBlock,
+  isJSXElement,
+  isUtopiaJSXComponent,
+  jsxArbitraryBlock,
+  jsxAttributeValue,
+  jsxElement,
+  utopiaJSXComponent,
+} from '../../shared/element-template'
 import { foldParsedTextFile } from '../../shared/project-file-types'
+import { parseSuccess } from '../common/project-file-utils'
+import { parseCode, printCode, printCodeOptions } from './parser-printer'
+import { emptyComments } from './parser-printer-comments'
 import { testParseCode } from './parser-printer.test-utils'
+import { applyPrettier } from './prettier-utils'
 
 describe('parseCode', () => {
   it('produces unique IDs for every element', () => {
@@ -20,5 +33,137 @@ describe('parseCode', () => {
       (_) => fail('Is unparsed.'),
       parseResult,
     )
+  })
+})
+
+describe('printCode', () => {
+  it('applies changes back into the original code', () => {
+    const startingCode = `
+/** @jsx jsx */
+import * as react from 'react'
+import { scene, storyboard, jsx, view } from 'utopia-api'
+export var app = (props) => {
+  return (
+    <div
+      style={{ width: '100%', height: '100%', position: 'relative' }}
+    >
+      {
+        <div
+          style={{
+            backgroundColor: 'red',
+            position: 'absolute',
+            width: 86,
+            height: 130,
+            left: 45,
+            top: 87,
+          }}
+        />
+      }
+    </div>
+  )
+}
+    `
+    const parsedCode = parseCode('test.js', startingCode)
+    const actualResult = foldParsedTextFile(
+      (_) => 'FAILURE',
+      (success) => {
+        const updatedTopLevelElements = success.topLevelElements.map((tle) => {
+          if (isUtopiaJSXComponent(tle)) {
+            const rootElement = tle.rootElement
+            if (isJSXElement(rootElement)) {
+              const firstChild = rootElement.children[0]
+              if (isJSXArbitraryBlock(firstChild)) {
+                const firstKey = Object.keys(firstChild.elementsWithin)[0]
+                const firstElementWithin = firstChild.elementsWithin[firstKey]
+                const updatedAttributes = {
+                  style: jsxAttributeValue(
+                    {
+                      backgroundColor: 'red',
+                      position: 'absolute',
+                      left: 0,
+                      top: 0,
+                      width: 100,
+                      height: 200,
+                    },
+                    emptyComments,
+                  ),
+                }
+                const updatedElementsWithin = {
+                  [firstKey]: jsxElement(
+                    firstElementWithin.name,
+                    updatedAttributes,
+                    firstElementWithin.children,
+                  ),
+                }
+                const updatedFirstChild = jsxArbitraryBlock(
+                  firstChild.originalJavascript,
+                  firstChild.javascript,
+                  firstChild.transpiledJavascript,
+                  firstChild.definedElsewhere,
+                  firstChild.sourceMap,
+                  updatedElementsWithin,
+                )
+                const updatedRootElement = jsxElement(rootElement.name, rootElement.props, [
+                  updatedFirstChild,
+                ])
+                const updatedComponent = utopiaJSXComponent(
+                  tle.name,
+                  tle.isFunction,
+                  tle.declarationSyntax,
+                  tle.blockOrExpression,
+                  tle.param,
+                  tle.propsUsed,
+                  updatedRootElement,
+                  tle.arbitraryJSBlock,
+                  tle.usedInReactDOMRender,
+                  tle.comments,
+                  tle.returnStatementComments,
+                )
+                return updatedComponent
+              }
+            }
+          }
+          return tle
+        })
+        return printCode(
+          printCodeOptions(false, true, false, true),
+          success.imports,
+          updatedTopLevelElements,
+          success.jsxFactoryFunction,
+          success.exportsDetail,
+        )
+      },
+      (_) => 'UNPARSED',
+      parsedCode,
+    )
+    const expectedResult = applyPrettier(
+      `
+/** @jsx jsx */
+import * as react from 'react'
+import { scene, storyboard, jsx, view } from 'utopia-api'
+export var app = (props) => {
+  return (
+    <div
+      style={{ width: '100%', height: '100%', position: 'relative' }}
+    >
+      {
+        <div
+          style={{
+            backgroundColor: 'red',
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 200,
+          }}
+        />
+      }
+    </div>
+  )
+}
+    `,
+      false,
+    ).formatted
+    expect(actualResult).toEqual(expectedResult)
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -385,7 +385,7 @@ function jsxElementToExpression(
           )]
         )`
       } else {
-        createExpressionAsString = creator(element.originalJavascript)
+        createExpressionAsString = creator(element.javascript)
       }
       let newExpression = SafeFunction(
         false,


### PR DESCRIPTION
Fixes #834

**Problem:**
In an earlier piece of work the printing of code was changed to pull across the comments, but inadvertently stopped some generated `data-uid` keys from coming through. This resulted in elements embedded in arbitrary blocks not getting updated correctly.

**Fix:**
The core of this was to carry over the correct variant of the JavaScript code, which then caused a bunch of fallout problems mostly around the start position as that shifts with the leading comments as they're earlier in the file than the code they relate to.

**Commit Details:**
- Fixes #834.
- `parseOtherJavaScript` supports a more complicated type instead of
  just raw `Node` elements so that the comments and the start position
  including those comments can be carried through.
- `parseJSXArbitraryBlock` does some juggling to get the right values
  passed through into `parseOtherJavaScript` including some surrounding
  whitespace.
- Switched `jsxElementToExpression` from using the `originalJavascript`
  property to the `javascript` property as that includes the comments
  and the `data-uid`.
- Additional mitigation in `transformSourceFile` to cater for expressions
  that now have an ending semicolon which trailing comments can be set on
  as leading comments.
