### PR TITLE
Feature/inspector flex controls

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -512,7 +512,7 @@ export function updateFramesOfScenesAndComponents(
                   const { flexBasis, width, height } = flexProps
                   if (flexBasis != null) {
                     propsToSet.push({
-                      path: createLayoutPropertyPath('FlexFlexBasis'),
+                      path: createLayoutPropertyPath('flexBasis'),
                       value: jsxAttributeValue(flexBasis, emptyComments),
                     })
                   }

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -735,7 +735,7 @@ describe('moveTemplate', () => {
     expect(isUtopiaJSXComponent(updatedRoot1)).toBeTruthy()
     expect(Utils.pathOr([], ['rootElement', 'children'], updatedRoot1)).toHaveLength(1)
     const actual: any = Utils.path(['rootElement', 'children', 0], updatedRoot1)
-    expect(getLayoutPropertyOr(undefined, 'FlexFlexBasis', right(actual.props))).toBeDefined()
+    expect(getLayoutPropertyOr(undefined, 'flexBasis', right(actual.props))).toBeDefined()
     expect(getLayoutPropertyOr(undefined, 'FlexCrossBasis', right(actual.props))).toBeDefined()
     expect(getLayoutPropertyOr(undefined, 'PinnedLeft', right(actual.props))).not.toBeDefined()
     expect(getLayoutPropertyOr(undefined, 'PinnedTop', right(actual.props))).not.toBeDefined()

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4619,7 +4619,7 @@ const layoutEmptyValuesNew: LayoutPropertyTypes = {
   Height: undefined,
 
   FlexGap: 0,
-  FlexFlexBasis: undefined,
+  flexBasis: undefined,
   FlexCrossBasis: undefined,
 
   PinnedLeft: undefined,
@@ -4641,7 +4641,7 @@ const layoutParsersNew: LayoutParsersNew = {
   Height: parseFramePin,
 
   FlexGap: isNumberParser,
-  FlexFlexBasis: parseFramePin,
+  flexBasis: parseFramePin,
   FlexCrossBasis: parseFramePin,
 
   PinnedLeft: parseFramePin,
@@ -4663,7 +4663,7 @@ const layoutPrintersNew: LayoutPrintersNew = {
   Height: printCSSNumberOrUndefinedAsAttributeValue,
 
   FlexGap: jsxAttributeValueWithNoComments,
-  FlexFlexBasis: printCSSNumberOrUndefinedAsAttributeValue,
+  flexBasis: printCSSNumberOrUndefinedAsAttributeValue,
   FlexCrossBasis: printCSSNumberOrUndefinedAsAttributeValue,
 
   PinnedLeft: printCSSNumberOrUndefinedAsAttributeValue,
@@ -5011,7 +5011,6 @@ export const trivialDefaultValues: ParsedPropertiesWithNonTrivial = {
   Width: undefined,
   Height: undefined,
   FlexGap: 0,
-  FlexFlexBasis: undefined,
   FlexCrossBasis: undefined,
   PinnedLeft: undefined,
   PinnedTop: undefined,

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -699,6 +699,14 @@ export const parseCSSTimePercent = (input: unknown) => parseCSSNumber(input, 'Ti
 export const parseCSSUnitless = (input: unknown) => parseCSSNumber(input, 'Unitless')
 export const parseCSSUnitlessPercent = (input: unknown) => parseCSSNumber(input, 'UnitlessPercent')
 export const parseCSSAnyValidNumber = (input: unknown) => parseCSSNumber(input, 'AnyValid')
+export const parseCSSUnitlessAsNumber = (input: unknown): Either<string, number> => {
+  const parsed = parseCSSNumber(input, 'Unitless')
+  if (isRight(parsed)) {
+    return right(parsed.value.value)
+  } else {
+    return parsed
+  }
+}
 
 export const parseCSSNumber = (
   input: unknown,
@@ -3996,9 +4004,9 @@ export interface ParsedCSSProperties {
   maxWidth: CSSNumber | undefined
   minHeight: CSSNumber | undefined
   maxHeight: CSSNumber | undefined
-  flexGrow: CSSNumber
-  flexShrink: CSSNumber
   flex: CSSFlex
+  flexGrow: number
+  flexShrink: number
   display: string
 }
 
@@ -4170,8 +4178,8 @@ export const cssEmptyValues: ParsedCSSProperties = {
       unit: null,
     },
   },
-  flexGrow: cssUnitlessLength(0),
-  flexShrink: cssUnitlessLength(1),
+  flexGrow: 0,
+  flexShrink: 1,
   display: 'block',
 }
 
@@ -4232,9 +4240,9 @@ const cssParsers: CSSParsers = {
   marginRight: parseCSSLengthPercent,
   marginBottom: parseCSSLengthPercent,
   marginLeft: parseCSSLengthPercent,
-  flexGrow: parseCSSUnitless,
-  flexShrink: parseCSSUnitless,
   flex: parseFlex,
+  flexGrow: parseCSSUnitlessAsNumber,
+  flexShrink: parseCSSUnitlessAsNumber,
   display: parseDisplay,
 }
 
@@ -4297,9 +4305,9 @@ const cssPrinters: CSSPrinters = {
   marginRight: printCSSNumberAsAttributeValue,
   marginBottom: printCSSNumberAsAttributeValue,
   marginLeft: printCSSNumberAsAttributeValue,
-  flexGrow: printCSSNumberAsAttributeValue,
-  flexShrink: printCSSNumberAsAttributeValue,
   flex: printFlexAsAttributeValue,
+  flexGrow: jsxAttributeValueWithNoComments,
+  flexShrink: jsxAttributeValueWithNoComments,
   display: printStringAsAttributeValue,
 }
 

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -74,6 +74,7 @@ import {
   parseMargin,
   printMarginAsAttributeValue,
 } from '../../../printer-parsers/css/css-parser-margin'
+import { parseFlex, printFlexAsAttributeValue } from '../../../printer-parsers/css/css-parser-flex'
 
 var combineRegExp = function (regexpList: Array<RegExp | string>, flags?: string) {
   let source: string = ''
@@ -3997,6 +3998,7 @@ export interface ParsedCSSProperties {
   maxHeight: CSSNumber | undefined
   flexGrow: CSSNumber
   flexShrink: CSSNumber
+  flex: CSSFlex
   display: string
 }
 
@@ -4160,6 +4162,14 @@ export const cssEmptyValues: ParsedCSSProperties = {
     value: 0,
     unit: null,
   },
+  flex: {
+    flexGrow: 0,
+    flexShrink: 1,
+    flexBasis: {
+      value: 0,
+      unit: null,
+    },
+  },
   flexGrow: cssUnitlessLength(0),
   flexShrink: cssUnitlessLength(1),
   display: 'block',
@@ -4224,6 +4234,7 @@ const cssParsers: CSSParsers = {
   marginLeft: parseCSSLengthPercent,
   flexGrow: parseCSSUnitless,
   flexShrink: parseCSSUnitless,
+  flex: parseFlex,
   display: parseDisplay,
 }
 
@@ -4288,6 +4299,7 @@ const cssPrinters: CSSPrinters = {
   marginLeft: printCSSNumberAsAttributeValue,
   flexGrow: printCSSNumberAsAttributeValue,
   flexShrink: printCSSNumberAsAttributeValue,
+  flex: printFlexAsAttributeValue,
   display: printStringAsAttributeValue,
 }
 
@@ -4960,6 +4972,7 @@ export const trivialDefaultValues: ParsedPropertiesWithNonTrivial = {
     value: 0,
     unit: 'px',
   },
+  flex: nontrivial,
   flexGrow: nontrivial,
   flexShrink: nontrivial,
   display: 'block',

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
@@ -1577,4 +1577,109 @@ describe('inspector tests with real metadata', () => {
       fontSizeControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"detected"`)
   })
+  it('Flex shorthand properties', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          style={{
+            display: 'flex',
+          }}
+          data-uid={'aaa'}
+        >
+          <div data-uid={'bbb'} style={{flex: '1 0 15px'}}>hello</div>
+        </div>
+      `),
+    )
+
+    await renderResult.dispatch(
+      [selectComponents([TP.instancePath(TestScenePath, ['aaa', 'bbb'])], false)],
+      false,
+    )
+
+    const metadata = renderResult.getEditorState().editor.jsxMetadataKILLME.elements[
+      'utopia-storyboard-uid/scene-aaa:aaa/bbb'
+    ]
+
+    const flexBasis = (await renderResult.renderedDOM.findByTestId(
+      'position-flexBasis-number-input',
+    )) as HTMLInputElement
+    const flexGrow = (await renderResult.renderedDOM.findByTestId(
+      'position-flexGrow-number-input',
+    )) as HTMLInputElement
+    const flexShrink = (await renderResult.renderedDOM.findByTestId(
+      'position-flexShrink-number-input',
+    )) as HTMLInputElement
+
+    expect(metadata.computedStyle?.['flexBasis']).toMatchInlineSnapshot(`"15px"`)
+    expect(flexBasis.value).toMatchInlineSnapshot(`"15"`)
+    expect(
+      flexBasis.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+    expect(metadata.computedStyle?.['flexGrow']).toMatchInlineSnapshot(`"1"`)
+    expect(flexGrow.value).toMatchInlineSnapshot(`"1"`)
+    expect(
+      flexGrow.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+    expect(metadata.computedStyle?.['flexShrink']).toMatchInlineSnapshot(`"0"`)
+    expect(flexShrink.value).toMatchInlineSnapshot(`"0"`)
+    expect(
+      flexShrink.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+  })
+  it('Flex longhand properties', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          style={{
+            display: 'flex',
+          }}
+          data-uid={'aaa'}
+        >
+          <div
+            data-uid={'bbb'}
+            style={{
+              flexGrow: 1,
+              flexShrink: 0,
+              flexBasis: '15px',
+            }}
+          >hello</div>
+        </div>
+      `),
+    )
+
+    await renderResult.dispatch(
+      [selectComponents([TP.instancePath(TestScenePath, ['aaa', 'bbb'])], false)],
+      false,
+    )
+
+    const metadata = renderResult.getEditorState().editor.jsxMetadataKILLME.elements[
+      'utopia-storyboard-uid/scene-aaa:aaa/bbb'
+    ]
+
+    const flexBasis = (await renderResult.renderedDOM.findByTestId(
+      'position-flexBasis-number-input',
+    )) as HTMLInputElement
+    const flexGrow = (await renderResult.renderedDOM.findByTestId(
+      'position-flexGrow-number-input',
+    )) as HTMLInputElement
+    const flexShrink = (await renderResult.renderedDOM.findByTestId(
+      'position-flexShrink-number-input',
+    )) as HTMLInputElement
+
+    expect(metadata.computedStyle?.['flexBasis']).toMatchInlineSnapshot(`"15px"`)
+    expect(flexBasis.value).toMatchInlineSnapshot(`"15"`)
+    expect(
+      flexBasis.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+    expect(metadata.computedStyle?.['flexGrow']).toMatchInlineSnapshot(`"1"`)
+    expect(flexGrow.value).toMatchInlineSnapshot(`"1"`)
+    expect(
+      flexGrow.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+    expect(metadata.computedStyle?.['flexShrink']).toMatchInlineSnapshot(`"0"`)
+    expect(flexShrink.value).toMatchInlineSnapshot(`"0"`)
+    expect(
+      flexShrink.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+    ).toMatchInlineSnapshot(`"simple"`)
+  })
 })

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -203,12 +203,16 @@ export const FlexShorthandNumberControl = betterReactMemo(
 interface FlexShorthandCSSNumberControlProps {
   label: string
   styleProp: LayoutFlexElementNumericProp
-  shorthandProp: ParsedCSSPropertiesKeys
+  shorthandProp: StyleLayoutProp
 }
 export const FlexShorthandCSSNumberControl = betterReactMemo(
   'FlexStyleNumberControl',
   (props: FlexShorthandCSSNumberControlProps) => {
-    const layoutPropInfo = useInspectorLayoutInfo(props.styleProp)
+    const layoutPropInfo = useInspectorInfoLonghandShorthand(
+      props.styleProp,
+      props.shorthandProp,
+      createLayoutPropertyPath,
+    )
     const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
       layoutPropInfo.onSubmitValue,
       layoutPropInfo.onUnsetValues,
@@ -350,12 +354,12 @@ const WidthHeightRow = betterReactMemo('WidthHeightRow', (props: WidthHeightRowP
       case 'horizontal':
       case null:
         widthControl = (
-          <FlexShorthandCSSNumberControl label='W' styleProp='FlexFlexBasis' shorthandProp='flex' />
+          <FlexShorthandCSSNumberControl label='W' styleProp='flexBasis' shorthandProp='flex' />
         )
         break
       case 'vertical':
         heightControl = (
-          <FlexShorthandCSSNumberControl label='H' styleProp='FlexFlexBasis' shorthandProp='flex' />
+          <FlexShorthandCSSNumberControl label='H' styleProp='flexBasis' shorthandProp='flex' />
         )
         break
       default:

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -4,6 +4,8 @@ import {
   framePointForPinnedProp,
   LayoutFlexElementNumericProp,
   LayoutPinnedProp,
+  LayoutProp,
+  StyleLayoutProp,
 } from '../../../../../core/layout/layout-helpers-new'
 import { LocalRectangle } from '../../../../../core/shared/math-utils'
 import Utils from '../../../../../utils/utils'
@@ -14,6 +16,7 @@ import {
   CSSNumber,
   cssNumberToFramePin,
   framePinToCSSNumber,
+  isCSSNumber,
   ParsedCSSPropertiesKeys,
 } from '../../../common/css-utils'
 import { FramePinsInfo, usePinToggling } from '../../../common/layout-property-path-hooks'
@@ -29,6 +32,7 @@ import {
   SquareButton,
   Icons,
   FlexColumn,
+  SimpleNumberInput,
 } from '../../../../../uuiui'
 import { betterReactMemo } from '../../../../../uuiui-deps'
 import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
@@ -115,55 +119,11 @@ export const FlexStyleNumberControl = betterReactMemo(
   'FlexStyleNumberControl',
   (props: FlexStyleNumberControlProps) => {
     const layoutPropInfo = useInspectorLayoutInfo(props.styleProp)
-
-    const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      layoutPropInfo.onSubmitValue,
-      layoutPropInfo.onUnsetValues,
-    )
-    const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      layoutPropInfo.onTransientSubmitValue,
-      layoutPropInfo.onUnsetValues,
-    )
-    return (
-      <InspectorContextMenuWrapper
-        id={`position-${props.styleProp}-context-menu`}
-        items={[unsetPropertyMenuItem(props.styleProp, layoutPropInfo.onUnsetValues)]}
-        data={{}}
-      >
-        <NumberInput
-          id={`position-${props.styleProp}-number-input`}
-          testId={`position-${props.styleProp}-number-input`}
-          value={layoutPropInfo.value}
-          onSubmitValue={wrappedOnSubmitValue}
-          onTransientSubmitValue={wrappedOnTransientSubmitValue}
-          controlStatus={layoutPropInfo.controlStatus}
-          numberType={'UnitlessPercent'}
-          labelInner={props.label}
-          defaultUnitToHide={'px'}
-        />
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
-
-interface FlexShorthandNumberControlProps {
-  label: string
-  styleProp: StyleLayoutNumberProp
-  shorthandProp: ParsedCSSPropertiesKeys
-}
-
-export const FlexShorthandNumberControl = betterReactMemo(
-  'FlexShorthandNumberControl',
-  (props: FlexShorthandNumberControlProps) => {
-    const layoutPropInfo = useInspectorInfoLonghandShorthand(
-      props.styleProp,
-      props.shorthandProp,
-      stylePropPathMappingFn,
-    )
     const value =
-      layoutPropInfo.value != null && typeof layoutPropInfo.value === 'number'
-        ? { value: layoutPropInfo.value, unit: null }
+      isCSSNumber(layoutPropInfo.value) || layoutPropInfo.value == null
+        ? layoutPropInfo.value
         : undefined
+
     const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
       layoutPropInfo.onSubmitValue,
       layoutPropInfo.onUnsetValues,
@@ -182,6 +142,91 @@ export const FlexShorthandNumberControl = betterReactMemo(
           id={`position-${props.styleProp}-number-input`}
           testId={`position-${props.styleProp}-number-input`}
           value={value}
+          onSubmitValue={wrappedOnSubmitValue}
+          onTransientSubmitValue={wrappedOnTransientSubmitValue}
+          controlStatus={layoutPropInfo.controlStatus}
+          numberType={'UnitlessPercent'}
+          labelInner={props.label}
+          defaultUnitToHide={'px'}
+        />
+      </InspectorContextMenuWrapper>
+    )
+  },
+)
+
+interface FlexShorthandNumberControlProps {
+  label: string
+  styleProp: StyleLayoutProp
+  shorthandProp: StyleLayoutProp
+}
+
+export const FlexShorthandNumberControl = betterReactMemo(
+  'FlexShorthandNumberControl',
+  (props: FlexShorthandNumberControlProps) => {
+    const layoutPropInfo = useInspectorInfoLonghandShorthand(
+      props.styleProp,
+      props.shorthandProp,
+      createLayoutPropertyPath,
+    )
+    const value = typeof layoutPropInfo.value === 'number' ? layoutPropInfo.value : undefined
+
+    const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+      layoutPropInfo.onSubmitValue,
+      layoutPropInfo.onUnsetValues,
+    )
+    const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+      layoutPropInfo.onTransientSubmitValue,
+      layoutPropInfo.onUnsetValues,
+    )
+    return (
+      <InspectorContextMenuWrapper
+        id={`position-${props.styleProp}-context-menu`}
+        items={[unsetPropertyMenuItem(props.styleProp, layoutPropInfo.onUnsetValues)]}
+        data={{}}
+      >
+        <SimpleNumberInput
+          id={`position-${props.styleProp}-number-input`}
+          testId={`position-${props.styleProp}-number-input`}
+          value={value}
+          onForcedSubmitValue={wrappedOnSubmitValue}
+          onSubmitValue={wrappedOnSubmitValue}
+          onTransientSubmitValue={wrappedOnTransientSubmitValue}
+          controlStatus={layoutPropInfo.controlStatus}
+          labelInner={props.label}
+          defaultUnitToHide={'px'}
+        />
+      </InspectorContextMenuWrapper>
+    )
+  },
+)
+
+interface FlexShorthandCSSNumberControlProps {
+  label: string
+  styleProp: LayoutFlexElementNumericProp
+  shorthandProp: ParsedCSSPropertiesKeys
+}
+export const FlexShorthandCSSNumberControl = betterReactMemo(
+  'FlexStyleNumberControl',
+  (props: FlexShorthandCSSNumberControlProps) => {
+    const layoutPropInfo = useInspectorLayoutInfo(props.styleProp)
+    const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+      layoutPropInfo.onSubmitValue,
+      layoutPropInfo.onUnsetValues,
+    )
+    const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+      layoutPropInfo.onTransientSubmitValue,
+      layoutPropInfo.onUnsetValues,
+    )
+    return (
+      <InspectorContextMenuWrapper
+        id={`position-${props.styleProp}-context-menu`}
+        items={[unsetPropertyMenuItem(props.styleProp, layoutPropInfo.onUnsetValues)]}
+        data={{}}
+      >
+        <NumberInput
+          id={`position-${props.styleProp}-number-input`}
+          testId={`position-${props.styleProp}-number-input`}
+          value={layoutPropInfo.value}
           onSubmitValue={wrappedOnSubmitValue}
           onTransientSubmitValue={wrappedOnTransientSubmitValue}
           controlStatus={layoutPropInfo.controlStatus}
@@ -304,10 +349,14 @@ const WidthHeightRow = betterReactMemo('WidthHeightRow', (props: WidthHeightRowP
     switch (parentFlexAxis) {
       case 'horizontal':
       case null:
-        widthControl = flexLayoutNumberControl('W', 'FlexFlexBasis')
+        widthControl = (
+          <FlexShorthandCSSNumberControl label='W' styleProp='FlexFlexBasis' shorthandProp='flex' />
+        )
         break
       case 'vertical':
-        heightControl = flexLayoutNumberControl('H', 'FlexFlexBasis')
+        heightControl = (
+          <FlexShorthandCSSNumberControl label='H' styleProp='FlexFlexBasis' shorthandProp='flex' />
+        )
         break
       default:
         break

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -10,9 +10,14 @@ import Utils from '../../../../../utils/utils'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { FullFrame, getFullFrame } from '../../../../frame'
 import { unsetPropertyMenuItem } from '../../../common/context-menu-items'
-import { CSSNumber, cssNumberToFramePin, framePinToCSSNumber } from '../../../common/css-utils'
+import {
+  CSSNumber,
+  cssNumberToFramePin,
+  framePinToCSSNumber,
+  ParsedCSSPropertiesKeys,
+} from '../../../common/css-utils'
 import { FramePinsInfo, usePinToggling } from '../../../common/layout-property-path-hooks'
-import { useInspectorLayoutInfo } from '../../../common/property-path-hooks'
+import { stylePropPathMappingFn, useInspectorLayoutInfo } from '../../../common/property-path-hooks'
 import { GridRow } from '../../../widgets/grid-row'
 import { PinControl, PinHeightControl, PinWidthControl } from '../../../controls/pin-control'
 import { PropertyLabel } from '../../../widgets/property-label'
@@ -26,6 +31,7 @@ import {
   FlexColumn,
 } from '../../../../../uuiui'
 import { betterReactMemo } from '../../../../../uuiui-deps'
+import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
 
 interface PinsLayoutNumberControlProps {
   label: string
@@ -128,6 +134,54 @@ export const FlexStyleNumberControl = betterReactMemo(
           id={`position-${props.styleProp}-number-input`}
           testId={`position-${props.styleProp}-number-input`}
           value={layoutPropInfo.value}
+          onSubmitValue={wrappedOnSubmitValue}
+          onTransientSubmitValue={wrappedOnTransientSubmitValue}
+          controlStatus={layoutPropInfo.controlStatus}
+          numberType={'UnitlessPercent'}
+          labelInner={props.label}
+          defaultUnitToHide={'px'}
+        />
+      </InspectorContextMenuWrapper>
+    )
+  },
+)
+
+interface FlexShorthandNumberControlProps {
+  label: string
+  styleProp: StyleLayoutNumberProp
+  shorthandProp: ParsedCSSPropertiesKeys
+}
+
+export const FlexShorthandNumberControl = betterReactMemo(
+  'FlexShorthandNumberControl',
+  (props: FlexShorthandNumberControlProps) => {
+    const layoutPropInfo = useInspectorInfoLonghandShorthand(
+      props.styleProp,
+      props.shorthandProp,
+      stylePropPathMappingFn,
+    )
+    const value =
+      layoutPropInfo.value != null && typeof layoutPropInfo.value === 'number'
+        ? { value: layoutPropInfo.value, unit: null }
+        : undefined
+    const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+      layoutPropInfo.onSubmitValue,
+      layoutPropInfo.onUnsetValues,
+    )
+    const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+      layoutPropInfo.onTransientSubmitValue,
+      layoutPropInfo.onUnsetValues,
+    )
+    return (
+      <InspectorContextMenuWrapper
+        id={`position-${props.styleProp}-context-menu`}
+        items={[unsetPropertyMenuItem(props.styleProp, layoutPropInfo.onUnsetValues)]}
+        data={{}}
+      >
+        <NumberInput
+          id={`position-${props.styleProp}-number-input`}
+          testId={`position-${props.styleProp}-number-input`}
+          value={value}
           onSubmitValue={wrappedOnSubmitValue}
           onTransientSubmitValue={wrappedOnTransientSubmitValue}
           controlStatus={layoutPropInfo.controlStatus}
@@ -374,9 +428,9 @@ const FlexGrowShrinkRow = betterReactMemo('FlexGrowShrinkRow', () => {
     <GridRow padded={true} type='<---1fr--->|------172px-------|'>
       <PropertyLabel target={flexGrowShrinkProps}>Flex</PropertyLabel>
       <GridRow padded={false} type='|--67px--||16px||--67px--||16px|'>
-        {flexStyleNumberControl('G', 'flexGrow')}
+        <FlexShorthandNumberControl label='G' styleProp='flexGrow' shorthandProp='flex' />
         {spacingButton}
-        {flexStyleNumberControl('S', 'flexShrink')}
+        <FlexShorthandNumberControl label='S' styleProp='flexShrink' shorthandProp='flex' />
         {spacingButton}
       </GridRow>
     </GridRow>

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -33,6 +33,7 @@ export const LayoutPinnedProps: Array<LayoutPinnedProp> = [
 ]
 
 export type StyleLayoutProp =
+  | 'flex'
   | 'flexWrap'
   | 'flexDirection'
   | 'flexGrow'
@@ -135,6 +136,7 @@ const LayoutPathMap: { [key in LayoutProp | StyleLayoutProp]: Array<PropertyPath
   alignSelf: ['style', 'alignSelf'],
   flexWrap: ['style', 'wrap'],
   flexDirection: ['style', 'flexDirection'],
+  flex: ['style', 'flex'],
   flexGrow: ['style', 'flexGrow'],
   flexShrink: ['style', 'flexShrink'],
   alignItems: ['style', 'alignItems'],

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -8,7 +8,7 @@ export type LayoutDimension = 'Width' | 'Height'
 
 export type LayoutFlexContainerProp = LayoutDimension | 'FlexGap'
 
-export type LayoutFlexElementNumericProp = 'Width' | 'Height' | 'FlexFlexBasis' | 'FlexCrossBasis'
+export type LayoutFlexElementNumericProp = 'Width' | 'Height' | 'flexBasis' | 'FlexCrossBasis'
 
 export type LayoutFlexElementProp = LayoutFlexElementNumericProp
 
@@ -125,7 +125,7 @@ const LayoutPathMap: { [key in LayoutProp | StyleLayoutProp]: Array<PropertyPath
 
   // TODO FIXME 'style' here should point to the inspector target selector's current target instead of always pointing to style
   FlexGap: ['style', 'gap'],
-  FlexFlexBasis: ['style', 'flexBasis'],
+  flexBasis: ['style', 'flexBasis'],
   PinnedLeft: ['style', 'left'],
   PinnedTop: ['style', 'top'],
   Width: ['style', 'width'],
@@ -170,7 +170,7 @@ export interface LayoutPropertyTypes {
   Height: CSSNumber | undefined
 
   FlexGap: number
-  FlexFlexBasis: CSSNumber | undefined
+  flexBasis: CSSNumber | undefined
   FlexCrossBasis: CSSNumber | undefined
 
   PinnedLeft: CSSNumber | undefined
@@ -187,7 +187,7 @@ export interface LayoutPropertyTypesAndCSSPropertyTypes extends ParsedCSSPropert
   Height: FramePin | undefined
 
   FlexGap: number
-  FlexFlexBasis: FlexLength
+  flexBasis: FlexLength
   FlexCrossBasis: FlexLength
 
   PinnedLeft: FramePin | undefined

--- a/editor/src/core/layout/layout-helpers.ts
+++ b/editor/src/core/layout/layout-helpers.ts
@@ -112,7 +112,7 @@ export type FixedAndBases = {
 
 export type TopLeftWidthHeight = Pick<FullFrame, 'top' | 'left' | 'width' | 'height'>
 
-export const FlexBasisPath = createLayoutPropertyPath('FlexFlexBasis')
+export const FlexBasisPath = createLayoutPropertyPath('flexBasis')
 
 export const FlexLayoutHelpers = {
   updateLayoutPropsToFlexWithFrame(
@@ -350,13 +350,13 @@ export const LayoutHelpers = {
     if (element.specialSizeMeasurements.parentLayoutSystem === 'flex') {
       if (element.specialSizeMeasurements.parentFlexDirection === 'row') {
         return {
-          horizontal: createLayoutPropertyPath('FlexFlexBasis'),
+          horizontal: createLayoutPropertyPath('flexBasis'),
           vertical: createLayoutPropertyPath('Height'),
         }
       } else {
         return {
           horizontal: createLayoutPropertyPath('Width'),
-          vertical: createLayoutPropertyPath('FlexFlexBasis'),
+          vertical: createLayoutPropertyPath('flexBasis'),
         }
       }
     } else {

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -248,9 +248,9 @@ function getLayoutFunction(
   }
 }
 
-export const PinningAndFlexPoints = [...AllFramePoints, 'FlexFlexBasis']
+export const PinningAndFlexPoints = [...AllFramePoints, 'flexBasis']
 
-export const PinningAndFlexPointsExceptSize = [...AllFramePointsExceptSize, 'FlexFlexBasis']
+export const PinningAndFlexPointsExceptSize = [...AllFramePointsExceptSize, 'flexBasis']
 
 function keepLayoutProps(
   target: InstancePath,
@@ -333,7 +333,7 @@ export function switchPinnedChildToFlex(
       const { flexBasis, width, height } = flexProps
       if (flexBasis != null) {
         propsToAdd.push({
-          path: createLayoutPropertyPath('FlexFlexBasis'),
+          path: createLayoutPropertyPath('flexBasis'),
           value: jsxAttributeValue(flexBasis, emptyComments),
         })
       }
@@ -701,7 +701,7 @@ function removeFlexAndNonDefaultPinsAddPinnedPropsToComponent(
     'PinnedRight',
     'PinnedCenterX',
     'PinnedCenterY',
-    'FlexFlexBasis',
+    'flexBasis',
     'FlexCrossBasis',
   ]
 
@@ -743,7 +743,7 @@ function removeFlexAndAddPinnedPropsToComponent(
       value: jsxAttributeValue('absolute', emptyComments),
     },
   ]
-  const propsToRemove: Array<LayoutProp | StyleLayoutProp> = ['FlexFlexBasis', 'FlexCrossBasis']
+  const propsToRemove: Array<LayoutProp | StyleLayoutProp> = ['flexBasis', 'FlexCrossBasis']
 
   return transformElementAtPath(components, target, (e: JSXElement) => {
     const flexPropsRemoved = unsetJSXValuesAtPaths(
@@ -808,7 +808,7 @@ function changePinsToDefaultOnComponent(
 const propertiesToRound: Array<PropertyPath> = [
   createLayoutPropertyPath('PinnedCenterX'),
   createLayoutPropertyPath('PinnedCenterY'),
-  createLayoutPropertyPath('FlexFlexBasis'),
+  createLayoutPropertyPath('flexBasis'),
   createLayoutPropertyPath('FlexCrossBasis'),
   createLayoutPropertyPath('PinnedLeft'),
   createLayoutPropertyPath('PinnedTop'),

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -311,9 +311,9 @@ export const MetadataUtils = {
           const element = findJSXElementChildAtPath(components, staticTarget)
           if (element != null && isJSXElement(element)) {
             const widthLookupAxis: LayoutProp =
-              flexDirection === 'horizontal' ? 'FlexFlexBasis' : 'Width'
+              flexDirection === 'horizontal' ? 'flexBasis' : 'Width'
             const heightLookupAxis: LayoutProp =
-              flexDirection === 'vertical' ? 'FlexFlexBasis' : 'Height'
+              flexDirection === 'vertical' ? 'flexBasis' : 'Height'
             let result: Partial<Size> = {}
             const width: Either<string, FlexLength> = alternativeEither(
               getLayoutProperty(widthLookupAxis, right(element.props)),

--- a/editor/src/printer-parsers/css/css-parser-flex.ts
+++ b/editor/src/printer-parsers/css/css-parser-flex.ts
@@ -21,7 +21,10 @@ import {
 export const AssumedFlexDefaults: CSSFlex = {
   flexGrow: 1,
   flexShrink: 1,
-  flexBasis: cssNumber(0),
+  flexBasis: {
+    value: 0,
+    unit: null,
+  },
 }
 export const parseFlex = (value: unknown): Either<string, CSSFlex> => {
   const lexer = getLexerPropertyMatches('flex', value, '')


### PR DESCRIPTION
This PR adds flex shorthand support for flex-basis, flex-grow and flex-shrink controls.

- renamed FlexFlexBasis to flexBasis, as this is its original name
- fixed flexGrow and flexShrink parsing, because these are just numbers without unit
- added the new controls to gigantic-size-pin-section
- new tests