### PR TITLE
fix: re-enable inserting onto selected element

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
@@ -47,7 +47,7 @@ export function useInsertModeSelectAndHover(): {
   onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 } {
   const getHiglightableViewsForInsertMode = useGetHiglightableViewsForInsertMode()
-  const { onMouseMove } = useHighlightCallbacks(getHiglightableViewsForInsertMode)
+  const { onMouseMove } = useHighlightCallbacks(true, getHiglightableViewsForInsertMode)
 
   return useKeepShallowReferenceEquality({
     onMouseMove: onMouseMove,

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -350,6 +350,7 @@ function useGetSelectableViewsForSelectMode() {
 }
 
 export function useHighlightCallbacks(
+  allowHoverOnSelectedView: boolean,
   getHighlightableViews: (
     allElementsDirectlySelectable: boolean,
     childrenSelectable: boolean,
@@ -368,17 +369,18 @@ export function useHighlightCallbacks(
         selectableViews,
         windowPoint(point(event.clientX, event.clientY)),
       )
-      if (validTemplatePath == null) {
+      if (
+        validTemplatePath == null ||
+        (!allowHoverOnSelectedView && validTemplatePath.isSelected) // we remove highlights if the hovered element is selected
+      ) {
         maybeClearHighlightsOnHoverEnd()
       } else if (!TP.pathsEqual(validTemplatePath.templatePath, previousTargetUnderPoint.current)) {
-        if (!validTemplatePath.isSelected) {
-          // do not highlight selected view
-          maybeHighlightOnHover(validTemplatePath.templatePath)
-        }
+        maybeHighlightOnHover(validTemplatePath.templatePath)
       }
       previousTargetUnderPoint.current = validTemplatePath?.templatePath ?? null
     },
     [
+      allowHoverOnSelectedView,
       maybeClearHighlightsOnHoverEnd,
       maybeHighlightOnHover,
       getHighlightableViews,
@@ -402,7 +404,7 @@ export function useSelectModeSelectAndHover(
   const getSelectableViewsForSelectMode = useGetSelectableViewsForSelectMode()
   const startDragStateAfterDragExceedsThreshold = useStartDragStateAfterDragExceedsThreshold()
 
-  const { onMouseMove } = useHighlightCallbacks(getSelectableViewsForSelectMode)
+  const { onMouseMove } = useHighlightCallbacks(false, getSelectableViewsForSelectMode)
 
   const onMouseDown = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {


### PR DESCRIPTION
**Problem:**
There was an embarrassing bug in which you couldn't insert anything onto the selected element. 
The problem is that insert mode uses highlights to select the insertion target parent. However, my new highlight logic explicitly disallowed highlighting selected elements.

**Fix:**
Change the highlight logic: it takes an extra parameter (`allowHoverOnSelectedView`) and only disallows hover when in select mode.

**Commit Details:**
- Add new parameter `allowHoverOnSelectedView` to `useHighlightCallbacks`
- In insert mode, allow highlighting the selected element so we can insert into it
- In select mode, actually deselect if the mouse is over a selected element (this is a second bugfix – the highlights were 'sticky' when mousing over a selected element)