### PR TITLE
Chore/metadata spring cleaning

### DIFF
--- a/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
@@ -488,7 +488,6 @@ Object {
       "props": Object {
         "data-label": "Plane",
         "data-uid": "bbb~~~1",
-        "data-utopia-original-uid": "bbb",
         "skipDeepFreeze": true,
       },
       "specialSizeMeasurements": Object {
@@ -576,7 +575,6 @@ Object {
       "props": Object {
         "data-label": "Plane",
         "data-uid": "bbb~~~2",
-        "data-utopia-original-uid": "bbb",
         "skipDeepFreeze": true,
       },
       "specialSizeMeasurements": Object {
@@ -664,7 +662,6 @@ Object {
       "props": Object {
         "data-label": "Plane",
         "data-uid": "bbb~~~3",
-        "data-utopia-original-uid": "bbb",
         "skipDeepFreeze": true,
       },
       "specialSizeMeasurements": Object {

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -25,7 +25,7 @@ exports[`UiJsxCanvas #747 - DOM object constructor cannot be called as a functio
     \\"
     data-uid=\\"8a6\\"
   >
-    <div data-uid=\\"fa7 031~~~1 088\\" data-utopia-original-uid=\\"031\\">hat</div>
+    <div data-uid=\\"fa7 031~~~1 088\\">hat</div>
   </div>
 </div>
 "

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -29,21 +29,9 @@ exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
       style=\\"position: absolute; left: 0; top: 0; right: 0; bottom: 0;\\"
       data-uid=\\"aaa scene-aaa\\"
     >
-      <div
-        data-uid=\\"bbb~~~1\\"
-        data-label=\\"Plane\\"
-        data-utopia-original-uid=\\"bbb\\"
-      ></div>
-      <div
-        data-uid=\\"bbb~~~2\\"
-        data-label=\\"Plane\\"
-        data-utopia-original-uid=\\"bbb\\"
-      ></div>
-      <div
-        data-uid=\\"bbb~~~3\\"
-        data-label=\\"Plane\\"
-        data-utopia-original-uid=\\"bbb\\"
-      ></div>
+      <div data-uid=\\"bbb~~~1\\" data-label=\\"Plane\\"></div>
+      <div data-uid=\\"bbb~~~2\\" data-label=\\"Plane\\"></div>
+      <div data-uid=\\"bbb~~~3\\" data-label=\\"Plane\\"></div>
     </div>
   </div>
 </div>
@@ -388,21 +376,6 @@ Object {
               "value": "Plane",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -413,7 +386,6 @@ Object {
     "props": Object {
       "data-label": "Plane",
       "data-uid": "bbb~~~1",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -512,21 +484,6 @@ Object {
               "value": "Plane",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -537,7 +494,6 @@ Object {
     "props": Object {
       "data-label": "Plane",
       "data-uid": "bbb~~~2",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -636,21 +592,6 @@ Object {
               "value": "Plane",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -661,7 +602,6 @@ Object {
     "props": Object {
       "data-label": "Plane",
       "data-uid": "bbb~~~3",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -1123,9 +1063,9 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"zzz scene-aaa\\">
-      <div data-uid=\\"aaa~~~1\\" data-utopia-original-uid=\\"aaa\\">1</div>
-      <div data-uid=\\"aaa~~~2\\" data-utopia-original-uid=\\"aaa\\">2</div>
-      <div data-uid=\\"aaa~~~3\\" data-utopia-original-uid=\\"aaa\\">3</div>
+      <div data-uid=\\"aaa~~~1\\">1</div>
+      <div data-uid=\\"aaa~~~2\\">2</div>
+      <div data-uid=\\"aaa~~~3\\">3</div>
     </div>
   </div>
 </div>
@@ -1439,21 +1379,6 @@ Object {
               "value": "aaa~~~1",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "aaa",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -1463,7 +1388,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~1",
-      "data-utopia-original-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -1596,21 +1520,6 @@ Object {
               "value": "aaa~~~2",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "aaa",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -1620,7 +1529,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~2",
-      "data-utopia-original-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -1753,21 +1661,6 @@ Object {
               "value": "aaa~~~3",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "aaa",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -1777,7 +1670,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~3",
-      "data-utopia-original-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -1859,20 +1751,20 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"zzz scene-aaa\\">
-      <div data-uid=\\"aaa~~~1\\" data-utopia-original-uid=\\"aaa\\">
-        <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">4</div>
-        <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">5</div>
-        <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">6</div>
+      <div data-uid=\\"aaa~~~1\\">
+        <div data-uid=\\"bbb~~~1\\">4</div>
+        <div data-uid=\\"bbb~~~2\\">5</div>
+        <div data-uid=\\"bbb~~~3\\">6</div>
       </div>
-      <div data-uid=\\"aaa~~~2\\" data-utopia-original-uid=\\"aaa\\">
-        <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">8</div>
-        <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">10</div>
-        <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">12</div>
+      <div data-uid=\\"aaa~~~2\\">
+        <div data-uid=\\"bbb~~~1\\">8</div>
+        <div data-uid=\\"bbb~~~2\\">10</div>
+        <div data-uid=\\"bbb~~~3\\">12</div>
       </div>
-      <div data-uid=\\"aaa~~~3\\" data-utopia-original-uid=\\"aaa\\">
-        <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">12</div>
-        <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">15</div>
-        <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">18</div>
+      <div data-uid=\\"aaa~~~3\\">
+        <div data-uid=\\"bbb~~~1\\">12</div>
+        <div data-uid=\\"bbb~~~2\\">15</div>
+        <div data-uid=\\"bbb~~~3\\">18</div>
       </div>
     </div>
   </div>
@@ -2398,21 +2290,6 @@ Object {
               "value": "aaa~~~1",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "aaa",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -2422,7 +2299,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~1",
-      "data-utopia-original-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -2561,21 +2437,6 @@ Object {
               "value": "bbb~~~1",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -2585,7 +2446,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -2725,21 +2585,6 @@ Object {
               "value": "bbb~~~2",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -2749,7 +2594,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -2889,21 +2733,6 @@ Object {
               "value": "bbb~~~3",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -2913,7 +2742,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -3145,21 +2973,6 @@ Object {
               "value": "aaa~~~2",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "aaa",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -3169,7 +2982,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~2",
-      "data-utopia-original-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -3308,21 +3120,6 @@ Object {
               "value": "bbb~~~1",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -3332,7 +3129,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -3472,21 +3268,6 @@ Object {
               "value": "bbb~~~2",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -3496,7 +3277,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -3636,21 +3416,6 @@ Object {
               "value": "bbb~~~3",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -3660,7 +3425,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -3892,21 +3656,6 @@ Object {
               "value": "aaa~~~3",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "aaa",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -3916,7 +3665,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~3",
-      "data-utopia-original-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -4055,21 +3803,6 @@ Object {
               "value": "bbb~~~1",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -4079,7 +3812,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -4219,21 +3951,6 @@ Object {
               "value": "bbb~~~2",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -4243,7 +3960,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -4383,21 +4099,6 @@ Object {
               "value": "bbb~~~3",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -4407,7 +4108,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -5116,9 +4816,9 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are not the ap
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"aaa scene-aaa\\">
-      <div data-uid=\\"xxx bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
-      <div data-uid=\\"xxx bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
-      <div data-uid=\\"xxx bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
+      <div data-uid=\\"xxx bbb~~~1\\">n1</div>
+      <div data-uid=\\"xxx bbb~~~2\\">n2</div>
+      <div data-uid=\\"xxx bbb~~~3\\">n3</div>
     </div>
   </div>
 </div>
@@ -5448,21 +5148,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -5472,7 +5157,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -5652,21 +5336,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -5676,7 +5345,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -5856,21 +5524,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -5880,7 +5533,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -6002,9 +5654,9 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are undefined 
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"aaa scene-aaa\\">
-      <div data-uid=\\"xxx bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
-      <div data-uid=\\"xxx bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
-      <div data-uid=\\"xxx bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
+      <div data-uid=\\"xxx bbb~~~1\\">n1</div>
+      <div data-uid=\\"xxx bbb~~~2\\">n2</div>
+      <div data-uid=\\"xxx bbb~~~3\\">n3</div>
     </div>
   </div>
 </div>
@@ -6337,21 +5989,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -6361,7 +5998,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -6542,21 +6178,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -6566,7 +6187,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -6747,21 +6367,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -6771,7 +6376,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -7319,8 +6923,8 @@ exports[`UiJsxCanvas render function component works inside a map 1`] = `
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"zzz scene-aaa\\">
-      <div data-uid=\\"ccc aaa~~~1\\" data-utopia-original-uid=\\"aaa\\">Thing</div>
-      <div data-uid=\\"ccc aaa~~~2\\" data-utopia-original-uid=\\"aaa\\">Thing</div>
+      <div data-uid=\\"ccc aaa~~~1\\">Thing</div>
+      <div data-uid=\\"ccc aaa~~~2\\">Thing</div>
     </div>
   </div>
 </div>
@@ -7537,21 +7141,6 @@ Object {
               "value": "aaa~~~1",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "aaa",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -7561,7 +7150,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~1",
-      "data-utopia-original-uid": "aaa",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -7658,21 +7246,6 @@ Object {
               "value": "aaa~~~2",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "aaa",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -7682,7 +7255,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~2",
-      "data-utopia-original-uid": "aaa",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -10530,85 +10102,28 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
         \\"
         data-uid=\\"eb1 03a\\"
       >
-        <div
-          data-uid=\\"834~~~1\\"
-          data-label=\\"Copy\\"
-          data-utopia-original-uid=\\"834\\"
-        >
-          Copy
-        </div>
-        <div
-          data-uid=\\"999~~~2\\"
-          data-label=\\"⌘,⎇,C\\"
-          data-utopia-original-uid=\\"999\\"
-        >
+        <div data-uid=\\"834~~~1\\" data-label=\\"Copy\\">Copy</div>
+        <div data-uid=\\"999~~~2\\" data-label=\\"⌘,⎇,C\\">
           <span data-uid=\\"6a8 000\\"
-            ><span
-              style=\\"padding: 6px;\\"
-              data-uid=\\"726~~~1\\"
-              data-utopia-original-uid=\\"726\\"
-              >⌘</span
-            ><span
-              style=\\"padding: 6px;\\"
-              data-uid=\\"726~~~2\\"
-              data-utopia-original-uid=\\"726\\"
-              >⎇</span
-            ><span
-              style=\\"padding: 6px;\\"
-              data-uid=\\"726~~~3\\"
-              data-utopia-original-uid=\\"726\\"
-              >C</span
-            ></span
+            ><span style=\\"padding: 6px;\\" data-uid=\\"726~~~1\\">⌘</span
+            ><span style=\\"padding: 6px;\\" data-uid=\\"726~~~2\\">⎇</span
+            ><span style=\\"padding: 6px;\\" data-uid=\\"726~~~3\\">C</span></span
           >
         </div>
-        <div
-          data-uid=\\"834~~~3\\"
-          data-label=\\"Paste\\"
-          data-utopia-original-uid=\\"834\\"
-        >
-          Paste
-        </div>
-        <div data-uid=\\"999~~~4\\" data-label=\\"⌘⎇V\\" data-utopia-original-uid=\\"999\\">
+        <div data-uid=\\"834~~~3\\" data-label=\\"Paste\\">Paste</div>
+        <div data-uid=\\"999~~~4\\" data-label=\\"⌘⎇V\\">
           <span data-uid=\\"6a8 000\\"
-            ><span
-              style=\\"padding: 6px;\\"
-              data-uid=\\"726~~~1\\"
-              data-utopia-original-uid=\\"726\\"
-              >⌘</span
-            ><span
-              style=\\"padding: 6px;\\"
-              data-uid=\\"726~~~2\\"
-              data-utopia-original-uid=\\"726\\"
-              >⎇</span
-            ><span
-              style=\\"padding: 6px;\\"
-              data-uid=\\"726~~~3\\"
-              data-utopia-original-uid=\\"726\\"
-              >V</span
-            ></span
+            ><span style=\\"padding: 6px;\\" data-uid=\\"726~~~1\\">⌘</span
+            ><span style=\\"padding: 6px;\\" data-uid=\\"726~~~2\\">⎇</span
+            ><span style=\\"padding: 6px;\\" data-uid=\\"726~~~3\\">V</span></span
           >
         </div>
-        <div data-uid=\\"834~~~5\\" data-label=\\"Cut\\" data-utopia-original-uid=\\"834\\">
-          Cut
-        </div>
-        <div data-uid=\\"999~~~6\\" data-label=\\"⌘⎇C\\" data-utopia-original-uid=\\"999\\">
+        <div data-uid=\\"834~~~5\\" data-label=\\"Cut\\">Cut</div>
+        <div data-uid=\\"999~~~6\\" data-label=\\"⌘⎇C\\">
           <span data-uid=\\"6a8 000\\"
-            ><span
-              style=\\"padding: 6px;\\"
-              data-uid=\\"726~~~1\\"
-              data-utopia-original-uid=\\"726\\"
-              >⌘</span
-            ><span
-              style=\\"padding: 6px;\\"
-              data-uid=\\"726~~~2\\"
-              data-utopia-original-uid=\\"726\\"
-              >⎇</span
-            ><span
-              style=\\"padding: 6px;\\"
-              data-uid=\\"726~~~3\\"
-              data-utopia-original-uid=\\"726\\"
-              >C</span
-            ></span
+            ><span style=\\"padding: 6px;\\" data-uid=\\"726~~~1\\">⌘</span
+            ><span style=\\"padding: 6px;\\" data-uid=\\"726~~~2\\">⎇</span
+            ><span style=\\"padding: 6px;\\" data-uid=\\"726~~~3\\">C</span></span
           >
         </div>
       </div>
@@ -12926,21 +12441,6 @@ export var storyboard = (props) => {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "834",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -12951,7 +12451,6 @@ export var storyboard = (props) => {
     "props": Object {
       "data-label": "Copy",
       "data-uid": "834~~~1",
-      "data-utopia-original-uid": "834",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -13278,21 +12777,6 @@ export var storyboard = (props) => {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "834",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -13303,7 +12787,6 @@ export var storyboard = (props) => {
     "props": Object {
       "data-label": "Paste",
       "data-uid": "834~~~3",
-      "data-utopia-original-uid": "834",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -13630,21 +13113,6 @@ export var storyboard = (props) => {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "834",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -13655,7 +13123,6 @@ export var storyboard = (props) => {
     "props": Object {
       "data-label": "Cut",
       "data-uid": "834~~~5",
-      "data-utopia-original-uid": "834",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -14014,21 +13481,6 @@ export var storyboard = (props) => {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "999",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -14043,7 +13495,6 @@ export var storyboard = (props) => {
         "C",
       ],
       "data-uid": "999~~~2",
-      "data-utopia-original-uid": "999",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -14639,21 +14090,6 @@ export var storyboard = (props) => {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "999",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -14664,7 +14100,6 @@ export var storyboard = (props) => {
     "props": Object {
       "data-label": "⌘⎇V",
       "data-uid": "999~~~4",
-      "data-utopia-original-uid": "999",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -15256,21 +14691,6 @@ export var storyboard = (props) => {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "999",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -15281,7 +14701,6 @@ export var storyboard = (props) => {
     "props": Object {
       "data-label": "⌘⎇C",
       "data-uid": "999~~~6",
-      "data-utopia-original-uid": "999",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -18149,9 +17568,9 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"aaa scene-aaa\\">
-      <div data-uid=\\"xxx bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
-      <div data-uid=\\"xxx bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
-      <div data-uid=\\"xxx bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
+      <div data-uid=\\"xxx bbb~~~1\\">n1</div>
+      <div data-uid=\\"xxx bbb~~~2\\">n2</div>
+      <div data-uid=\\"xxx bbb~~~3\\">n3</div>
     </div>
   </div>
 </div>
@@ -18481,21 +17900,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -18505,7 +17909,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -18685,21 +18088,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -18709,7 +18097,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -18889,21 +18276,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -18913,7 +18285,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -19035,9 +18406,9 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"aaa scene-aaa\\">
-      <div data-uid=\\"xxx bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
-      <div data-uid=\\"xxx bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
-      <div data-uid=\\"xxx bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
+      <div data-uid=\\"xxx bbb~~~1\\">n1</div>
+      <div data-uid=\\"xxx bbb~~~2\\">n2</div>
+      <div data-uid=\\"xxx bbb~~~3\\">n3</div>
     </div>
   </div>
 </div>
@@ -19369,21 +18740,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -19393,7 +18749,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -19574,21 +18929,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -19598,7 +18938,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -19779,21 +19118,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -19803,7 +19127,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -19925,9 +19248,9 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block with 
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"aaa scene-aaa\\">
-      <div data-uid=\\"xxx bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">n1</div>
-      <div data-uid=\\"xxx bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">n2</div>
-      <div data-uid=\\"xxx bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">n3</div>
+      <div data-uid=\\"xxx bbb~~~1\\">n1</div>
+      <div data-uid=\\"xxx bbb~~~2\\">n2</div>
+      <div data-uid=\\"xxx bbb~~~3\\">n3</div>
     </div>
   </div>
 </div>
@@ -20264,21 +19587,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -20288,7 +19596,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -20468,21 +19775,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -20492,7 +19784,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -20672,21 +19963,6 @@ Object {
               "uniqueID": "",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -20696,7 +19972,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
-      "data-utopia-original-uid": "bbb",
       "data-utopia-scene-path": Object {
         "sceneElementPaths": Array [
           Array [
@@ -21715,9 +20990,7 @@ exports[`UiJsxCanvas render renders fine with two components that reference each
     \\"
     data-uid=\\"utopia-storyboard-uid\\"
   >
-    <div data-uid=\\"2a2~~~1 aaa bbb BBB scene\\" data-utopia-original-uid=\\"2a2\\">
-      great
-    </div>
+    <div data-uid=\\"2a2~~~1 aaa bbb BBB scene\\">great</div>
   </div>
 </div>
 "
@@ -22946,15 +22219,9 @@ exports[`UiJsxCanvas render supports passing down the scope to children of compo
     data-uid=\\"utopia-storyboard-uid\\"
   >
     <div data-uid=\\"aaa scene-aaa\\">
-      <div data-uid=\\"bbb~~~1\\" data-utopia-original-uid=\\"bbb\\">
-        <div data-uid=\\"ccc\\">1</div>
-      </div>
-      <div data-uid=\\"bbb~~~2\\" data-utopia-original-uid=\\"bbb\\">
-        <div data-uid=\\"ccc\\">2</div>
-      </div>
-      <div data-uid=\\"bbb~~~3\\" data-utopia-original-uid=\\"bbb\\">
-        <div data-uid=\\"ccc\\">3</div>
-      </div>
+      <div data-uid=\\"bbb~~~1\\"><div data-uid=\\"ccc\\">1</div></div>
+      <div data-uid=\\"bbb~~~2\\"><div data-uid=\\"ccc\\">2</div></div>
+      <div data-uid=\\"bbb~~~3\\"><div data-uid=\\"ccc\\">3</div></div>
     </div>
   </div>
 </div>
@@ -23337,21 +22604,6 @@ Object {
               "value": "bbb~~~1",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -23361,7 +22613,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -23696,21 +22947,6 @@ Object {
               "value": "bbb~~~2",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -23720,7 +22956,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,
@@ -24055,21 +23290,6 @@ Object {
               "value": "bbb~~~3",
             },
           },
-          Object {
-            "comments": Object {
-              "leadingComments": Array [],
-              "trailingComments": Array [],
-            },
-            "key": "data-utopia-original-uid",
-            "value": Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "type": "ATTRIBUTE_VALUE",
-              "value": "bbb",
-            },
-          },
         ],
         "type": "JSX_ELEMENT",
       },
@@ -24079,7 +23299,6 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
-      "data-utopia-original-uid": "bbb",
       "skipDeepFreeze": true,
       "style": Object {
         "alignContent": undefined,

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -42,7 +42,6 @@ import {
 import {
   UTOPIA_DO_NOT_TRAVERSE_KEY,
   UTOPIA_LABEL_KEY,
-  UTOPIA_ORIGINAL_ID_KEY,
   UTOPIA_UIDS_KEY,
   UTOPIA_UID_ORIGINAL_PARENTS_KEY,
   UTOPIA_UID_PARENTS_KEY,
@@ -379,14 +378,10 @@ function collectMetadata(
   const globalFrame = globalFrameForElement(element, scale, containerRectLazy)
   const localFrame = localRectangle(Utils.offsetRect(globalFrame, Utils.negate(parentPoint)))
 
-  const originalUIDAttribute = getDOMAttribute(element, UTOPIA_ORIGINAL_ID_KEY)
   const labelAttribute = getDOMAttribute(element, UTOPIA_LABEL_KEY)
   let elementProps: any = {}
   if (uidAttribute != null) {
     elementProps[UTOPIA_UIDS_KEY] = uidAttribute // TODO Balazs we are making a fake prop with a single UID instead of the UID array – maybe this means changes to mergeComponentMetadata
-  }
-  if (originalUIDAttribute != null) {
-    elementProps[UTOPIA_ORIGINAL_ID_KEY] = originalUIDAttribute
   }
   if (labelAttribute != null) {
     elementProps[UTOPIA_LABEL_KEY] = labelAttribute

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -39,13 +39,7 @@ import {
   useRefEditorState,
   useSelectorWithCallback,
 } from '../editor/store/store-hook'
-import {
-  UTOPIA_DO_NOT_TRAVERSE_KEY,
-  UTOPIA_LABEL_KEY,
-  UTOPIA_UIDS_KEY,
-  UTOPIA_UID_ORIGINAL_PARENTS_KEY,
-  UTOPIA_UID_PARENTS_KEY,
-} from '../../core/model/utopia-constants'
+import { UTOPIA_DO_NOT_TRAVERSE_KEY } from '../../core/model/utopia-constants'
 import ResizeObserver from 'resize-observer-polyfill'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { PRODUCTION_ENV } from '../../common/env-vars'
@@ -378,15 +372,6 @@ function collectMetadata(
   const globalFrame = globalFrameForElement(element, scale, containerRectLazy)
   const localFrame = localRectangle(Utils.offsetRect(globalFrame, Utils.negate(parentPoint)))
 
-  const labelAttribute = getDOMAttribute(element, UTOPIA_LABEL_KEY)
-  let elementProps: any = {}
-  if (uidAttribute != null) {
-    elementProps[UTOPIA_UIDS_KEY] = uidAttribute // TODO Balazs we are making a fake prop with a single UID instead of the UID array – maybe this means changes to mergeComponentMetadata
-  }
-  if (labelAttribute != null) {
-    elementProps[UTOPIA_LABEL_KEY] = labelAttribute
-  }
-
   const { computedStyle, attributeMetadata } = getComputedStyle(
     element,
     instancePath,
@@ -397,7 +382,7 @@ function collectMetadata(
   return elementInstanceMetadata(
     instancePath,
     left(element.tagName.toLowerCase()),
-    elementProps,
+    {},
     globalFrame,
     localFrame,
     children,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -3,7 +3,6 @@ import { MapLike } from 'typescript'
 import { getUtopiaID } from '../../../core/model/element-template-utils'
 import { isSceneElement, PathForResizeContent } from '../../../core/model/scene-utils'
 import {
-  UTOPIA_ORIGINAL_ID_KEY,
   UTOPIA_SCENE_PATH,
   UTOPIA_UIDS_KEY,
   UTOPIA_UID_ORIGINAL_PARENTS_KEY,
@@ -58,20 +57,11 @@ export function createLookupRender(
   return (element: JSXElement, scope: MapLike<any>): React.ReactElement => {
     index++
     const innerUID = getUtopiaID(element)
-    const withOriginalID = setJSXValueAtPath(
-      element.props,
-      PP.create([UTOPIA_ORIGINAL_ID_KEY]),
-      jsxAttributeValue(innerUID, emptyComments),
-    )
     const generatedUID = createIndexedUid(innerUID, index)
-    const withGeneratedUID = flatMapEither(
-      (attrs) =>
-        setJSXValueAtPath(
-          attrs,
-          PP.create(['data-uid']),
-          jsxAttributeValue(generatedUID, emptyComments),
-        ),
-      withOriginalID,
+    const withGeneratedUID = setJSXValueAtPath(
+      element.props,
+      PP.create(['data-uid']),
+      jsxAttributeValue(generatedUID, emptyComments),
     )
 
     // TODO BALAZS should this be here? or should the arbitrary block never have a template path with that last generated element?
@@ -145,14 +135,6 @@ export function renderCoreElement(
       const uidsFromProps = assembledProps[UTOPIA_UIDS_KEY]
       const uidsToPass = appendToUidString(uidsFromProps, uid)
       passthroughProps[UTOPIA_UIDS_KEY] = uidsToPass
-
-      const originalIDForProps = Utils.defaultIfNull(
-        assembledProps[UTOPIA_ORIGINAL_ID_KEY],
-        parentComponentInputProps[UTOPIA_ORIGINAL_ID_KEY],
-      )
-      if (originalIDForProps != null) {
-        passthroughProps[UTOPIA_ORIGINAL_ID_KEY] = originalIDForProps
-      }
 
       const key = optionalMap(TP.toString, templatePath) ?? uidsFromProps
 

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1232,11 +1232,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
           \\"
           data-uid=\\"utopia-storyboard-uid\\"
         >
-          <div
-            id=\\"nasty-div\\"
-            data-uid=\\"2a7~~~1 150~~~2 2f5~~~1 aaa scene-aaa\\"
-            data-utopia-original-uid=\\"2a7\\"
-          >
+          <div id=\\"nasty-div\\" data-uid=\\"2a7~~~1 150~~~2 2f5~~~1 aaa scene-aaa\\">
             huhahuha
           </div>
         </div>

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -95,9 +95,7 @@ import { findJSXElementChildAtPath, getUtopiaID } from './element-template-utils
 import { isGivenUtopiaAPIElement, isUtopiaAPIComponent } from './project-file-utils'
 import { EmptyScenePathForStoryboard } from './scene-utils'
 import { fastForEach } from '../shared/utils'
-import { UTOPIA_UIDS_KEY } from './utopia-constants'
-import { extractOriginalUidFromIndexedUid, uidsFromString } from '../shared/uid-utils'
-import { forEachValue, omit } from '../shared/object-utils'
+import { omit } from '../shared/object-utils'
 const ObjectPathImmutable: any = OPI
 
 type MergeCandidate = These<ElementInstanceMetadata, ElementInstanceMetadata>

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -131,7 +131,7 @@ export function getValidTemplatePathsFromElement(
     const matchingFocusedPathPart =
       focusedElementPath == null
         ? null
-        : TP.staticScenePathContainsElementPath(focusedElementPath, TP.elementPathForPath(path))
+        : TP.scenePathUpToElementPath(focusedElementPath, TP.elementPathForPath(path))
 
     if (matchingFocusedPathPart != null) {
       paths = [

--- a/editor/src/core/model/utopia-constants.ts
+++ b/editor/src/core/model/utopia-constants.ts
@@ -1,6 +1,5 @@
 export const UTOPIA_UIDS_KEY = 'data-uid'
 export const UTOPIA_LABEL_KEY = 'data-label'
-export const UTOPIA_ORIGINAL_ID_KEY = 'data-utopia-original-uid'
 export const UTOPIA_DO_NOT_TRAVERSE_KEY = 'data-utopia-do-not-traverse'
 export const UTOPIA_SCENE_ID_KEY = 'data-utopia-scene-id'
 export const UTOPIA_UID_PARENTS_KEY = 'data-utopia-parents'
@@ -10,7 +9,6 @@ export const UTOPIA_SCENE_PATH = 'data-utopia-scene-path'
 export const UtopiaKeys: Array<string> = [
   UTOPIA_UIDS_KEY,
   UTOPIA_LABEL_KEY,
-  UTOPIA_ORIGINAL_ID_KEY,
   UTOPIA_DO_NOT_TRAVERSE_KEY,
   UTOPIA_SCENE_ID_KEY,
   UTOPIA_UID_PARENTS_KEY,

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -904,14 +904,7 @@ export function dynamicPathToStaticPath(path: TemplatePath): StaticTemplatePath 
   }
 }
 
-// TODO maybe delete me
-export function scenePathContainsElementPath(scene: ScenePath, elementPath: ElementPath): boolean {
-  return scene.sceneElementPaths.some((sceneElementPath) =>
-    elementPathsEqual(sceneElementPath, elementPath),
-  )
-}
-
-export function staticScenePathContainsElementPath( // TODO rename me!
+export function scenePathUpToElementPath(
   scene: ScenePath,
   elementPath: ElementPath,
 ): ScenePath | null {

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -1,4 +1,3 @@
-import * as R from 'ramda'
 import { v4 as UUID } from 'uuid'
 import { Either, flatMapEither, isLeft, isRight, left, right } from './either'
 import {
@@ -25,6 +24,7 @@ import { emptyComments } from '../workers/parser-printer/parser-printer-comments
 import { getDOMAttribute } from './dom-utils'
 import { UTOPIA_UIDS_KEY } from '../model/utopia-constants'
 import { optionalMap } from './optional-utils'
+import { addAllUniquely } from './array-utils'
 
 export const UtopiaIDPropertyPath = PP.create(['data-uid'])
 
@@ -224,18 +224,17 @@ export function uidsToString(uidList: Array<string>): string {
 
 export function appendToUidString(
   uidsString: string | null | undefined,
-  uidsToAppend: string | null | undefined,
+  uidsToAppendString: string | null | undefined,
 ): string | null {
-  if (uidsToAppend == null) {
+  if (uidsToAppendString == null) {
     return uidsString ?? null
   } else if (uidsString == null || uidsString.length === 0) {
-    return uidsToAppend
-  } else if (R.difference(uidsFromString(uidsToAppend), uidsFromString(uidsString)).length > 0) {
-    return `${uidsString} ${uidsToString(
-      R.difference(uidsFromString(uidsToAppend), uidsFromString(uidsString)),
-    )}`
+    return uidsToAppendString
   } else {
-    return uidsString
+    const existingUIDs = uidsFromString(uidsString)
+    const uidsToAppend = uidsFromString(uidsToAppendString)
+    const updatedUIDs = addAllUniquely(existingUIDs, uidsToAppend)
+    return uidsToString(updatedUIDs)
   }
 }
 

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -143,7 +143,7 @@ function attachDataUidToRoot(
         [UTOPIA_UIDS_KEY]: appendToUidString(originalResponse.props[UTOPIA_UIDS_KEY], dataUids),
       })
     } else {
-      return React.cloneElement(originalResponse) // This is probably an unnecessary clone
+      return originalResponse
     }
   }
 }


### PR DESCRIPTION
This PR is just performing some cleaning up after #980 

**Commit Details:**
- Removed all uses of `data-original-uid` since those aren't necessary now (we use indexed UIDs and are able to trivially map those back to their original UIDs, which we were mostly doing already anyway)
- Removed now unnecessary collection of `data-uid` and `data-label` in the props by the DOM walker
- Removed a function we didn't need from `template-path.ts`
- Renamed the function `staticScenePathContainsElementPath` (which previously returned a boolean indicating if the element path was in the scene path) to `scenePathUpToElementPath` (since it now returns a scene path containing the array of element paths up to the given one) in `template-path.ts`
- Removed a use of `Ramda.difference` in `uid-utils.ts`, since that function is potentially very expensive
- Removed a redundant use of `React.cloneElement` in `canvas-react-utils.ts`

The test case changes are reflecting the removal of the `data-original-uid` prop we were previously adding