### PR TITLE
Feature/inspector padding shorthands

### DIFF
--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -9549,11 +9549,11 @@
       }
     },
     "css-tree": {
-      "version": "1.0.0-alpha.39",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.39.tgz",
-      "integrity": "sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.2.tgz",
+      "integrity": "sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==",
       "requires": {
-        "mdn-data": "2.0.6",
+        "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
       },
       "dependencies": {
@@ -19627,9 +19627,9 @@
       }
     },
     "mdn-data": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.6.tgz",
-      "integrity": "sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA=="
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/editor/package.json
+++ b/editor/package.json
@@ -105,7 +105,7 @@
     "clipboard-polyfill": "2.4.6",
     "console-feed": "2.8.8",
     "create-react-class": "15.6.3",
-    "css-tree": "1.0.0-alpha.39",
+    "css-tree": "1.1.2",
     "draft-js": "git://github.com/concrete-utopia/draft-js.git#6b21131",
     "draft-js-custom-styles": "2.0.1",
     "eases": "1.0.8",

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -664,6 +664,20 @@ export function cssNumberToString(input: CSSNumber, showUnit: boolean = true): s
   return `${printed}`
 }
 
+export function printCSSNumberWithDefaultUnit(
+  input: CSSNumber,
+  defaultUnit: CSSNumberUnit,
+): string {
+  if (input.unit == null) {
+    return printCSSNumber({
+      ...input,
+      unit: defaultUnit,
+    }) as string
+  } else {
+    return printCSSNumber(input) as string
+  }
+}
+
 export const parseCSSLength = (input: unknown) => parseCSSNumber(input, 'Length')
 export const parseCSSLengthPercent = (input: unknown) => parseCSSNumber(input, 'LengthPercent')
 export const parseCSSAngle = (input: unknown) => parseCSSNumber(input, 'Angle')

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -65,6 +65,10 @@ import { toggleBorderEnabled } from '../sections/style-section/border-subsection
 import { toggleShadowEnabled } from '../sections/style-section/shadow-subsection/shadow-subsection'
 import { fontFamilyArrayToCSSFontFamilyString } from '../sections/style-section/text-subsection/fonts-list'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
+import {
+  parsePadding,
+  printPaddingAsAttributeValue,
+} from '../../../printer-parsers/css/css-parser-padding'
 
 var combineRegExp = function (regexpList: Array<RegExp | string>, flags?: string) {
   let source: string = ''
@@ -706,6 +710,13 @@ export function cssNumberToFramePin(value: CSSNumber): FramePin {
   } else {
     return printCSSNumber(value)
   }
+}
+
+export interface CSSPadding {
+  paddingTop: CSSNumber
+  paddingRight: CSSNumber
+  paddingBottom: CSSNumber
+  paddingLeft: CSSNumber
 }
 
 // For matching CSS Dimensions (lengths, angles etc.) as they are always specified as a number
@@ -3913,6 +3924,7 @@ export interface ParsedCSSProperties {
 
   objectFit: CSSObjectFit
 
+  padding: CSSPadding
   paddingTop: CSSNumber
   paddingRight: CSSNumber
   paddingBottom: CSSNumber
@@ -4011,6 +4023,24 @@ export const cssEmptyValues: ParsedCSSProperties = {
   alignItems: FlexAlignment.FlexStart,
   alignContent: FlexAlignment.FlexStart,
   justifyContent: FlexJustifyContent.FlexStart,
+  padding: {
+    paddingTop: {
+      value: 0,
+      unit: null,
+    },
+    paddingRight: {
+      value: 0,
+      unit: null,
+    },
+    paddingBottom: {
+      value: 0,
+      unit: null,
+    },
+    paddingLeft: {
+      value: 0,
+      unit: null,
+    },
+  },
   paddingTop: {
     value: 0,
     unit: null,
@@ -4106,6 +4136,7 @@ const cssParsers: CSSParsers = {
   alignItems: flexAlignmentsParser,
   alignContent: flexAlignmentsParser,
   justifyContent: flexJustifyContentParser,
+  padding: parsePadding,
   paddingTop: parseCSSLengthPercent,
   paddingRight: parseCSSLengthPercent,
   paddingBottom: parseCSSLengthPercent,
@@ -4168,6 +4199,7 @@ const cssPrinters: CSSPrinters = {
   alignItems: jsxAttributeValueWithNoComments,
   alignContent: jsxAttributeValueWithNoComments,
   justifyContent: jsxAttributeValueWithNoComments,
+  padding: printPaddingAsAttributeValue,
   paddingTop: printCSSNumberAsAttributeValue,
   paddingRight: printCSSNumberAsAttributeValue,
   paddingBottom: printCSSNumberAsAttributeValue,

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4848,6 +4848,7 @@ export const trivialDefaultValues: ParsedPropertiesWithNonTrivial = {
   alignItems: FlexAlignment.FlexStart,
   alignContent: FlexAlignment.FlexStart,
   justifyContent: FlexJustifyContent.FlexStart,
+  padding: nontrivial,
   paddingTop: {
     value: 0,
     unit: 'px',

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -669,14 +669,9 @@ export function printCSSNumberWithDefaultUnit(
   input: CSSNumber,
   defaultUnit: CSSNumberUnit,
 ): string {
-  if (input.unit == null) {
-    return printCSSNumber({
-      ...input,
-      unit: defaultUnit,
-    }) as string
-  } else {
-    return printCSSNumber(input) as string
-  }
+  const { value, unit } = input
+  const unitToUse = unit ?? defaultUnit
+  return `${fixNumber(value)}${unitToUse}`
 }
 
 export const parseCSSLength = (input: unknown) => parseCSSNumber(input, 'Length')

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -169,6 +169,7 @@ export const FlexPaddingControl = betterReactMemo('FlexPaddingControl', () => {
   const flexPaddingRight = useInspectorLayoutInfo('paddingRight')
   const flexPaddingBottom = useInspectorLayoutInfo('paddingBottom')
   const flexPaddingLeft = useInspectorLayoutInfo('paddingLeft')
+  const flexPadding = useInspectorLayoutInfo('padding')
 
   const flexPaddingTopOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
     flexPaddingTop.onSubmitValue,

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -169,7 +169,6 @@ export const FlexPaddingControl = betterReactMemo('FlexPaddingControl', () => {
   const flexPaddingRight = useInspectorLayoutInfo('paddingRight')
   const flexPaddingBottom = useInspectorLayoutInfo('paddingBottom')
   const flexPaddingLeft = useInspectorLayoutInfo('paddingLeft')
-  const flexPadding = useInspectorLayoutInfo('padding')
 
   const flexPaddingTopOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
     flexPaddingTop.onSubmitValue,

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -40,6 +40,7 @@ export type StyleLayoutProp =
   | 'alignItems'
   | 'alignContent'
   | 'justifyContent'
+  | 'padding'
   | 'paddingTop'
   | 'paddingRight'
   | 'paddingBottom'
@@ -152,6 +153,7 @@ const LayoutPathMap: { [key in LayoutProp | StyleLayoutProp]: Array<PropertyPath
   marginRight: ['style', 'marginRight'],
   marginBottom: ['style', 'marginBottom'],
   marginLeft: ['style', 'marginLeft'],
+  padding: ['style', 'padding'],
   paddingTop: ['style', 'paddingTop'],
   paddingRight: ['style', 'paddingRight'],
   paddingBottom: ['style', 'paddingBottom'],

--- a/editor/src/printer-parsers/css/css-parser-background-size.ts
+++ b/editor/src/printer-parsers/css/css-parser-background-size.ts
@@ -13,7 +13,12 @@ import {
   mapEither,
   sequenceEither,
 } from '../../core/shared/either'
-import { descriptionParseError, parseAlternative, Parser } from '../../utils/value-parser-utils'
+import {
+  descriptionParseError,
+  getParseErrorDetails,
+  parseAlternative,
+  Parser,
+} from '../../utils/value-parser-utils'
 import {
   getLexerTypeMatches,
   isLexerMatch,
@@ -69,7 +74,7 @@ export function parseBackgroundSize(value: unknown): Either<string, CSSBackgroun
         if (isRight(lexerMatch)) {
           const parsed = parseBGSize(lexerMatch.value)
           return bimapEither(
-            (l) => l.type,
+            (l) => getParseErrorDetails(l).description,
             (r) => {
               r.enabled = layer.enabled
               return r

--- a/editor/src/printer-parsers/css/css-parser-border.ts
+++ b/editor/src/printer-parsers/css/css-parser-border.ts
@@ -13,7 +13,7 @@ import { parseLineStyle } from './css-parser-border-style'
 import { getLexerPropertyMatches, parseDoubleBar, parseLexedColor } from './css-parser-utils'
 
 export function parseBorder(value: unknown): Either<string, CSSBorder> {
-  const lexer = getLexerPropertyMatches('border', value, ['line-style', 'line-width', 'color'])
+  const lexer = getLexerPropertyMatches('border', value, '', ['line-style', 'line-width', 'color'])
   if (isRight(lexer)) {
     const parsed = parseDoubleBar<CSSColor | CSSLineWidth | CSSLineStyle>(3, [
       parseLexedColor,

--- a/editor/src/printer-parsers/css/css-parser-map.ts
+++ b/editor/src/printer-parsers/css/css-parser-map.ts
@@ -3,6 +3,7 @@ import { parseBorder } from './css-parser-border'
 import { parseBorderColor } from './css-parser-border-color'
 import { parseBorderSize } from './css-parser-border-size'
 import { parseBorderStyle } from './css-parser-border-style'
+import { parsePadding } from './css-parser-padding'
 import {
   parseAlphaValue,
   parseAngle,
@@ -30,6 +31,7 @@ export const syntaxParsers = {
   '<length-percentage>': parseLengthPercentage,
   '<length>': parseLength,
   '<number>': parseNumber,
+  '<padding>': parsePadding,
   '<percentage>': parsePercentage,
   '<rgb()>': parseRGBColor,
   '<rgba()>': parseRGBColor,

--- a/editor/src/printer-parsers/css/css-parser-padding.spec.ts
+++ b/editor/src/printer-parsers/css/css-parser-padding.spec.ts
@@ -1,6 +1,7 @@
 import { syntaxParsers } from './css-parser-map'
+import { printPaddingAsAttributeValue } from './css-parser-padding'
 
-describe('padding', () => {
+describe('parse padding', () => {
   it("parses a simple number <'padding'> property", () => {
     const value = 155
     const parseResults = syntaxParsers['<padding>'](value)
@@ -187,6 +188,226 @@ describe('padding', () => {
             "value": 4,
           },
         },
+      }
+    `)
+  })
+})
+
+describe('print padding', () => {
+  it('4 different padding values', () => {
+    const cssPadding = {
+      paddingTop: {
+        value: 4,
+        unit: 'px' as const,
+      },
+      paddingRight: {
+        value: 24,
+        unit: 'px' as const,
+      },
+      paddingBottom: {
+        value: 12,
+        unit: 'px' as const,
+      },
+      paddingLeft: {
+        value: 8,
+        unit: 'px' as const,
+      },
+    }
+    const printResult = printPaddingAsAttributeValue(cssPadding)
+    expect(printResult).toMatchInlineSnapshot(`
+      Object {
+        "comments": Object {
+          "leadingComments": Array [],
+          "trailingComments": Array [],
+        },
+        "type": "ATTRIBUTE_VALUE",
+        "value": "4px 24px 12px 8px",
+      }
+    `)
+  })
+  it('4 different padding values, missing unit', () => {
+    const cssPadding = {
+      paddingTop: {
+        value: 4,
+        unit: null,
+      },
+      paddingRight: {
+        value: 24,
+        unit: null,
+      },
+      paddingBottom: {
+        value: 12,
+        unit: null,
+      },
+      paddingLeft: {
+        value: 8,
+        unit: null,
+      },
+    }
+    const printResult = printPaddingAsAttributeValue(cssPadding)
+    expect(printResult).toMatchInlineSnapshot(`
+      Object {
+        "comments": Object {
+          "leadingComments": Array [],
+          "trailingComments": Array [],
+        },
+        "type": "ATTRIBUTE_VALUE",
+        "value": "4px 24px 12px 8px",
+      }
+    `)
+  })
+  it('2-2 sides matching, 2-value-syntax', () => {
+    const cssPadding = {
+      paddingTop: {
+        value: 4,
+        unit: 'px' as const,
+      },
+      paddingRight: {
+        value: 24,
+        unit: 'px' as const,
+      },
+      paddingBottom: {
+        value: 4,
+        unit: 'px' as const,
+      },
+      paddingLeft: {
+        value: 24,
+        unit: 'px' as const,
+      },
+    }
+    const printResult = printPaddingAsAttributeValue(cssPadding)
+    expect(printResult).toMatchInlineSnapshot(`
+      Object {
+        "comments": Object {
+          "leadingComments": Array [],
+          "trailingComments": Array [],
+        },
+        "type": "ATTRIBUTE_VALUE",
+        "value": "4px 24px",
+      }
+    `)
+  })
+  it('2-2 sides matching, percentage values, 2-value-syntax', () => {
+    const cssPadding = {
+      paddingTop: {
+        value: 4,
+        unit: '%' as const,
+      },
+      paddingRight: {
+        value: 24,
+        unit: '%' as const,
+      },
+      paddingBottom: {
+        value: 4,
+        unit: '%' as const,
+      },
+      paddingLeft: {
+        value: 24,
+        unit: '%' as const,
+      },
+    }
+    const printResult = printPaddingAsAttributeValue(cssPadding)
+    expect(printResult).toMatchInlineSnapshot(`
+      Object {
+        "comments": Object {
+          "leadingComments": Array [],
+          "trailingComments": Array [],
+        },
+        "type": "ATTRIBUTE_VALUE",
+        "value": "4% 24%",
+      }
+    `)
+  })
+  it('left and right is the same, 3-value-syntax', () => {
+    const cssPadding = {
+      paddingTop: {
+        value: 4,
+        unit: null,
+      },
+      paddingRight: {
+        value: 8,
+        unit: null,
+      },
+      paddingBottom: {
+        value: 12,
+        unit: null,
+      },
+      paddingLeft: {
+        value: 8,
+        unit: null,
+      },
+    }
+    const printResult = printPaddingAsAttributeValue(cssPadding)
+    expect(printResult).toMatchInlineSnapshot(`
+      Object {
+        "comments": Object {
+          "leadingComments": Array [],
+          "trailingComments": Array [],
+        },
+        "type": "ATTRIBUTE_VALUE",
+        "value": "4px 8px 12px",
+      }
+    `)
+  })
+  it('all padding values are the same, 1-value-syntax', () => {
+    const cssPadding = {
+      paddingTop: {
+        value: 6,
+        unit: null,
+      },
+      paddingRight: {
+        value: 6,
+        unit: null,
+      },
+      paddingBottom: {
+        value: 6,
+        unit: null,
+      },
+      paddingLeft: {
+        value: 6,
+        unit: null,
+      },
+    }
+    const printResult = printPaddingAsAttributeValue(cssPadding)
+    expect(printResult).toMatchInlineSnapshot(`
+      Object {
+        "comments": Object {
+          "leadingComments": Array [],
+          "trailingComments": Array [],
+        },
+        "type": "ATTRIBUTE_VALUE",
+        "value": 6,
+      }
+    `)
+  })
+  it('all padding values are the same, percentage, 1-value-syntax', () => {
+    const cssPadding = {
+      paddingTop: {
+        value: 6,
+        unit: '%' as const,
+      },
+      paddingRight: {
+        value: 6,
+        unit: '%' as const,
+      },
+      paddingBottom: {
+        value: 6,
+        unit: '%' as const,
+      },
+      paddingLeft: {
+        value: 6,
+        unit: '%' as const,
+      },
+    }
+    const printResult = printPaddingAsAttributeValue(cssPadding)
+    expect(printResult).toMatchInlineSnapshot(`
+      Object {
+        "comments": Object {
+          "leadingComments": Array [],
+          "trailingComments": Array [],
+        },
+        "type": "ATTRIBUTE_VALUE",
+        "value": "6%",
       }
     `)
   })

--- a/editor/src/printer-parsers/css/css-parser-padding.spec.ts
+++ b/editor/src/printer-parsers/css/css-parser-padding.spec.ts
@@ -56,7 +56,7 @@ describe('parse padding', () => {
       }
     `)
   })
-  it("parses shorthand(2) <'padding'> property, number values", () => {
+  it("parses shorthand(2-value-syntax) <'padding'> property, number values", () => {
     const value = '3px 4px'
     const parseResults = syntaxParsers['<padding>'](value)
     expect(parseResults).toMatchInlineSnapshot(`
@@ -83,7 +83,7 @@ describe('parse padding', () => {
       }
     `)
   })
-  it("parses shorthand(2) <'padding'> property, percentage values", () => {
+  it("parses shorthand(2-value-syntax) <'padding'> property, percentage values", () => {
     const value = '3% 4%'
     const parseResults = syntaxParsers['<padding>'](value)
     expect(parseResults).toMatchInlineSnapshot(`
@@ -110,7 +110,7 @@ describe('parse padding', () => {
       }
     `)
   })
-  it("parses shorthand(3) <'padding'> property", () => {
+  it("parses shorthand(3-value-syntax) <'padding'> property", () => {
     const value = '2px 4px 8px'
     const parseResults = syntaxParsers['<padding>'](value)
     expect(parseResults).toMatchInlineSnapshot(`
@@ -287,7 +287,7 @@ describe('print padding', () => {
       }
     `)
   })
-  it('2-2 sides matching, percentage values, 2-value-syntax', () => {
+  it('2-2 sides matching percent values, 2-value-syntax', () => {
     const cssPadding = {
       paddingTop: {
         value: 4,
@@ -380,7 +380,7 @@ describe('print padding', () => {
       }
     `)
   })
-  it('all padding values are the same, percentage, 1-value-syntax', () => {
+  it('all padding values are the same percent values, 1-value-syntax', () => {
     const cssPadding = {
       paddingTop: {
         value: 6,

--- a/editor/src/printer-parsers/css/css-parser-padding.spec.ts
+++ b/editor/src/printer-parsers/css/css-parser-padding.spec.ts
@@ -6,8 +6,25 @@ describe('padding', () => {
     const parseResults = syntaxParsers['<padding>'](value)
     expect(parseResults).toMatchInlineSnapshot(`
       Object {
-        "type": "LEFT",
-        "value": "Value was not lexer match array",
+        "type": "RIGHT",
+        "value": Object {
+          "paddingBottom": Object {
+            "unit": "px",
+            "value": 155,
+          },
+          "paddingLeft": Object {
+            "unit": "px",
+            "value": 155,
+          },
+          "paddingRight": Object {
+            "unit": "px",
+            "value": 155,
+          },
+          "paddingTop": Object {
+            "unit": "px",
+            "value": 155,
+          },
+        },
       }
     `)
   })

--- a/editor/src/printer-parsers/css/css-parser-padding.spec.ts
+++ b/editor/src/printer-parsers/css/css-parser-padding.spec.ts
@@ -1,0 +1,176 @@
+import { syntaxParsers } from './css-parser-map'
+
+describe('padding', () => {
+  it("parses a simple number <'padding'> property", () => {
+    const value = 155
+    const parseResults = syntaxParsers['<padding>'](value)
+    expect(parseResults).toMatchInlineSnapshot(`
+      Object {
+        "type": "LEFT",
+        "value": "Value was not lexer match array",
+      }
+    `)
+  })
+  it("parses a <'padding'> property, percentage value", () => {
+    const value = '10%'
+    const parseResults = syntaxParsers['<padding>'](value)
+    expect(parseResults).toMatchInlineSnapshot(`
+      Object {
+        "type": "RIGHT",
+        "value": Object {
+          "paddingBottom": Object {
+            "unit": "%",
+            "value": 10,
+          },
+          "paddingLeft": Object {
+            "unit": "%",
+            "value": 10,
+          },
+          "paddingRight": Object {
+            "unit": "%",
+            "value": 10,
+          },
+          "paddingTop": Object {
+            "unit": "%",
+            "value": 10,
+          },
+        },
+      }
+    `)
+  })
+  it("parses shorthand(2) <'padding'> property, number values", () => {
+    const value = '3px 4px'
+    const parseResults = syntaxParsers['<padding>'](value)
+    expect(parseResults).toMatchInlineSnapshot(`
+      Object {
+        "type": "RIGHT",
+        "value": Object {
+          "paddingBottom": Object {
+            "unit": "px",
+            "value": 3,
+          },
+          "paddingLeft": Object {
+            "unit": "px",
+            "value": 4,
+          },
+          "paddingRight": Object {
+            "unit": "px",
+            "value": 4,
+          },
+          "paddingTop": Object {
+            "unit": "px",
+            "value": 3,
+          },
+        },
+      }
+    `)
+  })
+  it("parses shorthand(2) <'padding'> property, percentage values", () => {
+    const value = '3% 4%'
+    const parseResults = syntaxParsers['<padding>'](value)
+    expect(parseResults).toMatchInlineSnapshot(`
+      Object {
+        "type": "RIGHT",
+        "value": Object {
+          "paddingBottom": Object {
+            "unit": "%",
+            "value": 3,
+          },
+          "paddingLeft": Object {
+            "unit": "%",
+            "value": 4,
+          },
+          "paddingRight": Object {
+            "unit": "%",
+            "value": 4,
+          },
+          "paddingTop": Object {
+            "unit": "%",
+            "value": 3,
+          },
+        },
+      }
+    `)
+  })
+  it("parses shorthand(3) <'padding'> property", () => {
+    const value = '2px 4px 8px'
+    const parseResults = syntaxParsers['<padding>'](value)
+    expect(parseResults).toMatchInlineSnapshot(`
+      Object {
+        "type": "RIGHT",
+        "value": Object {
+          "paddingBottom": Object {
+            "unit": "px",
+            "value": 8,
+          },
+          "paddingLeft": Object {
+            "unit": "px",
+            "value": 4,
+          },
+          "paddingRight": Object {
+            "unit": "px",
+            "value": 4,
+          },
+          "paddingTop": Object {
+            "unit": "px",
+            "value": 2,
+          },
+        },
+      }
+    `)
+  })
+  it("parses the full <'padding'> property, number values", () => {
+    const value = '4px 6px 12px 8px'
+    const parseResults = syntaxParsers['<padding>'](value)
+    expect(parseResults).toMatchInlineSnapshot(`
+      Object {
+        "type": "RIGHT",
+        "value": Object {
+          "paddingBottom": Object {
+            "unit": "px",
+            "value": 12,
+          },
+          "paddingLeft": Object {
+            "unit": "px",
+            "value": 8,
+          },
+          "paddingRight": Object {
+            "unit": "px",
+            "value": 6,
+          },
+          "paddingTop": Object {
+            "unit": "px",
+            "value": 4,
+          },
+        },
+      }
+    `)
+  })
+  it("parses the full <'padding'> property, percentage values", () => {
+    const value = '4% 6% 12% 8%'
+    const parseResults = syntaxParsers['<padding>'](value)
+    expect(parseResults).toMatchInlineSnapshot(`
+      Object {
+        "type": "RIGHT",
+        "value": Object {
+          "paddingBottom": Object {
+            "unit": "%",
+            "value": 12,
+          },
+          "paddingLeft": Object {
+            "unit": "%",
+            "value": 8,
+          },
+          "paddingRight": Object {
+            "unit": "%",
+            "value": 6,
+          },
+          "paddingTop": Object {
+            "unit": "%",
+            "value": 4,
+          },
+        },
+      }
+    `)
+  })
+})

--- a/editor/src/printer-parsers/css/css-parser-padding.ts
+++ b/editor/src/printer-parsers/css/css-parser-padding.ts
@@ -1,0 +1,59 @@
+import { CSSNumber, CSSPadding, printCSSNumber } from '../../components/inspector/common/css-utils'
+import { Either, isRight, left, right } from '../../core/shared/either'
+import { JSXAttributeValue, jsxAttributeValue } from '../../core/shared/element-template'
+import { emptyComments } from '../../core/workers/parser-printer/parser-printer-comments'
+import { getLexerPropertyMatches, parseLengthPercentage, parseCSSArray } from './css-parser-utils'
+
+export const parsePadding = (value: unknown): Either<string, CSSPadding> => {
+  const lexer = getLexerPropertyMatches('padding', value)
+  if (isRight(lexer)) {
+    const parseResult = parseCSSArray([parseLengthPercentage])(lexer.value)
+    if (
+      isRight(parseResult) &&
+      Array.isArray(parseResult.value) &&
+      parseResult.value.every(isRight)
+    ) {
+      const resultArray = parseResult.value
+      let paddingTop, paddingRight, paddingBottom, paddingLeft
+      if (resultArray.length === 0 || resultArray.length > 4) {
+        return left(`Value ${JSON.stringify(value)} is not a valid padding`)
+      } else if (resultArray.length === 1) {
+        paddingTop = resultArray[0].value as CSSNumber
+        paddingRight = resultArray[0].value as CSSNumber
+        paddingBottom = resultArray[0].value as CSSNumber
+        paddingLeft = resultArray[0].value as CSSNumber
+      } else if (resultArray.length === 2) {
+        paddingTop = resultArray[0].value as CSSNumber
+        paddingRight = resultArray[1].value as CSSNumber
+        paddingBottom = resultArray[0].value as CSSNumber
+        paddingLeft = resultArray[1].value as CSSNumber
+      } else if (resultArray.length === 3) {
+        paddingTop = resultArray[0].value as CSSNumber
+        paddingRight = resultArray[1].value as CSSNumber
+        paddingBottom = resultArray[2].value as CSSNumber
+        paddingLeft = resultArray[1].value as CSSNumber
+      } else {
+        paddingTop = resultArray[0].value as CSSNumber
+        paddingRight = resultArray[1].value as CSSNumber
+        paddingBottom = resultArray[2].value as CSSNumber
+        paddingLeft = resultArray[3].value as CSSNumber
+      }
+      return right({
+        paddingTop: paddingTop,
+        paddingRight: paddingRight,
+        paddingBottom: paddingBottom,
+        paddingLeft: paddingLeft,
+      })
+    } else {
+      return left(`Value ${JSON.stringify(value)} is not a valid padding`)
+    }
+  }
+  return left('Value was not lexer match array')
+}
+
+export const printPaddingAsAttributeValue = (
+  value: CSSPadding,
+): JSXAttributeValue<number | string> => {
+  // TODO all paddings!
+  return jsxAttributeValue(printCSSNumber(value.paddingTop), emptyComments)
+}

--- a/editor/src/printer-parsers/css/css-parser-padding.ts
+++ b/editor/src/printer-parsers/css/css-parser-padding.ts
@@ -5,7 +5,7 @@ import { emptyComments } from '../../core/workers/parser-printer/parser-printer-
 import { getLexerPropertyMatches, parseLengthPercentage, parseCSSArray } from './css-parser-utils'
 
 export const parsePadding = (value: unknown): Either<string, CSSPadding> => {
-  const lexer = getLexerPropertyMatches('padding', value)
+  const lexer = getLexerPropertyMatches('padding', value, 'px')
   if (isRight(lexer)) {
     const parseResult = parseCSSArray([parseLengthPercentage])(lexer.value)
     if (isRight(parseResult)) {

--- a/editor/src/printer-parsers/css/css-parser-padding.ts
+++ b/editor/src/printer-parsers/css/css-parser-padding.ts
@@ -8,35 +8,31 @@ export const parsePadding = (value: unknown): Either<string, CSSPadding> => {
   const lexer = getLexerPropertyMatches('padding', value)
   if (isRight(lexer)) {
     const parseResult = parseCSSArray([parseLengthPercentage])(lexer.value)
-    if (
-      isRight(parseResult) &&
-      Array.isArray(parseResult.value) &&
-      parseResult.value.every(isRight)
-    ) {
+    if (isRight(parseResult)) {
       const resultArray = parseResult.value
       let paddingTop, paddingRight, paddingBottom, paddingLeft
       if (resultArray.length === 0 || resultArray.length > 4) {
         return left(`Value ${JSON.stringify(value)} is not a valid padding`)
       } else if (resultArray.length === 1) {
-        paddingTop = resultArray[0].value as CSSNumber
-        paddingRight = resultArray[0].value as CSSNumber
-        paddingBottom = resultArray[0].value as CSSNumber
-        paddingLeft = resultArray[0].value as CSSNumber
+        paddingTop = resultArray[0]
+        paddingRight = resultArray[0]
+        paddingBottom = resultArray[0]
+        paddingLeft = resultArray[0]
       } else if (resultArray.length === 2) {
-        paddingTop = resultArray[0].value as CSSNumber
-        paddingRight = resultArray[1].value as CSSNumber
-        paddingBottom = resultArray[0].value as CSSNumber
-        paddingLeft = resultArray[1].value as CSSNumber
+        paddingTop = resultArray[0]
+        paddingRight = resultArray[1]
+        paddingBottom = resultArray[0]
+        paddingLeft = resultArray[1]
       } else if (resultArray.length === 3) {
-        paddingTop = resultArray[0].value as CSSNumber
-        paddingRight = resultArray[1].value as CSSNumber
-        paddingBottom = resultArray[2].value as CSSNumber
-        paddingLeft = resultArray[1].value as CSSNumber
+        paddingTop = resultArray[0]
+        paddingRight = resultArray[1]
+        paddingBottom = resultArray[2]
+        paddingLeft = resultArray[1]
       } else {
-        paddingTop = resultArray[0].value as CSSNumber
-        paddingRight = resultArray[1].value as CSSNumber
-        paddingBottom = resultArray[2].value as CSSNumber
-        paddingLeft = resultArray[3].value as CSSNumber
+        paddingTop = resultArray[0]
+        paddingRight = resultArray[1]
+        paddingBottom = resultArray[2]
+        paddingLeft = resultArray[3]
       }
       return right({
         paddingTop: paddingTop,

--- a/editor/src/printer-parsers/css/css-parser-utils.ts
+++ b/editor/src/printer-parsers/css/css-parser-utils.ts
@@ -183,10 +183,18 @@ export const parseLength: Parser<CSSNumber> = (value: unknown) => {
 
 export const parseLengthPercentage: Parser<CSSNumber> = (value: unknown) => {
   if (isLexerMatch(value) && value.match.length === 1) {
-    return parseAlternative<CSSNumber>(
-      [parseLength, parsePercentage],
-      'Could not parse length-percentage',
-    )(value)
+    if (value.syntax.type === 'Type' && value.syntax.name === 'length-percentage') {
+      return parseAlternative<CSSNumber>(
+        [parseLength, parsePercentage],
+        'Could not parse length-percentage',
+      )(value.match[0])
+    } else {
+      // TODO let's check from syntax if it's a length or percentage
+      return parseAlternative<CSSNumber>(
+        [parseLength, parsePercentage],
+        'Could not parse length-percentage',
+      )(value)
+    }
   }
   return left(descriptionParseError('Could not parse length-percentage'))
 }

--- a/editor/src/printer-parsers/css/css-parser-utils.ts
+++ b/editor/src/printer-parsers/css/css-parser-utils.ts
@@ -43,10 +43,13 @@ import {
 export function getLexerPropertyMatches(
   propertyName: string,
   propertyValue: unknown,
+  defaultUnit: string,
   syntaxNamesToFilter?: ReadonlyArray<string>,
 ): Either<string, Array<LexerMatch>> {
-  if (typeof propertyValue === 'string') {
-    const ast = csstree.parse(propertyValue, {
+  if (typeof propertyValue === 'string' || typeof propertyValue === 'number') {
+    const valueToUse =
+      typeof propertyValue === 'number' ? `${propertyValue}${defaultUnit}` : propertyValue
+    const ast = csstree.parse(valueToUse, {
       context: 'value',
     })
     const lexerMatch = (csstree as any).lexer.matchProperty(propertyName, ast)

--- a/editor/src/printer-parsers/css/css-parser-utils.ts
+++ b/editor/src/printer-parsers/css/css-parser-utils.ts
@@ -29,7 +29,6 @@ import {
   traverseEither,
   mapEither,
 } from '../../core/shared/either'
-import { fastForEach } from '../../core/shared/utils'
 import * as csstreemissing from '../../missing-types/css-tree'
 import utils from '../../utils/utils'
 import {


### PR DESCRIPTION
**Problem:**
Shorthand css values are not supported in the inspector.

**Fix:**
This PR introduces padding shorthand parsing and printing, based on [mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties) using the 1-to-4-value syntax. Now the css-parser is capable of parsing values like `padding: "2px 4px"`.
It is not used anywhere in the inspector yet, that will be the next PR.

**Commit Details:**
- update css-tree to 1.1.2
- added helper to print cssnumber with default unit, as the shorthand syntax needs units
- interface for CSSPadding containing all sides
- fix an error in css-background-size where the error message was wrong
- extending `getLexerPropertyMatches` to add a default unit, this fixes the missing number type support
- fixed `parseLengthPercentage` in css-parser, this part is untyped using the css-tree, and in some cases the length-percentage contains a nested block (for background-size), some cases it is directly storing the value (for padding)
- unit tests for parser and printer