### PR TITLE
prevent highlights when resize controls are hovered

### DIFF
--- a/editor/src/components/canvas/controls/multiselect-resize-control.tsx
+++ b/editor/src/components/canvas/controls/multiselect-resize-control.tsx
@@ -172,6 +172,7 @@ export class MultiselectResizeControl extends React.Component<
               metadata={this.props.componentMetadata}
               onResizeStart={this.onResizeStart}
               testID={'component-resize-control-0'}
+              maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
             />
             {...guidelineElements}
           </>
@@ -224,6 +225,7 @@ export class SingleSelectResizeControls extends React.Component<SingleselectResi
               metadata={this.props.componentMetadata}
               onResizeStart={this.props.onResizeStart}
               testID={`component-resize-control-${TP.toComponentId(view)}-${index}`}
+              maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
             />
           </>
         )

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -94,6 +94,7 @@ export interface ControlProps {
   cmdKeyPressed: boolean
   showAdditionalControls: boolean
   elementsThatRespectLayout: Array<TemplatePath>
+  maybeClearHighlightsOnHoverEnd: () => void
 }
 
 interface NewCanvasControlsProps {
@@ -332,6 +333,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       cmdKeyPressed: props.editor.keysPressed['cmd'] ?? false,
       showAdditionalControls: props.editor.interfaceDesigner.additionalControls,
       elementsThatRespectLayout: elementsThatRespectLayout,
+      maybeClearHighlightsOnHoverEnd: maybeClearHighlightsOnHoverEnd,
     }
     const dragState = props.editor.canvas.dragState
     switch (props.editor.mode.type) {

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -39,6 +39,8 @@ import { useWindowToCanvasCoordinates } from '../../dom-lookup-hooks'
 import { selectElementsThatRespectLayout } from '../new-canvas-controls'
 import { useInsertModeSelectAndHover } from './insert-mode-hooks'
 
+export const PreventHighlightsForThisEvent = 'utopiaPreventHighlights'
+
 const DRAG_START_TRESHOLD = 2
 
 export function isResizing(dragState: DragState | null): boolean {
@@ -364,6 +366,11 @@ export function useHighlightCallbacks(
 
   const onMouseMove = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
+      if (PreventHighlightsForThisEvent in event) {
+        maybeClearHighlightsOnHoverEnd()
+        previousTargetUnderPoint.current = null
+        return
+      }
       const selectableViews: Array<TemplatePath> = getHighlightableViews(event.metaKey, false)
       const validTemplatePath = findValidTarget(
         selectableViews,

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -39,8 +39,6 @@ import { useWindowToCanvasCoordinates } from '../../dom-lookup-hooks'
 import { selectElementsThatRespectLayout } from '../new-canvas-controls'
 import { useInsertModeSelectAndHover } from './insert-mode-hooks'
 
-export const PreventHighlightsForThisEvent = 'utopiaPreventHighlights'
-
 const DRAG_START_TRESHOLD = 2
 
 export function isResizing(dragState: DragState | null): boolean {
@@ -362,15 +360,9 @@ export function useHighlightCallbacks(
 } {
   const { maybeHighlightOnHover, maybeClearHighlightsOnHoverEnd } = useMaybeHighlightElement()
   const findValidTarget = useFindValidTarget()
-  const previousTargetUnderPoint = React.useRef<TemplatePath | null>(null)
 
   const onMouseMove = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      if (PreventHighlightsForThisEvent in event) {
-        maybeClearHighlightsOnHoverEnd()
-        previousTargetUnderPoint.current = null
-        return
-      }
       const selectableViews: Array<TemplatePath> = getHighlightableViews(event.metaKey, false)
       const validTemplatePath = findValidTarget(
         selectableViews,
@@ -381,10 +373,9 @@ export function useHighlightCallbacks(
         (!allowHoverOnSelectedView && validTemplatePath.isSelected) // we remove highlights if the hovered element is selected
       ) {
         maybeClearHighlightsOnHoverEnd()
-      } else if (!TP.pathsEqual(validTemplatePath.templatePath, previousTargetUnderPoint.current)) {
+      } else {
         maybeHighlightOnHover(validTemplatePath.templatePath)
       }
-      previousTargetUnderPoint.current = validTemplatePath?.templatePath ?? null
     },
     [
       allowHoverOnSelectedView,
@@ -392,7 +383,6 @@ export function useHighlightCallbacks(
       maybeHighlightOnHover,
       getHighlightableViews,
       findValidTarget,
-      previousTargetUnderPoint,
     ],
   )
 

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -26,7 +26,6 @@ import { calculateExtraSizeForZeroSizedElement } from './outline-utils'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { SizeBoxLabel } from './size-box-label'
 import { colorTheme } from '../../../uuiui'
-import { PreventHighlightsForThisEvent } from './select-mode/select-mode-hooks'
 
 interface ResizeControlProps extends ResizeRectangleProps {
   cursor: CSSCursor
@@ -80,7 +79,8 @@ class ResizeControl extends React.Component<ResizeControlProps> {
   }
 
   onMouseMove = (event: React.MouseEvent<any>) => {
-    Object.defineProperty(event, PreventHighlightsForThisEvent, { value: true })
+    this.props.maybeClearHighlightsOnHoverEnd()
+    event.stopPropagation()
   }
 
   render() {
@@ -398,6 +398,7 @@ interface ResizeRectangleProps {
   metadata: JSXMetadata
   onResizeStart: (originalSize: CanvasRectangle, draggedPoint: EdgePosition) => void
   testID: string
+  maybeClearHighlightsOnHoverEnd: () => void
 }
 
 export class ResizeRectangle extends React.Component<ResizeRectangleProps> {

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -26,6 +26,7 @@ import { calculateExtraSizeForZeroSizedElement } from './outline-utils'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { SizeBoxLabel } from './size-box-label'
 import { colorTheme } from '../../../uuiui'
+import { PreventHighlightsForThisEvent } from './select-mode/select-mode-hooks'
 
 interface ResizeControlProps extends ResizeRectangleProps {
   cursor: CSSCursor
@@ -78,6 +79,10 @@ class ResizeControl extends React.Component<ResizeControlProps> {
     }
   }
 
+  onMouseMove = (event: React.MouseEvent<any>) => {
+    Object.defineProperty(event, PreventHighlightsForThisEvent, { value: true })
+  }
+
   render() {
     const currentSize = this.props.visualSize
     const top =
@@ -99,7 +104,9 @@ class ResizeControl extends React.Component<ResizeControlProps> {
     return (
       <React.Fragment>
         {this.props.resizeStatus === 'enabled' ? (
-          <div onMouseDown={this.onMouseDown}>{this.props.children}</div>
+          <div onMouseDown={this.onMouseDown} onMouseMove={this.onMouseMove}>
+            {this.props.children}
+          </div>
         ) : (
           this.props.children
         )}

--- a/editor/src/components/canvas/controls/yoga-control.tsx
+++ b/editor/src/components/canvas/controls/yoga-control.tsx
@@ -95,6 +95,7 @@ class YogaResizeControl extends React.Component<YogaResizeControlProps> {
         metadata={this.props.componentMetadata}
         onResizeStart={Utils.NO_OP}
         testID={`component-resize-control-${TP.toComponentId(this.props.target)}-0`}
+        maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
       />
     )
   }

--- a/editor/src/templates/editor-canvas.ts
+++ b/editor/src/templates/editor-canvas.ts
@@ -1135,7 +1135,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
     window.addEventListener('keyup', this.handleKeyUp)
     window.addEventListener('mousedown', this.handleMouseDown)
     window.addEventListener('mouseup', this.handleMouseUp)
-    window.addEventListener('mousemove', this.handleMouseMove)
+    window.addEventListener('mousemove', this.handleMouseMove, { capture: true }) // we use this event in the capture phase because size-box.ts calls stopPropagation() on mouseMove
     window.addEventListener('mouseleave', this.handleMouseLeave)
     window.addEventListener('click', this.handleClick)
     window.addEventListener('dblclick', this.handleDoubleClick)


### PR DESCRIPTION
**Problem:**
The resize controls have a click catcher area that sticks out from the element. This is deliberate to make it easier for the user to grab them. In the previous setup, the resize control divs were simply above the highlight catcher divs, so we didn't have an issue with the user accidentally highlighting the parent element when they want to start a resize. However, since I moved the highlight logic to an `onMouseMove` handler, these divs were no longer preventing the highlight on the parent from happening.

**Fix:**
This is a rather unorthodox fix to prevent the highlights from happening. 
The resize controls are a children element of the `new-canvas-controls-container` div where the `onMouseMove` controlling the highlights is attached. Using this fact, I could catch the bubbling mouseMove event in the resize control divs, and append an extra property to the event object itself. This event object then bubbles to `new-canvas-controls-container`'s highlight handler hook, and if we see this extra property on the event, we treat it as a command to remove any highlights.

**Commit Details:**
- `ResizeControl` catches the mouseMove event and adds a new property on it with the key `PreventHighlightsForThisEvent` 
- the `onMouseMove` event handler inside `useHighlightCallbacks` checks for the existence of this special property. if the property is there, it bails early and calls `maybeClearHighlightsOnHoverEnd`
