### PR TITLE
VS Code message triggered to get data on startup.

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -792,6 +792,10 @@ export interface SelectFromFileAndPosition {
   column: number
 }
 
+export interface SendCodeEditorInitialisation {
+  action: 'SEND_CODE_EDITOR_INITIALISATION'
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -923,6 +927,7 @@ export type EditorAction =
   | UpdateChildText
   | MarkVSCodeBridgeReady
   | SelectFromFileAndPosition
+  | SendCodeEditorInitialisation
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -180,6 +180,7 @@ import type {
   UpdateFromCodeEditor,
   MarkVSCodeBridgeReady,
   SelectFromFileAndPosition,
+  SendCodeEditorInitialisation,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -1245,5 +1246,11 @@ export function selectFromFileAndPosition(
     filePath: filePath,
     line: line,
     column: column,
+  }
+}
+
+export function sendCodeEditorInitialisation(): SendCodeEditorInitialisation {
+  return {
+    action: 'SEND_CODE_EDITOR_INITIALISATION',
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -82,6 +82,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SEND_LINTER_REQUEST_MESSAGE':
     case 'MARK_VSCODE_BRIDGE_READY':
     case 'SELECT_FROM_FILE_AND_POSITION':
+    case 'SEND_CODE_EDITOR_INITIALISATION':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -359,6 +359,7 @@ import {
   UpdateFromCodeEditor,
   MarkVSCodeBridgeReady,
   SelectFromFileAndPosition,
+  SendCodeEditorInitialisation,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -498,7 +499,12 @@ import { EditorTab, isOpenFileTab, openFileTab } from '../store/editor-tabs'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
 import { getAllTargetsAtPoint } from '../../canvas/dom-lookup'
 import { WindowMousePositionRaw } from '../../../templates/editor-canvas'
-import { initVSCodeBridge, sendOpenFileMessage } from '../../../core/vscode/vscode-bridge'
+import {
+  initVSCodeBridge,
+  sendCodeEditorDecorations,
+  sendOpenFileMessage,
+  sendSelectedElement,
+} from '../../../core/vscode/vscode-bridge'
 
 function applyUpdateToJSXElement(
   element: JSXElement,
@@ -4291,6 +4297,15 @@ export const UPDATE_FNS = {
     } else {
       return editor
     }
+  },
+  SEND_CODE_EDITOR_INITIALISATION: (
+    action: SendCodeEditorInitialisation,
+    editor: EditorModel,
+  ): EditorModel => {
+    // Side effects.
+    sendCodeEditorDecorations(editor)
+    sendSelectedElement(editor)
+    return editor
   },
 }
 

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -165,6 +165,9 @@ export async function initVSCodeBridge(
               'everyone',
             )
             break
+          default:
+            const _exhaustiveCheck: never = message
+            throw new Error(`Unhandled message type${JSON.stringify(message)}`)
         }
       })
       watchForChanges(dispatch)

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -12,6 +12,7 @@ import {
   selectFromFileAndPosition,
   markVSCodeBridgeReady,
   updateFromCodeEditor,
+  sendCodeEditorInitialisation,
 } from '../../components/editor/actions/action-creators'
 import { isDirectory } from '../model/project-file-utils'
 import {
@@ -37,9 +38,17 @@ import {
   selectedElementChanged,
   parseFromVSCodeMessage,
   FSUser,
+  decorationRange,
+  DecorationRangeType,
+  boundsInFile,
 } from 'utopia-vscode-common'
-import { isTextFile, ProjectFile, TextFile } from '../shared/project-file-types'
+import { isTextFile, ProjectFile, TemplatePath, TextFile } from '../shared/project-file-types'
 import { isBrowserEnvironment } from '../shared/utils'
+import {
+  EditorState,
+  getHighlightBoundsForTemplatePath,
+  getOpenTextFileKey,
+} from '../../components/editor/store/editor-state'
 
 const Scheme = 'utopia'
 const RootDir = `/${Scheme}`
@@ -146,10 +155,17 @@ export async function initVSCodeBridge(
       await clearBothMailboxes()
       await writeProjectContents(projectID, projectContents)
       await initMailbox(UtopiaInbox, parseFromVSCodeMessage, (message: FromVSCodeMessage) => {
-        dispatch(
-          [selectFromFileAndPosition(message.filePath, message.line, message.column)],
-          'everyone',
-        )
+        switch (message.type) {
+          case 'SEND_INITIAL_DATA':
+            dispatch([sendCodeEditorInitialisation()], 'everyone')
+            break
+          case 'EDITOR_CURSOR_POSITION_CHANGED':
+            dispatch(
+              [selectFromFileAndPosition(message.filePath, message.line, message.column)],
+              'everyone',
+            )
+            break
+        }
       })
       watchForChanges(dispatch)
     }
@@ -170,8 +186,10 @@ export async function sendUpdateDecorationsMessage(
   return sendMessage(updateDecorationsMessage(decorations))
 }
 
-export async function sendSelectedElementChangedMessage(boundsInFile: BoundsInFile): Promise<void> {
-  return sendMessage(selectedElementChanged(boundsInFile))
+export async function sendSelectedElementChangedMessage(
+  boundsForFile: BoundsInFile,
+): Promise<void> {
+  return sendMessage(selectedElementChanged(boundsForFile))
 }
 
 export async function applyProjectContentChanges(
@@ -260,5 +278,53 @@ export async function applyProjectContentChanges(
   }
   if (isBrowserEnvironment) {
     await zipContentsTreeAsync(oldContents, newContents, onElement)
+  }
+}
+
+export async function sendCodeEditorDecorations(editorState: EditorState): Promise<void> {
+  let decorations: Array<DecorationRange> = []
+  function addRange(filename: string, rangeType: DecorationRangeType, path: TemplatePath): void {
+    const highlightBounds = getHighlightBoundsForTemplatePath(path, editorState)
+    if (highlightBounds != null) {
+      decorations.push(
+        decorationRange(
+          rangeType,
+          filename,
+          highlightBounds.startLine,
+          highlightBounds.startCol,
+          highlightBounds.endLine,
+          highlightBounds.endCol,
+        ),
+      )
+    }
+  }
+  const openFilename = getOpenTextFileKey(editorState)
+  if (openFilename != null) {
+    editorState.selectedViews.forEach((selectedView) => {
+      addRange(openFilename, 'selection', selectedView)
+    })
+    editorState.highlightedViews.forEach((highlightedView) => {
+      addRange(openFilename, 'highlight', highlightedView)
+    })
+  }
+  await sendUpdateDecorationsMessage(decorations)
+}
+
+export async function sendSelectedElement(newEditorState: EditorState): Promise<void> {
+  const openFilename = getOpenTextFileKey(newEditorState)
+  if (openFilename != null) {
+    const selectedView = newEditorState.selectedViews[0]
+    const highlightBounds = getHighlightBoundsForTemplatePath(selectedView, newEditorState)
+    if (highlightBounds != null) {
+      await sendSelectedElementChangedMessage(
+        boundsInFile(
+          openFilename,
+          highlightBounds.startLine,
+          highlightBounds.startCol,
+          highlightBounds.endLine,
+          highlightBounds.endCol,
+        ),
+      )
+    }
   }
 }

--- a/utopia-vscode-common/src/messages.ts
+++ b/utopia-vscode-common/src/messages.ts
@@ -137,13 +137,31 @@ export function editorCursorPositionChanged(filePath: string, line: number, colu
   }
 }
 
-export type FromVSCodeMessage = EditorCursorPositionChanged
+export interface SendInitialData {
+  type: 'SEND_INITIAL_DATA'
+}
+
+export function sendInitialData(): SendInitialData {
+  return {
+    type: 'SEND_INITIAL_DATA'
+  }
+}
+
+export type FromVSCodeMessage = EditorCursorPositionChanged | SendInitialData
 
 export function isEditorCursorPositionChanged(message: unknown): message is EditorCursorPositionChanged {
   return (
     typeof message === 'object' &&
     !Array.isArray(message) &&
     (message as any).type === 'EDITOR_CURSOR_POSITION_CHANGED'
+  )
+}
+
+export function isSendInitialData(message: unknown): message is SendInitialData {
+  return (
+    typeof message === 'object' &&
+    !Array.isArray(message) &&
+    (message as any).type === 'SEND_INITIAL_DATA'
   )
 }
 

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -20,6 +20,7 @@ import {
   exists,
   writeFileUnsavedContentAsUTF8,
   clearFileUnsavedContent,
+  sendInitialData,
 } from 'utopia-vscode-common'
 import { UtopiaFSExtension } from './utopia-fs'
 import { fromUtopiaURI } from './path-utils'
@@ -35,6 +36,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   watchForUnsavedContentChangesFromFS(utopiaFS)
   watchForChangesFromVSCode(context, projectID)
+
+  sendMessage(sendInitialData())
 }
 
 async function initFS(projectID: string): Promise<void> {


### PR DESCRIPTION
**Problem:**
At load or reload, VS Code doesn't get sent the current state of things (for selection and the like), but is instead only sent that information on changes.

**Fix:**
Have the VS Code extension trigger a message which causes the main part of Utopia to send the current state of affairs back to the extension.

**Commit Details:**
- Added `SEND_CODE_EDITOR_INITIALISATION` action, which sends
  a messages to VS Code for the decorations and range that should
  be revealed.
- Refactored out `sendCodeEditorDecorations` and `sendSelectedElement`
  from `dispatch.tsx` so they can be used elsewhere.
- VS Code requests the initialisation data with the `SendInitialData`
  message.
