### PR TITLE
Fix/inspector keep style props in place

### DIFF
--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
@@ -565,7 +565,7 @@ describe('moving a scene/rootview on the canvas', () => {
       return (
         <Storyboard data-uid='utopia-storyboard-uid'>
           <Scene
-            style={{ position: 'absolute', width: 400, height: 400, top: -30, left: 40 }}
+            style={{ position: 'absolute', left: 40, top: -30, width: 400, height: 400 }}
             component={App}
             data-uid='scene-aaa'
           />
@@ -684,7 +684,7 @@ describe('resizing a scene/rootview on the canvas', () => {
       export var App = (props) => {
         return (
           <View
-            style={{ height: 370, width: 240 }}
+            style={{ width: 240, height: 370 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid='aaa'
             data-testid='aaa'
@@ -815,7 +815,7 @@ describe('resizing a scene/rootview on the canvas', () => {
       export var App = (props) => {
         return (
           <View
-            style={{ height: 370, width: 240 }}
+            style={{ width: 240, height: 370 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid='aaa'
           >
@@ -945,7 +945,7 @@ describe('resizing a scene/rootview on the canvas', () => {
       export var App = (props) => {
         return (
           <View
-            style={{ height: 170, width: 240 }}
+            style={{ width: 240, height: 170 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid='aaa'
           >
@@ -1077,7 +1077,7 @@ describe('resizing a scene/rootview on the canvas', () => {
     export var App = (props) => {
       return (
         <View
-          style={{ height: '92.5%', width: '120%' }}
+          style={{ width: '120%', height: '92.5%' }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid='aaa'
         >

--- a/editor/src/components/canvas/canvas-utils-unit-tests.spec.ts
+++ b/editor/src/components/canvas/canvas-utils-unit-tests.spec.ts
@@ -52,7 +52,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
-          style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, height: 340, width: 310 }}
+          style={{ backgroundColor: '#0091FFAA', left: 50, top: 50, width: 310, height: 340 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid='bbb'
         />
@@ -98,7 +98,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
-          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, height: 30, width: 296 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, width: 296, height: 30 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid='bbb'
         />
@@ -148,9 +148,9 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
             backgroundColor: '#0091FFAA',
             left: 52,
             top: 61,
+            width: 306,
             height: 252,
             bottom: 87,
-            width: 306,
             right: 43,
           }}
           layout={{ layoutSystem: 'pinSystem' }}
@@ -199,7 +199,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
-          style={{ backgroundColor: '#0091FFAA', right: 50, bottom: 20, top: 41, left: 2 }}
+          style={{ backgroundColor: '#0091FFAA', left: 2, top: 41, right: 50, bottom: 20 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid='bbb'
         />
@@ -245,7 +245,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
-          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, bottom: 30, right: -30 }}
+          style={{ backgroundColor: '#0091FFAA', left: 52, top: 61, right: -30, bottom: 30 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid='bbb'
         />
@@ -292,8 +292,8 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
-          style={{ backgroundColor: '#0091FFAA', top: 31, left: 12 }}
-          layout={{ layoutSystem: 'pinSystem', centerY: 85, centerX: 80 }}
+          style={{ backgroundColor: '#0091FFAA', left: 12, top: 31 }}
+          layout={{ layoutSystem: 'pinSystem', centerX: 80, centerY: 85 }}
           data-uid='bbb'
         />
       </View>`,
@@ -339,7 +339,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', left: 52, top: 61 }}
-          layout={{ layoutSystem: 'pinSystem', centerY: 115, centerX: 120 }}
+          layout={{ layoutSystem: 'pinSystem', centerX: 120, centerY: 115 }}
           data-uid='bbb'
         />
       </View>`,

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -53,7 +53,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
-          style={{ backgroundColor: '#0091FFAA', width: 100, height: 100, left: 20, top: 20 }}
+          style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, width: 100, height: 100 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid='bbb'
         />
@@ -86,7 +86,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
-          style={{ backgroundColor: '#0091FFAA', width: 100, height: 100, left: 20, top: 20 }}
+          style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, width: 100, height: 100 }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid='bbb'
         />
@@ -119,7 +119,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
-          style={{ backgroundColor: '#0091FFAA', width: '25%', height: '25%', left: 20, top: 20 }}
+          style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, width: '25%', height: '25%' }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid='bbb'
         />
@@ -619,8 +619,8 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
           style={{
             backgroundColor: '#0091FFAA',
             left: '15%',
-            right: '5%',
             top: '31.3%',
+            right: '5%',
             bottom: '8.8%',
           }}
           layout={{ layoutSystem: 'pinSystem' }}
@@ -729,12 +729,12 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
             }
             style={{
               backgroundColor: '#0091FFAA',
-              width: 256,
-              height: 202,
               left: 20,
               top: 20,
-              right: 125,
+              width: 256,
+              height: 202,
               bottom: 178,
+              right: 125,
             }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid='bbb'
@@ -804,7 +804,7 @@ describe('updateFramesOfScenesAndComponents - pinSizeChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
-            style={{ backgroundColor: '#0091FFAA', left: 20, width: 100, top: 20, height: 100 }}
+            style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, width: 100, height: 100 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid='bbb'
           />
@@ -840,7 +840,7 @@ describe('updateFramesOfScenesAndComponents - pinSizeChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
-            style={{ backgroundColor: '#0091FFAA', width: 100, left: 20, height: 100 }}
+            style={{ backgroundColor: '#0091FFAA', left: 20, width: 100, height: 100 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid='bbb'
           />
@@ -874,7 +874,7 @@ describe('updateFramesOfScenesAndComponents - pinSizeChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
           <View
-            style={{ backgroundColor: '#0091FFAA', left: 20, right: 280, top: 20, bottom: 280 }}
+            style={{ backgroundColor: '#0091FFAA', left: 20, top: 20, right: 280, bottom: 280 }}
             layout={{ layoutSystem: 'pinSystem' }}
             data-uid='bbb'
           />
@@ -910,7 +910,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
-          style={{ backgroundColor: '#0091FFAA', left: 40, top: 40, height: '17.5%', width: '45%' }}
+          style={{ backgroundColor: '#0091FFAA', left: 40, top: 40, width: '45%', height: '17.5%' }}
           layout={{ layoutSystem: 'pinSystem' }}
           data-uid='bbb'
         />
@@ -978,7 +978,7 @@ describe('moveTemplate', () => {
           data-uid='${NewUID}'
         >
           <View
-            style={{ backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202, position: 'absolute' }}
+            style={{ position: 'absolute', backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202 }}
             data-uid='bbb'
           />
         </View>
@@ -1090,7 +1090,7 @@ describe('moveTemplate', () => {
           data-uid='${NewUID}'
         >
           <View
-            style={{ backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202, position: 'absolute' }}
+            style={{ position: 'absolute', backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202 }}
             data-uid='bbb'
           >
             <View data-uid='ccc'>
@@ -1140,7 +1140,7 @@ describe('moveTemplate', () => {
         <View style={{ ...props.style }} data-uid='aaa'>
           <View data-uid='eee'>
             <View
-              style={{ backgroundColor: '#0091FFAA', left: 52, width: 256, height: 202, top: -141 }}
+              style={{ backgroundColor: '#0091FFAA', left: 52, top: -141, width: 256, height: 202 }}
               layout={{ layoutSystem: 'pinSystem'  }}
               data-uid='bbb'
             >
@@ -1189,7 +1189,7 @@ describe('moveTemplate', () => {
         <View style={{ ...props.style }} data-uid='aaa'>
           <View data-uid='eee'>
             <View
-              style={{ backgroundColor: '#0091FFAA', left: 52, width: 256, height: 202, top: -141 }}
+              style={{ backgroundColor: '#0091FFAA', left: 52, top: -141, width: 256, height: 202}}
               layout={{ layoutSystem: 'pinSystem' }}
               data-uid='bbb'
             >
@@ -1236,7 +1236,7 @@ describe('moveTemplate', () => {
           <View data-uid='eee'>
             <View data-uid='ddd' style={{ left: 52, top: -141 }} />
             <View
-              style={{ backgroundColor: '#0091FFAA', left: 52, width: 256, height: 202, top: -141 }}
+              style={{ backgroundColor: '#0091FFAA', left: 52, top: -141, width: 256, height: 202 }}
               layout={{ layoutSystem: 'pinSystem' }}
               data-uid='bbb'
             >
@@ -1532,8 +1532,8 @@ describe('moveTemplate', () => {
                 position: 'absolute',
                 width: 100,
                 height: 100,
-                top: 0,
                 left: 340,
+                top: 0,
               }}
               data-uid='orphan-bbb'
               data-testid='orphan-bbb'
@@ -1824,7 +1824,7 @@ describe('moveTemplate', () => {
           >
             <div data-uid='ccc' style={{ backgroundColor: '#ff00ff' }} layout={{ flexBasis: 20, crossBasis: 20 }} />
             <View
-              style={{ backgroundColor: '#0091FFAA', position: 'relative', flexBasis: 74, height: 74 }}
+              style={{ backgroundColor: '#0091FFAA', position: 'relative', height: 74, flexBasis: 74 }}
               data-uid='${NewUID}'
             />
           </div>
@@ -2080,7 +2080,7 @@ describe('moveTemplate', () => {
         <View
           data-testid='eee'
           data-uid='eee'
-          style={{ backgroundColor: '#00ff00', width: 80, height: 80, left: 100, top: 170 }}
+          style={{ backgroundColor: '#00ff00', left: 100, top: 170, width: 80, height: 80 }}
           layout={{ layoutSystem: 'pinSystem' }}
         />
       </View>
@@ -2193,7 +2193,7 @@ describe('moveTemplate', () => {
             data-uid='bbb'
           />
           <View
-            style={{ backgroundColor: '#0091FFAA', width: 200, height: 105, left: 95, top: 245 }}
+            style={{ backgroundColor: '#0091FFAA', left: 95, top: 245, width: 200, height: 105 }}
             data-uid='ccc'
             data-testid='ccc'
           />

--- a/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
+++ b/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
@@ -57,6 +57,46 @@ Array [
                       "leadingComments": Array [],
                       "trailingComments": Array [],
                     },
+                    "key": "position",
+                    "keyComments": Object {
+                      "leadingComments": Array [],
+                      "trailingComments": Array [],
+                    },
+                    "type": "PROPERTY_ASSIGNMENT",
+                    "value": Object {
+                      "comments": Object {
+                        "leadingComments": Array [],
+                        "trailingComments": Array [],
+                      },
+                      "type": "ATTRIBUTE_VALUE",
+                      "value": "absolute",
+                    },
+                  },
+                  Object {
+                    "comments": Object {
+                      "leadingComments": Array [],
+                      "trailingComments": Array [],
+                    },
+                    "key": "height",
+                    "keyComments": Object {
+                      "leadingComments": Array [],
+                      "trailingComments": Array [],
+                    },
+                    "type": "PROPERTY_ASSIGNMENT",
+                    "value": Object {
+                      "comments": Object {
+                        "leadingComments": Array [],
+                        "trailingComments": Array [],
+                      },
+                      "type": "ATTRIBUTE_VALUE",
+                      "value": 300,
+                    },
+                  },
+                  Object {
+                    "comments": Object {
+                      "leadingComments": Array [],
+                      "trailingComments": Array [],
+                    },
                     "key": "left",
                     "keyComments": Object {
                       "leadingComments": Array [],
@@ -110,46 +150,6 @@ Array [
                       },
                       "type": "ATTRIBUTE_VALUE",
                       "value": 200,
-                    },
-                  },
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "height",
-                    "keyComments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "type": "PROPERTY_ASSIGNMENT",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "type": "ATTRIBUTE_VALUE",
-                      "value": 300,
-                    },
-                  },
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "position",
-                    "keyComments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "type": "PROPERTY_ASSIGNMENT",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "type": "ATTRIBUTE_VALUE",
-                      "value": "absolute",
                     },
                   },
                 ],

--- a/editor/src/components/inspector/common/inspector-update-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-update-tests.spec.browser.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+import * as TP from '../../../core/shared/template-path'
+import {
+  getPrintedUiJsCode,
+  makeTestProjectCodeWithSnippet,
+  renderTestEditorWithCode,
+  TestScenePath,
+} from '../../canvas/ui-jsx.test-utils'
+import { act } from 'react-test-renderer'
+import { setElectronWindow } from '../../../core/shared/test-setup.test-utils'
+import { setProp_UNSAFE } from '../../editor/actions/action-creators'
+import * as PP from '../../../core/shared/property-path'
+import { jsxAttributeValue } from '../../../core/shared/element-template'
+import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
+
+describe('updating style properties keeps the original order', () => {
+  beforeAll(setElectronWindow)
+  it('element with different padding props', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+      <div style={{ ...props.style, position: 'absolute' }} data-uid='aaa'>
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            width: 256,
+            height: 202,
+            paddingRight: 15,
+            padding: '2px 4px',
+            paddingLeft: 10
+          }}
+          data-uid='bbb'
+        />
+      </div>
+      `),
+    )
+
+    const changePinProps = setProp_UNSAFE(
+      TP.instancePath(TestScenePath, ['aaa', 'bbb']),
+      PP.create(['style', 'paddingRight']),
+      jsxAttributeValue(30, emptyComments),
+    )
+
+    await renderResult.dispatch([changePinProps], true)
+
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<div style={{ ...props.style, position: 'absolute' }} data-uid='aaa'>
+          <div
+            style={{
+              backgroundColor: '#0091FFAA',
+              width: 256,
+              height: 202,
+              paddingRight: 30,
+              padding: '2px 4px',
+              paddingLeft: 10
+            }}
+            data-uid='bbb'
+          />
+        </div>`,
+      ),
+    )
+  })
+})

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -470,17 +470,30 @@ export function setJSXValueInAttributeAtPath(
           const attributeKey = PP.firstPart(path)
           const tailPath = PP.tail(path)
           const key = `${attributeKey}`
-          const newProps = dropKeyFromNestedObject(attribute, key).content
           if (lastPartOfPath) {
-            return right(
-              jsxAttributeNestedObject(
-                newProps.concat(
-                  jsxPropertyAssignment(key, newAttrib, emptyComments, emptyComments),
+            let updatedExistingProperty = false
+            let updatedContent = attribute.content.map((attr) => {
+              if (attr.type === 'PROPERTY_ASSIGNMENT' && attr.key === key) {
+                updatedExistingProperty = true
+                return jsxPropertyAssignment(key, newAttrib, emptyComments, emptyComments)
+              } else {
+                return attr
+              }
+            })
+            if (updatedExistingProperty) {
+              return right(jsxAttributeNestedObject(updatedContent, emptyComments))
+            } else {
+              return right(
+                jsxAttributeNestedObject(
+                  attribute.content.concat(
+                    jsxPropertyAssignment(key, newAttrib, emptyComments, emptyComments),
+                  ),
+                  emptyComments,
                 ),
-                emptyComments,
-              ),
-            )
+              )
+            }
           } else {
+            const newProps = dropKeyFromNestedObject(attribute, key).content
             const existingAttribute = nestedObjectValueForKey(attribute, key)
             const updatedNestedAttribute: Either<string, JSXAttribute> =
               existingAttribute.type === 'ATTRIBUTE_NOT_FOUND'


### PR DESCRIPTION
**Problem:**
Element style can contain longhand and shorthand values that affect the same style props, like padding, border, margin. For these style props the order matters, but the setProp update always pushes the new value to the end.

**Fix:**
Update `setJSXValueInAttributeAtPath` for nested objects to update in place instead of filtering and adding to the end of the content array.

**Commit Details:**
- update `setJSXValueInAttributeAtPath`
- added one test
- updated lots of canvas tests
