### PR TITLE
Groundwork before Spy changes

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.tsx
@@ -8,37 +8,57 @@ import { objectMap } from '../../../core/shared/object-utils'
 import * as TP from '../../../core/shared/template-path'
 import { renderTestEditorWithCode } from '../ui-jsx.test-utils'
 
+const exampleProject = `/** @jsx jsx */
+import * as React from 'react'
+import { Scene, Storyboard, jsx } from 'utopia-api'
+import { View } from 'utopia-api'
+
+const Button = (props) => {
+  return <div data-uid='button-root'>{props.children}</div>
+}
+const Card = () => {
+  return (
+    <Button data-uid='button-instance' >
+      <div data-uid='hi-element'>hi!</div>
+    </Button>
+  )
+}
+export var App = (props) => {
+  return (
+    <div
+      data-uid='app-root'
+      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}
+    >
+      <div data-uid='inner-div'>
+        <Card
+          data-uid='card-instance'
+          style={{
+            backgroundColor: '#0091FFAA',
+            position: 'absolute',
+            left: 70,
+            top: 387,
+            width: 193,
+            height: 221,
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+export var storyboard = (
+  <Storyboard data-uid='storyboard'>
+    <Scene
+      data-uid='scene'
+      component={App}
+      props={{}}
+      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+    />
+  </Storyboard>
+)`
+
 describe('Spy Wrapper Tests', () => {
   it('a simple component in a regular scene', async () => {
-    const { getEditorState } = await renderTestEditorWithCode(`
-    /** @jsx jsx */
-    import * as React from 'react'
-    import { Scene, Storyboard, jsx } from 'utopia-api'
-    import { View } from 'utopia-api'
-
-    export var App = (props) => {
-      return (
-        <div
-          data-uid='app-root'
-          style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}
-        >
-          <div data-uid='inner-div'>
-
-          </div>
-        </div>
-      )
-    }
-    export var storyboard = (
-      <Storyboard data-uid='storyboard-uid'>
-        <Scene
-          data-uid='scene-uid'
-          component={App}
-          props={{}}
-          style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
-        />
-      </Storyboard>
-    )
-  `)
+    const { getEditorState } = await renderTestEditorWithCode(exampleProject)
 
     const spiedMetadata = getEditorState().editor.spyMetadataKILLME
     const sanitizedSpyData = objectMap((elementMetadata, key) => {
@@ -57,33 +77,41 @@ describe('Spy Wrapper Tests', () => {
 
     expect(sanitizedSpyData).toMatchInlineSnapshot(`
       Object {
-        ":storyboard-uid": Object {
+        ":storyboard": Object {
           "children": Array [
-            ":storyboard-uid/scene-uid",
+            ":storyboard/scene",
           ],
           "name": "Storyboard",
-          "templatePathAsKey": ":storyboard-uid",
-          "templatePathAsReportedBySpy": ":storyboard-uid",
+          "templatePathAsKey": ":storyboard",
+          "templatePathAsReportedBySpy": ":storyboard",
         },
-        ":storyboard-uid/scene-uid": Object {
+        ":storyboard/scene": Object {
           "children": Array [],
           "name": "Scene",
-          "templatePathAsKey": ":storyboard-uid/scene-uid",
-          "templatePathAsReportedBySpy": ":storyboard-uid/scene-uid",
+          "templatePathAsKey": ":storyboard/scene",
+          "templatePathAsReportedBySpy": ":storyboard/scene",
         },
-        "storyboard-uid/scene-uid:app-root": Object {
+        "storyboard/scene:app-root": Object {
           "children": Array [
-            "storyboard-uid/scene-uid:app-root/inner-div",
+            "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
-          "templatePathAsKey": "storyboard-uid/scene-uid:app-root",
-          "templatePathAsReportedBySpy": "storyboard-uid/scene-uid:app-root",
+          "templatePathAsKey": "storyboard/scene:app-root",
+          "templatePathAsReportedBySpy": "storyboard/scene:app-root",
         },
-        "storyboard-uid/scene-uid:app-root/inner-div": Object {
-          "children": Array [],
+        "storyboard/scene:app-root/inner-div": Object {
+          "children": Array [
+            "storyboard/scene:app-root/inner-div/card-instance",
+          ],
           "name": "div",
-          "templatePathAsKey": "storyboard-uid/scene-uid:app-root/inner-div",
-          "templatePathAsReportedBySpy": "storyboard-uid/scene-uid:app-root/inner-div",
+          "templatePathAsKey": "storyboard/scene:app-root/inner-div",
+          "templatePathAsReportedBySpy": "storyboard/scene:app-root/inner-div",
+        },
+        "storyboard/scene:app-root/inner-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
+          "templatePathAsKey": "storyboard/scene:app-root/inner-div/card-instance",
+          "templatePathAsReportedBySpy": "storyboard/scene:app-root/inner-div/card-instance",
         },
       }
     `)

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.tsx
@@ -1,0 +1,91 @@
+import { bimapEither, foldEither, mapEither } from '../../../core/shared/either'
+import {
+  getJSXElementNameAsString,
+  getJSXElementNameNoPathName,
+  isJSXElement,
+} from '../../../core/shared/element-template'
+import { objectMap } from '../../../core/shared/object-utils'
+import * as TP from '../../../core/shared/template-path'
+import { renderTestEditorWithCode } from '../ui-jsx.test-utils'
+
+describe('Spy Wrapper Tests', () => {
+  it('a simple component in a regular scene', async () => {
+    const { getEditorState } = await renderTestEditorWithCode(`
+    /** @jsx jsx */
+    import * as React from 'react'
+    import { Scene, Storyboard, jsx } from 'utopia-api'
+    import { View } from 'utopia-api'
+
+    export var App = (props) => {
+      return (
+        <div
+          data-uid='app-root'
+          style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}
+        >
+          <div data-uid='inner-div'>
+
+          </div>
+        </div>
+      )
+    }
+    export var storyboard = (
+      <Storyboard data-uid='storyboard-uid'>
+        <Scene
+          data-uid='scene-uid'
+          component={App}
+          props={{}}
+          style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+        />
+      </Storyboard>
+    )
+  `)
+
+    const spiedMetadata = getEditorState().editor.spyMetadataKILLME
+    const sanitizedSpyData = objectMap((elementMetadata, key) => {
+      return {
+        templatePathAsKey: key,
+        templatePathAsReportedBySpy: TP.toString(elementMetadata.templatePath),
+        name: foldEither(
+          (name) => name,
+          (element) =>
+            isJSXElement(element) ? getJSXElementNameAsString(element.name) : 'not-jsx-element',
+          elementMetadata.element,
+        ),
+        children: elementMetadata.children.map(TP.toString),
+      }
+    }, spiedMetadata.elements)
+
+    expect(sanitizedSpyData).toMatchInlineSnapshot(`
+      Object {
+        ":storyboard-uid": Object {
+          "children": Array [
+            ":storyboard-uid/scene-uid",
+          ],
+          "name": "Storyboard",
+          "templatePathAsKey": ":storyboard-uid",
+          "templatePathAsReportedBySpy": ":storyboard-uid",
+        },
+        ":storyboard-uid/scene-uid": Object {
+          "children": Array [],
+          "name": "Scene",
+          "templatePathAsKey": ":storyboard-uid/scene-uid",
+          "templatePathAsReportedBySpy": ":storyboard-uid/scene-uid",
+        },
+        "storyboard-uid/scene-uid:app-root": Object {
+          "children": Array [
+            "storyboard-uid/scene-uid:app-root/inner-div",
+          ],
+          "name": "div",
+          "templatePathAsKey": "storyboard-uid/scene-uid:app-root",
+          "templatePathAsReportedBySpy": "storyboard-uid/scene-uid:app-root",
+        },
+        "storyboard-uid/scene-uid:app-root/inner-div": Object {
+          "children": Array [],
+          "name": "div",
+          "templatePathAsKey": "storyboard-uid/scene-uid:app-root/inner-div",
+          "templatePathAsReportedBySpy": "storyboard-uid/scene-uid:app-root/inner-div",
+        },
+      }
+    `)
+  })
+})

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.tsx
@@ -56,7 +56,7 @@ export var storyboard = (
   </Storyboard>
 )`
 
-describe('Spy Wrapper Tests', () => {
+describe('Spy Wrapper Template Path Tests', () => {
   it('a simple component in a regular scene', async () => {
     const { getEditorState } = await renderTestEditorWithCode(exampleProject)
 

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -3,6 +3,7 @@ import { TriggerEvent } from 'react-contexify'
 import { CanvasPoint } from '../core/shared/math-utils'
 import { InstancePath } from '../core/shared/project-file-types'
 import * as PP from '../core/shared/property-path'
+import * as TP from '../core/shared/template-path'
 import RU from '../utils/react-utils'
 import Utils from '../utils/utils'
 import { EditorDispatch } from './editor/action-types'
@@ -130,6 +131,19 @@ export const toggleShadowItem: ContextMenuItem<CanvasData> = {
       ),
     )
     requireDispatch(dispatch)(actions, 'everyone')
+  },
+}
+
+export const setAsFocusedElement: ContextMenuItem<CanvasData> = {
+  name: 'Set As Focused Element',
+  enabled: true,
+  action: (data, dispatch?: EditorDispatch) => {
+    if (data.selectedViews.length > 0) {
+      const sv = data.selectedViews[0]
+      requireDispatch(dispatch)([
+        EditorActions.setFocusedElement(TP.scenePathForElementAtInstancePath(sv)),
+      ])
+    }
   },
 }
 

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -782,6 +782,11 @@ export interface SendCodeEditorInitialisation {
   action: 'SEND_CODE_EDITOR_INITIALISATION'
 }
 
+export interface SetFocusedElement {
+  action: 'SET_FOCUSED_ELEMENT'
+  focusedElementPath: ScenePath | null
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -912,6 +917,7 @@ export type EditorAction =
   | MarkVSCodeBridgeReady
   | SelectFromFileAndPosition
   | SendCodeEditorInitialisation
+  | SetFocusedElement
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -178,6 +178,7 @@ import type {
   SelectFromFileAndPosition,
   SendCodeEditorInitialisation,
   CloseDesignerFile,
+  SetFocusedElement,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -1229,5 +1230,12 @@ export function selectFromFileAndPosition(
 export function sendCodeEditorInitialisation(): SendCodeEditorInitialisation {
   return {
     action: 'SEND_CODE_EDITOR_INITIALISATION',
+  }
+}
+
+export function setFocusedElement(focusedElementTemplatePath: ScenePath | null): SetFocusedElement {
+  return {
+    action: 'SET_FOCUSED_ELEMENT',
+    focusedElementPath: focusedElementTemplatePath,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -82,6 +82,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'MARK_VSCODE_BRIDGE_READY':
     case 'SELECT_FROM_FILE_AND_POSITION':
     case 'SEND_CODE_EDITOR_INITIALISATION':
+    case 'SET_FOCUSED_ELEMENT':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -356,6 +356,7 @@ import {
   MarkVSCodeBridgeReady,
   SelectFromFileAndPosition,
   SendCodeEditorInitialisation,
+  SetFocusedElement,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -1019,6 +1020,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     safeMode: currentEditor.safeMode,
     saveError: currentEditor.saveError,
     vscodeBridgeReady: currentEditor.vscodeBridgeReady,
+    focusedElementPath: currentEditor.focusedElementPath,
   }
 }
 
@@ -4194,6 +4196,12 @@ export const UPDATE_FNS = {
     sendCodeEditorDecorations(editor)
     sendSelectedElement(editor)
     return editor
+  },
+  SET_FOCUSED_ELEMENT: (action: SetFocusedElement, editor: EditorModel): EditorModel => {
+    return {
+      ...editor,
+      focusedElementPath: action.focusedElementPath,
+    }
   },
 }
 

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -338,6 +338,7 @@ export interface EditorState {
   safeMode: boolean
   saveError: boolean
   vscodeBridgeReady: boolean
+  focusedElementPath: ScenePath | null
 }
 
 export interface StoredEditorState {
@@ -1109,6 +1110,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     safeMode: false,
     saveError: false,
     vscodeBridgeReady: false,
+    focusedElementPath: null,
   }
 }
 
@@ -1349,6 +1351,7 @@ export function editorModelFromPersistentModel(
     },
     codeEditorErrors: persistentModel.codeEditorErrors,
     vscodeBridgeReady: false,
+    focusedElementPath: null,
   }
   return editor
 }

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -288,6 +288,8 @@ export function runSimpleLocalEditorAction(
       return state
     case 'MARK_VSCODE_BRIDGE_READY':
       return UPDATE_FNS.MARK_VSCODE_BRIDGE_READY(action, state)
+    case 'SET_FOCUSED_ELEMENT':
+      return UPDATE_FNS.SET_FOCUSED_ELEMENT(action, state)
     default:
       return state
   }

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -19,6 +19,7 @@ import {
   toggleShadowItem,
   ContextMenuItem,
   CanvasData,
+  setAsFocusedElement,
 } from './context-menu-items'
 import { ContextMenuInnerProps, MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState } from './editor/store/store-hook'
@@ -42,6 +43,7 @@ interface ElementContextMenuProps {
 }
 
 const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
+  setAsFocusedElement,
   cutElements,
   copyElements,
   duplicateElement,


### PR DESCRIPTION
This PR contains a new test suite that will help us figuring out if we are on the right path while working on the Spy. It also contains a (not yet used) new editor state variable that Eni can use in the navigator and we can use in the Spy.

**Commit Details:**
- new Spy Wrapper Template Path Tests that only test what template paths the spy uses as keys and as children
- new editor state entry `focusedElementPath: ScenePath | null` that in the future will point to the focused element
- action boilerplate for changing `focusedElementPath`