### PR TITLE
Fix/prevent losing selected view

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -799,5 +799,6 @@ function findMatchingTemplatePath(
     const newChildren = newAllPaths.filter((p) => TP.isChildOf(p, parentPath))
     const potentialNewPath = newChildren[oldChildIndex]
     return potentialNewPath == null ? [] : [potentialNewPath]
-  } else return []
+  }
+  return []
 }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -792,12 +792,14 @@ function findMatchingTemplatePath(
   newComponents: JSXMetadata,
   pathToUpdate: TemplatePath,
 ): TemplatePath | null {
+  const scenePathStillExists =
+    MetadataUtils.findSceneByTemplatePath(newComponents.components, pathToUpdate) != null
   const pathStillExists =
     MetadataUtils.getElementByInstancePathMaybe(
       newComponents.elements,
       pathToUpdate as InstancePath,
     ) != null
-  if (pathStillExists) {
+  if (pathStillExists || scenePathStillExists) {
     return pathToUpdate
   }
 

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -82,6 +82,7 @@ import {
   decorationRange,
   DecorationRangeType,
 } from 'utopia-vscode-common'
+import { TemplatePathArrayKeepDeepEquality } from '../../../utils/deep-equality-instances'
 
 export interface DispatchResult extends EditorStore {
   nothingChanged: boolean
@@ -755,15 +756,24 @@ function removeNonExistingViewReferencesFromState(
   const oldAllPaths = MetadataUtils.getAllPaths(oldRootComponents)
   const rootComponents = editorState.jsxMetadataKILLME
   const allPaths = MetadataUtils.getAllPaths(rootComponents)
-  const updatedSelectedViews = editorState.selectedViews.flatMap((selectedView) =>
-    findMatchingTemplatePath(oldAllPaths, allPaths, selectedView),
-  )
-  const updatedHighlightedViews = editorState.highlightedViews.flatMap((highlightedView) =>
-    findMatchingTemplatePath(oldAllPaths, allPaths, highlightedView),
-  )
-  const updatedHiddenInstances = editorState.hiddenInstances.flatMap((hiddenInstance) =>
-    findMatchingTemplatePath(oldAllPaths, allPaths, hiddenInstance),
-  )
+  const updatedSelectedViews = TemplatePathArrayKeepDeepEquality(
+    editorState.selectedViews,
+    editorState.selectedViews.flatMap((selectedView) =>
+      findMatchingTemplatePath(oldAllPaths, allPaths, selectedView),
+    ),
+  ).value
+  const updatedHighlightedViews = TemplatePathArrayKeepDeepEquality(
+    editorState.highlightedViews,
+    editorState.highlightedViews.flatMap((highlightedView) =>
+      findMatchingTemplatePath(oldAllPaths, allPaths, highlightedView),
+    ),
+  ).value
+  const updatedHiddenInstances = TemplatePathArrayKeepDeepEquality(
+    editorState.hiddenInstances,
+    editorState.hiddenInstances.flatMap((hiddenInstance) =>
+      findMatchingTemplatePath(oldAllPaths, allPaths, hiddenInstance),
+    ),
+  ).value
   return {
     ...editorState,
     selectedViews: updatedSelectedViews,


### PR DESCRIPTION
**Problem:**
When the user edits the source code in the code editor, we'd lose the selections.

This started happening when we introduced hash-based (not printed to the code) UIDs. When the source code of a JSX Element changes, their hash changes, which means the uid will also change, which means their TemplatePath changes.
This would lead to selections (still pointing to the old TemplatePath) become invalid and deleted.

**Fix:**
We already had a mechanism to filter out nonexistent TemplatePaths from selections and highlights. I've changed that mechanism so that instead of filtering out the lists, I try to update the old TemplatePath to the new TemplatePath. This only works for changes where the parent element doesn't lose its TemplatePath. If the parent path can still be found in the source code, I try to find a template path at the same child index as the previous selection. So if you are editing the 2nd child of a View, the code will try to select the second child using the newly parsed uids instead of the old ones.

**Commit Details:**
- Added `findMatchingTemplatePath` that uses the childIndex of the old parent to try to find the edited element in the new parent
- it only works if the parentPath remains the same
- using `TemplatePathArrayKeepDeepEquality` to not change the selected views array if I don't have to (the performance regression tests caught me blowing the template paths, yay for tests)
- Instead of `stripNulls`, I use `flatMap` and a helper function that returns an optional result wrapped in an Array. I am also utilizing the new Typescript tuple types, so instead of `Array<TemplatePath>` (which can have any number of elements), I could type  it as `[] | [TemplatePath]` (so empty array or an array with a single element) which to me reads much better as an optional, and doesn't allow code which would return an array with multiple elements. I actually quite like this! 

**Note:**
I started out by looking at using the cursor position and highlight the edited code range, but unfortunately the highlight ranges use `uid`s and not template paths. For the full template paths we need the spy run at the end of the dispatch function. I didn't want to add temporary state to the dispatch function (something along the lines of "select this uid once the spy finishes") and I looked for an alternative solution instead.