### PR TITLE
Support identifying the underlying file and path of a given element.

### DIFF
--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -1,4 +1,11 @@
-import { generateCodeResultCache } from './code-file'
+import {
+  generateCodeResultCache,
+  normalisePathEndsAtDependency,
+  normalisePathError,
+  normalisePathSuccess,
+  normalisePathToUnderlyingTarget,
+  normalisePathUnableToProceed,
+} from './code-file'
 import {
   ExportsInfo,
   MultiFileBuildResult,
@@ -11,9 +18,37 @@ import {
   initBrowserFS,
 } from '../../core/workers/ts/ts-worker'
 import { NO_OP, fastForEach } from '../../core/shared/utils'
-import { NodeModules, esCodeFile } from '../../core/shared/project-file-types'
+import {
+  NodeModules,
+  esCodeFile,
+  ProjectContents,
+  RevisionsState,
+  textFile,
+  textFileContents,
+  unparsed,
+  TextFile,
+  isTextFile,
+  codeFile,
+  ProjectFile,
+  StaticInstancePath,
+} from '../../core/shared/project-file-types'
 import { MapLike } from 'typescript'
 import { objectMap } from '../../core/shared/object-utils'
+import {
+  getDefaultUIJsFile,
+  getSamplePreviewFile,
+  getSamplePreviewHTMLFile,
+} from '../../core/model/new-project-files'
+import { directory, updateFileContents } from '../../core/model/project-file-utils'
+import { contentsToTree, getContentsTreeFileFromString, ProjectContentTreeRoot } from '../assets'
+import {
+  PersistentModel,
+  DefaultPackageJson,
+  StoryboardFilePath,
+  persistentModelForProjectContents,
+} from '../editor/store/editor-state'
+import { lintAndParse, parseCode } from '../../core/workers/parser-printer/parser-printer'
+import * as TP from '../../core/shared/template-path'
 
 function transpileCode(
   rootFilenames: Array<string>,
@@ -405,5 +440,181 @@ describe('Creating require function', () => {
     )
 
     expect(() => codeResultCache.requireFn('/', 'foo', false)).toThrowErrorMatchingSnapshot()
+  })
+})
+
+function createCodeFile(path: string, contents: string): TextFile {
+  const result = lintAndParse(path, contents)
+  return textFile(textFileContents(contents, result, RevisionsState.CodeAhead), null, Date.now())
+}
+
+function defaultProjectContentsForNormalising(): ProjectContentTreeRoot {
+  let projectContents: ProjectContents = {
+    '/package.json': textFile(
+      textFileContents(
+        JSON.stringify(DefaultPackageJson, null, 2),
+        unparsed,
+        RevisionsState.BothMatch,
+      ),
+      null,
+      0,
+    ),
+    '/src': directory(),
+    '/utopia': directory(),
+    [StoryboardFilePath]: createCodeFile(
+      StoryboardFilePath,
+      `/** @jsx jsx */
+import * as React from 'react'
+import { Scene, Storyboard, jsx } from 'utopia-api'
+import { App } from '/src/app.js'
+export var storyboard = (
+  <Storyboard data-uid='storyboard-entity'>
+    <Scene
+      data-uid='scene-entity'
+      component={App}
+      props={{}}
+      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+    />
+  </Storyboard>
+)
+`,
+    ),
+    '/src/app.js': createCodeFile(
+      '/src/app.js',
+      `/** @jsx jsx */
+import * as React from 'react'
+import { jsx } from 'utopia-api'
+import { Card } from '/src/card.js'
+export var App = (props) => {
+  return <div data-uid='app-outer-div'>
+    <Card data-uid='card-instance' />
+  </div>
+}
+`,
+    ),
+    '/src/card.js': createCodeFile(
+      '/src/app.js',
+      `/** @jsx jsx */
+import * as React from 'react'
+import { jsx, Rectangle } from 'utopia-api'
+export var Card = (props) => {
+  return <div data-uid='card-outer-div'>
+    <div data-uid='card-inner-div' />
+    <Rectangle data-uid='card-inner-rectangle' /> 
+  </div>
+}
+`,
+    ),
+    '/utopia/unparsedstoryboard.js': createCodeFile(
+      StoryboardFilePath,
+      `/** @jsx jsx */
+import * as React from 'react'
+import { Scene, Storyboard, jsx } from 'utopia-api'
+import { App } from '/src/app.js'
+export var storyboard = (
+  <Storyboard data-uid='storyboard-entity'>
+    <Scene
+      data-uid='scene-entity'
+      component={App}
+      props={{}}
+      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+    />
+  </Storyboard>
+)
+`,
+    ),
+  }
+
+  projectContents = objectMap((projectFile: ProjectFile, fullPath: string) => {
+    if (isTextFile(projectFile) && fullPath !== '/utopia/unparsedstoryboard.js') {
+      const code = projectFile.fileContents.code
+      const parsedFile = parseCode(fullPath, code)
+      return textFile(textFileContents(code, parsedFile, RevisionsState.BothMatch), null, 1000)
+    } else {
+      return projectFile
+    }
+  }, projectContents)
+
+  return contentsToTree(projectContents)
+}
+
+function getTextFileByPath(projectContents: ProjectContentTreeRoot, path: string): TextFile {
+  const possibleResult = getContentsTreeFileFromString(projectContents, path)
+  if (isTextFile(possibleResult)) {
+    return possibleResult
+  } else {
+    throw new Error(`Unable to find a text file at path ${path}.`)
+  }
+}
+
+function staticInstancePathFromString(path: string): StaticInstancePath {
+  const fromStringResult = TP.fromString(path)
+  if (TP.isScenePath(fromStringResult)) {
+    throw new Error(`${path} represents a scene path.`)
+  } else {
+    return TP.dynamicPathToStaticPath(fromStringResult)
+  }
+}
+
+describe('normalisePathToUnderlyingTarget', () => {
+  const projectContents = defaultProjectContentsForNormalising()
+  it('jumps across multiple files to reach the actual target', () => {
+    const actualResult = normalisePathToUnderlyingTarget(
+      projectContents,
+      StoryboardFilePath,
+      staticInstancePathFromString(
+        'storyboard-entity/scene-entity:app-outer-div/card-instance:card-outer-div/card-inner-div',
+      ),
+    )
+    const expectedResult = normalisePathSuccess(
+      staticInstancePathFromString(':card-outer-div/card-inner-div'),
+      '/src/card.js',
+      getTextFileByPath(projectContents, '/src/card.js'),
+    )
+    expect(actualResult).toEqual(expectedResult)
+  })
+  it('returns the same path because there are no hops to take', () => {
+    const actualResult = normalisePathToUnderlyingTarget(
+      projectContents,
+      '/src/card.js',
+      staticInstancePathFromString(':card-outer-div/card-inner-div'),
+    )
+    const expectedResult = normalisePathSuccess(
+      staticInstancePathFromString(':card-outer-div/card-inner-div'),
+      '/src/card.js',
+      getTextFileByPath(projectContents, '/src/card.js'),
+    )
+    expect(actualResult).toEqual(expectedResult)
+  })
+  it('gives an error when a file does not exist', () => {
+    const actualResult = normalisePathToUnderlyingTarget(
+      projectContents,
+      '/src/nonexistant.js',
+      staticInstancePathFromString(':card-outer-div/card-inner-div'),
+    )
+    const expectedResult = normalisePathError('No text file found at /src/nonexistant.js')
+    expect(actualResult).toEqual(expectedResult)
+  })
+  it('skips attempting to traverse when confronted with an unparsed code file', () => {
+    const actualResult = normalisePathToUnderlyingTarget(
+      projectContents,
+      '/utopia/unparsedstoryboard.js',
+      staticInstancePathFromString(
+        'storyboard-entity/scene-entity:app-outer-div/card-instance:card-outer-div/card-inner-div',
+      ),
+    )
+    const expectedResult = normalisePathUnableToProceed()
+    expect(actualResult).toEqual(expectedResult)
+  })
+  it('handles hitting an external dependency', () => {
+    const actualResult = normalisePathToUnderlyingTarget(
+      projectContents,
+      StoryboardFilePath,
+      staticInstancePathFromString(
+        'storyboard-entity/scene-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle:rectangle-inner-div',
+      ),
+    )
+    const expectedResult = normalisePathEndsAtDependency('utopia-api')
+    expect(actualResult).toEqual(expectedResult)
   })
 })

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -19,6 +19,13 @@ import {
   esCodeFile,
   ProjectContents,
   isEsCodeFile,
+  TemplatePath,
+  TextFile,
+  isTextFile,
+  RevisionsState,
+  InstancePath,
+  StaticInstancePath,
+  isParseSuccess,
 } from '../../core/shared/project-file-types'
 
 import { EditorDispatch } from '../editor/action-types'
@@ -27,7 +34,19 @@ import { updateNodeModulesContents } from '../editor/actions/action-creators'
 import { fastForEach } from '../../core/shared/utils'
 import { arrayToObject } from '../../core/shared/array-utils'
 import { objectMap } from '../../core/shared/object-utils'
-import { ProjectContentTreeRoot } from '../assets'
+import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../assets'
+import { Either, left, right } from '../../core/shared/either'
+import * as TP from '../../core/shared/template-path'
+import {
+  getJSXAttribute,
+  isIntrinsicElement,
+  isJSXAttributeOtherJavaScript,
+  JSXElement,
+} from '../../core/shared/element-template'
+import { findElementWithUID } from '../../core/shared/uid-utils'
+import { importedFromWhere } from '../editor/import-utils'
+import { absolutePathFromRelativePath } from '../../utils/path-utils'
+
 export interface CodeResult {
   exports: ModuleExportTypes
   transpiledCode: string | null
@@ -253,4 +272,170 @@ export function codeCacheToBuildResult(cache: {
       errors: [], // TODO: this is ugly, these errors are the build errors which are not stored in CodeResultCache, but directly in EditorState.codeEditorErrors
     }
   }, cache)
+}
+
+export interface NormalisePathSuccess {
+  type: 'NORMALISE_PATH_SUCCESS'
+  normalisedPath: StaticInstancePath
+  filePath: string
+  textFile: TextFile
+}
+
+export function normalisePathSuccess(
+  normalisedPath: StaticInstancePath,
+  filePath: string,
+  textFile: TextFile,
+): NormalisePathSuccess {
+  return {
+    type: 'NORMALISE_PATH_SUCCESS',
+    normalisedPath: normalisedPath,
+    filePath: filePath,
+    textFile: textFile,
+  }
+}
+
+export interface NormalisePathEndsAtDependency {
+  type: 'NORMALISE_PATH_ENDS_AT_DEPENDENCY'
+  dependency: string
+}
+
+export function normalisePathEndsAtDependency(dependency: string): NormalisePathEndsAtDependency {
+  return {
+    type: 'NORMALISE_PATH_ENDS_AT_DEPENDENCY',
+    dependency: dependency,
+  }
+}
+
+export interface NormalisePathError {
+  type: 'NORMALISE_PATH_ERROR'
+  errorMessage: string
+}
+
+export function normalisePathError(errorMessage: string): NormalisePathError {
+  return {
+    type: 'NORMALISE_PATH_ERROR',
+    errorMessage: errorMessage,
+  }
+}
+
+export interface NormalisePathUnableToProceed {
+  type: 'NORMALISE_PATH_UNABLE_TO_PROCEED'
+}
+
+export function normalisePathUnableToProceed(): NormalisePathUnableToProceed {
+  return {
+    type: 'NORMALISE_PATH_UNABLE_TO_PROCEED',
+  }
+}
+
+export interface NormalisePathImportNotFound {
+  type: 'NORMALISE_PATH_IMPORT_NOT_FOUND'
+}
+
+export function normalisePathImportNotFound(): NormalisePathImportNotFound {
+  return {
+    type: 'NORMALISE_PATH_IMPORT_NOT_FOUND',
+  }
+}
+
+export type NormalisePathResult =
+  | NormalisePathError
+  | NormalisePathUnableToProceed
+  | NormalisePathImportNotFound
+  | NormalisePathEndsAtDependency
+  | NormalisePathSuccess
+
+export function normalisePathToUnderlyingTarget(
+  projectContents: ProjectContentTreeRoot,
+  currentFilePath: string,
+  elementPath: InstancePath,
+): NormalisePathResult {
+  const currentFile = getContentsTreeFileFromString(projectContents, currentFilePath)
+  if (isTextFile(currentFile)) {
+    if (
+      currentFile.fileContents.revisionsState === RevisionsState.CodeAhead ||
+      !isParseSuccess(currentFile.fileContents.parsed)
+    ) {
+      // As the code is ahead this would potentially be looking at a path
+      // which now doesn't exist.
+      return normalisePathUnableToProceed()
+    } else {
+      const staticPath = TP.dynamicPathToStaticPath(elementPath)
+      const potentiallyDroppedFirstSceneElementResult = TP.dropFirstScenePathElement(staticPath)
+      if (potentiallyDroppedFirstSceneElementResult.droppedScenePathElements == null) {
+        // As the scene path is empty, there's no more traversing to do, the target is in this file.
+        return normalisePathSuccess(staticPath, currentFilePath, currentFile)
+      } else {
+        const droppedPathPart = potentiallyDroppedFirstSceneElementResult.droppedScenePathElements
+        if (droppedPathPart.length === 0) {
+          return normalisePathError(
+            `Unable to handle empty scene path part for ${TP.toString(elementPath)}`,
+          )
+        } else {
+          // Now need to identify the element relating to the last part of the dropped scene path.
+          const lastScenePathPart = droppedPathPart[droppedPathPart.length - 1]
+
+          // Walk the parsed representation to find the element with the given uid.
+          const parsedContent = currentFile.fileContents.parsed
+          let targetElement: JSXElement | null = null
+          for (const topLevelElement of parsedContent.topLevelElements) {
+            const possibleTarget = findElementWithUID(topLevelElement, lastScenePathPart)
+            if (possibleTarget != null) {
+              targetElement = possibleTarget
+              break
+            }
+          }
+
+          // Identify where the component is imported from or if it's in the same file.
+          if (targetElement == null) {
+            return normalisePathImportNotFound()
+          } else {
+            const nonNullTargetElement: JSXElement = targetElement
+            function lookupElementImport(elementBaseVariable: string): NormalisePathResult {
+              const importedFrom = importedFromWhere(elementBaseVariable, parsedContent.imports)
+              if (importedFrom == null) {
+                return normalisePathImportNotFound()
+              } else {
+                if (importedFrom === 'utopia-api' && elementBaseVariable === 'Scene') {
+                  // Navigate around the scene with the special case handling.
+                  const componentAttr = getJSXAttribute(nonNullTargetElement.props, 'component')
+                  if (componentAttr != null && isJSXAttributeOtherJavaScript(componentAttr)) {
+                    return lookupElementImport(componentAttr.javascript)
+                  } else {
+                    return normalisePathError(
+                      `Unable to handle Scene component definition for ${TP.toString(elementPath)}`,
+                    )
+                  }
+                } else if (importedFrom.includes('/')) {
+                  const absoluteImportedPath = absolutePathFromRelativePath(
+                    currentFilePath,
+                    importedFrom,
+                  )
+                  return normalisePathToUnderlyingTarget(
+                    projectContents,
+                    absoluteImportedPath,
+                    potentiallyDroppedFirstSceneElementResult.newPath,
+                  )
+                } else {
+                  return normalisePathEndsAtDependency(importedFrom)
+                }
+              }
+            }
+            // Handle things like divs.
+            if (isIntrinsicElement(targetElement.name)) {
+              return normalisePathSuccess(
+                TP.dynamicPathToStaticPath(potentiallyDroppedFirstSceneElementResult.newPath),
+                currentFilePath,
+                currentFile,
+              )
+            } else {
+              return lookupElementImport(targetElement.name.baseVariable)
+            }
+          }
+        }
+      }
+    }
+  } else {
+    return normalisePathError(`No text file found at ${currentFilePath}`)
+  }
 }

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -320,11 +320,13 @@ export function normalisePathError(errorMessage: string): NormalisePathError {
 
 export interface NormalisePathUnableToProceed {
   type: 'NORMALISE_PATH_UNABLE_TO_PROCEED'
+  filePath: string
 }
 
-export function normalisePathUnableToProceed(): NormalisePathUnableToProceed {
+export function normalisePathUnableToProceed(filePath: string): NormalisePathUnableToProceed {
   return {
     type: 'NORMALISE_PATH_UNABLE_TO_PROCEED',
+    filePath: filePath,
   }
 }
 
@@ -358,7 +360,7 @@ export function normalisePathToUnderlyingTarget(
     ) {
       // As the code is ahead this would potentially be looking at a path
       // which now doesn't exist.
-      return normalisePathUnableToProceed()
+      return normalisePathUnableToProceed(currentFilePath)
     } else {
       const staticPath = TP.dynamicPathToStaticPath(elementPath)
       const potentiallyDroppedFirstSceneElementResult = TP.dropFirstScenePathElement(staticPath)
@@ -392,7 +394,12 @@ export function normalisePathToUnderlyingTarget(
           } else {
             const nonNullTargetElement: JSXElement = targetElement
             function lookupElementImport(elementBaseVariable: string): NormalisePathResult {
-              const importedFrom = importedFromWhere(elementBaseVariable, parsedContent.imports)
+              const importedFrom = importedFromWhere(
+                currentFilePath,
+                elementBaseVariable,
+                parsedContent.topLevelElements,
+                parsedContent.imports,
+              )
               if (importedFrom == null) {
                 return normalisePathImportNotFound()
               } else {
@@ -436,6 +443,6 @@ export function normalisePathToUnderlyingTarget(
       }
     }
   } else {
-    return normalisePathError(`No text file found at ${currentFilePath}`)
+    return normalisePathUnableToProceed(currentFilePath)
   }
 }

--- a/editor/src/components/editor/import-utils.ts
+++ b/editor/src/components/editor/import-utils.ts
@@ -9,10 +9,11 @@ import {
   isJSXElement,
   isJSXAttributeFunctionCall,
   walkElements,
+  JSXElementName,
 } from '../../core/shared/element-template'
 import { walkAttributes } from '../../core/shared/jsx-attributes'
 import { pluck } from '../../core/shared/array-utils'
-import { importAlias } from '../../core/shared/project-file-types'
+import { importAlias, Imports } from '../../core/shared/project-file-types'
 import { emptyComments } from '../../core/workers/parser-printer/parser-printer-comments'
 
 // Adds an import for `UtopiaUtils` to the current open file.
@@ -62,4 +63,20 @@ export function addUtopiaUtilsImportIfUsed(editorState: EditorState): EditorStat
       return editorState
     }
   }
+}
+
+export function importedFromWhere(variableName: string, importsToSearch: Imports): string | null {
+  for (const importSource of Object.keys(importsToSearch)) {
+    const specificImport = importsToSearch[importSource]
+    if (specificImport.importedAs === variableName) {
+      return importSource
+    }
+    if (specificImport.importedWithName === variableName) {
+      return importSource
+    }
+    if (specificImport.importedFromWithin.some((within) => within.alias === variableName)) {
+      return importSource
+    }
+  }
+  return null
 }

--- a/editor/src/core/es-modules/package-manager/module-resolution.ts
+++ b/editor/src/core/es-modules/package-manager/module-resolution.ts
@@ -16,6 +16,7 @@ import { setOptionalProp } from '../../shared/object-utils'
 import { getContentsTreeFileFromElements, ProjectContentTreeRoot } from '../../../components/assets'
 import { loaderExistsForFile } from '../../webpack-loaders/loaders'
 import { dropLast, last } from '../../shared/array-utils'
+import { normalizePath } from '../../../utils/path-utils'
 
 interface ResolveSuccess<T> {
   type: 'RESOLVE_SUCCESS'
@@ -89,21 +90,6 @@ function fileLookupResult(
 
 function pathToElements(path: string): string[] {
   return path.split('/')
-}
-
-function normalizePath(path: string[]): string[] {
-  return path.reduce((pathSoFar: string[], pathElem: string, index: number) => {
-    if (pathElem === '' && index !== 0) {
-      return pathSoFar
-    }
-    if (pathElem === '.') {
-      return pathSoFar
-    }
-    if (pathElem === '..') {
-      return pathSoFar.slice(0, -1)
-    }
-    return [...pathSoFar, pathElem]
-  }, [])
 }
 
 type FileLookupFn = (path: string[]) => FileLookupResult

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -931,7 +931,7 @@ interface DropFirstScenePathElementResultType {
 export function dropFirstScenePathElement(
   path: StaticInstancePath,
 ): DropFirstScenePathElementResultType {
-  if (path.scene.sceneElementPaths.length === 0) {
+  if (isScenePathEmpty(path)) {
     return {
       newPath: path,
       droppedScenePathElements: null,

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -914,3 +914,35 @@ export function staticScenePathContainsElementPath(
     return elementPathsEqual(sceneElementPath, elementPath)
   })
 }
+
+export function isScenePathEmpty(path: TemplatePath): boolean {
+  if (isScenePath(path)) {
+    return path.sceneElementPaths.length === 0
+  } else {
+    return path.scene.sceneElementPaths.length === 0
+  }
+}
+
+interface DropFirstScenePathElementResultType {
+  newPath: InstancePath
+  droppedScenePathElements: StaticElementPath | null
+}
+
+export function dropFirstScenePathElement(
+  path: StaticInstancePath,
+): DropFirstScenePathElementResultType {
+  if (path.scene.sceneElementPaths.length === 0) {
+    return {
+      newPath: path,
+      droppedScenePathElements: null,
+    }
+  } else {
+    return {
+      newPath: {
+        ...path,
+        scene: scenePath(path.scene.sceneElementPaths.slice(1)),
+      },
+      droppedScenePathElements: path.scene.sceneElementPaths[0],
+    }
+  }
+}

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -1,5 +1,5 @@
 import { v4 as UUID } from 'uuid'
-import { Either, flatMapEither, isLeft, left, right } from './either'
+import { Either, flatMapEither, isLeft, isRight, left, right } from './either'
 import {
   JSXAttributes,
   jsxAttributeValue,
@@ -10,6 +10,7 @@ import {
   isJSXArbitraryBlock,
   setJSXAttributesAttribute,
   getJSXAttribute,
+  TopLevelElement,
 } from './element-template'
 import { shallowEqual } from './equality-utils'
 import {
@@ -18,7 +19,7 @@ import {
   setJSXValueAtPath,
 } from './jsx-attributes'
 import * as PP from './property-path'
-import { objectMap } from './object-utils'
+import { objectMap, objectValues } from './object-utils'
 import { emptyComments } from '../workers/parser-printer/parser-printer-comments'
 
 export const UtopiaIDPropertyPath = PP.create(['data-uid'])
@@ -207,4 +208,66 @@ export function fixUtopiaElement(
   }
 
   return fixUtopiaElementInner(elementToFix)
+}
+
+export function findElementWithUID(
+  topLevelElement: TopLevelElement,
+  targetUID: string,
+): JSXElement | null {
+  function findForJSXElementChild(element: JSXElementChild): JSXElement | null {
+    switch (element.type) {
+      case 'JSX_ELEMENT':
+        return findForJSXElement(element)
+      case 'JSX_FRAGMENT':
+        for (const child of element.children) {
+          const childResult = findForJSXElementChild(child)
+          if (childResult != null) {
+            return childResult
+          }
+        }
+        return null
+      case 'JSX_TEXT_BLOCK':
+        return null
+      case 'JSX_ARBITRARY_BLOCK':
+        if (targetUID in element.elementsWithin) {
+          return element.elementsWithin[targetUID]
+        }
+        for (const elementWithin of objectValues(element.elementsWithin)) {
+          const elementWithinResult = findForJSXElement(elementWithin)
+          if (elementWithinResult != null) {
+            return elementWithinResult
+          }
+        }
+        return null
+      default:
+        const _exhaustiveCheck: never = element
+        throw new Error(`Unhandled element type ${JSON.stringify(element)}`)
+    }
+  }
+
+  function findForJSXElement(element: JSXElement): JSXElement | null {
+    const parsedUID = parseUID(element.props)
+    if (isRight(parsedUID) && parsedUID.value === targetUID) {
+      return element
+    } else {
+      for (const child of element.children) {
+        const childResult = findForJSXElementChild(child)
+        if (childResult != null) {
+          return childResult
+        }
+      }
+    }
+    return null
+  }
+
+  switch (topLevelElement.type) {
+    case 'UTOPIA_JSX_COMPONENT':
+      return findForJSXElementChild(topLevelElement.rootElement)
+    case 'ARBITRARY_JS_BLOCK':
+      return null
+    case 'UNPARSED_CODE':
+      return null
+    case 'IMPORT_STATEMENT':
+      return null
+  }
 }

--- a/editor/src/utils/path-utils.ts
+++ b/editor/src/utils/path-utils.ts
@@ -1,0 +1,39 @@
+export function normalizePath(path: Array<string>): Array<string> {
+  return path.reduce((pathSoFar: Array<string>, pathElem: string, index: number) => {
+    if (pathElem === '' && index !== 0) {
+      return pathSoFar
+    }
+    if (pathElem === '.') {
+      return pathSoFar
+    }
+    if (pathElem === '..') {
+      return pathSoFar.slice(0, -1)
+    }
+    return [...pathSoFar, pathElem]
+  }, [])
+}
+
+export function stripTrailingSlash(path: string): string {
+  return path.endsWith('/') ? path.slice(0, -1) : path
+}
+
+export function stripLeadingSlash(path: string): string {
+  return path.startsWith('/') ? path.slice(1) : path
+}
+
+export function appendToPath(firstPart: string, secondPart: string): string {
+  const left = stripTrailingSlash(firstPart)
+  const right = stripLeadingSlash(secondPart)
+  return `${left}/${right}`
+}
+
+export function absolutePathFromRelativePath(origin: string, relativePath: string): string {
+  if (relativePath.startsWith('/')) {
+    // Not actually relative in this case.
+    return relativePath
+  } else {
+    const joinedPath = appendToPath(origin, relativePath)
+    const normalized = joinedPath.split('/')
+    return `/${normalized.join('/')}`
+  }
+}


### PR DESCRIPTION
**Problem:**
We want to be able to edit a component that is shown in the canvas for a given file but is not from that file, but have no way to "find" what element it is in which particular file.

**Fix:**
Provide functionality for identifying the originating file for a given element along with the component it relates to in that file.

**Commit Details:**
- Copied some path related functions and added `absolutePathFromRelativePath`.
- Added `findElementWithUID` to lookup a given element given the `data-uid`
  that relates to it.
- Added `dropFirstScenePathElement` to assist with walking a path down
  the various scenes that are included.
- Added `importedFromWhere` to find the import that a variable name relates to.
- Implemented `normalisePathToUnderlyingTarget` which performs the work
  of jumping around the project contents of a project finding the underlying
  components as it goes.
