### PR TITLE
JSX Attributes: getAllPathsFromAttributes

### DIFF
--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -24,6 +24,7 @@ import {
 } from '../shared/element-template'
 import {
   dropKeyFromNestedObject,
+  getAllPathsFromAttributes,
   getModifiableJSXAttributeAtPath,
   jsxAttributesToProps,
   jsxSimpleAttributeToValue,
@@ -702,5 +703,25 @@ describe('simplifyAttributeIfPossible', () => {
     const expectedValue = jsxAttributeValue('test', emptyComments)
     const actualValue = simplifyAttributeIfPossible(expectedValue)
     expect(actualValue).toBe(expectedValue)
+  })
+})
+
+describe('getAllPathsFromAttributes', () => {
+  it('works for a simple case', () => {
+    const result = getAllPathsFromAttributes(
+      jsxAttributesFromMap({ cica: jsxAttributeValue('hello!', emptyComments) }),
+    )
+    expect(result).toEqual([PP.create(['cica'])])
+  })
+
+  it('drills into paths of object values too', () => {
+    const result = getAllPathsFromAttributes(
+      jsxAttributesFromMap({ cica: jsxAttributeValue({ deep: { path: 5 } }, emptyComments) }),
+    )
+    expect(result).toEqual([
+      PP.create(['cica']),
+      PP.create(['cica', 'deep']),
+      PP.create(['cica', 'deep', 'path']),
+    ])
   })
 })

--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -714,6 +714,82 @@ describe('getAllPathsFromAttributes', () => {
     expect(result).toEqual([PP.create(['cica'])])
   })
 
+  it('works for a nested object', () => {
+    const result = getAllPathsFromAttributes(
+      jsxAttributesFromMap({
+        cica: jsxAttributeNestedObjectSimple(
+          jsxAttributesFromMap({
+            deep: jsxAttributeNestedObjectSimple(
+              jsxAttributesFromMap({ path: jsxAttributeValue(5, emptyComments) }),
+              emptyComments,
+            ),
+          }),
+          emptyComments,
+        ),
+      }),
+    )
+    expect(result).toEqual([
+      PP.create(['cica']),
+      PP.create(['cica', 'deep']),
+      PP.create(['cica', 'deep', 'path']),
+    ])
+  })
+
+  it('works with spread assignment', () => {
+    const result = getAllPathsFromAttributes(
+      jsxAttributesFromMap({
+        cica: jsxAttributeNestedObject(
+          [
+            jsxSpreadAssignment(
+              jsxAttributeNestedObjectSimple(
+                jsxAttributesFromMap({ path: jsxAttributeValue(5, emptyComments) }),
+                emptyComments,
+              ),
+              emptyComments,
+            ),
+          ],
+          emptyComments,
+        ),
+      }),
+    )
+    expect(result).toEqual([{ propertyElements: ['cica'] }, { propertyElements: ['cica', 'path'] }])
+  })
+
+  it('works for a nested array', () => {
+    const result = getAllPathsFromAttributes(
+      jsxAttributesFromMap({
+        cica: jsxAttributeNestedObjectSimple(
+          jsxAttributesFromMap({
+            deep: jsxAttributeNestedArraySimple([jsxAttributeValue(5, emptyComments)]),
+          }),
+          emptyComments,
+        ),
+      }),
+    )
+    expect(result).toEqual([
+      PP.create(['cica']),
+      PP.create(['cica', 'deep']),
+      PP.create(['cica', 'deep', '0']),
+    ])
+  })
+
+  it('does not drill into function parameters', () => {
+    const result = getAllPathsFromAttributes(
+      jsxAttributesFromMap({
+        cica: jsxAttributeNestedObjectSimple(
+          jsxAttributesFromMap({
+            deep: jsxAttributeFunctionCall('functionName', [
+              jsxAttributeValue(5, emptyComments),
+              jsxAttributeValue({ objectKey: 'hello' }, emptyComments),
+            ]),
+          }),
+          emptyComments,
+        ),
+      }),
+    )
+    expect(result).toEqual([PP.create(['cica']), PP.create(['cica', 'deep'])])
+  })
+
   it('drills into paths of object values too', () => {
     const result = getAllPathsFromAttributes(
       jsxAttributesFromMap({ cica: jsxAttributeValue({ deep: { path: 5 } }, emptyComments) }),

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -1,7 +1,7 @@
 import * as ObjectPath from 'object-path'
 import { MapLike } from 'typescript'
 import { UtopiaUtils } from 'utopia-api'
-import { findLastIndex } from './array-utils'
+import { findLastIndex, uniqBy } from './array-utils'
 import { Either, isLeft, left, mapEither, reduceWithEither, right, sequenceEither } from './either'
 import {
   isArraySpread,
@@ -839,5 +839,5 @@ export function getAllPathsFromAttributes(attributes: JSXAttributes): Array<Prop
       }
     }
   })
-  return paths
+  return uniqBy(paths, PP.pathsEqual)
 }

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -25,12 +25,15 @@ import {
   getJSXAttribute,
   deleteJSXAttribute,
   setJSXAttributesAttribute,
+  isJSXAttributeValue,
 } from './element-template'
 import { resolveParamsAndRunJsCode } from './javascript-cache'
 import { PropertyPath } from './project-file-types'
 import * as PP from './property-path'
 import { fastForEach } from './utils'
 import { emptyComments } from '../workers/parser-printer/parser-printer-comments'
+import { defaultIfNull, optionalMap } from './optional-utils'
+import { getAllObjectPaths } from './object-utils'
 
 export type AnyMap = { [key: string]: any }
 
@@ -764,25 +767,47 @@ export function unsetJSXValueAtPath(
   }
 }
 
-export function walkAttribute(attribute: JSXAttribute, walk: (a: JSXAttribute) => void): void {
-  walk(attribute)
+export function walkAttribute(
+  attribute: JSXAttribute,
+  path: PropertyPath | null,
+  walk: (a: JSXAttribute, path: PropertyPath | null) => void,
+): void {
+  walk(attribute, path)
   switch (attribute.type) {
     case 'ATTRIBUTE_VALUE':
     case 'ATTRIBUTE_OTHER_JAVASCRIPT':
       break
     case 'ATTRIBUTE_NESTED_ARRAY':
-      fastForEach(attribute.content, (elem) => {
-        walkAttribute(elem.value, walk)
+      fastForEach(attribute.content, (elem, index) => {
+        walkAttribute(
+          elem.value,
+          optionalMap((p) => PP.appendPropertyPathElems(p, [index]), path),
+          walk,
+        )
       })
       break
     case 'ATTRIBUTE_FUNCTION_CALL':
       fastForEach(attribute.parameters, (param) => {
-        walkAttribute(param, walk)
+        walkAttribute(param, null, walk)
       })
       break
     case 'ATTRIBUTE_NESTED_OBJECT':
       fastForEach(attribute.content, (elem) => {
-        walkAttribute(elem.value, walk)
+        switch (elem.type) {
+          case 'PROPERTY_ASSIGNMENT':
+            walkAttribute(
+              elem.value,
+              optionalMap((p) => PP.appendPropertyPathElems(p, [elem.key]), path),
+              walk,
+            )
+            break
+          case 'SPREAD_ASSIGNMENT':
+            walkAttribute(elem.value, path, walk)
+            break
+          default:
+            const _exhaustiveCheck: never = elem
+            throw new Error(`Unhandled attribute ${JSON.stringify(elem)}`)
+        }
       })
       break
     default:
@@ -793,9 +818,26 @@ export function walkAttribute(attribute: JSXAttribute, walk: (a: JSXAttribute) =
 
 export function walkAttributes(
   attributes: JSXAttributes,
-  walk: (attribute: JSXAttribute) => void,
+  walk: (attribute: JSXAttribute, path: PropertyPath | null) => void,
 ): void {
   fastForEach(attributes, (attr) => {
-    walkAttribute(attr.value, walk)
+    walkAttribute(attr.value, PP.create([attr.key]), walk)
   })
+}
+
+export function getAllPathsFromAttributes(attributes: JSXAttributes): Array<PropertyPath> {
+  let paths: Array<PropertyPath> = []
+  walkAttributes(attributes, (attribute, path) => {
+    if (path != null) {
+      paths.push(path)
+      if (isJSXAttributeValue(attribute) && typeof attribute.value === 'object') {
+        paths.push(
+          ...getAllObjectPaths(attribute.value).map((p) =>
+            PP.create([...path.propertyElements, ...p]),
+          ),
+        )
+      }
+    }
+  })
+  return paths
 }


### PR DESCRIPTION
The inspector needs to understand shorthand and longhand properties shadowing each other.

We made this new utility function to be able to list all property paths of a given `JSXAttributes` props object, in order of appearance.  

**Commit Details:**
- we modified `walkAttributes` to include the attribute's property path in the callback
- created a new `getAllPathsFromAttributes` that uses `walkAttributes` 
- wrote tests
