### PR TITLE
fix(canvas) remove storyboard filtering to allow direct canvas selection

### DIFF
--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -555,9 +555,7 @@ export const MetadataUtils = {
     return Utils.flatMapArray(getChildrenInner, immediateChildren)
   },
   getAllScenePaths(scenes: ComponentMetadata[]): ScenePath[] {
-    return scenes
-      .map((s) => s.scenePath)
-      .filter((s) => !TP.pathsEqual(s, EmptyScenePathForStoryboard))
+    return scenes.map((s) => s.scenePath)
   },
   getCanvasRootScenesAndElements(
     metadata: JSXMetadata,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -555,6 +555,11 @@ export const MetadataUtils = {
     return Utils.flatMapArray(getChildrenInner, immediateChildren)
   },
   getAllScenePaths(scenes: ComponentMetadata[]): ScenePath[] {
+    return scenes
+      .map((s) => s.scenePath)
+      .filter((s) => !TP.pathsEqual(s, EmptyScenePathForStoryboard))
+  },
+  getAllScenePathsIncludingStoryboardForOrphans(scenes: ComponentMetadata[]): ScenePath[] {
     return scenes.map((s) => s.scenePath)
   },
   getCanvasRootScenesAndElements(
@@ -614,7 +619,7 @@ export const MetadataUtils = {
       fastForEach(element?.children ?? [], recurseElement)
     }
 
-    const scenePaths = this.getAllScenePaths(metadata.components)
+    const scenePaths = this.getAllScenePathsIncludingStoryboardForOrphans(metadata.components)
 
     fastForEach(scenePaths, (scenePath) => {
       const scene = metadata.components.find((s) => TP.pathsEqual(scenePath, s.scenePath))


### PR DESCRIPTION
Fixes a bug where it is not possible to select elements that are directly inserted to the canvas (without Scenes).