### PR TITLE
tests(canvas-utils) added tests for orphans, reparent and insert

### DIFF
--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1406,7 +1406,8 @@ describe('moveTemplate', () => {
 
   it('reparents an orphan from the canvas', async () => {
     const renderResult = await renderTestEditorWithCode(
-      Prettier.format(`/** @jsx jsx */
+      Prettier.format(
+        `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
     
@@ -1439,11 +1440,18 @@ describe('moveTemplate', () => {
             />
           </Storyboard>
         )
-      }`, PrettierConfig)
+      }`,
+        PrettierConfig,
+      ),
     )
 
     await renderResult.dispatch(
-      [selectComponents([TP.instancePath(TP.scenePath([]), [BakedInStoryboardUID, 'orphan-bbb'])], false)],
+      [
+        selectComponents(
+          [TP.instancePath(TP.scenePath([]), [BakedInStoryboardUID, 'orphan-bbb'])],
+          false,
+        ),
+      ],
       false,
     )
 
@@ -1519,7 +1527,8 @@ describe('moveTemplate', () => {
     })
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-      Prettier.format(`/** @jsx jsx */
+      Prettier.format(
+        `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
     
@@ -1553,13 +1562,16 @@ describe('moveTemplate', () => {
             />
           </Storyboard>
         )
-      }`, PrettierConfig)
+      }`,
+        PrettierConfig,
+      ),
     )
   })
 
   it('reparenting to the canvas creates an orphan', async () => {
     const renderResult = await renderTestEditorWithCode(
-      Prettier.format(`/** @jsx jsx */
+      Prettier.format(
+        `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
     
@@ -1594,11 +1606,18 @@ describe('moveTemplate', () => {
             />
           </Storyboard>
         )
-      }`, PrettierConfig)
+      }`,
+        PrettierConfig,
+      ),
     )
 
     await renderResult.dispatch(
-      [selectComponents([TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['aaa', 'bbb'])], false)],
+      [
+        selectComponents(
+          [TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['aaa', 'bbb'])],
+          false,
+        ),
+      ],
       false,
     )
 
@@ -1674,7 +1693,8 @@ describe('moveTemplate', () => {
     })
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-      Prettier.format(`/** @jsx jsx */
+      Prettier.format(
+        `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
     
@@ -1708,7 +1728,9 @@ describe('moveTemplate', () => {
             />
           </Storyboard>
         )
-      }`, PrettierConfig)
+      }`,
+        PrettierConfig,
+      ),
     )
   })
 
@@ -1819,7 +1841,8 @@ describe('moveTemplate', () => {
 
   it('inserting a new element as an orphan', async () => {
     const renderResult = await renderTestEditorWithCode(
-      Prettier.format(`/** @jsx jsx */
+      Prettier.format(
+        `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
     
@@ -1841,7 +1864,9 @@ describe('moveTemplate', () => {
             />
           </Storyboard>
         )
-      }`, PrettierConfig)
+      }`,
+        PrettierConfig,
+      ),
     )
     ;(generateUidWithExistingComponents as any) = jest.fn().mockReturnValue(NewUID)
 
@@ -1913,7 +1938,8 @@ describe('moveTemplate', () => {
     })
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
-      Prettier.format(`/** @jsx jsx */
+      Prettier.format(
+        `/** @jsx jsx */
       import * as React from 'react'
       import { Scene, Storyboard, View, jsx } from 'utopia-api'
     
@@ -1946,7 +1972,9 @@ describe('moveTemplate', () => {
             />
           </Storyboard>
         )
-      }`, PrettierConfig)
+      }`,
+        PrettierConfig,
+      ),
     )
   })
 

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1886,7 +1886,7 @@ describe('moveTemplate', () => {
     await act(async () => {
       fireEvent(
         canvasControlContainer,
-        new MouseEvent('mouseover', {
+        new MouseEvent('mousemove', {
           bubbles: true,
           cancelable: true,
           clientX: areaControlBounds.left + 120,


### PR DESCRIPTION
Added 3 missing tests for the canvas selection changes. These tests are all for orphan elements.

- reparent from the canvas root
- reparent to the canvas root
- insert an element to the canvas root