### PR TITLE
Fix/inspector layout units

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -175,6 +175,7 @@ import { openFileTab } from '../editor/store/editor-tabs'
 import { emptyComments } from '../../core/workers/parser-printer/parser-printer-comments'
 import { getAllTargetsAtPoint } from './dom-lookup'
 import { WindowMousePositionRaw } from '../../templates/editor-canvas'
+import { cssNumberToFramePin, cssNumberToString } from '../inspector/common/css-utils'
 
 export function getOriginalFrames(
   selectedViews: Array<TemplatePath>,
@@ -367,8 +368,10 @@ export function updateFramesOfScenesAndComponents(
                 Utils.fastForEach(['PinnedLeft', 'PinnedTop'] as LayoutPinnedProp[], (p) => {
                   const framePoint = framePointForPinnedProp(p)
                   const value = getLayoutProperty(p, right(sceneElement.props))
-                  if (isLeft(value) || value.value != null) {
+                  if (isLeft(value)) {
                     frameProps[framePoint] = value.value
+                  } else if (value.value != null) {
+                    frameProps[framePoint] = cssNumberToFramePin(value.value)
                   }
                 })
                 let propsToSet = getPropsToSetToMoveElement(
@@ -411,8 +414,10 @@ export function updateFramesOfScenesAndComponents(
                   (p) => {
                     const framePoint = framePointForPinnedProp(p)
                     const value = getLayoutProperty(p, right(sceneElement.props))
-                    if (isLeft(value) || value.value != null) {
+                    if (isLeft(value)) {
                       frameProps[framePoint] = value.value
+                    } else if (value.value != null) {
+                      frameProps[framePoint] = cssNumberToFramePin(value.value)
                     }
                   },
                 )
@@ -622,7 +627,9 @@ export function updateFramesOfScenesAndComponents(
                   propsToSkip.push(propPathToUpdate)
                 } else {
                   const pinIsPercentage =
-                    existingProp.value == null ? false : isPercentPin(existingProp.value)
+                    existingProp.value == null
+                      ? false
+                      : isPercentPin(cssNumberToString(existingProp.value))
                   let valueToUse: string | number
                   if (parentFrame == null) {
                     valueToUse = absoluteValue
@@ -649,8 +656,11 @@ export function updateFramesOfScenesAndComponents(
               const framePoint = framePointForPinnedProp(p)
               if (framePoint !== FramePoint.Width && framePoint !== FramePoint.Height) {
                 const value = getLayoutProperty(p, right(element.props))
-                if (isLeft(value) || value.value != null) {
+                if (isLeft(value)) {
                   frameProps[framePoint] = value.value
+                  propsToSkip.push(createLayoutPropertyPath(p))
+                } else if (value.value != null) {
+                  frameProps[framePoint] = cssNumberToFramePin(value.value)
                   propsToSkip.push(createLayoutPropertyPath(p))
                 }
               }
@@ -684,8 +694,11 @@ export function updateFramesOfScenesAndComponents(
             Utils.fastForEach(LayoutPinnedProps, (p) => {
               const framePoint = framePointForPinnedProp(p)
               const value = getLayoutProperty(p, right(element.props))
-              if (isLeft(value) || value.value != null) {
+              if (isLeft(value)) {
                 frameProps[framePoint] = value.value
+                propsToSkip.push(createLayoutPropertyPath(p))
+              } else if (value.value != null) {
+                frameProps[framePoint] = cssNumberToFramePin(value.value)
                 propsToSkip.push(createLayoutPropertyPath(p))
               }
             })

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -175,7 +175,6 @@ import { openFileTab } from '../editor/store/editor-tabs'
 import { emptyComments } from '../../core/workers/parser-printer/parser-printer-comments'
 import { getAllTargetsAtPoint } from './dom-lookup'
 import { WindowMousePositionRaw } from '../../templates/editor-canvas'
-import { cssNumberToFramePin, cssNumberToString } from '../inspector/common/css-utils'
 
 export function getOriginalFrames(
   selectedViews: Array<TemplatePath>,
@@ -368,10 +367,8 @@ export function updateFramesOfScenesAndComponents(
                 Utils.fastForEach(['PinnedLeft', 'PinnedTop'] as LayoutPinnedProp[], (p) => {
                   const framePoint = framePointForPinnedProp(p)
                   const value = getLayoutProperty(p, right(sceneElement.props))
-                  if (isLeft(value)) {
+                  if (isLeft(value) || value.value != null) {
                     frameProps[framePoint] = value.value
-                  } else if (value.value != null) {
-                    frameProps[framePoint] = cssNumberToFramePin(value.value)
                   }
                 })
                 let propsToSet = getPropsToSetToMoveElement(
@@ -414,10 +411,8 @@ export function updateFramesOfScenesAndComponents(
                   (p) => {
                     const framePoint = framePointForPinnedProp(p)
                     const value = getLayoutProperty(p, right(sceneElement.props))
-                    if (isLeft(value)) {
+                    if (isLeft(value) || value.value != null) {
                       frameProps[framePoint] = value.value
-                    } else if (value.value != null) {
-                      frameProps[framePoint] = cssNumberToFramePin(value.value)
                     }
                   },
                 )
@@ -627,9 +622,7 @@ export function updateFramesOfScenesAndComponents(
                   propsToSkip.push(propPathToUpdate)
                 } else {
                   const pinIsPercentage =
-                    existingProp.value == null
-                      ? false
-                      : isPercentPin(cssNumberToString(existingProp.value))
+                    existingProp.value == null ? false : isPercentPin(existingProp.value)
                   let valueToUse: string | number
                   if (parentFrame == null) {
                     valueToUse = absoluteValue
@@ -656,11 +649,8 @@ export function updateFramesOfScenesAndComponents(
               const framePoint = framePointForPinnedProp(p)
               if (framePoint !== FramePoint.Width && framePoint !== FramePoint.Height) {
                 const value = getLayoutProperty(p, right(element.props))
-                if (isLeft(value)) {
+                if (isLeft(value) || value.value != null) {
                   frameProps[framePoint] = value.value
-                  propsToSkip.push(createLayoutPropertyPath(p))
-                } else if (value.value != null) {
-                  frameProps[framePoint] = cssNumberToFramePin(value.value)
                   propsToSkip.push(createLayoutPropertyPath(p))
                 }
               }
@@ -694,11 +684,8 @@ export function updateFramesOfScenesAndComponents(
             Utils.fastForEach(LayoutPinnedProps, (p) => {
               const framePoint = framePointForPinnedProp(p)
               const value = getLayoutProperty(p, right(element.props))
-              if (isLeft(value)) {
+              if (isLeft(value) || value.value != null) {
                 frameProps[framePoint] = value.value
-                propsToSkip.push(createLayoutPropertyPath(p))
-              } else if (value.value != null) {
-                frameProps[framePoint] = cssNumberToFramePin(value.value)
                 propsToSkip.push(createLayoutPropertyPath(p))
               }
             })

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -545,7 +545,7 @@ export function isCSSNumber(value: unknown): value is CSSNumber {
   return typeof value === 'object' && value != null && 'value' in value && 'unit' in value
 }
 
-export function getCSSNumberValue(value: CSSNumber | null): number | null {
+export function getCSSNumberValue(value: CSSNumber | null | undefined): number | null {
   return value == null ? null : value.value
 }
 
@@ -3798,15 +3798,8 @@ function printCSSObjectFit(value: CSSObjectFit): JSXAttributeValue<string> {
 function parseFramePin(
   simpleValue: unknown | null,
   _: ModifiableAttribute | null,
-): Either<string, FramePin> {
-  const parsedValue = parseCSSNumber(simpleValue, 'LengthPercent')
-  return mapEither((value: CSSNumber) => {
-    if (value.unit === 'px' || value.unit == null) {
-      return value.value
-    } else {
-      return `${value.value}${value.unit}`
-    }
-  }, parsedValue)
+): Either<string, CSSNumber> {
+  return parseCSSNumber(simpleValue, 'LengthPercent')
 }
 
 function isOneOfTheseParser<T extends PrimitiveType>(values: Array<T>): Parser<T> {
@@ -4120,10 +4113,10 @@ const cssParsers: CSSParsers = {
 
   alignSelf: flexAlignmentsParser,
   position: flexPositionParser,
-  left: parseCSSLength,
-  top: parseCSSLength,
-  right: parseCSSLength,
-  bottom: parseCSSLength,
+  left: parseCSSLengthPercent,
+  top: parseCSSLengthPercent,
+  right: parseCSSLengthPercent,
+  bottom: parseCSSLengthPercent,
   minWidth: parseCSSLengthPercent,
   maxWidth: parseCSSLengthPercent,
   minHeight: parseCSSLengthPercent,
@@ -4434,17 +4427,17 @@ const elementPropertiesPrinters: MetadataPrinters = {
 
 interface ParsedLayoutProperties {
   layoutSystem: LayoutSystem | undefined
-  pinLeft: FramePin | undefined
-  pinRight: FramePin | undefined
-  centerX: FramePin | undefined
-  width: FramePin | undefined
-  pinTop: FramePin | undefined
-  pinBottom: FramePin | undefined
-  centerY: FramePin | undefined
-  height: FramePin | undefined
+  pinLeft: CSSNumber | undefined
+  pinRight: CSSNumber | undefined
+  centerX: CSSNumber | undefined
+  width: CSSNumber | undefined
+  pinTop: CSSNumber | undefined
+  pinBottom: CSSNumber | undefined
+  centerY: CSSNumber | undefined
+  height: CSSNumber | undefined
   gapMain: number
-  flexBasis: FramePin | undefined
-  crossBasis: FramePin | undefined
+  flexBasis: CSSNumber | undefined
+  crossBasis: CSSNumber | undefined
 }
 
 export const layoutEmptyValues: ParsedLayoutProperties = {
@@ -4547,19 +4540,19 @@ type LayoutPrintersNew = {
 const layoutPrintersNew: LayoutPrintersNew = {
   LayoutSystem: jsxAttributeValueWithNoComments,
 
-  Width: jsxAttributeValueWithNoComments,
-  Height: jsxAttributeValueWithNoComments,
+  Width: printCSSNumberOrUndefinedAsAttributeValue,
+  Height: printCSSNumberOrUndefinedAsAttributeValue,
 
   FlexGap: jsxAttributeValueWithNoComments,
-  FlexFlexBasis: jsxAttributeValueWithNoComments,
-  FlexCrossBasis: jsxAttributeValueWithNoComments,
+  FlexFlexBasis: printCSSNumberOrUndefinedAsAttributeValue,
+  FlexCrossBasis: printCSSNumberOrUndefinedAsAttributeValue,
 
-  PinnedLeft: jsxAttributeValueWithNoComments,
-  PinnedTop: jsxAttributeValueWithNoComments,
-  PinnedRight: jsxAttributeValueWithNoComments,
-  PinnedBottom: jsxAttributeValueWithNoComments,
-  PinnedCenterX: jsxAttributeValueWithNoComments,
-  PinnedCenterY: jsxAttributeValueWithNoComments,
+  PinnedLeft: printCSSNumberOrUndefinedAsAttributeValue,
+  PinnedTop: printCSSNumberOrUndefinedAsAttributeValue,
+  PinnedRight: printCSSNumberOrUndefinedAsAttributeValue,
+  PinnedBottom: printCSSNumberOrUndefinedAsAttributeValue,
+  PinnedCenterX: printCSSNumberOrUndefinedAsAttributeValue,
+  PinnedCenterY: printCSSNumberOrUndefinedAsAttributeValue,
 }
 
 export interface ParsedProperties

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
@@ -323,6 +323,66 @@ describe('inspector tests with real metadata', () => {
       rightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"simple"`)
   })
+  it('TLWH layout controls non-px values', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          style={{ ...props.style, position: 'absolute', backgroundColor: '#FFFFFF' }}
+          data-uid={'aaa'}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              backgroundColor: '#DDDDDD',
+              left: '2em',
+              top: '1.4cm',
+              width: '10vw',
+              height: '124pt',
+            }}
+            data-uid={'bbb'}
+          ></div>
+        </div>
+      `),
+    )
+
+    await renderResult.dispatch(
+      [selectComponents([TP.instancePath(TestScenePath, ['aaa', 'bbb'])], false)],
+      false,
+    )
+
+    const widthControl = (await renderResult.renderedDOM.findByTestId(
+      'position-Width-number-input',
+    )) as HTMLInputElement
+    const heightControl = (await renderResult.renderedDOM.findByTestId(
+      'position-Height-number-input',
+    )) as HTMLInputElement
+    const topControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedTop-number-input',
+    )) as HTMLInputElement
+    const leftControl = (await renderResult.renderedDOM.findByTestId(
+      'position-PinnedLeft-number-input',
+    )) as HTMLInputElement
+
+    expect(widthControl.value).toMatchInlineSnapshot(`"10vw"`)
+    expect(
+      widthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(heightControl.value).toMatchInlineSnapshot(`"124pt"`)
+    expect(
+      heightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(topControl.value).toMatchInlineSnapshot(`"1.4cm"`)
+    expect(
+      topControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+
+    expect(leftControl.value).toMatchInlineSnapshot(`"2em"`)
+    expect(
+      leftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+  })
   it('Style props using numbers', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -24,6 +24,12 @@ import { getControlStyles, PropertyStatus } from './control-status'
 import { InspectorInfo } from './property-path-hooks'
 import { ScenePathForTestUiJsFile } from '../../../core/model/test-ui-js-file'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
+import { Frame } from 'utopia-api'
+import { PinsInfo } from './layout-property-path-hooks'
+import { CSSNumber } from './css-utils'
+import { mapValues } from '../../../core/shared/object-utils'
+import { LayoutPinnedProp } from '../../../core/layout/layout-helpers-new'
+import { LocalRectangle, localRectangle } from '../../../core/shared/math-utils'
 
 type UpdateFunctionHelpers = {
   updateStoreWithImmer: (fn: (store: EditorStore) => void) => void
@@ -130,4 +136,66 @@ export function testInspectorInfo<T>(value: T): InspectorInfo<T> {
       utils.NO_OP,
     ],
   }
+}
+
+export const SimpleRect: LocalRectangle = localRectangle({
+  x: 10,
+  y: 10,
+  width: 100,
+  height: 100,
+})
+
+export type SimplePinsInfo = { [key in LayoutPinnedProp]: CSSNumber | undefined }
+
+export function pinsInfoForPins(pins: SimplePinsInfo): PinsInfo {
+  return mapValues((pin) => testInspectorInfo(pin), pins) as PinsInfo
+}
+
+export function frameForPins(pins: SimplePinsInfo): Frame {
+  return {
+    left: pins.PinnedLeft?.value,
+    centerX: pins.PinnedCenterX?.value,
+    right: pins.PinnedRight?.value,
+    width: pins.Width?.value,
+    top: pins.PinnedTop?.value,
+    centerY: pins.PinnedCenterY?.value,
+    bottom: pins.PinnedBottom?.value,
+    height: pins.Height?.value,
+  }
+}
+
+export const TLWHSimplePins: SimplePinsInfo = {
+  PinnedLeft: {
+    value: SimpleRect.x,
+    unit: null,
+  },
+  Width: { value: SimpleRect.width, unit: null },
+  PinnedTop: { value: SimpleRect.y, unit: null },
+  Height: { value: SimpleRect.height, unit: null },
+  PinnedBottom: undefined,
+  PinnedRight: undefined,
+  PinnedCenterX: undefined,
+  PinnedCenterY: undefined,
+}
+
+export const TLBRSimplePins: SimplePinsInfo = {
+  PinnedLeft: { value: SimpleRect.x, unit: null },
+  Width: undefined,
+  PinnedTop: { value: SimpleRect.y, unit: null },
+  Height: undefined,
+  PinnedBottom: { value: SimpleRect.y + SimpleRect.height, unit: null },
+  PinnedRight: { value: SimpleRect.x + SimpleRect.width, unit: null },
+  PinnedCenterX: undefined,
+  PinnedCenterY: undefined,
+}
+
+export const CxCyWHSimplePins: SimplePinsInfo = {
+  PinnedLeft: undefined,
+  Width: { value: SimpleRect.width, unit: null },
+  PinnedTop: undefined,
+  Height: { value: SimpleRect.height, unit: null },
+  PinnedBottom: undefined,
+  PinnedRight: undefined,
+  PinnedCenterX: { value: SimpleRect.x, unit: null }, // Offset by 10 since both parent and element frames are the same width
+  PinnedCenterY: { value: SimpleRect.y, unit: null }, // Offset by 10 since both parent and element frames are the same height
 }

--- a/editor/src/components/inspector/common/layout-hooks.spec.ts
+++ b/editor/src/components/inspector/common/layout-hooks.spec.ts
@@ -1,37 +1,17 @@
 import { changePin, ElementFrameInfo, PinsInfo } from './layout-property-path-hooks'
-import { FramePin, Frame } from 'utopia-api'
-import { LayoutPinnedProp } from '../../../core/layout/layout-helpers-new'
-import { testInspectorInfo } from './inspector.test-utils'
+import {
+  SimplePinsInfo,
+  testInspectorInfo,
+  SimpleRect,
+  TLWHSimplePins,
+  pinsInfoForPins,
+  frameForPins,
+  TLBRSimplePins,
+  CxCyWHSimplePins,
+} from './inspector.test-utils'
 import { LocalRectangle, localRectangle } from '../../../core/shared/math-utils'
 import { ScenePathForTestUiJsFile } from '../../../core/model/test-ui-js-file'
 import * as TP from '../../../core/shared/template-path'
-import { mapValues } from '../../../core/shared/object-utils'
-
-type SimplePinsInfo = { [key in LayoutPinnedProp]: FramePin | undefined }
-
-function pinsInfoForPins(pins: SimplePinsInfo): PinsInfo {
-  return mapValues((pin) => testInspectorInfo(pin), pins) as PinsInfo
-}
-
-function frameForPins(pins: SimplePinsInfo): Frame {
-  return {
-    left: pins.PinnedLeft,
-    centerX: pins.PinnedCenterX,
-    right: pins.PinnedRight,
-    width: pins.Width,
-    top: pins.PinnedTop,
-    centerY: pins.PinnedCenterY,
-    bottom: pins.PinnedBottom,
-    height: pins.Height,
-  }
-}
-
-const SimpleRect: LocalRectangle = localRectangle({
-  x: 10,
-  y: 10,
-  width: 100,
-  height: 100,
-})
 
 function frameInfoForPins(
   pins: SimplePinsInfo,
@@ -47,41 +27,8 @@ function frameInfoForPins(
 }
 
 describe('changePin', () => {
-  const TLWH: SimplePinsInfo = {
-    PinnedLeft: SimpleRect.x,
-    Width: SimpleRect.width,
-    PinnedTop: SimpleRect.y,
-    Height: SimpleRect.height,
-    PinnedBottom: undefined,
-    PinnedRight: undefined,
-    PinnedCenterX: undefined,
-    PinnedCenterY: undefined,
-  }
-
-  const TLBR: SimplePinsInfo = {
-    PinnedLeft: SimpleRect.x,
-    Width: undefined,
-    PinnedTop: SimpleRect.y,
-    Height: undefined,
-    PinnedBottom: SimpleRect.y + SimpleRect.height,
-    PinnedRight: SimpleRect.x + SimpleRect.width,
-    PinnedCenterX: undefined,
-    PinnedCenterY: undefined,
-  }
-
-  const CxCyWH: SimplePinsInfo = {
-    PinnedLeft: undefined,
-    Width: SimpleRect.width,
-    PinnedTop: undefined,
-    Height: SimpleRect.height,
-    PinnedBottom: undefined,
-    PinnedRight: undefined,
-    PinnedCenterX: SimpleRect.x, // Offset by 10 since both parent and element frames are the same width
-    PinnedCenterY: SimpleRect.y, // Offset by 10 since both parent and element frames are the same height
-  }
-
   it('Toggles the pin type if clicking an already set pin', () => {
-    const pins = TLWH
+    const pins = TLWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Width',
       pinsInfoForPins(pins),
@@ -98,7 +45,7 @@ describe('changePin', () => {
   })
 
   it('Toggles the pin type if clicking an already set pin when that pin is also the last set', () => {
-    const pins = TLWH
+    const pins = TLWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Width',
       pinsInfoForPins(pins),
@@ -115,7 +62,7 @@ describe('changePin', () => {
   })
 
   it('Retains the last set pin if clicking a new pin', () => {
-    const pins = TLBR
+    const pins = TLBRSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Width',
       pinsInfoForPins(pins),
@@ -133,7 +80,7 @@ describe('changePin', () => {
   })
 
   it('Enables the width pin when setting the CX pin', () => {
-    const pins = TLBR
+    const pins = TLBRSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'PinnedCenterX',
       pinsInfoForPins(pins),
@@ -154,7 +101,7 @@ describe('changePin', () => {
   })
 
   it('Enables the height pin when setting the CY pin', () => {
-    const pins = TLBR
+    const pins = TLBRSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'PinnedCenterY',
       pinsInfoForPins(pins),
@@ -175,7 +122,7 @@ describe('changePin', () => {
   })
 
   it('Retains the width pin when the CX pin is last set and selecting a new pin', () => {
-    const pins = CxCyWH
+    const pins = CxCyWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'PinnedLeft',
       pinsInfoForPins(pins),
@@ -193,7 +140,7 @@ describe('changePin', () => {
   })
 
   it('Retains the height pin when the CY pin is last set and selecting a new pin', () => {
-    const pins = CxCyWH
+    const pins = CxCyWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'PinnedTop',
       pinsInfoForPins(pins),
@@ -211,7 +158,7 @@ describe('changePin', () => {
   })
 
   it('Toggles the width pin when the CX pin is last set and selecting the width pin', () => {
-    const pins = CxCyWH
+    const pins = CxCyWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Width',
       pinsInfoForPins(pins),
@@ -228,7 +175,7 @@ describe('changePin', () => {
   })
 
   it('Toggles the width pin when the width is last set, CX pin is set, and selecting the width pin', () => {
-    const pins = CxCyWH
+    const pins = CxCyWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Width',
       pinsInfoForPins(pins),
@@ -245,7 +192,7 @@ describe('changePin', () => {
   })
 
   it('Toggles the height pin when the CY pin is last set and selecting the height pin', () => {
-    const pins = CxCyWH
+    const pins = CxCyWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Height',
       pinsInfoForPins(pins),
@@ -262,7 +209,7 @@ describe('changePin', () => {
   })
 
   it('Toggles the height pin when the height pin is last set, CY pin is set, and selecting the height pin', () => {
-    const pins = CxCyWH
+    const pins = CxCyWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Height',
       pinsInfoForPins(pins),

--- a/editor/src/components/inspector/common/layout-property-path-hooks.spec.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.spec.ts
@@ -1,38 +1,17 @@
-import { Frame, FramePin } from 'utopia-api'
-import { LayoutPinnedProp } from '../../../core/layout/layout-helpers-new'
 import { ScenePathForTestUiJsFile } from '../../../core/model/test-ui-js-file'
 import { LocalRectangle, localRectangle } from '../../../core/shared/math-utils'
 import * as TP from '../../../core/shared/template-path'
-import { testInspectorInfo } from './inspector.test-utils'
+import {
+  SimplePinsInfo,
+  testInspectorInfo,
+  SimpleRect,
+  TLWHSimplePins,
+  pinsInfoForPins,
+  frameForPins,
+  TLBRSimplePins,
+  CxCyWHSimplePins,
+} from './inspector.test-utils'
 import { changePin, ElementFrameInfo, PinsInfo } from './layout-property-path-hooks'
-import { mapValues } from '../../../core/shared/object-utils'
-import { CSSNumber } from './css-utils'
-
-type SimplePinsInfo = { [key in LayoutPinnedProp]: CSSNumber | undefined }
-
-function pinsInfoForPins(pins: SimplePinsInfo): PinsInfo {
-  return mapValues((pin) => testInspectorInfo(pin), pins) as PinsInfo
-}
-
-function frameForPins(pins: SimplePinsInfo): Frame {
-  return {
-    left: pins.PinnedLeft?.value,
-    centerX: pins.PinnedCenterX?.value,
-    right: pins.PinnedRight?.value,
-    width: pins.Width?.value,
-    top: pins.PinnedTop?.value,
-    centerY: pins.PinnedCenterY?.value,
-    bottom: pins.PinnedBottom?.value,
-    height: pins.Height?.value,
-  }
-}
-
-const SimpleRect: LocalRectangle = localRectangle({
-  x: 10,
-  y: 10,
-  width: 100,
-  height: 100,
-})
 
 function frameInfoForPins(
   pins: SimplePinsInfo,
@@ -48,44 +27,8 @@ function frameInfoForPins(
 }
 
 describe('changePin', () => {
-  const TLWH: SimplePinsInfo = {
-    PinnedLeft: {
-      value: SimpleRect.x,
-      unit: null,
-    },
-    Width: { value: SimpleRect.width, unit: null },
-    PinnedTop: { value: SimpleRect.y, unit: null },
-    Height: { value: SimpleRect.height, unit: null },
-    PinnedBottom: undefined,
-    PinnedRight: undefined,
-    PinnedCenterX: undefined,
-    PinnedCenterY: undefined,
-  }
-
-  const TLBR: SimplePinsInfo = {
-    PinnedLeft: { value: SimpleRect.x, unit: null },
-    Width: undefined,
-    PinnedTop: { value: SimpleRect.y, unit: null },
-    Height: undefined,
-    PinnedBottom: { value: SimpleRect.y + SimpleRect.height, unit: null },
-    PinnedRight: { value: SimpleRect.x + SimpleRect.width, unit: null },
-    PinnedCenterX: undefined,
-    PinnedCenterY: undefined,
-  }
-
-  const CxCyWH: SimplePinsInfo = {
-    PinnedLeft: undefined,
-    Width: { value: SimpleRect.width, unit: null },
-    PinnedTop: undefined,
-    Height: { value: SimpleRect.height, unit: null },
-    PinnedBottom: undefined,
-    PinnedRight: undefined,
-    PinnedCenterX: { value: SimpleRect.x, unit: null }, // Offset by 10 since both parent and element frames are the same width
-    PinnedCenterY: { value: SimpleRect.y, unit: null }, // Offset by 10 since both parent and element frames are the same height
-  }
-
   it('Toggles the pin type if clicking an already set pin', () => {
-    const pins = TLWH
+    const pins = TLWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Width',
       pinsInfoForPins(pins),
@@ -102,7 +45,7 @@ describe('changePin', () => {
   })
 
   it('Toggles the pin type if clicking an already set pin when that pin is also the last set', () => {
-    const pins = TLWH
+    const pins = TLWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Width',
       pinsInfoForPins(pins),
@@ -119,7 +62,7 @@ describe('changePin', () => {
   })
 
   it('Retains the last set pin if clicking a new pin', () => {
-    const pins = TLBR
+    const pins = TLBRSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Width',
       pinsInfoForPins(pins),
@@ -137,7 +80,7 @@ describe('changePin', () => {
   })
 
   it('Enables the width pin when setting the CX pin', () => {
-    const pins = TLBR
+    const pins = TLBRSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'PinnedCenterX',
       pinsInfoForPins(pins),
@@ -158,7 +101,7 @@ describe('changePin', () => {
   })
 
   it('Enables the height pin when setting the CY pin', () => {
-    const pins = TLBR
+    const pins = TLBRSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'PinnedCenterY',
       pinsInfoForPins(pins),
@@ -179,7 +122,7 @@ describe('changePin', () => {
   })
 
   it('Retains the width pin when the CX pin is last set and selecting a new pin', () => {
-    const pins = CxCyWH
+    const pins = CxCyWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'PinnedLeft',
       pinsInfoForPins(pins),
@@ -197,7 +140,7 @@ describe('changePin', () => {
   })
 
   it('Retains the height pin when the CY pin is last set and selecting a new pin', () => {
-    const pins = CxCyWH
+    const pins = CxCyWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'PinnedTop',
       pinsInfoForPins(pins),
@@ -215,7 +158,7 @@ describe('changePin', () => {
   })
 
   it('Toggles the width pin when the CX pin is last set and selecting the width pin', () => {
-    const pins = CxCyWH
+    const pins = CxCyWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Width',
       pinsInfoForPins(pins),
@@ -232,7 +175,7 @@ describe('changePin', () => {
   })
 
   it('Toggles the width pin when the width is last set, CX pin is set, and selecting the width pin', () => {
-    const pins = CxCyWH
+    const pins = CxCyWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Width',
       pinsInfoForPins(pins),
@@ -249,7 +192,7 @@ describe('changePin', () => {
   })
 
   it('Toggles the height pin when the CY pin is last set and selecting the height pin', () => {
-    const pins = CxCyWH
+    const pins = CxCyWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Height',
       pinsInfoForPins(pins),
@@ -266,7 +209,7 @@ describe('changePin', () => {
   })
 
   it('Toggles the height pin when the height pin is last set, CY pin is set, and selecting the height pin', () => {
-    const pins = CxCyWH
+    const pins = CxCyWHSimplePins
     const { pinsToSet, pinsToUnset } = changePin(
       'Height',
       pinsInfoForPins(pins),

--- a/editor/src/components/inspector/common/layout-property-path-hooks.spec.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.spec.ts
@@ -6,8 +6,9 @@ import * as TP from '../../../core/shared/template-path'
 import { testInspectorInfo } from './inspector.test-utils'
 import { changePin, ElementFrameInfo, PinsInfo } from './layout-property-path-hooks'
 import { mapValues } from '../../../core/shared/object-utils'
+import { CSSNumber } from './css-utils'
 
-type SimplePinsInfo = { [key in LayoutPinnedProp]: FramePin | undefined }
+type SimplePinsInfo = { [key in LayoutPinnedProp]: CSSNumber | undefined }
 
 function pinsInfoForPins(pins: SimplePinsInfo): PinsInfo {
   return mapValues((pin) => testInspectorInfo(pin), pins) as PinsInfo
@@ -15,14 +16,14 @@ function pinsInfoForPins(pins: SimplePinsInfo): PinsInfo {
 
 function frameForPins(pins: SimplePinsInfo): Frame {
   return {
-    left: pins.PinnedLeft,
-    centerX: pins.PinnedCenterX,
-    right: pins.PinnedRight,
-    width: pins.Width,
-    top: pins.PinnedTop,
-    centerY: pins.PinnedCenterY,
-    bottom: pins.PinnedBottom,
-    height: pins.Height,
+    left: pins.PinnedLeft?.value,
+    centerX: pins.PinnedCenterX?.value,
+    right: pins.PinnedRight?.value,
+    width: pins.Width?.value,
+    top: pins.PinnedTop?.value,
+    centerY: pins.PinnedCenterY?.value,
+    bottom: pins.PinnedBottom?.value,
+    height: pins.Height?.value,
   }
 }
 
@@ -48,10 +49,13 @@ function frameInfoForPins(
 
 describe('changePin', () => {
   const TLWH: SimplePinsInfo = {
-    PinnedLeft: SimpleRect.x,
-    Width: SimpleRect.width,
-    PinnedTop: SimpleRect.y,
-    Height: SimpleRect.height,
+    PinnedLeft: {
+      value: SimpleRect.x,
+      unit: null,
+    },
+    Width: { value: SimpleRect.width, unit: null },
+    PinnedTop: { value: SimpleRect.y, unit: null },
+    Height: { value: SimpleRect.height, unit: null },
     PinnedBottom: undefined,
     PinnedRight: undefined,
     PinnedCenterX: undefined,
@@ -59,25 +63,25 @@ describe('changePin', () => {
   }
 
   const TLBR: SimplePinsInfo = {
-    PinnedLeft: SimpleRect.x,
+    PinnedLeft: { value: SimpleRect.x, unit: null },
     Width: undefined,
-    PinnedTop: SimpleRect.y,
+    PinnedTop: { value: SimpleRect.y, unit: null },
     Height: undefined,
-    PinnedBottom: SimpleRect.y + SimpleRect.height,
-    PinnedRight: SimpleRect.x + SimpleRect.width,
+    PinnedBottom: { value: SimpleRect.y + SimpleRect.height, unit: null },
+    PinnedRight: { value: SimpleRect.x + SimpleRect.width, unit: null },
     PinnedCenterX: undefined,
     PinnedCenterY: undefined,
   }
 
   const CxCyWH: SimplePinsInfo = {
     PinnedLeft: undefined,
-    Width: SimpleRect.width,
+    Width: { value: SimpleRect.width, unit: null },
     PinnedTop: undefined,
-    Height: SimpleRect.height,
+    Height: { value: SimpleRect.height, unit: null },
     PinnedBottom: undefined,
     PinnedRight: undefined,
-    PinnedCenterX: SimpleRect.x, // Offset by 10 since both parent and element frames are the same width
-    PinnedCenterY: SimpleRect.y, // Offset by 10 since both parent and element frames are the same height
+    PinnedCenterX: { value: SimpleRect.x, unit: null }, // Offset by 10 since both parent and element frames are the same width
+    PinnedCenterY: { value: SimpleRect.y, unit: null }, // Offset by 10 since both parent and element frames are the same height
   }
 
   it('Toggles the pin type if clicking an already set pin', () => {

--- a/editor/src/components/inspector/common/layout-property-path-hooks.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.ts
@@ -38,6 +38,7 @@ import {
 import React = require('react')
 import { usePropControlledRef_DANGEROUS } from './inspector-utils'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
+import { CSSNumber, cssNumberToString } from './css-utils'
 
 const HorizontalPinPreference = [
   FramePoint.Left,
@@ -93,7 +94,7 @@ export interface ElementFrameInfo {
   parentFrame: LocalRectangle | null
 }
 
-type PinInspectorInfo = InspectorInfo<string | number | undefined>
+type PinInspectorInfo = InspectorInfo<CSSNumber | undefined>
 
 export type PinsInfo = { [key in LayoutPinnedProp]: PinInspectorInfo }
 
@@ -152,7 +153,7 @@ export function changePin(
   const toggleToRelative =
     pinInfoForProp.propertyStatus.identical &&
     pinInfoForProp.value != null &&
-    !isPercentPin(pinInfoForProp.value)
+    !isPercentPin(cssNumberToString(pinInfoForProp.value, true))
 
   let pinsToSet: Array<PinToSet> = []
   let pinsToUnset: Array<PinToUnset> = []

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -72,7 +72,7 @@ export const PinsLayoutNumberControl = betterReactMemo(
           onSubmitValue={wrappedOnSubmit}
           onTransientSubmitValue={wrappedOnTransientSubmit}
           controlStatus={pointInfo.controlStatus}
-          numberType={'UnitlessPercent'}
+          numberType={'LengthPercent'}
           defaultUnitToHide={'px'}
         />
       </InspectorContextMenuWrapper>
@@ -172,7 +172,7 @@ export const FlexLayoutNumberControl = betterReactMemo(
           onSubmitValue={wrappedOnSubmitValue}
           onTransientSubmitValue={wrappedOnTransientSubmitValue}
           controlStatus={layoutPropInfo.controlStatus}
-          numberType={'UnitlessPercent'}
+          numberType={'LengthPercent'}
           labelInner={props.label}
           defaultUnitToHide={'px'}
         />

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -48,20 +48,13 @@ export const PinsLayoutNumberControl = betterReactMemo(
   (props: PinsLayoutNumberControlProps) => {
     const framePoint = framePointForPinnedProp(props.prop)
     const pointInfo = useInspectorLayoutInfo(props.prop)
-    const framePinToUse = pointInfo.value
-    const asCSSNumber = framePinToCSSNumber(framePinToUse)
-    const [onSubmitValue, onTransientSubmitValue] = pointInfo.useSubmitValueFactory(
-      (newValue: CSSNumber) => {
-        return cssNumberToFramePin(newValue)
-      },
-    )
 
     const wrappedOnSubmit = useWrappedEmptyOrUnknownOnSubmitValue(
-      onSubmitValue,
+      pointInfo.onSubmitValue,
       pointInfo.onUnsetValues,
     )
     const wrappedOnTransientSubmit = useWrappedEmptyOrUnknownOnSubmitValue(
-      onTransientSubmitValue,
+      pointInfo.onTransientSubmitValue,
       pointInfo.onUnsetValues,
     )
 
@@ -72,7 +65,7 @@ export const PinsLayoutNumberControl = betterReactMemo(
         data={{}}
       >
         <NumberInput
-          value={asCSSNumber}
+          value={pointInfo.value}
           id={`position-${props.prop}-number-input`}
           testId={`position-${props.prop}-number-input`}
           labelInner={props.label}
@@ -156,19 +149,13 @@ export const FlexLayoutNumberControl = betterReactMemo(
   'FlexLayoutNumberControl',
   (props: FlexLayoutNumberControlProps) => {
     const layoutPropInfo = useInspectorLayoutInfo(props.layoutProp)
-    const asCSSNumber = framePinToCSSNumber(layoutPropInfo.value)
-    const [onSubmitValue, onTransientSubmitValue] = layoutPropInfo.useSubmitValueFactory(
-      (newValue: CSSNumber, oldValue) => {
-        return cssNumberToFramePin(newValue)
-      },
-    )
 
     const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      onSubmitValue,
+      layoutPropInfo.onSubmitValue,
       layoutPropInfo.onUnsetValues,
     )
     const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      onTransientSubmitValue,
+      layoutPropInfo.onTransientSubmitValue,
       layoutPropInfo.onUnsetValues,
     )
 
@@ -181,7 +168,7 @@ export const FlexLayoutNumberControl = betterReactMemo(
         <NumberInput
           id={`position-${props.layoutProp}-number-input`}
           testId={`position-${props.layoutProp}-number-input`}
-          value={asCSSNumber}
+          value={layoutPropInfo.value}
           onSubmitValue={wrappedOnSubmitValue}
           onTransientSubmitValue={wrappedOnTransientSubmitValue}
           controlStatus={layoutPropInfo.controlStatus}

--- a/editor/src/components/inspector/sections/scene-inspector/scene-section.tsx
+++ b/editor/src/components/inspector/sections/scene-inspector/scene-section.tsx
@@ -140,8 +140,8 @@ export const SceneSection = betterReactMemo('SceneSection', () => {
       </PropertyRow>
       <InspectorSubsectionHeader>Layout</InspectorSubsectionHeader>
       <PropertyRow style={{ gridColumnGap: 16 }}>
-        <PositionWidgetForCSSNumber inspectorInfo={frameLeft} point={'left'} />
-        <PositionWidgetForCSSNumber inspectorInfo={frameTop} point={'top'} />
+        <PositionWidget inspectorInfo={frameLeft} point={'left'} />
+        <PositionWidget inspectorInfo={frameTop} point={'top'} />
       </PropertyRow>
       <PropertyRow style={{ gridColumnGap: 16 }}>
         <PositionWidget inspectorInfo={frameWidth} point={'width'} />
@@ -157,47 +157,9 @@ export const SceneSection = betterReactMemo('SceneSection', () => {
 const PositionWidget = betterReactMemo(
   'PositionWidget',
   (props: {
-    inspectorInfo: InspectorInfo<string | number | undefined>
+    inspectorInfo: InspectorInfo<CSSNumber> | InspectorInfo<CSSNumber | undefined>
     point: keyof NormalisedFrame
   }) => {
-    const { inspectorInfo, point } = props
-    const pinnedProp = pinnedPropForFramePoint(point as FramePoint)
-    const label = pinLabels[pinnedProp]
-    const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      inspectorInfo.onSubmitValue,
-      inspectorInfo.onUnsetValues,
-    )
-    const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      inspectorInfo.onTransientSubmitValue,
-      inspectorInfo.onUnsetValues,
-    )
-    return (
-      <div style={{ gridColumn: 'span 2' }}>
-        <div
-          style={{
-            gridColumn: '1 / span 4',
-            gridRow: '1 / span 2',
-          }}
-        >
-          <SimpleNumberInput
-            value={inspectorInfo.value as any} // I will delete this code once the scenes are merged to components
-            labelInner={label}
-            id={`scene-frame-${pinnedProp}-number-input`}
-            testId={`scene-frame-${pinnedProp}-number-input`}
-            onSubmitValue={wrappedOnSubmitValue}
-            onTransientSubmitValue={wrappedOnTransientSubmitValue}
-            onForcedSubmitValue={wrappedOnSubmitValue}
-            defaultUnitToHide={'px'}
-          />
-        </div>
-      </div>
-    )
-  },
-)
-
-const PositionWidgetForCSSNumber = betterReactMemo(
-  'PositionWidget',
-  (props: { inspectorInfo: InspectorInfo<CSSNumber>; point: keyof NormalisedFrame }) => {
     const { inspectorInfo, point } = props
     const pinnedProp = pinnedPropForFramePoint(point as FramePoint)
     const label = pinLabels[pinnedProp]

--- a/editor/src/components/inspector/sections/style-section/containter-subsection/radius-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/containter-subsection/radius-row.tsx
@@ -161,12 +161,10 @@ const radiusTypeOptions: OptionsType<SelectOption> = [
   },
 ]
 
-function getSliderMax(widthPin: FramePin | undefined, heightPin: FramePin | undefined): number {
+function getSliderMax(widthPin: CSSNumber | undefined, heightPin: CSSNumber | undefined): number {
   const defaultMax = 100
-  const parsedWidth = framePinToCSSNumber(widthPin)
-  const parsedHeight = framePinToCSSNumber(heightPin)
-  const width = utils.defaultIfNull(defaultMax, getCSSNumberValue(parsedWidth))
-  const height = utils.defaultIfNull(defaultMax, getCSSNumberValue(parsedHeight))
+  const width = utils.defaultIfNull(defaultMax, getCSSNumberValue(widthPin))
+  const height = utils.defaultIfNull(defaultMax, getCSSNumberValue(heightPin))
   return Math.min(width, height)
 }
 

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -2,7 +2,7 @@ import { FramePin, FlexLength, LayoutSystem, FramePoint } from 'utopia-api'
 import { PropertyPath, PropertyPathPart } from '../shared/project-file-types'
 import * as PP from '../shared/property-path'
 import { ElementInstanceMetadata } from '../shared/element-template'
-import { ParsedCSSProperties } from '../../components/inspector/common/css-utils'
+import { CSSNumber, ParsedCSSProperties } from '../../components/inspector/common/css-utils'
 
 export type LayoutDimension = 'Width' | 'Height'
 
@@ -162,19 +162,19 @@ const LayoutPathMap: { [key in LayoutProp | StyleLayoutProp]: Array<PropertyPath
 export interface LayoutPropertyTypes {
   LayoutSystem: LayoutSystem | undefined
 
-  Width: FramePin | undefined
-  Height: FramePin | undefined
+  Width: CSSNumber | undefined
+  Height: CSSNumber | undefined
 
   FlexGap: number
-  FlexFlexBasis: FlexLength
-  FlexCrossBasis: FlexLength
+  FlexFlexBasis: CSSNumber | undefined
+  FlexCrossBasis: CSSNumber | undefined
 
-  PinnedLeft: FramePin | undefined
-  PinnedTop: FramePin | undefined
-  PinnedRight: FramePin | undefined
-  PinnedBottom: FramePin | undefined
-  PinnedCenterX: FramePin | undefined
-  PinnedCenterY: FramePin | undefined
+  PinnedLeft: CSSNumber | undefined
+  PinnedTop: CSSNumber | undefined
+  PinnedRight: CSSNumber | undefined
+  PinnedBottom: CSSNumber | undefined
+  PinnedCenterX: CSSNumber | undefined
+  PinnedCenterY: CSSNumber | undefined
 }
 
 export interface LayoutPropertyTypesAndCSSPropertyTypes

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -177,9 +177,22 @@ export interface LayoutPropertyTypes {
   PinnedCenterY: CSSNumber | undefined
 }
 
-export interface LayoutPropertyTypesAndCSSPropertyTypes
-  extends LayoutPropertyTypes,
-    ParsedCSSProperties {}
+export interface LayoutPropertyTypesAndCSSPropertyTypes extends ParsedCSSProperties {
+  LayoutSystem: LayoutSystem | undefined
+  Width: FramePin | undefined
+  Height: FramePin | undefined
+
+  FlexGap: number
+  FlexFlexBasis: FlexLength
+  FlexCrossBasis: FlexLength
+
+  PinnedLeft: FramePin | undefined
+  PinnedTop: FramePin | undefined
+  PinnedRight: FramePin | undefined
+  PinnedBottom: FramePin | undefined
+  PinnedCenterX: FramePin | undefined
+  PinnedCenterY: FramePin | undefined
+}
 
 export function createLayoutPropertyPath(layoutProp: LayoutProp | StyleLayoutProp): PropertyPath {
   return PP.create(LayoutPathMap[layoutProp])


### PR DESCRIPTION
#905 fixes % in layout controls, with this PR it's possible to show/add other unit types through the inspector, but not through canvas dragging.

**Problem:**
Layout controls are still not using the `CSSNumber` type of value like other controls.

**Commit Details:**
- a test
- update cssprinters to convert from CSSNumber to string
- in scene-section removed `PositionWidget` as this was not using CSSNumbers, there is another component called `PositionWidgetForCSSNumber`, renamed that to `PositionWidget`
