### PR TITLE
Unify insertion and similar options for components.

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -673,6 +673,12 @@ export interface UpdateJSXElementName {
   action: 'UPDATE_JSX_ELEMENT_NAME'
   target: InstancePath
   elementName: JSXElementName
+  importsToAdd: Imports
+}
+
+export interface AddImports {
+  action: 'ADD_IMPORTS'
+  importsToAdd: Imports
 }
 
 export interface SetAspectRatioLock {
@@ -897,6 +903,7 @@ export type EditorAction =
   | UnwrapLayoutable
   | SetAspectRatioLock
   | UpdateJSXElementName
+  | AddImports
   | ToggleCanvasIsLive
   | RenameStyleSelector
   | SetSafeMode

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -179,6 +179,7 @@ import type {
   SendCodeEditorInitialisation,
   CloseDesignerFile,
   SetFocusedElement,
+  AddImports,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -1055,11 +1056,20 @@ export function unwrapLayoutable(target: InstancePath): UnwrapLayoutable {
 export function updateJSXElementName(
   target: InstancePath,
   elementName: JSXElementName,
+  importsToAdd: Imports,
 ): UpdateJSXElementName {
   return {
     action: 'UPDATE_JSX_ELEMENT_NAME',
     target: target,
     elementName: elementName,
+    importsToAdd: importsToAdd,
+  }
+}
+
+export function addImports(importsToAdd: Imports): AddImports {
+  return {
+    action: 'ADD_IMPORTS',
+    importsToAdd: importsToAdd,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -133,6 +133,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'WRAP_IN_LAYOUTABLE':
     case 'UNWRAP_LAYOUTABLE':
     case 'UPDATE_JSX_ELEMENT_NAME':
+    case 'ADD_IMPORTS':
     case 'SET_ASPECT_RATIO_LOCK':
     case 'INSERT_DROPPED_IMAGE':
     case 'RESET_PROP_TO_DEFAULT':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -357,6 +357,7 @@ import {
   SelectFromFileAndPosition,
   SendCodeEditorInitialisation,
   SetFocusedElement,
+  AddImports,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -488,6 +489,7 @@ import {
   finishCheckpointTimer,
   selectComponents,
   markVSCodeBridgeReady,
+  addImports,
 } from './action-creators'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
 import { getAllTargetsAtPoint } from '../../canvas/dom-lookup'
@@ -3799,22 +3801,7 @@ export const UPDATE_FNS = {
       MetadataUtils.getElementByInstancePathMaybe(editor.jsxMetadataKILLME.elements, action.target),
     )
 
-    let updatedEditor = editor
-    if (action.elementName.baseVariable === 'animated') {
-      updatedEditor = modifyOpenParseSuccess((success) => {
-        const updatedImport = addImport(
-          'react-spring',
-          null,
-          [importAlias('animated')],
-          null,
-          success.imports,
-        )
-        return {
-          ...success,
-          imports: updatedImport,
-        }
-      }, editor)
-    }
+    const updatedEditor = UPDATE_FNS.ADD_IMPORTS(addImports(action.importsToAdd), editor)
 
     return modifyOpenJsxElementAtPath(
       action.target,
@@ -3846,6 +3833,14 @@ export const UPDATE_FNS = {
       },
       updatedEditor,
     )
+  },
+  ADD_IMPORTS: (action: AddImports, editor: EditorModel): EditorModel => {
+    return modifyOpenParseSuccess((success) => {
+      return {
+        ...success,
+        imports: mergeImports(success.imports, action.importsToAdd),
+      }
+    }, editor)
   },
   SET_ASPECT_RATIO_LOCK: (action: SetAspectRatioLock, editor: EditorModel): EditorModel => {
     return modifyOpenJsxElementAtPath(

--- a/editor/src/components/editor/export-utils.spec.ts
+++ b/editor/src/components/editor/export-utils.spec.ts
@@ -1,0 +1,50 @@
+import { isParseSuccess, unparsed } from '../../core/shared/project-file-types'
+import { parseFailure } from '../../core/workers/common/project-file-utils'
+import { parseCode } from '../../core/workers/parser-printer/parser-printer'
+import { getExportedComponentImports } from './export-utils'
+
+describe('getExportedComponentImports', () => {
+  it('returns null for an unparsed value', () => {
+    const actualResult = getExportedComponentImports('/src/app.js', '/src/index.js', unparsed)
+    expect(actualResult).toMatchInlineSnapshot(`null`)
+  })
+  it('returns null for a parse failure', () => {
+    const actualResult = getExportedComponentImports(
+      '/src/app.js',
+      '/src/index.js',
+      parseFailure(null, null, 'Parse test failure.', []),
+    )
+    expect(actualResult).toMatchInlineSnapshot(`null`)
+  })
+  it('returns the expected components for a parse success', () => {
+    const codeForFile = `import React from "react";
+export var Whatever = (props) => {
+  return (
+    <div />
+  )
+}`
+    const parseResult = parseCode('/src/index.js', codeForFile)
+    expect(isParseSuccess(parseResult)).toEqual(true)
+
+    const actualResult = getExportedComponentImports('/src/app.js', '/src/index.js', parseResult)
+    expect(actualResult).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "importsToAdd": Object {
+            "/src/index.js": Object {
+              "importedAs": null,
+              "importedFromWithin": Array [
+                Object {
+                  "alias": "Whatever",
+                  "name": "Whatever",
+                },
+              ],
+              "importedWithName": null,
+            },
+          },
+          "listingName": "Whatever",
+        },
+      ]
+    `)
+  })
+})

--- a/editor/src/components/editor/export-utils.ts
+++ b/editor/src/components/editor/export-utils.ts
@@ -1,0 +1,117 @@
+import { BakedInStoryboardVariableName } from '../../core/model/scene-utils'
+import { isUtopiaJSXComponent, UtopiaJSXComponent } from '../../core/shared/element-template'
+import {
+  foldParsedTextFile,
+  importAlias,
+  ImportDetails,
+  importDetails,
+  Imports,
+  ParsedTextFile,
+  ParseSuccess,
+} from '../../core/shared/project-file-types'
+import { emptyImports } from '../../core/workers/common/project-file-utils'
+import { StoryboardFilePath } from './store/editor-state'
+
+interface ExportedComponentDetail {
+  importsToAdd: Imports
+  listingName: string
+}
+
+function exportedComponentDetail(
+  importsToAdd: Imports,
+  listingName: string,
+): ExportedComponentDetail {
+  return {
+    importsToAdd: importsToAdd,
+    listingName: listingName,
+  }
+}
+
+type ExportedComponentImports = Array<ExportedComponentDetail>
+
+function pathLastPartWithoutExtension(path: string): string {
+  const splitPath = path.split('/')
+  const lastPart = splitPath[splitPath.length - 1]
+  const splitByFullStop = lastPart.split('.')
+  return splitByFullStop[0]
+}
+
+export function getExportedComponentImports(
+  originatingPath: string,
+  fullPath: string,
+  textFile: ParsedTextFile,
+): ExportedComponentImports | null {
+  return foldParsedTextFile(
+    () => {
+      return null
+    },
+    (success: ParseSuccess) => {
+      const pathLastPart = pathLastPartWithoutExtension(fullPath)
+      let result: ExportedComponentImports = []
+
+      function isStoryboard(component: UtopiaJSXComponent): boolean {
+        return fullPath === StoryboardFilePath && component.name === BakedInStoryboardVariableName
+      }
+
+      // All the heavy lifting for what to add happens in here.
+      function addToResult(
+        elementMatchesName: string,
+        listingName: string,
+        importDetailsToAdd: ImportDetails,
+      ): void {
+        for (const topLevelElement of success.topLevelElements) {
+          if (
+            isUtopiaJSXComponent(topLevelElement) &&
+            topLevelElement.name === elementMatchesName &&
+            !isStoryboard(topLevelElement)
+          ) {
+            // Don't add an import if this is from the same file.
+            const importsToAdd =
+              originatingPath === fullPath ? emptyImports() : { [fullPath]: importDetailsToAdd }
+            result.push(exportedComponentDetail(importsToAdd, listingName))
+          }
+        }
+      }
+
+      // Default export for the entire file.
+      if (success.exportsDetail.defaultExport != null) {
+        const defaultExport = success.exportsDetail.defaultExport
+        switch (defaultExport.type) {
+          case 'EXPORT_DEFAULT_NAMED':
+            addToResult(defaultExport.name, '(default)', importDetails(pathLastPart, [], null))
+            break
+          case 'EXPORT_DEFAULT_MODIFIER':
+            addToResult(defaultExport.name, '(default)', importDetails(pathLastPart, [], null))
+            break
+        }
+      }
+
+      // Handle exports where the component is against a key in the exports object.
+      for (const namedExportKey of Object.keys(success.exportsDetail.namedExports)) {
+        const namedExport = success.exportsDetail.namedExports[namedExportKey]
+        switch (namedExport.type) {
+          case 'EXPORT_DETAIL_NAMED':
+            addToResult(
+              namedExport.name,
+              namedExportKey,
+              importDetails(null, [importAlias(namedExportKey)], null),
+            )
+            break
+          case 'EXPORT_DETAIL_MODIFIER':
+            addToResult(
+              namedExportKey,
+              namedExportKey,
+              importDetails(null, [importAlias(namedExportKey)], null),
+            )
+            break
+        }
+      }
+
+      return result
+    },
+    () => {
+      return null
+    },
+    textFile,
+  )
+}

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -335,230 +335,62 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
             this.props.currentlyOpenFilename,
           )
 
-    return insertableGroups.map((insertableGroup, groupIndex) => {
-      return (
-        <InsertGroup
-          label={getInsertableGroupLabel(insertableGroup.source)}
-          key={`insert-group-${groupIndex}`}
-          dependencyVersion={null}
-          dependencyStatus={getInsertableGroupPackageStatus(insertableGroup.source)}
-        >
-          {insertableGroup.insertableComponents.map((component, componentIndex) => {
-            const insertItemOnMouseDown = () => {
-              const newUID = generateUID(this.props.existingUIDs)
-              const newElement = {
-                ...component.element,
-                props: setJSXAttributesAttribute(
-                  component.element.props,
-                  'data-uid',
-                  jsxAttributeValue(newUID, emptyComments),
-                ),
-              }
-              this.props.editorDispatch(
-                [enableInsertModeForJSXElement(newElement, newUID, component.importsToAdd, null)],
-                'everyone',
-              )
-            }
-            return (
-              <InsertItem
-                key={`insert-item-third-party-${groupIndex}-${componentIndex}`}
-                type={'component'}
-                label={component.name}
-                selected={componentBeingInsertedEquals(
-                  currentlyBeingInserted,
-                  componentBeingInserted(component.importsToAdd, component.element.name),
-                )}
-                onMouseDown={insertItemOnMouseDown}
-              />
-            )
-          })}
-        </InsertGroup>
-      )
-    })
-    /*
-    return (
-      <React.Fragment>
-        <InsertGroup label='Storyboard' dependencyStatus='loaded' dependencyVersion={null}>
-          <InsertItem
-            type='scene'
-            label='Scene'
-            selected={sceneSelected}
-            onMouseDown={this.sceneInsertMode}
-          />
-        </InsertGroup>
-        <InsertGroup label='Utopia Components' dependencyStatus='loaded' dependencyVersion={null}>
-          <InsertItem
-            type='div'
-            label='div'
-            selected={componentBeingInsertedEquals(
-              currentlyBeingInserted,
-              divComponentBeingInserted,
-            )}
-            onMouseDown={this.divInsertMode}
-          />
-          <InsertItem
-            type='image'
-            label='Image'
-            selected={componentBeingInsertedEquals(
-              currentlyBeingInserted,
-              imageComponentBeingInserted,
-            )}
-            onMouseDown={this.imageInsert}
-          />
-          <InsertItem
-            type='text'
-            label='Text'
-            selected={componentBeingInsertedEquals(
-              currentlyBeingInserted,
-              textComponentBeingInserted,
-            )}
-            onMouseDown={this.textInsertMode}
-          />
-          <InsertItem
-            type='ellipse'
-            label='Ellipse'
-            selected={componentBeingInsertedEquals(
-              currentlyBeingInserted,
-              ellipseComponentBeingInserted,
-            )}
-            onMouseDown={this.ellipseInsertMode}
-          />
-          <InsertItem
-            type='rectangle'
-            label='Rectangle'
-            selected={componentBeingInsertedEquals(
-              currentlyBeingInserted,
-              rectangleComponentBeingInserted,
-            )}
-            onMouseDown={this.rectangleInsertMode}
-          />
-          <InsertItem
-            type='div'
-            label='Animated Div'
-            selected={componentBeingInsertedEquals(
-              currentlyBeingInserted,
-              animatedDivComponentBeingInserted,
-            )}
-            onMouseDown={this.animatedDivInsertMode}
-          />
-        </InsertGroup>
-        {this.props.currentlyOpenFilename == null ? null : (
+    return [
+      // FIXME: Once scenes are refactored, this should be removed.
+      <InsertGroup
+        label='Storyboard'
+        key='insert-group-storyboard'
+        dependencyStatus='loaded'
+        dependencyVersion={null}
+      >
+        <InsertItem
+          type='scene'
+          label='Scene'
+          selected={sceneSelected}
+          onMouseDown={this.sceneInsertMode}
+        />
+      </InsertGroup>,
+      ...insertableGroups.map((insertableGroup, groupIndex) => {
+        return (
           <InsertGroup
-            label='Current File'
-            subLabel={this.props.currentlyOpenFilename}
-            dependencyStatus='loaded'
+            label={getInsertableGroupLabel(insertableGroup.source)}
+            key={`insert-group-${groupIndex}`}
             dependencyVersion={null}
+            dependencyStatus={getInsertableGroupPackageStatus(insertableGroup.source)}
           >
-            {this.props.currentFileComponents.map((currentFileComponent) => {
-              const { componentName, defaultProps, detectedProps } = currentFileComponent
-              const warningMessage = findMissingDefaultsAndGetWarning(detectedProps, defaultProps)
+            {insertableGroup.insertableComponents.map((component, componentIndex) => {
               const insertItemOnMouseDown = () => {
                 const newUID = generateUID(this.props.existingUIDs)
-                let props: JSXAttributes = jsxAttributesFromMap(
-                  objectMap((value) => jsxAttributeValue(value, emptyComments), defaultProps),
-                )
-                props = setJSXAttributesAttribute(
-                  props,
-                  'data-uid',
-                  jsxAttributeValue(newUID, emptyComments),
-                )
-                const newElement = jsxElement(jsxElementName(componentName, []), props, [])
+                const newElement = {
+                  ...component.element,
+                  props: setJSXAttributesAttribute(
+                    component.element.props,
+                    'data-uid',
+                    jsxAttributeValue(newUID, emptyComments),
+                  ),
+                }
                 this.props.editorDispatch(
-                  [enableInsertModeForJSXElement(newElement, newUID, {}, null)],
+                  [enableInsertModeForJSXElement(newElement, newUID, component.importsToAdd, null)],
                   'everyone',
                 )
               }
-
               return (
                 <InsertItem
-                  key={`insert-item-${currentFileComponent.componentName}`}
+                  key={`insert-item-third-party-${groupIndex}-${componentIndex}`}
                   type={'component'}
-                  label={currentFileComponent.componentName}
+                  label={component.name}
                   selected={componentBeingInsertedEquals(
                     currentlyBeingInserted,
-                    componentBeingInserted(
-                      {},
-                      jsxElementName(currentFileComponent.componentName, []),
-                    ),
+                    componentBeingInserted(component.importsToAdd, component.element.name),
                   )}
                   onMouseDown={insertItemOnMouseDown}
-                  warningMessage={warningMessage}
                 />
               )
             })}
           </InsertGroup>
-        )}
-        {this.props.dependencies.map((dependency, dependencyIndex) => {
-          if (isResolvedNpmDependency(dependency)) {
-            const componentDescriptor = getThirdPartyComponents(dependency.name, dependency.version)
-            if (componentDescriptor == null) {
-              return null
-            } else {
-              const dependencyStatus = getDependencyStatus(this.props.packageStatus, this.props.propertyControlsInfo, dependency.name, 'loaded')
-              const components = dependencyStatus === 'loaded' ? componentDescriptor.components : []
-              return (
-                <InsertGroup
-                  label={componentDescriptor.name}
-                  key={dependency.name}
-                  dependencyVersion={dependency.version}
-                  dependencyStatus={dependencyStatus}
-                >
-                  {components.map((component, componentIndex) => {
-                    const insertItemOnMouseDown = () => {
-                      const newUID = generateUID(this.props.existingUIDs)
-                      const newElement = {
-                        ...component.element,
-                        props: setJSXAttributesAttribute(
-                          component.element.props,
-                          'data-uid',
-                          jsxAttributeValue(newUID, emptyComments),
-                        ),
-                      }
-                      this.props.editorDispatch(
-                        [
-                          enableInsertModeForJSXElement(
-                            newElement,
-                            newUID,
-                            component.importsToAdd,
-                            null,
-                          ),
-                        ],
-                        'everyone',
-                      )
-                    }
-                    return (
-                      <InsertItem
-                        key={`insert-item-third-party-${dependencyIndex}-${componentIndex}`}
-                        type={'component'}
-                        label={component.name}
-                        selected={componentBeingInsertedEquals(
-                          currentlyBeingInserted,
-                          componentBeingInserted(component.importsToAdd, component.element.name),
-                        )}
-                        onMouseDown={insertItemOnMouseDown}
-                      />
-                    )
-                  })}
-                </InsertGroup>
-              )
-            }
-          } else {
-            if (isBuiltInDependency(dependency.name)) {
-              return null
-            } else {
-              return (
-                <InsertGroup
-                  label={dependency.name}
-                  dependencyStatus={getDependencyStatus(this.props.packageStatus, this.props.propertyControlsInfo, dependency.name, 'loading')}
-                  dependencyVersion={null}
-                />
-              )
-            }
-          }
-        })}
-      </React.Fragment>
-    )
-    */
+        )
+      }),
+    ]
   }
 }
 

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -246,6 +246,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UNWRAP_LAYOUTABLE(action, state)
     case 'UPDATE_JSX_ELEMENT_NAME':
       return UPDATE_FNS.UPDATE_JSX_ELEMENT_NAME(action, state)
+    case 'ADD_IMPORTS':
+      return UPDATE_FNS.ADD_IMPORTS(action, state)
     case 'SET_ASPECT_RATIO_LOCK':
       return UPDATE_FNS.SET_ASPECT_RATIO_LOCK(action, state)
     case 'TOGGLE_CANVAS_IS_LIVE':

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -29,6 +29,7 @@ import {
 import { getJSXAttributeAtPath } from '../../core/shared/jsx-attributes'
 import { canvasRectangle, localRectangle } from '../../core/shared/math-utils'
 import {
+  Imports,
   InstancePath,
   LayoutWrapper,
   PropertyPath,
@@ -374,7 +375,7 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
     if (props.elementPath.length == 0 || anyUnknownElements) {
       return <SettingsPanel />
     } else if (props.elementPath.length === 1 && TP.isScenePath(props.elementPath[0].path)) {
-      return <SceneSection />
+      return <SceneSection scenePath={props.elementPath[0].path} />
     } else {
       return (
         <React.Fragment>
@@ -759,9 +760,9 @@ export const SingleInspectorEntryPoint: React.FunctionComponent<{
   }, [dispatch, refElementsToTargetForUpdates])
 
   const onElementTypeChange = React.useCallback(
-    (value: JSXElementName) => {
-      const actions = refElementsToTargetForUpdates.current.map((path) => {
-        return EditorActions.updateJSXElementName(path, value)
+    (newElementName: JSXElementName, importsToAdd: Imports) => {
+      const actions = refElementsToTargetForUpdates.current.flatMap((path) => {
+        return EditorActions.updateJSXElementName(path, newElementName, importsToAdd)
       })
       dispatch(actions, 'everyone')
     },

--- a/editor/src/components/inspector/sections/header-section/header-section.tsx
+++ b/editor/src/components/inspector/sections/header-section/header-section.tsx
@@ -14,9 +14,10 @@ import {
 import { allHtmlElements } from '../../../../utils/html-elements'
 import { UtopiaTheme, UtopiaStyles, colorTheme, Section, H2, FlexRow } from '../../../../uuiui'
 import { betterReactMemo } from '../../../../uuiui-deps'
+import { Imports } from '../../../../core/shared/project-file-types'
 
 export interface HeaderSectionCoreProps extends ElementPathProps {
-  onElementTypeChange: (value: JSXElementName) => void
+  onElementTypeChange: (value: JSXElementName, importsToAdd: Imports) => void
   style?: React.CSSProperties
   className?: string
 }

--- a/editor/src/components/inspector/sections/scene-inspector/scene-section.spec.tsx
+++ b/editor/src/components/inspector/sections/scene-inspector/scene-section.spec.tsx
@@ -37,7 +37,7 @@ describe('Scene Section', () => {
         selectedViews={selectedViews}
         editorStoreData={storeHookForTest}
       >
-        <SceneSection />
+        <SceneSection scenePath={ScenePathForTestUiJsFile} />
       </TestInspectorContextProvider>,
     )
 

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -1,0 +1,489 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getComponentGroups returns all the various default groups 1`] = `
+Array [
+  Object {
+    "insertableComponents": Array [
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "App",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "/utopia/storyboard.js": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [
+              Object {
+                "alias": "App",
+                "name": "App",
+              },
+            ],
+            "importedWithName": null,
+          },
+        },
+        "name": "App",
+      },
+    ],
+    "source": Object {
+      "path": "/utopia/storyboard.js",
+      "type": "PROJECT_COMPONENT_GROUP",
+    },
+  },
+  Object {
+    "insertableComponents": Array [
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "div",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "div",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "span",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "span",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "button",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "button",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "input",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "input",
+      },
+    ],
+    "source": Object {
+      "type": "HTML_GROUP",
+    },
+  },
+  Object {
+    "insertableComponents": Array [
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "DatePicker",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "antd": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [
+              Object {
+                "alias": "DatePicker",
+                "name": "DatePicker",
+              },
+            ],
+            "importedWithName": null,
+          },
+          "antd/dist/antd.css": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "Date Picker",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "Button",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "antd": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [
+              Object {
+                "alias": "Button",
+                "name": "Button",
+              },
+            ],
+            "importedWithName": null,
+          },
+          "antd/dist/antd.css": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "Button",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "InputNumber",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "antd": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [
+              Object {
+                "alias": "InputNumber",
+                "name": "InputNumber",
+              },
+            ],
+            "importedWithName": null,
+          },
+          "antd/dist/antd.css": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "Number Input",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "Row",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "antd": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [
+              Object {
+                "alias": "Row",
+                "name": "Row",
+              },
+            ],
+            "importedWithName": null,
+          },
+          "antd/dist/antd.css": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "Row",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "Col",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "antd": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [
+              Object {
+                "alias": "Col",
+                "name": "Col",
+              },
+            ],
+            "importedWithName": null,
+          },
+          "antd/dist/antd.css": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "Col",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "Space",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "antd": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [
+              Object {
+                "alias": "Space",
+                "name": "Space",
+              },
+            ],
+            "importedWithName": null,
+          },
+          "antd/dist/antd.css": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "Space",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "Menu",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "antd": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [
+              Object {
+                "alias": "Menu",
+                "name": "Menu",
+              },
+            ],
+            "importedWithName": null,
+          },
+          "antd/dist/antd.css": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "Menu",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "Menu",
+            "propertyPath": Object {
+              "propertyElements": Array [
+                "Item",
+              ],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "antd": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [
+              Object {
+                "alias": "Menu",
+                "name": "Menu",
+              },
+            ],
+            "importedWithName": null,
+          },
+          "antd/dist/antd.css": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "Menu Item",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "Menu",
+            "propertyPath": Object {
+              "propertyElements": Array [
+                "SubMenu",
+              ],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "antd": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [
+              Object {
+                "alias": "Menu",
+                "name": "Menu",
+              },
+            ],
+            "importedWithName": null,
+          },
+          "antd/dist/antd.css": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "Menu SubMenu",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "Menu",
+            "propertyPath": Object {
+              "propertyElements": Array [
+                "ItemGroup",
+              ],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "antd": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [
+              Object {
+                "alias": "Menu",
+                "name": "Menu",
+              },
+            ],
+            "importedWithName": null,
+          },
+          "antd/dist/antd.css": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "Menu ItemGroup",
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "Typography",
+            "propertyPath": Object {
+              "propertyElements": Array [
+                "Text",
+              ],
+            },
+          },
+          "props": Array [],
+          "type": "JSX_ELEMENT",
+        },
+        "importsToAdd": Object {
+          "antd": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [
+              Object {
+                "alias": "Typography",
+                "name": "Typography",
+              },
+            ],
+            "importedWithName": null,
+          },
+          "antd/dist/antd.css": Object {
+            "importedAs": null,
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "Typography Text",
+      },
+    ],
+    "source": Object {
+      "dependencyName": "antd",
+      "dependencyStatus": "loaded",
+      "type": "PROJECT_DEPENDENCY_GROUP",
+    },
+  },
+]
+`;

--- a/editor/src/components/shared/project-components.spec.ts
+++ b/editor/src/components/shared/project-components.spec.ts
@@ -1,0 +1,32 @@
+import { getControlsForExternalDependencies } from '../../core/property-controls/property-controls-utils'
+import {
+  PackageStatusMap,
+  PossiblyUnversionedNpmDependency,
+  resolvedNpmDependency,
+} from '../../core/shared/npm-dependency-types'
+import { defaultProject } from '../../sample-projects/sample-project-utils'
+import { PropertyControlsInfo } from '../custom-code/code-file'
+import { getComponentGroups } from './project-components'
+
+describe('getComponentGroups', () => {
+  it('returns all the various default groups', () => {
+    const packageStatus: PackageStatusMap = {
+      antd: { status: 'loaded' },
+    }
+    const dependencies: Array<PossiblyUnversionedNpmDependency> = [
+      resolvedNpmDependency('antd', '4.1.0'),
+    ]
+    const propertyControlsInfo: PropertyControlsInfo = getControlsForExternalDependencies(
+      dependencies,
+    )
+    const actualResult = getComponentGroups(
+      packageStatus,
+      propertyControlsInfo,
+      defaultProject().projectContents,
+      dependencies,
+      '/src/app.js',
+    )
+
+    expect(actualResult).toMatchSnapshot()
+  })
+})

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -1,0 +1,266 @@
+import { isUtopiaJSXComponent, jsxElement, JSXElement } from '../../core/shared/element-template'
+import {
+  isResolvedNpmDependency,
+  PackageStatus,
+  PackageStatusMap,
+  PossiblyUnversionedNpmDependency,
+} from '../../core/shared/npm-dependency-types'
+import {
+  Imports,
+  isParsedTextFile,
+  isParseSuccess,
+  isTextFile,
+  ProjectFile,
+} from '../../core/shared/project-file-types'
+import { getThirdPartyComponents } from '../../core/third-party/third-party-components'
+import { emptyImports } from '../../core/workers/common/project-file-utils'
+import { SelectOption } from '../../uuiui-deps'
+import { ProjectContentTreeRoot, walkContentsTree } from '../assets'
+import { PropertyControlsInfo } from '../custom-code/code-file'
+import { getExportedComponentImports } from '../editor/export-utils'
+
+export interface InsertableComponent {
+  importsToAdd: Imports
+  element: JSXElement
+  name: string
+}
+
+export function insertableComponent(
+  importsToAdd: Imports,
+  element: JSXElement,
+  name: string,
+): InsertableComponent {
+  return {
+    importsToAdd: importsToAdd,
+    element: element,
+    name: name,
+  }
+}
+
+export interface InsertableComponentGroupHTML {
+  type: 'HTML_GROUP'
+}
+
+export function insertableComponentGroupHTML(): InsertableComponentGroupHTML {
+  return {
+    type: 'HTML_GROUP',
+  }
+}
+
+export interface InsertableComponentGroupProjectComponent {
+  type: 'PROJECT_COMPONENT_GROUP'
+  path: string
+}
+
+export function insertableComponentGroupProjectComponent(
+  path: string,
+): InsertableComponentGroupProjectComponent {
+  return {
+    type: 'PROJECT_COMPONENT_GROUP',
+    path: path,
+  }
+}
+
+export interface InsertableComponentGroupProjectDependency {
+  type: 'PROJECT_DEPENDENCY_GROUP'
+  dependencyName: string
+  dependencyStatus: PackageStatus
+}
+
+export function insertableComponentGroupProjectDependency(
+  dependencyName: string,
+  dependencyStatus: PackageStatus,
+): InsertableComponentGroupProjectDependency {
+  return {
+    type: 'PROJECT_DEPENDENCY_GROUP',
+    dependencyName: dependencyName,
+    dependencyStatus: dependencyStatus,
+  }
+}
+
+export type InsertableComponentGroupType =
+  | InsertableComponentGroupHTML
+  | InsertableComponentGroupProjectComponent
+  | InsertableComponentGroupProjectDependency
+
+export interface InsertableComponentGroup {
+  source: InsertableComponentGroupType
+  insertableComponents: Array<InsertableComponent>
+}
+
+export function insertableComponentGroup(
+  source: InsertableComponentGroupType,
+  insertableComponents: Array<InsertableComponent>,
+): InsertableComponentGroup {
+  return {
+    source: source,
+    insertableComponents: insertableComponents,
+  }
+}
+
+export function getInsertableGroupLabel(insertableType: InsertableComponentGroupType): string {
+  switch (insertableType.type) {
+    case 'HTML_GROUP':
+      return 'HTML Elements'
+    case 'PROJECT_DEPENDENCY_GROUP':
+      return insertableType.dependencyName
+    case 'PROJECT_COMPONENT_GROUP':
+      return insertableType.path
+    default:
+      const _exhaustiveCheck: never = insertableType
+      throw new Error(`Unhandled insertable type ${JSON.stringify(insertableType)}`)
+  }
+}
+
+export function getInsertableGroupPackageStatus(
+  insertableType: InsertableComponentGroupType,
+): PackageStatus {
+  switch (insertableType.type) {
+    case 'HTML_GROUP':
+      return 'loaded'
+    case 'PROJECT_DEPENDENCY_GROUP':
+      return insertableType.dependencyStatus
+    case 'PROJECT_COMPONENT_GROUP':
+      return 'loaded'
+    default:
+      const _exhaustiveCheck: never = insertableType
+      throw new Error(`Unhandled insertable type ${JSON.stringify(insertableType)}`)
+  }
+}
+
+export function getDependencyStatus(
+  packageStatus: PackageStatusMap,
+  propertyControlsInfo: PropertyControlsInfo,
+  dependencyName: string,
+  defaultStatus: PackageStatus,
+): PackageStatus {
+  const regularStatus = packageStatus[dependencyName]?.status
+  switch (regularStatus) {
+    case null:
+      return defaultStatus
+    case 'loaded':
+      if (dependencyName in propertyControlsInfo) {
+        return 'loaded'
+      } else {
+        return 'loading'
+      }
+    default:
+      return regularStatus
+  }
+}
+
+const basicHTMLEntities = ['div', 'span', 'button', 'input']
+const emptyImportsValue = emptyImports()
+
+export function getComponentGroups(
+  packageStatus: PackageStatusMap,
+  propertyControlsInfo: PropertyControlsInfo,
+  projectContents: ProjectContentTreeRoot,
+  dependencies: Array<PossiblyUnversionedNpmDependency>,
+  originatingPath: string,
+): Array<InsertableComponentGroup> {
+  let result: Array<InsertableComponentGroup> = []
+  // Add entries for the exported components of files within the project.
+  walkContentsTree(projectContents, (fullPath: string, file: ProjectFile) => {
+    if (isTextFile(file)) {
+      const possibleExportedComponents = getExportedComponentImports(
+        originatingPath,
+        fullPath,
+        file.fileContents.parsed,
+      )
+      if (possibleExportedComponents != null) {
+        const insertableComponents = possibleExportedComponents.map((exportedComponent) => {
+          return insertableComponent(
+            exportedComponent.importsToAdd,
+            jsxElement(exportedComponent.listingName, [], []),
+            exportedComponent.listingName,
+          )
+        })
+        result.push(
+          insertableComponentGroup(
+            insertableComponentGroupProjectComponent(fullPath),
+            insertableComponents,
+          ),
+        )
+      }
+    }
+  })
+
+  // Add entries for basic HTML entities.
+  result.push(
+    insertableComponentGroup(
+      insertableComponentGroupHTML(),
+      basicHTMLEntities.map((basicHTMLEntity) => {
+        return insertableComponent(
+          emptyImportsValue,
+          jsxElement(basicHTMLEntity, [], []),
+          basicHTMLEntity,
+        )
+      }),
+    ),
+  )
+
+  // Add entries for dependencies of the project.
+  for (const dependency of dependencies) {
+    if (isResolvedNpmDependency(dependency)) {
+      const componentDescriptor = getThirdPartyComponents(dependency.name, dependency.version)
+      if (componentDescriptor != null) {
+        const dependencyStatus = getDependencyStatus(
+          packageStatus,
+          propertyControlsInfo,
+          dependency.name,
+          'loaded',
+        )
+        const components = dependencyStatus === 'loaded' ? componentDescriptor.components : []
+        const insertableComponents = components.map((component) =>
+          insertableComponent(component.importsToAdd, component.element, component.name),
+        )
+        result.push(
+          insertableComponentGroup(
+            insertableComponentGroupProjectDependency(dependency.name, dependencyStatus),
+            insertableComponents,
+          ),
+        )
+      }
+    }
+  }
+
+  return result
+}
+
+export function getComponentGroupsAsSelectOptions(
+  packageStatus: PackageStatusMap,
+  propertyControlsInfo: PropertyControlsInfo,
+  projectContents: ProjectContentTreeRoot,
+  dependencies: Array<PossiblyUnversionedNpmDependency>,
+  originatingPath: string,
+): Array<SelectOption> {
+  const insertableGroups = getComponentGroups(
+    packageStatus,
+    propertyControlsInfo,
+    projectContents,
+    dependencies,
+    originatingPath,
+  )
+  let result: Array<SelectOption> = []
+  for (const insertableGroup of insertableGroups) {
+    // If there's nothing in the group, don't include it otherwise we end up with a broken
+    // looking entry in the drop down.
+    if (insertableGroup.insertableComponents.length > 0) {
+      const componentOptions: Array<SelectOption> = insertableGroup.insertableComponents.map(
+        (component) => {
+          return {
+            label: component.name,
+            value: component,
+          }
+        },
+      )
+      result.push({
+        label: getInsertableGroupLabel(insertableGroup.source),
+        value: null,
+        options: componentOptions,
+      })
+    }
+  }
+  return result
+}

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -13,7 +13,7 @@ import {
   ProjectFile,
 } from '../../core/shared/project-file-types'
 import { getThirdPartyComponents } from '../../core/third-party/third-party-components'
-import { emptyImports } from '../../core/workers/common/project-file-utils'
+import { addImport, emptyImports } from '../../core/workers/common/project-file-utils'
 import { SelectOption } from '../../uuiui-deps'
 import { ProjectContentTreeRoot, walkContentsTree } from '../assets'
 import { PropertyControlsInfo } from '../custom-code/code-file'
@@ -192,7 +192,7 @@ export function getComponentGroups(
       insertableComponentGroupHTML(),
       basicHTMLEntities.map((basicHTMLEntity) => {
         return insertableComponent(
-          emptyImportsValue,
+          addImport('react', null, [], 'React', emptyImportsValue),
           jsxElement(basicHTMLEntity, [], []),
           basicHTMLEntity,
         )


### PR DESCRIPTION
**Problem:**
Scene selection, the insert menu and the "Render as" drop down are all using wildly different source values which mean it might be possible to insert something as using component X, but it would be impossible to easily update an existing element to use X.

**Fix:**
Created functionality to pull together components within the project, basic HTML entities and dependencies to create a single list which applies to all three locations above.

**Commit Details:**
- Added the `AddImports` action.
- Added `export-utils.ts` which provides some functionality for turning
  exports from one file into imports for another.
- Implemented `getComponentGroups` to get metadata about the components
  available that can be inserted and/or used as components in place of
  already existing ones.
- Implemented `getComponentGroupsAsSelectOptions` that uses `getComponentGroups`
  to provide the same data in a form for the `react-select` drop down.
- Modified `SceneSection`, `NameRow` and `InsertMenu` to use `getComponentGroups`.

**Notes:**
- Currently it is possible to make the component for a storyboard scene be `div`, which lawn darts the editor and some further testing is needed which is why I'm making this a draft PR for the moment.