### PR TITLE
Fix/inspector hide px from style

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4319,6 +4319,7 @@ const cssPrinters: CSSPrinters = {
   marginRight: printCSSNumberAsAttributeValue('px'),
   marginBottom: printCSSNumberAsAttributeValue('px'),
   marginLeft: printCSSNumberAsAttributeValue('px'),
+  flex: printFlexAsAttributeValue,
   flexGrow: jsxAttributeValueWithNoComments,
   flexShrink: jsxAttributeValueWithNoComments,
   display: printStringAsAttributeValue,

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -655,9 +655,12 @@ function fixNumber(n: number): number {
   return Number(n.toFixed(11))
 }
 
-export function printCSSNumber(input: CSSNumber): string | number {
+export function printCSSNumber(
+  input: CSSNumber,
+  defaultUnitToSkip: string | null,
+): string | number {
   const { value, unit } = input
-  if (unit == null) {
+  if (unit == null || unit === defaultUnitToSkip) {
     return fixNumber(value)
   } else {
     return `${fixNumber(value)}${unit}`
@@ -665,7 +668,7 @@ export function printCSSNumber(input: CSSNumber): string | number {
 }
 
 export function cssNumberToString(input: CSSNumber, showUnit: boolean = true): string {
-  const printed = showUnit ? printCSSNumber(input) : fixNumber(input.value)
+  const printed = showUnit ? printCSSNumber(input, null) : fixNumber(input.value)
   return `${printed}`
 }
 
@@ -731,7 +734,7 @@ export function cssNumberToFramePin(value: CSSNumber): FramePin {
   if (value.unit == null) {
     return value.value
   } else {
-    return printCSSNumber(value)
+    return printCSSNumber(value, 'px')
   }
 }
 
@@ -1014,10 +1017,12 @@ export function printBoxShadow(boxShadows: CSSBoxShadows): JSXAttributeValue<str
         const { inset, offsetX, offsetY, blurRadius, spreadRadius, color } = boxShadow
         const parts = Utils.stripNulls([
           inset ? 'inset' : null,
-          printCSSNumber(offsetX),
-          printCSSNumber(offsetY),
-          blurRadius.default && spreadRadius.default ? null : printCSSNumber(blurRadius.value),
-          spreadRadius.default ? null : printCSSNumber(spreadRadius.value),
+          printCSSNumber(offsetX, null),
+          printCSSNumber(offsetY, null),
+          blurRadius.default && spreadRadius.default
+            ? null
+            : printCSSNumber(blurRadius.value, null),
+          spreadRadius.default ? null : printCSSNumber(spreadRadius.value, null),
           printColor(color),
         ])
         return printEnabled(printComma(`${parts.join(' ')}`, comma), boxShadow.enabled)
@@ -1582,19 +1587,20 @@ export function parseTransform(transform: unknown): Either<string, CSSTransforms
 function printCSSTransformItem(cssTransform: CSSTransformItem): string {
   if (isCSSTransformSingleItem(cssTransform)) {
     return printEnabled(
-      `${cssTransform.type}(${printCSSNumber(cssTransform.value)})`,
+      `${cssTransform.type}(${printCSSNumber(cssTransform.value, null)})`,
       cssTransform.enabled,
     )
   } else if (isCSSTransformDoubleItem(cssTransform)) {
     if (cssTransform.values[1].default) {
       return printEnabled(
-        `${cssTransform.type}(${printCSSNumber(cssTransform.values[0])})`,
+        `${cssTransform.type}(${printCSSNumber(cssTransform.values[0], null)})`,
         cssTransform.enabled,
       )
     } else {
       return printEnabled(
-        `${cssTransform.type}(${printCSSNumber(cssTransform.values[0])}, ${printCSSNumber(
+        `${cssTransform.type}(${printCSSNumber(cssTransform.values[0], null)}, ${printCSSNumber(
           cssTransform.values[1].value,
+          null,
         )})`,
         cssTransform.enabled,
       )
@@ -1911,11 +1917,14 @@ export function printBorderRadius(
   borderRadius: CSSBorderRadius,
 ): JSXAttributeValue<string | number> {
   if (isLeft(borderRadius)) {
-    return printCSSNumberAsAttributeValue(borderRadius.value)
+    return printCSSNumberAsAttributeValue('px')(borderRadius.value)
   } else {
     const { tl, tr, br, bl } = borderRadius.value
     return jsxAttributeValue(
-      `${printCSSNumber(tl)} ${printCSSNumber(tr)} ${printCSSNumber(br)} ${printCSSNumber(bl)}`,
+      `${printCSSNumber(tl, null)} ${printCSSNumber(tr, null)} ${printCSSNumber(
+        br,
+        null,
+      )} ${printCSSNumber(bl, null)}`,
       emptyComments,
     )
   }
@@ -3329,7 +3338,7 @@ export function printBackgroundSize(value: CSSBackgroundSize): JSXAttributeValue
                 bgSize.size.value.value
                   .map((item) => {
                     if (isCSSNumber(item)) {
-                      return printCSSNumber(item)
+                      return printCSSNumber(item, null)
                     } else {
                       return printCSSKeyword(item)
                     }
@@ -3468,9 +3477,9 @@ function printTextShadow(textShadows: CSSTextShadows): JSXAttributeValue<string>
         const comma = indexOfLastEnabledLayer > i && textShadow.enabled
         const { offsetX, offsetY, blurRadius, color } = textShadow
         const parts = Utils.stripNulls([
-          printCSSNumber(offsetX),
-          printCSSNumber(offsetY),
-          blurRadius == null ? null : printCSSNumber(blurRadius.value),
+          printCSSNumber(offsetX, null),
+          printCSSNumber(offsetY, null),
+          blurRadius == null ? null : printCSSNumber(blurRadius.value, null),
           printColor(color),
         ])
         return printEnabled(printComma(`${parts.join(' ')}`, comma), textShadow.enabled)
@@ -3581,7 +3590,7 @@ function printLetterSpacing(
   if (cssLetterSpacing === 'normal') {
     return jsxAttributeValue(cssLetterSpacing, emptyComments)
   } else {
-    return printCSSNumberAsAttributeValue(cssLetterSpacing)
+    return printCSSNumberAsAttributeValue(null)(cssLetterSpacing)
   }
 }
 
@@ -3599,7 +3608,7 @@ function printLineHeight(
   if (cssLineHeight === 'normal') {
     return jsxAttributeValue(cssLineHeight, emptyComments)
   } else {
-    return printCSSNumberAsAttributeValue(cssLineHeight)
+    return printCSSNumberAsAttributeValue(null)(cssLineHeight)
   }
 }
 
@@ -3802,16 +3811,21 @@ export function toggleStylePropPaths(toggleFn: (attribute: JSXAttribute) => JSXA
   }
 }
 
-function printCSSNumberAsAttributeValue(value: CSSNumber): JSXAttributeValue<string | number> {
-  return jsxAttributeValue(printCSSNumber(value), emptyComments)
+function printCSSNumberAsAttributeValue(
+  defaultUnitToSkip: string | null,
+): (value: CSSNumber) => JSXAttributeValue<string | number> {
+  return (value: CSSNumber) =>
+    jsxAttributeValue(printCSSNumber(value, defaultUnitToSkip), emptyComments)
 }
 
 function printCSSNumberOrUndefinedAsAttributeValue(
-  value: CSSNumber | undefined,
-): JSXAttributeValue<string | number | undefined> {
-  return value != null
-    ? printCSSNumberAsAttributeValue(value)
-    : jsxAttributeValue(undefined, emptyComments)
+  defaultUnitToSkip: string | null,
+): (value: CSSNumber | undefined) => JSXAttributeValue<string | number | undefined> {
+  return (value: CSSNumber | undefined) => {
+    return value != null
+      ? printCSSNumberAsAttributeValue(defaultUnitToSkip)(value)
+      : jsxAttributeValue(undefined, emptyComments)
+  }
 }
 
 function parseString(value: unknown): Either<string, string> {
@@ -4243,12 +4257,12 @@ const cssPrinters: CSSPrinters = {
   boxShadow: printBoxShadow,
   color: printColorToJsx,
   fontFamily: printFontFamily,
-  fontSize: printCSSNumberAsAttributeValue,
+  fontSize: printCSSNumberAsAttributeValue(null),
   fontStyle: printFontStyle,
   fontWeight: printFontWeight,
   letterSpacing: printLetterSpacing,
   lineHeight: printLineHeight,
-  opacity: printCSSNumberAsAttributeValue,
+  opacity: printCSSNumberAsAttributeValue(null),
   overflow: printOverflow,
   textAlign: printTextAlign,
   textDecorationColor: printColorToJsx,
@@ -4266,28 +4280,28 @@ const cssPrinters: CSSPrinters = {
   alignContent: jsxAttributeValueWithNoComments,
   justifyContent: jsxAttributeValueWithNoComments,
   padding: printPaddingAsAttributeValue,
-  paddingTop: printCSSNumberAsAttributeValue,
-  paddingRight: printCSSNumberAsAttributeValue,
-  paddingBottom: printCSSNumberAsAttributeValue,
-  paddingLeft: printCSSNumberAsAttributeValue,
+  paddingTop: printCSSNumberAsAttributeValue('px'),
+  paddingRight: printCSSNumberAsAttributeValue('px'),
+  paddingBottom: printCSSNumberAsAttributeValue('px'),
+  paddingLeft: printCSSNumberAsAttributeValue('px'),
 
   alignSelf: jsxAttributeValueWithNoComments,
   position: jsxAttributeValueWithNoComments,
-  left: printCSSNumberOrUndefinedAsAttributeValue,
-  top: printCSSNumberOrUndefinedAsAttributeValue,
-  right: printCSSNumberOrUndefinedAsAttributeValue,
-  bottom: printCSSNumberOrUndefinedAsAttributeValue,
-  minWidth: printCSSNumberOrUndefinedAsAttributeValue,
-  maxWidth: printCSSNumberOrUndefinedAsAttributeValue,
-  minHeight: printCSSNumberOrUndefinedAsAttributeValue,
-  maxHeight: printCSSNumberOrUndefinedAsAttributeValue,
+  left: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  top: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  right: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  bottom: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  minWidth: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  maxWidth: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  minHeight: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  maxHeight: printCSSNumberOrUndefinedAsAttributeValue('px'),
   margin: printMarginAsAttributeValue,
-  marginTop: printCSSNumberAsAttributeValue,
-  marginRight: printCSSNumberAsAttributeValue,
-  marginBottom: printCSSNumberAsAttributeValue,
-  marginLeft: printCSSNumberAsAttributeValue,
-  flexGrow: printCSSNumberAsAttributeValue,
-  flexShrink: printCSSNumberAsAttributeValue,
+  marginTop: printCSSNumberAsAttributeValue('px'),
+  marginRight: printCSSNumberAsAttributeValue('px'),
+  marginBottom: printCSSNumberAsAttributeValue('px'),
+  marginLeft: printCSSNumberAsAttributeValue('px'),
+  flexGrow: printCSSNumberAsAttributeValue(null),
+  flexShrink: printCSSNumberAsAttributeValue(null),
   display: printStringAsAttributeValue,
 }
 
@@ -4639,19 +4653,19 @@ type LayoutPrintersNew = {
 const layoutPrintersNew: LayoutPrintersNew = {
   LayoutSystem: jsxAttributeValueWithNoComments,
 
-  Width: printCSSNumberOrUndefinedAsAttributeValue,
-  Height: printCSSNumberOrUndefinedAsAttributeValue,
+  Width: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  Height: printCSSNumberOrUndefinedAsAttributeValue('px'),
 
   FlexGap: jsxAttributeValueWithNoComments,
-  FlexFlexBasis: printCSSNumberOrUndefinedAsAttributeValue,
-  FlexCrossBasis: printCSSNumberOrUndefinedAsAttributeValue,
+  FlexFlexBasis: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  FlexCrossBasis: printCSSNumberOrUndefinedAsAttributeValue('px'),
 
-  PinnedLeft: printCSSNumberOrUndefinedAsAttributeValue,
-  PinnedTop: printCSSNumberOrUndefinedAsAttributeValue,
-  PinnedRight: printCSSNumberOrUndefinedAsAttributeValue,
-  PinnedBottom: printCSSNumberOrUndefinedAsAttributeValue,
-  PinnedCenterX: printCSSNumberOrUndefinedAsAttributeValue,
-  PinnedCenterY: printCSSNumberOrUndefinedAsAttributeValue,
+  PinnedLeft: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  PinnedTop: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  PinnedRight: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  PinnedBottom: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  PinnedCenterX: printCSSNumberOrUndefinedAsAttributeValue('px'),
+  PinnedCenterY: printCSSNumberOrUndefinedAsAttributeValue('px'),
 }
 
 export interface ParsedProperties

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -270,7 +270,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingLeft']),
-            jsxAttributeValue('100px', emptyComments),
+            jsxAttributeValue(100, emptyComments),
           ),
         ],
       ],
@@ -314,7 +314,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingRight']),
-            jsxAttributeValue('5px', emptyComments),
+            jsxAttributeValue(5, emptyComments),
           ),
         ],
       ],
@@ -336,7 +336,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingLeft']),
-            jsxAttributeValue('8px', emptyComments),
+            jsxAttributeValue(8, emptyComments),
           ),
         ],
       ],
@@ -358,7 +358,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingLeft']),
-            jsxAttributeValue('8px', emptyComments),
+            jsxAttributeValue(8, emptyComments),
           ),
         ],
       ],
@@ -381,7 +381,7 @@ describe('useInspectorInfo: updating padding shorthand and longhands', () => {
           setProp_UNSAFE(
             TestSelectedComponent,
             PP.create(['style', 'paddingLeft']),
-            jsxAttributeValue('16px', emptyComments),
+            jsxAttributeValue(16, emptyComments),
           ),
         ],
       ],

--- a/editor/src/components/inspector/common/property-path-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.spec.tsx
@@ -203,7 +203,7 @@ describe('useCallbackFactory', () => {
 const WellBehavedInspectorSubsection = betterReactMemo('WellBehavedInspectorSubsection', () => {
   const { value, onSubmitValue } = useInspectorStyleInfo('opacity')
   onSubmitValue(cssNumber(0.9))
-  return <div onClick={() => onSubmitValue(cssNumber(0.5))}>{printCSSNumber(value)}</div>
+  return <div onClick={() => onSubmitValue(cssNumber(0.5))}>{printCSSNumber(value, null)}</div>
 })
 enableWhyDidYouRenderOnComponent(WellBehavedInspectorSubsection)
 

--- a/editor/src/printer-parsers/css/css-parser-flex.ts
+++ b/editor/src/printer-parsers/css/css-parser-flex.ts
@@ -36,9 +36,9 @@ export const parseFlex = (value: unknown): Either<string, CSSFlex> => {
         if (isCSSFlexBasis(target)) {
           return { ...working, flexBasis: target.value } as CSSFlex
         } else if (isCSSFlexGrow(target)) {
-          return { ...working, flexGrow: printCSSNumber(target.value) } as CSSFlex
+          return { ...working, flexGrow: printCSSNumber(target.value, null) } as CSSFlex
         } else if (isCSSFlexShrink(target)) {
-          return { ...working, flexShrink: printCSSNumber(target.value) } as CSSFlex
+          return { ...working, flexShrink: printCSSNumber(target.value, null) } as CSSFlex
         } else {
           return working
         }
@@ -130,9 +130,9 @@ function isCSSFlexBasis(value: CSSFlexGrow | CSSFlexShrink | CSSFlexBasis): valu
 export const printFlexAsAttributeValue = (value: CSSFlex): JSXAttributeValue<number | string> => {
   const flexGrow = value.flexGrow
   const flexShrink = value.flexShrink
-  const flexBasis = printCSSNumber(value.flexBasis)
+  const flexBasis = printCSSNumber(value.flexBasis, null)
 
-  if (flexBasis === printCSSNumber(AssumedFlexDefaults.flexBasis)) {
+  if (flexBasis === printCSSNumber(AssumedFlexDefaults.flexBasis, null)) {
     if (flexShrink === AssumedFlexDefaults.flexShrink) {
       return jsxAttributeValue(`${flexGrow}`, emptyComments)
     } else {

--- a/editor/src/printer-parsers/css/css-parser-margin.ts
+++ b/editor/src/printer-parsers/css/css-parser-margin.ts
@@ -69,7 +69,7 @@ export const printMarginAsAttributeValue = (
   const marginLeft = printCSSNumberWithDefaultUnit(value.marginLeft, 'px')
 
   if (canUseOneValueSyntax(marginTop, marginRight, marginBottom, marginLeft)) {
-    const marginValue = printCSSNumber(value.marginTop)
+    const marginValue = printCSSNumber(value.marginTop, 'px')
     return jsxAttributeValue(marginValue, emptyComments)
   } else if (canUseTwoValueSyntax(marginTop, marginRight, marginBottom, marginLeft)) {
     const marginValue = `${marginTop} ${marginLeft}`

--- a/editor/src/printer-parsers/css/css-parser-padding.ts
+++ b/editor/src/printer-parsers/css/css-parser-padding.ts
@@ -65,7 +65,7 @@ export const printPaddingAsAttributeValue = (
   const paddingLeft = printCSSNumberWithDefaultUnit(value.paddingLeft, 'px')
 
   if (canUseOneValueSyntax(paddingTop, paddingRight, paddingBottom, paddingLeft)) {
-    const paddingValue = printCSSNumber(value.paddingTop)
+    const paddingValue = printCSSNumber(value.paddingTop, 'px')
     return jsxAttributeValue(paddingValue, emptyComments)
   } else if (canUseTwoValueSyntax(paddingTop, paddingRight, paddingBottom, paddingLeft)) {
     const paddingValue = `${paddingTop} ${paddingLeft}`


### PR DESCRIPTION
**Problem:**
When changing padding/margin/dimension the inspector adds an extra `px` to the printed style object, even if it was just a number before while the default units are hidden in the inspector. As React works nicely with these as numbers, we should convert them to just numbers when they use default units.

**Commit Details:**
- `printCSSNumber` has an extra parameter to not print the default unit
- updated the printers
