### PR TITLE
fix(design) - remove font smoothing properties

### DIFF
--- a/editor/resources/editor/css/loadscreen.css
+++ b/editor/resources/editor/css/loadscreen.css
@@ -62,7 +62,7 @@
   font-family: garamond;
   font-size: 48px;
   font-weight: 100;
-  -webkit-font-smoothing: none;
+  /* -webkit-font-smoothing: none; */
   text-rendering: geometricPrecision;
 }
 

--- a/editor/resources/editor/css/loadscreen.css
+++ b/editor/resources/editor/css/loadscreen.css
@@ -1,19 +1,13 @@
 .loading-screen {
-  /* background-image: linear-gradient(180deg, #baf0ff 0%, #84dcff 100%); */
-  /* background-image: linear-gradient(180deg, #fff4ba 0%, #84dcff 100%); */
   --stroke1: rgba(46, 179, 255, 0.5);
   --background: white;
 }
 
 @keyframes loadingKeyframes {
   from {
-    /* transform: rotateZ(0deg); */
-    /* height: 0px; */
     transform: translateY(812px) translateX(-440px);
   }
   to {
-    /* transform: rotateZ(300deg); */
-    /* height: 412px; */
     transform: translateY(0) translateX(0px);
   }
 }
@@ -62,7 +56,6 @@
   font-family: garamond;
   font-size: 48px;
   font-weight: 100;
-  /* -webkit-font-smoothing: none; */
   text-rendering: geometricPrecision;
 }
 

--- a/editor/resources/editor/initial-load.css
+++ b/editor/resources/editor/initial-load.css
@@ -4,9 +4,6 @@ body {
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; /* from GitHub */
   font-size: 11px !important;
   overflow: hidden;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-rendering: geometricPrecision;
   cursor: default;
   outline: none;
   overscroll-behavior-x: contain;


### PR DESCRIPTION
**Problem:**
After switching to the correct Inter font, rendering still looked a bit "off"

**Fix:**
Removes legacy-electron-recommended font-smoothing / aliasing-related properties
