### PR TITLE
Include commit hash in iframe urls

### DIFF
--- a/editor/src/components/code-editor/code-editor-container.tsx
+++ b/editor/src/components/code-editor/code-editor-container.tsx
@@ -48,7 +48,6 @@ import {
   useBridgeTowardsIframe,
 } from './code-editor-bridge'
 import { MONACO_EDITOR_IFRAME_BASE_URL } from '../../common/env-vars'
-import urljoin = require('url-join')
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import {
   CodeEditorNonIframeEntryPoint,
@@ -60,6 +59,7 @@ import {
   useUpdateOnConsoleLogs,
   useUpdateOnRuntimeErrors,
 } from '../../core/shared/runtime-report-logs'
+import { createIframeUrl } from '../../core/shared/utils'
 
 const CodeEditorIframeID = 'code-editor-iframe'
 
@@ -75,7 +75,7 @@ const CodeEditorIframeContainer = betterReactMemo<{ propsToSend: JSONStringified
     useUpdateOnRuntimeErrors(sendRuntimeErrors)
     useUpdateOnConsoleLogs(sendCanvasConsoleLogs)
 
-    const iframeSrc = urljoin(MONACO_EDITOR_IFRAME_BASE_URL, 'editor', 'monaco-editor-iframe.html')
+    const iframeSrc = createIframeUrl(MONACO_EDITOR_IFRAME_BASE_URL, 'monaco-editor-iframe.html')
 
     return (
       <iframe

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -30,7 +30,6 @@ import { Toast } from '../common/notices'
 import { chrome as isChrome } from 'platform-detect'
 import { applyShortcutConfigurationToDefaults } from './shortcut-definitions'
 import { UserConfiguration } from '../user-configuration'
-import urljoin = require('url-join')
 import { PROPERTY_CONTROLS_INFO_BASE_URL } from '../../common/env-vars'
 import {
   PropertyControlsInfoIFrameID,
@@ -50,6 +49,7 @@ import {
   FlexColumn,
 } from '../../uuiui'
 import { betterReactMemo } from '../../uuiui-deps'
+import { createIframeUrl } from '../../core/shared/utils'
 
 interface NumberSize {
   width: number
@@ -427,11 +427,7 @@ const ToastRenderer = betterReactMemo('ToastRenderer', () => {
 })
 
 const PropertyControlsInfoComponent = betterReactMemo('PropertyControlsInfoComponent', () => {
-  const iframeSrc = urljoin(
-    PROPERTY_CONTROLS_INFO_BASE_URL,
-    'editor',
-    'property-controls-info.html',
-  )
+  const iframeSrc = createIframeUrl(PROPERTY_CONTROLS_INFO_BASE_URL, 'property-controls-info.html')
 
   return (
     <iframe

--- a/editor/src/core/shared/dom-utils.ts
+++ b/editor/src/core/shared/dom-utils.ts
@@ -244,7 +244,7 @@ export function addStyleSheetToPage(url: string, shouldAppendHash: boolean = tru
   document.getElementsByTagName('head')[0].appendChild(cssElement)
 }
 
-function appendHash(url: string): string {
+export function appendHash(url: string): string {
   return `${url}?hash=${URL_HASH}`
 }
 

--- a/editor/src/core/shared/utils.ts
+++ b/editor/src/core/shared/utils.ts
@@ -1,6 +1,7 @@
 import { MapLike } from 'typescript'
 import { replaceAll } from './string-utils'
 import urljoin = require('url-join')
+import { appendHash } from './dom-utils'
 
 // This file shouldn't import anything as it is for exporting simple shared utility functions between various projects
 export const EditorID = 'editor'
@@ -136,4 +137,8 @@ export function unknownObjectProperty(o: unknown, key: string): any {
     }
   }
   return undefined
+}
+
+export function createIframeUrl(base: string, assetName: string): string {
+  return appendHash(urljoin(base, 'editor', assetName))
 }


### PR DESCRIPTION
Fixes #889 

**Problem:**
The code editor and property controls iframe were making a request for their respective HTML files against an endpoint that includes cache headers, and weren't providing a build identifier in those requests.

**Fix:**
Append the commit hash to the URL so that those iframes are only requesting the HTML files for their specific build.

**Commit Details:**
- Added a helper function for creating an iframe URL using a base endpoint and an asset file name
- Use that helper function in the two offending iframes
