### PR TITLE
Fix/overlapping scenes orphans

### DIFF
--- a/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
@@ -186,7 +186,12 @@ Object {
         "x": 0,
         "y": 0,
       },
-      "localFrame": null,
+      "localFrame": Object {
+        "height": 812,
+        "width": 375,
+        "x": 0,
+        "y": 0,
+      },
       "props": Object {},
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
@@ -814,7 +819,12 @@ Object {
         "x": 0,
         "y": 0,
       },
-      "localFrame": null,
+      "localFrame": Object {
+        "height": 812,
+        "width": 375,
+        "x": 0,
+        "y": 0,
+      },
       "props": Object {},
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
@@ -1163,7 +1173,12 @@ Object {
         "x": 0,
         "y": 0,
       },
-      "localFrame": null,
+      "localFrame": Object {
+        "height": 812,
+        "width": 375,
+        "x": 0,
+        "y": 0,
+      },
       "props": Object {},
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
@@ -1750,7 +1765,12 @@ Object {
         "x": 0,
         "y": 0,
       },
-      "localFrame": null,
+      "localFrame": Object {
+        "height": 812,
+        "width": 375,
+        "x": 0,
+        "y": 0,
+      },
       "props": Object {},
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
@@ -2338,7 +2358,12 @@ Object {
         "x": 0,
         "y": 0,
       },
-      "localFrame": null,
+      "localFrame": Object {
+        "height": 812,
+        "width": 375,
+        "x": 0,
+        "y": 0,
+      },
       "props": Object {},
       "specialSizeMeasurements": Object {
         "clientHeight": 812,

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -16,6 +16,7 @@ import { getCanvasRectangleFromElement, getDOMAttribute } from '../../core/share
 import { applicative4Either, isRight, left } from '../../core/shared/either'
 import Utils from '../../utils/utils'
 import {
+  canvasPoint,
   CanvasPoint,
   CanvasRectangle,
   LocalPoint,
@@ -397,7 +398,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
               const sceneMetadata = collectMetadata(
                 scene,
                 TP.instancePath([], TP.elementPathForPath(scenePath)),
-                null,
+                canvasPoint({ x: 0, y: 0 }),
                 rootElements,
               )
               rootMetadata.push(sceneMetadata)
@@ -570,14 +571,11 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
       function collectMetadata(
         element: HTMLElement,
         instancePath: InstancePath,
-        parentPoint: CanvasPoint | null,
+        parentPoint: CanvasPoint,
         children: InstancePath[],
       ): ElementInstanceMetadata {
         const globalFrame = globalFrameForElement(element)
-        const localFrame =
-          parentPoint != null
-            ? localRectangle(Utils.offsetRect(globalFrame, Utils.negate(parentPoint)))
-            : null
+        const localFrame = localRectangle(Utils.offsetRect(globalFrame, Utils.negate(parentPoint)))
 
         const uidAttribute = getDOMAttribute(element, UTOPIA_UID_KEY)
         const originalUIDAttribute = getDOMAttribute(element, UTOPIA_ORIGINAL_ID_KEY)


### PR DESCRIPTION
**Problem:**
My changes re-introducing the AABB-based lookup introduced a regression: if an Orphan on the canvas overlaps a Scene, the Orphan is treated as "below" the scene, even if it is visually on top of it.
The problem was that we used the order of metadata.components as the basis of the ordering of the elements. The order is Storyboard, Scene 1, Scene 2, etc. This means that Orphans living on Storyboard were always treated as the bottom layer.

**Fix:**
Instead of iterating through metadata.components, we find the Storyboard component, and use its children as the basis of the AABB lookup. This gives us the correct ordering of scenes and orpans

**Note:**
I realized that since we now rely on the AABB lookup for ordering, that means that if the user has a z-index or other css way of changing the element order, we won't follow that. I think that can remain a WONTFIX for now, but I want to ask @maltenuhn  about it.

