### PR TITLE
fix(scenes) componentmetadata should keep empty scenes

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -77,6 +77,7 @@ import {
   foldParsedTextFile,
   textFile,
   textFileContents,
+  ScenePath,
 } from '../../core/shared/project-file-types'
 import {
   getOrDefaultScenes,
@@ -2507,7 +2508,12 @@ export function cullSpyCollector(
   })
   // Eliminate the scene paths which are invalid.
   fastForEach(Object.keys(spyCollector.current.spyValues.scenes), (scenePath) => {
-    if (!scenePaths.has(scenePath)) {
+    if (
+      !scenePaths.has(scenePath) &&
+      !elementPaths.has(
+        TP.toString(TP.instancePath([], (TP.fromString(scenePath) as ScenePath).sceneElementPath)),
+      ) // this is needed because empty scenes are stored in metadata with an instancepath
+    ) {
       delete spyCollector.current.spyValues.scenes[scenePath]
     }
   })

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2511,7 +2511,12 @@ export function cullSpyCollector(
     if (
       !scenePaths.has(scenePath) &&
       !elementPaths.has(
-        TP.toString(TP.instancePath([], (TP.fromString(scenePath) as ScenePath).sceneElementPath)),
+        TP.toString(
+          TP.instancePath(
+            [],
+            spyCollector.current.spyValues.scenes[scenePath].scenePath.sceneElementPath,
+          ),
+        ),
       ) // this is needed because empty scenes are stored in metadata with an instancepath
     ) {
       delete spyCollector.current.spyValues.scenes[scenePath]


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/888

When you insert a new scene on the canvas it shows an element inspector instead of a scene inspector and the canvas control label is missing.

Since the storyboard+Scene changes the scene metadata (and other direct children of the storyboard, like orphans) use instance path as a templatepath, this was easily filtered from real scenes with the spy cleaner.