### PR TITLE
fix(hook) - update when any values are not the same

### DIFF
--- a/editor/src/components/inspector/common/name-and-icon-hook.ts
+++ b/editor/src/components/inspector/common/name-and-icon-hook.ts
@@ -40,7 +40,7 @@ export function useNameAndIcon(path: TemplatePath): NameAndIconResult {
       const newNamePath = newResult.name?.propertyPath != null ? newResult.name?.propertyPath : null
       const namePathEquals = PP.pathsEqual(oldNamePath, newNamePath)
       const nameVariableEquals = oldResult.name?.baseVariable === newResult.name?.baseVariable
-      return pathEquals || labelEquals || iconPropsEqual || namePathEquals || nameVariableEquals
+      return pathEquals && labelEquals && iconPropsEqual && namePathEquals && nameVariableEquals
     },
   )
 }


### PR DESCRIPTION
**Problem:**
The `useNameAndIcon` hook did not update when the underlying information changed. We discovered this in the `RenderAs` component that lets you change the currently selected element or component to a different one.

**Fix:**
Changed the equality function to use `and` not `or`