### PR TITLE
Fix/canvas element context menu

### DIFF
--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -87,7 +87,7 @@ function useCanvasContextMenuItems(
         details: {
           path: path,
         },
-        submenuName: 'Elements',
+        submenuName: 'Select Elements',
         enabled: true,
         action: () => dispatch([selectComponents([path], false)], 'canvas'),
         isHidden: ({ props }: { props: ContextMenuInnerProps }) => {
@@ -101,7 +101,7 @@ function useCanvasContextMenuItems(
         },
       }
     })
-    return [...ElementContextMenuItems, ...elementListSubmenu]
+    return [...elementListSubmenu, ...ElementContextMenuItems]
   } else {
     return ElementContextMenuItems
   }

--- a/editor/src/components/inspector/common/name-and-icon-hook.ts
+++ b/editor/src/components/inspector/common/name-and-icon-hook.ts
@@ -1,0 +1,171 @@
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import {
+  isAnimatedElementAgainstImports,
+  isEllipseAgainstImports,
+  isHTMLComponent,
+  isImg,
+  isRectangleAgainstImports,
+  isTextAgainstImports,
+  isViewAgainstImports,
+} from '../../../core/model/project-file-utils'
+import {
+  JSXElementName,
+  JSXMetadata,
+  UtopiaJSXComponent,
+} from '../../../core/shared/element-template'
+import * as TP from '../../../core/shared/template-path'
+import { Imports, TemplatePath } from '../../../core/shared/project-file-types'
+import {
+  getOpenImportsFromState,
+  getOpenUtopiaJSXComponentsFromState,
+} from '../../editor/store/editor-state'
+import { useEditorState } from '../../editor/store/store-hook'
+import { IcnProps } from '../../../uuiui'
+
+export interface NameAndIconResult {
+  path: TemplatePath
+  name: JSXElementName | null
+  label: string
+  iconProps: IcnProps
+}
+
+export function useNameAndIcon(path: TemplatePath): NameAndIconResult {
+  const metadata = useEditorState(
+    (store) => store.editor.jsxMetadataKILLME,
+    'useNameAndIcon metadata',
+  )
+  const components = useEditorState(
+    (store) => getOpenUtopiaJSXComponentsFromState(store.editor),
+    'useNameAndIcon components',
+  )
+  const imports = useEditorState(
+    (store) => getOpenImportsFromState(store.editor),
+    'useNameAndIcon imports',
+  )
+
+  return getNameAndIconResult(path, components, metadata, imports)
+}
+
+export function useNamesAndIconsAllPaths(): NameAndIconResult[] {
+  const metadata = useEditorState(
+    (store) => store.editor.jsxMetadataKILLME,
+    'useNamesAndIconsAllPaths metadata',
+  )
+  const components = useEditorState(
+    (store) => getOpenUtopiaJSXComponentsFromState(store.editor),
+    'useNamesAndIconsAllPaths components',
+  )
+  const imports = useEditorState(
+    (store) => getOpenImportsFromState(store.editor),
+    'useNamesAndIconsAllPaths imports',
+  )
+
+  return MetadataUtils.getAllPaths(metadata).map((path) =>
+    getNameAndIconResult(path, components, metadata, imports),
+  )
+}
+
+function getNameAndIconResult(
+  path: TemplatePath,
+  components: UtopiaJSXComponent[],
+  metadata: JSXMetadata,
+  imports: Imports,
+): NameAndIconResult {
+  const elementName = MetadataUtils.getJSXElementName(path, components, metadata.components)
+
+  return {
+    path: path,
+    name: elementName,
+    label: MetadataUtils.getElementLabel(path, metadata),
+    iconProps: createIconProps(path, metadata, components, imports, elementName),
+  }
+}
+
+function createIconProps(
+  path: TemplatePath,
+  metadata: JSXMetadata,
+  components: UtopiaJSXComponent[],
+  imports: Imports,
+  elementName: JSXElementName | null,
+): IcnProps {
+  const element = TP.isInstancePath(path)
+    ? MetadataUtils.getElementByInstancePathMaybe(metadata.elements, path)
+    : null
+  const isFlexLayoutedContainer = MetadataUtils.isFlexLayoutedContainer(element)
+  const flexDirection = MetadataUtils.getYogaDirection(element)
+  const flexWrap = MetadataUtils.getYogaWrap(element)
+  const componentInstance = MetadataUtils.isComponentInstance(path, components, metadata, imports)
+  const isAutosizingView = MetadataUtils.isAutoSizingView(element)
+
+  return {
+    category: 'element',
+    type: getIconTypeForElement(
+      imports,
+      elementName,
+      isFlexLayoutedContainer,
+      flexDirection,
+      flexWrap,
+      'open',
+      componentInstance,
+      isAutosizingView,
+    ),
+    width: 18,
+    height: 18,
+  }
+}
+
+export function getIconTypeForElement(
+  imports: Imports,
+  elementName: JSXElementName | null,
+  isFlexLayoutedContainer: boolean,
+  originalFlexDirection: 'row' | 'row-reverse' | 'column' | 'column-reverse',
+  flexWrap: 'wrap' | 'wrap-reverse' | 'nowrap',
+  openStatus: 'closed' | 'open',
+  componentInstance: boolean,
+  isGroup: boolean,
+): string {
+  let role: string = 'default'
+  const flexDirection: 'column' | 'row' =
+    originalFlexDirection === 'column' || originalFlexDirection === 'column-reverse'
+      ? 'column'
+      : 'row'
+  const flexWrapped: boolean = flexWrap === 'wrap' || flexWrap === 'wrap-reverse'
+
+  if (elementName == null) {
+    role = 'scene'
+  } else {
+    if (isViewAgainstImports(elementName, imports)) {
+      if (isGroup) {
+        role = 'group'
+      } else {
+        role = 'view'
+      }
+    } else if (isEllipseAgainstImports(elementName, imports)) {
+      role = 'ellipse'
+    } else if (isRectangleAgainstImports(elementName, imports)) {
+      role = 'rectangle'
+    } else if (isImg(elementName)) {
+      role = 'image'
+    } else if (isTextAgainstImports(elementName, imports)) {
+      role = 'text'
+    } else if (isAnimatedElementAgainstImports(elementName, imports)) {
+      role = 'animated'
+    } else if (componentInstance) {
+      role = 'componentinstance'
+    } else if (isHTMLComponent(elementName, imports)) {
+      role = 'div'
+    }
+  }
+
+  let specifierPath: string
+  if (isFlexLayoutedContainer && role === 'view') {
+    specifierPath = `-flex-${flexWrapped ? 'wrap' : 'nowrap'}-${flexDirection}`
+  } else {
+    if (role === 'group') {
+      specifierPath = `-${openStatus}`
+    } else {
+      specifierPath = ''
+    }
+  }
+  return `${role}${specifierPath}`
+}

--- a/editor/src/components/navigator/navigator-item/item-preview.tsx
+++ b/editor/src/components/navigator/navigator-item/item-preview.tsx
@@ -1,16 +1,8 @@
 import * as React from 'react'
 import { JSXElementName } from '../../../core/shared/element-template'
-import {
-  isHTMLComponent,
-  isViewAgainstImports,
-  isEllipseAgainstImports,
-  isRectangleAgainstImports,
-  isImg,
-  isTextAgainstImports,
-  isAnimatedElementAgainstImports,
-} from '../../../core/model/project-file-utils'
 import { Imports, TemplatePath } from '../../../core/shared/project-file-types'
 import { IcnProps, Icn } from '../../../uuiui'
+import { getIconTypeForElement } from '../../inspector/common/name-and-icon-hook'
 
 interface ItemPreviewProps {
   isAutosizingView: boolean
@@ -26,9 +18,15 @@ interface ItemPreviewProps {
   imports: Imports
 }
 
-export const ItemPreview: React.StatelessComponent<ItemPreviewProps> = (props) => {
-  const isGroup = props.isAutosizingView
-  const { isFlexLayoutedContainer, yogaDirection, yogaWrap, staticElementName, imports } = props
+export const ItemPreview: React.FunctionComponent<ItemPreviewProps> = (props) => {
+  const {
+    isAutosizingView,
+    isFlexLayoutedContainer,
+    yogaDirection,
+    yogaWrap,
+    staticElementName,
+    imports,
+  } = props
 
   // preview depends on three things:
   // 1 - role
@@ -38,66 +36,23 @@ export const ItemPreview: React.StatelessComponent<ItemPreviewProps> = (props) =
   // 5 if it's generated or not
 
   // state
-  const openStatus: string = props.collapsed ? 'closed' : 'open'
+  const openStatus: 'closed' | 'open' = props.collapsed ? 'closed' : 'open'
 
-  // role
-  let role: string = 'default'
-  const originalFlexDirection = yogaDirection
-  const flexDirection: 'column' | 'row' =
-    originalFlexDirection === 'column' || originalFlexDirection === 'column-reverse'
-      ? 'column'
-      : 'row'
-  const flexWrap = yogaWrap
-  const flexWrapped: boolean = flexWrap === 'wrap' || flexWrap === 'wrap-reverse'
-
-  if (staticElementName == null) {
-    role = 'scene'
-  } else {
-    if (isViewAgainstImports(staticElementName, imports)) {
-      if (isGroup) {
-        role = 'group'
-      } else {
-        role = 'view'
-      }
-    } else if (isEllipseAgainstImports(staticElementName, imports)) {
-      role = 'ellipse'
-    } else if (isRectangleAgainstImports(staticElementName, imports)) {
-      role = 'rectangle'
-    } else if (isImg(staticElementName)) {
-      role = 'image'
-    } else if (isTextAgainstImports(staticElementName, imports)) {
-      role = 'text'
-    } else if (isAnimatedElementAgainstImports(staticElementName, imports)) {
-      role = 'animated'
-    } else if (props.componentInstance) {
-      role = 'componentinstance'
-    } else if (isHTMLComponent(staticElementName, imports)) {
-      role = 'div'
-    }
-  }
-
-  let specifierPath: string
-  if (isFlexLayoutedContainer && role === 'view') {
-    specifierPath = `-flex-${flexWrapped ? 'wrap' : 'nowrap'}-${flexDirection}`
-  } else {
-    if (role === 'group') {
-      specifierPath = `-${openStatus}`
-    } else {
-      specifierPath = ''
-    }
-  }
-
+  const type = getIconTypeForElement(
+    imports,
+    staticElementName,
+    isFlexLayoutedContainer,
+    yogaDirection,
+    yogaWrap,
+    openStatus,
+    props.componentInstance,
+    isAutosizingView,
+  )
   const color = props.color
 
   return (
     <div className='w20 h20 flex justify-center items-center relative'>
-      <Icn
-        category='element'
-        type={`${role}${specifierPath}`}
-        color={color}
-        width={18}
-        height={18}
-      />
+      <Icn category='element' type={type} color={color} width={18} height={18} />
     </div>
   )
 }


### PR DESCRIPTION
This PR adds more functionality to the contextmenu submenu that lists the elements under cursor.
- moved the submenu to the top of the context menu
- rename submenu to 'Select element'
- mouseover highlights for elements
- icons

Changes:
- New hook to get element label, type and icon
- inner parts from the navigator item-preview moved to a common function to get the icon type
- in a future PR TODO is cleaning up navigator props, because it could use this nice new hook