### PR TITLE
fix: elements were sometimes not selectable

### DIFF
--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -121,7 +121,7 @@ export function getAllTargetsAtPoint(
       if (!foundElement.canBeFilteredOut) {
         return true
       } else {
-        return elementsFromDOM.includes(foundElement.templatePath)
+        return elementsFromDOM.some((e) => TP.pathsEqual(e, foundElement.templatePath))
       }
     })
     .map((e) => e.templatePath)


### PR DESCRIPTION
**Problem:**
When editing the code, or doing some things on the canvas, select-mode would suddenly lock up, not letting you select elements, or only select them via cmd-click. It took us some time to track it down that the easiest to reproduce way was to edit the code, then the entire canvas would lock up.

Oh. My. God. It turns out the problem was this sneaky (_sneaky!_) line I made in my zero-dimension-elements PR:
```typescript
return elementsFromDOM.includes(foundElement.templatePath)
```
where `elementsFromDOM` is an `Array<TemplatePath>`.

The code mistakenly/accidentally assumed that `TP.fromString('aaa') === TP.fromString('aaa')` which became somewhat true somewhat recently as part of a performance optimization by Rheese.
However, to avoid growin the cache ad inifinitum, if the code changes, our `UPDATE_FROM_WORKER` update function explicitly calls `TP.clearTemplatePathCache()` which resets the Template Path cache, which leads to this:

```typescript
const a = TP.fromString('aaa')
const b = TP.fromString('aaa')
a === b // True
TP.clearTemplatePathCache() // code updated, cache reset
const c = TP.fromString('aaa')
a === b // Still True
a === c // FALSE!!!
```

![](http://1.bp.blogspot.com/-5pcj5R3DqGE/USQP-hcvioI/AAAAAAAAAMc/5Z44Pbuw2d0/s1600/picard-double-facepalm-gif-5917.gif)

**Fix:**
Do not rely on template path reference equality EVER

**Commit Details:**
- Sigh

**Notes:**
What can we do to prevent this? Performance-wise this is a very useful trick we have, but as my code exemplified, people in a hurry might mistakenly assume they can rely on `===` equality for Template Paths.
