### PR TITLE
Fix/inspector controlled values for broken code

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -66,6 +66,7 @@ import {
   jsxAttributesFromMap,
   deleteJSXAttribute,
   setJSXAttributesAttribute,
+  emptyJsxMetadata,
 } from '../../../core/shared/element-template'
 import {
   generateUidWithExistingComponents,
@@ -3633,6 +3634,7 @@ export const UPDATE_FNS = {
       return {
         ...editor,
         codeEditorErrors: updatedCodeEditorErrors,
+        jsxMetadataKILLME: emptyJsxMetadata,
       }
     }
   },

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -833,9 +833,16 @@ export const InspectorContextProvider = betterReactMemo<{
            */
           return
         }
-
         const jsxElement = findElementAtPath(path, rootComponents)
-        const jsxAttributes = jsxElement != null && isJSXElement(jsxElement) ? jsxElement.props : []
+        if (jsxElement == null) {
+          /**
+           * This early return will cause the inspector to render with empty fields.
+           * With missing jsxElement manipulating style props is not possible.
+           */
+          return
+        }
+
+        const jsxAttributes = isJSXElement(jsxElement) ? jsxElement.props : []
         newEditedMultiSelectedProps.push(jsxAttributes)
         newSpiedProps.push(elementMetadata.props)
         newComputedStyles.push(elementMetadata.computedStyle)


### PR DESCRIPTION
**Problem:**
Breaking the code while an element is selected the inspector shows controlled values instead of showing nothing/disabled state.

**Fix:**
I found two things, one is that receiving build errors should clear the metadata the other is that the inspector has these controlled values when there is no jsxElement but the editorstate still has some old metadata. As the build errors arrive later from the worker it's possible to see this invalid inspector state.
