### PR TITLE
fix: force update the dom-walker if the selected views change

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -245,6 +245,7 @@ function useInvalidateScenesWhenSelectedViewChanges(
   invalidatedSceneIDsRef: React.MutableRefObject<Set<string>>,
   invalidatedPathsForStylesheetCacheRef: React.MutableRefObject<Set<string>>,
 ): void {
+  const [, forceUpdate] = React.useReducer((c) => c + 1, 0)
   return useSelectorWithCallback(
     (store) => store.editor.selectedViews,
     (newSelectedViews) => {
@@ -253,6 +254,7 @@ function useInvalidateScenesWhenSelectedViewChanges(
         const sceneID = TP.toString(scenePath)
         invalidatedSceneIDsRef.current.add(sceneID)
         invalidatedPathsForStylesheetCacheRef.current.add(TP.toString(sv))
+        forceUpdate()
       })
     },
   )

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -117,7 +117,7 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(460) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(470)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(620) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(630)
   })
 })


### PR DESCRIPTION
**Problem:**
We have some expensive computedStyle-related lookups in the dom-walker that we only want to run on selected view changes. However, there was a bug that would sometimes mean changing the selected view would not re-run the dom-walker (until for example the user scrolled the canvas) – the bug would manifest in an empty inspector and was not predictable to reproduce.

**Fix:**
I realized that the issue was that while the selected view change callback correctly detected selected view change and invalidated the cache, the callback would not force a re-render on the dom-walker. Since sometimes the canvas would re-render on selected view change, this bug would only happen every now and then.

**Commit Details:**
- the dom-walker forces a rerender on the canvas if the selected views change. this results in a dom-walker re-run as well.

**Note:**
I expect the "change selected view" performance measurement to be more reliable now, also it should show a significantly higher number since my previous PR has an extra 40ms dom-walking cost when the selected view is changed.
