### PR TITLE
Use main base domain for vscode inner iframe

### DIFF
--- a/editor/src/templates/vscode-editor-outer-iframe.tsx
+++ b/editor/src/templates/vscode-editor-outer-iframe.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
-import { MONACO_EDITOR_IFRAME_BASE_URL } from '../common/env-vars'
+import { VSCODE_EDITOR_IFRAME_BASE_URL } from '../common/env-vars'
 import { createIframeUrl } from '../core/shared/utils'
 
 function VSCodeOuterIframe(): React.ReactElement {
   // TODO: Alternative root handling.
   const urlParams = new URLSearchParams(window.location.search)
   const projectID = urlParams.get('project_id')!
-  const baseIframeSrc = createIframeUrl(MONACO_EDITOR_IFRAME_BASE_URL, 'vscode-editor-inner-iframe')
+  const baseIframeSrc = createIframeUrl(VSCODE_EDITOR_IFRAME_BASE_URL, 'vscode-editor-inner-iframe')
   const url = new URL(baseIframeSrc)
   url.searchParams.append('project_id', projectID)
   return (

--- a/website/src/common/env-vars.ts
+++ b/website/src/common/env-vars.ts
@@ -43,6 +43,11 @@ export const MONACO_EDITOR_IFRAME_BASE_URL: string = PRODUCTION_CONFIG
   : STAGING_CONFIG
   ? 'https://utopia.baby/'
   : BASE_URL
+export const VSCODE_EDITOR_IFRAME_BASE_URL: string = PRODUCTION_CONFIG
+  ? `https://utopia.app/`
+  : STAGING_CONFIG
+  ? 'https://utopia.pizza/'
+  : BASE_URL
 export const UTOPIA_BACKEND = BASE_URL + 'v1/'
 export const UTOPIA_BACKEND_WS = BASE_WS + 'v1/'
 export const ASSET_ENDPOINT = UTOPIA_BACKEND + 'asset/'


### PR DESCRIPTION
We were accidentally using the secondary domains for the inner iframe when we were supposed to be using the primaries, so this change fixes that. This will be immediately merged, and is only being opened for posterity.