### PR TITLE
Fix/set jsx value at path dedupe key

### DIFF
--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -431,6 +431,73 @@ describe('jsxAttributesToProps', () => {
     )
     expect(compiledProps).toEqual(expectedCompiledProps)
   })
+
+  it('even supports irregular duplicated property inside a JSX_ATTRIBUTE_VALUE', () => {
+    const attributes = jsxAttributesFromMap({
+      style: jsxAttributeValue(
+        {
+          paddingLeft: 5,
+          padding: 5,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          paddingLeft: 15,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          paddingLeft: 23,
+        },
+        emptyComments,
+      ),
+    })
+    const compiledProps = jsxAttributesToProps({}, attributes, {})
+
+    expect(compiledProps).toEqual({ style: { paddingLeft: 23, padding: 5 } })
+    expect(Object.entries(compiledProps.style)).toEqual([
+      ['paddingLeft', 23],
+      ['padding', 5],
+    ])
+  })
+
+  it('even supports irregular duplicated property inside a JSX_ATTRIBUTE_NESTED_OBJECT', () => {
+    const attributes = jsxAttributesFromMap({
+      style: jsxAttributeNestedObject(
+        [
+          jsxPropertyAssignment(
+            'paddingLeft',
+            jsxAttributeValue(5, emptyComments),
+            emptyComments,
+            emptyComments,
+          ),
+          jsxPropertyAssignment(
+            'padding',
+            jsxAttributeValue(5, emptyComments),
+            emptyComments,
+            emptyComments,
+          ),
+          jsxPropertyAssignment(
+            'paddingLeft',
+            jsxAttributeValue(15, emptyComments),
+            emptyComments,
+            emptyComments,
+          ),
+          jsxPropertyAssignment(
+            'paddingLeft',
+            jsxAttributeValue(23, emptyComments),
+            emptyComments,
+            emptyComments,
+          ),
+        ],
+        emptyComments,
+      ),
+    })
+
+    const compiledProps = jsxAttributesToProps({}, attributes, {})
+
+    expect(compiledProps).toEqual({ style: { paddingLeft: 23, padding: 5 } })
+    expect(Object.entries(compiledProps.style)).toEqual([
+      ['paddingLeft', 23],
+      ['padding', 5],
+    ])
+  })
 })
 
 describe('getModifiableJSXAttributeAtPath', () => {

--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -306,6 +306,120 @@ describe('setJSXValueAtPath', () => {
     expect(result2.type).toBe('LEFT')
     expect(result3.type).toBe('LEFT')
   })
+
+  it('when setting an irregular duplicated property inside a JSX_ATTRIBUTE_VALUE, deduplicate it', () => {
+    const attributes = jsxAttributesFromMap({
+      style: jsxAttributeValue(
+        {
+          paddingLeft: 5,
+          padding: 5,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          paddingLeft: 15,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          paddingLeft: 23,
+        },
+        emptyComments,
+      ),
+    })
+
+    const result = setJSXValueAtPath(
+      attributes,
+      PP.create(['style', 'paddingLeft']),
+      jsxAttributeValue(100, emptyComments),
+    )
+    if (isLeft(result)) {
+      fail(`result is LEFT`)
+    }
+
+    expect(result.value).toEqual(
+      jsxAttributesFromMap({
+        style: jsxAttributeNestedObject(
+          [
+            jsxPropertyAssignment(
+              'paddingLeft',
+              jsxAttributeValue(100, emptyComments),
+              emptyComments,
+              emptyComments,
+            ),
+            jsxPropertyAssignment(
+              'padding',
+              jsxAttributeValue(5, emptyComments),
+              emptyComments,
+              emptyComments,
+            ),
+          ],
+          emptyComments,
+        ),
+      }),
+    )
+  })
+
+  it('when setting an irregular duplicated property inside a JSX_ATTRIBUTE_NESTED_OBJECT, deduplicate it', () => {
+    const attributes = jsxAttributesFromMap({
+      style: jsxAttributeNestedObject(
+        [
+          jsxPropertyAssignment(
+            'paddingLeft',
+            jsxAttributeValue(5, emptyComments),
+            emptyComments,
+            emptyComments,
+          ),
+          jsxPropertyAssignment(
+            'padding',
+            jsxAttributeValue(5, emptyComments),
+            emptyComments,
+            emptyComments,
+          ),
+          jsxPropertyAssignment(
+            'paddingLeft',
+            jsxAttributeValue(15, emptyComments),
+            emptyComments,
+            emptyComments,
+          ),
+          jsxPropertyAssignment(
+            'paddingLeft',
+            jsxAttributeValue(23, emptyComments),
+            emptyComments,
+            emptyComments,
+          ),
+        ],
+        emptyComments,
+      ),
+    })
+
+    const result = setJSXValueAtPath(
+      attributes,
+      PP.create(['style', 'paddingLeft']),
+      jsxAttributeValue(100, emptyComments),
+    )
+    if (isLeft(result)) {
+      fail(`result is LEFT`)
+    }
+
+    expect(result.value).toEqual(
+      jsxAttributesFromMap({
+        style: jsxAttributeNestedObject(
+          [
+            jsxPropertyAssignment(
+              'paddingLeft',
+              jsxAttributeValue(100, emptyComments),
+              emptyComments,
+              emptyComments,
+            ),
+            jsxPropertyAssignment(
+              'padding',
+              jsxAttributeValue(5, emptyComments),
+              emptyComments,
+              emptyComments,
+            ),
+          ],
+          emptyComments,
+        ),
+      }),
+    )
+  })
 })
 
 describe('jsxAttributesToProps', () => {

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -475,12 +475,16 @@ export function setJSXValueInAttributeAtPath(
           const key = `${attributeKey}`
           if (lastPartOfPath) {
             let updatedExistingProperty = false
-            let updatedContent = attribute.content.map((attr) => {
+            let updatedContent = attribute.content.flatMap((attr) => {
               if (attr.type === 'PROPERTY_ASSIGNMENT' && attr.key === key) {
-                updatedExistingProperty = true
-                return jsxPropertyAssignment(key, newAttrib, emptyComments, emptyComments)
+                if (updatedExistingProperty) {
+                  return []
+                } else {
+                  updatedExistingProperty = true
+                  return [jsxPropertyAssignment(key, newAttrib, emptyComments, emptyComments)]
+                }
               } else {
-                return attr
+                return [attr]
               }
             })
             if (updatedExistingProperty) {


### PR DESCRIPTION
**Problem:**
In ECMAScript 6 (even in strict mode!) the user is not forbidden from writing weird objects with duplicated properties, such as:
```
{
  paddingLeft: 5,
  padding: 10,
  paddingLeft: 15,
  paddingLeft: 100,
}
```
🙀

The way Chrome and Safari and Node.js resolves the value of this object is not immediately intuitive:
```
{
  paddingLeft: 100,
  padding: 10,
}
```
the value of the last property wins, but the property will be placed at the first position the browser encounters it in the object literal.

Without reading too much about the reasons, I think we can find an explanation in _our_ `jsxAttributesToProps` code:
```javascript
  let result: any = {}
  for (const entry of attributes) {
    result[entry.key] = jsxAttributeToValue(inScope, requireResult, entry.value)
  }
  return result
```
here you can see that as we iterate over the entries of an object, we create a property for `key` and then we assign a value to it. we then keep assigning newer values to it in case of duplicated property keys.

This entire edge case behavior is made very prominent by the fact that longhand and shorthand style properties shadow each other depending on property order: `{ paddingLeft: 100, padding: 10, }` and `{ padding: 10,  paddingLeft: 100, }` have different meanings....

**Commit Details:**
- We accidentally nailed the correct JS behavior here, so I added a test to make sure we don't change it in the future.
- Furthermore, updating a property using `setJSXValueAtPath`, we make sure that we only update the first time we encounter a property, and delete the duplicates.
- I've also added tests for this
