### PR TITLE
Inspector: hide trivial default values

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4862,8 +4862,8 @@ export const trivialDefaultValues: ParsedPropertiesWithNonTrivial = {
     value: 0,
     unit: 'px',
   },
-  flexGrow: cssUnitlessLength(0),
-  flexShrink: cssUnitlessLength(1),
+  flexGrow: nontrivial,
+  flexShrink: nontrivial,
   display: 'block',
 
   // ParsedElementProperties

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4782,7 +4782,7 @@ export const trivialDefaultValues: ParsedPropertiesWithNonTrivial = {
   letterSpacing: 'normal',
   lineHeight: 'normal',
   mixBlendMode: 'normal', // <-finish from here
-  opacity: cssNumber(1),
+  opacity: nontrivial,
   overflow: true,
   textAlign: 'left',
   textDecorationColor: undefined,

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4781,9 +4781,9 @@ export const trivialDefaultValues: ParsedPropertiesWithNonTrivial = {
   fontWeight: 400,
   letterSpacing: 'normal',
   lineHeight: 'normal',
-  mixBlendMode: 'normal', // <-finish from here
+  mixBlendMode: 'normal',
   opacity: nontrivial,
-  overflow: true,
+  overflow: nontrivial,
   textAlign: 'left',
   textDecorationColor: undefined,
   textDecorationLine: 'none',

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
@@ -569,10 +569,10 @@ describe('inspector tests with real metadata', () => {
     expect(minWidthControl.value).toMatchInlineSnapshot(`"0"`)
     expect(
       minWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"simple-unknown-css"`)
+    ).toMatchInlineSnapshot(`"simple"`)
 
     expect(metadata.computedStyle?.['maxWidth']).toMatchInlineSnapshot(`"none"`)
-    expect(maxWidthControl.value).toMatchInlineSnapshot(`"0"`)
+    expect(maxWidthControl.value).toMatchInlineSnapshot(`""`)
     expect(
       maxWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"simple-unknown-css"`)
@@ -1406,16 +1406,16 @@ describe('inspector tests with real metadata', () => {
     )) as HTMLInputElement
 
     expect(metadata.computedStyle?.['minWidth']).toMatchInlineSnapshot(`"0px"`)
-    expect(minWidthControl.value).toMatchInlineSnapshot(`"0"`)
+    expect(minWidthControl.value).toMatchInlineSnapshot(`""`)
     expect(
       minWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"detected"`)
+    ).toMatchInlineSnapshot(`"trivial-default"`)
 
     expect(metadata.computedStyle?.['maxWidth']).toMatchInlineSnapshot(`"none"`)
-    expect(maxWidthControl.value).toMatchInlineSnapshot(`"0"`)
+    expect(maxWidthControl.value).toMatchInlineSnapshot(`""`)
     expect(
       maxWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"detected"`)
+    ).toMatchInlineSnapshot(`"unset"`)
 
     expect(metadata.computedStyle?.['paddingLeft']).toMatchInlineSnapshot(`"0px"`)
     expect(paddingLeftControl.value).toMatchInlineSnapshot(`""`)
@@ -1508,7 +1508,7 @@ describe('inspector tests with real metadata', () => {
     expect(maxWidthControl.value).toMatchInlineSnapshot(`""`)
     expect(
       maxWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"trivial-default"`)
+    ).toMatchInlineSnapshot(`"unset"`)
 
     expect(metadata.computedStyle?.['paddingLeft']).toMatchInlineSnapshot(`"0px"`)
     expect(paddingLeftControl.value).toMatchInlineSnapshot(`""`)

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
@@ -519,10 +519,10 @@ describe('inspector tests with real metadata', () => {
       'opacity-number-control',
     )) as HTMLInputElement
     const minWidthControl = (await renderResult.renderedDOM.findByTestId(
-      'position-Width-number-input',
+      'position-minWidth-number-input',
     )) as HTMLInputElement
     const maxWidthControl = (await renderResult.renderedDOM.findByTestId(
-      'position-Height-number-input',
+      'position-maxWidth-number-input',
     )) as HTMLInputElement
 
     expect(widthControl.value).toMatchInlineSnapshot(`"0"`)
@@ -545,10 +545,10 @@ describe('inspector tests with real metadata', () => {
       leftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"simple-unknown-css"`)
 
-    expect(paddingLeftControl.value).toMatchInlineSnapshot(`"0"`)
+    expect(paddingLeftControl.value).toMatchInlineSnapshot(`""`)
     expect(
       paddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"detected"`)
+    ).toMatchInlineSnapshot(`"trivial-default"`)
 
     expect(paddingRightControl.value).toMatchInlineSnapshot(`"0"`)
     expect(
@@ -1390,10 +1390,10 @@ describe('inspector tests with real metadata', () => {
     ]
 
     const minWidthControl = (await renderResult.renderedDOM.findByTestId(
-      'position-Width-number-input',
+      'position-minWidth-number-input',
     )) as HTMLInputElement
     const maxWidthControl = (await renderResult.renderedDOM.findByTestId(
-      'position-Height-number-input',
+      'position-maxWidth-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
       'flexPadding-L',
@@ -1418,10 +1418,10 @@ describe('inspector tests with real metadata', () => {
     ).toMatchInlineSnapshot(`"detected"`)
 
     expect(metadata.computedStyle?.['paddingLeft']).toMatchInlineSnapshot(`"0px"`)
-    expect(paddingLeftControl.value).toMatchInlineSnapshot(`"0"`)
+    expect(paddingLeftControl.value).toMatchInlineSnapshot(`""`)
     expect(
       paddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"detected"`)
+    ).toMatchInlineSnapshot(`"trivial-default"`) // this will be `detected-fromcss` once we use the padding shorthand
 
     expect(metadata.computedStyle?.['borderRadius']).toMatchInlineSnapshot(`"0px"`)
     expect(radiusControl.value).toMatchInlineSnapshot(`"0"`)
@@ -1434,6 +1434,99 @@ describe('inspector tests with real metadata', () => {
     expect(
       opacityControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"detected-fromcss"`)
+  })
+
+  it('Empty style with lots of trivial defaults', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      Prettier.format(
+        `/** @jsx jsx */
+      import * as React from 'react'
+      import { Scene, Storyboard, View, jsx } from 'utopia-api'
+    
+      export var App = (props) => {
+        return (
+          <div
+            data-uid={'aaa'}
+          >
+            <div
+              style={{ }}
+              data-uid={'bbb'}
+            ></div>
+          </div>
+        )
+      }
+
+      export var ${BakedInStoryboardVariableName} = (props) => {
+        return (
+          <Storyboard data-uid='${BakedInStoryboardUID}'>
+            <Scene
+              style={{ left: 0, top: 0, width: 400, height: 400 }}
+              component={App}
+              static
+              props={{ style: { position: 'absolute', bottom: 0, left: 0, right: 0, top: 0 } }}
+              data-uid='scene-aaa'
+            />
+          </Storyboard>
+        )
+      }`,
+        PrettierConfig,
+      ),
+    )
+
+    await renderResult.dispatch(
+      [selectComponents([TP.instancePath(TestScenePath, ['aaa', 'bbb'])], false)],
+      false,
+    )
+
+    const metadata = renderResult.getEditorState().editor.jsxMetadataKILLME.elements[
+      'utopia-storyboard-uid/scene-aaa:aaa/bbb'
+    ]
+
+    const minWidthControl = (await renderResult.renderedDOM.findByTestId(
+      'position-minWidth-number-input',
+    )) as HTMLInputElement
+    const maxWidthControl = (await renderResult.renderedDOM.findByTestId(
+      'position-maxHeight-number-input',
+    )) as HTMLInputElement
+    const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
+      'flexPadding-L',
+    )) as HTMLInputElement
+    const radiusControl = (await renderResult.renderedDOM.findByTestId(
+      'radius-all-number-input',
+    )) as HTMLInputElement
+    const opacityControl = (await renderResult.renderedDOM.findByTestId(
+      'opacity-number-control',
+    )) as HTMLInputElement
+
+    expect(metadata.computedStyle?.['minWidth']).toMatchInlineSnapshot(`"0px"`)
+    expect(minWidthControl.value).toMatchInlineSnapshot(`""`)
+    expect(
+      minWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"trivial-default"`)
+
+    expect(metadata.computedStyle?.['maxWidth']).toMatchInlineSnapshot(`"none"`)
+    expect(maxWidthControl.value).toMatchInlineSnapshot(`""`)
+    expect(
+      maxWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"trivial-default"`)
+
+    expect(metadata.computedStyle?.['paddingLeft']).toMatchInlineSnapshot(`"0px"`)
+    expect(paddingLeftControl.value).toMatchInlineSnapshot(`""`)
+    expect(
+      paddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"trivial-default"`) // this will be `detected-fromcss` once we use the padding shorthand
+
+    expect(metadata.computedStyle?.['borderRadius']).toMatchInlineSnapshot(`"0px"`)
+    expect(radiusControl.value).toMatchInlineSnapshot(`""`)
+    expect(
+      radiusControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"trivial-default"`)
+
+    expect(metadata.computedStyle?.['opacity']).toMatchInlineSnapshot(`"1"`)
+    expect(opacityControl.value).toMatchInlineSnapshot(`"1"`)
+    expect(
+      opacityControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"detected"`)
   })
   it('Style properties inherited from parent', async () => {
     const renderResult = await renderTestEditorWithCode(

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -118,6 +118,7 @@ const dummyPropertyStatus: PropertyStatus = {
   identical: true,
   detected: false,
   fromCssStyleSheet: false,
+  trivialDefault: false,
 }
 
 const simpleControlStyles = getControlStyles('simple')

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -53,8 +53,9 @@ const getDisplayValue = (
   value: CSSNumber | null,
   defaultUnitToHide: CSSNumberUnit | null,
   mixed: boolean,
+  showContent: boolean,
 ): string => {
-  if (!mixed && value != null) {
+  if (!mixed && value != null && showContent) {
     const unit = getCSSNumberUnit(value)
     const showUnit = unit !== defaultUnitToHide
     return cssNumberToString(value, showUnit)
@@ -176,15 +177,19 @@ export const NumberInput = betterReactMemo<NumberInputProps>(
       [controlStyles],
     )
 
+    const { showContent } = controlStyles
+
     const [mixed, setMixed] = React.useState<boolean>(controlStyles.mixed)
     const [
       stateValue,
       setStateValueDirectly,
       forceStateValueToUpdateFromProps,
-    ] = usePropControlledState(getDisplayValue(propsValue ?? null, defaultUnitToHide, mixed))
+    ] = usePropControlledState(
+      getDisplayValue(propsValue ?? null, defaultUnitToHide, mixed, showContent),
+    )
     const updateStateValue = React.useCallback(
       (newValue: CSSNumber) =>
-        setStateValueDirectly(getDisplayValue(newValue, defaultUnitToHide, false)),
+        setStateValueDirectly(getDisplayValue(newValue, defaultUnitToHide, false, true)),
       [defaultUnitToHide, setStateValueDirectly],
     )
     const parsedStateValue = parseDisplayValue(stateValue, numberType, defaultUnitToHide)


### PR DESCRIPTION
**Problem:**
Our "empty" inspector is full of greyed-out default numbers: half a dozen 0s for padding, margin, etc.

**Fix:**
Only show default numbers if those are not trivial

**Commit Details:**
- Created a new dictionary named `trivialDefaultValues`. For every property, we store if the default value is trivial (and what it is). If something is nontrivial, we store `nontrivial`
        **Rules:**
            -- if the value is set in the style prop, show it plainly as ‘set’
            -- otherwise, if the value is coming from a css rule, show it as ‘detected-fromcss’ 
            -- otherwise, compare the detected value with the value stored in `trivialDefaultValues`. If it doesn't match or `trivialDefaultValues` has a `nontrivial` entry for the given prop , show it as `detected`
            -- othwerwise, do not show the value

- When calculating the control style, if the value is not set in the style prop, and not set via css stylesheet (so it is either inherited or a browser default) AND the value matches the stored trivial default, we set the control style to `showContent: false`
- Added a new end-to-end unit test for an element that has only default style.
