### PR TITLE
fix(canvas) use cssparser to have parsed result of a prop while resizing/moving

### DIFF
--- a/editor/src/components/canvas/canvas-utils-unit-tests.spec.ts
+++ b/editor/src/components/canvas/canvas-utils-unit-tests.spec.ts
@@ -346,4 +346,136 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       ),
     )
   })
+  it('a simple TLWH pin change with values in string pixels', async () => {
+    const testProject = getTestParseSuccess(
+      makeTestProjectCodeWithSnippet(`
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '50px', top: '50px', width: '250px', height: '350px' }}
+        data-uid='bbb'
+      />
+    </View>
+    `),
+    )
+
+    const pinChange = singleResizeChange(
+      TP.instancePath(TestScenePath, ['aaa', 'bbb']),
+      { x: 1, y: 1 } as EdgePosition,
+      { x: 60, y: 40 } as CanvasVector,
+    )
+
+    const transformedComponents = updateFramesOfScenesAndComponents(
+      getComponentsFromTopLevelElements(testProject.topLevelElements),
+      createFakeMetadataForParseSuccess(testProject),
+      [pinChange],
+      canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+    )
+
+    const updatedProject: ParseSuccess = {
+      ...testProject,
+      topLevelElements: applyUtopiaJSXComponentsChanges(
+        testProject.topLevelElements,
+        transformedComponents,
+      ),
+    }
+
+    expect(testPrintCode(updatedProject)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '50px', top: '50px', width: 310, height: 390 }}
+          data-uid='bbb'
+        />
+      </View>`,
+      ),
+    )
+  })
+  it('a simple TLWH pin change with expression, the expression is not changed', async () => {
+    const testProject = getTestParseSuccess(
+      makeTestProjectCodeWithSnippet(`
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50, top: 50, width: 200 + 50, height: 300 }}
+        data-uid='bbb'
+      />
+    </View>
+    `),
+    )
+
+    const pinChange = singleResizeChange(
+      TP.instancePath(TestScenePath, ['aaa', 'bbb']),
+      { x: 1, y: 1 } as EdgePosition,
+      { x: 60, y: 40 } as CanvasVector,
+    )
+
+    const transformedComponents = updateFramesOfScenesAndComponents(
+      getComponentsFromTopLevelElements(testProject.topLevelElements),
+      createFakeMetadataForParseSuccess(testProject),
+      [pinChange],
+      canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+    )
+
+    const updatedProject: ParseSuccess = {
+      ...testProject,
+      topLevelElements: applyUtopiaJSXComponentsChanges(
+        testProject.topLevelElements,
+        transformedComponents,
+      ),
+    }
+
+    expect(testPrintCode(updatedProject)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50, top: 50, width: 200 + 50, height: 340 }}
+          data-uid='bbb'
+        />
+      </View>`,
+      ),
+    )
+  })
+  it('a simple TLWH pin change with values in exotic units', async () => {
+    const testProject = getTestParseSuccess(
+      makeTestProjectCodeWithSnippet(`
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '50pt', top: '5em', width: '50vw', height: '10cm' }}
+        data-uid='bbb'
+      />
+    </View>
+    `),
+    )
+
+    const pinChange = singleResizeChange(
+      TP.instancePath(TestScenePath, ['aaa', 'bbb']),
+      { x: 1, y: 1 } as EdgePosition,
+      { x: 60, y: 40 } as CanvasVector,
+    )
+
+    const transformedComponents = updateFramesOfScenesAndComponents(
+      getComponentsFromTopLevelElements(testProject.topLevelElements),
+      createFakeMetadataForParseSuccess(testProject),
+      [pinChange],
+      canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+    )
+
+    const updatedProject: ParseSuccess = {
+      ...testProject,
+      topLevelElements: applyUtopiaJSXComponentsChanges(
+        testProject.topLevelElements,
+        transformedComponents,
+      ),
+    }
+
+    expect(testPrintCode(updatedProject)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '50pt', top: '5em', width: '50vw', height: '10cm' }}
+          data-uid='bbb'
+        />
+      </View>`,
+      ),
+    )
+  })
 })

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -817,13 +817,17 @@ function updateFrameValueForProp(
         value: jsxAttributeValue(delta, emptyComments),
       }
     }
-    const parsedProp = parseCSSLengthPercent(existingProp)
-    if (isRight(parsedProp)) {
-      const pinIsPercentage = parsedProp.value.unit === '%'
-      const pinIsUnitlessOrPx = parsedProp.value.unit == null || parsedProp.value.unit === 'px'
+    const parsedProp = foldEither(
+      (_) => null,
+      (r) => r,
+      parseCSSLengthPercent(existingProp),
+    )
+    if (parsedProp != null) {
+      const pinIsPercentage = parsedProp.unit === '%'
+      const pinIsUnitlessOrPx = parsedProp.unit == null || parsedProp.unit === 'px'
       let valueToUse: string | number
       if (pinIsPercentage) {
-        const percentValue = parsedProp.value.value
+        const percentValue = parsedProp.value
         if (parentFrame != null) {
           const referenceSize = isHorizontalPoint(framePoint)
             ? parentFrame.width
@@ -840,7 +844,7 @@ function updateFrameValueForProp(
       } else if (pinIsUnitlessOrPx) {
         return {
           path: createLayoutPropertyPath(pinnedPropForFramePoint(framePoint)),
-          value: jsxAttributeValue(parsedProp.value.value + delta, emptyComments),
+          value: jsxAttributeValue(parsedProp.value + delta, emptyComments),
         }
       }
     }

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -825,8 +825,8 @@ function updateFrameValueForProp(
     if (parsedProp != null) {
       const pinIsPercentage = parsedProp.unit === '%'
       const pinIsUnitlessOrPx = parsedProp.unit == null || parsedProp.unit === 'px'
-      let valueToUse: string | number
       if (pinIsPercentage) {
+        let valueToUse: string | number
         const percentValue = parsedProp.value
         if (parentFrame != null) {
           const referenceSize = isHorizontalPoint(framePoint)


### PR DESCRIPTION
**Problem:**
The canvas breaks when resizing/moving an element with an expression or string value. It is possible that the target frameProp is a string like `5px`, where it just wanted to add the resize delta to the string. 

**Fix:**
The frame prop calculation uses the cssparser to have a correct parsed result of a prop. Only %, px, and unitless number is supported for now. Dragging with other units and expressions keeps the element in place.
