### PR TITLE
Feature/inspector hooks emptyvalues

### DIFF
--- a/editor/src/components/inspector/common/inspector-utils.ts
+++ b/editor/src/components/inspector/common/inspector-utils.ts
@@ -29,8 +29,11 @@ export function useGetSubsectionHeaderStyle(controlStatus: ControlStatus): React
 export type CSSArrayItem = CSSBackgroundLayer | CSSTransformItem | CSSUnknownArrayItem
 
 export function getIndexedSpliceArrayItem<T extends CSSArrayItem>(index: number) {
-  return function spliceArrayItem(_: any, oldValue: ReadonlyArray<T>): ReadonlyArray<T> {
-    let newArrayItems = [...oldValue]
+  return function spliceArrayItem(
+    _: any,
+    oldValue: ReadonlyArray<T> | undefined,
+  ): ReadonlyArray<T> {
+    let newArrayItems = oldValue != null ? [...oldValue] : []
     newArrayItems.splice(index, 1)
     return newArrayItems
   }

--- a/editor/src/components/inspector/common/property-path-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.spec.tsx
@@ -199,7 +199,11 @@ describe('useCallbackFactory', () => {
 const WellBehavedInspectorSubsection = betterReactMemo('WellBehavedInspectorSubsection', () => {
   const { value, onSubmitValue } = useInspectorStyleInfo('opacity')
   onSubmitValue(cssNumber(0.9))
-  return <div onClick={() => onSubmitValue(cssNumber(0.5))}>{printCSSNumber(value)}</div>
+  return (
+    <div onClick={() => onSubmitValue(cssNumber(0.5))}>
+      {value != null ? printCSSNumber(value) : ''}
+    </div>
+  )
 })
 enableWhyDidYouRenderOnComponent(WellBehavedInspectorSubsection)
 

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -355,7 +355,7 @@ export function useInspectorStyleInfo<P extends ParsedCSSPropertiesKeys>(
     ({
       [prop]: transformedType,
     } as Partial<ParsedValues<P>>),
-): InspectorInfo<ParsedCSSProperties[P] | undefined> {
+): InspectorInfo<ParsedCSSProperties[P] | undefined, P> {
   return useInspectorInfoNoDefaults(
     [prop],
     transformValue,
@@ -1053,7 +1053,7 @@ export function useInspectorLayoutInfo<P extends LayoutProp | StyleLayoutProp>(
     return { [property]: transformedType } as Partial<ParsedValues<P>>
   }
 
-  let inspectorInfo = useInspectorInfo(
+  let inspectorInfo = useInspectorInfoNoDefaults(
     [property],
     transformValue,
     untransformValue,

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -320,7 +320,9 @@ function elementPathMappingFn<P extends ParsedElementPropertiesKeys>(p: P) {
   return PP.create([p])
 }
 
-export function useInspectorElementInfo<P extends ParsedElementPropertiesKeys>(prop: P) {
+export function useInspectorElementInfo<P extends ParsedElementPropertiesKeys>(
+  prop: P,
+): InspectorInfo<ParsedElementProperties[P] | undefined> {
   type T = ParsedElementProperties[P] | undefined
   const transformValue: (parsedValues: Partial<ParsedValues<P>>) => T = (parsedValues) =>
     parsedValues[prop]
@@ -336,7 +338,7 @@ export function useInspectorElementInfo<P extends ParsedElementPropertiesKeys>(p
 export function stylePropPathMappingFn<P extends ParsedCSSPropertiesKeys>(
   p: P,
   target: readonly string[],
-) {
+): PropertyPath {
   return PP.create([...target, p])
 }
 
@@ -1000,7 +1002,9 @@ export function useInspectorInfoSimpleUntyped(
   }
 }
 
-export function useInspectorLayoutInfo<P extends LayoutProp | StyleLayoutProp>(property: P) {
+export function useInspectorLayoutInfo<P extends LayoutProp | StyleLayoutProp>(
+  property: P,
+): InspectorInfo<ParsedProperties[P] | undefined> {
   type T = ParsedProperties[P] | undefined
   const transformValue: (parsedValues: Partial<ParsedValues<P>>) => T = (parsedValues) =>
     parsedValues[property]

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -344,16 +344,22 @@ export function stylePropPathMappingFn<P extends ParsedCSSPropertiesKeys>(
 
 export function useInspectorStyleInfo<P extends ParsedCSSPropertiesKeys>(
   prop: P,
-  transformValue: (parsedValues: ParsedValues<P>) => ParsedCSSProperties[P] = (parsedValues) =>
-    parsedValues[prop],
-  untransformValue: (transformedType: ParsedCSSProperties[P]) => Partial<ParsedValues<P>> = (
-    transformedType,
-  ) =>
+  transformValue: (parsedValues: Partial<ParsedValues<P>>) => ParsedCSSProperties[P] | undefined = (
+    parsedValues,
+  ) => parsedValues[prop],
+  untransformValue: (
+    transformedType: ParsedCSSProperties[P] | undefined,
+  ) => Partial<ParsedValues<P>> = (transformedType) =>
     ({
       [prop]: transformedType,
     } as Partial<ParsedValues<P>>),
-) {
-  return useInspectorInfo([prop], transformValue, untransformValue, stylePropPathMappingFn)
+): InspectorInfo<ParsedCSSProperties[P] | undefined> {
+  return useInspectorInfoNoDefaults(
+    [prop],
+    transformValue,
+    untransformValue,
+    stylePropPathMappingFn,
+  )
 }
 
 export function useInspectorContext() {
@@ -437,7 +443,7 @@ export type SubmitValueFactoryReturn<T> = [(newValue: T) => void, (newValue: T) 
  * @returns [onSubmitValue, onTransientSubmitValue]
  */
 export type UseSubmitValueFactory<T> = <NewType>(
-  transform: (newValue: NewType, oldValue: T) => T,
+  transform: (newValue: NewType, oldValue: T | undefined) => T,
 ) => SubmitValueFactoryReturn<NewType>
 
 export type OnUnsetValues = () => void

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -334,7 +334,7 @@ export function useInspectorElementInfo<P extends ParsedElementPropertiesKeys>(
       [prop]: transformedType,
     } as Partial<ParsedValues<P>>)
 
-  return useInspectorInfo([prop], transformValue, untransformValue, elementPathMappingFn)
+  return useInspectorInfoNoDefaults([prop], transformValue, untransformValue, elementPathMappingFn)
 }
 
 export function stylePropPathMappingFn<P extends ParsedCSSPropertiesKeys>(

--- a/editor/src/components/inspector/controls/background-solid-or-gradient-thumbnail-control.tsx
+++ b/editor/src/components/inspector/controls/background-solid-or-gradient-thumbnail-control.tsx
@@ -41,7 +41,7 @@ export interface BackgroundThumbnailControlProps {
   showString?: boolean
   onSubmitSolidStringValue?: (value: string) => void
   backgroundIndex: number
-  useSubmitValueFactory: UseSubmitValueFactory<CSSBackgroundLayers>
+  useSubmitValueFactory: UseSubmitValueFactory<CSSBackgroundLayers | undefined>
 }
 
 interface BackgroundSolidOrGradientThumbnailControlProps extends BackgroundThumbnailControlProps {

--- a/editor/src/components/inspector/controls/bg-size-metadata-control.tsx
+++ b/editor/src/components/inspector/controls/bg-size-metadata-control.tsx
@@ -61,9 +61,9 @@ const BGSizeKeywordValueSelectOptions = [
 function getIndexedUpdateBGSizePopupList(index: number) {
   return function updateBGSizePopupList(
     newValue: BGSizeSelectOption,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
-    let newCSSBackgroundLayers = [...oldValue]
+    let newCSSBackgroundLayers = oldValue != null ? [...oldValue] : []
     const indexedLayer = newCSSBackgroundLayers[index]
     if (isCSSBackgroundLayerWithBGSize(indexedLayer)) {
       const bgSize = ((): CSSBGSize => {
@@ -95,9 +95,9 @@ function getIndexedUpdateBGSizePopupList(index: number) {
 function getIndexedUpdateBGSizeWidthNumberValue(index: number) {
   return function updateBGSizeWidthNumberValue(
     newValue: UnknownOrEmptyInput<CSSNumber | CSSKeyword>,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
-    let newCSSBackgroundLayers = [...oldValue]
+    let newCSSBackgroundLayers = oldValue != null ? [...oldValue] : []
     const indexedLayer = newCSSBackgroundLayers[index]
     if (isCSSBackgroundLayerWithBGSize(indexedLayer)) {
       const bgSizeValue = indexedLayer.bgSize.size.value
@@ -142,9 +142,9 @@ function getIndexedUpdateBGSizeWidthNumberValue(index: number) {
 function getIndexedUpdateBGSizeHeightNumberValue(index: number) {
   return function updateBGSizeHeightNumberValue(
     newValue: UnknownOrEmptyInput<CSSNumber | CSSKeyword>,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
-    let newCSSBackgroundLayers = [...oldValue]
+    let newCSSBackgroundLayers = oldValue != null ? [...oldValue] : []
     const indexedLayer = newCSSBackgroundLayers[index]
     if (isCSSBackgroundLayerWithBGSize(indexedLayer)) {
       const bgSizeValue = indexedLayer.bgSize.size.value

--- a/editor/src/components/inspector/controls/unknown-array-item.tsx
+++ b/editor/src/components/inspector/controls/unknown-array-item.tsx
@@ -40,9 +40,9 @@ export const FakeUnknownArrayItem = betterReactMemo<FakeUnknownArrayItemProps>(
 function getIndexedUpdateUnknownArrayItemValue<T>(index: number) {
   return function updateUnknownArrayItemValue(
     newValue: string | EmptyInputValue,
-    oldValue: ReadonlyArray<T>,
+    oldValue?: ReadonlyArray<T>,
   ): ReadonlyArray<T> {
-    if (oldValue[index] != null) {
+    if (Array.isArray(oldValue) && oldValue[index] != null) {
       const oldLayer = oldValue[index]
       let newCSSBackgroundLayers = [...oldValue]
       if (isCSSUnknownArrayItem(oldLayer)) {
@@ -56,7 +56,7 @@ function getIndexedUpdateUnknownArrayItemValue<T>(index: number) {
         }
       }
     }
-    return oldValue
+    return oldValue ?? []
   }
 }
 
@@ -65,7 +65,9 @@ interface UnknownArrayItemProps<T> {
   value: CSSUnknownArrayItem
   controlStatus: ControlStatus
   controlStyles: ControlStyles
-  useSubmitTransformedValuesFactory: UseSubmitValueFactory<ReadonlyArray<T | CSSUnknownArrayItem>>
+  useSubmitTransformedValuesFactory: UseSubmitValueFactory<
+    ReadonlyArray<T | CSSUnknownArrayItem> | undefined
+  >
 }
 
 export function UnknownArrayItem<T>(props: UnknownArrayItemProps<T>) {

--- a/editor/src/components/inspector/controls/url-background-layer-metadata-controls.tsx
+++ b/editor/src/components/inspector/controls/url-background-layer-metadata-controls.tsx
@@ -14,9 +14,9 @@ import { StringControl } from './string-control'
 export function getIndexedUpdateCSSBackgroundLayerURLImageValue(index: number) {
   return function updateCSSBackgroundLayerURLImageValue(
     newValue: string,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
-    let newBackgroundLayers = [...oldValue]
+    let newBackgroundLayers = oldValue != null ? [...oldValue] : []
     let workingBackgroundLayer = { ...newBackgroundLayers[index] }
     if (isCSSImageURLBackgroundLayer(workingBackgroundLayer)) {
       workingBackgroundLayer.url = newValue

--- a/editor/src/components/inspector/sections/image-section/image-section.tsx
+++ b/editor/src/components/inspector/sections/image-section/image-section.tsx
@@ -18,6 +18,7 @@ import { PropertyLabel } from '../../widgets/property-label'
 import { ImageDensityControl } from './image-density-control'
 import { colorTheme, InspectorSectionHeader } from '../../../../uuiui'
 import { betterReactMemo } from '../../../../uuiui-deps'
+import { emptyValues } from '../../common/css-utils'
 
 const imgSrcProp = [PP.create(['src'])]
 const imgAltProp = [PP.create(['alt'])]
@@ -96,7 +97,7 @@ export const ImgSection = betterReactMemo('ImgSection', () => {
             id='image-src'
             key='image-src'
             testId='image-src'
-            value={srcValue}
+            value={srcValue ?? emptyValues['src']}
             onSubmitValue={srcOnSubmitValue}
             controlStyles={srcControlStyles}
             controlStatus={srcControlStatus}
@@ -115,7 +116,7 @@ export const ImgSection = betterReactMemo('ImgSection', () => {
             id='image-alt'
             key='image-alt'
             testId='image-alt'
-            value={altValue}
+            value={altValue ?? emptyValues['alt']}
             onSubmitValue={altOnSubmitValue}
             controlStyles={altControlStyles}
             controlStatus={altControlStatus}

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../../../../uuiui'
 import { betterReactMemo } from '../../../../../uuiui-deps'
 import { OnSubmitValueOrEmpty } from '../../../controls/control'
+import { emptyValues } from '../../../common/css-utils'
 
 type uglyLabel =
   | 'left'
@@ -57,7 +58,7 @@ const PrettyLabel: { [K in uglyLabel]: prettyLabel } = {
 }
 
 interface FlexFieldControlProps<T> {
-  value: T
+  value: T | undefined
   controlStatus: ControlStatus
   controlStyles: ControlStyles
   onSubmitValue: (newValue: T) => void
@@ -250,7 +251,7 @@ export const FlexGapControl = betterReactMemo('FlexGapControl', (props: FlexGapC
             id='flex.container.gap.main'
             key='flex.container.gap.main'
             testId='flex.container.gap.main'
-            value={props.value}
+            value={props.value ?? emptyValues['FlexGap']}
             DEPRECATED_controlOptions={
               {
                 minimum: 0,

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
@@ -16,6 +16,7 @@ import { PropertyLabel } from '../../../widgets/property-label'
 import { createLayoutPropertyPath } from '../../../../../core/layout/layout-helpers-new'
 import { useWrappedEmptyOrUnknownOnSubmitValue } from '../../../../../uuiui'
 import { betterReactMemo } from '../../../../../uuiui-deps'
+import { emptyValues } from '../../../common/css-utils'
 
 const flexGapProp = [createLayoutPropertyPath('FlexGap')]
 const alignItemsProp = [createLayoutPropertyPath('alignItems')]
@@ -31,6 +32,9 @@ export const FlexContainerControls = betterReactMemo<{ seeMoreVisible: boolean }
     const justifyContent = useInspectorLayoutInfo('justifyContent')
     const flexGap = useInspectorLayoutInfo('FlexGap')
 
+    const flexWrapValueOrDefault = flexWrap.value ?? emptyValues['flexWrap']
+    const flexDirectionOrDefault = flexDirection.value ?? emptyValues['flexDirection']
+
     const {
       justifyFlexStart,
       justifyFlexEnd,
@@ -39,7 +43,7 @@ export const FlexContainerControls = betterReactMemo<{ seeMoreVisible: boolean }
       alignItemsFlexEnd,
       alignContentFlexStart,
       alignContentFlexEnd,
-    } = getDirectionAwareLabels(flexWrap.value, flexDirection.value)
+    } = getDirectionAwareLabels(flexWrapValueOrDefault, flexDirectionOrDefault)
 
     const alignItemsControlStatus: ControlStatus =
       flexWrap.value === FlexWrap.NoWrap ? 'disabled' : alignItems.controlStatus
@@ -64,7 +68,7 @@ export const FlexContainerControls = betterReactMemo<{ seeMoreVisible: boolean }
             controlStyles={flexDirection.controlStyles}
             onSubmitValue={flexDirection.onSubmitValue}
             onUnset={flexDirection.onUnsetValues}
-            flexWrap={flexWrap.value}
+            flexWrap={flexWrapValueOrDefault}
           />
           <FlexJustifyContentControl
             value={justifyContent.value}
@@ -72,7 +76,7 @@ export const FlexContainerControls = betterReactMemo<{ seeMoreVisible: boolean }
             onUnset={justifyContent.onUnsetValues}
             controlStatus={justifyContent.controlStatus}
             controlStyles={justifyContent.controlStyles}
-            flexDirection={flexDirection.value}
+            flexDirection={flexDirectionOrDefault}
             justifyFlexStart={justifyFlexStart}
             justifyFlexEnd={justifyFlexEnd}
           />

--- a/editor/src/components/inspector/sections/style-section/background-subsection/background-layer-helpers.ts
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/background-layer-helpers.ts
@@ -36,9 +36,9 @@ export interface BackgroundLayerProps {
 export function getIndexedUpdateEnabled(index: number) {
   return function indexedUpdateEnabled(
     enabled: boolean,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
-    let newCSSBackgroundLayers = [...oldValue]
+    let newCSSBackgroundLayers = oldValue != null ? [...oldValue] : []
     const workingValue = newCSSBackgroundLayers[index]
     workingValue.enabled = enabled
     if (isCSSBackgroundLayerWithBGSize(workingValue)) {
@@ -89,11 +89,11 @@ export const backgroundLayerTypeSelectOptions: Array<CSSBackgroundLayerTypeSelec
 export function getIndexedOnCSSBackgroundLayerTypeSelectSubmitValue(backgroundLayerIndex: number) {
   return function onCSSBackgroundLayerTypeSelectSubmitValue(
     newValue: CSSBackgroundLayerTypeSelectOption,
-    oldValue: CSSBackgroundLayers,
+    oldValue: CSSBackgroundLayers | undefined,
   ): CSSBackgroundLayers {
     const newBackgroundLayerType = newValue.value
-    let newBackgroundLayers = [...oldValue]
-    const oldBackgroundLayer = oldValue[backgroundLayerIndex]
+    let newBackgroundLayers = oldValue != null ? [...oldValue] : []
+    const oldBackgroundLayer = oldValue != null ? oldValue[backgroundLayerIndex] : null
     if (oldBackgroundLayer != null) {
       if (newBackgroundLayerType === oldBackgroundLayer.type) {
         return newBackgroundLayers
@@ -145,7 +145,7 @@ export function getIndexedOnCSSBackgroundLayerTypeSelectSubmitValue(backgroundLa
           newStops[1].color = { type: 'Hex', hex: color1.hex() }
           switch (newBackgroundLayerType) {
             case 'solid-background-layer': {
-              return oldValue
+              return oldValue != null ? oldValue : []
             }
             case 'linear-gradient-background-layer': {
               newBackgroundLayers[backgroundLayerIndex] = {
@@ -266,7 +266,7 @@ export function getIndexedOnCSSBackgroundLayerTypeSelectSubmitValue(backgroundLa
               return newBackgroundLayers
             }
             case 'url-function-background-layer': {
-              return oldValue
+              return oldValue != null ? oldValue : []
             }
             default: {
               const _exhaustiveCheck: never = newBackgroundLayerType
@@ -289,9 +289,9 @@ export function getIndexedOnCSSBackgroundLayerTypeSelectSubmitValue(backgroundLa
 export function getIndexedUpdateRadialOrConicGradientCenterX(index: number) {
   return function updateRadialOrConicGradientCenterX(
     newX: CSSNumber | EmptyInputValue,
-    cssBackgroundImages: CSSBackgroundLayers,
+    cssBackgroundImages: CSSBackgroundLayers | undefined,
   ): CSSBackgroundLayers {
-    const newCssBackgroundImages = [...cssBackgroundImages]
+    const newCssBackgroundImages = cssBackgroundImages != null ? [...cssBackgroundImages] : []
     const workingBackgroundImage = newCssBackgroundImages[index]
     if (
       workingBackgroundImage.type === 'radial-gradient-background-layer' ||
@@ -317,9 +317,9 @@ export function getIndexedUpdateRadialOrConicGradientCenterX(index: number) {
 export function getIndexedUpdateRadialOrConicGradientCenterY(index: number) {
   return function updateRadialOrConicGradientCenterY(
     newY: CSSNumber | EmptyInputValue,
-    cssBackgroundImages: CSSBackgroundLayers,
+    cssBackgroundImages: CSSBackgroundLayers | undefined,
   ): CSSBackgroundLayers {
-    const newCssBackgroundImages = [...cssBackgroundImages]
+    const newCssBackgroundImages = cssBackgroundImages != null ? [...cssBackgroundImages] : []
     const workingBackgroundImage = newCssBackgroundImages[index]
     if (
       workingBackgroundImage.type === 'radial-gradient-background-layer' ||
@@ -343,4 +343,6 @@ export function getIndexedUpdateRadialOrConicGradientCenterY(index: number) {
   }
 }
 
-export type UseSubmitTransformedValuesFactory = UseSubmitValueFactory<CSSBackgroundLayers>
+export type UseSubmitTransformedValuesFactory = UseSubmitValueFactory<
+  CSSBackgroundLayers | undefined
+>

--- a/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/background-picker.tsx
@@ -77,7 +77,7 @@ interface BackgroundPickerProps {
   value: CSSSolidBackgroundLayer | CSSGradientBackgroundLayer | CSSURLFunctionBackgroundLayer
   closePopup: () => void
   portalTarget?: HTMLElement
-  useSubmitValueFactory: UseSubmitValueFactory<CSSBackgroundLayers>
+  useSubmitValueFactory: UseSubmitValueFactory<CSSBackgroundLayers | undefined>
   offsetX: number
   offsetY: number
   id: string
@@ -89,11 +89,11 @@ interface BackgroundPickerProps {
 function getIndexedUpdateCSSBackgroundLayerStop(index: number, backgroundLayerIndex: number) {
   return function indexedUpdateCSSBackgroundLayerStop(
     newValue: CSSColor,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
-    const oldBackgroundLayer = oldValue[backgroundLayerIndex]
+    const oldBackgroundLayer = oldValue != null ? oldValue[backgroundLayerIndex] : null
     if (oldBackgroundLayer != null) {
-      const newBackgroundLayers = [...oldValue]
+      const newBackgroundLayers = oldValue != null ? [...oldValue] : []
       if (isCSSGradientBackgroundLayer(oldBackgroundLayer)) {
         const newStopsArray = [...oldBackgroundLayer.stops]
         newStopsArray[index].color = { ...newValue }
@@ -106,7 +106,7 @@ function getIndexedUpdateCSSBackgroundLayerStop(index: number, backgroundLayerIn
       }
       return newBackgroundLayers
     }
-    return oldValue
+    return oldValue != null ? oldValue : []
   }
 }
 
@@ -114,7 +114,7 @@ export const inspectorEdgePadding = 8
 
 export interface BackgroundLayerControlsProps {
   value: CSSBackgroundLayer
-  useSubmitValueFactory: UseSubmitValueFactory<CSSBackgroundLayers>
+  useSubmitValueFactory: UseSubmitValueFactory<CSSBackgroundLayers | undefined>
   controlStatus: ControlStatus
   index: number
 }
@@ -170,9 +170,9 @@ interface RadialGradientControlsProps extends BackgroundLayerControlsProps {
 function getIndexedUpdateRadialGradientWidth(index: number) {
   return function updateRadialGradientWidth(
     newValue: CSSNumber | EmptyInputValue,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
-    const newCssBackgroundImagesizing = [...oldValue]
+    const newCssBackgroundImagesizing = oldValue != null ? [...oldValue] : []
     const workingRadialGradient = { ...newCssBackgroundImagesizing[index] }
     if (isCSSRadialGradientBackgroundLayer(workingRadialGradient)) {
       workingRadialGradient.gradientSize.width = fallbackOnEmptyInputValueToCSSDefaultEmptyValue(
@@ -188,9 +188,9 @@ function getIndexedUpdateRadialGradientWidth(index: number) {
 function getIndexedUpdateRadialGradientHeight(index: number) {
   return function updateRadialGradientHeight(
     newValue: CSSNumber | EmptyInputValue,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
-    const newCssBackgroundImagesizing = [...oldValue]
+    const newCssBackgroundImagesizing = oldValue != null ? [...oldValue] : []
     const workingRadialGradient = { ...newCssBackgroundImagesizing[index] }
     if (isCSSRadialGradientBackgroundLayer(workingRadialGradient)) {
       workingRadialGradient.gradientSize.height = fallbackOnEmptyInputValueToCSSDefaultEmptyValue(
@@ -305,9 +305,9 @@ interface ConicGradientControlsProps extends BackgroundLayerControlsProps {
 function getIndexedUpdateConicGradientFromAngle(index: number) {
   return function updateConicGradientFromAngle(
     newValue: CSSNumber | EmptyInputValue,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
-    const newCssBackgroundImagesizing = [...oldValue]
+    const newCssBackgroundImagesizing = oldValue != null ? [...oldValue] : []
     const workingConicGradient = { ...newCssBackgroundImagesizing[index] }
     if (isCSSConicGradientBackgroundLayer(workingConicGradient)) {
       workingConicGradient.fromAngle = fallbackOnEmptyInputValueToCSSDefaultEmptyValue(
@@ -420,11 +420,11 @@ export const BackgroundPicker: React.FunctionComponent<BackgroundPickerProps> = 
 
   const { backgroundLayerIndex } = props
   const updateStops = React.useCallback(
-    (newStops: Array<CSSGradientStop>, oldValue: CSSBackgroundLayers) => {
-      const oldBackgroundLayer = oldValue[backgroundLayerIndex]
+    (newStops: Array<CSSGradientStop>, oldValue?: CSSBackgroundLayers) => {
+      const oldBackgroundLayer = oldValue != null ? oldValue[backgroundLayerIndex] : null
       if (oldBackgroundLayer != null) {
         if (isCSSGradientBackgroundLayer(oldBackgroundLayer)) {
-          const newBackgroundLayers = [...oldValue]
+          const newBackgroundLayers = oldValue != null ? [...oldValue] : []
           newBackgroundLayers[backgroundLayerIndex] = {
             ...oldBackgroundLayer,
             stops: newStops,
@@ -432,7 +432,7 @@ export const BackgroundPicker: React.FunctionComponent<BackgroundPickerProps> = 
           return newBackgroundLayers
         }
       }
-      return oldValue
+      return oldValue != null ? oldValue : []
     },
     [backgroundLayerIndex],
   )

--- a/editor/src/components/inspector/sections/style-section/background-subsection/gradient-stop-editor.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/gradient-stop-editor.tsx
@@ -228,7 +228,7 @@ const GradientStop = betterReactMemo<GradientStopProps>(
 export interface GradientControlProps {
   stops: Array<CSSGradientStop>
   onSubmitValueAndUpdateLocalStops: OnSubmitValueAndUpdateLocalState<Array<CSSGradientStop>>
-  useSubmitValueFactory: UseSubmitValueFactory<CSSBackgroundLayers>
+  useSubmitValueFactory: UseSubmitValueFactory<CSSBackgroundLayers | undefined>
   selectedStopUnorderedIndex: number
   setSelectedStopUnorderedIndex: (index: number) => void
   style?: React.CSSProperties

--- a/editor/src/components/inspector/sections/style-section/background-subsection/linear-gradient-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/linear-gradient-layer.tsx
@@ -35,9 +35,9 @@ import { betterReactMemo } from '../../../../../uuiui-deps'
 export function getIndexedUpdateCSSBackgroundLayerLinearGradientAngle(index: number) {
   return function updateCSSBackgroundLayersLinearGradientAngle(
     newAngle: CSSNumber | EmptyInputValue,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
-    let newBackgroundLayers = [...oldValue]
+    let newBackgroundLayers = oldValue != null ? [...oldValue] : []
     let workingBackgroundLayer = newBackgroundLayers[index]
     if (workingBackgroundLayer.type === 'linear-gradient-background-layer') {
       workingBackgroundLayer.angle = fallbackOnEmptyInputValueToCSSDefaultEmptyValue(

--- a/editor/src/components/inspector/sections/style-section/background-subsection/solid-background-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/solid-background-layer.tsx
@@ -32,10 +32,10 @@ import { betterReactMemo } from '../../../../../uuiui-deps'
 function getIndexedUpdateStringCSSBackgroundLayerSolidColor(index: number) {
   return function indexedUpdateStringCSSBackgroundLayerSolidColor(
     newValue: string,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
     const parsedColor = parseColor(newValue)
-    let newCSSBackgroundLayers = [...oldValue]
+    let newCSSBackgroundLayers = oldValue != null ? [...oldValue] : []
     if (isRight(parsedColor)) {
       const oldIndexedValue = newCSSBackgroundLayers[index]
       if (isCSSSolidBackgroundLayer(oldIndexedValue)) {
@@ -52,11 +52,11 @@ function getIndexedUpdateStringCSSBackgroundLayerSolidColor(index: number) {
 function getIndexedUpdateNewAlpha(index: number) {
   return function updateNewAlpha(
     newValue: number | EmptyInputValue,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
-    const oldColor = oldValue[index]
+    const oldColor = oldValue != null ? oldValue[index] : null
     if (oldColor != null) {
-      let newCSSBackgroundLayers = [...oldValue]
+      let newCSSBackgroundLayers = oldValue != null ? [...oldValue] : []
       if (oldColor.type === 'solid-background-layer') {
         newCSSBackgroundLayers[index] = {
           ...oldColor,

--- a/editor/src/components/inspector/sections/style-section/background-subsection/url-background-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/url-background-layer.tsx
@@ -32,11 +32,11 @@ interface URLBackgroundLayerProps extends BackgroundLayerProps {
 function getIndexedUpdateNewURL(index: number) {
   return function updateNewURL(
     newValue: string | EmptyInputValue,
-    oldValue: CSSBackgroundLayers,
+    oldValue?: CSSBackgroundLayers,
   ): CSSBackgroundLayers {
-    const oldLayer = oldValue[index]
+    const oldLayer = oldValue != null ? oldValue[index] : null
     if (oldLayer != null) {
-      let newCSSBackgroundLayers = [...oldValue]
+      let newCSSBackgroundLayers = oldValue != null ? [...oldValue] : []
       const newURL = fallbackOnEmptyInputValueToCSSEmptyValue('', newValue)
       if (isCSSImageURLBackgroundLayer(oldLayer)) {
         newCSSBackgroundLayers[index] = {

--- a/editor/src/components/inspector/sections/style-section/border-subsection/border-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/border-subsection/border-subsection.tsx
@@ -33,15 +33,15 @@ import { ColorControl, StringColorControl } from '../../../controls/color-contro
 import { FakeUnknownArrayItem } from '../../../controls/unknown-array-item'
 import { GridRow } from '../../../widgets/grid-row'
 
-export function toggleBorderEnabled(_: null, oldValue: CSSBorder): CSSBorder {
-  const valueIsEnabled = (oldValue.style?.value.value ?? 'none') !== 'none'
+export function toggleBorderEnabled(_: null, oldValue?: CSSBorder): CSSBorder {
+  const valueIsEnabled = (oldValue?.style?.value.value ?? 'none') !== 'none'
   if (valueIsEnabled) {
-    let workingNewValue = { ...oldValue }
+    let workingNewValue = { ...(oldValue ?? defaultCSSBorder) }
     delete workingNewValue.style
     return workingNewValue
   } else {
     return {
-      ...oldValue,
+      ...(oldValue ?? defaultCSSBorder),
       style: cssLineStyle(cssKeyword('solid')),
     }
   }
@@ -49,47 +49,47 @@ export function toggleBorderEnabled(_: null, oldValue: CSSBorder): CSSBorder {
 
 export function updateBorderWidth(
   newWidth: CSSNumber | EmptyInputValue,
-  oldValue: CSSBorder,
+  oldValue?: CSSBorder,
 ): CSSBorder {
   if (isEmptyInputValue(newWidth)) {
     let newValue = {
-      ...oldValue,
+      ...(oldValue ?? defaultCSSBorder),
     }
     delete newValue.width
     return newValue
   } else {
     return {
-      ...oldValue,
+      ...(oldValue ?? defaultCSSBorder),
       style:
-        (oldValue.style?.value.value ?? 'none') === 'none'
+        (oldValue?.style?.value.value ?? 'none') === 'none'
           ? cssLineStyle(cssKeyword('solid'))
-          : oldValue.style,
+          : oldValue?.style,
       width: cssLineWidth(newWidth),
     }
   }
 }
 
-export function updateBorderColor(newColor: CSSColor, oldValue: CSSBorder): CSSBorder {
+export function updateBorderColor(newColor: CSSColor, oldValue?: CSSBorder): CSSBorder {
   return {
-    ...oldValue,
+    ...(oldValue ?? defaultCSSBorder),
     style:
-      (oldValue.style?.value.value ?? 'none') === 'none'
+      (oldValue?.style?.value.value ?? 'none') === 'none'
         ? cssLineStyle(cssKeyword('solid'))
-        : oldValue.style,
+        : oldValue?.style,
     color: newColor,
   }
 }
 
-export function updateBorderColorString(newValue: string, oldValue: CSSBorder): CSSBorder {
+export function updateBorderColorString(newValue: string, oldValue?: CSSBorder): CSSBorder {
   const parsed = parseColor(newValue)
   if (isRight(parsed)) {
     return updateBorderColor(parsed.value, oldValue)
   } else {
-    return oldValue
+    return oldValue ?? defaultCSSBorder
   }
 }
 
-function insertBorder(_: null, oldValue: CSSBorder): CSSBorder {
+function insertBorder(_: null, oldValue?: CSSBorder): CSSBorder {
   return { ...defaultCSSBorder }
 }
 
@@ -107,10 +107,10 @@ export const BorderSubsection: React.FunctionComponent = betterReactMemo('Border
 
   const headerStyle = useGetSubsectionHeaderStyle(controlStatus)
 
-  const borderEnabled = (value.style?.value.value ?? 'none') !== 'none'
-  const borderColor: CSSColor = value.color ?? defaultCSSBorder.color
+  const borderEnabled = (value?.style?.value.value ?? 'none') !== 'none'
+  const borderColor: CSSColor = value?.color ?? defaultCSSBorder.color
   const borderWidth: CSSNumber = (() => {
-    if (value.width == null) {
+    if (value?.width == null) {
       return { ...defaultBorderWidth }
     } else if (isCSSNumber(value.width.value)) {
       return value.width.value

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -234,7 +234,7 @@ export const ClassNameSubsection = betterReactMemo('ClassNameSubSection', () => 
   } = useInspectorElementInfo('className')
 
   const values: ReadonlyArray<SelectOption> =
-    value === '' ? [] : value.split(' ').map((v) => ({ value: v, label: `.${v}` }))
+    value === '' || value == null ? [] : value.split(' ').map((v) => ({ value: v, label: `.${v}` }))
 
   const headerStyle = useGetSubsectionHeaderStyle(controlStatus)
 

--- a/editor/src/components/inspector/sections/style-section/containter-subsection/opacity-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/containter-subsection/opacity-row.tsx
@@ -11,6 +11,7 @@ import {
   InspectorContextMenuWrapper,
   SliderControl,
 } from '../../../../../uuiui-deps'
+import { CSSNumber, emptyValues } from '../../../common/css-utils'
 
 const sliderControlOptions = {
   minimum: 0,
@@ -26,14 +27,13 @@ const opacityProp = [PP.create(['style', 'opacity'])]
 export const OpacityRow = betterReactMemo('OpacityRow', () => {
   const opacityMetadata = useInspectorStyleInfo('opacity')
 
-  const opacity = opacityMetadata.value
+  const opacity = opacityMetadata.value ?? emptyValues['opacity']
   const scale = opacity.unit === '%' ? 100 : 1
   const scaledOpacity = opacity.value / scale
-
   const isVisible = useIsSubSectionVisible('opacity')
   const [onScaledSubmit, onScaledTransientSubmit] = opacityMetadata.useSubmitValueFactory(
-    (newValue: number, oldValue) => {
-      return CSSUtils.setCSSNumberValue(oldValue, newValue * scale)
+    (newValue: number, oldValue?: CSSNumber) => {
+      return CSSUtils.setCSSNumberValue(oldValue ?? null, newValue * scale)
     },
   )
 

--- a/editor/src/components/inspector/sections/style-section/containter-subsection/radius-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/containter-subsection/radius-row.tsx
@@ -14,6 +14,7 @@ import {
   cssNumber,
   defaultBorderRadiusIndividual,
   EmptyInputValue,
+  emptyValues,
   fallbackOnEmptyInputValueToCSSEmptyValue,
   framePinToCSSNumber,
   getCSSNumberValue,
@@ -31,40 +32,42 @@ import { betterReactMemo, InspectorContextMenuItems } from '../../../../../uuiui
 
 function updateRadiusType(
   newRadiusTypeValue: SelectOption,
-  borderRadius: CSSBorderRadius,
+  borderRadius?: CSSBorderRadius,
 ): CSSBorderRadius {
+  const oldValue = borderRadius != null ? borderRadius : emptyValues['borderRadius']
   if (newRadiusTypeValue.value === 'individual') {
-    if (isLeft(borderRadius)) {
+    if (isLeft(oldValue)) {
       return right({
-        tl: borderRadius.value,
-        tr: borderRadius.value,
-        br: borderRadius.value,
-        bl: borderRadius.value,
+        tl: oldValue.value,
+        tr: oldValue.value,
+        br: oldValue.value,
+        bl: oldValue.value,
       })
     } else {
-      return borderRadius
+      return oldValue
     }
   } else {
-    if (isRight(borderRadius)) {
-      return left(borderRadius.value.tl)
+    if (isRight(oldValue)) {
+      return left(oldValue.value.tl)
     } else {
-      return borderRadius
+      return oldValue
     }
   }
 }
 
 function updateBorderRadiusAll(
   newBorderRadiusAllValue: number,
-  borderRadius: CSSBorderRadius,
+  borderRadius?: CSSBorderRadius,
 ): CSSBorderRadius {
-  if (isLeft(borderRadius)) {
+  const oldValue = borderRadius != null ? borderRadius : emptyValues['borderRadius']
+  if (isLeft(oldValue)) {
     return left({
-      ...borderRadius.value,
+      ...oldValue.value,
       value: newBorderRadiusAllValue,
     })
   } else {
     return left({
-      ...borderRadius.value.tr,
+      ...oldValue.value.tr,
       value: newBorderRadiusAllValue,
     })
   }
@@ -76,15 +79,16 @@ function updateBorderRadiusAllCSSNumber(newBorderRadiusAllValue: CSSNumber): CSS
 
 function updateBorderRadiusTL(
   newBorderRadiusTLValue: CSSNumber | EmptyInputValue,
-  borderRadius: CSSBorderRadius,
+  borderRadius?: CSSBorderRadius,
 ): CSSBorderRadius {
   const safeNewValue = fallbackOnEmptyInputValueToCSSEmptyValue(
     cssNumber(0),
     newBorderRadiusTLValue,
   )
-  if (isRight(borderRadius)) {
+  const oldValue = borderRadius != null ? borderRadius : emptyValues['borderRadius']
+  if (isRight(oldValue)) {
     const newBorderRadius: CSSBorderRadiusIndividual = {
-      ...borderRadius.value,
+      ...oldValue.value,
       tl: safeNewValue,
     }
     return right(newBorderRadius)
@@ -95,15 +99,16 @@ function updateBorderRadiusTL(
 
 function updateBorderRadiusTR(
   newBorderRadiusTRValue: CSSNumber | EmptyInputValue,
-  borderRadius: CSSBorderRadius,
+  borderRadius?: CSSBorderRadius,
 ): CSSBorderRadius {
   const safeNewValue = fallbackOnEmptyInputValueToCSSEmptyValue(
     cssNumber(0),
     newBorderRadiusTRValue,
   )
-  if (isRight(borderRadius)) {
+  const oldValue = borderRadius != null ? borderRadius : emptyValues['borderRadius']
+  if (isRight(oldValue)) {
     const newBorderRadius: CSSBorderRadiusIndividual = {
-      ...borderRadius.value,
+      ...oldValue.value,
       tr: safeNewValue,
     }
     return right(newBorderRadius)
@@ -114,15 +119,16 @@ function updateBorderRadiusTR(
 
 function updateBorderRadiusBL(
   newBorderRadiusBLValue: CSSNumber | EmptyInputValue,
-  borderRadius: CSSBorderRadius,
+  borderRadius?: CSSBorderRadius,
 ): CSSBorderRadius {
   const safeNewValue = fallbackOnEmptyInputValueToCSSEmptyValue(
     cssNumber(0),
     newBorderRadiusBLValue,
   )
-  if (isRight(borderRadius)) {
+  const oldValue = borderRadius != null ? borderRadius : emptyValues['borderRadius']
+  if (isRight(oldValue)) {
     const newBorderRadius: CSSBorderRadiusIndividual = {
-      ...borderRadius.value,
+      ...oldValue.value,
       bl: safeNewValue,
     }
     return right(newBorderRadius)
@@ -133,15 +139,16 @@ function updateBorderRadiusBL(
 
 function updateBorderRadiusBR(
   newBorderRadiusBRValue: CSSNumber | EmptyInputValue,
-  borderRadius: CSSBorderRadius,
+  borderRadius?: CSSBorderRadius,
 ): CSSBorderRadius {
   const safeNewValue = fallbackOnEmptyInputValueToCSSEmptyValue(
     cssNumber(0),
     newBorderRadiusBRValue,
   )
-  if (isRight(borderRadius)) {
+  const oldValue = borderRadius != null ? borderRadius : emptyValues['borderRadius']
+  if (isRight(oldValue)) {
     const newBorderRadius: CSSBorderRadiusIndividual = {
-      ...borderRadius.value,
+      ...oldValue.value,
       br: safeNewValue,
     }
     return right(newBorderRadius)
@@ -170,12 +177,13 @@ function getSliderMax(widthPin: CSSNumber | undefined, heightPin: CSSNumber | un
 
 export const RadiusRow = betterReactMemo('RadiusControls', () => {
   const {
-    value: borderRadiusValue,
+    value,
     controlStatus,
     controlStyles,
     useSubmitValueFactory,
     onUnsetValues,
   } = useInspectorStyleInfo('borderRadius')
+  const borderRadiusValue = value != null ? value : emptyValues['borderRadius']
   const valueWidth = useInspectorLayoutInfo('Width')
   const valueHeight = useInspectorLayoutInfo('Height')
   const sliderMax = getSliderMax(valueWidth.value, valueHeight.value)

--- a/editor/src/components/inspector/sections/style-section/shadow-subsection/shadow-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/shadow-subsection/shadow-subsection.tsx
@@ -27,6 +27,7 @@ import {
   fallbackOnEmptyInputValueToCSSEmptyValue,
   cssPixelLength,
   cssDefault,
+  emptyValues,
 } from '../../../common/css-utils'
 import { useGetSubsectionHeaderStyle } from '../../../common/inspector-utils'
 import {
@@ -45,8 +46,8 @@ export function toggleShadowEnabled(oldValue: CSSBoxShadow): CSSBoxShadow {
 }
 
 export function getIndexedToggleShadowEnabled(index: number) {
-  return function (_: null, oldValue: CSSBoxShadows): CSSBoxShadows {
-    let newBoxShadows = [...oldValue]
+  return function (_: null, oldValue?: CSSBoxShadows): CSSBoxShadows {
+    let newBoxShadows = oldValue != null ? [...oldValue] : []
     newBoxShadows[index] = toggleShadowEnabled(newBoxShadows[index])
     return newBoxShadows
   }
@@ -54,9 +55,9 @@ export function getIndexedToggleShadowEnabled(index: number) {
 function getIndexedUpdateShadowColor(index: number) {
   return function indexedUpdateShadowColor(
     newValue: CSSColor,
-    oldValue: CSSBoxShadows,
+    oldValue?: CSSBoxShadows,
   ): CSSBoxShadows {
-    let newBoxShadows = [...oldValue]
+    let newBoxShadows = oldValue != null ? [...oldValue] : []
     newBoxShadows[index] = { ...newBoxShadows[index], color: newValue }
     return newBoxShadows
   }
@@ -65,9 +66,9 @@ function getIndexedUpdateShadowColor(index: number) {
 function getIndexedUpdateShadowOffsetX(index: number) {
   return function indexedUpdateShadowOffsetX(
     newOffsetX: CSSNumber | EmptyInputValue,
-    oldValue: CSSBoxShadows,
+    oldValue?: CSSBoxShadows,
   ): CSSBoxShadows {
-    let newBoxShadows = [...oldValue]
+    let newBoxShadows = oldValue != null ? [...oldValue] : []
     newBoxShadows[index] = {
       ...newBoxShadows[index],
       offsetX: fallbackOnEmptyInputValueToCSSEmptyValue(cssPixelLength(0), newOffsetX),
@@ -79,9 +80,9 @@ function getIndexedUpdateShadowOffsetX(index: number) {
 function getIndexedUpdateShadowOffsetY(index: number) {
   return function indexedUpdateShadowOffsetY(
     newOffsetY: CSSNumber | EmptyInputValue,
-    oldValue: CSSBoxShadows,
+    oldValue?: CSSBoxShadows,
   ): CSSBoxShadows {
-    let newBoxShadows = [...oldValue]
+    let newBoxShadows = oldValue != null ? [...oldValue] : []
     newBoxShadows[index] = {
       ...newBoxShadows[index],
       offsetY: fallbackOnEmptyInputValueToCSSEmptyValue(cssPixelLength(0), newOffsetY),
@@ -93,9 +94,9 @@ function getIndexedUpdateShadowOffsetY(index: number) {
 function getIndexedUpdateShadowBlurRadius(index: number) {
   return function indexedUpdateShadowBlurRadius(
     newBlurRadius: CSSNumber | EmptyInputValue,
-    oldValue: CSSBoxShadows,
+    oldValue?: CSSBoxShadows,
   ): CSSBoxShadows {
-    let newBoxShadows = [...oldValue]
+    let newBoxShadows = oldValue != null ? [...oldValue] : []
     newBoxShadows[index] = {
       ...newBoxShadows[index],
       blurRadius: fallbackOnEmptyInputValueToCSSDefaultEmptyValue(
@@ -110,9 +111,9 @@ function getIndexedUpdateShadowBlurRadius(index: number) {
 function getIndexedUpdateShadowSpreadRadius(index: number) {
   return function indexedUpdateShadowSpreadRadius(
     newSpreadRadius: CSSNumber | EmptyInputValue,
-    oldValue: CSSBoxShadows,
+    oldValue?: CSSBoxShadows,
   ): CSSBoxShadows {
-    let newBoxShadows = [...oldValue]
+    let newBoxShadows = oldValue != null ? [...oldValue] : []
     newBoxShadows[index] = {
       ...newBoxShadows[index],
       spreadRadius: fallbackOnEmptyInputValueToCSSDefaultEmptyValue(
@@ -124,13 +125,13 @@ function getIndexedUpdateShadowSpreadRadius(index: number) {
   }
 }
 
-function updateInsertShadow(_: any, oldValue: CSSBoxShadows): CSSBoxShadows {
-  return [...oldValue, { ...defaultBoxShadow }]
+function updateInsertShadow(_: any, oldValue?: CSSBoxShadows): CSSBoxShadows {
+  return oldValue != null ? [...oldValue, { ...defaultBoxShadow }] : [{ ...defaultBoxShadow }]
 }
 
 function getIndexedSpliceShadow(index: number) {
-  return function (_: any, oldValue: CSSBoxShadows) {
-    let newCSSBoxShadow = [...oldValue]
+  return function (_: any, oldValue?: CSSBoxShadows) {
+    let newCSSBoxShadow = oldValue != null ? [...oldValue] : []
     newCSSBoxShadow.splice(index, 1)
     return newCSSBoxShadow
   }
@@ -143,7 +144,7 @@ interface ShadowItemProps {
   index: number
   controlStatus: ControlStatus
   controlStyles: ControlStyles
-  useSubmitValueFactory: UseSubmitValueFactory<CSSBoxShadows>
+  useSubmitValueFactory: UseSubmitValueFactory<CSSBoxShadows | undefined>
   contextMenuItems: Array<ContextMenuItem<null>>
 }
 
@@ -286,14 +287,15 @@ export const ShadowSubsection = betterReactMemo('ShadowSubsection', () => {
     propertyStatus,
     useSubmitValueFactory,
   } = useInspectorStyleInfo('boxShadow')
+  const shadowValue = value != null ? value : emptyValues['boxShadow']
   const headerStyle = useGetSubsectionHeaderStyle(controlStatus)
 
   const [insertShadowValue] = useSubmitValueFactory(updateInsertShadow)
 
-  const { springs, bind } = useArraySuperControl(value, onSubmitValue, rowHeight)
+  const { springs, bind } = useArraySuperControl(shadowValue, onSubmitValue, rowHeight)
 
   const contextMenuItems = utils.stripNulls([
-    value.length > 0 ? addOnUnsetValues(['boxShadow'], onUnsetValues) : null,
+    shadowValue.length > 0 ? addOnUnsetValues(['boxShadow'], onUnsetValues) : null,
   ])
 
   if (!isVisible) {
@@ -333,7 +335,7 @@ export const ShadowSubsection = betterReactMemo('ShadowSubsection', () => {
         }}
       >
         {springs.map((springStyle: { [x: string]: SpringValue<any> }, index: number) => {
-          const boxShadow = value[index]
+          const boxShadow = shadowValue[index]
           if (boxShadow != null) {
             return (
               <animated.div
@@ -348,7 +350,7 @@ export const ShadowSubsection = betterReactMemo('ShadowSubsection', () => {
               >
                 <ShadowItem
                   value={boxShadow}
-                  shadowsLength={value.length}
+                  shadowsLength={shadowValue.length}
                   useSubmitValueFactory={useSubmitValueFactory}
                   onUnsetValues={onUnsetValues}
                   index={index}

--- a/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select-popup.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select-popup.tsx
@@ -67,7 +67,7 @@ interface FontFamilySelectPopupProps {
   controlStyles: ControlStyles
   closePopup: () => void
   useSubmitFontVariantFactory: UseSubmitValueFactory<
-    ParsedValues<'fontFamily' | 'fontStyle' | 'fontWeight'>
+    Partial<ParsedValues<'fontFamily' | 'fontStyle' | 'fontWeight'>>
   >
 }
 

--- a/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select.tsx
@@ -15,6 +15,12 @@ import {
 import { PropertyRow } from '../../../widgets/property-row'
 import { FontFamilySelectPopup } from './font-family-select-popup'
 
+export function transformFontFamily(
+  values: Partial<ParsedValues<'fontFamily' | 'fontStyle' | 'fontWeight'>> = {},
+): Partial<ParsedValues<'fontFamily' | 'fontStyle' | 'fontWeight'>> {
+  return values
+}
+
 export const FontFamilySelect = betterReactMemo('FontFamilySelect', () => {
   const [referenceElement, setReferenceElement] = React.useState<HTMLDivElement | null>(null)
   const [popperElement, setPopperElement] = React.useState<HTMLDivElement | null>(null)
@@ -43,7 +49,7 @@ export const FontFamilySelect = betterReactMemo('FontFamilySelect', () => {
 
   const { value, useSubmitValueFactory, onUnsetValues, controlStyles } = useInspectorInfoNoDefaults(
     ['fontFamily', 'fontStyle', 'fontWeight'],
-    identity,
+    transformFontFamily,
     identity,
     stylePropPathMappingFn,
   )

--- a/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select.tsx
@@ -2,11 +2,16 @@ import * as React from 'react'
 import { usePopper } from 'react-popper'
 import { identity } from '../../../../../core/shared/utils'
 import utils from '../../../../../utils/utils'
-import { FlexRow, UtopiaTheme, Icons } from '../../../../../uuiui'
+import { FlexRow, UtopiaTheme, Icons, fontSize, fontWeight } from '../../../../../uuiui'
 import { betterReactMemo } from '../../../../../uuiui-deps'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { addOnUnsetValues } from '../../../common/context-menu-items'
-import { stylePropPathMappingFn, useInspectorInfo } from '../../../common/property-path-hooks'
+import { emptyValues } from '../../../common/css-utils'
+import {
+  ParsedValues,
+  stylePropPathMappingFn,
+  useInspectorInfoNoDefaults,
+} from '../../../common/property-path-hooks'
 import { PropertyRow } from '../../../widgets/property-row'
 import { FontFamilySelectPopup } from './font-family-select-popup'
 
@@ -36,7 +41,7 @@ export const FontFamilySelect = betterReactMemo('FontFamilySelect', () => {
     [togglePopup],
   )
 
-  const { value, useSubmitValueFactory, onUnsetValues, controlStyles } = useInspectorInfo(
+  const { value, useSubmitValueFactory, onUnsetValues, controlStyles } = useInspectorInfoNoDefaults(
     ['fontFamily', 'fontStyle', 'fontWeight'],
     identity,
     identity,
@@ -46,6 +51,12 @@ export const FontFamilySelect = betterReactMemo('FontFamilySelect', () => {
   const fontFamilyContextMenuItems = utils.stripNulls([
     controlStyles.unsettable ? addOnUnsetValues(['fontFamily'], onUnsetValues) : null,
   ])
+
+  const fontFamilyValue: ParsedValues<'fontFamily' | 'fontStyle' | 'fontWeight'> = {
+    fontFamily: value?.fontFamily ?? emptyValues['fontFamily'],
+    fontStyle: value?.fontStyle ?? emptyValues['fontStyle'],
+    fontWeight: value?.fontWeight ?? emptyValues['fontWeight'],
+  }
 
   return (
     <PropertyRow>
@@ -60,7 +71,7 @@ export const FontFamilySelect = betterReactMemo('FontFamilySelect', () => {
             {...attributes.popper}
             style={styles.popper}
             ref={setPopperElement}
-            value={value}
+            value={fontFamilyValue}
             onUnsetValues={onUnsetValues}
             controlStyles={controlStyles}
             closePopup={closePopup}
@@ -78,7 +89,7 @@ export const FontFamilySelect = betterReactMemo('FontFamilySelect', () => {
             borderRadius: UtopiaTheme.inputBorderRadius,
           }}
         >
-          <div style={{ flexGrow: 1 }}>{value.fontFamily[0]}</div>
+          <div style={{ flexGrow: 1 }}>{fontFamilyValue.fontFamily[0]}</div>
           <Icons.ExpansionArrowDown />
         </FlexRow>
       </InspectorContextMenuWrapper>

--- a/editor/src/components/inspector/sections/style-section/text-subsection/font-variant-select.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/font-variant-select.tsx
@@ -18,10 +18,12 @@ import {
   webFontFamilyVariant,
 } from '../../../../navigator/external-resources/google-fonts-utils'
 import { addOnUnsetValues } from '../../../common/context-menu-items'
+import { emptyValues } from '../../../common/css-utils'
 import {
   ParsedValues,
   stylePropPathMappingFn,
   useInspectorInfo,
+  useInspectorInfoNoDefaults,
   useInspectorStyleInfo,
 } from '../../../common/property-path-hooks'
 
@@ -38,10 +40,10 @@ function updateFontWeightAndStyle(
 
 function updateAddNewFontVariant(
   newValue: FontWeightAndStyleSelectOption,
-  oldValue: ExternalResources,
+  oldValue?: ExternalResources,
 ): ExternalResources {
   const newVariant = newValue.value.fontVariant
-  let workingGoogleFontsResources = [...oldValue.googleFontsResources]
+  let workingGoogleFontsResources = oldValue != null ? [...oldValue.googleFontsResources] : []
   const workingResourceIndex = workingGoogleFontsResources.findIndex(
     (v) => v.fontFamily === newValue.value.familyName,
   )
@@ -81,7 +83,8 @@ function updateAddNewFontVariant(
     }
   }
   return {
-    ...oldValue,
+    type: oldValue != null ? oldValue.type : 'external-resources',
+    genericExternalResources: oldValue != null ? oldValue.genericExternalResources : [],
     googleFontsResources: workingGoogleFontsResources,
   }
 }
@@ -91,7 +94,7 @@ interface FontWeightAndStyleSelectOption {
 }
 
 export const FontVariantSelect = betterReactMemo('FontVariantSelect', () => {
-  const { value, controlStyles, onUnsetValues, useSubmitValueFactory } = useInspectorInfo(
+  const { value, controlStyles, onUnsetValues, useSubmitValueFactory } = useInspectorInfoNoDefaults(
     weightAndStylePaths,
     identity,
     identity,
@@ -99,7 +102,7 @@ export const FontVariantSelect = betterReactMemo('FontVariantSelect', () => {
   )
 
   const { value: fontFamilyValue } = useInspectorStyleInfo('fontFamily')
-  const primaryFont = fontFamilyValue[0]
+  const primaryFont = (fontFamilyValue ?? emptyValues['fontFamily'])[0]
 
   const fontWeightAndStyleContextMenuItems = utils.stripNulls([
     controlStyles.unsettable ? addOnUnsetValues(['fontWeight', 'fontStyle'], onUnsetValues) : null,

--- a/editor/src/components/inspector/sections/style-section/text-subsection/project-typeface-item.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/project-typeface-item.tsx
@@ -10,10 +10,10 @@ import { ProjectTypeface } from './font-family-select-popup'
 
 export function updateRemoveFontFamily(
   fontFamilyToDelete: string,
-  oldValue: ExternalResources,
+  oldValue?: ExternalResources,
 ): ExternalResources {
   const googleFontsResources: Array<GoogleFontsResource> = (() => {
-    let workingGoogleFontsResources = [...oldValue.googleFontsResources]
+    let workingGoogleFontsResources = oldValue != null ? [...oldValue.googleFontsResources] : []
     const familyIndex = workingGoogleFontsResources.findIndex(
       (resource) => resource.fontFamily === fontFamilyToDelete,
     )
@@ -23,7 +23,8 @@ export function updateRemoveFontFamily(
     return workingGoogleFontsResources
   })()
   return {
-    ...oldValue,
+    type: oldValue != null ? oldValue.type : 'external-resources',
+    genericExternalResources: oldValue != null ? oldValue.genericExternalResources : [],
     googleFontsResources,
   }
 }

--- a/editor/src/components/inspector/sections/style-section/text-subsection/text-shadow-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/text-shadow-subsection.tsx
@@ -16,6 +16,7 @@ import {
   EmptyInputValue,
   fallbackOnEmptyInputValueToCSSEmptyValue,
   fallbackOnEmptyInputValueToCSSDefaultEmptyValue,
+  emptyValues,
 } from '../../../common/css-utils'
 import { useInspectorStyleInfo, useIsSubSectionVisible } from '../../../common/property-path-hooks'
 import { stopPropagation } from '../../../common/inspector-utils'
@@ -36,9 +37,9 @@ import { betterReactMemo } from '../../../../../uuiui-deps'
 function getIndexedToggleTextShadowEnabled(index: number) {
   return function indexedToggleTextShadowEnabled(
     enabled: boolean,
-    cssTextShadows: CSSTextShadows,
+    cssTextShadows?: CSSTextShadows,
   ): CSSTextShadows {
-    let newTextShadow = [...cssTextShadows]
+    let newTextShadow = cssTextShadows != null ? [...cssTextShadows] : []
     newTextShadow[index].enabled = enabled
     return newTextShadow
   }
@@ -47,9 +48,9 @@ function getIndexedToggleTextShadowEnabled(index: number) {
 function getIndexedUpdateTextShadowColor(index: number) {
   return function updateTextShadowColor(
     newColor: CSSColor,
-    cssTextShadows: CSSTextShadows,
+    cssTextShadows?: CSSTextShadows,
   ): CSSTextShadows {
-    let newTextShadows = [...cssTextShadows]
+    let newTextShadows = cssTextShadows != null ? [...cssTextShadows] : []
     let newTextShadow: CSSTextShadow = { ...newTextShadows[index] }
     newTextShadow.color = newColor
     newTextShadows[index] = newTextShadow
@@ -60,9 +61,9 @@ function getIndexedUpdateTextShadowColor(index: number) {
 function getIndexedUpdateTextShadowOffsetX(index: number) {
   return function updateTextShadowOffsetX(
     newOffsetX: CSSNumber | EmptyInputValue,
-    cssTextShadows: CSSTextShadows,
+    cssTextShadows?: CSSTextShadows,
   ): CSSTextShadows {
-    let newTextShadows = [...cssTextShadows]
+    let newTextShadows = cssTextShadows != null ? [...cssTextShadows] : []
     let newTextShadow: CSSTextShadow = { ...newTextShadows[index] }
     newTextShadow.offsetX = fallbackOnEmptyInputValueToCSSEmptyValue(
       {
@@ -78,9 +79,9 @@ function getIndexedUpdateTextShadowOffsetX(index: number) {
 function getIndexedUpdateTextShadowOffsetY(index: number) {
   return function updateTextShadowOffsetY(
     newOffsetY: CSSNumber | EmptyInputValue,
-    cssTextShadows: CSSTextShadows,
+    cssTextShadows?: CSSTextShadows,
   ): CSSTextShadows {
-    let newTextShadows = [...cssTextShadows]
+    let newTextShadows = cssTextShadows != null ? [...cssTextShadows] : []
     let newTextShadow: CSSTextShadow = { ...newTextShadows[index] }
     newTextShadow.offsetY = fallbackOnEmptyInputValueToCSSEmptyValue(
       {
@@ -96,9 +97,9 @@ function getIndexedUpdateTextShadowOffsetY(index: number) {
 function getIndexedUpdateTextShadowBlurRadius(index: number) {
   return function updateTextShadowBlurRadius(
     newBlurRadius: CSSNumber | EmptyInputValue,
-    cssTextShadows: CSSTextShadows,
+    cssTextShadows?: CSSTextShadows,
   ): CSSTextShadows {
-    let newTextShadows = [...cssTextShadows]
+    let newTextShadows = cssTextShadows != null ? [...cssTextShadows] : []
     let newTextShadow: CSSTextShadow = { ...newTextShadows[index] }
     newTextShadow.blurRadius = fallbackOnEmptyInputValueToCSSDefaultEmptyValue(
       defaultTextShadow.blurRadius,
@@ -110,13 +111,13 @@ function getIndexedUpdateTextShadowBlurRadius(index: number) {
 }
 
 function getIndexedSpliceTextShadow(index: number) {
-  return function spliceTextShadow(_: any, cssTextShadows: CSSTextShadows): CSSTextShadows {
-    return R.remove(index, 1, [...cssTextShadows])
+  return function spliceTextShadow(_: any, cssTextShadows?: CSSTextShadows): CSSTextShadows {
+    return R.remove(index, 1, cssTextShadows != null ? [...cssTextShadows] : [])
   }
 }
 
-function insertTextShadow(_: any, cssTextShadows: CSSTextShadows): CSSTextShadows {
-  return [...cssTextShadows, defaultTextShadow]
+function insertTextShadow(_: any, cssTextShadows?: CSSTextShadows): CSSTextShadows {
+  return cssTextShadows != null ? [...cssTextShadows, defaultTextShadow] : [defaultTextShadow]
 }
 
 type TextShadowItemProps = {
@@ -126,7 +127,7 @@ type TextShadowItemProps = {
   controlStatus: ControlStatus
   controlStyles: ControlStyles
   useSubmitValueFactory: <NT>(
-    transform: (newValue: NT, oldValue: CSSTextShadows) => CSSTextShadows,
+    transform: (newValue: NT, oldValue?: CSSTextShadows) => CSSTextShadows,
   ) => [(newValue: NT) => void, (newValue: NT) => void]
 }
 
@@ -254,7 +255,7 @@ export const TextShadowSubsection = betterReactMemo('TextShadowSubsection', () =
     onUnsetValues,
     onSubmitValue,
     useSubmitValueFactory,
-  } = useInspectorStyleInfo('textShadow', undefined, (transformedType: CSSTextShadows) => {
+  } = useInspectorStyleInfo('textShadow', undefined, (transformedType?: CSSTextShadows) => {
     if (Array.isArray(transformedType) && transformedType.length === 0) {
       return {}
     } else {
@@ -269,7 +270,7 @@ export const TextShadowSubsection = betterReactMemo('TextShadowSubsection', () =
   const isVisible = useIsSubSectionVisible('textShadow')
 
   const { springs, bind } = useArraySuperControl(
-    textShadowsValue,
+    textShadowsValue ?? [],
     onSubmitValue,
     PropertyRowHeightWithLabel,
   )
@@ -279,10 +280,10 @@ export const TextShadowSubsection = betterReactMemo('TextShadowSubsection', () =
   }, [onUnsetValues])
 
   const contextMenuItems = utils.stripNulls([
-    textShadowsValue.length > 0 ? addOnUnsetValues(['textShadow'], onUnsetValues) : null,
+    (textShadowsValue ?? []).length > 0 ? addOnUnsetValues(['textShadow'], onUnsetValues) : null,
   ])
 
-  const length = textShadowsValue.length
+  const length = (textShadowsValue ?? []).length
 
   const insertShadow = React.useCallback(() => {
     insertTextShadowItemSubmitValue(null)
@@ -323,7 +324,7 @@ export const TextShadowSubsection = betterReactMemo('TextShadowSubsection', () =
             <FakeUnknownArrayItem controlStatus={controlStatus} />
           ) : (
             springs.map((springStyle: { [x: string]: SpringValue<any> }, index: number) => {
-              const value = textShadowsValue[index]
+              const value = (textShadowsValue ?? emptyValues['textShadow'])[index]
               if (value != null) {
                 return (
                   <animated.div

--- a/editor/src/components/inspector/sections/style-section/text-subsection/text-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/text-subsection.tsx
@@ -26,7 +26,12 @@ import * as EditorActions from '../../../../editor/actions/action-creators'
 import { useRefEditorState } from '../../../../editor/store/store-hook'
 import { measureTextFieldNew } from '../../../../text-utils'
 import { addOnUnsetValues } from '../../../common/context-menu-items'
-import { CSSFontStyle, cssNumber, CSSTextDecorationLine } from '../../../common/css-utils'
+import {
+  CSSFontStyle,
+  cssNumber,
+  CSSTextDecorationLine,
+  emptyValues,
+} from '../../../common/css-utils'
 import { usePropControlledRef_DANGEROUS } from '../../../common/inspector-utils'
 import {
   InspectorCallbackContext,
@@ -45,7 +50,7 @@ import { emptyComments } from '../../../../../core/workers/parser-printer/parser
 
 const ObjectPathImmutable: any = OPI
 
-function updateItalicFontStyle(newValue: boolean, oldValue: CSSFontStyle): CSSFontStyle {
+function updateItalicFontStyle(newValue: boolean, oldValue?: CSSFontStyle): CSSFontStyle {
   return newValue ? 'italic' : 'normal'
 }
 
@@ -245,7 +250,7 @@ export const TextSubsection = betterReactMemo('TextSubsection', () => {
             id='color-control'
             key='color-control'
             testId='text-subsection-color-control'
-            value={colorMetadata.value}
+            value={colorMetadata.value ?? emptyValues['color']}
             onSubmitValue={colorMetadata.onSubmitValue}
             onTransientSubmitValue={colorMetadata.onTransientSubmitValue}
             pickerOffset={{ x: -223, y: 0 }}

--- a/editor/src/components/navigator/external-resources/google-fonts-resources-list-search.tsx
+++ b/editor/src/components/navigator/external-resources/google-fonts-resources-list-search.tsx
@@ -6,10 +6,10 @@ import {
   ExternalResources,
   GoogleFontsResource,
   googleFontsResource,
+  UseSubmitValueFactoryNavigator,
 } from '../../../printer-parsers/html/external-resources-parser'
 import { StringInput } from '../../../uuiui'
 import { betterReactMemo, Utils } from '../../../uuiui-deps'
-import { UseSubmitValueFactory } from '../../inspector/common/property-path-hooks'
 import {
   fontFamilyData,
   FontFamilyData,
@@ -24,7 +24,7 @@ import { GoogleFontsListItem } from './google-fonts-variant-list-item'
 
 interface GoogleFontsResourcesListSearchProps {
   linkedResources: Array<GoogleFontsResource>
-  useSubmitValueFactory: UseSubmitValueFactory<ExternalResources>
+  useSubmitValueFactory: UseSubmitValueFactoryNavigator<ExternalResources>
 }
 
 export type PushNewFontFamilyVariant = (newValue: WebFontFamilyVariant) => void

--- a/editor/src/printer-parsers/html/external-resources-parser.tsx
+++ b/editor/src/printer-parsers/html/external-resources-parser.tsx
@@ -6,10 +6,7 @@ import { EditorDispatch } from '../../components/editor/action-types'
 import { addToast, updateFile } from '../../components/editor/actions/action-creators'
 import { defaultIndexHtmlFilePath, EditorState } from '../../components/editor/store/editor-state'
 import { useEditorState } from '../../components/editor/store/store-hook'
-import {
-  useCallbackFactory,
-  UseSubmitValueFactory,
-} from '../../components/inspector/common/property-path-hooks'
+import { useCallbackFactory } from '../../components/inspector/common/property-path-hooks'
 import {
   WebFontVariant,
   webFontVariant,
@@ -453,10 +450,14 @@ export function getExternalResourcesInfo(
   }
 }
 
+export type UseSubmitValueFactoryNavigator<T> = <NewType>(
+  transform: (newValue: NewType, oldValue: T) => T,
+) => [(newValue: NewType) => void, (newValue: NewType) => void]
+
 export function useExternalResources(): {
   values: Either<DescriptionParseError, ExternalResources>
   onSubmitValue: OnSubmitValue<ExternalResources>
-  useSubmitValueFactory: UseSubmitValueFactory<ExternalResources>
+  useSubmitValueFactory: UseSubmitValueFactoryNavigator<ExternalResources>
 } {
   const { dispatch, editorState } = useEditorState(
     (store) => ({


### PR DESCRIPTION
The goal is to use the new hook which has no emptyValues inside the hook. Since cssdefaults and computedstyles is used to provide fallback where it's possible the emptyValues are causing only confusion.
But most of the control types rely on having a real value instead of undefined, so this fixes that.

- changed layout, style, and element hooks to use `useInspectorInfoNoDefaults`
- Changed all other places that directly use `useInspectorInfo` to  have `useInspectorInfoNoDefaults`