### PR TITLE
Add glob filters to the parse-print analysis script.

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -272,6 +272,7 @@
     "jsdom-global": "3.0.2",
     "lint-staged": "8.1.7",
     "livereloadify": "2.0.0",
+    "minimatch": "3.0.4",
     "minimist": "1.2.0",
     "monaco-editor-webpack-plugin": "1.9.0",
     "patch-package": "6.1.2",

--- a/editor/src/scripts/github-projects.ts
+++ b/editor/src/scripts/github-projects.ts
@@ -14,6 +14,8 @@ export interface GitRepoWithRevision {
   pathsToIgnore: Array<string>
 }
 
+export const githubProjectsFileFilters: Array<string> = ['**/__tests__']
+
 export const githubProjects: Array<GitRepoWithRevision> = [
   {
     name: 'react-three-flex-examples',
@@ -34,14 +36,14 @@ export const githubProjects: Array<GitRepoWithRevision> = [
     username: 'utopia-test',
     repositoryName: 'ant-design',
     revision: '739f87ed3dcf613214e7504cf712ac9f1c03d315',
-    pathsToIgnore: [],
+    pathsToIgnore: ['tests'],
   },
   {
     name: 'react-select',
     username: 'JedWatson',
     repositoryName: 'react-select',
     revision: 'd1e660c6b261d7fd60a85a6eca2ee9e3e0348ea2',
-    pathsToIgnore: ['__tests__'],
+    pathsToIgnore: [],
   },
   {
     name: 'react-data-grid',

--- a/editor/src/scripts/parse-print-analysis.ts
+++ b/editor/src/scripts/parse-print-analysis.ts
@@ -9,7 +9,13 @@ import {
 } from '../core/workers/parser-printer/parser-printer'
 import { foldParsedTextFile } from '../core/shared/project-file-types'
 import * as Diff from 'diff'
-import { GitRepoWithRevision, downloadAndExtractRepo, githubProjects } from './github-projects'
+import {
+  GitRepoWithRevision,
+  downloadAndExtractRepo,
+  githubProjects,
+  githubProjectsFileFilters,
+} from './github-projects'
+import * as minimatch from 'minimatch'
 
 const javascriptFileEndings = ['.js', '.ts', '.jsx', '.tsx']
 
@@ -53,6 +59,12 @@ async function processFile(
   )
 }
 
+function allowedByGlobFilters(filePath: string): boolean {
+  return githubProjectsFileFilters.every((filter) => {
+    return !minimatch(filePath, filter)
+  })
+}
+
 async function processProjectCode(
   repo: GitRepoWithRevision,
   rootProjectPath: string,
@@ -66,7 +78,10 @@ async function processProjectCode(
     const fullPathWithoutRoot = fullPath.slice(rootProjectPath.length)
     // Some projects have built files in them which are potentially gigantic.
     // This allows us to filter them out of the results.
-    if (!repo.pathsToIgnore.some((pathToIgnore) => pathToIgnore === fullPathWithoutRoot)) {
+    if (
+      !repo.pathsToIgnore.some((pathToIgnore) => pathToIgnore === fullPathWithoutRoot) &&
+      allowedByGlobFilters(fullPathWithoutRoot)
+    ) {
       // Walk down into the directory if it is one.
       if (dirEntry.isDirectory()) {
         const dirResult = await processProjectCode(repo, rootProjectPath, fullPath)


### PR DESCRIPTION
**Problem:**
Some projects we analyse have test code that is spread throughout the folder hierarchy, like `__tests__`.

**Fix:**
Added the ability to include global wildcard glob filters.

**Commit Details:**
- Added a value containing general glob filters.
- Tweaked a couple of the project listings to improve the results slightly.
- `processProjectCode` now checks the global glob filters.
