### PR TITLE
introduce jest-clean-console-reporter

### DIFF
--- a/editor/jest.config.js
+++ b/editor/jest.config.js
@@ -1,4 +1,87 @@
+const rules = [
+  {
+    match: /^Warning: Invalid value for prop `(\w*)` on <(\w*)> tag. Either remove it from the element, or pass a string or number value to keep it in the DOM./,
+    group:
+      'Warning: Invalid value for prop *** on *** tag. Either remove it from the element, or pass a string or number value to keep it in the DOM.',
+    level: 'error',
+  },
+  {
+    match: /^Warning: React.createElement: type is invalid -- expected a string \(for built-in components\) or a class\/function \(for composite components\) but got: undefined./,
+    group: 'Warning: React.createElement called with undefined',
+    level: 'error',
+  },
+  {
+    match: /^Warning: Each child in a list should have a unique "key" prop./,
+    group: 'Warning: Each child in a list should have a unique "key" prop.',
+    level: 'error',
+  },
+  {
+    match: /^Warning: componentWillReceiveProps has been renamed, and is not recommended for use./,
+    group:
+      'Depreciation Warning: componentWillReceiveProps has been renamed, and is not recommended for use.',
+    level: 'error',
+  },
+  {
+    match: /^Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format./,
+    group:
+      'Warning: React.useLayoutEffect used in the tests – should replace with useIsoLayoutEffect',
+    level: 'error',
+  },
+  {
+    match: /^Warning: Cannot update a component \(`OpenFileEditor`\) while rendering a different component \(`UiJsxCanvas`\)./,
+    group:
+      'Warning: FIXME: Cannot update a component (`OpenFileEditor`) while rendering a different component (`UiJsxCanvas`). We should actually fix this!',
+    level: 'error',
+  },
+  {
+    match: /Check the render method of .*Tippy/,
+    group: 'Warning: FIXME: Function components cannot be given refs. Fix Tippy!',
+    level: 'error',
+  },
+  {
+    match: /Cannot log after tests are done. Did you forget to wait for something async in your test\?/,
+    group:
+      'Warning: FIXME: Cannot log after tests are done. Did you forget to wait for something async in your test?',
+    level: 'error',
+  },
+  {
+    match: /Warning: An update to OpenFileEditor inside a test was not wrapped in act/,
+    group: 'Warning: FIXME: An update to OpenFileEditor inside a test was not wrapped in act',
+    level: 'error',
+  },
+  {
+    match: /^Warning: React does not recognize the `(\w*)` prop on a DOM element./,
+    group: 'Warning: React does not recognize the **** prop on a DOM element.',
+    level: 'warning',
+  },
+  {
+    match: /^Warning: Invalid prop `(.*)` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props./,
+    group:
+      'Warning: Invalid prop *** supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props.',
+    level: 'warning',
+  },
+  {
+    match: /gles2_cmd_decoder\.cc/,
+    group: 'Chromium GL errors',
+    level: 'warning',
+  },
+  {
+    match: /Bundler Fatal Error.*ignore me/,
+    group: 'Bundler test output',
+    level: 'log',
+  },
+  {
+    match: /WE EXPECT AN ERROR MESSAGE ON THE CONSOLE - DONT WORRY ITS FOR A TEST/,
+    group: 'Bundler test output',
+    level: 'log',
+  },
+]
+
 module.exports = {
+  reporters: [
+    ['jest-clean-console-reporter', { rules: rules }],
+    '@jest/reporters/build/summary_reporter', // when upgrading to jest 26.6.2 or newer, replace this with "@jest/reporters/build/SummaryReporter"
+  ],
   projects: [
     '../utopia-api',
     {

--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -15604,6 +15604,66 @@
         }
       }
     },
+    "jest-clean-console-reporter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/jest-clean-console-reporter/-/jest-clean-console-reporter-0.2.0.tgz",
+      "integrity": "sha512-+crUBrBbGCHU6hI/yTEnpJhDF+bLg7FFwFgyhL+3qx2qkR9ZRaiTXlRw1rhSUud/PZAWs8wBdg3EtgR3AvTuFg==",
+      "dev": true,
+      "requires": {
+        "chalk": ">=3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "jest-config": {
       "version": "25.5.4",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.5.4.tgz",

--- a/editor/package.json
+++ b/editor/package.json
@@ -265,6 +265,7 @@
     "immutable": "3.8.1",
     "jStat": "1.5.3",
     "jest": "26.1.0",
+    "jest-clean-console-reporter": "^0.2.0",
     "jest-environment-jsdom-global": "2.0.4",
     "jest-matcher-deep-close-to": "2.0.1",
     "jest-transform-stub": "2.0.0",

--- a/editor/package.json
+++ b/editor/package.json
@@ -265,7 +265,7 @@
     "immutable": "3.8.1",
     "jStat": "1.5.3",
     "jest": "26.1.0",
-    "jest-clean-console-reporter": "^0.2.0",
+    "jest-clean-console-reporter": "0.2.0",
     "jest-environment-jsdom-global": "2.0.4",
     "jest-matcher-deep-close-to": "2.0.1",
     "jest-transform-stub": "2.0.0",


### PR DESCRIPTION
**Problem:**
Running `npm run test` produced 80,000 lines of console output, making it impossible to query the logs from GitHub.

**Fix:**
Introducing jest-clean-console-reporter, which helped me categorize most of those console output into a few groups. This reduces the entire console output to less than 2000 lines!

