### PR TITLE
exp(performance) - less tall tests

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -125,4 +125,4 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Speed test: ${{ steps.run-performance-test.outputs.perf-result }}
+            Performance: ${{ steps.run-performance-test.outputs.perf-result }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -125,6 +125,4 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            These are the results of the :racing_car: **SPEED TEST** that runs right after the test editor was deployed
-
-            ${{ steps.run-performance-test.outputs.perf-result }}
+            Speed test: ${{ steps.run-performance-test.outputs.perf-result }}

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -271,7 +271,7 @@ async function createSummaryPng(
     margin: {
       l: 50,
       r: 50,
-      b: 40,
+      b: 60,
       t: 10,
       pad: 4,
     },

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -114,7 +114,7 @@ export const testPerformance = async function () {
   const summaryImage = await uploadSummaryImage([selectionResult, scrollResult, resizeResult])
 
   console.info(
-    `::set-output name=perf-result:: ${scrollResult.title}: fastest ${scrollResult.analytics.frameMin}ms, average ${scrollResult.analytics.frameAvg}ms %0A ${resizeResult.title}: fastest ${resizeResult.analytics.frameMin}ms, average ${resizeResult.analytics.frameAvg}ms %0A ${selectionResult.title}: fastest ${selectionResult.analytics.frameMin}ms, average ${selectionResult.analytics.frameAvg}ms ![SummaryChart](${summaryImage})`,
+    `::set-output name=perf-result:: ${scrollResult.title}: fastest ${scrollResult.analytics.frameMin}ms, average ${scrollResult.analytics.frameAvg}ms | ${resizeResult.title}: fastest ${resizeResult.analytics.frameMin}ms, avg ${resizeResult.analytics.frameAvg}ms | ${selectionResult.title}: fastest ${selectionResult.analytics.frameMin}ms, average ${selectionResult.analytics.frameAvg}ms ![SummaryChart](${summaryImage})`,
   )
 }
 

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -270,7 +270,7 @@ async function createSummaryPng(
   const layout = {
     title: 'Automated Performance Test (100 runs, fastest counts)',
     showlegend: false,
-    height: 60 * numberOfTests,
+    height: 50 * numberOfTests,
     width: 720,
     yaxis: {
       automargin: true,
@@ -309,7 +309,7 @@ async function createSummaryPng(
   const imgOpts = {
     format: 'png',
     width: 800,
-    height: 600,
+    height: 300,
   }
   const figure = { data: processedData, layout: layout }
 

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -268,6 +268,13 @@ async function createSummaryPng(
   const processedData = results.map((result) => boxPlotConfig(result.title, result.timeSeries))
 
   const layout = {
+    margin: {
+      l: 50,
+      r: 50,
+      b: 40,
+      t: 10,
+      pad: 4,
+    },
     showlegend: false,
     height: 50 * numberOfTests,
     width: 720,

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -114,7 +114,7 @@ export const testPerformance = async function () {
   const summaryImage = await uploadSummaryImage([selectionResult, scrollResult, resizeResult])
 
   console.info(
-    `::set-output name=perf-result:: ${scrollResult.title}: fastest ${scrollResult.analytics.frameMin}ms, average ${scrollResult.analytics.frameAvg}ms | ${resizeResult.title}: fastest ${resizeResult.analytics.frameMin}ms, avg ${resizeResult.analytics.frameAvg}ms | ${selectionResult.title}: fastest ${selectionResult.analytics.frameMin}ms, average ${selectionResult.analytics.frameAvg}ms ![SummaryChart](${summaryImage})`,
+    `::set-output name=perf-result:: ${scrollResult.title}:  ${scrollResult.analytics.frameMin}ms | ${resizeResult.title}: ${resizeResult.analytics.frameMin}ms | ${selectionResult.title}: ${selectionResult.analytics.frameMin}ms ![SummaryChart](${summaryImage})`,
   )
 }
 
@@ -268,7 +268,6 @@ async function createSummaryPng(
   const processedData = results.map((result) => boxPlotConfig(result.title, result.timeSeries))
 
   const layout = {
-    title: 'Automated Performance Test (100 runs, fastest counts)',
     showlegend: false,
     height: 50 * numberOfTests,
     width: 720,
@@ -293,7 +292,7 @@ async function createSummaryPng(
       },
     ],
     xaxis: {
-      title: 'ms / frame (16.67 = 60fps)',
+      title: 'lower is better, ms / frame (16.67 = 60fps), 100 runs',
       autorange: true,
       showgrid: true,
       zeroline: true,
@@ -302,14 +301,14 @@ async function createSummaryPng(
       gridwidth: 1,
       zerolinecolor: 'rgba(0,0,0,.1)',
       zerolinewidth: 1,
-      color: '#bbb',
+      color: '#999',
     },
   }
 
   const imgOpts = {
     format: 'png',
     width: 800,
-    height: 300,
+    height: 220,
   }
   const figure = { data: processedData, layout: layout }
 


### PR DESCRIPTION
**Problem:**
Test perf charts take up a lot of vertical space in the PRs.

**Fix:**
Make it 300px tall, give 10px less space to the tests. Maybe that'll make it better, maybe can shave another _n_ pixels. We'll see.