### PR TITLE
Fix/inspector layout section

### DIFF
--- a/editor/src/components/inspector/common/control-status.tsx
+++ b/editor/src/components/inspector/common/control-status.tsx
@@ -16,8 +16,8 @@ import {
 } from '../../../core/shared/jsx-attributes'
 import { isLeft, isRight, Either } from '../../../core/shared/either'
 import Utils from '../../../utils/utils'
-import { ParsedPropertiesKeys } from './css-utils'
-import { MultiselectAtProps, MultiselectAtStringProps } from './property-path-hooks'
+import { CSSNumber, ParsedPropertiesKeys } from './css-utils'
+import { InspectorInfo, MultiselectAtProps, MultiselectAtStringProps } from './property-path-hooks'
 import { fastForEach } from '../../../core/shared/utils'
 
 export interface ControlStyles {
@@ -638,4 +638,8 @@ export function calculateMultiStringPropertyStatusForSelection(
     fromCssStyleSheet,
     trivialDefault,
   }
+}
+
+export function isNotUnsetOrDefault(controlStatus: ControlStatus): boolean {
+  return controlStatus !== 'unset' && controlStatus !== 'trivial-default' && controlStatus !== 'off'
 }

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
@@ -1389,6 +1389,9 @@ describe('inspector tests with real metadata', () => {
       await screen.findByTestId('toggle-min-max-button')
       fireEvent.click(screen.getByTestId('toggle-min-max-button'))
       await screen.findByTestId('position-maxWidth-number-input')
+      await screen.findByTestId('layout-system-expand')
+      fireEvent.click(screen.getByTestId('layout-system-expand'))
+      await screen.findByTestId('flexPadding-L')
     })
 
     const metadata = renderResult.getEditorState().editor.jsxMetadataKILLME.elements[
@@ -1488,6 +1491,9 @@ describe('inspector tests with real metadata', () => {
       await screen.findByTestId('toggle-min-max-button')
       fireEvent.click(screen.getByTestId('toggle-min-max-button'))
       await screen.findByTestId('position-maxWidth-number-input')
+      await screen.findByTestId('layout-system-expand')
+      fireEvent.click(screen.getByTestId('layout-system-expand'))
+      await screen.findByTestId('flexPadding-L')
     })
 
     const metadata = renderResult.getEditorState().editor.jsxMetadataKILLME.elements[

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
@@ -49,7 +49,7 @@ export const LayoutSystemSubsection = betterReactMemo<LayoutSystemSubsectionProp
           {layoutSectionOpen && <DeleteAllLayoutSystemConfigButton />}
           <SquareButton highlight onClick={toggleSection}>
             <ExpandableIndicator
-              testId='target-selector'
+              testId='layout-system-expand'
               visible
               collapsed={!layoutSectionOpen}
               selected={false}

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
@@ -12,8 +12,13 @@ import {
   DetectedLayoutSystem,
   SpecialSizeMeasurements,
 } from '../../../../../core/shared/element-template'
-import { InspectorSubsectionHeader } from '../../../../../uuiui'
+import { InspectorSubsectionHeader, SquareButton } from '../../../../../uuiui'
 import { betterReactMemo } from '../../../../../uuiui-deps'
+import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
+import { createLayoutPropertyPath } from '../../../../../core/layout/layout-helpers-new'
+import { isNotUnsetOrDefault } from '../../../common/control-status'
+import { ExpandableIndicator } from '../../../../navigator/navigator-item/expandable-indicator'
+import { usePropControlledStateV2 } from '../../../common/inspector-utils'
 
 interface LayoutSystemSubsectionProps {
   specialSizeMeasurements: SpecialSizeMeasurements
@@ -22,32 +27,58 @@ interface LayoutSystemSubsectionProps {
 export const LayoutSystemSubsection = betterReactMemo<LayoutSystemSubsectionProps>(
   'LayoutSystemSubsection',
   (props) => {
-    const layoutSystem = props.specialSizeMeasurements.layoutSystemForChildren
+    const isFlexParent = props.specialSizeMeasurements.layoutSystemForChildren === 'flex'
+    const paddings = useInspectorInfoLonghandShorthand(
+      ['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft'],
+      'padding',
+      createLayoutPropertyPath,
+    )
+    const hasAnyLayoutProps =
+      isFlexParent || Object.values(paddings).some((i) => isNotUnsetOrDefault(i.controlStatus))
+    const [layoutSectionOpen, setLayoutSectionOpen] = usePropControlledStateV2(hasAnyLayoutProps)
+
+    const toggleSection = React.useCallback(() => setLayoutSectionOpen(!layoutSectionOpen), [
+      layoutSectionOpen,
+      setLayoutSectionOpen,
+    ])
+
     return (
       <>
         <InspectorSubsectionHeader>
           <span style={{ flexGrow: 1 }}>Layout System</span>
-          <DeleteAllLayoutSystemConfigButton />
+          {layoutSectionOpen && <DeleteAllLayoutSystemConfigButton />}
+          <SquareButton highlight onClick={toggleSection}>
+            <ExpandableIndicator
+              testId='target-selector'
+              visible
+              collapsed={!layoutSectionOpen}
+              selected={false}
+            />
+          </SquareButton>
         </InspectorSubsectionHeader>
-        <GridRow padded={true} type='<-------------1fr------------->'>
-          <LayoutSystemControl
-            layoutSystem={layoutSystem}
-            providesCoordinateSystemForChildren={
-              props.specialSizeMeasurements.providesBoundsForChildren
-            }
-          />
-        </GridRow>
-        {layoutSystem === 'flex' ? <FlexContainerControls seeMoreVisible={true} /> : null}
-        <GridRow tall padded={true} type='<---1fr--->|------172px-------|'>
-          <PropertyLabel
-            target={paddingPropsToUnset}
-            propNamesToUnset={['all paddings']}
-            style={{ paddingBottom: 12 }}
-          >
-            Padding
-          </PropertyLabel>
-          <FlexPaddingControl />
-        </GridRow>
+        {layoutSectionOpen ? (
+          <>
+            <GridRow padded={true} type='<-------------1fr------------->'>
+              <LayoutSystemControl
+                layoutSystem={props.specialSizeMeasurements.layoutSystemForChildren}
+                providesCoordinateSystemForChildren={
+                  props.specialSizeMeasurements.providesBoundsForChildren
+                }
+              />
+            </GridRow>
+            {isFlexParent ? <FlexContainerControls seeMoreVisible={true} /> : null}
+            <GridRow tall padded={true} type='<---1fr--->|------172px-------|'>
+              <PropertyLabel
+                target={paddingPropsToUnset}
+                propNamesToUnset={['all paddings']}
+                style={{ paddingBottom: 12 }}
+              >
+                Padding
+              </PropertyLabel>
+              <FlexPaddingControl />
+            </GridRow>
+          </>
+        ) : null}
       </>
     )
   },

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -43,6 +43,7 @@ import {
   InspectorInfoWithPropKeys,
   useInspectorInfoLonghandShorthand,
 } from '../../../common/longhand-shorthand-hooks'
+import { isNotUnsetOrDefault } from '../../../common/control-status'
 
 interface PinsLayoutNumberControlProps {
   label: string
@@ -569,14 +570,6 @@ interface GiganticSizePinsSubsectionProps {
   toggleAspectRatioLock: () => void
 }
 
-function isNotUnsetOrDefault(info: InspectorInfo<CSSNumber | undefined>): boolean {
-  return (
-    info.controlStatus !== 'unset' &&
-    info.controlStatus !== 'trivial-default' &&
-    info.controlStatus !== 'off'
-  )
-}
-
 export const GiganticSizePinsSubsection = betterReactMemo(
   'GiganticSizePinsSubsection',
   (props: GiganticSizePinsSubsectionProps) => {
@@ -589,10 +582,10 @@ export const GiganticSizePinsSubsection = betterReactMemo(
     const maxHeight = useInspectorLayoutInfo('maxHeight')
 
     const hasMinMaxValues =
-      isNotUnsetOrDefault(minWidth) ||
-      isNotUnsetOrDefault(maxWidth) ||
-      isNotUnsetOrDefault(minHeight) ||
-      isNotUnsetOrDefault(maxHeight)
+      isNotUnsetOrDefault(minWidth.controlStatus) ||
+      isNotUnsetOrDefault(maxWidth.controlStatus) ||
+      isNotUnsetOrDefault(minHeight.controlStatus) ||
+      isNotUnsetOrDefault(maxHeight.controlStatus)
     const [minMaxToggled, setMinMaxToggled] = React.useState<boolean>(hasMinMaxValues)
     const toggleMinMax = React.useCallback(() => {
       setMinMaxToggled(!minMaxToggled)


### PR DESCRIPTION
Changing the inspector layout section to keep the Layout Section hidden for elements without layout props. It can be toggled with an arrow next to the Layout Section text.

**Commit Details:**
- added button to toggle the layout subsection
- hide the delete button when there are no layout props
- updated the tests to open the hidden part
