### PR TITLE
Fix: recalculate highlighted views when mode changes or cmd toggles

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -251,6 +251,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
   const startDragStateAfterDragExceedsThreshold = useStartDragStateAfterDragExceedsThreshold()
 
   const { localSelectedViews, localHighlightedViews, setLocalSelectedViews } = props
+  const cmdKeyPressed = props.editor.keysPressed['cmd'] ?? false
 
   const componentMetadata = getMetadata(props.editor)
 
@@ -260,14 +261,14 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
 
   const { maybeHighlightOnHover, maybeClearHighlightsOnHoverEnd } = useMaybeHighlightElement()
 
-  const { onMouseMove, onMouseDown } = useSelectAndHover(setLocalSelectedViews)
+  const { onMouseMove, onMouseDown } = useSelectAndHover(cmdKeyPressed, setLocalSelectedViews)
 
   const getResizeStatus = () => {
     const selectedViews = localSelectedViews
     if (props.editor.canvas.textEditor != null || props.editor.keysPressed['z']) {
       return 'disabled'
     }
-    if (props.editor.keysPressed['cmd'] === true) {
+    if (cmdKeyPressed) {
       return 'noninteractive'
     }
     const anyIncomprehensibleElementsSelected = selectedViews.some((selectedView) => {
@@ -329,7 +330,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       elementAspectRatioLocked: elementAspectRatioLocked,
       imageMultiplier: imageMultiplier,
       windowToCanvasPosition: props.windowToCanvasPosition,
-      cmdKeyPressed: props.editor.keysPressed['cmd'] ?? false,
+      cmdKeyPressed: cmdKeyPressed,
       showAdditionalControls: props.editor.interfaceDesigner.additionalControls,
       elementsThatRespectLayout: elementsThatRespectLayout,
     }

--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
@@ -42,12 +42,20 @@ function useGetHiglightableViewsForInsertMode() {
   }, [storeRef])
 }
 
-export function useInsertModeSelectAndHover(): {
+export function useInsertModeSelectAndHover(
+  active: boolean,
+  cmdPressed: boolean,
+): {
   onMouseMove: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 } {
   const getHiglightableViewsForInsertMode = useGetHiglightableViewsForInsertMode()
-  const { onMouseMove } = useHighlightCallbacks(true, getHiglightableViewsForInsertMode)
+  const { onMouseMove } = useHighlightCallbacks(
+    active,
+    cmdPressed,
+    true,
+    getHiglightableViewsForInsertMode,
+  )
 
   return useKeepShallowReferenceEquality({
     onMouseMove: onMouseMove,

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -13,6 +13,7 @@ import {
 import { ScenePath, TemplatePath } from '../../../../core/shared/project-file-types'
 import * as TP from '../../../../core/shared/template-path'
 import { fastForEach, NO_OP } from '../../../../core/shared/utils'
+import { WindowMousePositionRaw } from '../../../../templates/editor-canvas'
 import { KeysPressed } from '../../../../utils/keyboard'
 import { useKeepShallowReferenceEquality } from '../../../../utils/react-performance'
 import Utils from '../../../../utils/utils'
@@ -350,6 +351,8 @@ function useGetSelectableViewsForSelectMode() {
 }
 
 export function useHighlightCallbacks(
+  active: boolean,
+  cmdPressed: boolean,
   allowHoverOnSelectedView: boolean,
   getHighlightableViews: (
     allElementsDirectlySelectable: boolean,
@@ -362,13 +365,10 @@ export function useHighlightCallbacks(
   const findValidTarget = useFindValidTarget()
   const previousTargetUnderPoint = React.useRef<TemplatePath | null>(null)
 
-  const onMouseMove = React.useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
-      const selectableViews: Array<TemplatePath> = getHighlightableViews(event.metaKey, false)
-      const validTemplatePath = findValidTarget(
-        selectableViews,
-        windowPoint(point(event.clientX, event.clientY)),
-      )
+  const calculateHighlightedViews = React.useCallback(
+    (targetPoint: WindowPoint, eventCmdPressed: boolean) => {
+      const selectableViews: Array<TemplatePath> = getHighlightableViews(eventCmdPressed, false)
+      const validTemplatePath = findValidTarget(selectableViews, targetPoint)
       if (
         validTemplatePath == null ||
         (!allowHoverOnSelectedView && validTemplatePath.isSelected) // we remove highlights if the hovered element is selected
@@ -389,10 +389,30 @@ export function useHighlightCallbacks(
     ],
   )
 
+  const onMouseMove = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      return calculateHighlightedViews(
+        windowPoint(point(event.clientX, event.clientY)),
+        event.metaKey,
+      )
+    },
+    [calculateHighlightedViews],
+  )
+
+  React.useEffect(() => {
+    if (active && WindowMousePositionRaw != null) {
+      // this useEffect will re-calculate (and update) the highlighted views if the user presses or releases 'cmd' without moving the mouse,
+      // or if the user enters a new mode (the `active` flag will change for the modes), this is important when entering insert mode
+      calculateHighlightedViews(WindowMousePositionRaw, cmdPressed)
+    }
+  }, [calculateHighlightedViews, active, cmdPressed])
+
   return { onMouseMove }
 }
 
 export function useSelectModeSelectAndHover(
+  active: boolean,
+  cmdPressed: boolean,
   setSelectedViewsForCanvasControlsOnly: (newSelectedViews: TemplatePath[]) => void,
 ): {
   onMouseMove: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
@@ -404,7 +424,12 @@ export function useSelectModeSelectAndHover(
   const getSelectableViewsForSelectMode = useGetSelectableViewsForSelectMode()
   const startDragStateAfterDragExceedsThreshold = useStartDragStateAfterDragExceedsThreshold()
 
-  const { onMouseMove } = useHighlightCallbacks(false, getSelectableViewsForSelectMode)
+  const { onMouseMove } = useHighlightCallbacks(
+    active,
+    cmdPressed,
+    false,
+    getSelectableViewsForSelectMode,
+  )
 
   const onMouseDown = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
@@ -470,14 +495,19 @@ function usePreviewModeSelectAndHover(): {
 }
 
 export function useSelectAndHover(
+  cmdPressed: boolean,
   setSelectedViewsForCanvasControlsOnly: (newSelectedViews: TemplatePath[]) => void,
 ): {
   onMouseMove: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 } {
   const modeType = useEditorState((store) => store.editor.mode.type, 'useSelectAndHover mode')
-  const selectModeCallbacks = useSelectModeSelectAndHover(setSelectedViewsForCanvasControlsOnly)
-  const insertModeCallbacks = useInsertModeSelectAndHover()
+  const selectModeCallbacks = useSelectModeSelectAndHover(
+    modeType === 'select',
+    cmdPressed,
+    setSelectedViewsForCanvasControlsOnly,
+  )
+  const insertModeCallbacks = useInsertModeSelectAndHover(modeType === 'insert', cmdPressed)
   const previewModeCallbacks = usePreviewModeSelectAndHover()
   if (modeType === 'select') {
     return selectModeCallbacks


### PR DESCRIPTION
**Problem:**
When the user presses or releases cmd, but does not move the mouse, we left the (outdated) highlights on the screen. When the user enters insert mode, they had to move the mouse a bit to select the target parent, instead of it being already selected when entering insert mode.

**Fix:**
Add a new useEffect which recalculates (and updates) the highlighted views if the active mode changes or if the cmd is toggled.

**Commit Details:**
- add new flags `active` and `cmdPressed` to the `useSelectAndHover` hooks
- moved highlight logic to `calculateHighlightedViews`
- it is called from `onMouseMove` just like before
- it is also called from a useEffect when `active` or `cmdPressed` changes, triggering a refresh of what is highlighted