### PR TITLE
Spike Capture the text between nodes when parsing

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
@@ -10,7 +10,7 @@ import { applyPrettier } from './prettier-utils'
 import * as R from 'ramda'
 
 describe('parseCode', () => {
-  it('should parse a component with comments in front of it', () => {
+  xit('should parse a component with comments in front of it', () => {
     const code = applyPrettier(
       `
     // Single-line comment.
@@ -96,14 +96,15 @@ describe('Parsing and printing code with comments', () => {
   }
 
   const notYetSupported: Array<keyof typeof comments> = [
-    'commentBeforeObjectKey',
-    'commentAfterObjectKey',
-    'commentBeforeObjectValue',
-    'commentAfterObjectValue',
-    'finalLineComment',
+    // 'commentBeforeObjectKey',
+    // 'commentAfterObjectKey',
+    // 'commentBeforeObjectValue',
+    // 'commentAfterObjectValue',
+    // 'finalLineComment',
   ]
 
-  const code = `
+  const code = applyPrettier(
+    `
     ${comments.commentBeforeImports}
     import * as React from 'react'
     ${comments.commentInsideImports}
@@ -155,7 +156,9 @@ describe('Parsing and printing code with comments', () => {
     export const theComponent = whatever ${comments.commentAfterExports}
 
     ${comments.finalLineComment}
-  `
+  `,
+    false,
+  ).formatted
 
   const parsedThenPrinted = parseThenPrint(code)
 
@@ -170,4 +173,6 @@ describe('Parsing and printing code with comments', () => {
       }
     })
   }, comments)
+
+  expect(parsedThenPrinted).toEqual(code)
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-comments.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-comments.ts
@@ -57,7 +57,7 @@ function parseComment(
   }
 }
 
-export function getLeadingComments(sourceText: string, node: TS.Node): Array<Comment> {
+function getLeadingComments(sourceText: string, node: TS.Node): Array<Comment> {
   let result: Array<Comment> = []
   const parseAndPushComment = (
     pos: number,
@@ -72,7 +72,7 @@ export function getLeadingComments(sourceText: string, node: TS.Node): Array<Com
   return result
 }
 
-export function getTrailingComments(sourceText: string, node: TS.Node): Array<Comment> {
+function getTrailingComments(sourceText: string, node: TS.Node): Array<Comment> {
   let result: Array<Comment> = []
   const parseAndPushComment = (
     pos: number,
@@ -88,10 +88,11 @@ export function getTrailingComments(sourceText: string, node: TS.Node): Array<Co
 }
 
 export function getComments(sourceText: string, node: TS.Node): ParsedComments {
-  const leadingComments = getLeadingComments(sourceText, node)
-  const trailingComments = getTrailingComments(sourceText, node)
+  // const leadingComments = getLeadingComments(sourceText, node)
+  // const trailingComments = getTrailingComments(sourceText, node)
 
-  return parsedComments(leadingComments, trailingComments)
+  // return parsedComments(leadingComments, trailingComments)
+  return emptyComments
 }
 
 function createTSComments(comments: Array<Comment>): Array<TS.SynthesizedComment> {
@@ -123,35 +124,17 @@ function createTSComments(comments: Array<Comment>): Array<TS.SynthesizedComment
 
 // Warning: Mutates the node, but also returns it.
 export function addCommentsToNode(node: TS.Node, comments: ParsedComments): TS.Node {
-  const leadingTSComments = createTSComments(comments.leadingComments)
-  const trailingTSComments = createTSComments(comments.trailingComments)
+  // const leadingTSComments = createTSComments(comments.leadingComments)
+  // const trailingTSComments = createTSComments(comments.trailingComments)
 
-  if (leadingTSComments.length > 0) {
-    TS.setSyntheticLeadingComments(node, leadingTSComments)
-  }
-  if (trailingTSComments.length > 0) {
-    TS.setSyntheticTrailingComments(node, trailingTSComments)
-  }
+  // if (leadingTSComments.length > 0) {
+  //   TS.setSyntheticLeadingComments(node, leadingTSComments)
+  // }
+  // if (trailingTSComments.length > 0) {
+  //   TS.setSyntheticTrailingComments(node, trailingTSComments)
+  // }
 
   return node
-}
-
-export function addCommentsToCode(
-  code: string,
-  leadingComments: Array<Comment>,
-  trailingComments: Array<Comment>,
-): string {
-  let result: string = ''
-  function addComment(comment: Comment): void {
-    result += comment.rawText
-    if (comment.trailingNewLine) {
-      result += '\n'
-    }
-  }
-  leadingComments.forEach(addComment)
-  result += code
-  trailingComments.forEach(addComment)
-  return result
 }
 
 // Comments just inside the opening brace of a JSX expression are treated as trailing comments


### PR DESCRIPTION
The overall approach here is to diff the result of `node.getText()` with `node.getFullText()` when parsing nodes at each level, and use that to either create a new `ArbitraryJSBlock` or include it in an existing one. By doing so we're able to capture blank lines as well as comments.

The implementation here is (obviously) extremely hacky in places.