### PR TITLE
fixing useRefEditorState

### DIFF
--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -89,17 +89,24 @@ export const useRefEditorState = <U>(
   // https://github.com/pmndrs/zustand/blob/d82e103cc6702ed10a404a587163e42fc3ac1338/src/index.ts#L161
   sliceRef.current = selector(api.getState()) // ensure that callers of this always have the latest data
   if (explainMe) {
-    console.info('reading useEditorState', sliceRef.current)
+    console.info('useRefEditorState: reading editor state', sliceRef.current)
   }
   React.useEffect(() => {
+    sliceRef.current = selectorRef.current(api.getState()) // the state might have changed between the render and this Effect being called
     if (explainMe) {
-      console.info('subscribing to the api')
+      console.info(
+        'useRefEditorState: re-reading editor state in useEffect, just in case it changed since the hook was called',
+        sliceRef.current,
+      )
+    }
+    if (explainMe) {
+      console.info('useRefEditorState: subscribing to the zustand api')
     }
     const unsubscribe = api.subscribe(
       (newSlice) => {
         if (newSlice) {
           if (explainMe) {
-            console.info('new slice arrived', newSlice)
+            console.info('useRefEditorState: new state slice arrived', newSlice)
           }
           sliceRef.current = newSlice
         }
@@ -109,7 +116,7 @@ export const useRefEditorState = <U>(
     )
     return function cleanup() {
       if (explainMe) {
-        console.info('unsubscribing from the api')
+        console.info('useRefEditorState: unsubscribing from the zustand api')
       }
       unsubscribe()
     }


### PR DESCRIPTION
**Problem:**
<img width="340" alt="image" src="https://user-images.githubusercontent.com/2226774/106157269-d27d4580-6182-11eb-93c8-8b67be6f3b44.png">
We have these useful helper buttons that can print the editor state and the canvas metadata. @enidemi noticed that sometimes they print stale state. it was very scary because a lot of code relies on the useRefEditorState hook.

Turns out the problem was that the hook queries the editor state whenever the hook is called (ie during the render phase) and it subscribes to editor state changes in a useEffect. 

However!

If the editor state changes between first query and the useEffect being called (roghly a `setTimeout(0)` amount of time later, which is to say in a callback after everything rendered) then simply subscribing to the editorState changes is not sufficient, because this happens:
`State1 -> hook called, queries state, saves State1 -> State changes to State2 -> useEffect called, subscribes to changes -> State2 never changes again. the callback is not called, we failed to update the ref to State2`.

**Fix:**
When the useEffect callback is fired, we update the ref to the then-current state. 

**Commit Details:**
- re-query the editor state when the useEffect hook is fired
- fix the console log messages when `explainMe` is true
