### PR TITLE
show action errors in production env too

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -524,9 +524,10 @@ function editorDispatchInner(
       frozenDerivedState = optionalDeepFreeze(derivedState)
     }
 
+    const actionNames = dispatchedActions.map((action) => action.action).join(',')
+    getAllUniqueUids(getOpenUtopiaJSXComponentsFromState(frozenEditorState), actionNames)
+
     if (!PRODUCTION_ENV) {
-      const actionNames = dispatchedActions.map((action) => action.action).join(',')
-      getAllUniqueUids(getOpenUtopiaJSXComponentsFromState(frozenEditorState), actionNames)
 
       if (typeof window.performance.mark === 'function') {
         window.performance.mark('dispatch_end')

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -528,7 +528,6 @@ function editorDispatchInner(
     getAllUniqueUids(getOpenUtopiaJSXComponentsFromState(frozenEditorState), actionNames)
 
     if (!PRODUCTION_ENV) {
-
       if (typeof window.performance.mark === 'function') {
         window.performance.mark('dispatch_end')
         window.performance.measure(


### PR DESCRIPTION
Problem:
Errors during the editor update are ignored in production mode, so bug reports can be misleading.
For example `Found duplicate UID` errors during action update, in dev mode it makes it clear that something is very wrong when it happens, while in production it makes a faulty editor state which will break only later.

