### PR TITLE
fixing scene selection using the scene label

### DIFF
--- a/editor/src/components/canvas/controls/component-area-control.tsx
+++ b/editor/src/components/canvas/controls/component-area-control.tsx
@@ -118,6 +118,8 @@ class ComponentAreaControlInner extends React.Component<ComponentAreaControlProp
         throw new Error('onMouseDown must be provided for mouse enabled controls')
       }
 
+      event.stopPropagation()
+
       this.props.onMouseDown(
         selectedViews,
         this.props.target,


### PR DESCRIPTION
**Problem:**
Clicking on the scene ('App' in the default project) label no longer selected the scene.

**Fix:**
Turns out the problem was that we didn't stop the propagation of the mouse event, it reached the canvas controls overlay div, and that ran the new mousedown handler hook, which then immediately deselected everything.

**Commit Details:**
- Stop propagation of mouse event selecting the scene
