### PR TITLE
test: elements outside of their parents can be non-cmd-click selected

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser.ts
@@ -1,0 +1,133 @@
+import { act, fireEvent } from '@testing-library/react'
+import * as TP from '../../../../core/shared/template-path'
+import { wait } from '../../../../utils/test-utils'
+import { makeTestProjectCodeWithSnippet, renderTestEditorWithCode } from '../../ui-jsx.test-utils'
+import { CanvasControlsContainerID } from '../new-canvas-controls'
+
+describe('Select Mode Selection', () => {
+  beforeAll((done) => {
+    // we need to set the Electron window to a larger size so document.elementsUnderPoint works correctly!
+    const currentWindow = require('electron').remote.getCurrentWindow()
+    const size = currentWindow.getSize()
+    if (size.width !== 2200) {
+      currentWindow.once('resize', () => {
+        done()
+      })
+      currentWindow.setSize(2200, 1000)
+    }
+  })
+
+  it('keep clicking on an children eventually selects it – even if it is out of bounds of the parents', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+          <div data-uid='a' style={{ ...props.style }}>
+            <div
+              data-uid='b'
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                overflow: 'visible',
+                left: 50,
+                top: 50,
+                height: 120,
+                width: 120,
+              }}
+            >
+              <div
+              data-uid='c'
+                style={{
+                  backgroundColor: '#0091FFAA',
+                  position: 'absolute',
+                  left: 30,
+                  top: 30,
+                  height: 120,
+                  width: 120,
+                }}
+              >
+                <div
+                  data-uid='d'
+                  style={{
+                    backgroundColor: '#0091FFAA',
+                    position: 'absolute',
+                    height: 120,
+                    width: 120,
+                    left: 30,
+                    top: 30,
+                  }}
+                >
+                  <div
+                    data-uid='e'
+                    style={{
+                      backgroundColor: '#0091FFAA',
+                      position: 'absolute',
+                      left: 30,
+                      top: 30,
+                      height: 120,
+                      width: 120,
+                    }}
+                  >
+                    <div
+                      data-uid='targetdiv'
+                      data-testid='targetdiv'
+                      style={{
+                        backgroundColor: '#0091FFAA',
+                        position: 'absolute',
+                        left: 30,
+                        top: 30,
+                        height: 120,
+                        width: 120,
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+      `),
+    )
+
+    const areaControl = renderResult.renderedDOM.getByTestId('targetdiv')
+    const areaControlBounds = areaControl.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    await act(async () => {
+      const domFinished = renderResult.getDomReportDispatched()
+      const dispatchDone = renderResult.getDispatchFollowUpactionsFinished()
+      fireEvent(
+        canvasControlsLayer,
+        new MouseEvent('mousedown', {
+          detail: 0,
+          bubbles: true,
+          cancelable: true,
+          metaKey: true,
+          clientX: areaControlBounds.left + 20,
+          clientY: areaControlBounds.top + 20,
+          buttons: 1,
+        }),
+      )
+      fireEvent(
+        canvasControlsLayer,
+        new MouseEvent('mousedown', {
+          detail: 1,
+          bubbles: true,
+          cancelable: true,
+          metaKey: true,
+          clientX: areaControlBounds.left + 20,
+          clientY: areaControlBounds.top + 20,
+          buttons: 1,
+        }),
+      )
+      await domFinished
+      await dispatchDone
+    })
+
+    // after 5 "double clicks", the `targetdiv` div should be selected
+    expect(renderResult.getEditorState().editor.selectedViews).toEqual([
+      TP.instancePath(
+        ['utopia-storyboard-uid', 'scene-aaa'],
+        ['a', 'b', 'c', 'd', 'e', 'targetdiv'],
+      ),
+    ])
+  })
+})


### PR DESCRIPTION
This is a new test that codifies a desired behavior:
![image](https://user-images.githubusercontent.com/2226774/105348576-d2ac9c80-5be8-11eb-9976-65c46e3ca678.png)

if the user keeps double clicking on an element that sticks out of its parents' bounds, eventually we want to successfully select the element.

previously this was only possible with cmd-clicking