### PR TITLE
Chore/fix test generated uid

### DIFF
--- a/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
@@ -245,7 +245,7 @@ Object {
         Object {
           "element": Array [
             "aaa",
-            "bbb-1",
+            "bbb~~~1",
           ],
           "scene": Object {
             "sceneElementPath": Array [
@@ -258,7 +258,7 @@ Object {
         Object {
           "element": Array [
             "aaa",
-            "bbb-2",
+            "bbb~~~2",
           ],
           "scene": Object {
             "sceneElementPath": Array [
@@ -271,7 +271,7 @@ Object {
         Object {
           "element": Array [
             "aaa",
-            "bbb-3",
+            "bbb~~~3",
           ],
           "scene": Object {
             "sceneElementPath": Array [
@@ -384,7 +384,7 @@ Object {
         },
       },
     },
-    "utopia-storyboard-uid/scene-aaa:aaa/bbb-1": Object {
+    "utopia-storyboard-uid/scene-aaa:aaa/bbb~~~1": Object {
       "children": Array [],
       "componentInstance": false,
       "computedStyle": null,
@@ -406,7 +406,7 @@ Object {
       },
       "props": Object {
         "data-label": "Plane",
-        "data-uid": "bbb-1",
+        "data-uid": "bbb~~~1",
         "data-utopia-original-uid": "bbb",
       },
       "specialSizeMeasurements": Object {
@@ -453,7 +453,7 @@ Object {
       "templatePath": Object {
         "element": Array [
           "aaa",
-          "bbb-1",
+          "bbb~~~1",
         ],
         "scene": Object {
           "sceneElementPath": Array [
@@ -464,7 +464,7 @@ Object {
         },
       },
     },
-    "utopia-storyboard-uid/scene-aaa:aaa/bbb-2": Object {
+    "utopia-storyboard-uid/scene-aaa:aaa/bbb~~~2": Object {
       "children": Array [],
       "componentInstance": false,
       "computedStyle": null,
@@ -486,7 +486,7 @@ Object {
       },
       "props": Object {
         "data-label": "Plane",
-        "data-uid": "bbb-2",
+        "data-uid": "bbb~~~2",
         "data-utopia-original-uid": "bbb",
       },
       "specialSizeMeasurements": Object {
@@ -533,7 +533,7 @@ Object {
       "templatePath": Object {
         "element": Array [
           "aaa",
-          "bbb-2",
+          "bbb~~~2",
         ],
         "scene": Object {
           "sceneElementPath": Array [
@@ -544,7 +544,7 @@ Object {
         },
       },
     },
-    "utopia-storyboard-uid/scene-aaa:aaa/bbb-3": Object {
+    "utopia-storyboard-uid/scene-aaa:aaa/bbb~~~3": Object {
       "children": Array [],
       "componentInstance": false,
       "computedStyle": null,
@@ -566,7 +566,7 @@ Object {
       },
       "props": Object {
         "data-label": "Plane",
-        "data-uid": "bbb-3",
+        "data-uid": "bbb~~~3",
         "data-utopia-original-uid": "bbb",
       },
       "specialSizeMeasurements": Object {
@@ -613,7 +613,7 @@ Object {
       "templatePath": Object {
         "element": Array [
           "aaa",
-          "bbb-3",
+          "bbb~~~3",
         ],
         "scene": Object {
           "sceneElementPath": Array [

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -30,17 +30,17 @@ exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
       data-uid=\\"aaa\\"
     >
       <div
-        data-uid=\\"bbb-1\\"
+        data-uid=\\"bbb~~~1\\"
         data-label=\\"Plane\\"
         data-utopia-original-uid=\\"bbb\\"
       ></div>
       <div
-        data-uid=\\"bbb-2\\"
+        data-uid=\\"bbb~~~2\\"
         data-label=\\"Plane\\"
         data-utopia-original-uid=\\"bbb\\"
       ></div>
       <div
-        data-uid=\\"bbb-3\\"
+        data-uid=\\"bbb~~~3\\"
         data-label=\\"Plane\\"
         data-utopia-original-uid=\\"bbb\\"
       ></div>
@@ -716,9 +716,9 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"zzz\\">
-      <div data-uid=\\"aaa-1\\" data-utopia-original-uid=\\"aaa\\">1</div>
-      <div data-uid=\\"aaa-2\\" data-utopia-original-uid=\\"aaa\\">2</div>
-      <div data-uid=\\"aaa-3\\" data-utopia-original-uid=\\"aaa\\">3</div>
+      <div data-uid=\\"aaa~~~1\\" data-utopia-original-uid=\\"aaa\\">1</div>
+      <div data-uid=\\"aaa~~~2\\" data-utopia-original-uid=\\"aaa\\">2</div>
+      <div data-uid=\\"aaa~~~3\\" data-utopia-original-uid=\\"aaa\\">3</div>
     </div>
   </div>
 </div>
@@ -973,20 +973,20 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"zzz\\">
-      <div data-uid=\\"aaa-1\\" data-utopia-original-uid=\\"aaa\\">
-        <div data-uid=\\"bbb-1\\" data-utopia-original-uid=\\"bbb\\">4</div>
-        <div data-uid=\\"bbb-2\\" data-utopia-original-uid=\\"bbb\\">5</div>
-        <div data-uid=\\"bbb-3\\" data-utopia-original-uid=\\"bbb\\">6</div>
+      <div data-uid=\\"aaa~~~1\\" data-utopia-original-uid=\\"aaa\\">
+        <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">4</div>
+        <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">5</div>
+        <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">6</div>
       </div>
-      <div data-uid=\\"aaa-2\\" data-utopia-original-uid=\\"aaa\\">
-        <div data-uid=\\"bbb-1\\" data-utopia-original-uid=\\"bbb\\">8</div>
-        <div data-uid=\\"bbb-2\\" data-utopia-original-uid=\\"bbb\\">10</div>
-        <div data-uid=\\"bbb-3\\" data-utopia-original-uid=\\"bbb\\">12</div>
+      <div data-uid=\\"aaa~~~2\\" data-utopia-original-uid=\\"aaa\\">
+        <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">8</div>
+        <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">10</div>
+        <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">12</div>
       </div>
-      <div data-uid=\\"aaa-3\\" data-utopia-original-uid=\\"aaa\\">
-        <div data-uid=\\"bbb-1\\" data-utopia-original-uid=\\"bbb\\">12</div>
-        <div data-uid=\\"bbb-2\\" data-utopia-original-uid=\\"bbb\\">15</div>
-        <div data-uid=\\"bbb-3\\" data-utopia-original-uid=\\"bbb\\">18</div>
+      <div data-uid=\\"aaa~~~3\\" data-utopia-original-uid=\\"aaa\\">
+        <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">12</div>
+        <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">15</div>
+        <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">18</div>
       </div>
     </div>
   </div>
@@ -1948,9 +1948,9 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are not the ap
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"aaa\\">
-      <div data-uid=\\"bbb-1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
-      <div data-uid=\\"bbb-2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
-      <div data-uid=\\"bbb-3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
+      <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
+      <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
+      <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
     </div>
   </div>
 </div>
@@ -2214,9 +2214,9 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are undefined 
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"aaa\\">
-      <div data-uid=\\"bbb-1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
-      <div data-uid=\\"bbb-2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
-      <div data-uid=\\"bbb-3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
+      <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
+      <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
+      <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
     </div>
   </div>
 </div>
@@ -2857,8 +2857,8 @@ exports[`UiJsxCanvas render function component works inside a map 1`] = `
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"zzz\\">
-      <div data-uid=\\"aaa-1\\" data-utopia-original-uid=\\"aaa\\">Thing</div>
-      <div data-uid=\\"aaa-2\\" data-utopia-original-uid=\\"aaa\\">Thing</div>
+      <div data-uid=\\"aaa~~~1\\" data-utopia-original-uid=\\"aaa\\">Thing</div>
+      <div data-uid=\\"aaa~~~2\\" data-utopia-original-uid=\\"aaa\\">Thing</div>
     </div>
   </div>
 </div>
@@ -5682,70 +5682,82 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
         \\"
         data-uid=\\"03a\\"
       >
-        <div data-uid=\\"834-1\\" data-label=\\"Copy\\" data-utopia-original-uid=\\"834\\">
+        <div
+          data-uid=\\"834~~~1\\"
+          data-label=\\"Copy\\"
+          data-utopia-original-uid=\\"834\\"
+        >
           Copy
         </div>
-        <div data-uid=\\"999-2\\" data-label=\\"⌘,⎇,C\\" data-utopia-original-uid=\\"999\\">
+        <div
+          data-uid=\\"999~~~2\\"
+          data-label=\\"⌘,⎇,C\\"
+          data-utopia-original-uid=\\"999\\"
+        >
           <span data-uid=\\"000\\"
             ><span
               style=\\"padding: 6px;\\"
-              data-uid=\\"726-1\\"
+              data-uid=\\"726~~~1\\"
               data-utopia-original-uid=\\"726\\"
               >⌘</span
             ><span
               style=\\"padding: 6px;\\"
-              data-uid=\\"726-2\\"
+              data-uid=\\"726~~~2\\"
               data-utopia-original-uid=\\"726\\"
               >⎇</span
             ><span
               style=\\"padding: 6px;\\"
-              data-uid=\\"726-3\\"
+              data-uid=\\"726~~~3\\"
               data-utopia-original-uid=\\"726\\"
               >C</span
             ></span
           >
         </div>
-        <div data-uid=\\"834-3\\" data-label=\\"Paste\\" data-utopia-original-uid=\\"834\\">
+        <div
+          data-uid=\\"834~~~3\\"
+          data-label=\\"Paste\\"
+          data-utopia-original-uid=\\"834\\"
+        >
           Paste
         </div>
-        <div data-uid=\\"999-4\\" data-label=\\"⌘⎇V\\" data-utopia-original-uid=\\"999\\">
+        <div data-uid=\\"999~~~4\\" data-label=\\"⌘⎇V\\" data-utopia-original-uid=\\"999\\">
           <span data-uid=\\"000\\"
             ><span
               style=\\"padding: 6px;\\"
-              data-uid=\\"726-1\\"
+              data-uid=\\"726~~~1\\"
               data-utopia-original-uid=\\"726\\"
               >⌘</span
             ><span
               style=\\"padding: 6px;\\"
-              data-uid=\\"726-2\\"
+              data-uid=\\"726~~~2\\"
               data-utopia-original-uid=\\"726\\"
               >⎇</span
             ><span
               style=\\"padding: 6px;\\"
-              data-uid=\\"726-3\\"
+              data-uid=\\"726~~~3\\"
               data-utopia-original-uid=\\"726\\"
               >V</span
             ></span
           >
         </div>
-        <div data-uid=\\"834-5\\" data-label=\\"Cut\\" data-utopia-original-uid=\\"834\\">
+        <div data-uid=\\"834~~~5\\" data-label=\\"Cut\\" data-utopia-original-uid=\\"834\\">
           Cut
         </div>
-        <div data-uid=\\"999-6\\" data-label=\\"⌘⎇C\\" data-utopia-original-uid=\\"999\\">
+        <div data-uid=\\"999~~~6\\" data-label=\\"⌘⎇C\\" data-utopia-original-uid=\\"999\\">
           <span data-uid=\\"000\\"
             ><span
               style=\\"padding: 6px;\\"
-              data-uid=\\"726-1\\"
+              data-uid=\\"726~~~1\\"
               data-utopia-original-uid=\\"726\\"
               >⌘</span
             ><span
               style=\\"padding: 6px;\\"
-              data-uid=\\"726-2\\"
+              data-uid=\\"726~~~2\\"
               data-utopia-original-uid=\\"726\\"
               >⎇</span
             ><span
               style=\\"padding: 6px;\\"
-              data-uid=\\"726-3\\"
+              data-uid=\\"726~~~3\\"
               data-utopia-original-uid=\\"726\\"
               >C</span
             ></span
@@ -10193,9 +10205,9 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"aaa\\">
-      <div data-uid=\\"bbb-1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
-      <div data-uid=\\"bbb-2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
-      <div data-uid=\\"bbb-3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
+      <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
+      <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
+      <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
     </div>
   </div>
 </div>
@@ -10459,9 +10471,9 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"aaa\\">
-      <div data-uid=\\"bbb-1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
-      <div data-uid=\\"bbb-2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
-      <div data-uid=\\"bbb-3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
+      <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
+      <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
+      <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
     </div>
   </div>
 </div>
@@ -10726,9 +10738,9 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block with 
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"aaa\\">
-      <div data-uid=\\"bbb-1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
-      <div data-uid=\\"bbb-2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
-      <div data-uid=\\"bbb-3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
+      <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
+      <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
+      <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
     </div>
   </div>
 </div>
@@ -13026,13 +13038,13 @@ exports[`UiJsxCanvas render supports passing down the scope to children of compo
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"aaa\\">
-      <div data-uid=\\"bbb-1\\" data-utopia-original-uid=\\"bbb\\">
+      <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">
         <div data-uid=\\"ccc\\">1</div>
       </div>
-      <div data-uid=\\"bbb-2\\" data-utopia-original-uid=\\"bbb\\">
+      <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">
         <div data-uid=\\"ccc\\">2</div>
       </div>
-      <div data-uid=\\"bbb-3\\" data-utopia-original-uid=\\"bbb\\">
+      <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">
         <div data-uid=\\"ccc\\">3</div>
       </div>
     </div>

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -103,7 +103,7 @@ export function generateUID(existingIDs: Array<string> | Set<string>): string {
   return generateUID(existingIDs)
 }
 
-export const GeneratedUIDSeparator = `-`
+export const GeneratedUIDSeparator = `~~~`
 export function createIndexedUid(originalUid: string, index: string | number): string {
   return `${originalUid}${GeneratedUIDSeparator}${index}`
 }


### PR DESCRIPTION
**Problem:**
A whole bunch of tests contain human-readable uids such as `uid='scene-aaa'`. This was not a problem in the past, but around 3 months ago I changed the generated uids to look like this: `<originaluid>-<index>` and use the `-` as a magic character that we use to determine if something was generated or not. This _seemed_ like a good idea at that time as the uids only contain alphanumeric characters, but it turns out that a whole lot of test code also uses the `-` for human readable names. 

This caused a hard to track down issue for @enidemi where a reparent didn't work for an element which had a dash in its UID. 

**Fix:**
Instead of fixing all the tests, this PR changes the magic generated uid separator from `-` to `~~~`, which should be much harder to accidentally clash with human-written UIDs.

