### PR TITLE
fixing multiselect dragging

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -431,10 +431,10 @@ export function useSelectModeSelectAndHover(
           updatedSelection = foundTarget != null ? [foundTarget.templatePath] : []
         }
 
-        // first we only set the selected views for the canvas controls
-        setSelectedViewsForCanvasControlsOnly(updatedSelection)
-
         if (!(foundTarget?.isSelected ?? false)) {
+          // first we only set the selected views for the canvas controls
+          setSelectedViewsForCanvasControlsOnly(updatedSelection)
+
           requestAnimationFrame(() => {
             requestAnimationFrame(() => {
               // then we set the selected views for the editor state, 1 frame later


### PR DESCRIPTION
you can try me here: http://utopia.pizza/p/25647216-cypress-emperor/?branch_name=fix/multiselect-dragging

**Problem:**
Click to drag on an element that was multiselected accidentally led the canvas controls thinking only that one element was selected. This rendered an incorrect selection outline, and applied the wrong snapping.

**Fix:**
It's a one liner basically, we already had code to check if an element is already selected or not, but it was not applied for the local-to-canvas-controls localSelectedViews state.
