### PR TITLE
Fix inspector layout parsers

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -3799,13 +3799,15 @@ function parseFramePin(
   simpleValue: unknown | null,
   _: ModifiableAttribute | null,
 ): Either<string, FramePin> {
-  if (
-    typeof simpleValue === 'number' ||
-    (typeof simpleValue === 'string' && isPercentPin(simpleValue))
-  ) {
-    return right(simpleValue)
+  const parsedValue = parseCSSNumber(simpleValue, 'Length')
+  if (isRight(parsedValue)) {
+    if (parsedValue.value.unit === 'px') {
+      return right(parsedValue.value.value)
+    } else {
+      return right(`${parsedValue.value.value}${parsedValue.value.unit}`)
+    }
   } else {
-    return left('Value is not a valid frame pin.')
+    return parsedValue
   }
 }
 

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -3800,15 +3800,13 @@ function parseFramePin(
   _: ModifiableAttribute | null,
 ): Either<string, FramePin> {
   const parsedValue = parseCSSNumber(simpleValue, 'Length')
-  if (isRight(parsedValue)) {
-    if (parsedValue.value.unit === 'px' || parsedValue.value.unit == null) {
-      return right(parsedValue.value.value)
+  return mapEither((value: CSSNumber) => {
+    if (value.unit === 'px' || value.unit == null) {
+      return value.value
     } else {
-      return right(`${parsedValue.value.value}${parsedValue.value.unit}`)
+      return `${value.value}${value.unit}`
     }
-  } else {
-    return parsedValue
-  }
+  }, parsedValue)
 }
 
 function isOneOfTheseParser<T extends PrimitiveType>(values: Array<T>): Parser<T> {

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -3801,7 +3801,7 @@ function parseFramePin(
 ): Either<string, FramePin> {
   const parsedValue = parseCSSNumber(simpleValue, 'Length')
   if (isRight(parsedValue)) {
-    if (parsedValue.value.unit === 'px') {
+    if (parsedValue.value.unit === 'px' || parsedValue.value.unit == null) {
       return right(parsedValue.value.value)
     } else {
       return right(`${parsedValue.value.value}${parsedValue.value.unit}`)

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
@@ -87,15 +87,15 @@ describe('inspector tests with real metadata', () => {
       leftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"simple"`)
 
-    expect(bottomControl.value).toMatchInlineSnapshot(`""`)
+    expect(bottomControl.value).toMatchInlineSnapshot(`"178"`)
     expect(
       bottomControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"unset"`)
+    ).toMatchInlineSnapshot(`"detected"`)
 
-    expect(rightControl.value).toMatchInlineSnapshot(`""`)
+    expect(rightControl.value).toMatchInlineSnapshot(`"79"`)
     expect(
       rightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"unset"`)
+    ).toMatchInlineSnapshot(`"detected"`)
   })
   it('TLBR layout controls', async () => {
     const renderResult = await renderTestEditorWithCode(
@@ -147,15 +147,15 @@ describe('inspector tests with real metadata', () => {
       'position-PinnedRight-number-input',
     )) as HTMLInputElement
 
-    expect(widthControl.value).toMatchInlineSnapshot(`""`)
+    expect(widthControl.value).toMatchInlineSnapshot(`"335"`)
     expect(
       widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"unset"`)
+    ).toMatchInlineSnapshot(`"detected"`)
 
-    expect(heightControl.value).toMatchInlineSnapshot(`""`)
+    expect(heightControl.value).toMatchInlineSnapshot(`"102"`)
     expect(
       heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"unset"`)
+    ).toMatchInlineSnapshot(`"detected"`)
 
     expect(metadata.computedStyle?.['top']).toMatchInlineSnapshot(`"98px"`)
     expect(topControl.value).toMatchInlineSnapshot(`"98"`)
@@ -243,15 +243,15 @@ describe('inspector tests with real metadata', () => {
       heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"simple"`)
 
-    expect(topControl.value).toMatchInlineSnapshot(`""`)
+    expect(topControl.value).toMatchInlineSnapshot(`"98"`)
     expect(
       topControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"unset"`)
+    ).toMatchInlineSnapshot(`"detected"`)
 
-    expect(leftControl.value).toMatchInlineSnapshot(`""`)
+    expect(leftControl.value).toMatchInlineSnapshot(`"187"`)
     expect(
       leftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"unset"`)
+    ).toMatchInlineSnapshot(`"detected"`)
 
     expect(metadata.computedStyle?.['bottom']).toMatchInlineSnapshot(`"200px"`)
     expect(bottomControl.value).toMatchInlineSnapshot(`"200"`)


### PR DESCRIPTION
This is a fix to unify the inspector controls a little. FramePin parsing was not using the css parser, but something custom simple version of it. I couldn't use the CSSNumber directly because that's a more complex type and effects more things (like canvas-utils frame updating), this is a smaller step to at least use the same parser.

Fixes:
- use `parseCSSNumber`
- for px and unitless cases return the number value
- other cases use it as a string
- tests are updated too, because this introduces new behavior in the layout section

