### PR TITLE
Reduce the number of React errors that end up in the console.

### DIFF
--- a/editor/src/components/canvas/controls/multiselect-resize-control.tsx
+++ b/editor/src/components/canvas/controls/multiselect-resize-control.tsx
@@ -182,6 +182,7 @@ export class MultiselectResizeControl extends React.Component<
           <>
             <SingleSelectResizeControls
               {...this.props}
+              key={'single-select-resize-controls'}
               obtainOriginalFrames={this.obtainOriginalFrames}
               onResizeStart={this.onResizeStart}
             />
@@ -201,36 +202,35 @@ export class SingleSelectResizeControls extends React.Component<SingleselectResi
   render() {
     return this.props.selectedViews.map((view, index) => {
       const frame = MetadataUtils.getFrameInCanvasCoords(view, this.props.componentMetadata)
-      if (frame != null) {
-        return (
-          <>
-            <ResizeRectangle
-              dispatch={this.props.dispatch}
-              scale={this.props.scale}
-              canvasOffset={this.props.canvasOffset}
-              measureSize={frame}
-              visualSize={frame}
-              resizeStatus={this.props.resizeStatus}
-              selectedViews={[view]}
-              elementAspectRatioLocked={this.props.elementAspectRatioLocked}
-              imageMultiplier={this.props.imageMultiplier}
-              sideResizer={false}
-              dragState={
-                this.props.dragState != null && this.props.dragState.type === 'RESIZE_DRAG_STATE'
-                  ? this.props.dragState
-                  : null
-              }
-              windowToCanvasPosition={this.props.windowToCanvasPosition}
-              getOriginalFrames={this.props.obtainOriginalFrames}
-              metadata={this.props.componentMetadata}
-              onResizeStart={this.props.onResizeStart}
-              testID={`component-resize-control-${TP.toComponentId(view)}-${index}`}
-              maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
-            />
-          </>
-        )
+      if (frame == null) {
+        return null
       } else {
-        return <></>
+        return (
+          <ResizeRectangle
+            key={`single-select-resize-controls-rect-${index}`}
+            dispatch={this.props.dispatch}
+            scale={this.props.scale}
+            canvasOffset={this.props.canvasOffset}
+            measureSize={frame}
+            visualSize={frame}
+            resizeStatus={this.props.resizeStatus}
+            selectedViews={[view]}
+            elementAspectRatioLocked={this.props.elementAspectRatioLocked}
+            imageMultiplier={this.props.imageMultiplier}
+            sideResizer={false}
+            dragState={
+              this.props.dragState != null && this.props.dragState.type === 'RESIZE_DRAG_STATE'
+                ? this.props.dragState
+                : null
+            }
+            windowToCanvasPosition={this.props.windowToCanvasPosition}
+            getOriginalFrames={this.props.obtainOriginalFrames}
+            metadata={this.props.componentMetadata}
+            onResizeStart={this.props.onResizeStart}
+            testID={`component-resize-control-${TP.toComponentId(view)}-${index}`}
+            maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
+          />
+        )
       }
     })
   }

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -416,6 +416,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
           <React.Fragment>
             <ResizeControl
               {...controlProps}
+              key={'resize-control-v-0.5-0.0'}
               cursor={CSSCursor.ResizeNS}
               position={{ x: 0.5, y: 0 }}
               enabledDirection={DirectionVertical}
@@ -431,6 +432,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
             </ResizeControl>
             <ResizeControl
               {...controlProps}
+              key={'resize-control-v-0.5-1.0'}
               cursor={CSSCursor.ResizeNS}
               position={{ x: 0.5, y: 1 }}
               enabledDirection={DirectionVertical}
@@ -452,6 +454,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
           <React.Fragment>
             <ResizeControl
               {...controlProps}
+              key={'resize-control-h-0.0-0.5'}
               cursor={CSSCursor.ResizeEW}
               position={{ x: 0, y: 0.5 }}
               enabledDirection={DirectionHorizontal}
@@ -467,6 +470,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
             </ResizeControl>
             <ResizeControl
               {...controlProps}
+              key={'resize-control-h-1.0-0.5'}
               cursor={CSSCursor.ResizeEW}
               position={{ x: 1, y: 0.5 }}
               enabledDirection={DirectionHorizontal}
@@ -493,6 +497,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
         <React.Fragment>
           <ResizeControl
             {...controlProps}
+            key={'resize-control-v-0.5-0.0'}
             cursor={CSSCursor.ResizeNS}
             position={{ x: 0.5, y: 0 }}
             enabledDirection={DirectionVertical}
@@ -506,6 +511,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
           </ResizeControl>
           <ResizeControl
             {...controlProps}
+            key={'resize-control-v-0.5-1.0'}
             cursor={CSSCursor.ResizeNS}
             position={{ x: 0.5, y: 1 }}
             enabledDirection={DirectionVertical}
@@ -519,6 +525,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
           </ResizeControl>
           <ResizeControl
             {...controlProps}
+            key={'resize-control-h-0.0-0.5'}
             cursor={CSSCursor.ResizeEW}
             position={{ x: 0, y: 0.5 }}
             enabledDirection={DirectionHorizontal}
@@ -532,6 +539,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
           </ResizeControl>
           <ResizeControl
             {...controlProps}
+            key={'resize-control-h-1.0-0.5'}
             cursor={CSSCursor.ResizeEW}
             position={{ x: 1, y: 0.5 }}
             enabledDirection={DirectionHorizontal}
@@ -545,6 +553,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
           </ResizeControl>
           <ResizeControl
             {...controlProps}
+            key={'resize-control-a-0.0-0.0'}
             cursor={CSSCursor.ResizeNWSE}
             position={{ x: 0, y: 0 }}
             enabledDirection={DirectionAll}
@@ -557,6 +566,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
           </ResizeControl>
           <ResizeControl
             {...controlProps}
+            key={'resize-control-a-1.0-0.0'}
             cursor={CSSCursor.ResizeNESW}
             position={{ x: 1, y: 0 }}
             enabledDirection={DirectionAll}
@@ -569,6 +579,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
           </ResizeControl>
           <ResizeControl
             {...controlProps}
+            key={'resize-control-a-0.0-1.0'}
             cursor={CSSCursor.ResizeNESW}
             position={{ x: 0, y: 1 }}
             enabledDirection={DirectionAll}
@@ -581,6 +592,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
           </ResizeControl>
           <ResizeControl
             {...controlProps}
+            key={'resize-control-a-1.0-1.0'}
             cursor={CSSCursor.ResizeNWSE}
             position={{ x: 1, y: 1 }}
             enabledDirection={DirectionAll}
@@ -598,6 +610,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
         <React.Fragment>
           <ResizeControl
             {...controlProps}
+            key={'resize-control-v-0.5-0.0'}
             cursor={CSSCursor.ResizeNS}
             position={{ x: 0.5, y: 0 }}
             enabledDirection={DirectionVertical}
@@ -611,6 +624,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
           </ResizeControl>
           <ResizeControl
             {...controlProps}
+            key={'resize-control-v-0.5-1.0'}
             cursor={CSSCursor.ResizeNS}
             position={{ x: 0.5, y: 1 }}
             enabledDirection={DirectionVertical}
@@ -624,6 +638,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
           </ResizeControl>
           <ResizeControl
             {...controlProps}
+            key={'resize-control-h-0.0-0.5'}
             cursor={CSSCursor.ResizeEW}
             position={{ x: 0, y: 0.5 }}
             enabledDirection={DirectionHorizontal}
@@ -637,6 +652,7 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
           </ResizeControl>
           <ResizeControl
             {...controlProps}
+            key={'resize-control-h-1.0-0.5'}
             cursor={CSSCursor.ResizeEW}
             position={{ x: 1, y: 0.5 }}
             enabledDirection={DirectionHorizontal}

--- a/editor/src/components/inspector/controls/select-control.tsx
+++ b/editor/src/components/inspector/controls/select-control.tsx
@@ -67,13 +67,22 @@ export const CustomReactSelectInput = (props: InputProps) => {
       color: 'inherit',
     }
   }, [props.isHidden])
+
+  let strippedProps: any = { ...props }
+  delete strippedProps['getStyles']
+  delete strippedProps['innerRef']
+  delete strippedProps['isHidden']
+  delete strippedProps['isDisabled']
+  delete strippedProps['cx']
+  delete strippedProps['selectProps']
+
   return (
     <div>
       <input
         className={props.className}
         style={inputStyle}
         disabled={props.isDisabled}
-        {...props}
+        {...strippedProps}
       />
     </div>
   )

--- a/editor/src/components/inspector/sections/header-section/target-selector.tsx
+++ b/editor/src/components/inspector/sections/header-section/target-selector.tsx
@@ -413,7 +413,7 @@ const TargetListHeader = betterReactMemo('TargetListHeader', (props: TargetListH
       }}
     >
       <H1
-        data-testId={`target-selector-${selectedItem[0]}`}
+        data-testid={`target-selector-${selectedItem[0]}`}
         style={{ flexGrow: 1, display: 'inline', overflow: 'hidden', ...titleStyle }}
       >
         {selectedItem}

--- a/editor/src/uuiui/widgets/popup-list/popup-list.tsx
+++ b/editor/src/uuiui/widgets/popup-list/popup-list.tsx
@@ -479,13 +479,22 @@ const Input = (props: InputProps) => {
       color: 'inherit',
     }
   }, [props.isHidden])
+
+  let strippedProps: any = { ...props }
+  delete strippedProps['getStyles']
+  delete strippedProps['innerRef']
+  delete strippedProps['isHidden']
+  delete strippedProps['isDisabled']
+  delete strippedProps['cx']
+  delete strippedProps['selectProps']
+
   return (
     <div>
       <input
         className={props.className}
         style={inputStyle}
         disabled={props.isDisabled}
-        {...props}
+        {...strippedProps}
       />
     </div>
   )


### PR DESCRIPTION
**Problem:**
The console gets a few React warnings which can obscure more pressing issues.

**Fix:**
Primarily the fixes are:
- Adding `key` attributes for components ending up in a list.
- Removing properties from some props passed down into a regular HTML element.

**Commit Details:**
- Added some `key` fields to some components.
- Refactored `SingleSelectResizeControls` to remove some fragments.
- Stripped some properties from `CustomReactSelectInput` and the popup list
  `Input` component when passed to an `input` element as they are
  not regular HTML attributes.