### PR TITLE
Re-enable zero-sized elements selection

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1719,10 +1719,21 @@ export function filterMultiSelectScenes(targets: Array<TemplatePath>): Array<Tem
 }
 
 function getReparentTargetAtPosition(
+  componentMeta: JSXMetadata,
   selectedViews: Array<TemplatePath>,
-  position: CanvasPoint,
+  hiddenInstances: Array<TemplatePath>,
+  canvasScale: number,
+  canvasOffset: CanvasVector,
 ): TemplatePath | undefined {
-  const allTargets = getAllTargetsAtPoint(WindowMousePositionRaw)
+  const allTargets = getAllTargetsAtPoint(
+    componentMeta,
+    selectedViews,
+    hiddenInstances,
+    'no-filter',
+    WindowMousePositionRaw,
+    canvasScale,
+    canvasOffset,
+  )
   // filtering for non-selected views from alltargets
   return R.head(
     allTargets.filter((target) => selectedViews.every((view) => !TP.pathsEqual(view, target))),
@@ -1738,7 +1749,13 @@ export function getReparentTarget(
   shouldReparent: boolean
   newParent: TemplatePath | null
 } {
-  const result = getReparentTargetAtPosition(selectedViews, position)
+  const result = getReparentTargetAtPosition(
+    editorState.jsxMetadataKILLME,
+    selectedViews,
+    editorState.hiddenInstances,
+    editorState.canvas.scale,
+    editorState.canvas.realCanvasOffset,
+  )
   const possibleNewParent = result == undefined ? null : result
   const currentParents = Utils.stripNulls(
     toReparent.map((view) => MetadataUtils.getParent(editorState.jsxMetadataKILLME, view)),

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -174,15 +174,28 @@ function useFindValidTarget(): (
       componentMetadata: store.editor.jsxMetadataKILLME,
       selectedViews: store.editor.selectedViews,
       hiddenInstances: store.editor.hiddenInstances,
+      canvasScale: store.editor.canvas.scale,
+      canvasOffset: store.editor.canvas.realCanvasOffset,
     }
   })
 
   return React.useCallback(
     (selectableViews: Array<TemplatePath>, mousePoint: WindowPoint | null) => {
-      const { selectedViews } = storeRef.current
+      const {
+        selectedViews,
+        componentMetadata,
+        hiddenInstances,
+        canvasScale,
+        canvasOffset,
+      } = storeRef.current
       const validElementMouseOver: TemplatePath | null = getValidTargetAtPoint(
+        componentMetadata,
+        selectedViews,
+        hiddenInstances,
         selectableViews.map(TP.toString),
         mousePoint,
+        canvasScale,
+        canvasOffset,
       )
       const validTemplatePath: TemplatePath | null =
         validElementMouseOver != null ? validElementMouseOver : null

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -1,6 +1,7 @@
 import * as R from 'ramda'
 import { last, stripNulls } from '../../core/shared/array-utils'
 import { getDOMAttribute } from '../../core/shared/dom-utils'
+import { JSXMetadata } from '../../core/shared/element-template'
 import {
   canvasPoint,
   CanvasVector,
@@ -13,6 +14,7 @@ import {
 } from '../../core/shared/math-utils'
 import { TemplatePath } from '../../core/shared/project-file-types'
 import * as TP from '../../core/shared/template-path'
+import Canvas, { TargetSearchType } from './canvas'
 import { CanvasPositions } from './canvas-types'
 
 export function findParentSceneValidPaths(target: Element): Array<string> | null {
@@ -29,13 +31,16 @@ export function findParentSceneValidPaths(target: Element): Array<string> | null
 }
 
 export function findFirstParentWithValidUID(
-  validTemplatePathsForLookup: Array<string>,
+  validTemplatePathsForLookup: Array<string> | 'no-filter',
   target: Element,
 ): string | null {
   const uid = getDOMAttribute(target, 'data-uid')
   const originalUid = getDOMAttribute(target, 'data-utopia-original-uid')
   const validTemplatePathsForScene = findParentSceneValidPaths(target) ?? []
-  const validTemplatePaths = R.intersection(validTemplatePathsForLookup, validTemplatePathsForScene)
+  const validTemplatePaths =
+    validTemplatePathsForLookup === 'no-filter'
+      ? validTemplatePathsForScene
+      : R.intersection(validTemplatePathsForLookup, validTemplatePathsForScene)
   if (originalUid != null && validTemplatePaths.find((tp) => tp.endsWith(originalUid))) {
     return last(validTemplatePaths.filter((tp) => tp.endsWith(originalUid))) ?? null
   } else if (uid != null && validTemplatePaths.find((tp) => tp.endsWith(uid))) {
@@ -50,39 +55,76 @@ export function findFirstParentWithValidUID(
 }
 
 export function getValidTargetAtPoint(
-  validTemplatePaths: Array<string>,
+  componentMetadata: JSXMetadata,
+  selectedViews: Array<TemplatePath>,
+  hiddenInstances: Array<TemplatePath>,
+  validTemplatePathsForLookup: Array<string> | 'no-filter',
   point: WindowPoint | null,
+  canvasScale: number,
+  canvasOffset: CanvasVector,
 ): TemplatePath | null {
   if (point == null) {
     return null
   }
-  const elementsUnderPoint = document.elementsFromPoint(point.x, point.y)
-  for (const element of elementsUnderPoint) {
-    const foundValidtemplatePath = findFirstParentWithValidUID(validTemplatePaths, element)
-    if (foundValidtemplatePath != null) {
-      return TP.fromString(foundValidtemplatePath)
-    }
-  }
-  return null
+  return (
+    getAllTargetsAtPoint(
+      componentMetadata,
+      selectedViews,
+      hiddenInstances,
+      validTemplatePathsForLookup,
+      point,
+      canvasScale,
+      canvasOffset,
+    )[0] ?? null
+  )
 }
 
-export function getAllTargetsAtPoint(point: WindowPoint | null): Array<TemplatePath> {
+export function getAllTargetsAtPoint(
+  componentMetadata: JSXMetadata,
+  selectedViews: Array<TemplatePath>,
+  hiddenInstances: Array<TemplatePath>,
+  validTemplatePathsForLookup: Array<string> | 'no-filter',
+  point: WindowPoint | null,
+  canvasScale: number,
+  canvasOffset: CanvasVector,
+): Array<TemplatePath> {
   if (point == null) {
     return []
   }
+  const pointOnCanvas = windowToCanvasCoordinates(canvasScale, canvasOffset, point)
+  const getElementsUnderPointFromAABB = Canvas.getAllTargetsAtPoint(
+    componentMetadata,
+    selectedViews,
+    hiddenInstances,
+    pointOnCanvas.canvasPositionRaw,
+    [TargetSearchType.All],
+    false,
+    'loose',
+  )
   const elementsUnderPoint = document.elementsFromPoint(point.x, point.y)
-  return stripNulls(
+  const elementsFromDOM = stripNulls(
     elementsUnderPoint.map((element) => {
-      const validTPs = findParentSceneValidPaths(element)
-      if (validTPs != null) {
-        const foundValidtemplatePath = findFirstParentWithValidUID(validTPs, element)
-        if (foundValidtemplatePath != null) {
-          return TP.fromString(foundValidtemplatePath)
-        }
+      const foundValidtemplatePath = findFirstParentWithValidUID(
+        validTemplatePathsForLookup,
+        element,
+      )
+      if (foundValidtemplatePath != null) {
+        return TP.fromString(foundValidtemplatePath)
+      } else {
+        return null
       }
-      return null
     }),
   )
+
+  return getElementsUnderPointFromAABB
+    .filter((foundElement) => {
+      if (!foundElement.canBeFilteredOut) {
+        return true
+      } else {
+        return elementsFromDOM.includes(foundElement.templatePath)
+      }
+    })
+    .map((e) => e.templatePath)
 }
 
 export function windowToCanvasCoordinates(

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -462,7 +462,15 @@ export function handleKeyDown(
           if (CanvasMousePositionRaw == null) {
             return [EditorActions.clearSelection()]
           }
-          const targetStack = getAllTargetsAtPoint(WindowMousePositionRaw)
+          const targetStack = getAllTargetsAtPoint(
+            editor.jsxMetadataKILLME,
+            editor.selectedViews,
+            editor.hiddenInstances,
+            'no-filter',
+            WindowMousePositionRaw,
+            editor.canvas.scale,
+            editor.canvas.realCanvasOffset,
+          )
           const nextTarget = Canvas.getNextTarget(editor.selectedViews, targetStack)
           if (targetStack.length === 0 || nextTarget === null) {
             return [EditorActions.clearSelection()]


### PR DESCRIPTION
**Problem:**
We lost the ability to select zero-sized elements (using a 5px threshold) when I implemented the DOM-based canvas selection. Unfortunately since these elements have one or two missing dimensions, we cannot rely on the DOM apis to be able to select them.

**Fix:**
Resurrect `Canvas.getAllTargetsAtPoint`. `Canvas.getAllTargetsAtPoint` is the primary source of information and ordering of elements. We use the list from `document.elementsFromPoint` to filter out elements which are _not_ under the mouse, unless they have zero size in either dimension.

**Commit Details:**
- Resurrect `Canvas.getAllTargetsAtPoint`.
- make `dom-lookup@getValidTargetAtPoint` use `dom-lookup@getAllTargetsAtPoint`
- make `dom-lookup@getAllTargetsAtPoint` cross-reference `Canvas.getAllTargetsAtPoint` and `document.elementsFromPoint`.

