### PR TITLE
Feature/canvas contextmenu submenu

### DIFF
--- a/editor/resources/editor/ReactContexify.css
+++ b/editor/resources/editor/ReactContexify.css
@@ -11,7 +11,8 @@
 }
 .react-contexify .react-contexify__submenu {
   position: absolute;
-  top: 0;
+  /* negate padding */
+  top: -4px;
   pointer-events: none;
   transition: opacity 0.275s;
 }
@@ -24,7 +25,6 @@
 }
 
 .react-contexify__separator {
-  float: left;
   width: 100%;
   height: 1px;
   cursor: default;
@@ -36,6 +36,7 @@
   font-size: 10px;
   font-weight: 500; /* medium */
   cursor: default;
+  position: relative;
 }
 .react-contexify__item:not(.react-contexify__item--disabled):hover
   > .react-contexify__item__content {
@@ -63,73 +64,53 @@
   margin-right: 6px;
 }
 
-@keyframes react-contexify__popIn {
-  0% {
-    transform: scale(0);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-@keyframes react-contexify__popOut {
-  0% {
-    transform: scale(1);
-  }
-  100% {
-    transform: scale(0);
-  }
-}
-.react-contexify__will-enter--pop {
-  animation: react-contexify__popIn 0.3s cubic-bezier(0.51, 0.92, 0.24, 1.2);
-}
 
-.react-contexify__will-leave--pop {
-  animation: react-contexify__popOut 0.3s cubic-bezier(0.51, 0.92, 0.24, 1.2);
-}
-
-@keyframes react-contexify__zoomIn {
+@keyframes react-contexify__scaleIn {
   from {
-    opacity: 0;
-    transform: scale3d(0.3, 0.3, 0.3);
-  }
-  50% {
-    opacity: 1;
-  }
-}
-@keyframes react-contexify__zoomOut {
-  from {
-    opacity: 1;
-  }
-  50% {
     opacity: 0;
     transform: scale3d(0.3, 0.3, 0.3);
   }
   to {
-    opacity: 0;
+    opacity: 1;
   }
 }
-.react-contexify__will-enter--zoom {
-  animation: react-contexify__zoomIn 0.4s;
+@keyframes react-contexify__scaleOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+    transform: scale3d(0.3, 0.3, 0.3);
+  }
+}
+.react-contexify__will-enter--scale {
+  transform-origin: top left;
+  animation: react-contexify__scaleIn 0.3s;
 }
 
-.react-contexify__will-leave--zoom {
-  animation: react-contexify__zoomOut 0.4s;
+.react-contexify__will-leave--scale {
+  transform-origin: top left;
+  animation: react-contexify__scaleOut 0.3s;
 }
 
 @keyframes react-contexify__fadeIn {
   from {
     opacity: 0;
+    transform: translateY(10px);
   }
   to {
     opacity: 1;
+    transform: translateY(0);
   }
 }
 @keyframes react-contexify__fadeOut {
   from {
     opacity: 1;
+    transform: translateY(0);
   }
   to {
     opacity: 0;
+    transform: translateY(10px);
   }
 }
 .react-contexify__will-enter--fade {
@@ -142,42 +123,71 @@
 
 @keyframes react-contexify__flipInX {
   from {
-    transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
-    animation-timing-function: ease-in;
-  }
-  40% {
-    transform: perspective(400px) rotate3d(1, 0, 0, -20deg);
-    animation-timing-function: ease-in;
-  }
-  60% {
-    transform: perspective(400px) rotate3d(1, 0, 0, 10deg);
-  }
-  80% {
-    transform: perspective(400px) rotate3d(1, 0, 0, -5deg);
+    transform: perspective(800px) rotate3d(1, 0, 0, 45deg);
   }
   to {
-    transform: perspective(400px);
+    transform: perspective(800px);
   }
 }
 @keyframes react-contexify__flipOutX {
   from {
-    transform: perspective(400px);
-  }
-  30% {
-    transform: perspective(400px) rotate3d(1, 0, 0, -20deg);
-    opacity: 1;
+    transform: perspective(800px);
   }
   to {
-    transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
+    transform: perspective(800px) rotate3d(1, 0, 0, 45deg);
     opacity: 0;
   }
 }
 .react-contexify__will-enter--flip {
-  backface-visibility: visible !important;
-  animation: react-contexify__flipInX 0.65s;
+  -webkit-backface-visibility: visible !important;
+          backface-visibility: visible !important;
+  transform-origin: top center;
+  animation: react-contexify__flipInX 0.3s;
 }
 
 .react-contexify__will-leave--flip {
-  animation: react-contexify__flipOutX 0.65s;
-  backface-visibility: visible !important;
+  transform-origin: top center;
+  animation: react-contexify__flipOutX 0.3s;
+  -webkit-backface-visibility: visible !important;
+          backface-visibility: visible !important;
+}
+
+@keyframes swing-in-top-fwd {
+  0% {
+    transform: rotateX(-100deg);
+    transform-origin: top;
+    opacity: 0;
+  }
+  100% {
+    transform: rotateX(0deg);
+    transform-origin: top;
+    opacity: 1;
+  }
+}
+@keyframes react-contexify__slideIn {
+  from {
+    opacity: 0;
+    transform: scale3d(1, 0.3, 1);
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes react-contexify__slideOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+    transform: scale3d(1, 0.3, 1);
+  }
+}
+.react-contexify__will-enter--slide {
+  transform-origin: top center;
+  animation: react-contexify__slideIn 0.3s;
+}
+
+.react-contexify__will-leave--slide {
+  transform-origin: top center;
+  animation: react-contexify__slideOut 0.3s;
 }

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -29,6 +29,8 @@ import { JSXMetadata } from '../../../core/shared/element-template'
 import { BoundingMarks } from './parent-bounding-marks'
 import { RightMenuTab } from '../right-menu'
 import { getSelectableViews } from './select-mode/select-mode-hooks'
+import { getAllTargetsAtPoint } from '../dom-lookup'
+import { WindowMousePositionRaw } from '../../../templates/editor-canvas'
 
 export const SnappingThreshold = 5
 
@@ -145,8 +147,9 @@ export class SelectModeControlContainer extends React.Component<
   onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation()
     event.preventDefault()
+    const elementsUnderCursor = getAllTargetsAtPoint(WindowMousePositionRaw)
     this.props.dispatch(
-      [EditorActions.showContextMenu('context-menu-canvas', event.nativeEvent)],
+      [EditorActions.showContextMenu('context-menu-canvas', event.nativeEvent, { elementsUnderCursor })],
       'canvas',
     )
   }

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -26,6 +26,7 @@ export interface ContextMenuItem<T> {
   submenuName?: string | null
   shortcut?: string
   isSeparator?: boolean
+  details?: {[key: string]: any}
   action: (data: T, dispatch?: EditorDispatch, event?: MouseEvent) => void
 }
 

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -1,4 +1,5 @@
 import * as R from 'ramda'
+import { TriggerEvent } from 'react-contexify'
 import { CanvasPoint } from '../core/shared/math-utils'
 import { InstancePath } from '../core/shared/project-file-types'
 import * as PP from '../core/shared/property-path'
@@ -26,7 +27,7 @@ export interface ContextMenuItem<T> {
   submenuName?: string | null
   shortcut?: string
   isSeparator?: boolean
-  details?: { [key: string]: any }
+  isHidden?: ({props, data, triggerEvent}: {props: any, data: T, triggerEvent: TriggerEvent}) => boolean
   action: (data: T, dispatch?: EditorDispatch, event?: MouseEvent) => void
 }
 

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -26,7 +26,7 @@ export interface ContextMenuItem<T> {
   submenuName?: string | null
   shortcut?: string
   isSeparator?: boolean
-  details?: {[key: string]: any}
+  details?: { [key: string]: any }
   action: (data: T, dispatch?: EditorDispatch, event?: MouseEvent) => void
 }
 

--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react'
 import { Component as ReactComponent } from 'react'
-import { Menu, Item, Submenu as SubmenuComponent, contextMenu, useContextMenu } from 'react-contexify'
+import {
+  Menu,
+  Item,
+  Submenu as SubmenuComponent,
+  contextMenu,
+  useContextMenu,
+} from 'react-contexify'
 import { ContextMenuItem } from './context-menu-items'
 import { EditorDispatch } from './editor/action-types'
 import * as fastDeepEquals from 'fast-deep-equal'
@@ -82,14 +88,16 @@ export class MomentumContextMenu<T> extends ReactComponent<ContextMenuProps<T>> 
     return splitItems
   }
 
-  isHidden = (item: ContextMenuItem<T>): ({ props }: {props: ContextMenuInnerProps}) => boolean => {
-    return (({ props }: {props: ContextMenuInnerProps}) => {
+  isHidden = (
+    item: ContextMenuItem<T>,
+  ): (({ props }: { props: ContextMenuInnerProps }) => boolean) => {
+    return ({ props }: { props: ContextMenuInnerProps }) => {
       if (item.details != null && item.details.path != null && props.elementsUnderCursor != null) {
-        return !props.elementsUnderCursor.some(path => TP.pathsEqual(path, item.details!.path))
+        return !props.elementsUnderCursor.some((path) => TP.pathsEqual(path, item.details!.path))
       } else {
         return false
       }
-    })
+    }
   }
 
   renderItem(item: ContextMenuItem<T>, index: number) {
@@ -98,7 +106,7 @@ export class MomentumContextMenu<T> extends ReactComponent<ContextMenuProps<T>> 
         key={`context-menu-${index}-item`}
         disabled={!item.enabled}
         // eslint-disable-next-line react/jsx-no-bind
-        onClick={({event}: {event: React.MouseEvent<HTMLElement>}) => {
+        onClick={({ event }: { event: React.MouseEvent<HTMLElement> }) => {
           event.stopPropagation()
           item.action(this.props.getData(), this.props.dispatch, event.nativeEvent)
           contextMenu.hideAll()
@@ -212,15 +220,15 @@ interface MenuProviderProps {
 
 export const MenuProvider: React.FunctionComponent<MenuProviderProps> = (props) => {
   const { show } = useContextMenu({ id: props.id })
-  const onContextMenu = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    show(event)
-  }, [show])
+  const onContextMenu = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      show(event)
+    },
+    [show],
+  )
 
   return (
-    <div
-      style={props.style}
-      onContextMenu={onContextMenu}
-    >
+    <div style={props.style} onContextMenu={onContextMenu}>
       {props.children}
     </div>
   )

--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -11,7 +11,6 @@ import { ContextMenuItem } from './context-menu-items'
 import { EditorDispatch } from './editor/action-types'
 import * as fastDeepEquals from 'fast-deep-equal'
 import { TemplatePath } from '../core/shared/project-file-types'
-import * as TP from '../core/shared/template-path'
 
 export interface ContextMenuWrapperProps<T> {
   id: string
@@ -29,7 +28,7 @@ export interface ContextMenuInnerProps {
   elementsUnderCursor: Array<TemplatePath>
 }
 
-export function openMenu(id: string, nativeEvent: MouseEvent, props?: ContextMenuInnerProps) {
+export function openMenu(id: string, nativeEvent: MouseEvent, props: ContextMenuInnerProps | null) {
   contextMenu.show({
     id: id,
     event: nativeEvent,
@@ -88,17 +87,7 @@ export class MomentumContextMenu<T> extends ReactComponent<ContextMenuProps<T>> 
     return splitItems
   }
 
-  isHidden = (
-    item: ContextMenuItem<T>,
-  ): (({ props }: { props: ContextMenuInnerProps }) => boolean) => {
-    return ({ props }: { props: ContextMenuInnerProps }) => {
-      if (item.details != null && item.details.path != null && props.elementsUnderCursor != null) {
-        return !props.elementsUnderCursor.some((path) => TP.pathsEqual(path, item.details!.path))
-      } else {
-        return false
-      }
-    }
-  }
+  isHidden = (): boolean => false
 
   renderItem(item: ContextMenuItem<T>, index: number) {
     return (
@@ -111,7 +100,7 @@ export class MomentumContextMenu<T> extends ReactComponent<ContextMenuProps<T>> 
           item.action(this.props.getData(), this.props.dispatch, event.nativeEvent)
           contextMenu.hideAll()
         }}
-        hidden={this.isHidden(item)}
+        hidden={item.isHidden ?? this.isHidden}
       >
         <span className='react-contexify-span'>{item.name}</span>
         <span className='shortcut'>{item.shortcut}</span>

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -51,6 +51,7 @@ import {
 import { Notice } from '../common/notice'
 import { BuildType } from '../../core/workers/ts/ts-worker'
 import type { EditorTab } from './store/editor-tabs'
+import { ContextMenuInnerProps } from '../../uuiui-deps'
 export { isLoggedIn, loggedInUser, LoginState, notLoggedIn, UserDetails } from '../../common/user'
 
 export interface PropertyTarget {
@@ -513,6 +514,7 @@ export interface ShowContextMenu {
   action: 'SHOW_CONTEXT_MENU'
   menuName: ElementContextMenuInstance
   event: MouseEvent
+  props: ContextMenuInnerProps | null
 }
 
 export interface SetCursorOverlay {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -34,7 +34,7 @@ import type {
 import type { BuildType } from '../../../core/workers/ts/ts-worker'
 import type { Key, KeysPressed } from '../../../utils/keyboard'
 import type { objectKeyParser, parseString } from '../../../utils/value-parser-utils'
-import type { CSSCursor } from '../../../uuiui-deps'
+import type { ContextMenuInnerProps, CSSCursor } from '../../../uuiui-deps'
 import type {
   addFileToProjectContents,
   getContentsTreeFileFromString,
@@ -799,11 +799,13 @@ export function distributeSelectedViews(distribution: Distribution): DistributeS
 export function showContextMenu(
   menuName: ElementContextMenuInstance,
   event: MouseEvent,
+  props: ContextMenuInnerProps | null
 ): ShowContextMenu {
   return {
     action: 'SHOW_CONTEXT_MENU',
     menuName: menuName,
     event: event,
+    props: props,
   }
 }
 

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3149,15 +3149,7 @@ export const UPDATE_FNS = {
   SHOW_CONTEXT_MENU: (action: ShowContextMenu, editor: EditorModel): EditorModel => {
     // side effect!
     if (action.menuName === 'context-menu-canvas') {
-      const elementsUnderCursor = getAllTargetsAtPoint(
-        editor.jsxMetadataKILLME,
-        editor.selectedViews,
-        editor.hiddenInstances,
-        'no-filter',
-        WindowMousePositionRaw,
-        editor.canvas.scale,
-        editor.canvas.realCanvasOffset,
-      )
+      const elementsUnderCursor = getAllTargetsAtPoint(WindowMousePositionRaw)
       openMenu(action.menuName, action.event, {
         elementsUnderCursor: elementsUnderCursor,
       })

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -485,6 +485,8 @@ import {
 } from './action-creators'
 import { EditorTab, isOpenFileTab, openFileTab } from '../store/editor-tabs'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
+import { getAllTargetsAtPoint } from '../../canvas/dom-lookup'
+import { WindowMousePositionRaw } from '../../../templates/editor-canvas'
 
 function applyUpdateToJSXElement(
   element: JSXElement,
@@ -3146,7 +3148,22 @@ export const UPDATE_FNS = {
   },
   SHOW_CONTEXT_MENU: (action: ShowContextMenu, editor: EditorModel): EditorModel => {
     // side effect!
-    openMenu(action.menuName, action.event)
+    if (action.menuName === 'context-menu-canvas') {
+      const elementsUnderCursor = getAllTargetsAtPoint(
+        editor.jsxMetadataKILLME,
+        editor.selectedViews,
+        editor.hiddenInstances,
+        'no-filter',
+        WindowMousePositionRaw,
+        editor.canvas.scale,
+        editor.canvas.realCanvasOffset,
+      )
+      openMenu(action.menuName, action.event, {
+        elementsUnderCursor: elementsUnderCursor
+      })
+    } else {
+      openMenu(action.menuName, action.event)
+    }
     return editor
   },
   SEND_PREVIEW_MODEL: (action: SendPreviewModel, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3148,14 +3148,7 @@ export const UPDATE_FNS = {
   },
   SHOW_CONTEXT_MENU: (action: ShowContextMenu, editor: EditorModel): EditorModel => {
     // side effect!
-    if (action.menuName === 'context-menu-canvas') {
-      const elementsUnderCursor = getAllTargetsAtPoint(WindowMousePositionRaw)
-      openMenu(action.menuName, action.event, {
-        elementsUnderCursor: elementsUnderCursor,
-      })
-    } else {
-      openMenu(action.menuName, action.event)
-    }
+    openMenu(action.menuName, action.event, action.props)
     return editor
   },
   SEND_PREVIEW_MODEL: (action: SendPreviewModel, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3159,7 +3159,7 @@ export const UPDATE_FNS = {
         editor.canvas.realCanvasOffset,
       )
       openMenu(action.menuName, action.event, {
-        elementsUnderCursor: elementsUnderCursor
+        elementsUnderCursor: elementsUnderCursor,
       })
     } else {
       openMenu(action.menuName, action.event)

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -20,14 +20,15 @@ import {
   ContextMenuItem,
   CanvasData,
 } from './context-menu-items'
-import { ContextMenuInnerProps, MomentumContextMenu } from './context-menu-wrapper'
+import { MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState } from './editor/store/store-hook'
 import { filterScenes } from '../core/shared/template-path'
 import { betterReactMemo, Utils } from '../uuiui-deps'
 import { CanvasContextMenuPortalTargetID } from '../core/shared/utils'
 import { MetadataUtils } from '../core/model/element-metadata-utils'
 import { getOpenUtopiaJSXComponentsFromState } from './editor/store/editor-state'
-import { useKeepReferenceEqualityIfPossible } from '../utils/react-performance'
+import { EditorDispatch } from './editor/action-types'
+import { selectComponents } from './editor/actions/action-creators'
 
 export type ElementContextMenuInstance =
   | 'context-menu-navigator'
@@ -61,7 +62,7 @@ const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
   toggleShadowItem,
 ]
 
-function useCanvasContextMenuItems(contextMenuInstance: ElementContextMenuInstance): Array<ContextMenuItem<CanvasData>> {
+function useCanvasContextMenuItems(contextMenuInstance: ElementContextMenuInstance, dispatch: EditorDispatch): Array<ContextMenuItem<CanvasData>> {
   const metadata = useEditorState((store) => store.editor.jsxMetadataKILLME, 'ElementContextMenu metadata')
   const components = useEditorState((store) => getOpenUtopiaJSXComponentsFromState(store.editor), 'ElementContextMenu components')
 
@@ -75,7 +76,7 @@ function useCanvasContextMenuItems(contextMenuInstance: ElementContextMenuInstan
         },
         submenuName: 'Elements',
         enabled: true,
-        action: Utils.NO_OP,
+        action: () => dispatch([selectComponents([path], false)], 'canvas'),
       }
     })
     return [...ElementContextMenuItems, ...elementListSubmenu]
@@ -108,7 +109,7 @@ export const ElementContextMenu = betterReactMemo(
       }
     }, [editorSliceRef])
 
-    const contextMenuItems = useKeepReferenceEqualityIfPossible(useCanvasContextMenuItems(contextMenuInstance))
+    const contextMenuItems = useCanvasContextMenuItems(contextMenuInstance, dispatch)
 
     const portalTarget = document.getElementById(CanvasContextMenuPortalTargetID)
     if (portalTarget == null) {

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -20,15 +20,17 @@ import {
   ContextMenuItem,
   CanvasData,
 } from './context-menu-items'
-import { MomentumContextMenu } from './context-menu-wrapper'
+import { ContextMenuInnerProps, MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState } from './editor/store/store-hook'
 import { filterScenes } from '../core/shared/template-path'
-import { betterReactMemo, Utils } from '../uuiui-deps'
+import { betterReactMemo } from '../uuiui-deps'
 import { CanvasContextMenuPortalTargetID } from '../core/shared/utils'
 import { MetadataUtils } from '../core/model/element-metadata-utils'
 import { getOpenUtopiaJSXComponentsFromState } from './editor/store/editor-state'
 import { EditorDispatch } from './editor/action-types'
 import { selectComponents } from './editor/actions/action-creators'
+import * as TP from '../core/shared/template-path'
+import { TemplatePath } from '../core/shared/project-file-types'
 
 export type ElementContextMenuInstance =
   | 'context-menu-navigator'
@@ -88,6 +90,13 @@ function useCanvasContextMenuItems(
         submenuName: 'Elements',
         enabled: true,
         action: () => dispatch([selectComponents([path], false)], 'canvas'),
+        isHidden: ({props}: {props: ContextMenuInnerProps}) => {
+          if (props.elementsUnderCursor != null && Array.isArray(props.elementsUnderCursor)) {
+            return !props.elementsUnderCursor.some((underCursor: TemplatePath) => TP.pathsEqual(underCursor, path))
+          } else {
+            return true
+          }
+        }
       }
     })
     return [...ElementContextMenuItems, ...elementListSubmenu]

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -62,12 +62,23 @@ const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
   toggleShadowItem,
 ]
 
-function useCanvasContextMenuItems(contextMenuInstance: ElementContextMenuInstance, dispatch: EditorDispatch): Array<ContextMenuItem<CanvasData>> {
-  const metadata = useEditorState((store) => store.editor.jsxMetadataKILLME, 'ElementContextMenu metadata')
-  const components = useEditorState((store) => getOpenUtopiaJSXComponentsFromState(store.editor), 'ElementContextMenu components')
+function useCanvasContextMenuItems(
+  contextMenuInstance: ElementContextMenuInstance,
+  dispatch: EditorDispatch,
+): Array<ContextMenuItem<CanvasData>> {
+  const metadata = useEditorState(
+    (store) => store.editor.jsxMetadataKILLME,
+    'ElementContextMenu metadata',
+  )
+  const components = useEditorState(
+    (store) => getOpenUtopiaJSXComponentsFromState(store.editor),
+    'ElementContextMenu components',
+  )
 
   if (contextMenuInstance === 'context-menu-canvas') {
-    const elementListSubmenu: Array<ContextMenuItem<CanvasData>> = MetadataUtils.getAllPaths(metadata).map(path => {
+    const elementListSubmenu: Array<ContextMenuItem<CanvasData>> = MetadataUtils.getAllPaths(
+      metadata,
+    ).map((path) => {
       const elementName = MetadataUtils.getJSXElementName(path, components, metadata.components)
       return {
         name: elementName?.baseVariable || '',
@@ -115,15 +126,16 @@ export const ElementContextMenu = betterReactMemo(
     if (portalTarget == null) {
       return null
     } else {
-      return ReactDOM.createPortal((
+      return ReactDOM.createPortal(
         <MomentumContextMenu
           id={contextMenuInstance}
           key='element-context-menu'
           items={contextMenuItems}
           dispatch={dispatch}
           getData={getData}
-        />
-      ), portalTarget)
+        />,
+        portalTarget,
+      )
     }
   },
 )

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -503,7 +503,7 @@ export const ComponentSectionInner = betterReactMemo(
     const onResetClicked = React.useCallback(
       (event: React.MouseEvent<HTMLElement>) => {
         dispatch(
-          [showContextMenu('context-menu-instance-inspector', event.nativeEvent), null],
+          [showContextMenu('context-menu-instance-inspector', event.nativeEvent, null)],
           'everyone',
         )
       },

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -503,7 +503,7 @@ export const ComponentSectionInner = betterReactMemo(
     const onResetClicked = React.useCallback(
       (event: React.MouseEvent<HTMLElement>) => {
         dispatch(
-          [showContextMenu('context-menu-instance-inspector', event.nativeEvent)],
+          [showContextMenu('context-menu-instance-inspector', event.nativeEvent), null],
           'everyone',
         )
       },

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -73,7 +73,7 @@ export const NavigatorComponent = betterReactMemo(
 
     const onContextMenu = React.useCallback(
       (event: React.MouseEvent<HTMLElement>) => {
-        dispatch([showContextMenu('context-menu-navigator', event.nativeEvent)], 'everyone')
+        dispatch([showContextMenu('context-menu-navigator', event.nativeEvent, null)], 'everyone')
       },
       [dispatch],
     )

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -16,7 +16,14 @@ import Utils, { IndexPosition } from '../../utils/utils'
 import { getLayoutProperty } from '../layout/getLayoutProperty'
 import { FlexLayoutHelpers, LayoutHelpers } from '../layout/layout-helpers'
 import { LayoutProp } from '../layout/layout-helpers-new'
-import { flattenArray, mapDropNulls, pluck, stripNulls, flatMapArray, uniqBy } from '../shared/array-utils'
+import {
+  flattenArray,
+  mapDropNulls,
+  pluck,
+  stripNulls,
+  flatMapArray,
+  uniqBy,
+} from '../shared/array-utils'
 import { intrinsicHTMLElementNamesThatSupportChildren } from '../shared/dom-utils'
 import {
   alternativeEither,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -16,7 +16,7 @@ import Utils, { IndexPosition } from '../../utils/utils'
 import { getLayoutProperty } from '../layout/getLayoutProperty'
 import { FlexLayoutHelpers, LayoutHelpers } from '../layout/layout-helpers'
 import { LayoutProp } from '../layout/layout-helpers-new'
-import { flattenArray, mapDropNulls, pluck, stripNulls, flatMapArray } from '../shared/array-utils'
+import { flattenArray, mapDropNulls, pluck, stripNulls, flatMapArray, uniqBy } from '../shared/array-utils'
 import { intrinsicHTMLElementNamesThatSupportChildren } from '../shared/dom-utils'
 import {
   alternativeEither,
@@ -629,7 +629,7 @@ export const MetadataUtils = {
       }
     })
 
-    return result
+    return uniqBy<TemplatePath>(result, TP.pathsEqual)
   },
   isElementOfType(instance: ElementInstanceMetadata, elementType: string): boolean {
     return foldEither(


### PR DESCRIPTION
Extending the canvas context menu to have a submenu listing all elements under the cursor. Clicking on the element list item changes the selection.
- updated the css file, this should have been in the previous PR as it was changed with the 5.0.0 update
- creating the element context menu adds the array of all submenu element items with an extra detail about their templatepaths
- when opening the menu the elements under the cursor array is passed in as a prop to the contextmenu open
- the new hidden prop on contextmenu items help with hiding the non-matching elements, with comparing the templatepaths
- `MetadataUtils.getAllPaths` had some duplicated values since the orphan changes