### PR TITLE
Feature/scene paths array

### DIFF
--- a/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
@@ -48,8 +48,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -57,8 +59,10 @@ Object {
       ],
       "scenePath": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -169,8 +173,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -257,8 +263,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -270,8 +278,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -283,8 +293,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -385,8 +397,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -466,8 +480,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -547,8 +563,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -628,8 +646,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -687,8 +707,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -696,8 +718,10 @@ Object {
       ],
       "scenePath": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -808,8 +832,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -985,8 +1011,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -1044,8 +1072,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -1053,8 +1083,10 @@ Object {
       ],
       "scenePath": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -1165,8 +1197,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -1253,8 +1287,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -1356,8 +1392,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -1374,8 +1412,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -1474,8 +1514,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -1582,8 +1624,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -1641,8 +1685,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -1650,8 +1696,10 @@ Object {
       ],
       "scenePath": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -1762,8 +1810,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -1850,8 +1900,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -1954,8 +2006,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -1972,8 +2026,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -2072,8 +2128,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -2180,8 +2238,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -2239,8 +2299,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -2248,8 +2310,10 @@ Object {
       ],
       "scenePath": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -2360,8 +2424,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -2448,8 +2514,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -2551,8 +2619,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -2569,8 +2639,10 @@ Object {
           ],
           "scene": Object {
             "sceneElementPaths": Array [
-              "utopia-storyboard-uid",
-              "scene-aaa",
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
             ],
             "type": "scenepath",
           },
@@ -2673,8 +2745,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -2781,8 +2855,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },

--- a/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
@@ -13,13 +13,13 @@ Object {
             "utopia-storyboard-uid",
           ],
           "scene": Object {
-            "sceneElementPath": Array [],
+            "sceneElementPaths": Array [],
             "type": "scenepath",
           },
         },
       ],
       "scenePath": Object {
-        "sceneElementPath": Array [],
+        "sceneElementPaths": Array [],
         "type": "scenepath",
       },
       "sceneResizesContent": false,
@@ -27,7 +27,7 @@ Object {
       "templatePath": Object {
         "element": Array [],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -47,7 +47,7 @@ Object {
             "aaa",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -56,7 +56,7 @@ Object {
         },
       ],
       "scenePath": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -76,7 +76,7 @@ Object {
           "scene-aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -92,7 +92,7 @@ Object {
             "scene-aaa",
           ],
           "scene": Object {
-            "sceneElementPath": Array [],
+            "sceneElementPaths": Array [],
             "type": "scenepath",
           },
         },
@@ -155,7 +155,7 @@ Object {
           "utopia-storyboard-uid",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -168,7 +168,7 @@ Object {
             "aaa",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -242,7 +242,7 @@ Object {
           "scene-aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -256,7 +256,7 @@ Object {
             "bbb~~~1",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -269,7 +269,7 @@ Object {
             "bbb~~~2",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -282,7 +282,7 @@ Object {
             "bbb~~~3",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -384,7 +384,7 @@ Object {
           "aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -465,7 +465,7 @@ Object {
           "bbb~~~1",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -546,7 +546,7 @@ Object {
           "bbb~~~2",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -627,7 +627,7 @@ Object {
           "bbb~~~3",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -652,13 +652,13 @@ Object {
             "utopia-storyboard-uid",
           ],
           "scene": Object {
-            "sceneElementPath": Array [],
+            "sceneElementPaths": Array [],
             "type": "scenepath",
           },
         },
       ],
       "scenePath": Object {
-        "sceneElementPath": Array [],
+        "sceneElementPaths": Array [],
         "type": "scenepath",
       },
       "sceneResizesContent": false,
@@ -666,7 +666,7 @@ Object {
       "templatePath": Object {
         "element": Array [],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -686,7 +686,7 @@ Object {
             "aaa",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -695,7 +695,7 @@ Object {
         },
       ],
       "scenePath": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -715,7 +715,7 @@ Object {
           "scene-aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -731,7 +731,7 @@ Object {
             "scene-aaa",
           ],
           "scene": Object {
-            "sceneElementPath": Array [],
+            "sceneElementPaths": Array [],
             "type": "scenepath",
           },
         },
@@ -794,7 +794,7 @@ Object {
           "utopia-storyboard-uid",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -807,7 +807,7 @@ Object {
             "aaa",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -881,7 +881,7 @@ Object {
           "scene-aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -984,7 +984,7 @@ Object {
           "aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -1009,13 +1009,13 @@ Object {
             "utopia-storyboard-uid",
           ],
           "scene": Object {
-            "sceneElementPath": Array [],
+            "sceneElementPaths": Array [],
             "type": "scenepath",
           },
         },
       ],
       "scenePath": Object {
-        "sceneElementPath": Array [],
+        "sceneElementPaths": Array [],
         "type": "scenepath",
       },
       "sceneResizesContent": false,
@@ -1023,7 +1023,7 @@ Object {
       "templatePath": Object {
         "element": Array [],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -1043,7 +1043,7 @@ Object {
             "05c",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -1052,7 +1052,7 @@ Object {
         },
       ],
       "scenePath": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -1072,7 +1072,7 @@ Object {
           "scene-aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -1088,7 +1088,7 @@ Object {
             "scene-aaa",
           ],
           "scene": Object {
-            "sceneElementPath": Array [],
+            "sceneElementPaths": Array [],
             "type": "scenepath",
           },
         },
@@ -1151,7 +1151,7 @@ Object {
           "utopia-storyboard-uid",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -1164,7 +1164,7 @@ Object {
             "05c",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -1238,7 +1238,7 @@ Object {
           "scene-aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -1252,7 +1252,7 @@ Object {
             "ef0",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -1355,7 +1355,7 @@ Object {
           "05c",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -1373,7 +1373,7 @@ Object {
             "488",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -1473,7 +1473,7 @@ Object {
           "ef0",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -1581,7 +1581,7 @@ Object {
           "488",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -1606,13 +1606,13 @@ Object {
             "utopia-storyboard-uid",
           ],
           "scene": Object {
-            "sceneElementPath": Array [],
+            "sceneElementPaths": Array [],
             "type": "scenepath",
           },
         },
       ],
       "scenePath": Object {
-        "sceneElementPath": Array [],
+        "sceneElementPaths": Array [],
         "type": "scenepath",
       },
       "sceneResizesContent": false,
@@ -1620,7 +1620,7 @@ Object {
       "templatePath": Object {
         "element": Array [],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -1640,7 +1640,7 @@ Object {
             "05c",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -1649,7 +1649,7 @@ Object {
         },
       ],
       "scenePath": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -1669,7 +1669,7 @@ Object {
           "scene-aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -1685,7 +1685,7 @@ Object {
             "scene-aaa",
           ],
           "scene": Object {
-            "sceneElementPath": Array [],
+            "sceneElementPaths": Array [],
             "type": "scenepath",
           },
         },
@@ -1748,7 +1748,7 @@ Object {
           "utopia-storyboard-uid",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -1761,7 +1761,7 @@ Object {
             "05c",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -1835,7 +1835,7 @@ Object {
           "scene-aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -1849,7 +1849,7 @@ Object {
             "ef0",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -1953,7 +1953,7 @@ Object {
           "05c",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -1971,7 +1971,7 @@ Object {
             "488",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -2071,7 +2071,7 @@ Object {
           "ef0",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -2179,7 +2179,7 @@ Object {
           "488",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -2204,13 +2204,13 @@ Object {
             "utopia-storyboard-uid",
           ],
           "scene": Object {
-            "sceneElementPath": Array [],
+            "sceneElementPaths": Array [],
             "type": "scenepath",
           },
         },
       ],
       "scenePath": Object {
-        "sceneElementPath": Array [],
+        "sceneElementPaths": Array [],
         "type": "scenepath",
       },
       "sceneResizesContent": false,
@@ -2218,7 +2218,7 @@ Object {
       "templatePath": Object {
         "element": Array [],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -2238,7 +2238,7 @@ Object {
             "05c",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -2247,7 +2247,7 @@ Object {
         },
       ],
       "scenePath": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -2267,7 +2267,7 @@ Object {
           "scene-aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -2283,7 +2283,7 @@ Object {
             "scene-aaa",
           ],
           "scene": Object {
-            "sceneElementPath": Array [],
+            "sceneElementPaths": Array [],
             "type": "scenepath",
           },
         },
@@ -2346,7 +2346,7 @@ Object {
           "utopia-storyboard-uid",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -2359,7 +2359,7 @@ Object {
             "05c",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -2433,7 +2433,7 @@ Object {
           "scene-aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [],
+          "sceneElementPaths": Array [],
           "type": "scenepath",
         },
       },
@@ -2447,7 +2447,7 @@ Object {
             "ef0",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -2550,7 +2550,7 @@ Object {
           "05c",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -2568,7 +2568,7 @@ Object {
             "488",
           ],
           "scene": Object {
-            "sceneElementPath": Array [
+            "sceneElementPaths": Array [
               "utopia-storyboard-uid",
               "scene-aaa",
             ],
@@ -2672,7 +2672,7 @@ Object {
           "ef0",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -2780,7 +2780,7 @@ Object {
           "488",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -327,8 +327,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -562,8 +564,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -683,8 +687,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -941,8 +947,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -1323,8 +1331,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -1379,8 +1389,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -1392,8 +1404,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -1529,8 +1543,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -1615,8 +1631,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -1701,8 +1719,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -1921,8 +1941,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -2188,8 +2210,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -2457,8 +2481,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -2513,8 +2539,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -2526,8 +2554,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -2663,8 +2693,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -2749,8 +2781,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -2835,8 +2869,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -3043,8 +3079,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -3111,8 +3149,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-0",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-0",
+            ],
           ],
           "type": "scenepath",
         },
@@ -3420,8 +3460,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-0",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-0",
+          ],
         ],
         "type": "scenepath",
       },
@@ -3611,8 +3653,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-0",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-0",
+          ],
         ],
         "type": "scenepath",
       },
@@ -3686,8 +3730,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-0",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-0",
+            ],
           ],
           "type": "scenepath",
         },
@@ -3995,8 +4041,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-0",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-0",
+          ],
         ],
         "type": "scenepath",
       },
@@ -4186,8 +4234,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-0",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-0",
+          ],
         ],
         "type": "scenepath",
       },
@@ -4254,8 +4304,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-0",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-0",
+            ],
           ],
           "type": "scenepath",
         },
@@ -4611,8 +4663,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-0",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-0",
+          ],
         ],
         "type": "scenepath",
       },
@@ -4856,8 +4910,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-0",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-0",
+          ],
         ],
         "type": "scenepath",
       },
@@ -4924,8 +4980,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-0",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-0",
+            ],
           ],
           "type": "scenepath",
         },
@@ -5281,8 +5339,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-0",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-0",
+          ],
         ],
         "type": "scenepath",
       },
@@ -5526,8 +5586,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-0",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-0",
+          ],
         ],
         "type": "scenepath",
       },
@@ -5647,8 +5709,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -5806,8 +5870,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -6962,8 +7028,10 @@ export var storyboard = (props) => {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -7791,8 +7859,10 @@ export var storyboard = (props) => {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -7863,8 +7933,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -7876,8 +7948,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -8043,8 +8117,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -8145,8 +8221,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -8247,8 +8325,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -8430,8 +8510,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -8705,8 +8787,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -8769,8 +8853,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "eee",
-            "fff",
+            Array [
+              "eee",
+              "fff",
+            ],
           ],
           "type": "scenepath",
         },
@@ -8974,8 +9060,10 @@ export var storyboard = (
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "eee",
-          "fff",
+          Array [
+            "eee",
+            "fff",
+          ],
         ],
         "type": "scenepath",
       },
@@ -9125,8 +9213,10 @@ export var storyboard = (
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "eee",
-          "fff",
+          Array [
+            "eee",
+            "fff",
+          ],
         ],
         "type": "scenepath",
       },
@@ -9223,8 +9313,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -9424,8 +9516,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -9442,8 +9536,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -9620,8 +9716,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -9755,8 +9853,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -9818,8 +9918,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-0",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-0",
+            ],
           ],
           "type": "scenepath",
         },
@@ -10072,8 +10174,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-0",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-0",
+          ],
         ],
         "type": "scenepath",
       },
@@ -10207,8 +10311,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-0",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-0",
+          ],
         ],
         "type": "scenepath",
       },
@@ -10474,8 +10580,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -10742,8 +10850,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -11016,8 +11126,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -11144,8 +11256,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -11235,8 +11349,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -11292,8 +11408,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "ccc",
-            "ddd",
+            Array [
+              "ccc",
+              "ddd",
+            ],
           ],
           "type": "scenepath",
         },
@@ -11485,8 +11603,10 @@ export var storyboard = (
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "ccc",
-          "ddd",
+          Array [
+            "ccc",
+            "ddd",
+          ],
         ],
         "type": "scenepath",
       },
@@ -11596,8 +11716,10 @@ export var storyboard = (
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "ccc",
-          "ddd",
+          Array [
+            "ccc",
+            "ddd",
+          ],
         ],
         "type": "scenepath",
       },
@@ -11880,8 +12002,10 @@ export var storyboard = (
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene",
+          Array [
+            "utopia-storyboard-uid",
+            "scene",
+          ],
         ],
         "type": "scenepath",
       },
@@ -12017,8 +12141,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene",
+          Array [
+            "utopia-storyboard-uid",
+            "scene",
+          ],
         ],
         "type": "scenepath",
       },
@@ -12094,8 +12220,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "eee",
-            "fff",
+            Array [
+              "eee",
+              "fff",
+            ],
           ],
           "type": "scenepath",
         },
@@ -12503,8 +12631,10 @@ export var storyboard = (
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "eee",
-          "fff",
+          Array [
+            "eee",
+            "fff",
+          ],
         ],
         "type": "scenepath",
       },
@@ -12621,8 +12751,10 @@ export var storyboard = (
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "eee",
-          "fff",
+          Array [
+            "eee",
+            "fff",
+          ],
         ],
         "type": "scenepath",
       },
@@ -12679,8 +12811,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -12804,8 +12938,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -12932,8 +13068,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -13054,8 +13192,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -13356,8 +13496,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -13413,8 +13555,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -13557,8 +13701,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -13575,8 +13721,10 @@ Object {
         ],
         "scene": Object {
           "sceneElementPaths": Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
+            Array [
+              "utopia-storyboard-uid",
+              "scene-aaa",
+            ],
           ],
           "type": "scenepath",
         },
@@ -13692,8 +13840,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -13789,8 +13939,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -13915,8 +14067,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },
@@ -14042,8 +14196,10 @@ Object {
       ],
       "scene": Object {
         "sceneElementPaths": Array [
-          "utopia-storyboard-uid",
-          "scene-aaa",
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+          ],
         ],
         "type": "scenepath",
       },

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -326,7 +326,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -561,7 +561,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -682,7 +682,7 @@ Object {
         "567",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -940,7 +940,7 @@ Object {
         "zzz",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -1322,7 +1322,7 @@ Object {
         "zzz",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -1378,7 +1378,7 @@ Object {
           "aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -1391,7 +1391,7 @@ Object {
           "bbb",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -1528,7 +1528,7 @@ Object {
         "zzz",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -1614,7 +1614,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -1700,7 +1700,7 @@ Object {
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -1920,7 +1920,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -2187,7 +2187,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -2456,7 +2456,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -2512,7 +2512,7 @@ Object {
           "aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -2525,7 +2525,7 @@ Object {
           "bbb",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -2662,7 +2662,7 @@ Object {
         "zzz",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -2748,7 +2748,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -2834,7 +2834,7 @@ Object {
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -3042,7 +3042,7 @@ Object {
         "zzz",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -3110,7 +3110,7 @@ Object {
           "bbb",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-0",
           ],
@@ -3419,7 +3419,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-0",
         ],
@@ -3610,7 +3610,7 @@ Object {
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-0",
         ],
@@ -3685,7 +3685,7 @@ Object {
           "bbb",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-0",
           ],
@@ -3994,7 +3994,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-0",
         ],
@@ -4185,7 +4185,7 @@ Object {
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-0",
         ],
@@ -4253,7 +4253,7 @@ Object {
           "bbb",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-0",
           ],
@@ -4610,7 +4610,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-0",
         ],
@@ -4855,7 +4855,7 @@ Object {
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-0",
         ],
@@ -4923,7 +4923,7 @@ Object {
           "bbb",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-0",
           ],
@@ -5280,7 +5280,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-0",
         ],
@@ -5525,7 +5525,7 @@ Object {
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-0",
         ],
@@ -5646,7 +5646,7 @@ Object {
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -5805,7 +5805,7 @@ Object {
           "03a",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -6961,7 +6961,7 @@ export var storyboard = (props) => {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -7790,7 +7790,7 @@ export var storyboard = (props) => {
         "03a",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -7862,7 +7862,7 @@ Object {
           "aaa",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -7875,7 +7875,7 @@ Object {
           "bbb",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -8042,7 +8042,7 @@ Object {
         "zzz",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -8144,7 +8144,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -8246,7 +8246,7 @@ Object {
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -8429,7 +8429,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -8704,7 +8704,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -8768,7 +8768,7 @@ Object {
           "bbb",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "eee",
             "fff",
           ],
@@ -8973,7 +8973,7 @@ export var storyboard = (
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "eee",
           "fff",
         ],
@@ -9124,7 +9124,7 @@ export var storyboard = (
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "eee",
           "fff",
         ],
@@ -9222,7 +9222,7 @@ Object {
           "d59",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -9423,7 +9423,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -9441,7 +9441,7 @@ Object {
           "dd5",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -9619,7 +9619,7 @@ Object {
         "d59",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -9754,7 +9754,7 @@ Object {
         "dd5",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -9817,7 +9817,7 @@ Object {
           "bbb",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-0",
           ],
@@ -10071,7 +10071,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-0",
         ],
@@ -10206,7 +10206,7 @@ Object {
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-0",
         ],
@@ -10473,7 +10473,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -10741,7 +10741,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -11015,7 +11015,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -11143,7 +11143,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -11234,7 +11234,7 @@ Object {
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -11291,7 +11291,7 @@ Object {
           "bbb",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "ccc",
             "ddd",
           ],
@@ -11484,7 +11484,7 @@ export var storyboard = (
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "ccc",
           "ddd",
         ],
@@ -11595,7 +11595,7 @@ export var storyboard = (
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "ccc",
           "ddd",
         ],
@@ -11879,7 +11879,7 @@ export var storyboard = (
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene",
         ],
@@ -12016,7 +12016,7 @@ Object {
         "BBB",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene",
         ],
@@ -12093,7 +12093,7 @@ Object {
           "ddd",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "eee",
             "fff",
           ],
@@ -12502,7 +12502,7 @@ export var storyboard = (
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "eee",
           "fff",
         ],
@@ -12620,7 +12620,7 @@ export var storyboard = (
         "ddd",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "eee",
           "fff",
         ],
@@ -12678,7 +12678,7 @@ Object {
           "bbb",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -12803,7 +12803,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -12931,7 +12931,7 @@ Object {
         "bbb",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -13053,7 +13053,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -13355,7 +13355,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -13412,7 +13412,7 @@ Object {
           "cloner",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -13556,7 +13556,7 @@ Object {
         "zzz",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -13574,7 +13574,7 @@ Object {
           "cloned",
         ],
         "scene": Object {
-          "sceneElementPath": Array [
+          "sceneElementPaths": Array [
             "utopia-storyboard-uid",
             "scene-aaa",
           ],
@@ -13691,7 +13691,7 @@ Object {
         "cloner",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -13788,7 +13788,7 @@ Object {
         "cloned",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -13914,7 +13914,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],
@@ -14041,7 +14041,7 @@ Object {
         "aaa",
       ],
       "scene": Object {
-        "sceneElementPath": Array [
+        "sceneElementPaths": Array [
           "utopia-storyboard-uid",
           "scene-aaa",
         ],

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1439,7 +1439,7 @@ describe('moveTemplate', () => {
     await renderResult.dispatch(
       [
         selectComponents(
-          [TP.instancePath(TP.scenePath([]), [BakedInStoryboardUID, 'orphan-bbb'])],
+          [TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, 'orphan-bbb'])],
           false,
         ),
       ],
@@ -1605,7 +1605,7 @@ describe('moveTemplate', () => {
     await renderResult.dispatch(
       [
         selectComponents(
-          [TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['aaa', 'bbb'])],
+          [TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['aaa', 'bbb'])],
           false,
         ),
       ],

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2511,9 +2511,7 @@ export function cullSpyCollector(
     while (workingPath != null) {
       const pathAsString = TP.toString(workingPath)
       if (TP.isScenePath(workingPath)) {
-        elementPaths.add(
-          TP.toString(TP.instancePath(TP.emptyScenePath, workingPath.sceneElementPath)),
-        )
+        elementPaths.add(TP.toString(TP.instancePathForScenePath(workingPath)))
         scenePaths.add(pathAsString)
       } else {
         elementPaths.add(pathAsString)
@@ -2533,10 +2531,7 @@ export function cullSpyCollector(
       !scenePaths.has(scenePath) &&
       !elementPaths.has(
         TP.toString(
-          TP.instancePath(
-            TP.emptyScenePath,
-            spyCollector.current.spyValues.scenes[scenePath].scenePath.sceneElementPath,
-          ),
+          TP.instancePathForScenePath(spyCollector.current.spyValues.scenes[scenePath].scenePath),
         ),
       ) // this is needed because empty scenes are stored in metadata with an instancepath
     ) {

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2511,7 +2511,7 @@ export function cullSpyCollector(
     while (workingPath != null) {
       const pathAsString = TP.toString(workingPath)
       if (TP.isScenePath(workingPath)) {
-        elementPaths.add(TP.toString(TP.instancePathForLastPartOfScenePath(workingPath)))
+        elementPaths.add(TP.toString(TP.instancePathForElementAtScenePath(workingPath)))
         scenePaths.add(pathAsString)
       } else {
         elementPaths.add(pathAsString)
@@ -2531,7 +2531,7 @@ export function cullSpyCollector(
       !scenePaths.has(scenePath) &&
       !elementPaths.has(
         TP.toString(
-          TP.instancePathForLastPartOfScenePath(
+          TP.instancePathForElementAtScenePath(
             spyCollector.current.spyValues.scenes[scenePath].scenePath,
           ),
         ),

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2377,7 +2377,7 @@ export function duplicate(
                 'Could not find storyboard element',
                 getStoryboardUID(utopiaComponents),
               )
-              newPath = TP.scenePath([storyboardUID, uid])
+              newPath = TP.scenePath([[storyboardUID, uid]])
             } else {
               newPath = TP.appendToPath(newParentPath, uid)
             }

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2511,7 +2511,7 @@ export function cullSpyCollector(
     while (workingPath != null) {
       const pathAsString = TP.toString(workingPath)
       if (TP.isScenePath(workingPath)) {
-        elementPaths.add(TP.toString(TP.instancePathForScenePath(workingPath)))
+        elementPaths.add(TP.toString(TP.instancePathForLastPartOfScenePath(workingPath)))
         scenePaths.add(pathAsString)
       } else {
         elementPaths.add(pathAsString)
@@ -2531,7 +2531,9 @@ export function cullSpyCollector(
       !scenePaths.has(scenePath) &&
       !elementPaths.has(
         TP.toString(
-          TP.instancePathForScenePath(spyCollector.current.spyValues.scenes[scenePath].scenePath),
+          TP.instancePathForLastPartOfScenePath(
+            spyCollector.current.spyValues.scenes[scenePath].scenePath,
+          ),
         ),
       ) // this is needed because empty scenes are stored in metadata with an instancepath
     ) {

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2511,7 +2511,9 @@ export function cullSpyCollector(
     while (workingPath != null) {
       const pathAsString = TP.toString(workingPath)
       if (TP.isScenePath(workingPath)) {
-        elementPaths.add(TP.toString(TP.instancePath([], workingPath.sceneElementPath)))
+        elementPaths.add(
+          TP.toString(TP.instancePath(TP.emptyScenePath, workingPath.sceneElementPath)),
+        )
         scenePaths.add(pathAsString)
       } else {
         elementPaths.add(pathAsString)
@@ -2532,7 +2534,7 @@ export function cullSpyCollector(
       !elementPaths.has(
         TP.toString(
           TP.instancePath(
-            [],
+            TP.emptyScenePath,
             spyCollector.current.spyValues.scenes[scenePath].scenePath.sceneElementPath,
           ),
         ),

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser.ts
@@ -116,7 +116,7 @@ describe('Select Mode Selection', () => {
 
     const selectedViews1 = renderResult.getEditorState().editor.selectedViews
     expect(selectedViews1).toEqual([
-      TP.instancePath(TP.scenePath(['utopia-storyboard-uid', 'scene-aaa']), ['a']),
+      TP.instancePath(TP.scenePath([['utopia-storyboard-uid', 'scene-aaa']]), ['a']),
     ])
 
     await act(async () => {
@@ -153,7 +153,7 @@ describe('Select Mode Selection', () => {
 
     const selectedViews2 = renderResult.getEditorState().editor.selectedViews
     expect(selectedViews2).toEqual([
-      TP.instancePath(TP.scenePath(['utopia-storyboard-uid', 'scene-aaa']), ['a', 'b']),
+      TP.instancePath(TP.scenePath([['utopia-storyboard-uid', 'scene-aaa']]), ['a', 'b']),
     ])
 
     await act(async () => {
@@ -190,7 +190,7 @@ describe('Select Mode Selection', () => {
 
     const selectedViews3 = renderResult.getEditorState().editor.selectedViews
     expect(selectedViews3).toEqual([
-      TP.instancePath(TP.scenePath(['utopia-storyboard-uid', 'scene-aaa']), ['a', 'b', 'c']),
+      TP.instancePath(TP.scenePath([['utopia-storyboard-uid', 'scene-aaa']]), ['a', 'b', 'c']),
     ])
 
     await act(async () => {
@@ -227,7 +227,7 @@ describe('Select Mode Selection', () => {
 
     const selectedViews4 = renderResult.getEditorState().editor.selectedViews
     expect(selectedViews4).toEqual([
-      TP.instancePath(TP.scenePath(['utopia-storyboard-uid', 'scene-aaa']), ['a', 'b', 'c', 'd']),
+      TP.instancePath(TP.scenePath([['utopia-storyboard-uid', 'scene-aaa']]), ['a', 'b', 'c', 'd']),
     ])
 
     await act(async () => {
@@ -264,7 +264,7 @@ describe('Select Mode Selection', () => {
 
     const selectedViews5 = renderResult.getEditorState().editor.selectedViews
     expect(selectedViews5).toEqual([
-      TP.instancePath(TP.scenePath(['utopia-storyboard-uid', 'scene-aaa']), [
+      TP.instancePath(TP.scenePath([['utopia-storyboard-uid', 'scene-aaa']]), [
         'a',
         'b',
         'c',
@@ -308,7 +308,7 @@ describe('Select Mode Selection', () => {
     // after 6 "double clicks", the `targetdiv` div should be selected
     const selectedViews6 = renderResult.getEditorState().editor.selectedViews
     expect(selectedViews6).toEqual([
-      TP.instancePath(TP.scenePath(['utopia-storyboard-uid', 'scene-aaa']), [
+      TP.instancePath(TP.scenePath([['utopia-storyboard-uid', 'scene-aaa']]), [
         'a',
         'b',
         'c',

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser.ts
@@ -115,7 +115,9 @@ describe('Select Mode Selection', () => {
     await waitForAnimationFrame()
 
     const selectedViews1 = renderResult.getEditorState().editor.selectedViews
-    expect(selectedViews1).toEqual([TP.instancePath(['utopia-storyboard-uid', 'scene-aaa'], ['a'])])
+    expect(selectedViews1).toEqual([
+      TP.instancePath(TP.scenePath(['utopia-storyboard-uid', 'scene-aaa']), ['a']),
+    ])
 
     await act(async () => {
       const domFinished = renderResult.getDomReportDispatched()
@@ -151,7 +153,7 @@ describe('Select Mode Selection', () => {
 
     const selectedViews2 = renderResult.getEditorState().editor.selectedViews
     expect(selectedViews2).toEqual([
-      TP.instancePath(['utopia-storyboard-uid', 'scene-aaa'], ['a', 'b']),
+      TP.instancePath(TP.scenePath(['utopia-storyboard-uid', 'scene-aaa']), ['a', 'b']),
     ])
 
     await act(async () => {
@@ -188,7 +190,7 @@ describe('Select Mode Selection', () => {
 
     const selectedViews3 = renderResult.getEditorState().editor.selectedViews
     expect(selectedViews3).toEqual([
-      TP.instancePath(['utopia-storyboard-uid', 'scene-aaa'], ['a', 'b', 'c']),
+      TP.instancePath(TP.scenePath(['utopia-storyboard-uid', 'scene-aaa']), ['a', 'b', 'c']),
     ])
 
     await act(async () => {
@@ -225,7 +227,7 @@ describe('Select Mode Selection', () => {
 
     const selectedViews4 = renderResult.getEditorState().editor.selectedViews
     expect(selectedViews4).toEqual([
-      TP.instancePath(['utopia-storyboard-uid', 'scene-aaa'], ['a', 'b', 'c', 'd']),
+      TP.instancePath(TP.scenePath(['utopia-storyboard-uid', 'scene-aaa']), ['a', 'b', 'c', 'd']),
     ])
 
     await act(async () => {
@@ -262,7 +264,13 @@ describe('Select Mode Selection', () => {
 
     const selectedViews5 = renderResult.getEditorState().editor.selectedViews
     expect(selectedViews5).toEqual([
-      TP.instancePath(['utopia-storyboard-uid', 'scene-aaa'], ['a', 'b', 'c', 'd', 'e']),
+      TP.instancePath(TP.scenePath(['utopia-storyboard-uid', 'scene-aaa']), [
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
+      ]),
     ])
 
     await act(async () => {
@@ -300,10 +308,14 @@ describe('Select Mode Selection', () => {
     // after 6 "double clicks", the `targetdiv` div should be selected
     const selectedViews6 = renderResult.getEditorState().editor.selectedViews
     expect(selectedViews6).toEqual([
-      TP.instancePath(
-        ['utopia-storyboard-uid', 'scene-aaa'],
-        ['a', 'b', 'c', 'd', 'e', 'targetdiv'],
-      ),
+      TP.instancePath(TP.scenePath(['utopia-storyboard-uid', 'scene-aaa']), [
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
+        'targetdiv',
+      ]),
     ])
   })
 })

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -251,7 +251,7 @@ function useInvalidateScenesWhenSelectedViewChanges(
     (store) => store.editor.selectedViews,
     (newSelectedViews) => {
       newSelectedViews.forEach((sv) => {
-        const scenePath = TP.scenePathForPath(sv)
+        const scenePath = TP.scenePathPartOfTemplatePath(sv)
         const sceneID = TP.toString(scenePath)
         invalidatedSceneIDsRef.current.add(sceneID)
         invalidatedPathsForStylesheetCacheRef.current.add(TP.toString(sv))
@@ -476,7 +476,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
 
               const sceneMetadata = collectMetadata(
                 scene,
-                TP.instancePathForScenePath(scenePath),
+                TP.instancePathForLastPartOfScenePath(scenePath),
                 canvasPoint({ x: 0, y: 0 }),
                 rootElements,
               )

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -471,7 +471,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
 
               const sceneMetadata = collectMetadata(
                 scene,
-                TP.instancePath([], TP.elementPathForPath(scenePath)),
+                TP.instancePath(TP.emptyScenePath, TP.elementPathForPath(scenePath)),
                 canvasPoint({ x: 0, y: 0 }),
                 rootElements,
               )

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -476,7 +476,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
 
               const sceneMetadata = collectMetadata(
                 scene,
-                TP.instancePathForLastPartOfScenePath(scenePath),
+                TP.instancePathForElementAtScenePath(scenePath),
                 canvasPoint({ x: 0, y: 0 }),
                 rootElements,
               )

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -444,11 +444,16 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
           // and that they can only have a single root element
           const sceneIndexAttr = scene.attributes.getNamedItemNS(null, 'data-utopia-scene-id')
           const validPathsAttr = scene.attributes.getNamedItemNS(null, 'data-utopia-valid-paths')
+          const sceneID = sceneIndexAttr?.value ?? null
+          const scenePath = sceneID == null ? null : TP.fromString(sceneID)
 
-          if (sceneIndexAttr != null && validPathsAttr != null) {
-            const scenePath = TP.fromString(sceneIndexAttr.value)
+          if (
+            sceneID != null &&
+            scenePath != null &&
+            TP.isScenePath(scenePath) &&
+            validPathsAttr != null
+          ) {
             const validPaths = validPathsAttr.value.split(' ')
-            const sceneID = sceneIndexAttr.value
             let cachedMetadata: ElementInstanceMetadata | null = null
             if (ObserversAvailable && invalidatedSceneIDsRef.current != null) {
               if (!invalidatedSceneIDsRef.current.has(sceneID)) {
@@ -471,7 +476,7 @@ export function useDomWalker(props: CanvasContainerProps): React.Ref<HTMLDivElem
 
               const sceneMetadata = collectMetadata(
                 scene,
-                TP.instancePath(TP.emptyScenePath, TP.elementPathForPath(scenePath)),
+                TP.instancePathForScenePath(scenePath),
                 canvasPoint({ x: 0, y: 0 }),
                 rootElements,
               )

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
@@ -126,7 +126,7 @@ export const SceneRootRenderer = betterReactMemo(
       [inScope, props.sceneElement.props, requireResult],
     )
     const templatePath = React.useMemo(() => TP.appendToPath(parentPath, uid), [parentPath, uid])
-    const scenePath = TP.scenePathForCombinedPartsOfInstancePath(templatePath)
+    const scenePath = TP.scenePathForElementAtInstancePath(templatePath)
 
     const topLevelElementName = getTopLevelElementName(sceneProps.component)
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
@@ -126,7 +126,7 @@ export const SceneRootRenderer = betterReactMemo(
       [inScope, props.sceneElement.props, requireResult],
     )
     const templatePath = React.useMemo(() => TP.appendToPath(parentPath, uid), [parentPath, uid])
-    const scenePath = TP.scenePathFromInstancePath(templatePath)
+    const scenePath = TP.scenePathForCombinedPartsOfInstancePath(templatePath)
 
     const topLevelElementName = getTopLevelElementName(sceneProps.component)
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
@@ -126,7 +126,7 @@ export const SceneRootRenderer = betterReactMemo(
       [inScope, props.sceneElement.props, requireResult],
     )
     const templatePath = React.useMemo(() => TP.appendToPath(parentPath, uid), [parentPath, uid])
-    const scenePath = TP.scenePath(TP.elementPathForPath(templatePath))
+    const scenePath = TP.scenePathFromInstancePath(templatePath)
 
     const topLevelElementName = getTopLevelElementName(sceneProps.component)
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -46,7 +46,7 @@ export function buildSpyWrappedElement(
       attributeMetadatada: emptyAttributeMetadatada,
     }
     const isChildOfRootScene = TP.pathsEqual(
-      TP.scenePathForPath(templatePath),
+      TP.scenePathPartOfTemplatePath(templatePath),
       EmptyScenePathForStoryboard,
     )
     if (!isChildOfRootScene || shouldIncludeCanvasRootInTheSpy) {

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -415,7 +415,7 @@ function useGetStoryboardRoot(
     component: BakedInStoryboardVariableName,
     sceneResizesContent: false,
     scenePath: EmptyScenePathForStoryboard,
-    templatePath: TP.instancePath([], []), // TODO use the real storyboardRootElementPath path here instead of this baked in empty path, so we can remove the hack from https://github.com/concrete-utopia/utopia/blob/264d96276f832ac0213cf3f142ac2c246d588448/editor/src/components/canvas/canvas.ts#L135
+    templatePath: TP.emptyInstancePath, // TODO use the real storyboardRootElementPath path here instead of this baked in empty path, so we can remove the hack from https://github.com/concrete-utopia/utopia/blob/264d96276f832ac0213cf3f142ac2c246d588448/editor/src/components/canvas/canvas.ts#L135
     globalFrame: null,
     label: 'Storyboard',
     style: {},

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -224,7 +224,7 @@ export function getPrintedUiJsCodeWithoutUIDs(store: EditorStore): string {
 }
 
 const TestSceneUID = 'scene-aaa'
-export const TestScenePath = scenePath([BakedInStoryboardUID, TestSceneUID])
+export const TestScenePath = scenePath([[BakedInStoryboardUID, TestSceneUID]])
 
 export function makeTestProjectCodeWithSnippet(snippet: string): string {
   const code = `/** @jsx jsx */

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -836,10 +836,12 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     null,
     0,
   )
-  const scenePath = TP.scenePath([BakedInStoryboardUID, `scene-0`])
-  const sceneTemplatePath = TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, `scene-0`])
-  const rootElementPath = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-0']), ['aaa'])
-  const childElementPath = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-0']), [
+  const scenePath = TP.scenePath([[BakedInStoryboardUID, 'scene-0']])
+  const sceneTemplatePath = TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, 'scene-0'])
+  const rootElementPath = TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-0']]), [
+    'aaa',
+  ])
+  const childElementPath = TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-0']]), [
     'aaa',
     'bbb',
   ])
@@ -901,7 +903,7 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
       [StoryboardFilePath]: fileForUI,
     }),
     jsxMetadataKILLME: jsxMetadata([componentMetadata], elementMetadataMap),
-    selectedViews: [TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-0']), ['aaa'])],
+    selectedViews: [TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-0']]), ['aaa'])],
   })
   it('switches from pins to flex correctly', () => {
     const switchActionToFlex = switchLayoutSystem('flex')

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -837,7 +837,7 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     0,
   )
   const scenePath = TP.scenePath([BakedInStoryboardUID, `scene-0`])
-  const sceneTemplatePath = TP.instancePath([], [BakedInStoryboardUID, `scene-0`])
+  const sceneTemplatePath = TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, `scene-0`])
   const rootElementPath = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-0']), ['aaa'])
   const childElementPath = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-0']), [
     'aaa',

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -1906,7 +1906,7 @@ export const UPDATE_FNS = {
     )
     const storyBoardPath = getStoryboardTemplatePath(components)
     const newSelection =
-      storyBoardPath != null ? [TP.scenePath([TP.toUid(storyBoardPath), sceneUID])] : []
+      storyBoardPath != null ? [TP.scenePath([[TP.toUid(storyBoardPath), sceneUID]])] : []
     return {
       ...addNewScene(editor, newScene),
       selectedViews: newSelection,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -762,7 +762,7 @@ export function addSceneToJSXComponents(
     storyoardComponentRootElement != null ? getUtopiaID(storyoardComponentRootElement) : null
   if (storyboardComponentUID != null) {
     const storyboardComponentTemplatePath = staticInstancePath(
-      scenePath([storyboardComponentUID]),
+      scenePath([[storyboardComponentUID]]),
       [storyboardComponentUID],
     )
     return insertJSXElementChild(storyboardComponentTemplatePath, newSceneElement, components, null)

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -129,6 +129,7 @@ import {
   toUid,
   toString,
   dynamicPathToStaticPath,
+  scenePath,
 } from '../../../core/shared/template-path'
 
 import { Notice } from '../../common/notice'
@@ -761,7 +762,7 @@ export function addSceneToJSXComponents(
     storyoardComponentRootElement != null ? getUtopiaID(storyoardComponentRootElement) : null
   if (storyboardComponentUID != null) {
     const storyboardComponentTemplatePath = staticInstancePath(
-      [storyboardComponentUID],
+      scenePath([storyboardComponentUID]),
       [storyboardComponentUID],
     )
     return insertJSXElementChild(storyboardComponentTemplatePath, newSceneElement, components, null)
@@ -770,9 +771,9 @@ export function addSceneToJSXComponents(
   }
 }
 
-export function removeScene(model: EditorState, scenePath: ScenePath): EditorState {
+export function removeScene(model: EditorState, path: ScenePath): EditorState {
   return modifyOpenScenes_INTERNAL((components) => {
-    return removeJSXElementChild(createSceneTemplatePath(scenePath), components)
+    return removeJSXElementChild(createSceneTemplatePath(path), components)
   }, model)
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
@@ -18,8 +18,8 @@ import {
 describe('TransientCanvasStateKeepDeepEquality', () => {
   it('same reference returns the same reference', () => {
     const state: TransientCanvasState = transientCanvasState(
-      [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-      [TP.instancePath(['scene'], ['aaa', 'ccc'])],
+      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
       transientFileState(
         [
           utopiaJSXComponent(
@@ -45,8 +45,8 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
   })
   it('same value returns the same reference', () => {
     const oldState: TransientCanvasState = transientCanvasState(
-      [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-      [TP.instancePath(['scene'], ['aaa', 'ccc'])],
+      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
       transientFileState(
         [
           utopiaJSXComponent(
@@ -66,8 +66,8 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
       ),
     )
     const newState: TransientCanvasState = transientCanvasState(
-      [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-      [TP.instancePath(['scene'], ['aaa', 'ccc'])],
+      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
       transientFileState(
         [
           utopiaJSXComponent(
@@ -93,8 +93,8 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
   })
   it('different but similar value handled appropriately', () => {
     const oldState: TransientCanvasState = transientCanvasState(
-      [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-      [TP.instancePath(['scene'], ['aaa', 'ccc'])],
+      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
       transientFileState(
         [
           utopiaJSXComponent(
@@ -114,8 +114,8 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
       ),
     )
     const newState: TransientCanvasState = transientCanvasState(
-      [TP.instancePath(['scene'], ['aaa', 'ddd'])],
-      [TP.instancePath(['scene'], ['aaa', 'ccc'])],
+      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ddd'])],
+      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
       transientFileState(
         [
           utopiaJSXComponent(
@@ -147,14 +147,14 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
 describe('DerivedStateKeepDeepEquality', () => {
   it('same reference returns the same reference', () => {
     const state: DerivedState = {
-      navigatorTargets: [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-      visibleNavigatorTargets: [TP.instancePath(['scene'], ['aaa', 'bbb'])],
+      navigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      visibleNavigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
       canvas: {
         descendantsOfHiddenInstances: [],
         controls: [],
         transientState: transientCanvasState(
-          [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-          [TP.instancePath(['scene'], ['aaa', 'ccc'])],
+          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
           transientFileState(
             [
               utopiaJSXComponent(
@@ -177,7 +177,7 @@ describe('DerivedStateKeepDeepEquality', () => {
       elementWarnings: addToComplexMap(
         TP.toString,
         emptyComplexMap(),
-        TP.instancePath(['scene'], ['aaa', 'bbb']),
+        TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb']),
         defaultElementWarnings,
       ),
     }
@@ -187,14 +187,14 @@ describe('DerivedStateKeepDeepEquality', () => {
   })
   it('same value returns the same reference', () => {
     const oldState: DerivedState = {
-      navigatorTargets: [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-      visibleNavigatorTargets: [TP.instancePath(['scene'], ['aaa', 'bbb'])],
+      navigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      visibleNavigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
       canvas: {
         descendantsOfHiddenInstances: [],
         controls: [],
         transientState: transientCanvasState(
-          [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-          [TP.instancePath(['scene'], ['aaa', 'ccc'])],
+          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
           transientFileState(
             [
               utopiaJSXComponent(
@@ -217,19 +217,19 @@ describe('DerivedStateKeepDeepEquality', () => {
       elementWarnings: addToComplexMap(
         TP.toString,
         emptyComplexMap(),
-        TP.instancePath(['scene'], ['aaa', 'bbb']),
+        TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb']),
         defaultElementWarnings,
       ),
     }
     const newState: DerivedState = {
-      navigatorTargets: [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-      visibleNavigatorTargets: [TP.instancePath(['scene'], ['aaa', 'bbb'])],
+      navigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      visibleNavigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
       canvas: {
         descendantsOfHiddenInstances: [],
         controls: [],
         transientState: transientCanvasState(
-          [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-          [TP.instancePath(['scene'], ['aaa', 'ccc'])],
+          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
           transientFileState(
             [
               utopiaJSXComponent(
@@ -252,7 +252,7 @@ describe('DerivedStateKeepDeepEquality', () => {
       elementWarnings: addToComplexMap(
         TP.toString,
         emptyComplexMap(),
-        TP.instancePath(['scene'], ['aaa', 'bbb']),
+        TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb']),
         defaultElementWarnings,
       ),
     }
@@ -262,14 +262,14 @@ describe('DerivedStateKeepDeepEquality', () => {
   })
   it('different but similar value handled appropriately', () => {
     const oldState: DerivedState = {
-      navigatorTargets: [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-      visibleNavigatorTargets: [TP.instancePath(['scene'], ['aaa', 'bbb'])],
+      navigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      visibleNavigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
       canvas: {
         descendantsOfHiddenInstances: [],
         controls: [],
         transientState: transientCanvasState(
-          [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-          [TP.instancePath(['scene'], ['aaa', 'ccc'])],
+          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
           transientFileState(
             [
               utopiaJSXComponent(
@@ -292,19 +292,19 @@ describe('DerivedStateKeepDeepEquality', () => {
       elementWarnings: addToComplexMap(
         TP.toString,
         emptyComplexMap(),
-        TP.instancePath(['scene'], ['aaa', 'bbb']),
+        TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb']),
         defaultElementWarnings,
       ),
     }
     const newState: DerivedState = {
-      navigatorTargets: [TP.instancePath(['scene'], ['aaa', 'bbb'])],
-      visibleNavigatorTargets: [TP.instancePath(['scene'], ['aaa', 'bbb'])],
+      navigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      visibleNavigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
       canvas: {
         descendantsOfHiddenInstances: [],
         controls: [],
         transientState: transientCanvasState(
-          [TP.instancePath(['scene'], ['aaa', 'ddd'])],
-          [TP.instancePath(['scene'], ['aaa', 'ccc'])],
+          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ddd'])],
+          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
           transientFileState(
             [
               utopiaJSXComponent(
@@ -327,7 +327,7 @@ describe('DerivedStateKeepDeepEquality', () => {
       elementWarnings: addToComplexMap(
         TP.toString,
         emptyComplexMap(),
-        TP.instancePath(['scene'], ['aaa', 'bbb']),
+        TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb']),
         defaultElementWarnings,
       ),
     }

--- a/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
@@ -18,8 +18,8 @@ import {
 describe('TransientCanvasStateKeepDeepEquality', () => {
   it('same reference returns the same reference', () => {
     const state: TransientCanvasState = transientCanvasState(
-      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
+      [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+      [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
       transientFileState(
         [
           utopiaJSXComponent(
@@ -45,8 +45,8 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
   })
   it('same value returns the same reference', () => {
     const oldState: TransientCanvasState = transientCanvasState(
-      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
+      [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+      [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
       transientFileState(
         [
           utopiaJSXComponent(
@@ -66,8 +66,8 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
       ),
     )
     const newState: TransientCanvasState = transientCanvasState(
-      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
+      [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+      [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
       transientFileState(
         [
           utopiaJSXComponent(
@@ -93,8 +93,8 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
   })
   it('different but similar value handled appropriately', () => {
     const oldState: TransientCanvasState = transientCanvasState(
-      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
+      [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+      [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
       transientFileState(
         [
           utopiaJSXComponent(
@@ -114,8 +114,8 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
       ),
     )
     const newState: TransientCanvasState = transientCanvasState(
-      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ddd'])],
-      [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
+      [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ddd'])],
+      [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
       transientFileState(
         [
           utopiaJSXComponent(
@@ -147,14 +147,14 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
 describe('DerivedStateKeepDeepEquality', () => {
   it('same reference returns the same reference', () => {
     const state: DerivedState = {
-      navigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-      visibleNavigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      navigatorTargets: [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+      visibleNavigatorTargets: [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
       canvas: {
         descendantsOfHiddenInstances: [],
         controls: [],
         transientState: transientCanvasState(
-          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
+          [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+          [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
           transientFileState(
             [
               utopiaJSXComponent(
@@ -177,7 +177,7 @@ describe('DerivedStateKeepDeepEquality', () => {
       elementWarnings: addToComplexMap(
         TP.toString,
         emptyComplexMap(),
-        TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb']),
+        TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb']),
         defaultElementWarnings,
       ),
     }
@@ -187,14 +187,14 @@ describe('DerivedStateKeepDeepEquality', () => {
   })
   it('same value returns the same reference', () => {
     const oldState: DerivedState = {
-      navigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-      visibleNavigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      navigatorTargets: [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+      visibleNavigatorTargets: [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
       canvas: {
         descendantsOfHiddenInstances: [],
         controls: [],
         transientState: transientCanvasState(
-          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
+          [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+          [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
           transientFileState(
             [
               utopiaJSXComponent(
@@ -217,19 +217,19 @@ describe('DerivedStateKeepDeepEquality', () => {
       elementWarnings: addToComplexMap(
         TP.toString,
         emptyComplexMap(),
-        TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb']),
+        TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb']),
         defaultElementWarnings,
       ),
     }
     const newState: DerivedState = {
-      navigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-      visibleNavigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      navigatorTargets: [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+      visibleNavigatorTargets: [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
       canvas: {
         descendantsOfHiddenInstances: [],
         controls: [],
         transientState: transientCanvasState(
-          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
+          [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+          [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
           transientFileState(
             [
               utopiaJSXComponent(
@@ -252,7 +252,7 @@ describe('DerivedStateKeepDeepEquality', () => {
       elementWarnings: addToComplexMap(
         TP.toString,
         emptyComplexMap(),
-        TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb']),
+        TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb']),
         defaultElementWarnings,
       ),
     }
@@ -262,14 +262,14 @@ describe('DerivedStateKeepDeepEquality', () => {
   })
   it('different but similar value handled appropriately', () => {
     const oldState: DerivedState = {
-      navigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-      visibleNavigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      navigatorTargets: [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+      visibleNavigatorTargets: [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
       canvas: {
         descendantsOfHiddenInstances: [],
         controls: [],
         transientState: transientCanvasState(
-          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
+          [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+          [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
           transientFileState(
             [
               utopiaJSXComponent(
@@ -292,19 +292,19 @@ describe('DerivedStateKeepDeepEquality', () => {
       elementWarnings: addToComplexMap(
         TP.toString,
         emptyComplexMap(),
-        TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb']),
+        TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb']),
         defaultElementWarnings,
       ),
     }
     const newState: DerivedState = {
-      navigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
-      visibleNavigatorTargets: [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb'])],
+      navigatorTargets: [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
+      visibleNavigatorTargets: [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
       canvas: {
         descendantsOfHiddenInstances: [],
         controls: [],
         transientState: transientCanvasState(
-          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ddd'])],
-          [TP.instancePath(TP.scenePath(['scene']), ['aaa', 'ccc'])],
+          [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ddd'])],
+          [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
           transientFileState(
             [
               utopiaJSXComponent(
@@ -327,7 +327,7 @@ describe('DerivedStateKeepDeepEquality', () => {
       elementWarnings: addToComplexMap(
         TP.toString,
         emptyComplexMap(),
-        TP.instancePath(TP.scenePath(['scene']), ['aaa', 'bbb']),
+        TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb']),
         defaultElementWarnings,
       ),
     }

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -40,9 +40,7 @@ type UpdateFunctionHelpers = {
 export function getStoreHook(
   mockDispatch: EditorDispatch,
 ): EditorStateContextData & UpdateFunctionHelpers {
-  const editor = createEditorStates([
-    TP.instancePath(ScenePathForTestUiJsFile.sceneElementPath, ['aaa', 'bbb']),
-  ])
+  const editor = createEditorStates([TP.instancePath(ScenePathForTestUiJsFile, ['aaa', 'bbb'])])
   const defaultState: EditorStore = {
     editor: editor.editor,
     derived: editor.derivedState,

--- a/editor/src/components/inspector/common/layout-hooks.spec.ts
+++ b/editor/src/components/inspector/common/layout-hooks.spec.ts
@@ -19,7 +19,7 @@ function frameInfoForPins(
   parentFrame: LocalRectangle = SimpleRect,
 ): ElementFrameInfo {
   return {
-    path: TP.instancePath(ScenePathForTestUiJsFile.sceneElementPath, ['aaa']),
+    path: TP.instancePath(ScenePathForTestUiJsFile, ['aaa']),
     frame: frameForPins(pins),
     localFrame,
     parentFrame,

--- a/editor/src/components/inspector/common/layout-property-path-hooks.spec.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.spec.ts
@@ -19,7 +19,7 @@ function frameInfoForPins(
   parentFrame: LocalRectangle = SimpleRect,
 ): ElementFrameInfo {
   return {
-    path: TP.instancePath(ScenePathForTestUiJsFile.sceneElementPath, ['aaa']),
+    path: TP.instancePath(ScenePathForTestUiJsFile, ['aaa']),
     frame: frameForPins(pins),
     localFrame,
     parentFrame,

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -20,7 +20,7 @@ import * as PP from '../../../core/shared/property-path'
 import { setProp_UNSAFE, unsetProperty } from '../../editor/actions/action-creators'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
 
-const TestSelectedComponent = TP.instancePath(['scene1'], ['aaa', 'bbb'])
+const TestSelectedComponent = TP.instancePath(TP.scenePath(['scene1']), ['aaa', 'bbb'])
 
 function getPaddingHookResult<P extends ParsedPropertiesKeys, S extends ParsedPropertiesKeys>(
   longhands: Array<P>,

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -20,7 +20,7 @@ import * as PP from '../../../core/shared/property-path'
 import { setProp_UNSAFE, unsetProperty } from '../../editor/actions/action-creators'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
 
-const TestSelectedComponent = TP.instancePath(TP.scenePath(['scene1']), ['aaa', 'bbb'])
+const TestSelectedComponent = TP.instancePath(TP.scenePath([['scene1']]), ['aaa', 'bbb'])
 
 function getPaddingHookResult<P extends ParsedPropertiesKeys, S extends ParsedPropertiesKeys>(
   longhands: Array<P>,

--- a/editor/src/components/inspector/sections/component-section/component-section.spec.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.spec.tsx
@@ -23,7 +23,7 @@ describe('Component Section', () => {
     const storeHookForTest = getStoreHook(utils.NO_OP)
     storeHookForTest.updateStoreWithImmer((store) => {
       store.editor.selectedViews = [
-        TP.instancePath(ScenePathForTestUiJsFile.sceneElementPath, ['aaa', 'mycomponent']),
+        TP.instancePath(ScenePathForTestUiJsFile, ['aaa', 'mycomponent']),
       ] // TODO add a Component instance to the test file and select that!
       store.editor.codeResultCache = {
         propertyControlsInfo: {

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -31,7 +31,7 @@ export const BasePaddingUnit = 20
 export function getElementPadding(templatePath: TemplatePath): number {
   // if an element is the child of the Storyboard component, let's show it at the root level
   const extraDepthRemoval = TP.pathsEqual(
-    TP.scenePathForPath(templatePath),
+    TP.scenePathPartOfTemplatePath(templatePath),
     EmptyScenePathForStoryboard,
   )
   const depthOffset = extraDepthRemoval ? 2 : 0

--- a/editor/src/core/layout/layout-utils.spec.browser.ts
+++ b/editor/src/core/layout/layout-utils.spec.browser.ts
@@ -51,7 +51,7 @@ describe('maybeSwitchLayoutProps', () => {
     await renderResult.dispatch(
       [
         selectComponents(
-          [TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['aaa', 'bbb'])],
+          [TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['aaa', 'bbb'])],
           false,
         ),
       ],
@@ -74,10 +74,10 @@ describe('maybeSwitchLayoutProps', () => {
       }),
       [],
     )
-    const elementPath = TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], [NewUID])
+    const elementPath = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [NewUID])
     const elements: ElementInstanceMetadataMap = {
       [TP.toString(elementPath)]: {
-        templatePath: TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], [NewUID]),
+        templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [NewUID]),
         element: right(elementToPaste),
         props: {
           'data-uid': NewUID,
@@ -112,7 +112,7 @@ describe('maybeSwitchLayoutProps', () => {
     const components: ComponentMetadata[] = [
       {
         scenePath: TP.scenePath([BakedInStoryboardUID, 'scene-aaa']),
-        templatePath: TP.instancePath([], [BakedInStoryboardUID, 'scene-aaa']),
+        templatePath: TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, 'scene-aaa']),
         component: 'Component1',
         sceneResizesContent: false,
         globalFrame: { x: 0, y: 0, width: 375, height: 812 } as CanvasRectangle,
@@ -123,7 +123,7 @@ describe('maybeSwitchLayoutProps', () => {
     const metadata = jsxMetadata(components, elements)
     const pasteElements = pasteJSXElements(
       [elementToPaste],
-      [TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], [NewUID])],
+      [TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [NewUID])],
       metadata,
     )
     await renderResult.dispatch([pasteElements], true)

--- a/editor/src/core/layout/layout-utils.spec.browser.ts
+++ b/editor/src/core/layout/layout-utils.spec.browser.ts
@@ -51,7 +51,7 @@ describe('maybeSwitchLayoutProps', () => {
     await renderResult.dispatch(
       [
         selectComponents(
-          [TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['aaa', 'bbb'])],
+          [TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['aaa', 'bbb'])],
           false,
         ),
       ],
@@ -74,10 +74,14 @@ describe('maybeSwitchLayoutProps', () => {
       }),
       [],
     )
-    const elementPath = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [NewUID])
+    const elementPath = TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), [
+      NewUID,
+    ])
     const elements: ElementInstanceMetadataMap = {
       [TP.toString(elementPath)]: {
-        templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [NewUID]),
+        templatePath: TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), [
+          NewUID,
+        ]),
         element: right(elementToPaste),
         props: {
           'data-uid': NewUID,
@@ -111,7 +115,7 @@ describe('maybeSwitchLayoutProps', () => {
 
     const components: ComponentMetadata[] = [
       {
-        scenePath: TP.scenePath([BakedInStoryboardUID, 'scene-aaa']),
+        scenePath: TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]),
         templatePath: TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, 'scene-aaa']),
         component: 'Component1',
         sceneResizesContent: false,
@@ -123,7 +127,7 @@ describe('maybeSwitchLayoutProps', () => {
     const metadata = jsxMetadata(components, elements)
     const pasteElements = pasteJSXElements(
       [elementToPaste],
-      [TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [NewUID])],
+      [TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), [NewUID])],
       metadata,
     )
     await renderResult.dispatch([pasteElements], true)

--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -41,7 +41,7 @@ const TestScenePath = 'scene-aaa'
 const testComponentMetadataChild1: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
-  templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), [
+  templatePath: TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), [
     'View',
     'View0',
   ]),
@@ -56,7 +56,7 @@ const testComponentMetadataChild1: ElementInstanceMetadata = {
 const testComponentMetadataChild2: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
-  templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), [
+  templatePath: TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), [
     'View',
     'View1',
   ]),
@@ -72,7 +72,7 @@ const testComponentMetadataChild2: ElementInstanceMetadata = {
 const testComponentMetadataGrandchild: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
-  templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), [
+  templatePath: TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), [
     'View',
     'View2',
     'View0',
@@ -91,7 +91,7 @@ const testComponentMetadataGrandchild: ElementInstanceMetadata = {
 const testComponentMetadataChild3: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
-  templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), [
+  templatePath: TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), [
     'View',
     'View2',
   ]),
@@ -107,7 +107,7 @@ const testComponentMetadataChild3: ElementInstanceMetadata = {
 const testComponentRoot1: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
-  templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View']),
+  templatePath: TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), ['View']),
   props: {},
   element: right(jsxTestElement('View', [], [])),
   children: [
@@ -122,7 +122,7 @@ const testComponentRoot1: ElementInstanceMetadata = {
 }
 
 const testComponentScene: ComponentMetadata = {
-  scenePath: TP.scenePath([BakedInStoryboardUID, TestScenePath]),
+  scenePath: TP.scenePath([[BakedInStoryboardUID, TestScenePath]]),
   templatePath: TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, 'scene-aaa']),
   component: 'MyView',
   rootElements: [testComponentRoot1.templatePath],
@@ -174,35 +174,35 @@ describe('getElementByInstancePathMaybe', () => {
   it('works with an empty object', () => {
     const actualResult = MetadataUtils.getElementByInstancePathMaybe(
       {},
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View', 'View0']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), ['View', 'View0']),
     )
     expect(actualResult).toBeNull()
   })
   it('returns null for a nonsense path', () => {
     const actualResult = MetadataUtils.getElementByInstancePathMaybe(
       {},
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['Hats', 'Cats']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), ['Hats', 'Cats']),
     )
     expect(actualResult).toBeNull()
   })
   it('returns null for a partially nonsense path', () => {
     const actualResult = MetadataUtils.getElementByInstancePathMaybe(
       {},
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View', 'Cats']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), ['View', 'Cats']),
     )
     expect(actualResult).toBeNull()
   })
   it('returns the element from the map', () => {
     const actualResult = MetadataUtils.getElementByInstancePathMaybe(
       testElementMetadataMap,
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), ['View']),
     )
     expect(actualResult).toBe(testComponentRoot1)
   })
   it('returns the element for a child of the root', () => {
     const actualResult = MetadataUtils.getElementByInstancePathMaybe(
       testElementMetadataMap,
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View', 'View1']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), ['View', 'View1']),
     )
     expect(actualResult).toBe(testComponentMetadataChild2)
   })
@@ -215,7 +215,7 @@ describe('targetElementSupportsChildren', () => {
     return {
       globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
       localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
-      templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), [
+      templatePath: TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), [
         'Dummy',
         'Element',
       ]),
@@ -271,7 +271,7 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
     expect(
       MetadataUtils.isPinnedAndNotAbsolutePositioned(
         jsxMetadata(testComponentMetadata, elementMapForTest),
-        TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View']),
+        TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), ['View']),
       ),
     ).toEqual(true)
   })
@@ -289,7 +289,7 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
     expect(
       MetadataUtils.isPinnedAndNotAbsolutePositioned(
         jsxMetadata(testComponentMetadata, elementMapForTest),
-        TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View']),
+        TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), ['View']),
       ),
     ).toEqual(false)
   })
@@ -307,7 +307,7 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
     expect(
       MetadataUtils.isPinnedAndNotAbsolutePositioned(
         jsxMetadata(testComponentMetadata, elementMapForTest),
-        TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View']),
+        TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), ['View']),
       ),
     ).toEqual(false)
   })
@@ -325,14 +325,14 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
     expect(
       MetadataUtils.isPinnedAndNotAbsolutePositioned(
         jsxMetadata(testComponentMetadata, elementMapForTest),
-        TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View']),
+        TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), ['View']),
       ),
     ).toEqual(false)
   })
 })
 
 describe('getElementLabel', () => {
-  const scenePath = TP.scenePath([BakedInStoryboardUID, 'scene-0'])
+  const scenePath = TP.scenePath([[BakedInStoryboardUID, 'scene-0']])
   const instancePath = TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, `scene-0`])
   const divPath = TP.appendToPath(scenePath, 'div-1')
   const spanPath = TP.appendToPath(divPath, 'span-1')
@@ -414,7 +414,7 @@ describe('getAllPaths', () => {
       testComponentMetadataChild1.templatePath,
       testComponentMetadataChild2.templatePath,
       testComponentMetadataChild3.templatePath,
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), [
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, TestScenePath]]), [
         'View',
         'View2',
         'View0',

--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -41,7 +41,10 @@ const TestScenePath = 'scene-aaa'
 const testComponentMetadataChild1: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
-  templatePath: TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View', 'View0']),
+  templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), [
+    'View',
+    'View0',
+  ]),
   props: {},
   element: right(jsxTestElement('View', [], [])),
   children: [],
@@ -53,7 +56,10 @@ const testComponentMetadataChild1: ElementInstanceMetadata = {
 const testComponentMetadataChild2: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
-  templatePath: TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View', 'View1']),
+  templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), [
+    'View',
+    'View1',
+  ]),
   props: {},
   element: right(jsxTestElement('View', [], [])),
   children: [],
@@ -66,7 +72,11 @@ const testComponentMetadataChild2: ElementInstanceMetadata = {
 const testComponentMetadataGrandchild: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
-  templatePath: TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View', 'View2', 'View0']),
+  templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), [
+    'View',
+    'View2',
+    'View0',
+  ]),
   props: {
     cica: 'hello',
   },
@@ -81,7 +91,10 @@ const testComponentMetadataGrandchild: ElementInstanceMetadata = {
 const testComponentMetadataChild3: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
-  templatePath: TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View', 'View2']),
+  templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), [
+    'View',
+    'View2',
+  ]),
   props: {},
   element: right(jsxTestElement('View', [], [])),
   children: [testComponentMetadataGrandchild.templatePath],
@@ -94,7 +107,7 @@ const testComponentMetadataChild3: ElementInstanceMetadata = {
 const testComponentRoot1: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
-  templatePath: TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View']),
+  templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View']),
   props: {},
   element: right(jsxTestElement('View', [], [])),
   children: [
@@ -110,7 +123,7 @@ const testComponentRoot1: ElementInstanceMetadata = {
 
 const testComponentScene: ComponentMetadata = {
   scenePath: TP.scenePath([BakedInStoryboardUID, TestScenePath]),
-  templatePath: TP.instancePath([], [BakedInStoryboardUID, 'scene-aaa']),
+  templatePath: TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, 'scene-aaa']),
   component: 'MyView',
   rootElements: [testComponentRoot1.templatePath],
   sceneResizesContent: false,
@@ -161,35 +174,35 @@ describe('getElementByInstancePathMaybe', () => {
   it('works with an empty object', () => {
     const actualResult = MetadataUtils.getElementByInstancePathMaybe(
       {},
-      TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View', 'View0']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View', 'View0']),
     )
     expect(actualResult).toBeNull()
   })
   it('returns null for a nonsense path', () => {
     const actualResult = MetadataUtils.getElementByInstancePathMaybe(
       {},
-      TP.instancePath([BakedInStoryboardUID, TestScenePath], ['Hats', 'Cats']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['Hats', 'Cats']),
     )
     expect(actualResult).toBeNull()
   })
   it('returns null for a partially nonsense path', () => {
     const actualResult = MetadataUtils.getElementByInstancePathMaybe(
       {},
-      TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View', 'Cats']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View', 'Cats']),
     )
     expect(actualResult).toBeNull()
   })
   it('returns the element from the map', () => {
     const actualResult = MetadataUtils.getElementByInstancePathMaybe(
       testElementMetadataMap,
-      TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View']),
     )
     expect(actualResult).toBe(testComponentRoot1)
   })
   it('returns the element for a child of the root', () => {
     const actualResult = MetadataUtils.getElementByInstancePathMaybe(
       testElementMetadataMap,
-      TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View', 'View1']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View', 'View1']),
     )
     expect(actualResult).toBe(testComponentMetadataChild2)
   })
@@ -202,7 +215,10 @@ describe('targetElementSupportsChildren', () => {
     return {
       globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
       localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
-      templatePath: TP.instancePath([BakedInStoryboardUID, TestScenePath], ['Dummy', 'Element']),
+      templatePath: TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), [
+        'Dummy',
+        'Element',
+      ]),
       props: {},
       element: right(jsxTestElement(elementName, [], [])),
       children: [],
@@ -255,7 +271,7 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
     expect(
       MetadataUtils.isPinnedAndNotAbsolutePositioned(
         jsxMetadata(testComponentMetadata, elementMapForTest),
-        TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View']),
+        TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View']),
       ),
     ).toEqual(true)
   })
@@ -273,7 +289,7 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
     expect(
       MetadataUtils.isPinnedAndNotAbsolutePositioned(
         jsxMetadata(testComponentMetadata, elementMapForTest),
-        TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View']),
+        TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View']),
       ),
     ).toEqual(false)
   })
@@ -291,7 +307,7 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
     expect(
       MetadataUtils.isPinnedAndNotAbsolutePositioned(
         jsxMetadata(testComponentMetadata, elementMapForTest),
-        TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View']),
+        TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View']),
       ),
     ).toEqual(false)
   })
@@ -309,7 +325,7 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
     expect(
       MetadataUtils.isPinnedAndNotAbsolutePositioned(
         jsxMetadata(testComponentMetadata, elementMapForTest),
-        TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View']),
+        TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), ['View']),
       ),
     ).toEqual(false)
   })
@@ -317,7 +333,7 @@ describe('isPinnedAndNotAbsolutePositioned', () => {
 
 describe('getElementLabel', () => {
   const scenePath = TP.scenePath([BakedInStoryboardUID, 'scene-0'])
-  const instancePath = TP.instancePath([], [BakedInStoryboardUID, `scene-0`])
+  const instancePath = TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, `scene-0`])
   const divPath = TP.appendToPath(scenePath, 'div-1')
   const spanPath = TP.appendToPath(divPath, 'span-1')
   const textBlock = jsxTextBlock('test text')
@@ -398,7 +414,11 @@ describe('getAllPaths', () => {
       testComponentMetadataChild1.templatePath,
       testComponentMetadataChild2.templatePath,
       testComponentMetadataChild3.templatePath,
-      TP.instancePath([BakedInStoryboardUID, TestScenePath], ['View', 'View2', 'View0']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, TestScenePath]), [
+        'View',
+        'View2',
+        'View0',
+      ]),
     ]
     expect(actualResult).toEqual(expectedResult)
   })

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1400,9 +1400,7 @@ export const MetadataUtils = {
     target: TemplatePath,
     elements: Array<ElementInstanceMetadata>,
   ): ElementInstanceMetadata | null {
-    const pathToUse = TP.isScenePath(target)
-      ? TP.instancePath(TP.emptyScenePath, TP.elementPathForPath(target))
-      : target
+    const pathToUse = TP.isScenePath(target) ? TP.instancePathForScenePath(target) : target
     return elements.find((elem) => TP.pathsEqual(pathToUse, elem.templatePath)) ?? null
   },
   getStaticElementName(

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -579,7 +579,7 @@ export const MetadataUtils = {
       )
       return rootChildrenOfStoryboard.map((child) => {
         if (isLeft(child.element) && child.element.value === 'Scene') {
-          const foundScenePath = TP.scenePath(child.templatePath.element)
+          const foundScenePath = TP.scenePath([child.templatePath.element])
           const realSceneRoot = MetadataUtils.findSceneByTemplatePath(
             metadata.components,
             foundScenePath,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -185,7 +185,7 @@ export const MetadataUtils = {
     scenes: ComponentMetadata[],
     path: TemplatePath,
   ): ComponentMetadata | null {
-    const scenePath = TP.scenePathForPath(path)
+    const scenePath = TP.scenePathPartOfTemplatePath(path)
     return scenes.find((s) => TP.pathsEqual(s.scenePath, scenePath)) ?? null
   },
   isSceneTreatedAsGroup(scene: ComponentMetadata | null): boolean {
@@ -1400,7 +1400,9 @@ export const MetadataUtils = {
     target: TemplatePath,
     elements: Array<ElementInstanceMetadata>,
   ): ElementInstanceMetadata | null {
-    const pathToUse = TP.isScenePath(target) ? TP.instancePathForScenePath(target) : target
+    const pathToUse = TP.isScenePath(target)
+      ? TP.instancePathForLastPartOfScenePath(target)
+      : target
     return elements.find((elem) => TP.pathsEqual(pathToUse, elem.templatePath)) ?? null
   },
   getStaticElementName(

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1401,7 +1401,7 @@ export const MetadataUtils = {
     elements: Array<ElementInstanceMetadata>,
   ): ElementInstanceMetadata | null {
     const pathToUse = TP.isScenePath(target)
-      ? TP.instancePath([], TP.elementPathForPath(target))
+      ? TP.instancePath(TP.emptyScenePath, TP.elementPathForPath(target))
       : target
     return elements.find((elem) => TP.pathsEqual(pathToUse, elem.templatePath)) ?? null
   },

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1400,9 +1400,7 @@ export const MetadataUtils = {
     target: TemplatePath,
     elements: Array<ElementInstanceMetadata>,
   ): ElementInstanceMetadata | null {
-    const pathToUse = TP.isScenePath(target)
-      ? TP.instancePathForLastPartOfScenePath(target)
-      : target
+    const pathToUse = TP.isScenePath(target) ? TP.instancePathForElementAtScenePath(target) : target
     return elements.find((elem) => TP.pathsEqual(pathToUse, elem.templatePath)) ?? null
   },
   getStaticElementName(

--- a/editor/src/core/model/element-template-utils.spec.ts
+++ b/editor/src/core/model/element-template-utils.spec.ts
@@ -178,7 +178,7 @@ describe('removeJSXElementChild', () => {
   xit('removes a root element', () => {
     // TODO Scene Implementation
     const updatedElements = removeJSXElementChild(
-      TP.staticInstancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['aaa']),
+      TP.staticInstancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['aaa']),
       utopiaComponents,
     )
     expect(updatedElements.length).toEqual(1)
@@ -186,7 +186,7 @@ describe('removeJSXElementChild', () => {
   })
   it('removes a non-root element', () => {
     const updatedElements = removeJSXElementChild(
-      TP.staticInstancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['aab', 'aac']),
+      TP.staticInstancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['aab', 'aac']),
       utopiaComponents,
     )
     const expectedResult = R.over(

--- a/editor/src/core/model/element-template-utils.spec.ts
+++ b/editor/src/core/model/element-template-utils.spec.ts
@@ -178,7 +178,7 @@ describe('removeJSXElementChild', () => {
   xit('removes a root element', () => {
     // TODO Scene Implementation
     const updatedElements = removeJSXElementChild(
-      TP.staticInstancePath([BakedInStoryboardUID, 'scene-aaa'], ['aaa']),
+      TP.staticInstancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['aaa']),
       utopiaComponents,
     )
     expect(updatedElements.length).toEqual(1)
@@ -186,7 +186,7 @@ describe('removeJSXElementChild', () => {
   })
   it('removes a non-root element', () => {
     const updatedElements = removeJSXElementChild(
-      TP.staticInstancePath([BakedInStoryboardUID, 'scene-aaa'], ['aab', 'aac']),
+      TP.staticInstancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['aab', 'aac']),
       utopiaComponents,
     )
     const expectedResult = R.over(

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -44,7 +44,7 @@ import { UTOPIA_UID_KEY } from './utopia-constants'
 import { getUtopiaID } from './element-template-utils'
 import { emptyComments } from '../workers/parser-printer/parser-printer-comments'
 
-export const EmptyScenePathForStoryboard = TP.scenePath([])
+export const EmptyScenePathForStoryboard = TP.emptyScenePath
 
 export const PathForSceneComponent = PP.create(['component'])
 export const PathForSceneDataUid = PP.create(['data-uid'])

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -66,7 +66,7 @@ export function createSceneUidFromIndex(sceneIndex: number): string {
 }
 
 export function createSceneTemplatePath(scenePath: ScenePath): StaticInstancePath {
-  return TP.instancePathForScenePath(scenePath)
+  return TP.instancePathForLastPartOfScenePath(scenePath)
 }
 
 export function mapScene(scene: SceneMetadata): JSXElement {

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -66,7 +66,7 @@ export function createSceneUidFromIndex(sceneIndex: number): string {
 }
 
 export function createSceneTemplatePath(scenePath: ScenePath): StaticInstancePath {
-  return TP.instancePathForLastPartOfScenePath(scenePath)
+  return TP.instancePathForElementAtScenePath(scenePath)
 }
 
 export function mapScene(scene: SceneMetadata): JSXElement {

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -66,7 +66,7 @@ export function createSceneUidFromIndex(sceneIndex: number): string {
 }
 
 export function createSceneTemplatePath(scenePath: ScenePath): StaticInstancePath {
-  return TP.staticInstancePath(scenePath, scenePath.sceneElementPath)
+  return TP.instancePathForScenePath(scenePath)
 }
 
 export function mapScene(scene: SceneMetadata): JSXElement {

--- a/editor/src/core/model/test-ui-js-file.ts
+++ b/editor/src/core/model/test-ui-js-file.ts
@@ -324,9 +324,9 @@ const scene = utopiaJSXComponent(
 )
 
 const Scene0UID = 'scene-0'
-export const ScenePathForTestUiJsFile = scenePath([BakedInStoryboardUID, Scene0UID])
+export const ScenePathForTestUiJsFile = scenePath([[BakedInStoryboardUID, Scene0UID]])
 const Scene1UID = 'scene-1'
-export const ScenePath1ForTestUiJsFile = scenePath([BakedInStoryboardUID, Scene1UID])
+export const ScenePath1ForTestUiJsFile = scenePath([[BakedInStoryboardUID, Scene1UID]])
 
 const Scene1 = defaultSceneElement(
   Scene0UID,

--- a/editor/src/core/shared/array-utils.ts
+++ b/editor/src/core/shared/array-utils.ts
@@ -166,6 +166,10 @@ export function last<T>(array: Array<T>): T | undefined {
   return array[array.length - 1]
 }
 
+export function splitAt<T>(n: number, array: Array<T>): [Array<T>, Array<T>] {
+  return [take(n, array), drop(n, array)]
+}
+
 export function removeIndexFromArray<T>(index: number, arr: Array<T>): Array<T> {
   let result: Array<T> = [...arr]
   result.splice(index, 1)

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -15,7 +15,7 @@ export type id = string
 
 export type ScenePath = {
   type: 'scenepath'
-  sceneElementPaths: StaticElementPath
+  sceneElementPaths: StaticElementPath[]
 }
 export type StaticElementPath = StaticModifier & Array<id>
 export type ElementPath = Array<id> | StaticElementPath

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -15,7 +15,7 @@ export type id = string
 
 export type ScenePath = {
   type: 'scenepath'
-  sceneElementPath: StaticElementPath
+  sceneElementPaths: StaticElementPath
 }
 export type StaticElementPath = StaticModifier & Array<id>
 export type ElementPath = Array<id> | StaticElementPath

--- a/editor/src/core/shared/template-path.spec.ts
+++ b/editor/src/core/shared/template-path.spec.ts
@@ -5,7 +5,7 @@ const chaiExpect = Chai.expect
 
 describe('serialization', function () {
   it('path survives serialization', function () {
-    const path = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [
+    const path = TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), [
       'VIEW1',
       'VIEW2',
     ])
@@ -15,21 +15,21 @@ describe('serialization', function () {
   })
 
   it('empty path survives serialization', function () {
-    const path = TP.instancePath(TP.scenePath([]), [])
+    const path = TP.instancePath(TP.emptyScenePath, [])
     const pathString = TP.toComponentId(path)
     const restoredPath = TP.fromString(pathString)
     chaiExpect(restoredPath).to.deep.equal(path)
   })
 
   it('ScenePath survives serialization', function () {
-    const path = TP.scenePath([BakedInStoryboardUID, 'scene-aaa'])
+    const path = TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']])
     const pathString = TP.toString(path)
     const restoredPath = TP.fromString(pathString)
     chaiExpect(restoredPath).to.deep.equal(path)
   })
 
   it('Empty ScenePath survives serialization', function () {
-    const path = TP.scenePath([])
+    const path = TP.emptyScenePath
     const pathString = TP.toString(path)
     const restoredPath = TP.fromString(pathString)
     chaiExpect(restoredPath).to.deep.equal(path)
@@ -39,32 +39,32 @@ describe('serialization', function () {
 describe('isAncestorOf', () => {
   it('is not an ancestor', () => {
     const result = TP.isAncestorOf(
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['Y']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['Y']),
     )
     chaiExpect(result).to.be.false
   })
 
   it('is an ancestor', () => {
     const result = TP.isAncestorOf(
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X', 'Y']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X', 'Y']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
     )
     chaiExpect(result).to.be.true
   })
 
   it('the two paths are the same', () => {
     const result = TP.isAncestorOf(
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
     )
     chaiExpect(result).to.be.true
   })
 
   it('does not match same paths with flag set to false', () => {
     const result = TP.isAncestorOf(
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
       false,
     )
     chaiExpect(result).to.be.false
@@ -72,8 +72,8 @@ describe('isAncestorOf', () => {
 
   it('target ancestor is children of path', () => {
     const result = TP.isAncestorOf(
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X', 'Y']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X', 'Y']),
     )
     chaiExpect(result).to.be.false
   })
@@ -82,37 +82,37 @@ describe('isAncestorOf', () => {
 describe('replaceIfAncestor', () => {
   it('where the path does not match', () => {
     const result = TP.replaceIfAncestor(
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['A']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['B']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['A']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['B']),
     )
     chaiExpect(result).to.be.null
   })
   it('where the path matches exactly', () => {
     const result = TP.replaceIfAncestor(
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['A', 'B']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['A', 'B']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['C', 'D']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['A', 'B']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['A', 'B']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['C', 'D']),
     )
     expect(result).toEqual(
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['C', 'D']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['C', 'D']),
     )
   })
   it('where the path is an ancestor', () => {
     const result = TP.replaceIfAncestor(
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['A', 'B', 'X']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['A', 'B']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['C', 'D']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['A', 'B', 'X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['A', 'B']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['C', 'D']),
     )
     chaiExpect(result).to.deep.equal(
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['C', 'D', 'X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['C', 'D', 'X']),
     )
   })
 })
 
 describe('fromString', () => {
   it('parses a simple path correctly', () => {
-    const expectedResult = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [
+    const expectedResult = TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), [
       'A',
       'B',
       'C',
@@ -129,17 +129,19 @@ describe('getCommonParent', () => {
   })
   it('single element returns the parent', () => {
     const actualResult = TP.getCommonParent([
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['a', 'b']),
     ])
-    const expectedResult = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a'])
+    const expectedResult = TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), [
+      'a',
+    ])
     expect(actualResult).toEqual(expectedResult)
   })
   it('for two elements returns the common parent', () => {
     const actualResult = TP.getCommonParent([
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b', 'c']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b', 'd']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['a', 'b', 'c']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['a', 'b', 'd']),
     ])
-    const expectedResult = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [
+    const expectedResult = TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), [
       'a',
       'b',
     ])
@@ -147,21 +149,21 @@ describe('getCommonParent', () => {
   })
   it('for three elements without a common parent returns null', () => {
     const actualResult = TP.getCommonParent([
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b', 'c']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-bbb']), ['a', 'b', 'd']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-ccc']), ['x', 'b', 'd']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['a', 'b', 'c']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-bbb']]), ['a', 'b', 'd']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-ccc']]), ['x', 'b', 'd']),
     ])
     expect(actualResult).toBeNull()
   })
   it('returns one of the passed paths if it is a common parent of the rest and includeSelf is set to true', () => {
     const actualResult = TP.getCommonParent(
       [
-        TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b']),
-        TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b', 'd']),
+        TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['a', 'b']),
+        TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['a', 'b', 'd']),
       ],
       true,
     )
-    const expectedResult = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [
+    const expectedResult = TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), [
       'a',
       'b',
     ])
@@ -169,10 +171,12 @@ describe('getCommonParent', () => {
   })
   it('does not return one of the passed paths if it is a common parent of the rest and includeSelf is not set', () => {
     const actualResult = TP.getCommonParent([
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b']),
-      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b', 'd']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['a', 'b']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['a', 'b', 'd']),
     ])
-    const expectedResult = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a'])
+    const expectedResult = TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), [
+      'a',
+    ])
     expect(actualResult).toEqual(expectedResult)
   })
 })

--- a/editor/src/core/shared/template-path.spec.ts
+++ b/editor/src/core/shared/template-path.spec.ts
@@ -180,3 +180,53 @@ describe('getCommonParent', () => {
     expect(actualResult).toEqual(expectedResult)
   })
 })
+
+describe('Scenes, Instances and Element Paths', () => {
+  const appInstanceElementPath = ['storyboard', 'app-instance']
+  const cardInstanceElementPath = ['app-root', 'card-instance']
+  const cardRootElementPath = ['card-root']
+
+  const appScenePath = TP.scenePath([appInstanceElementPath])
+  const cardScenePath = TP.scenePath([appInstanceElementPath, cardInstanceElementPath])
+  const cardRootScenePath = TP.scenePath([
+    appInstanceElementPath,
+    cardInstanceElementPath,
+    cardRootElementPath,
+  ])
+
+  const appInstancePath = TP.instancePath(TP.emptyScenePath, appInstanceElementPath)
+  const cardInstancePath = TP.instancePath(appScenePath, cardInstanceElementPath)
+  const cardRootInstancePath = TP.instancePath(cardScenePath, cardRootElementPath)
+
+  it('scenePathPartOfTemplatePath returns the scene path part of a given instance path', () => {
+    expect(TP.scenePathPartOfTemplatePath(TP.emptyInstancePath)).toEqual(TP.emptyScenePath)
+    expect(TP.scenePathPartOfTemplatePath(appInstancePath)).toEqual(TP.emptyScenePath)
+    expect(TP.scenePathPartOfTemplatePath(cardInstancePath)).toEqual(appScenePath)
+    expect(TP.scenePathPartOfTemplatePath(cardRootInstancePath)).toEqual(cardScenePath)
+  })
+
+  it('calling scenePathPartOfTemplatePath with a scene path returns that same scene path', () => {
+    expect(TP.scenePathPartOfTemplatePath(TP.emptyScenePath)).toEqual(TP.emptyScenePath)
+    expect(TP.scenePathPartOfTemplatePath(appScenePath)).toEqual(appScenePath)
+    expect(TP.scenePathPartOfTemplatePath(cardScenePath)).toEqual(cardScenePath)
+    expect(TP.scenePathPartOfTemplatePath(cardRootScenePath)).toEqual(cardRootScenePath)
+  })
+
+  it('instancePathForScenePath creates a new instance path pointing to last element path of a scene', () => {
+    expect(TP.instancePathForLastPartOfScenePath(TP.emptyScenePath)).toEqual(TP.emptyInstancePath)
+    expect(TP.instancePathForLastPartOfScenePath(appScenePath)).toEqual(appInstancePath)
+    expect(TP.instancePathForLastPartOfScenePath(cardScenePath)).toEqual(cardInstancePath)
+    expect(TP.instancePathForLastPartOfScenePath(cardRootScenePath)).toEqual(cardRootInstancePath)
+  })
+
+  it('scenePathFromInstancePath creates a new scene path pointing to full element path of an instance path', () => {
+    expect(TP.scenePathForCombinedPartsOfInstancePath(TP.emptyInstancePath)).toEqual(
+      TP.emptyScenePath,
+    )
+    expect(TP.scenePathForCombinedPartsOfInstancePath(appInstancePath)).toEqual(appScenePath)
+    expect(TP.scenePathForCombinedPartsOfInstancePath(cardInstancePath)).toEqual(cardScenePath)
+    expect(TP.scenePathForCombinedPartsOfInstancePath(cardRootInstancePath)).toEqual(
+      cardRootScenePath,
+    )
+  })
+})

--- a/editor/src/core/shared/template-path.spec.ts
+++ b/editor/src/core/shared/template-path.spec.ts
@@ -212,21 +212,17 @@ describe('Scenes, Instances and Element Paths', () => {
     expect(TP.scenePathPartOfTemplatePath(cardRootScenePath)).toEqual(cardRootScenePath)
   })
 
-  it('instancePathForScenePath creates a new instance path pointing to last element path of a scene', () => {
-    expect(TP.instancePathForLastPartOfScenePath(TP.emptyScenePath)).toEqual(TP.emptyInstancePath)
-    expect(TP.instancePathForLastPartOfScenePath(appScenePath)).toEqual(appInstancePath)
-    expect(TP.instancePathForLastPartOfScenePath(cardScenePath)).toEqual(cardInstancePath)
-    expect(TP.instancePathForLastPartOfScenePath(cardRootScenePath)).toEqual(cardRootInstancePath)
+  it('instancePathForElementAtScenePath creates a new instance path pointing to last element path of a scene', () => {
+    expect(TP.instancePathForElementAtScenePath(TP.emptyScenePath)).toEqual(TP.emptyInstancePath)
+    expect(TP.instancePathForElementAtScenePath(appScenePath)).toEqual(appInstancePath)
+    expect(TP.instancePathForElementAtScenePath(cardScenePath)).toEqual(cardInstancePath)
+    expect(TP.instancePathForElementAtScenePath(cardRootScenePath)).toEqual(cardRootInstancePath)
   })
 
-  it('scenePathFromInstancePath creates a new scene path pointing to full element path of an instance path', () => {
-    expect(TP.scenePathForCombinedPartsOfInstancePath(TP.emptyInstancePath)).toEqual(
-      TP.emptyScenePath,
-    )
-    expect(TP.scenePathForCombinedPartsOfInstancePath(appInstancePath)).toEqual(appScenePath)
-    expect(TP.scenePathForCombinedPartsOfInstancePath(cardInstancePath)).toEqual(cardScenePath)
-    expect(TP.scenePathForCombinedPartsOfInstancePath(cardRootInstancePath)).toEqual(
-      cardRootScenePath,
-    )
+  it('scenePathForElementAtInstancePath creates a new scene path pointing to full element path of an instance path', () => {
+    expect(TP.scenePathForElementAtInstancePath(TP.emptyInstancePath)).toEqual(TP.emptyScenePath)
+    expect(TP.scenePathForElementAtInstancePath(appInstancePath)).toEqual(appScenePath)
+    expect(TP.scenePathForElementAtInstancePath(cardInstancePath)).toEqual(cardScenePath)
+    expect(TP.scenePathForElementAtInstancePath(cardRootInstancePath)).toEqual(cardRootScenePath)
   })
 })

--- a/editor/src/core/shared/template-path.spec.ts
+++ b/editor/src/core/shared/template-path.spec.ts
@@ -5,14 +5,17 @@ const chaiExpect = Chai.expect
 
 describe('serialization', function () {
   it('path survives serialization', function () {
-    const path = TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['VIEW1', 'VIEW2'])
+    const path = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [
+      'VIEW1',
+      'VIEW2',
+    ])
     const pathString = TP.toComponentId(path)
     const restoredPath = TP.fromString(pathString)
     chaiExpect(restoredPath).to.deep.equal(path)
   })
 
   it('empty path survives serialization', function () {
-    const path = TP.instancePath([], [])
+    const path = TP.instancePath(TP.scenePath([]), [])
     const pathString = TP.toComponentId(path)
     const restoredPath = TP.fromString(pathString)
     chaiExpect(restoredPath).to.deep.equal(path)
@@ -36,32 +39,32 @@ describe('serialization', function () {
 describe('isAncestorOf', () => {
   it('is not an ancestor', () => {
     const result = TP.isAncestorOf(
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['X']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['Y']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['Y']),
     )
     chaiExpect(result).to.be.false
   })
 
   it('is an ancestor', () => {
     const result = TP.isAncestorOf(
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['X', 'Y']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['X']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X', 'Y']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
     )
     chaiExpect(result).to.be.true
   })
 
   it('the two paths are the same', () => {
     const result = TP.isAncestorOf(
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['X']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['X']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
     )
     chaiExpect(result).to.be.true
   })
 
   it('does not match same paths with flag set to false', () => {
     const result = TP.isAncestorOf(
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['X']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['X']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
       false,
     )
     chaiExpect(result).to.be.false
@@ -69,8 +72,8 @@ describe('isAncestorOf', () => {
 
   it('target ancestor is children of path', () => {
     const result = TP.isAncestorOf(
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['X']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['X', 'Y']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X', 'Y']),
     )
     chaiExpect(result).to.be.false
   })
@@ -79,35 +82,41 @@ describe('isAncestorOf', () => {
 describe('replaceIfAncestor', () => {
   it('where the path does not match', () => {
     const result = TP.replaceIfAncestor(
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['X']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['A']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['B']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['X']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['A']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['B']),
     )
     chaiExpect(result).to.be.null
   })
   it('where the path matches exactly', () => {
     const result = TP.replaceIfAncestor(
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['A', 'B']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['A', 'B']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['C', 'D']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['A', 'B']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['A', 'B']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['C', 'D']),
     )
-    expect(result).toEqual(TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['C', 'D']))
+    expect(result).toEqual(
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['C', 'D']),
+    )
   })
   it('where the path is an ancestor', () => {
     const result = TP.replaceIfAncestor(
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['A', 'B', 'X']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['A', 'B']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['C', 'D']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['A', 'B', 'X']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['A', 'B']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['C', 'D']),
     )
     chaiExpect(result).to.deep.equal(
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['C', 'D', 'X']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['C', 'D', 'X']),
     )
   })
 })
 
 describe('fromString', () => {
   it('parses a simple path correctly', () => {
-    const expectedResult = TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['A', 'B', 'C'])
+    const expectedResult = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [
+      'A',
+      'B',
+      'C',
+    ])
     const actualResult = TP.fromString(TP.toComponentId(expectedResult))
     chaiExpect(actualResult).to.deep.equal(expectedResult)
   })
@@ -120,44 +129,50 @@ describe('getCommonParent', () => {
   })
   it('single element returns the parent', () => {
     const actualResult = TP.getCommonParent([
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['a', 'b']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b']),
     ])
-    const expectedResult = TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['a'])
+    const expectedResult = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a'])
     expect(actualResult).toEqual(expectedResult)
   })
   it('for two elements returns the common parent', () => {
     const actualResult = TP.getCommonParent([
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['a', 'b', 'c']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['a', 'b', 'd']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b', 'c']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b', 'd']),
     ])
-    const expectedResult = TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['a', 'b'])
+    const expectedResult = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [
+      'a',
+      'b',
+    ])
     expect(actualResult).toEqual(expectedResult)
   })
   it('for three elements without a common parent returns null', () => {
     const actualResult = TP.getCommonParent([
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['a', 'b', 'c']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-bbb'], ['a', 'b', 'd']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-ccc'], ['x', 'b', 'd']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b', 'c']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-bbb']), ['a', 'b', 'd']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-ccc']), ['x', 'b', 'd']),
     ])
     expect(actualResult).toBeNull()
   })
   it('returns one of the passed paths if it is a common parent of the rest and includeSelf is set to true', () => {
     const actualResult = TP.getCommonParent(
       [
-        TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['a', 'b']),
-        TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['a', 'b', 'd']),
+        TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b']),
+        TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b', 'd']),
       ],
       true,
     )
-    const expectedResult = TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['a', 'b'])
+    const expectedResult = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), [
+      'a',
+      'b',
+    ])
     expect(actualResult).toEqual(expectedResult)
   })
   it('does not return one of the passed paths if it is a common parent of the rest and includeSelf is not set', () => {
     const actualResult = TP.getCommonParent([
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['a', 'b']),
-      TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['a', 'b', 'd']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b']),
+      TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a', 'b', 'd']),
     ])
-    const expectedResult = TP.instancePath([BakedInStoryboardUID, 'scene-aaa'], ['a'])
+    const expectedResult = TP.instancePath(TP.scenePath([BakedInStoryboardUID, 'scene-aaa']), ['a'])
     expect(actualResult).toEqual(expectedResult)
   })
 })

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -165,7 +165,7 @@ function newScenePath(elementPaths: StaticElementPath[]): ScenePath {
   }
 }
 
-export const emptyScenePath: ScenePath = newScenePath(([] as any) as StaticElementPath[])
+export const emptyScenePath: ScenePath = newScenePath([])
 
 function newInstancePath(scene: ScenePath, elementPath: ElementPath): InstancePath {
   return {

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -156,7 +156,7 @@ function newScenePath(elements: StaticElementPath): ScenePath {
   }
 }
 
-const emptyScenePath: ScenePath = newScenePath(([] as any) as StaticElementPath)
+export const emptyScenePath: ScenePath = newScenePath(([] as any) as StaticElementPath)
 
 function newInstancePath(scene: ScenePath | ElementPath, elementPath: ElementPath): InstancePath {
   return {
@@ -165,7 +165,7 @@ function newInstancePath(scene: ScenePath | ElementPath, elementPath: ElementPat
   }
 }
 
-const emptyInstancePath: InstancePath = newInstancePath(emptyScenePath, [])
+export const emptyInstancePath: InstancePath = newInstancePath(emptyScenePath, [])
 
 export function scenePath(elements: ElementPath): ScenePath {
   const staticElements = elements as StaticElementPath
@@ -187,33 +187,22 @@ function scenePathFromElementPathOrScenePath(scene: ScenePath | ElementPath): Sc
   }
 }
 
-export function instancePath(
-  scene: ScenePath | ElementPath,
-  elementPath: ElementPath,
-): InstancePath {
-  if (isScenePath(scene as ScenePath)) {
-    return instancePath((scene as ScenePath).sceneElementPath, elementPath)
+export function instancePath(scene: ScenePath, elementPath: ElementPath): InstancePath {
+  if (scene.sceneElementPath.length === 0 && elementPath.length === 0) {
+    return emptyInstancePath
   } else {
-    const sceneElementPath = scene as StaticElementPath
-    if (sceneElementPath.length === 0 && elementPath.length === 0) {
-      return emptyInstancePath
+    const pathCache = getInstancePathCache(scene.sceneElementPath, elementPath)
+    if (pathCache.cached == null) {
+      const newPath = newInstancePath(scene, elementPath)
+      pathCache.cached = newPath
+      return newPath
     } else {
-      const pathCache = getInstancePathCache(sceneElementPath, elementPath)
-      if (pathCache.cached == null) {
-        const newPath = newInstancePath(sceneElementPath, elementPath)
-        pathCache.cached = newPath
-        return newPath
-      } else {
-        return pathCache.cached
-      }
+      return pathCache.cached
     }
   }
 }
 
-export function staticInstancePath(
-  scene: ScenePath | ElementPath,
-  elementPath: ElementPath,
-): StaticInstancePath {
+export function staticInstancePath(scene: ScenePath, elementPath: ElementPath): StaticInstancePath {
   return instancePath(scene, elementPath) as StaticInstancePath
 }
 

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -239,7 +239,7 @@ export function scenePathPartOfTemplatePath(path: TemplatePath): ScenePath {
   }
 }
 
-export function instancePathForLastPartOfScenePath(path: ScenePath): StaticInstancePath {
+export function instancePathForElementAtScenePath(path: ScenePath): StaticInstancePath {
   // Uses the last `ElementPath` in a `ScenePath` to create an `InstancePath` pointing to that element
   const lastElementPath = last(path.sceneElementPaths)
   if (lastElementPath == null) {
@@ -251,7 +251,7 @@ export function instancePathForLastPartOfScenePath(path: ScenePath): StaticInsta
   }
 }
 
-export function scenePathForCombinedPartsOfInstancePath(path: InstancePath): ScenePath {
+export function scenePathForElementAtInstancePath(path: InstancePath): ScenePath {
   // Appends the `ElementPath` part of an `InstancePath` to that instance's `ScenePath`, to create a
   // `ScenePath` pointing to that element
   return scenePath([...path.scene.sceneElementPaths, path.element])

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -74,6 +74,10 @@ function getScenePathCache(sceneElementPath: StaticElementPath): ScenePathCache 
   return workingPathCache
 }
 
+function getScenePathCacheForScenePath(scene: ScenePath): ScenePathCache {
+  return getScenePathCache(scene.sceneElementPath)
+}
+
 function getInstancePathCacheFromScenePathCache(
   elementPath: ElementPath,
   startingPoint: ScenePathCache,
@@ -94,11 +98,8 @@ function getInstancePathCacheFromScenePathCache(
   return workingPathCache
 }
 
-function getInstancePathCache(
-  sceneElementPath: StaticElementPath,
-  elementPath: ElementPath,
-): InstancePathCache {
-  const scenePathCache = getScenePathCache(sceneElementPath)
+function getInstancePathCache(scene: ScenePath, elementPath: ElementPath): InstancePathCache {
+  const scenePathCache = getScenePathCacheForScenePath(scene)
   return getInstancePathCacheFromScenePathCache(elementPath, scenePathCache)
 }
 
@@ -106,7 +107,7 @@ const SceneSeparator = ':'
 const ElementSeparator = '/'
 
 function scenePathToString(path: ScenePath): string {
-  const pathCache = getScenePathCache(path.sceneElementPath)
+  const pathCache = getScenePathCacheForScenePath(path)
   if (pathCache.cachedToString == null) {
     const result = elementPathToString(path.sceneElementPath)
     pathCache.cachedToString = result
@@ -129,7 +130,7 @@ export function elementPathToString(path: ElementPath): string {
 }
 
 function instancePathToString(path: InstancePath): string {
-  const pathCache = getInstancePathCache(path.scene.sceneElementPath, path.element)
+  const pathCache = getInstancePathCache(path.scene, path.element)
   if (pathCache.cachedToString == null) {
     const result = `${scenePathToString(path.scene)}${SceneSeparator}${elementPathToString(
       path.element,
@@ -191,7 +192,7 @@ export function instancePath(scene: ScenePath, elementPath: ElementPath): Instan
   if (scene.sceneElementPath.length === 0 && elementPath.length === 0) {
     return emptyInstancePath
   } else {
-    const pathCache = getInstancePathCache(scene.sceneElementPath, elementPath)
+    const pathCache = getInstancePathCache(scene, elementPath)
     if (pathCache.cached == null) {
       const newPath = newInstancePath(scene, elementPath)
       pathCache.cached = newPath
@@ -230,16 +231,16 @@ export function scenePathForPath(path: TemplatePath): ScenePath {
   }
 }
 
-export function elementPathForPath(path: ScenePath): StaticElementPath
+export function instancePathForScenePath(path: ScenePath): StaticInstancePath {
+  const lastElementPath = path.sceneElementPath
+  const targetScenePath = emptyScenePath
+  return staticInstancePath(targetScenePath, lastElementPath)
+}
+
 export function elementPathForPath(path: StaticInstancePath): StaticElementPath
 export function elementPathForPath(path: InstancePath): ElementPath
-export function elementPathForPath(path: TemplatePath): ElementPath
-export function elementPathForPath(path: TemplatePath): ElementPath {
-  if (isScenePath(path)) {
-    return path.sceneElementPath
-  } else {
-    return path.element
-  }
+export function elementPathForPath(path: InstancePath): ElementPath {
+  return path.element
 }
 
 export function filterScenes(paths: StaticTemplatePath[]): StaticInstancePath[]

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -269,12 +269,11 @@ export function filterScenes(paths: TemplatePath[]): StaticInstancePath | Instan
 // FIXME: This should be retired, it's just plain dangerous.
 // Right now this is only used for SpecialNodes (in CanvasMetaData)
 function fromStringUncached(path: string): TemplatePath {
-  const elementPathStrs = path.split(SceneSeparator)
-  const [sceneStrs, elementStrs] =
-    elementPathStrs.length > 1
-      ? splitAt(elementPathStrs.length - 1, elementPathStrs)
-      : [elementPathStrs, []]
-  const elementStr = elementStrs[0] ?? null
+  let elementPathStrs = path.split(SceneSeparator)
+  const lastElementStr = elementPathStrs.pop()! // We know this is safe because ''.split(SceneSeparator).pop() returns ''
+  let sceneStrs = elementPathStrs.length > 0 ? elementPathStrs : [lastElementStr]
+  let elementStr = elementPathStrs.length > 0 ? lastElementStr : null
+
   const sceneElementPaths = sceneStrs.map((scene) =>
     scene.split(ElementSeparator).filter((e) => e.length > 0),
   )

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -230,7 +230,8 @@ export function isTopLevelInstancePath(path: TemplatePath): path is InstancePath
   return isInstancePath(path) && path.element.length === 1
 }
 
-export function scenePathForPath(path: TemplatePath): ScenePath {
+export function scenePathPartOfTemplatePath(path: TemplatePath): ScenePath {
+  // Returns the `scene` part of an `InstancePath`, or if given a `ScenePath` it just returns that
   if (isScenePath(path)) {
     return path
   } else {
@@ -238,7 +239,8 @@ export function scenePathForPath(path: TemplatePath): ScenePath {
   }
 }
 
-export function instancePathForScenePath(path: ScenePath): StaticInstancePath {
+export function instancePathForLastPartOfScenePath(path: ScenePath): StaticInstancePath {
+  // Uses the last `ElementPath` in a `ScenePath` to create an `InstancePath` pointing to that element
   const lastElementPath = last(path.sceneElementPaths)
   if (lastElementPath == null) {
     return emptyInstancePath
@@ -249,8 +251,9 @@ export function instancePathForScenePath(path: ScenePath): StaticInstancePath {
   }
 }
 
-export function scenePathFromInstancePath(path: InstancePath): ScenePath {
-  // FIXME Rename? The use of this is a bit confusing
+export function scenePathForCombinedPartsOfInstancePath(path: InstancePath): ScenePath {
+  // Appends the `ElementPath` part of an `InstancePath` to that instance's `ScenePath`, to create a
+  // `ScenePath` pointing to that element
   return scenePath([...path.scene.sceneElementPaths, path.element])
 }
 
@@ -665,8 +668,8 @@ export function closestSharedAncestor(
   } else if (l === r) {
     return toTargetPath(l)
   } else {
-    const lScene = scenePathForPath(lTarget)
-    const rScene = scenePathForPath(rTarget)
+    const lScene = scenePathPartOfTemplatePath(lTarget)
+    const rScene = scenePathPartOfTemplatePath(rTarget)
     const scenesEqual = scenePathsEqual(lScene, rScene)
     if (scenesEqual) {
       if (isScenePath(lTarget) || isScenePath(rTarget)) {
@@ -843,13 +846,13 @@ export function areAllElementsInSameScene(paths: TemplatePath[]): boolean {
   if (paths.length === 0) {
     return true
   } else {
-    const firstScenePath = scenePathForPath(paths[0])
-    return paths.every((p) => scenePathsEqual(firstScenePath, scenePathForPath(p)))
+    const firstScenePath = scenePathPartOfTemplatePath(paths[0])
+    return paths.every((p) => scenePathsEqual(firstScenePath, scenePathPartOfTemplatePath(p)))
   }
 }
 
 export function isFromSameSceneAs(a: TemplatePath, b: TemplatePath): boolean {
-  return scenePathsEqual(scenePathForPath(a), scenePathForPath(b))
+  return scenePathsEqual(scenePathPartOfTemplatePath(a), scenePathPartOfTemplatePath(b))
 }
 
 export function dynamicPathToStaticPath(path: InstancePath): StaticInstancePath {

--- a/editor/src/utils/deep-equality-instances.spec.ts
+++ b/editor/src/utils/deep-equality-instances.spec.ts
@@ -11,7 +11,7 @@ import {
 describe('TemplatePathKeepDeepEquality', () => {
   it('same reference returns the same reference', () => {
     const path: TemplatePath = {
-      scene: TP.scenePath(['scene']),
+      scene: TP.scenePath([['scene']]),
       element: ['aaa', 'bbb'],
     }
     const result = TemplatePathKeepDeepEquality(path, path)
@@ -20,11 +20,11 @@ describe('TemplatePathKeepDeepEquality', () => {
   })
   it('same value returns the same reference', () => {
     const oldPath: TemplatePath = {
-      scene: TP.scenePath(['scene']),
+      scene: TP.scenePath([['scene']]),
       element: ['aaa', 'bbb'],
     }
     const newPath: TemplatePath = {
-      scene: TP.scenePath(['scene']),
+      scene: TP.scenePath([['scene']]),
       element: ['aaa', 'bbb'],
     }
     const result = TemplatePathKeepDeepEquality(oldPath, newPath)
@@ -33,11 +33,11 @@ describe('TemplatePathKeepDeepEquality', () => {
   })
   it('different but similar value handled appropriately', () => {
     const oldPath: InstancePath = {
-      scene: TP.scenePath(['scene']),
+      scene: TP.scenePath([['scene']]),
       element: ['aaa', 'bbb'],
     }
     const newPath: InstancePath = {
-      scene: TP.scenePath(['scene']),
+      scene: TP.scenePath([['scene']]),
       element: ['aaa', 'ccc'],
     }
     const result = TemplatePathKeepDeepEquality(oldPath, newPath)

--- a/editor/src/utils/test-utils.ts
+++ b/editor/src/utils/test-utils.ts
@@ -197,7 +197,7 @@ export function createFakeMetadataForParseSuccess(success: ParseSuccess): JSXMet
     if (component != null) {
       const elementMetadata = createFakeMetadataForJSXElement(
         component.rootElement,
-        TP.scenePath([BakedInStoryboardUID, createSceneUidFromIndex(index)]),
+        TP.scenePath([[BakedInStoryboardUID, createSceneUidFromIndex(index)]]),
         {
           props: {
             style: sceneResizesContent ? props.style : undefined,
@@ -217,7 +217,7 @@ export function createFakeMetadataForParseSuccess(success: ParseSuccess): JSXMet
     return {
       component: props[PP.toString(PathForSceneComponent)],
       label: props[PP.toString(PathForSceneDataLabel)],
-      scenePath: TP.scenePath([BakedInStoryboardUID, props[PP.toString(PathForSceneDataUid)]]),
+      scenePath: TP.scenePath([[BakedInStoryboardUID, props[PP.toString(PathForSceneDataUid)]]]),
       templatePath: TP.instancePath(TP.emptyScenePath, [
         BakedInStoryboardUID,
         createSceneUidFromIndex(index),
@@ -241,7 +241,7 @@ export function createFakeMetadataForComponents(
     if (isUtopiaJSXComponent(component)) {
       const elementMetadata = createFakeMetadataForJSXElement(
         component.rootElement,
-        TP.scenePath([BakedInStoryboardUID, createSceneUidFromIndex(index)]),
+        TP.scenePath([[BakedInStoryboardUID, createSceneUidFromIndex(index)]]),
         {},
         {},
       )
@@ -253,7 +253,7 @@ export function createFakeMetadataForComponents(
       })
 
       components.push({
-        scenePath: TP.scenePath([BakedInStoryboardUID, `scene-${index}`]),
+        scenePath: TP.scenePath([[BakedInStoryboardUID, `scene-${index}`]]),
         templatePath: TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, `scene-${index}`]),
         component: component.name,
         globalFrame: { x: 0, y: 0, width: 100, height: 100 } as CanvasRectangle,

--- a/editor/src/utils/test-utils.ts
+++ b/editor/src/utils/test-utils.ts
@@ -218,7 +218,10 @@ export function createFakeMetadataForParseSuccess(success: ParseSuccess): JSXMet
       component: props[PP.toString(PathForSceneComponent)],
       label: props[PP.toString(PathForSceneDataLabel)],
       scenePath: TP.scenePath([BakedInStoryboardUID, props[PP.toString(PathForSceneDataUid)]]),
-      templatePath: TP.instancePath([], [BakedInStoryboardUID, createSceneUidFromIndex(index)]),
+      templatePath: TP.instancePath(TP.emptyScenePath, [
+        BakedInStoryboardUID,
+        createSceneUidFromIndex(index),
+      ]),
       globalFrame: { x: 0, y: 0, width: 400, height: 400 } as CanvasRectangle,
       sceneResizesContent: sceneResizesContent ?? true,
       style: {},
@@ -251,7 +254,7 @@ export function createFakeMetadataForComponents(
 
       components.push({
         scenePath: TP.scenePath([BakedInStoryboardUID, `scene-${index}`]),
-        templatePath: TP.instancePath([], [BakedInStoryboardUID, `scene-${index}`]),
+        templatePath: TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, `scene-${index}`]),
         component: component.name,
         globalFrame: { x: 0, y: 0, width: 100, height: 100 } as CanvasRectangle,
         sceneResizesContent: false,


### PR DESCRIPTION
Fixes #965 

**Problem:**
Scene Paths only contain an Element Path, which is an array of strings. We want them to contain multiple Element Paths so that we can use them to drill into components, so e.g. if the user selects `storyboard/scene:app/card` and wants to then drill into the card component, we could represent the root level element of the Card component as `storyboard/scene:app/card:card-rood`

**Fix:**
Change the `ScenePath` definition from:

```
export type ScenePath = {
  type: 'scenepath'
  sceneElementPath: StaticElementPath
}
```

To:

```
export type ScenePath = {
  type: 'scenepath'
  sceneElementPaths: StaticElementPath[]
}
```

**Commit Details:**
- Reduced explicit use of `ScenePath.sceneElementPaths` throughout
- Changed the various factory functions to support an array of `ElementPath`s as part of the creation
- Introduced the function `instancePathForElementAtScenePath` for taking a Scene Path and creating the Instance Path that points to the instance of that scene - right now we record metadata for the scene `storyboard/scene` at `:storyboard/scene`, so we were previously creating this by using `TP.instancePath([], TP.elementPathForPath(scenePath))`, but with this new shape of Scene Paths in the above Card example the path for the Card "scene" would be `storyboard/scene:app/card` (so we want to take the Scene Path, pop the last Element Path, and use that to create the new Instance Path)
- Introduced a `splitAt` function for splitting an array into two to support the above (definitely could have used `Array.pop()` in hindsight, but you live and you learn - update: I used `Array.pop`, but kept the new useful function)
- Also introduced `scenePathForElementAtInstancePath` which is the inverse of `instancePathForElementAtScenePath`, pushing the `InstancePath`'s element path onto its `ScenePath`, and returning that
- Updated the logic for looking up a Scene Path from the cache, using the `SceneSeparator` in a rather nasty and unacceptable way but I thought that any other way of forking the caching logic there would have been more complex - happy to reevaluate though if anyone wants to challenge that
- Updated all of the tests to reflect these changes

**Note:** The vast majority of the logic changes are inside `template-path.ts`, with the model change in `project-file-types.ts`, so I'd recommend starting there an then referring to either the snapshots or other tests to see how those changes are reflected in practice.