### PR TITLE
Fix to selection retention logic

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -776,7 +776,11 @@ function findMatchingTemplatePath(
 
   const parentPath = TP.parentPath(pathToUpdate)
   if (parentPath == null) {
-    return null
+    const oldRootPaths = MetadataUtils.getAllCanvasRootPaths(oldComponents)
+    const newRootPaths = MetadataUtils.getAllCanvasRootPaths(oldComponents)
+    const oldRootIndex = oldRootPaths.findIndex((p) => TP.pathsEqual(p, pathToUpdate))
+    const newRootPath = newRootPaths[oldRootIndex]
+    return newRootPath ?? null
   } else {
     const oldElementsHere = MetadataUtils.getImmediateChildren(oldComponents, parentPath)
     const newElementsHere = MetadataUtils.getImmediateChildren(newComponents, parentPath)

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -770,24 +770,20 @@ function findMatchingTemplatePath(
       newComponents.elements,
       pathToUpdate as InstancePath,
     ) != null
-  if (pathStillExists || scenePathStillExists) {
+  if (pathStillExists || (TP.isScenePath(pathToUpdate) && scenePathStillExists)) {
     return pathToUpdate
   }
 
   const parentPath = TP.parentPath(pathToUpdate)
-  const oldParent = MetadataUtils.getElementByInstancePathMaybe(
-    oldComponents.elements,
-    parentPath as InstancePath,
-  )
-  const newParent = MetadataUtils.getElementByInstancePathMaybe(
-    newComponents.elements,
-    parentPath as InstancePath,
-  )
-  if (oldParent != null && newParent != null) {
-    const oldChildIndex = oldParent.children.findIndex((p) => TP.pathsEqual(p, pathToUpdate))
-    const potentialNewPath = newParent.children[oldChildIndex]
-    return potentialNewPath ?? null
+  if (parentPath == null) {
+    return null
+  } else {
+    const oldElementsHere = MetadataUtils.getImmediateChildren(oldComponents, parentPath)
+    const newElementsHere = MetadataUtils.getImmediateChildren(newComponents, parentPath)
+    const oldChildIndex = oldElementsHere.findIndex((e) =>
+      TP.pathsEqual(e.templatePath, pathToUpdate),
+    )
+    const potentialNewElement = newElementsHere[oldChildIndex]
+    return potentialNewElement?.templatePath ?? null
   }
-
-  return null
 }


### PR DESCRIPTION
Fixes #940 and fixes a `forceNotNull` bug in the Inspector

**Problem:**
When making a code change we were trying to keep the selected template path, but the path we were keeping was now non-existent. The logic also failed for root elements of scenes.

**Fix:**
Fix the check that would return the original path, and use existing functions to get all children of the existing parent so that we also handle root elements.