### PR TITLE
Fix/focused elements missing items

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4196,6 +4196,10 @@ export const UPDATE_FNS = {
     return {
       ...editor,
       focusedElementPath: action.focusedElementPath,
+      canvas: {
+        ...editor.canvas,
+        mountCount: editor.canvas.mountCount + 1,
+      },
     }
   },
 }

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -544,6 +544,16 @@ function elementIsDescendent(l: ElementPath, r: ElementPath): boolean {
   return elementPathsEqual(slicedL, r)
 }
 
+function scenePathIsDescendent(path: ScenePath, targetAncestor: ScenePath): boolean {
+  return targetAncestor.sceneElementPaths.every((elementPath, i) => {
+    if (path.sceneElementPaths[i] != null) {
+      return elementPathsEqual(elementPath, path.sceneElementPaths[i])
+    } else {
+      return false
+    }
+  })
+}
+
 // This is sooooo badly named! It should be `isDescendentOf`, and tbh that was probably me...
 // e.g. isAncestorOf(instancePath(['A'], ['B', 'C']), instancePath(['A'], ['B']) would return true,
 //      isAncestorOf(instancePath(['A'], ['B']), instancePath(['A'], ['B', 'C']) would return false
@@ -558,10 +568,10 @@ export function isAncestorOf(
     // we've already tested the case where they equals, and a scene can't be a descendent
     return false
   } else if (isScenePath(targetAncestor)) {
-    return scenePathsEqual(path.scene, targetAncestor)
+    return scenePathIsDescendent(path.scene, targetAncestor)
   } else {
     return (
-      scenePathsEqual(path.scene, targetAncestor.scene) &&
+      scenePathIsDescendent(path.scene, targetAncestor.scene) &&
       elementIsDescendent(path.element, targetAncestor.element)
     )
   }


### PR DESCRIPTION
There are 2 problems with sometimes missing elements on the navigator.
When focusing a component the dom-walking only returns the cached values, so the new focused element children will be added when reparsing the code. For this the `mountCount` is incremented when a new element is focused.

The other problem is when the selection changes children go missing from the focused component, this is also a problem in the dom-walker, it fails to find it in the cache at the end of `walkScene`. The `isAncestorOf` is updated to be aware of the complex scenepath descendants too. 