### PR TITLE
css shorthand longhand support hook

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -3898,7 +3898,7 @@ function isNumberParser(simpleValue: unknown): Either<string, number> {
   }
 }
 
-type DOMEventHandlerMetadata = ModifiableAttribute
+type DOMEventHandlerMetadata = JSXAttribute
 
 export function parseDOMEventHandlerMetadata(
   _: unknown,
@@ -3914,7 +3914,7 @@ export function parseDOMEventHandlerMetadata(
   }
 }
 
-export function printDOMEventHandlerMetadata(value: ModifiableAttribute): ModifiableAttribute {
+export function printDOMEventHandlerMetadata(value: JSXAttribute): JSXAttribute {
   return value
 }
 
@@ -4691,7 +4691,7 @@ export function parseAnyParseableValue<K extends keyof ParsedProperties>(
 }
 
 // hmmmm
-type PrintedValue = ModifiableAttribute
+type PrintedValue = JSXAttribute
 
 type Printer<V extends ValueOf<ParsedProperties>> = (value: V) => PrintedValue
 

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
@@ -62,7 +62,7 @@ describe('inspector tests with real metadata', () => {
     expect(flexPaddingTopControl.value).toMatchInlineSnapshot(`"20"`)
     expect(
       flexPaddingTopControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"detected"`)
+    ).toMatchInlineSnapshot(`"simple"`)
 
     // Padding left is coming from the `paddingLeft` value.
     expect(metadata.computedStyle?.['paddingLeft']).toMatchInlineSnapshot(`"15px"`)
@@ -446,7 +446,7 @@ describe('inspector tests with real metadata', () => {
     expect(paddingLeftControl.value).toMatchInlineSnapshot(`"16"`)
     expect(
       paddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"detected"`)
+    ).toMatchInlineSnapshot(`"simple"`)
 
     expect(paddingRightControl.value).toMatchInlineSnapshot(`"12"`)
     expect(
@@ -545,10 +545,10 @@ describe('inspector tests with real metadata', () => {
       leftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"simple-unknown-css"`)
 
-    expect(paddingLeftControl.value).toMatchInlineSnapshot(`""`)
+    expect(paddingLeftControl.value).toMatchInlineSnapshot(`"0"`)
     expect(
       paddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"trivial-default"`)
+    ).toMatchInlineSnapshot(`"simple"`)
 
     expect(paddingRightControl.value).toMatchInlineSnapshot(`"0"`)
     expect(
@@ -652,7 +652,7 @@ describe('inspector tests with real metadata', () => {
     expect(paddingLeftControl.value).toMatchInlineSnapshot(`"4"`)
     expect(
       paddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"detected"`)
+    ).toMatchInlineSnapshot(`"simple"`)
 
     expect(paddingRightControl.value).toMatchInlineSnapshot(`"8"`)
     expect(
@@ -736,10 +736,10 @@ describe('inspector tests with real metadata', () => {
       leftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"simple"`)
 
-    expect(paddingLeftControl.value).toMatchInlineSnapshot(`"16"`)
+    expect(paddingLeftControl.value).toMatchInlineSnapshot(`"4%"`)
     expect(
       paddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"detected"`)
+    ).toMatchInlineSnapshot(`"simple"`)
 
     expect(paddingRightControl.value).toMatchInlineSnapshot(`"8%"`)
     expect(
@@ -826,12 +826,12 @@ describe('inspector tests with real metadata', () => {
     expect(paddingLeftControl.value).toMatchInlineSnapshot(`"44"`)
     expect(
       paddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"detected"`)
+    ).toMatchInlineSnapshot(`"simple"`)
 
     expect(paddingRightControl.value).toMatchInlineSnapshot(`"42"`)
     expect(
       paddingRightControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"simple-unknown-css"`)
+    ).toMatchInlineSnapshot(`"simple"`)
 
     expect(radiusControl.value).toMatchInlineSnapshot(`"15%"`)
     expect(
@@ -913,7 +913,7 @@ describe('inspector tests with real metadata', () => {
     expect(paddingLeftControl.value).toMatchInlineSnapshot(`"4"`)
     expect(
       paddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"detected"`)
+    ).toMatchInlineSnapshot(`"controlled"`)
 
     expect(paddingRightControl.value).toMatchInlineSnapshot(`"5"`)
     expect(
@@ -1038,7 +1038,7 @@ describe('inspector tests with real metadata', () => {
     expect(paddingLeftControl.value).toMatchInlineSnapshot(`"5"`)
     expect(
       paddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
-    ).toMatchInlineSnapshot(`"detected"`)
+    ).toMatchInlineSnapshot(`"controlled"`)
 
     expect(paddingRightControl.value).toMatchInlineSnapshot(`"10"`)
     expect(

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.ts
@@ -1,0 +1,205 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { ComputedStyle, StyleAttributeMetadata } from '../../../core/shared/element-template'
+import { ParsedPropertiesKeys } from './css-utils'
+import { useInspectorInfoLonghandShorthand } from './longhand-shorthand-hooks'
+import { stylePropPathMappingFn } from './property-path-hooks'
+import {
+  getPropsForStyleProp,
+  makeInspectorHookContextProvider,
+} from './property-path-hooks.test-utils'
+
+describe('useInspectorInfo: padding shorthand and longhands', () => {
+  function getPaddingHookResult<P extends ParsedPropertiesKeys>(
+    longhand: P,
+    shorthand: P,
+    styleObjectExpressions: Array<string>,
+    spiedProps: Array<any>,
+    computedStyles: Array<ComputedStyle>,
+    attributeMetadatas: Array<StyleAttributeMetadata>,
+  ) {
+    const props = styleObjectExpressions.map(
+      (styleExpression) => getPropsForStyleProp(styleExpression, ['style'])!,
+    )
+
+    const contextProvider = makeInspectorHookContextProvider(
+      [],
+      props,
+      ['style'],
+      spiedProps,
+      computedStyles,
+      attributeMetadatas,
+    )
+
+    const { result } = renderHook(
+      () =>
+        useInspectorInfoLonghandShorthand(
+          longhand,
+          shorthand,
+          stylePropPathMappingFn as any, // ¯\_(ツ)_/¯
+        ),
+      {
+        wrapper: contextProvider,
+      },
+    )
+    return result.current
+  }
+
+  it('paddingLeft', () => {
+    const hookResult = getPaddingHookResult(
+      'paddingLeft',
+      'padding',
+      [`{ paddingLeft: 5 }`],
+      [{ paddingLeft: 5 }],
+      [{ paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '5px' }],
+      [],
+    )
+    expect(hookResult.value).toEqual({ unit: null, value: 5 })
+    expect(hookResult.orderedPropKeys).toEqual([['paddingLeft']])
+  })
+
+  it('paddingLeft, padding', () => {
+    const hookResult = getPaddingHookResult(
+      'paddingLeft',
+      'padding',
+      [`{ paddingLeft: 5, padding: 15 }`],
+      [{ paddingLeft: 5, padding: 15 }],
+      [{ paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '15px' }],
+      [],
+    )
+    expect(hookResult.value).toEqual({ unit: 'px', value: 15 })
+    expect(hookResult.orderedPropKeys).toEqual([['paddingLeft', 'padding']])
+  })
+
+  it('padding, paddingLeft', () => {
+    const hookResult = getPaddingHookResult(
+      'paddingLeft',
+      'padding',
+      [`{ padding: 15, paddingLeft: 5 }`],
+      [{ padding: 15, paddingLeft: 5 }],
+      [{ paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '5px' }],
+      [],
+    )
+    expect(hookResult.value).toEqual({ unit: null, value: 5 })
+    expect(hookResult.orderedPropKeys).toEqual([['padding', 'paddingLeft']])
+  })
+
+  it('paddingLeft, padding, paddingRight', () => {
+    const hookResult = getPaddingHookResult(
+      'paddingLeft',
+      'padding',
+      [`{ paddingLeft: 5, padding: 15, paddingRight: 20 }`], // paddingRight is irrelevant, we are making sure it doesn't affect anything
+      [{ paddingLeft: 5, padding: 15, paddingRight: 20 }],
+      [{ paddingTop: '15px', paddingRight: '20px', paddingBottom: '15px', paddingLeft: '15px' }],
+      [],
+    )
+    expect(hookResult.value).toEqual({ unit: 'px', value: 15 })
+    expect(hookResult.orderedPropKeys).toEqual([['paddingLeft', 'padding']])
+  })
+
+  it('paddingLeft controlled', () => {
+    const hookResult = getPaddingHookResult(
+      'paddingLeft',
+      'padding',
+      [`{ paddingLeft: 5 + 5 }`],
+      [{ paddingLeft: 10 }],
+      [{ paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '10px' }],
+      [],
+    )
+    expect(hookResult.value).toEqual({ unit: 'px', value: 10 })
+    expect(hookResult.orderedPropKeys).toEqual([['paddingLeft']])
+    expect(hookResult.controlStatus).toEqual('controlled')
+  })
+
+  it('paddingLeft, padding controlled', () => {
+    const hookResult = getPaddingHookResult(
+      'paddingLeft',
+      'padding',
+      [`{ paddingLeft: 5, padding: 15 + 5 }`],
+      [{ paddingLeft: 5, padding: 20 }],
+      [{ paddingTop: '20px', paddingRight: '20px', paddingBottom: '20px', paddingLeft: '20px' }],
+      [],
+    )
+    expect(hookResult.value).toEqual({ unit: 'px', value: 20 })
+    expect(hookResult.orderedPropKeys).toEqual([['paddingLeft', 'padding']])
+    expect(hookResult.controlStatus).toEqual('controlled')
+  })
+
+  it('padding controlled, paddingLeft', () => {
+    const hookResult = getPaddingHookResult(
+      'paddingLeft',
+      'padding',
+      [`{ padding: 15 + 5, paddingLeft: 5 }`],
+      [{ padding: 20, paddingLeft: 5 }],
+      [{ paddingTop: '20px', paddingRight: '20px', paddingBottom: '20px', paddingLeft: '5px' }],
+      [],
+    )
+    expect(hookResult.value).toEqual({ unit: null, value: 5 })
+    expect(hookResult.orderedPropKeys).toEqual([['padding', 'paddingLeft']])
+    expect(hookResult.controlStatus).toEqual('simple')
+  })
+
+  it('paddingLeft controlled, padding', () => {
+    const hookResult = getPaddingHookResult(
+      'paddingLeft',
+      'padding',
+      [`{ paddingLeft: 5 + 5, padding: 15 }`],
+      [{ paddingLeft: 10, padding: 15 }],
+      [{ paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '15px' }],
+      [],
+    )
+    expect(hookResult.value).toEqual({ unit: 'px', value: 15 })
+    expect(hookResult.orderedPropKeys).toEqual([['paddingLeft', 'padding']])
+    expect(hookResult.controlStatus).toEqual('simple')
+  })
+
+  it('multiselect: [paddingLeft], [paddingLeft] identical', () => {
+    const hookResult = getPaddingHookResult(
+      'paddingLeft',
+      'padding',
+      [`{ paddingLeft: 5 }`, `{ paddingLeft: 5 }`],
+      [{ paddingLeft: 5 }, { paddingLeft: 5 }],
+      [
+        { paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '5px' },
+        { paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '5px' },
+      ],
+      [],
+    )
+    expect(hookResult.value).toEqual({ unit: null, value: 5 })
+    expect(hookResult.orderedPropKeys).toEqual([['paddingLeft'], ['paddingLeft']])
+    expect(hookResult.controlStatus).toEqual('multiselect-identical-simple')
+  })
+
+  it('multiselect: [paddingLeft], [padding, paddingLeft] if not identical, return unoverwritable', () => {
+    const hookResult = getPaddingHookResult(
+      'paddingLeft',
+      'padding',
+      [`{ paddingLeft: 5 }`, `{ padding: 5, paddingLeft: 5 }`],
+      [{ paddingLeft: 5 }, { paddingLeft: 5 }],
+      [
+        { paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '5px' },
+        { paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '5px' },
+      ],
+      [],
+    )
+    expect(hookResult.value).toEqual(undefined)
+    expect(hookResult.orderedPropKeys).toEqual([['paddingLeft'], ['padding', 'paddingLeft']])
+    expect(hookResult.controlStatus).toEqual('multiselect-unoverwritable')
+  })
+
+  it('multiselect: [paddingLeft], [paddingLeft, padding] if not identical, return unoverwritable', () => {
+    const hookResult = getPaddingHookResult(
+      'paddingLeft',
+      'padding',
+      [`{ paddingLeft: 5 }`, `{ paddingLeft: 5, padding: 5 }`],
+      [{ paddingLeft: 5 }, { paddingLeft: 5 }],
+      [
+        { paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '5px' },
+        { paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '5px' },
+      ],
+      [],
+    )
+    expect(hookResult.value).toEqual(undefined)
+    expect(hookResult.orderedPropKeys).toEqual([['paddingLeft'], ['paddingLeft', 'padding']])
+    expect(hookResult.controlStatus).toEqual('multiselect-unoverwritable')
+  })
+})

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -256,7 +256,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
         [
           setProp_UNSAFE(
             TestSelectedComponent,
-            { propertyElements: ['style', 'paddingLeft'] },
+            PP.create(['style', 'paddingLeft']),
             jsxAttributeValue('100px', emptyComments),
           ),
         ],

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -12,6 +12,7 @@ import { EditorStore } from '../../editor/store/editor-state'
 import create from 'zustand'
 import { EditorStateContext } from '../../editor/store/store-hook'
 import * as TP from '../../../core/shared/template-path'
+import { setProp_UNSAFE, unsetProperty } from '../../editor/actions/action-creators'
 
 const TestSelectedComponent = TP.instancePath(['scene1'], ['aaa', 'bbb'])
 
@@ -247,16 +248,15 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          {
-            action: 'SET_PROP',
-            propertyPath: { propertyElements: ['style', 'paddingLeft'] },
-            target: TestSelectedComponent,
-            value: {
+          setProp_UNSAFE(
+            TestSelectedComponent,
+            { propertyElements: ['style', 'paddingLeft'] },
+            {
               comments: { leadingComments: [], trailingComments: [] },
               type: 'ATTRIBUTE_VALUE',
               value: { unit: 'px', value: 100 },
             },
-          },
+          ),
         ],
       ],
     ])
@@ -274,11 +274,10 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          {
-            action: 'SET_PROP',
-            propertyPath: { propertyElements: ['style', 'padding'] },
-            target: TestSelectedComponent,
-            value: {
+          setProp_UNSAFE(
+            TestSelectedComponent,
+            { propertyElements: ['style', 'padding'] },
+            {
               comments: { leadingComments: [], trailingComments: [] },
               type: 'ATTRIBUTE_VALUE',
               value: {
@@ -288,7 +287,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
                 paddingLeft: { unit: 'px', value: 50 },
               },
             },
-          },
+          ),
         ],
       ],
     ])
@@ -306,16 +305,15 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          {
-            action: 'SET_PROP',
-            propertyPath: { propertyElements: ['style', 'paddingRight'] },
-            target: TestSelectedComponent,
-            value: {
+          setProp_UNSAFE(
+            TestSelectedComponent,
+            { propertyElements: ['style', 'paddingRight'] },
+            {
               comments: { leadingComments: [], trailingComments: [] },
               type: 'ATTRIBUTE_VALUE',
               value: { unit: 'px', value: 5 },
             },
-          },
+          ),
         ],
       ],
     ])
@@ -333,16 +331,15 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          {
-            action: 'SET_PROP',
-            propertyPath: { propertyElements: ['style', 'paddingLeft'] },
-            target: TestSelectedComponent,
-            value: {
+          setProp_UNSAFE(
+            TestSelectedComponent,
+            { propertyElements: ['style', 'paddingLeft'] },
+            {
               comments: { leadingComments: [], trailingComments: [] },
               type: 'ATTRIBUTE_VALUE',
               value: { unit: 'px', value: 8 },
             },
-          },
+          ),
         ],
       ],
     ])
@@ -360,16 +357,15 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          {
-            action: 'SET_PROP',
-            propertyPath: { propertyElements: ['style', 'paddingLeft'] },
-            target: TestSelectedComponent,
-            value: {
+          setProp_UNSAFE(
+            TestSelectedComponent,
+            { propertyElements: ['style', 'paddingLeft'] },
+            {
               comments: { leadingComments: [], trailingComments: [] },
               type: 'ATTRIBUTE_VALUE',
               value: { unit: 'px', value: 8 },
             },
-          },
+          ),
         ],
       ],
     ])
@@ -387,24 +383,16 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          {
-            action: 'UNSET_PROPERTY',
-            propertyPath: { propertyElements: ['style', 'paddingLeft'] },
-            target: {
-              element: ['hello', 'eni'],
-              scene: { sceneElementPath: [], type: 'scenepath' },
-            },
-          },
-          {
-            action: 'SET_PROP',
-            propertyPath: { propertyElements: ['style', 'paddingLeft'] },
-            target: TestSelectedComponent,
-            value: {
+          unsetProperty(TestSelectedComponent, { propertyElements: ['style', 'paddingLeft'] }),
+          setProp_UNSAFE(
+            TestSelectedComponent,
+            { propertyElements: ['style', 'paddingLeft'] },
+            {
               comments: { leadingComments: [], trailingComments: [] },
               type: 'ATTRIBUTE_VALUE',
               value: { unit: 'px', value: 8 },
             },
-          },
+          ),
         ],
       ],
     ])
@@ -422,19 +410,11 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
-          {
-            action: 'UNSET_PROPERTY',
-            propertyPath: { propertyElements: ['style', 'paddingLeft'] },
-            target: {
-              element: ['hello', 'eni'],
-              scene: { sceneElementPath: [], type: 'scenepath' },
-            },
-          },
-          {
-            action: 'SET_PROP',
-            propertyPath: { propertyElements: ['style', 'padding'] },
-            target: TestSelectedComponent,
-            value: {
+          unsetProperty(TestSelectedComponent, { propertyElements: ['style', 'paddingLeft'] }),
+          setProp_UNSAFE(
+            TestSelectedComponent,
+            { propertyElements: ['style', 'padding'] },
+            {
               comments: { leadingComments: [], trailingComments: [] },
               type: 'ATTRIBUTE_VALUE',
               value: {
@@ -444,7 +424,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
                 paddingLeft: { unit: 'px', value: 18 },
               },
             },
-          },
+          ),
         ],
       ],
     ])

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -210,14 +210,14 @@ describe('useInspectorInfo: reading padding shorthand and longhands', () => {
       'paddingLeft',
       'padding',
       [`{ paddingLeft: 5 }`, `{ padding: 5, paddingLeft: 5 }`],
-      [{ paddingLeft: 5 }, { paddingLeft: 5 }],
+      [{ paddingLeft: 5 }, { padding: 5, paddingLeft: 5 }],
       [
         { paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '5px' },
         { paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '5px' },
       ],
       [],
     )
-    expect(hookResult.value).toEqual(undefined)
+    expect(hookResult.value).toEqual({ unit: null, value: 5 })
     expect(hookResult.orderedPropKeys).toEqual([['paddingLeft'], ['padding', 'paddingLeft']])
     expect(hookResult.controlStatus).toEqual('multiselect-unoverwritable')
   })
@@ -234,7 +234,7 @@ describe('useInspectorInfo: reading padding shorthand and longhands', () => {
       ],
       [],
     )
-    expect(hookResult.value).toEqual(undefined)
+    expect(hookResult.value).toEqual({ unit: null, value: 5 })
     expect(hookResult.orderedPropKeys).toEqual([['paddingLeft'], ['paddingLeft', 'padding']])
     expect(hookResult.controlStatus).toEqual('multiselect-unoverwritable')
   })

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react'
 import { renderHook } from '@testing-library/react-hooks'
-import { ComputedStyle, StyleAttributeMetadata } from '../../../core/shared/element-template'
+import {
+  ComputedStyle,
+  jsxAttributeValue,
+  StyleAttributeMetadata,
+} from '../../../core/shared/element-template'
 import { cssNumber, ParsedPropertiesKeys } from './css-utils'
 import { useInspectorInfoLonghandShorthand } from './longhand-shorthand-hooks'
 import { stylePropPathMappingFn } from './property-path-hooks'
@@ -12,7 +16,9 @@ import { EditorStore } from '../../editor/store/editor-state'
 import create from 'zustand'
 import { EditorStateContext } from '../../editor/store/store-hook'
 import * as TP from '../../../core/shared/template-path'
+import * as PP from '../../../core/shared/property-path'
 import { setProp_UNSAFE, unsetProperty } from '../../editor/actions/action-creators'
+import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
 
 const TestSelectedComponent = TP.instancePath(['scene1'], ['aaa', 'bbb'])
 
@@ -251,11 +257,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             { propertyElements: ['style', 'paddingLeft'] },
-            {
-              comments: { leadingComments: [], trailingComments: [] },
-              type: 'ATTRIBUTE_VALUE',
-              value: { unit: 'px', value: 100 },
-            },
+            jsxAttributeValue({ unit: 'px', value: 100 }, emptyComments),
           ),
         ],
       ],
@@ -276,17 +278,16 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
         [
           setProp_UNSAFE(
             TestSelectedComponent,
-            { propertyElements: ['style', 'padding'] },
-            {
-              comments: { leadingComments: [], trailingComments: [] },
-              type: 'ATTRIBUTE_VALUE',
-              value: {
+            PP.create(['style', 'padding']),
+            jsxAttributeValue(
+              {
                 paddingTop: { unit: 'px', value: 8 },
                 paddingRight: { unit: 'px', value: 8 },
                 paddingBottom: { unit: 'px', value: 8 },
                 paddingLeft: { unit: 'px', value: 50 },
               },
-            },
+              emptyComments,
+            ),
           ),
         ],
       ],
@@ -307,12 +308,8 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
         [
           setProp_UNSAFE(
             TestSelectedComponent,
-            { propertyElements: ['style', 'paddingRight'] },
-            {
-              comments: { leadingComments: [], trailingComments: [] },
-              type: 'ATTRIBUTE_VALUE',
-              value: { unit: 'px', value: 5 },
-            },
+            PP.create(['style', 'paddingRight']),
+            jsxAttributeValue({ unit: 'px', value: 5 }, emptyComments),
           ),
         ],
       ],
@@ -333,12 +330,8 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
         [
           setProp_UNSAFE(
             TestSelectedComponent,
-            { propertyElements: ['style', 'paddingLeft'] },
-            {
-              comments: { leadingComments: [], trailingComments: [] },
-              type: 'ATTRIBUTE_VALUE',
-              value: { unit: 'px', value: 8 },
-            },
+            PP.create(['style', 'paddingLeft']),
+            jsxAttributeValue({ unit: 'px', value: 8 }, emptyComments),
           ),
         ],
       ],
@@ -359,12 +352,8 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
         [
           setProp_UNSAFE(
             TestSelectedComponent,
-            { propertyElements: ['style', 'paddingLeft'] },
-            {
-              comments: { leadingComments: [], trailingComments: [] },
-              type: 'ATTRIBUTE_VALUE',
-              value: { unit: 'px', value: 8 },
-            },
+            PP.create(['style', 'paddingLeft']),
+            jsxAttributeValue({ unit: 'px', value: 8 }, emptyComments),
           ),
         ],
       ],
@@ -379,19 +368,15 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
       [{ paddingTop: '10px', paddingRight: '10px', paddingBottom: '10px', paddingLeft: '4px' }],
       [],
     )
-    hookResult.onSubmitValue(cssNumber(8, 'px'))
+    hookResult.onSubmitValue(cssNumber(16, 'px'))
     expect(mockDispatch.mock.calls).toEqual([
       [
         [
           unsetProperty(TestSelectedComponent, { propertyElements: ['style', 'paddingLeft'] }),
           setProp_UNSAFE(
             TestSelectedComponent,
-            { propertyElements: ['style', 'paddingLeft'] },
-            {
-              comments: { leadingComments: [], trailingComments: [] },
-              type: 'ATTRIBUTE_VALUE',
-              value: { unit: 'px', value: 8 },
-            },
+            PP.create(['style', 'paddingLeft']),
+            jsxAttributeValue({ unit: 'px', value: 16 }, emptyComments),
           ),
         ],
       ],
@@ -413,17 +398,16 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           unsetProperty(TestSelectedComponent, { propertyElements: ['style', 'paddingLeft'] }),
           setProp_UNSAFE(
             TestSelectedComponent,
-            { propertyElements: ['style', 'padding'] },
-            {
-              comments: { leadingComments: [], trailingComments: [] },
-              type: 'ATTRIBUTE_VALUE',
-              value: {
+            PP.create(['style', 'padding']),
+            jsxAttributeValue(
+              {
                 paddingTop: { unit: 'px', value: 4 },
                 paddingRight: { unit: 'px', value: 8 },
                 paddingBottom: { unit: 'px', value: 4 },
                 paddingLeft: { unit: 'px', value: 18 },
               },
-            },
+              emptyComments,
+            ),
           ),
         ],
       ],

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -119,6 +119,19 @@ describe('useInspectorInfo: reading padding shorthand and longhands', () => {
     expect(hookResult.orderedPropKeys).toEqual([['padding', 'paddingLeft']])
   })
 
+  it('padding, undefined paddingLeft', () => {
+    const { hookResult } = getPaddingHookResult(
+      'paddingLeft',
+      'padding',
+      [`{ padding: 15, paddingLeft: undefined }`],
+      [{ padding: 15, paddingLeft: undefined }],
+      [{ paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '0px' }],
+      [],
+    )
+    expect(hookResult.value).toEqual({ unit: 'px', value: 0 })
+    expect(hookResult.orderedPropKeys).toEqual([['padding', 'paddingLeft']])
+  })
+
   it('paddingLeft, padding, paddingRight', () => {
     const { hookResult } = getPaddingHookResult(
       'paddingLeft',

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -141,7 +141,7 @@ describe('useInspectorInfo: reading padding shorthand and longhands', () => {
       [{ paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '10px' }],
       [],
     )
-    expect(hookResult.value).toEqual({ unit: 'px', value: 10 })
+    expect(hookResult.value).toEqual({ unit: null, value: 10 })
     expect(hookResult.orderedPropKeys).toEqual([['paddingLeft']])
     expect(hookResult.controlStatus).toEqual('controlled')
   })

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -257,7 +257,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             { propertyElements: ['style', 'paddingLeft'] },
-            jsxAttributeValue(100, emptyComments),
+            jsxAttributeValue('100px', emptyComments),
           ),
         ],
       ],
@@ -301,7 +301,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingRight']),
-            jsxAttributeValue(5, emptyComments),
+            jsxAttributeValue('5px', emptyComments),
           ),
         ],
       ],
@@ -323,7 +323,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingLeft']),
-            jsxAttributeValue(8, emptyComments),
+            jsxAttributeValue('8px', emptyComments),
           ),
         ],
       ],
@@ -345,7 +345,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingLeft']),
-            jsxAttributeValue(8, emptyComments),
+            jsxAttributeValue('8px', emptyComments),
           ),
         ],
       ],
@@ -368,7 +368,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingLeft']),
-            jsxAttributeValue(16, emptyComments),
+            jsxAttributeValue('16px', emptyComments),
           ),
         ],
       ],

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -257,7 +257,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             { propertyElements: ['style', 'paddingLeft'] },
-            jsxAttributeValue({ unit: 'px', value: 100 }, emptyComments),
+            jsxAttributeValue(100, emptyComments),
           ),
         ],
       ],
@@ -279,15 +279,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'padding']),
-            jsxAttributeValue(
-              {
-                paddingTop: { unit: 'px', value: 8 },
-                paddingRight: { unit: 'px', value: 8 },
-                paddingBottom: { unit: 'px', value: 8 },
-                paddingLeft: { unit: 'px', value: 50 },
-              },
-              emptyComments,
-            ),
+            jsxAttributeValue('8px 8px 8px 50px', emptyComments),
           ),
         ],
       ],
@@ -309,7 +301,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingRight']),
-            jsxAttributeValue({ unit: 'px', value: 5 }, emptyComments),
+            jsxAttributeValue(5, emptyComments),
           ),
         ],
       ],
@@ -331,7 +323,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingLeft']),
-            jsxAttributeValue({ unit: 'px', value: 8 }, emptyComments),
+            jsxAttributeValue(8, emptyComments),
           ),
         ],
       ],
@@ -353,7 +345,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingLeft']),
-            jsxAttributeValue({ unit: 'px', value: 8 }, emptyComments),
+            jsxAttributeValue(8, emptyComments),
           ),
         ],
       ],
@@ -376,7 +368,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingLeft']),
-            jsxAttributeValue({ unit: 'px', value: 16 }, emptyComments),
+            jsxAttributeValue(16, emptyComments),
           ),
         ],
       ],
@@ -399,15 +391,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'padding']),
-            jsxAttributeValue(
-              {
-                paddingTop: { unit: 'px', value: 4 },
-                paddingRight: { unit: 'px', value: 8 },
-                paddingBottom: { unit: 'px', value: 4 },
-                paddingLeft: { unit: 'px', value: 18 },
-              },
-              emptyComments,
-            ),
+            jsxAttributeValue('4px 8px 4px 18px', emptyComments),
           ),
         ],
       ],

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -32,7 +32,7 @@ function getPaddingHookResult<P extends ParsedPropertiesKeys>(
   // eslint-disable-next-line @typescript-eslint/ban-types
   const contextProvider: React.FunctionComponent<{}> = ({ children }) => {
     const InspectorContextProvider = makeInspectorHookContextProvider(
-      [],
+      [TestSelectedComponent],
       props,
       ['style'],
       spiedProps,

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -131,7 +131,7 @@ describe('useInspectorInfo: reading padding shorthand and longhands', () => {
       [{ paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '10px' }],
       [],
     )
-    expect(hookResult.value).toEqual({ unit: 'px', value: 10 })
+    expect(hookResult.value).toEqual({ unit: null, value: 10 })
     expect(hookResult.orderedPropKeys).toEqual([['paddingLeft']])
     expect(hookResult.controlStatus).toEqual('controlled')
   })

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -38,7 +38,7 @@ function getShadowedLonghandShorthandValue<
   longhandPropertyStatus: PropertyStatus,
   shorthandPropertyStatus: PropertyStatus,
   longhandValue: ParsedProperties[LonghandKey],
-  shorthandValue: ParsedProperties[ShorthandKey],
+  shorthandValueObject: ParsedProperties[ShorthandKey], // the shorthand value has to be an object where the keys are longhand property names and the types are same as the longhand values
   orderedPropKeys: (LonghandKey | ShorthandKey)[][], // multiselect
 ): { value: ParsedProperties[LonghandKey]; propertyStatus: PropertyStatus } {
   const allPropKeysEqual = orderedPropKeys.every((propKeys) => {
@@ -67,11 +67,11 @@ function getShadowedLonghandShorthandValue<
             },
       }
     } else {
-      // Important: we ASSUME that the transformed shorthand value is an object,
+      // Important: we assume that shorthandValue is an object
       // where the keys are the longhand keys and the values are the individual longhand values
-      if (longhand in shorthandValue) {
+      if (longhand in shorthandValueObject) {
         return {
-          value: (shorthandValue as any)?.[longhand] as ParsedProperties[LonghandKey],
+          value: (shorthandValueObject as any)?.[longhand] as ParsedProperties[LonghandKey],
           propertyStatus: allPropKeysEqual
             ? shorthandPropertyStatus
             : {

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -162,15 +162,13 @@ export function useInspectorInfoLonghandShorthand<
       const longhandPropertyPath = pathMappingFn(longhand, inspectorTargetPath)
       const shorthandPropertyPath = pathMappingFn(shorthand, inspectorTargetPath)
       const printedValue = printCSSValue(shorthand, updatedValue)
-      const actionsToDispatch = flatMapArray((sv) => {
-        if (isInstancePath(sv)) {
+      const actionsToDispatch = flatMapArray((selectedView) => {
+        if (isInstancePath(selectedView)) {
           return [
-            ...(doWeHaveToRemoveAShadowedLonghand ? [unsetProperty(sv, longhandPropertyPath)] : []),
-            setProp_UNSAFE(
-              sv, // who is sv?
-              shorthandPropertyPath,
-              printedValue,
-            ),
+            ...(doWeHaveToRemoveAShadowedLonghand
+              ? [unsetProperty(selectedView, longhandPropertyPath)]
+              : []),
+            setProp_UNSAFE(selectedView, shorthandPropertyPath, printedValue),
           ]
         } else {
           return []
@@ -181,15 +179,13 @@ export function useInspectorInfoLonghandShorthand<
       // we either have a dominant longhand key, or we need to append a new one
       const propertyPath = pathMappingFn(longhand, inspectorTargetPath)
       const printedValue = printCSSValue(longhand, newTransformedValues)
-      const actionsToDispatch = flatMapArray((sv) => {
-        if (isInstancePath(sv)) {
+      const actionsToDispatch = flatMapArray((selectedView) => {
+        if (isInstancePath(selectedView)) {
           return [
-            ...(doWeHaveToRemoveAShadowedLonghand ? [unsetProperty(sv, propertyPath)] : []),
-            setProp_UNSAFE(
-              sv, // who is sv?
-              propertyPath,
-              printedValue,
-            ),
+            ...(doWeHaveToRemoveAShadowedLonghand
+              ? [unsetProperty(selectedView, propertyPath)]
+              : []),
+            setProp_UNSAFE(selectedView, propertyPath, printedValue),
           ]
         } else {
           return []

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -203,8 +203,22 @@ export function useInspectorInfoLonghandShorthand<
     newTransformedValues: ParsedProperties[LonghandKey] | undefined,
   ) => onSubmitValue(newTransformedValues, true)
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  const onUnsetValues = () => {}
+  const onUnsetValues = () => {
+    const longhandPropertyPath = pathMappingFn(longhand, inspectorTargetPath)
+    const shorthandPropertyPath = pathMappingFn(shorthand, inspectorTargetPath)
+
+    const actionsToDispatch = flatMapArray((selectedView) => {
+      if (isInstancePath(selectedView)) {
+        return [
+          unsetProperty(selectedView, longhandPropertyPath),
+          unsetProperty(selectedView, shorthandPropertyPath),
+        ]
+      } else {
+        return []
+      }
+    }, selectedViewsRef.current)
+    dispatch(actionsToDispatch)
+  }
 
   const controlStatus = getControlStatusFromPropertyStatus(propertyStatus)
   return {

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -32,7 +32,13 @@ function getShadowedLonghandShorthandValue<
   if (!allPropKeysEqual) {
     return {
       value: undefined,
-      propertyStatus: longhandPropertyStatus,
+      propertyStatus: {
+        ...longhandPropertyStatus,
+        set: true,
+        controlled: true,
+        overwritable: false,
+        identical: false,
+      },
     }
   }
 

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -151,8 +151,12 @@ export function useInspectorInfoLonghandShorthand<
       propkeysToUse.length === 2 && propkeysToUse[0] === longhand
 
     const dominantPropKey = last(propkeysToUse)
-    if (dominantPropKey === shorthand && !shorthandInfo.propertyStatus.controlled) {
-      // the shorthand key is the dominant, and it _can_ be updated
+    if (
+      dominantPropKey === shorthand &&
+      !shorthandInfo.propertyStatus.controlled &&
+      shorthandInfo.propertyStatus.overwritable
+    ) {
+      // the shorthand key is the dominant AND it can be updated
       // let's figure out the new value for the prop
       const currentValue = shorthandInfo.value
       const updatedValue = ({

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -1,0 +1,133 @@
+import { last } from '../../../core/shared/array-utils'
+import { arrayEquals } from '../../../core/shared/utils'
+import { getControlStatusFromPropertyStatus, PropertyStatus } from '../../../uuiui-deps'
+import { ParsedProperties, ParsedPropertiesKeys } from './css-utils'
+import {
+  InspectorInfo,
+  ParsedValues,
+  PathMappingFn,
+  useGetOrderedPropertyKeys,
+  useInspectorInfo,
+} from './property-path-hooks'
+
+function getShadowedLonghandShorthandValue<
+  LonghandKey extends ParsedPropertiesKeys,
+  ShorthandKey extends ParsedPropertiesKeys
+>(
+  longhand: LonghandKey,
+  shorthand: ShorthandKey,
+  longhandPropertyStatus: PropertyStatus,
+  shorthandPropertyStatus: PropertyStatus,
+  values: Partial<ParsedValues<LonghandKey | ShorthandKey>>,
+  orderedPropKeys: (LonghandKey | ShorthandKey)[][], // multiselect
+): { value: ParsedProperties[LonghandKey] | undefined; propertyStatus: PropertyStatus } {
+  const allPropKeysEqual = orderedPropKeys.every((propKeys) => {
+    return arrayEquals(propKeys, orderedPropKeys[0])
+  })
+  if (!allPropKeysEqual) {
+    return {
+      value: undefined,
+      propertyStatus: longhandPropertyStatus,
+    }
+  }
+
+  const propKeys = orderedPropKeys[0] ?? []
+  const lastKey = last(propKeys)
+  if (lastKey == null) {
+    return {
+      value: undefined,
+      propertyStatus: longhandPropertyStatus,
+    }
+  } else {
+    if (lastKey === longhand) {
+      return {
+        value: values[lastKey],
+        propertyStatus: longhandPropertyStatus,
+      }
+    } else {
+      // Important: we ASSUME that the transformed shorthand value is an object,
+      // where the keys are the longhand keys and the values are the individual longhand values
+      const shorthandValue = values[shorthand] as any
+      if (longhand in shorthandValue) {
+        return {
+          value: shorthandValue?.[longhand] as ParsedProperties[LonghandKey] | undefined,
+          propertyStatus: shorthandPropertyStatus,
+        }
+      } else {
+        throw new Error(
+          `We didn't find longhand key ${longhand} in resolved shorthand value for shorthand ${shorthand}`,
+        )
+      }
+    }
+  }
+}
+
+export function useInspectorInfoLonghandShorthand<
+  LonghandKey extends ParsedPropertiesKeys,
+  ShorthandKey extends ParsedPropertiesKeys
+>(
+  longhand: LonghandKey,
+  shorthand: ShorthandKey,
+  pathMappingFn: PathMappingFn<LonghandKey | ShorthandKey>,
+): Omit<InspectorInfo<ParsedProperties[LonghandKey] | undefined>, 'useSubmitValueFactory'> & {
+  orderedPropKeys: Array<Array<LonghandKey | ShorthandKey>>
+} {
+  const orderedPropKeys = useGetOrderedPropertyKeys(pathMappingFn, [longhand, shorthand])
+  let inspectorInfo = useInspectorInfo(
+    [longhand, shorthand],
+    (v) => v,
+    () => {
+      return null as any
+    },
+    pathMappingFn,
+  )
+
+  const longhandPropertyStatus = useInspectorInfo(
+    [longhand],
+    (v) => v,
+    () => {
+      return null as any
+    },
+    pathMappingFn,
+  ).propertyStatus
+  const shorthandPropertyStatus = useInspectorInfo(
+    [shorthand],
+    (v) => v,
+    () => {
+      return null as any
+    },
+    pathMappingFn,
+  ).propertyStatus
+  const { value, propertyStatus } = getShadowedLonghandShorthandValue(
+    longhand,
+    shorthand,
+    longhandPropertyStatus,
+    shorthandPropertyStatus,
+    inspectorInfo.value,
+    orderedPropKeys,
+  )
+
+  const onSubmitValue = (
+    newTransformedValues: ParsedProperties[LonghandKey] | undefined,
+    transient?: boolean | undefined,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+  ) => {}
+
+  const onTransientSubmitValue = (
+    newTransformedValues: ParsedProperties[LonghandKey] | undefined,
+  ) => onSubmitValue(newTransformedValues, true)
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const onUnsetValues = () => {}
+
+  return {
+    value: value,
+    controlStatus: getControlStatusFromPropertyStatus(propertyStatus),
+    propertyStatus: propertyStatus,
+    controlStyles: inspectorInfo.controlStyles,
+    onSubmitValue: onSubmitValue,
+    onTransientSubmitValue: onTransientSubmitValue,
+    onUnsetValues: onUnsetValues,
+    orderedPropKeys: orderedPropKeys,
+  }
+}

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -12,7 +12,11 @@ import {
   getControlStyles,
   PropertyStatus,
 } from '../../../uuiui-deps'
-import { setProp_UNSAFE, unsetProperty } from '../../editor/actions/action-creators'
+import {
+  setProp_UNSAFE,
+  transientActions,
+  unsetProperty,
+} from '../../editor/actions/action-creators'
 import { useEditorState } from '../../editor/store/store-hook'
 import { ParsedProperties, ParsedPropertiesKeys, printCSSValue } from './css-utils'
 import {
@@ -158,44 +162,40 @@ export function useInspectorInfoLonghandShorthand<
       const longhandPropertyPath = pathMappingFn(longhand, inspectorTargetPath)
       const shorthandPropertyPath = pathMappingFn(shorthand, inspectorTargetPath)
       const printedValue = printCSSValue(shorthand, updatedValue)
-      dispatch(
-        flatMapArray((sv) => {
-          if (isInstancePath(sv)) {
-            return [
-              ...(doWeHaveToRemoveAShadowedLonghand
-                ? [unsetProperty(sv, longhandPropertyPath)]
-                : []),
-              setProp_UNSAFE(
-                sv, // who is sv?
-                shorthandPropertyPath,
-                printedValue,
-              ),
-            ]
-          } else {
-            return []
-          }
-        }, selectedViewsRef.current),
-      )
+      const actionsToDispatch = flatMapArray((sv) => {
+        if (isInstancePath(sv)) {
+          return [
+            ...(doWeHaveToRemoveAShadowedLonghand ? [unsetProperty(sv, longhandPropertyPath)] : []),
+            setProp_UNSAFE(
+              sv, // who is sv?
+              shorthandPropertyPath,
+              printedValue,
+            ),
+          ]
+        } else {
+          return []
+        }
+      }, selectedViewsRef.current)
+      dispatch(transient ? [transientActions(actionsToDispatch)] : actionsToDispatch)
     } else {
       // we either have a dominant longhand key, or we need to append a new one
       const propertyPath = pathMappingFn(longhand, inspectorTargetPath)
       const printedValue = printCSSValue(longhand, newTransformedValues)
-      dispatch(
-        flatMapArray((sv) => {
-          if (isInstancePath(sv)) {
-            return [
-              ...(doWeHaveToRemoveAShadowedLonghand ? [unsetProperty(sv, propertyPath)] : []),
-              setProp_UNSAFE(
-                sv, // who is sv?
-                propertyPath,
-                printedValue,
-              ),
-            ]
-          } else {
-            return []
-          }
-        }, selectedViewsRef.current),
-      )
+      const actionsToDispatch = flatMapArray((sv) => {
+        if (isInstancePath(sv)) {
+          return [
+            ...(doWeHaveToRemoveAShadowedLonghand ? [unsetProperty(sv, propertyPath)] : []),
+            setProp_UNSAFE(
+              sv, // who is sv?
+              propertyPath,
+              printedValue,
+            ),
+          ]
+        } else {
+          return []
+        }
+      }, selectedViewsRef.current)
+      dispatch(transient ? [transientActions(actionsToDispatch)] : actionsToDispatch)
     }
   }
 

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -139,7 +139,6 @@ export function useInspectorInfoLonghandShorthand<
   const onSubmitValue = (
     newTransformedValues: ParsedProperties[LonghandKey],
     transient?: boolean | undefined,
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
   ) => {
     const allPropKeysEqual = orderedPropKeys.every((propKeys) => {
       return arrayEquals(propKeys, orderedPropKeys[0])

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -114,7 +114,7 @@ export function useInspectorInfoLonghandShorthand<
     [longhand],
     (v) => v[longhand],
     () => {
-      return null as any
+      throw new Error(`do not use useInspectorInfo's built-in onSubmitValue!`)
     },
     pathMappingFn,
   )
@@ -122,7 +122,7 @@ export function useInspectorInfoLonghandShorthand<
     [shorthand],
     (v) => v[shorthand],
     () => {
-      return null as any
+      throw new Error(`do not use useInspectorInfo's built-in onSubmitValue!`)
     },
     pathMappingFn,
   )

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -1,10 +1,16 @@
 import { last } from '../../../core/shared/array-utils'
+import { jsxAttributeValue } from '../../../core/shared/element-template'
+import { create } from '../../../core/shared/property-path'
+import { instancePath } from '../../../core/shared/template-path'
 import { arrayEquals } from '../../../core/shared/utils'
+import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
 import {
   getControlStatusFromPropertyStatus,
   getControlStyles,
   PropertyStatus,
 } from '../../../uuiui-deps'
+import { setProp_UNSAFE } from '../../editor/actions/action-creators'
+import { useEditorState } from '../../editor/store/store-hook'
 import { ParsedProperties, ParsedPropertiesKeys } from './css-utils'
 import {
   InspectorInfo,
@@ -83,6 +89,10 @@ export function useInspectorInfoLonghandShorthand<
 ): Omit<InspectorInfo<ParsedProperties[LonghandKey] | undefined>, 'useSubmitValueFactory'> & {
   orderedPropKeys: Array<Array<LonghandKey | ShorthandKey>>
 } {
+  const dispatch = useEditorState(
+    (store) => store.dispatch,
+    'useInspectorInfoLonghandShorthand dispatch',
+  )
   const orderedPropKeys = useGetOrderedPropertyKeys(pathMappingFn, [longhand, shorthand])
   const longhandInfo = useInspectorInfo(
     [longhand],
@@ -114,7 +124,15 @@ export function useInspectorInfoLonghandShorthand<
     newTransformedValues: ParsedProperties[LonghandKey] | undefined,
     transient?: boolean | undefined,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-  ) => {}
+  ) => {
+    dispatch([
+      setProp_UNSAFE(
+        instancePath([], ['hello', 'eni']),
+        create(['what', 'up']),
+        jsxAttributeValue(newTransformedValues, emptyComments),
+      ),
+    ])
+  }
 
   const onTransientSubmitValue = (
     newTransformedValues: ParsedProperties[LonghandKey] | undefined,

--- a/editor/src/components/inspector/common/property-path-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.spec.tsx
@@ -50,6 +50,10 @@ import {
 import { isParseSuccess, TemplatePath } from '../../../core/shared/project-file-types'
 import { betterReactMemo } from '../../../utils/react-performance'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
+import {
+  getPropsForStyleProp,
+  makeInspectorHookContextProvider,
+} from './property-path-hooks.test-utils'
 
 interface RenderTestHookProps<T> {
   value: T
@@ -442,80 +446,6 @@ describe('useInspectorMetadataForPropsObject memoization', () => {
     expect(getUpdateCount()).toBeGreaterThan(0)
   })
 })
-
-function getPropsForStyleProp(
-  targetPropExpression: string,
-  target: string[],
-): JSXAttributes | null {
-  // this test starts with real code, and uses the parser
-  // the aim here is to capture a vertical understanding from code -> UI
-
-  const targetExprPrefix1 = `${target[0]}={`
-  const targetExprPrefix2 = target
-    .slice(1)
-    .map((t) => `{${t}:`)
-    .join('\n')
-
-  const targetExprPostfix = target.map((t) => `}`).join('\n')
-  const code = `import * as React from "react";
-  import {
-    Ellipse,
-    Image,
-    Rectangle,
-    Text,
-    View
-  } from "utopia-api";
-  import { cake } from 'cake'
-  
-  export var App = (props) => {
-    return (
-      <View
-        uid={'aaa'} 
-        ${targetExprPrefix1}
-        ${targetExprPrefix2}
-          ${targetPropExpression}
-        ${targetExprPostfix}
-      />
-    )
-  }`
-
-  const parseResult = testParseCode(code)
-  if (!isParseSuccess(parseResult)) {
-    fail('expected parseResult to be Right')
-  }
-  const appComponent = parseResult.topLevelElements.find(isUtopiaJSXComponent)
-
-  if (appComponent == null || !isUtopiaJSXComponent(appComponent) || appComponent.name !== `App`) {
-    fail('expected the second topLevelElement to be the App component')
-  }
-  if (!isJSXElement(appComponent.rootElement)) {
-    fail(`expected the App component's root element to be a JSXElement`)
-  }
-
-  return appComponent.rootElement.props
-}
-
-const makeInspectorHookContextProvider = (
-  selectedViews: Array<TemplatePath>,
-  multiselectAttributes: JSXAttributes[],
-  targetPath: string[],
-  spiedProps: Array<{ [key: string]: any }>,
-  computedStyles: Array<ComputedStyle>,
-  attributeMetadatas: Array<StyleAttributeMetadata>,
-) => ({ children }: any) => (
-  <InspectorPropsContext.Provider
-    value={{
-      selectedViews: selectedViews,
-      editedMultiSelectedProps: multiselectAttributes,
-      targetPath,
-      spiedProps: spiedProps,
-      computedStyles: computedStyles,
-      selectedAttributeMetadatas: attributeMetadatas,
-    }}
-  >
-    {children}
-  </InspectorPropsContext.Provider>
-)
 
 function getBackgroundColorHookResult(
   backgroundColorExpressions: Array<string>,

--- a/editor/src/components/inspector/common/property-path-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.spec.tsx
@@ -450,18 +450,11 @@ describe('useInspectorMetadataForPropsObject memoization', () => {
 function getBackgroundColorHookResult(
   backgroundColorExpressions: Array<string>,
   targetPath: string[],
-  realInnerValues: Array<any>,
+  spiedProps: Array<any>,
 ) {
   const propses = backgroundColorExpressions.map(
     (expression) => getPropsForStyleProp(expression, ['myStyleOuter', 'myStyleInner'])!,
   )
-  const spiedProps = realInnerValues.map((realInnerValue) => {
-    return targetPath.reduceRight((working, pathPart) => {
-      return {
-        [pathPart]: working,
-      }
-    }, realInnerValue)
-  })
 
   const contextProvider = makeInspectorHookContextProvider(
     [],

--- a/editor/src/components/inspector/common/property-path-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.spec.tsx
@@ -33,6 +33,8 @@ import {
   defaultLinearGradientBackgroundLayer,
   printCSSNumber,
   cssSolidBackgroundLayer,
+  ParsedPropertiesKeys,
+  ParsedCSSPropertiesKeys,
 } from './css-utils'
 import {
   InspectorCallbackContext,
@@ -41,6 +43,7 @@ import {
   InspectorPropsContextData,
   stylePropPathMappingFn,
   useCallbackFactory,
+  useGetOrderedPropertyKeys,
   useInspectorInfo,
   useInspectorStyleInfo,
 } from './property-path-hooks'
@@ -1099,5 +1102,166 @@ describe('Integration Test: boxShadow property', () => {
     )
     const expectedControlStatus: ControlStatus = 'multiselect-controlled'
     expect(hookResult.controlStatus).toEqual(expectedControlStatus)
+  })
+})
+
+describe('useGetOrderedPropertyKeys', () => {
+  function getPaddingHookResult<P extends ParsedCSSPropertiesKeys>(
+    propsKeys: Array<P>,
+    styleObjectExpressions: Array<string>,
+    spiedProps: Array<any>,
+    computedStyles: Array<ComputedStyle>,
+    attributeMetadatas: Array<StyleAttributeMetadata>,
+  ) {
+    const props = styleObjectExpressions.map(
+      (styleExpression) => getPropsForStyleProp(styleExpression, ['style'])!,
+    )
+
+    const contextProvider = makeInspectorHookContextProvider(
+      [],
+      props,
+      ['style'],
+      spiedProps,
+      computedStyles,
+      attributeMetadatas,
+    )
+
+    const { result } = renderHook(
+      () => useGetOrderedPropertyKeys<P>(stylePropPathMappingFn, propsKeys),
+      {
+        wrapper: contextProvider,
+      },
+    )
+    return result.current
+  }
+
+  it('does not contain entry for nonexistent prop 1', () => {
+    const hookResult = getPaddingHookResult(
+      ['paddingLeft', 'padding'],
+      [`{ paddingLeft: 5 }`],
+      [{ paddingLeft: 5 }],
+      [{ paddingTop: '0px', paddingRight: '0px', paddingBottom: '0px', paddingLeft: '15px' }],
+      [],
+    )
+    expect(hookResult).toEqual([['paddingLeft']])
+  })
+
+  it('does not contain entry for nonexistent prop 2', () => {
+    const hookResult = getPaddingHookResult(
+      ['paddingLeft', 'padding'],
+      [`{ padding: 15 }`],
+      [{ padding: 15 }],
+      [{ paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '15px' }],
+      [],
+    )
+    expect(hookResult).toEqual([['padding']])
+  })
+
+  it('does contain entry for prop explicitly set to undefined', () => {
+    const hookResult = getPaddingHookResult(
+      ['paddingLeft', 'padding'],
+      [`{ padding: 15, paddingLeft: undefined }`],
+      [{ padding: 15, paddingLeft: undefined }],
+      [{ paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '15px' }],
+      [],
+    )
+    expect(hookResult).toEqual([['padding', 'paddingLeft']])
+  })
+
+  it('keeps the order of props for single select 1', () => {
+    const hookResult = getPaddingHookResult(
+      ['paddingLeft', 'padding'],
+      [`{ paddingLeft: 5, padding: 15 }`],
+      [{ paddingLeft: 5, padding: 15 }],
+      [{ paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '15px' }],
+      [],
+    )
+    expect(hookResult).toEqual([['paddingLeft', 'padding']])
+  })
+
+  it('keeps the order of props for single select 2', () => {
+    const hookResult = getPaddingHookResult(
+      ['paddingLeft', 'padding'],
+      [`{ padding: 15, paddingLeft: 5 }`],
+      [{ padding: 15, paddingLeft: 5 }],
+      [{ paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '5px' }],
+      [],
+    )
+    expect(hookResult).toEqual([['padding', 'paddingLeft']])
+  })
+
+  it('works with controlled longhand', () => {
+    const hookResult = getPaddingHookResult(
+      ['paddingLeft', 'padding'],
+      [`{ paddingLeft: 5 + 5 }`],
+      [{ paddingLeft: 10 }],
+      [{ paddingLeft: '10px' }],
+      [],
+    )
+    expect(hookResult).toEqual([['paddingLeft']])
+  })
+
+  it('keeps the order of props for multi select 1', () => {
+    const hookResult = getPaddingHookResult(
+      ['paddingLeft', 'padding'],
+      [`{ padding: 15 }`, `{ padding: 15 }`],
+      [{ padding: 15 }, { padding: 15 }],
+      [
+        { paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '15px' },
+        { paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '15px' },
+      ],
+      [],
+    )
+    expect(hookResult).toEqual([['padding'], ['padding']])
+  })
+
+  it('keeps the order of props for multi select 2', () => {
+    const hookResult = getPaddingHookResult(
+      ['paddingLeft', 'padding'],
+      [`{ paddingLeft: 5, padding: 15 }`, `{ paddingLeft: 5, padding: 15 }`],
+      [
+        { paddingLeft: 5, padding: 15 },
+        { paddingLeft: 5, padding: 15 },
+      ],
+      [
+        { paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '15px' },
+        { paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '15px' },
+      ],
+      [],
+    )
+
+    expect(hookResult).toEqual([
+      ['paddingLeft', 'padding'],
+      ['paddingLeft', 'padding'],
+    ])
+  })
+
+  it('multiselect: the paddings are in different order 1', () => {
+    const hookResult = getPaddingHookResult(
+      ['paddingLeft', 'padding'],
+      [`{ paddingLeft: 5, padding: 15 }`, `{ padding: 15 }`],
+      [{ paddingLeft: 5, padding: 15 }, { padding: 15 }],
+      [
+        { paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '15px' },
+        { paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '15px' },
+      ],
+      [],
+    )
+
+    expect(hookResult).toEqual([['paddingLeft', 'padding'], ['padding']])
+  })
+
+  it('multiselect: the paddings are in different order 2', () => {
+    const hookResult = getPaddingHookResult(
+      ['paddingLeft', 'padding'],
+      [`{ padding: 15, paddingLeft: 5 }`, `{ padding: 15 }`],
+      [{ padding: 15, paddingLeft: 5 }, { padding: 15 }],
+      [
+        { paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '5px' },
+        { paddingTop: '15px', paddingRight: '15px', paddingBottom: '15px', paddingLeft: '15px' },
+      ],
+      [],
+    )
+    expect(hookResult).toEqual([['padding', 'paddingLeft'], ['padding']])
   })
 })

--- a/editor/src/components/inspector/common/property-path-hooks.test-utils.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.test-utils.tsx
@@ -7,8 +7,9 @@ import {
   StyleAttributeMetadata,
 } from '../../../core/shared/element-template'
 import { isParseSuccess, TemplatePath } from '../../../core/shared/project-file-types'
+import { NO_OP } from '../../../core/shared/utils'
 import { testParseCode } from '../../../core/workers/parser-printer/parser-printer.test-utils'
-import { InspectorPropsContext } from './property-path-hooks'
+import { InspectorCallbackContext, InspectorPropsContext } from './property-path-hooks'
 
 export const makeInspectorHookContextProvider = (
   selectedViews: Array<TemplatePath>,
@@ -26,18 +27,26 @@ export const makeInspectorHookContextProvider = (
     }, realInnerValue)
   })
   return (
-    <InspectorPropsContext.Provider
+    <InspectorCallbackContext.Provider
       value={{
-        selectedViews: selectedViews,
-        editedMultiSelectedProps: multiselectAttributes,
-        targetPath,
-        spiedProps: spiedPropsWrappedInTargetPath,
-        computedStyles: computedStyles,
-        selectedAttributeMetadatas: attributeMetadatas,
+        selectedViewsRef: { current: selectedViews },
+        onSubmitValue: NO_OP,
+        onUnsetValue: NO_OP,
       }}
     >
-      {children}
-    </InspectorPropsContext.Provider>
+      <InspectorPropsContext.Provider
+        value={{
+          selectedViews: selectedViews,
+          editedMultiSelectedProps: multiselectAttributes,
+          targetPath,
+          spiedProps: spiedPropsWrappedInTargetPath,
+          computedStyles: computedStyles,
+          selectedAttributeMetadatas: attributeMetadatas,
+        }}
+      >
+        {children}
+      </InspectorPropsContext.Provider>
+    </InspectorCallbackContext.Provider>
   )
 }
 

--- a/editor/src/components/inspector/common/property-path-hooks.test-utils.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.test-utils.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react'
+import {
+  ComputedStyle,
+  isJSXElement,
+  isUtopiaJSXComponent,
+  JSXAttributes,
+  StyleAttributeMetadata,
+} from '../../../core/shared/element-template'
+import { isParseSuccess, TemplatePath } from '../../../core/shared/project-file-types'
+import { testParseCode } from '../../../core/workers/parser-printer/parser-printer.test-utils'
+import { InspectorPropsContext } from './property-path-hooks'
+
+export const makeInspectorHookContextProvider = (
+  selectedViews: Array<TemplatePath>,
+  multiselectAttributes: JSXAttributes[],
+  targetPath: string[],
+  spiedProps: Array<{ [key: string]: any }>,
+  computedStyles: Array<ComputedStyle>,
+  attributeMetadatas: Array<StyleAttributeMetadata>,
+) => ({ children }: any) => (
+  <InspectorPropsContext.Provider
+    value={{
+      selectedViews: selectedViews,
+      editedMultiSelectedProps: multiselectAttributes,
+      targetPath,
+      spiedProps: spiedProps,
+      computedStyles: computedStyles,
+      selectedAttributeMetadatas: attributeMetadatas,
+    }}
+  >
+    {children}
+  </InspectorPropsContext.Provider>
+)
+
+export function getPropsForStyleProp(
+  targetPropExpression: string,
+  target: string[],
+): JSXAttributes | null {
+  // this test starts with real code, and uses the parser
+  // the aim here is to capture a vertical understanding from code -> UI
+
+  const targetExprPrefix1 = `${target[0]}={`
+  const targetExprPrefix2 = target
+    .slice(1)
+    .map((t) => `{${t}:`)
+    .join('\n')
+
+  const targetExprPostfix = target.map((t) => `}`).join('\n')
+  const code = `import * as React from "react";
+  import {
+    Ellipse,
+    Image,
+    Rectangle,
+    Text,
+    View
+  } from "utopia-api";
+  import { cake } from 'cake'
+  
+  export var App = (props) => {
+    return (
+      <View
+        uid={'aaa'} 
+        ${targetExprPrefix1}
+        ${targetExprPrefix2}
+          ${targetPropExpression}
+        ${targetExprPostfix}
+      />
+    )
+  }`
+
+  const parseResult = testParseCode(code)
+  if (!isParseSuccess(parseResult)) {
+    fail('expected parseResult to be Right')
+  }
+  const appComponent = parseResult.topLevelElements.find(isUtopiaJSXComponent)
+
+  if (appComponent == null || !isUtopiaJSXComponent(appComponent) || appComponent.name !== `App`) {
+    fail('expected the second topLevelElement to be the App component')
+  }
+  if (!isJSXElement(appComponent.rootElement)) {
+    fail(`expected the App component's root element to be a JSXElement`)
+  }
+
+  return appComponent.rootElement.props
+}

--- a/editor/src/components/inspector/common/property-path-hooks.test-utils.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.test-utils.tsx
@@ -17,20 +17,29 @@ export const makeInspectorHookContextProvider = (
   spiedProps: Array<{ [key: string]: any }>,
   computedStyles: Array<ComputedStyle>,
   attributeMetadatas: Array<StyleAttributeMetadata>,
-) => ({ children }: any) => (
-  <InspectorPropsContext.Provider
-    value={{
-      selectedViews: selectedViews,
-      editedMultiSelectedProps: multiselectAttributes,
-      targetPath,
-      spiedProps: spiedProps,
-      computedStyles: computedStyles,
-      selectedAttributeMetadatas: attributeMetadatas,
-    }}
-  >
-    {children}
-  </InspectorPropsContext.Provider>
-)
+) => ({ children }: any) => {
+  const spiedPropsWrappedInTargetPath = spiedProps.map((realInnerValue) => {
+    return targetPath.reduceRight((working, pathPart) => {
+      return {
+        [pathPart]: working,
+      }
+    }, realInnerValue)
+  })
+  return (
+    <InspectorPropsContext.Provider
+      value={{
+        selectedViews: selectedViews,
+        editedMultiSelectedProps: multiselectAttributes,
+        targetPath,
+        spiedProps: spiedPropsWrappedInTargetPath,
+        computedStyles: computedStyles,
+        selectedAttributeMetadatas: attributeMetadatas,
+      }}
+    >
+      {children}
+    </InspectorPropsContext.Provider>
+  )
+}
 
 export function getPropsForStyleProp(
   targetPropExpression: string,

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -53,7 +53,7 @@ import {
   removeIgnored,
   getPropertyControlsForTargetFromEditor,
 } from '../../../core/property-controls/property-controls-utils'
-import { addUniquely } from '../../../core/shared/array-utils'
+import { addUniquely, stripNulls } from '../../../core/shared/array-utils'
 import {
   defaultEither,
   Either,
@@ -76,6 +76,7 @@ import {
   StyleAttributeMetadataEntry,
 } from '../../../core/shared/element-template'
 import {
+  getAllPathsFromAttributes,
   GetModifiableAttributeResult,
   getModifiableJSXAttributeAtPath,
   jsxSimpleAttributeToValue,
@@ -1135,4 +1136,27 @@ export function useSelectedViews() {
 export function useRefSelectedViews() {
   const { selectedViewsRef } = React.useContext(InspectorCallbackContext)
   return selectedViewsRef
+}
+
+export function useGetOrderedPropertyKeys<P>(
+  pathMappingFn: PathMappingFn<P>,
+  propKeys: Readonly<Array<P>>,
+): Array<Array<P>> {
+  return useKeepReferenceEqualityIfPossible(
+    useContextSelector(
+      InspectorPropsContext,
+      (contextData) => {
+        return contextData.editedMultiSelectedProps.map((props) =>
+          stripNulls(
+            getAllPathsFromAttributes(props).map((path) =>
+              propKeys.find((propKey) =>
+                PP.pathsEqual(path, pathMappingFn(propKey, contextData.targetPath)),
+              ),
+            ),
+          ),
+        )
+      },
+      deepEqual,
+    ),
+  )
 }

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -31,6 +31,7 @@ import {
   FunctionIcons,
 } from '../../../../../uuiui'
 import { betterReactMemo } from '../../../../../uuiui-deps'
+import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
 
 function useDefaultedLayoutSystemInfo(): {
   value: LayoutSystem | 'flow'
@@ -165,10 +166,26 @@ export const paddingPropsToUnset = [
 ]
 
 export const FlexPaddingControl = betterReactMemo('FlexPaddingControl', () => {
-  const flexPaddingTop = useInspectorLayoutInfo('paddingTop')
-  const flexPaddingRight = useInspectorLayoutInfo('paddingRight')
-  const flexPaddingBottom = useInspectorLayoutInfo('paddingBottom')
-  const flexPaddingLeft = useInspectorLayoutInfo('paddingLeft')
+  const flexPaddingTop = useInspectorInfoLonghandShorthand(
+    'paddingTop',
+    'padding',
+    createLayoutPropertyPath,
+  )
+  const flexPaddingRight = useInspectorInfoLonghandShorthand(
+    'paddingRight',
+    'padding',
+    createLayoutPropertyPath,
+  )
+  const flexPaddingBottom = useInspectorInfoLonghandShorthand(
+    'paddingBottom',
+    'padding',
+    createLayoutPropertyPath,
+  )
+  const flexPaddingLeft = useInspectorInfoLonghandShorthand(
+    'paddingLeft',
+    'padding',
+    createLayoutPropertyPath,
+  )
 
   const flexPaddingTopOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
     flexPaddingTop.onSubmitValue,

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -159,6 +159,7 @@ const layoutSystemOptions = [
 ]
 
 export const paddingPropsToUnset = [
+  createLayoutPropertyPath('padding'),
   createLayoutPropertyPath('paddingLeft'),
   createLayoutPropertyPath('paddingTop'),
   createLayoutPropertyPath('paddingRight'),


### PR DESCRIPTION
**Problem:**
We want to support css properties which can be expressed as either shorthand or longhand. To make things harder, the property which is defined _later_ in the style object shadows the other. 
So these are various cases with different meaning:
```javascript
{ padding: 5, paddingLeft: 10 }  ===> paddingLeft is 10
{ paddingLeft: 10, padding: 5 } ===> paddingLeft is 5
{ padding: 5, paddingLeft: undefined } ===> paddingLeft is 0!!!!!!!!!!!!!!!!!! 
```

**Fix:**
We made a new hook that can support any css property which can be expressed as part of a shorthand, or in a single longhand. The main use case (and the tests focus on) is padding and paddingLeft. We expect the hook to be easily generalizable to margin, borderRadius. 

**Commit Details:**
- created hook `useGetOrderedPropertyKeys` which returns the shorthand and longhand keys in order of appearance. we later use this information to figure out shadowing
- created new super-hook `useInspectorInfoLonghandShorthand` that uses `useInspectorInfo` and `useGetOrderedPropertyKeys` internally
- written extensive test coverage for both `useGetOrderedPropertyKeys` and `useInspectorInfoLonghandShorthand`

**Notes:**
For this first iteration, the hooks bail out in case of a multiselect where the selected elements have non identical property shadowing situation. (so if I select two elements: one with { paddingLeft: 5, padding: 5 }, and another with { padding: 5 } we bail out unceremoniously.) We can improve on this later and widen the happy path, but the PR is already large as it is.
