### PR TITLE
Fix: hide min-max width-height controls if they are empty

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -663,6 +663,15 @@ export function cssNumberToString(input: CSSNumber, showUnit: boolean = true): s
 
 export const parseCSSLength = (input: unknown) => parseCSSNumber(input, 'Length')
 export const parseCSSLengthPercent = (input: unknown) => parseCSSNumber(input, 'LengthPercent')
+export const parseCSSLengthPercentNone = (
+  input: unknown,
+): Either<string, CSSNumber | undefined> => {
+  if (typeof input === 'string' && input === 'none') {
+    return right(undefined)
+  } else {
+    return parseCSSNumber(input, 'LengthPercent')
+  }
+}
 export const parseCSSAngle = (input: unknown) => parseCSSNumber(input, 'Angle')
 export const parseCSSAnglePercent = (input: unknown) => parseCSSNumber(input, 'AnglePercent')
 export const parseCSSPercent = (input: unknown) => parseCSSNumber(input, 'Percent', '%')
@@ -4121,9 +4130,9 @@ const cssParsers: CSSParsers = {
   right: parseCSSLengthPercent,
   bottom: parseCSSLengthPercent,
   minWidth: parseCSSLengthPercent,
-  maxWidth: parseCSSLengthPercent,
+  maxWidth: parseCSSLengthPercentNone,
   minHeight: parseCSSLengthPercent,
-  maxHeight: parseCSSLengthPercent,
+  maxHeight: parseCSSLengthPercentNone,
   marginTop: parseCSSLengthPercent,
   marginRight: parseCSSLengthPercent,
   marginBottom: parseCSSLengthPercent,
@@ -4840,12 +4849,12 @@ export const trivialDefaultValues: ParsedPropertiesWithNonTrivial = {
     value: 0,
     unit: 'px',
   },
-  maxWidth: undefined, // should be `none`
+  maxWidth: undefined,
   minHeight: {
     value: 0,
     unit: 'px',
   },
-  maxHeight: undefined, // should be `none`
+  maxHeight: undefined,
   marginTop: {
     value: 0,
     unit: 'px',

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
@@ -575,7 +575,7 @@ describe('inspector tests with real metadata', () => {
     expect(maxWidthControl.value).toMatchInlineSnapshot(`""`)
     expect(
       maxWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"simple-unknown-css"`)
+    ).toMatchInlineSnapshot(`"simple"`)
   })
   it('Style props strings using px', async () => {
     const renderResult = await renderTestEditorWithCode(
@@ -1385,6 +1385,12 @@ describe('inspector tests with real metadata', () => {
       false,
     )
 
+    await act(async () => {
+      await screen.findByTestId('toggle-min-max-button')
+      fireEvent.click(screen.getByTestId('toggle-min-max-button'))
+      await screen.findByTestId('position-maxWidth-number-input')
+    })
+
     const metadata = renderResult.getEditorState().editor.jsxMetadataKILLME.elements[
       'utopia-storyboard-uid/scene-aaa:aaa/bbb'
     ]
@@ -1415,7 +1421,7 @@ describe('inspector tests with real metadata', () => {
     expect(maxWidthControl.value).toMatchInlineSnapshot(`""`)
     expect(
       maxWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"unset"`)
+    ).toMatchInlineSnapshot(`"trivial-default"`)
 
     expect(metadata.computedStyle?.['paddingLeft']).toMatchInlineSnapshot(`"0px"`)
     expect(paddingLeftControl.value).toMatchInlineSnapshot(`""`)
@@ -1478,6 +1484,12 @@ describe('inspector tests with real metadata', () => {
       false,
     )
 
+    await act(async () => {
+      await screen.findByTestId('toggle-min-max-button')
+      fireEvent.click(screen.getByTestId('toggle-min-max-button'))
+      await screen.findByTestId('position-maxWidth-number-input')
+    })
+
     const metadata = renderResult.getEditorState().editor.jsxMetadataKILLME.elements[
       'utopia-storyboard-uid/scene-aaa:aaa/bbb'
     ]
@@ -1508,7 +1520,7 @@ describe('inspector tests with real metadata', () => {
     expect(maxWidthControl.value).toMatchInlineSnapshot(`""`)
     expect(
       maxWidthControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"unset"`)
+    ).toMatchInlineSnapshot(`"trivial-default"`)
 
     expect(metadata.computedStyle?.['paddingLeft']).toMatchInlineSnapshot(`"0px"`)
     expect(paddingLeftControl.value).toMatchInlineSnapshot(`""`)

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -302,7 +302,11 @@ const WidthHeightRow = betterReactMemo('WidthHeightRow', (props: WidthHeightRowP
           {aspectRatioLocked ? <Icons.LockClosed /> : <Icons.LockOpen />}
         </SquareButton>
         {heightControl}
-        <SquareButton onClick={toggleMinMax} style={{ width: 16, height: 16, fontSize: 8 }}>
+        <SquareButton
+          data-testid='toggle-min-max-button'
+          onClick={toggleMinMax}
+          style={{ width: 16, height: 16, fontSize: 8 }}
+        >
           min
           <br />
           max
@@ -470,10 +474,10 @@ export const GiganticSizePinsSubsection = betterReactMemo(
     const maxHeight = useInspectorLayoutInfo('maxHeight')
 
     const hasMinMaxValues =
-      minWidth.controlStatus !== 'unset' ||
-      maxWidth.controlStatus !== 'unset' ||
-      minHeight.controlStatus !== 'unset' ||
-      maxHeight.controlStatus !== 'unset'
+      (minWidth.controlStatus !== 'unset' && minWidth.controlStatus !== 'trivial-default') ||
+      (maxWidth.controlStatus !== 'unset' && maxWidth.controlStatus !== 'trivial-default') ||
+      (minHeight.controlStatus !== 'unset' && minHeight.controlStatus !== 'trivial-default') ||
+      (maxHeight.controlStatus !== 'unset' && maxHeight.controlStatus !== 'trivial-default')
 
     const [minMaxToggled, setMinMaxToggled] = React.useState<boolean>(hasMinMaxValues)
     const toggleMinMax = React.useCallback(() => {


### PR DESCRIPTION
**Problem:**
The min-max row was showing up with default computedStyle (showing 0 for min, nothing for max, to make things more interesting) instead of being hidden when unset.

**Fix:**
The regression happened with the introduction of computedStyle measurements. The 0 for min was interpreted as a not-unset value and that would make the subsection show up. 

**Commit Details:**
- max-width and max-height uses a new parser called `parseCSSLengthPercentNone` which can interpret a `<length> | <percentage> | none`. **Note:** `none` is parsed as `undefined` as that makes it easier to work with the number input.
- change `hasMinMaxValues` to hide minmax if the value is `unset` or if it is `trivial-default` (the new control style)
- update the tests
