### PR TITLE
feature(navigator) new scene label

### DIFF
--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -203,12 +203,8 @@ function createComponentIconProps(
   imports: Imports,
 ): IcnPropsBase | null {
   const elementName = MetadataUtils.getJSXElementName(path, components, metadata.components)
-  const element = TP.isInstancePath(path)
-    ? MetadataUtils.getElementByInstancePathMaybe(metadata.elements, path)
-    : MetadataUtils.getElementByInstancePathMaybe(
-        metadata.elements,
-        TP.instancePathForElementAtScenePath(path),
-      )
+  const elementInstancePath = TP.isInstancePath(path) ? path : TP.instancePathForElementAtScenePath(path)
+  const element = MetadataUtils.getElementByInstancePathMaybe(metadata.elements, elementInstancePath)
   if (element?.isEmotionOrStyledComponent) {
     return {
       category: 'component',

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -205,7 +205,10 @@ function createComponentIconProps(
   const elementName = MetadataUtils.getJSXElementName(path, components, metadata.components)
   const element = TP.isInstancePath(path)
     ? MetadataUtils.getElementByInstancePathMaybe(metadata.elements, path)
-    : null
+    : MetadataUtils.getElementByInstancePathMaybe(
+        metadata.elements,
+        TP.instancePathForElementAtScenePath(path),
+      )
   if (element?.isEmotionOrStyledComponent) {
     return {
       category: 'component',

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -203,8 +203,13 @@ function createComponentIconProps(
   imports: Imports,
 ): IcnPropsBase | null {
   const elementName = MetadataUtils.getJSXElementName(path, components, metadata.components)
-  const elementInstancePath = TP.isInstancePath(path) ? path : TP.instancePathForElementAtScenePath(path)
-  const element = MetadataUtils.getElementByInstancePathMaybe(metadata.elements, elementInstancePath)
+  const elementInstancePath = TP.isInstancePath(path)
+    ? path
+    : TP.instancePathForElementAtScenePath(path)
+  const element = MetadataUtils.getElementByInstancePathMaybe(
+    metadata.elements,
+    elementInstancePath,
+  )
   if (element?.isEmotionOrStyledComponent) {
     return {
       category: 'component',

--- a/editor/src/components/navigator/navigator-item/component-preview.tsx
+++ b/editor/src/components/navigator/navigator-item/component-preview.tsx
@@ -15,7 +15,7 @@ export const ComponentPreview: React.FunctionComponent<ComponentPreviewProps> = 
   (props) => {
     const iconProps = useComponentIcon(props.path)
 
-    if (iconProps == null || TP.isScenePath(props.path)) {
+    if (iconProps == null) {
       return null
     } else {
       return (

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -166,7 +166,11 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
       }
 
       // additional style for scenes
-      result.style = { ...result.style, fontWeight: isScene ? 500 : 'inherit' }
+      result.style = {
+        ...result.style,
+        fontWeight: isScene ? 500 : 'inherit',
+        boxShadow: isScene ? `inset 0 -1px ${colorTheme.inputBorder.value}` : undefined,
+      }
 
       return result
     }
@@ -182,14 +186,6 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
       warningText = 'Element is trying to be position absolutely with an unconfigured parent'
     }
 
-    const layoutIcon = (
-      <LayoutIcon
-        key={`layout-type-${label}`}
-        path={templatePath}
-        color={resultingStyle.iconColor}
-        warningText={warningText}
-      />
-    )
     const collapse = React.useCallback(
       (event: any) => collapseItem(dispatch, templatePath, event),
       [dispatch, templatePath],
@@ -228,23 +224,23 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
             selected={selected}
             onMouseDown={collapse}
           />
-          {layoutIcon}
-          <ItemLabel
-            key={`label-${label}`}
-            testId={`navigator-item-label-${label}`}
-            name={label}
-            isDynamic={isDynamic}
-            target={templatePath}
-            canRename={selected}
-            dispatch={dispatch}
-            inputVisible={TP.pathsEqual(renamingTarget, templatePath)}
-            elementOriginType={elementOriginType}
-          />
-          <ComponentPreview
-            key={`preview-${label}`}
-            path={templatePath}
-            color={resultingStyle.iconColor}
-          />
+          {TP.isScenePath(templatePath) ? (
+            <SceneNavigatorRowLabel
+              {...props}
+              collapse={collapse}
+              isDynamic={isDynamic}
+              iconColor={resultingStyle.iconColor}
+              warningText={warningText}
+            />
+          ) : (
+            <NavigatorRowLabel
+              {...props}
+              collapse={collapse}
+              isDynamic={isDynamic}
+              iconColor={resultingStyle.iconColor}
+              warningText={warningText}
+            />
+          )}
         </FlexRow>
         <NavigatorItemActionSheet
           templatePath={templatePath}
@@ -259,3 +255,94 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
   },
 )
 NavigatorItem.displayName = 'NavigatorItem'
+
+interface NavigatorRowProps extends NavigatorItemInnerProps {
+  collapse: (event: any) => void
+  isDynamic: boolean
+  iconColor: IcnProps['color']
+  warningText: string | null
+}
+
+const NavigatorRowLabel = (props: NavigatorRowProps) => {
+  return (
+    <React.Fragment>
+      <LayoutIcon
+        key={`layout-type-${props.label}`}
+        path={props.templatePath}
+        color={props.iconColor}
+        warningText={props.warningText}
+      />
+      <ItemLabel
+        key={`label-${props.label}`}
+        testId={`navigator-item-label-${props.label}`}
+        name={props.label}
+        isDynamic={props.isDynamic}
+        target={props.templatePath}
+        canRename={props.selected}
+        dispatch={props.dispatch}
+        inputVisible={TP.pathsEqual(props.renamingTarget, props.templatePath)}
+        elementOriginType={props.elementOriginType}
+      />
+      <ComponentPreview
+        key={`preview-${props.label}`}
+        path={props.templatePath}
+        color={props.iconColor}
+      />
+    </React.Fragment>
+  )
+}
+
+const SceneNavigatorRowLabel = (props: NavigatorRowProps) => {
+  return (
+    <React.Fragment>
+      <LayoutIcon
+        key={`layout-type-${props.label}`}
+        path={props.templatePath}
+        color={props.iconColor}
+        warningText={props.warningText}
+      />
+      <span
+        style={{
+          marginLeft: 4,
+          marginRight: 4,
+          fontWeight: 600,
+        }}
+      >
+        Scene
+      </span>
+      <span
+        style={{
+          color: props.selected ? undefined : colorTheme.h3Foreground.value,
+          paddingRight: 4,
+        }}
+      >
+        editing
+      </span>
+      <div
+        style={{
+          display: 'flex',
+          backgroundColor: props.selected ? undefined : colorTheme.subduedBorder.value,
+          borderRadius: 1,
+          paddingRight: 4,
+        }}
+      >
+        <ItemLabel
+          key={`label-${props.label}`}
+          testId={`navigator-item-label-${props.label}`}
+          name={props.label}
+          isDynamic={props.isDynamic}
+          target={props.templatePath}
+          canRename={props.selected}
+          dispatch={props.dispatch}
+          inputVisible={TP.pathsEqual(props.renamingTarget, props.templatePath)}
+          elementOriginType={props.elementOriginType}
+        />
+        <ComponentPreview
+          key={`preview-${props.label}`}
+          path={props.templatePath}
+          color={props.iconColor}
+        />
+      </div>
+    </React.Fragment>
+  )
+}


### PR DESCRIPTION
This PR is part of the navigator redesign, adding special labels for Scenes.

Changes:
- component-preview, showing component icons for Scenes
- wrapper divs and spans for the new labels

<img width="259" alt="Screenshot 2021-03-17 at 13 25 09" src="https://user-images.githubusercontent.com/4403069/111467048-4a4c0300-8724-11eb-910a-11f4c844821b.png">
