### PR TITLE
fix: only update from code editor if the code file actually changed

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3485,6 +3485,12 @@ export const UPDATE_FNS = {
     dispatch: EditorDispatch,
   ): EditorModel => {
     const existing = getContentsTreeFileFromString(editor.projectContents, action.filePath)
+
+    if (isTextFile(existing) && existing.fileContents.code === action.fileContents) {
+      // the text part of the text file did not change, skip updating the editor
+      return editor
+    }
+
     let updatedFile: ProjectFile
 
     if (existing == null || !isTextFile(existing)) {


### PR DESCRIPTION
**Problem:**
After updating the model, a few moments later we would loose selection. 

Turns out the problem was `vscode-bridge.ts@watchForChanges` dispatches an `UPDATE_FROM_CODE_EDITOR` even if the update actually came _from_ the editor.

**Fix:**

Added a simple if to `UPDATE_FROM_CODE_EDITOR` to check if the action's code file matches the editorState's code file. in that case we don't need to update the editor state and we can just bail out.