### PR TITLE
Fix/inspector layout pin displayed values

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
@@ -13,4 +13,256 @@ describe('inspector tests with real metadata', () => {
   it('placeholder', () => {
     // the tests will come here
   })
+  it('TLWH layout controls', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          style={{ ...props.style, position: 'absolute', backgroundColor: '#FFFFFF' }}
+          data-uid={'aaa'}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              backgroundColor: '#DDDDDD',
+              left: 55,
+              top: 98,
+              width: 266,
+              height: 124,
+            }}
+            data-uid={'bbb'}
+          ></div>
+        </div>
+      `),
+    )
+
+    await renderResult.dispatch(
+      [selectComponents([TP.instancePath(TestScenePath, ['aaa', 'bbb'])], false)],
+      false,
+    )
+
+    const metadata = renderResult.getEditorState().editor.jsxMetadataKILLME.elements[
+      'utopia-storyboard-uid/scene-aaa:aaa/bbb'
+    ]
+
+    const widthControl = (await renderResult.renderedDOM.findByTestId(
+      'position-Width-number-input',
+    )) as HTMLInputElement
+    const heightControl = (await renderResult.renderedDOM.findByTestId(
+      'position-Height-number-input',
+    )) as HTMLInputElement
+    const topControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedTop-number-input',
+    )) as HTMLInputElement
+    const leftControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedLeft-number-input',
+    )) as HTMLInputElement
+    const bottomControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedBottom-number-input',
+    )) as HTMLInputElement
+    const rightControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedRight-number-input',
+    )) as HTMLInputElement
+
+    expect(metadata.computedStyle?.['width']).toMatchInlineSnapshot(`"266px"`)
+    expect(widthControl.value).toMatchInlineSnapshot(`"266"`)
+    expect(
+      widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(metadata.computedStyle?.['height']).toMatchInlineSnapshot(`"124px"`)
+    expect(heightControl.value).toMatchInlineSnapshot(`"124"`)
+    expect(
+      heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(metadata.computedStyle?.['top']).toMatchInlineSnapshot(`"98px"`)
+    expect(topControl.value).toMatchInlineSnapshot(`"98"`)
+    expect(
+      topControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(metadata.computedStyle?.['left']).toMatchInlineSnapshot(`"55px"`)
+    expect(leftControl.value).toMatchInlineSnapshot(`"55"`)
+    expect(
+      leftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(bottomControl.value).toMatchInlineSnapshot(`""`)
+    expect(
+      bottomControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"unset"`)
+
+    expect(rightControl.value).toMatchInlineSnapshot(`""`)
+    expect(
+      rightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"unset"`)
+  })
+  it('TLBR layout controls', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          style={{ ...props.style, position: 'absolute', backgroundColor: '#FFFFFF' }}
+          data-uid={'aaa'}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              backgroundColor: '#DDDDDD',
+              left: 55,
+              top: 98,
+              bottom: 200,
+              right: 10,
+            }}
+            data-uid={'bbb'}
+          ></div>
+        </div>
+      `),
+    )
+
+    await renderResult.dispatch(
+      [selectComponents([TP.instancePath(TestScenePath, ['aaa', 'bbb'])], false)],
+      false,
+    )
+
+    const metadata = renderResult.getEditorState().editor.jsxMetadataKILLME.elements[
+      'utopia-storyboard-uid/scene-aaa:aaa/bbb'
+    ]
+
+    const widthControl = (await renderResult.renderedDOM.findByTestId(
+      'position-Width-number-input',
+    )) as HTMLInputElement
+    const heightControl = (await renderResult.renderedDOM.findByTestId(
+      'position-Height-number-input',
+    )) as HTMLInputElement
+    const topControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedTop-number-input',
+    )) as HTMLInputElement
+    const leftControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedLeft-number-input',
+    )) as HTMLInputElement
+    const bottomControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedBottom-number-input',
+    )) as HTMLInputElement
+    const rightControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedRight-number-input',
+    )) as HTMLInputElement
+
+    expect(widthControl.value).toMatchInlineSnapshot(`""`)
+    expect(
+      widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"unset"`)
+
+    expect(heightControl.value).toMatchInlineSnapshot(`""`)
+    expect(
+      heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"unset"`)
+
+    expect(metadata.computedStyle?.['top']).toMatchInlineSnapshot(`"98px"`)
+    expect(topControl.value).toMatchInlineSnapshot(`"98"`)
+    expect(
+      topControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(metadata.computedStyle?.['left']).toMatchInlineSnapshot(`"55px"`)
+    expect(leftControl.value).toMatchInlineSnapshot(`"55"`)
+    expect(
+      leftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(metadata.computedStyle?.['bottom']).toMatchInlineSnapshot(`"200px"`)
+    expect(bottomControl.value).toMatchInlineSnapshot(`"200"`)
+    expect(
+      bottomControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(metadata.computedStyle?.['right']).toMatchInlineSnapshot(`"10px"`)
+    expect(rightControl.value).toMatchInlineSnapshot(`"10"`)
+    expect(
+      rightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+  })
+  it('WHBR layout controls', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          style={{ ...props.style, position: 'absolute', backgroundColor: '#FFFFFF' }}
+          data-uid={'aaa'}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              backgroundColor: '#DDDDDD',
+              width: 203,
+              height: 102,
+              bottom: 200,
+              right: 10,
+            }}
+            data-uid={'bbb'}
+          ></div>
+        </div>
+      `),
+    )
+
+    await renderResult.dispatch(
+      [selectComponents([TP.instancePath(TestScenePath, ['aaa', 'bbb'])], false)],
+      false,
+    )
+
+    const metadata = renderResult.getEditorState().editor.jsxMetadataKILLME.elements[
+      'utopia-storyboard-uid/scene-aaa:aaa/bbb'
+    ]
+
+    const widthControl = (await renderResult.renderedDOM.findByTestId(
+      'position-Width-number-input',
+    )) as HTMLInputElement
+    const heightControl = (await renderResult.renderedDOM.findByTestId(
+      'position-Height-number-input',
+    )) as HTMLInputElement
+    const topControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedTop-number-input',
+    )) as HTMLInputElement
+    const leftControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedLeft-number-input',
+    )) as HTMLInputElement
+    const bottomControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedBottom-number-input',
+    )) as HTMLInputElement
+    const rightControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedRight-number-input',
+    )) as HTMLInputElement
+
+    expect(metadata.computedStyle?.['width']).toMatchInlineSnapshot(`"203px"`)
+    expect(widthControl.value).toMatchInlineSnapshot(`"203"`)
+    expect(
+      widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(metadata.computedStyle?.['height']).toMatchInlineSnapshot(`"102px"`)
+    expect(heightControl.value).toMatchInlineSnapshot(`"102"`)
+    expect(
+      heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(topControl.value).toMatchInlineSnapshot(`""`)
+    expect(
+      topControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"unset"`)
+
+    expect(leftControl.value).toMatchInlineSnapshot(`""`)
+    expect(
+      leftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"unset"`)
+
+    expect(metadata.computedStyle?.['bottom']).toMatchInlineSnapshot(`"200px"`)
+    expect(bottomControl.value).toMatchInlineSnapshot(`"200"`)
+    expect(
+      bottomControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(metadata.computedStyle?.['right']).toMatchInlineSnapshot(`"10px"`)
+    expect(rightControl.value).toMatchInlineSnapshot(`"10"`)
+    expect(
+      rightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+  })
 })

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -49,11 +49,7 @@ export const PinsLayoutNumberControl = betterReactMemo(
   (props: PinsLayoutNumberControlProps) => {
     const framePoint = framePointForPinnedProp(props.prop)
     const pointInfo = useInspectorLayoutInfo(props.prop)
-    const fullFrame = Utils.defaultIfNull(
-      {} as FullFrame,
-      Utils.optionalMap(getFullFrame, props.frame),
-    )
-    const framePinToUse = Utils.defaultIfNull(fullFrame[framePoint], pointInfo.value)
+    const framePinToUse = pointInfo.value
     const asCSSNumber = framePinToCSSNumber(framePinToUse)
     const [onSubmitValue, onTransientSubmitValue] = pointInfo.useSubmitValueFactory(
       (newValue: CSSNumber) => {

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -30,7 +30,6 @@ import { betterReactMemo } from '../../../../../uuiui-deps'
 interface PinsLayoutNumberControlProps {
   label: string
   prop: LayoutPinnedProp
-  frame: LocalRectangle | null
 }
 
 export const pinLabels: { [key in LayoutPinnedProp]: string } = {
@@ -218,8 +217,8 @@ const PinControls = betterReactMemo('PinControls', (props: PinControlsProps) => 
   )
 })
 
-function pinsLayoutNumberControl(frame: LocalRectangle | null, prop: LayoutPinnedProp) {
-  return <PinsLayoutNumberControl label={pinLabels[prop]} prop={prop} frame={frame} />
+function pinsLayoutNumberControl(prop: LayoutPinnedProp) {
+  return <PinsLayoutNumberControl label={pinLabels[prop]} prop={prop} />
 }
 
 function flexLayoutNumberControl(label: string, layoutProp: LayoutFlexElementNumericProp) {
@@ -270,8 +269,8 @@ const WidthHeightRow = betterReactMemo('WidthHeightRow', (props: WidthHeightRowP
         break
     }
   } else {
-    widthControl = pinsLayoutNumberControl(frame, 'Width')
-    heightControl = pinsLayoutNumberControl(frame, 'Height')
+    widthControl = pinsLayoutNumberControl('Width')
+    heightControl = pinsLayoutNumberControl('Height')
   }
 
   const toggleWidth = React.useCallback(() => {
@@ -401,8 +400,8 @@ const OtherPinsRow = betterReactMemo('OtherPinsRow', (props: PinControlsProps) =
   // const topInfo = useInspectorLayoutInfo('PinnedTop')
   // if (centerXInfo.value == null) {
   // No CenterX value, just show top and bottom.
-  firstXAxisControl = pinsLayoutNumberControl(frame, 'PinnedTop')
-  secondXAxisControl = pinsLayoutNumberControl(frame, 'PinnedBottom')
+  firstXAxisControl = pinsLayoutNumberControl('PinnedTop')
+  secondXAxisControl = pinsLayoutNumberControl('PinnedBottom')
   // } else {
   //   // We have a CenterX value, so put that first and then top or bottom after it.
   //   firstXAxisControl = pinsLayoutNumberControl(frame, 'PinnedCenterX')
@@ -418,8 +417,8 @@ const OtherPinsRow = betterReactMemo('OtherPinsRow', (props: PinControlsProps) =
   // const leftInfo = useInspectorLayoutInfo('PinnedLeft')
   // if (centerYInfo.value == null) {
   // No CenterY value, just show left and right.
-  firstYAxisControl = pinsLayoutNumberControl(frame, 'PinnedLeft')
-  secondYAxisControl = pinsLayoutNumberControl(frame, 'PinnedRight')
+  firstYAxisControl = pinsLayoutNumberControl('PinnedLeft')
+  secondYAxisControl = pinsLayoutNumberControl('PinnedRight')
   // } else {
   //   // We have a CenterY value, so put that first and then left or right after it.
   //   firstYAxisControl = pinsLayoutNumberControl(frame, 'PinnedCenterY')


### PR DESCRIPTION
Fixes a layout/pin section bug in the inspector where unset values are shown even if they are unset.

Fix:
- use the hook result pointInfo to get the display value
- remove the fullFrame calculated fallback, because in general we use computedStyle as fallback with different controlstatus/style, that should come from the hook.
- 3 tests that show the expected result checking the controlstatus and the input value.
