### PR TITLE
Fix: focusing on components inside generated elements were not showing up in the Navigator

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -187,7 +187,13 @@ function isFocused(focusedElementPath: ScenePath | null, path: TemplatePath): bo
   if (focusedElementPath == null || TP.isScenePath(path)) {
     return false
   } else {
-    return TP.scenePathContainsElementPath(focusedElementPath, TP.elementPathForPath(path)) != null
+    return (
+      TP.scenePathUpToElementPath(
+        focusedElementPath,
+        TP.elementPathForPath(path),
+        'dynamic-scene-path',
+      ) != null
+    )
   }
 }
 

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -187,9 +187,7 @@ function isFocused(focusedElementPath: ScenePath | null, path: TemplatePath): bo
   if (focusedElementPath == null || TP.isScenePath(path)) {
     return false
   } else {
-    return (
-      TP.staticScenePathContainsElementPath(focusedElementPath, TP.elementPathForPath(path)) != null
-    )
+    return TP.scenePathContainsElementPath(focusedElementPath, TP.elementPathForPath(path)) != null
   }
 }
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -801,7 +801,7 @@ export const MetadataUtils = {
       const matchingFocusPath =
         focusedElementPath == null
           ? null
-          : TP.staticScenePathContainsElementPath(focusedElementPath, TP.elementPathForPath(path))
+          : TP.scenePathContainsElementPath(focusedElementPath, TP.elementPathForPath(path))
       const focusedRootElementPaths =
         matchingFocusPath == null
           ? []

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -799,7 +799,11 @@ export const MetadataUtils = {
       const matchingFocusPath =
         focusedElementPath == null
           ? null
-          : TP.scenePathContainsElementPath(focusedElementPath, TP.elementPathForPath(path))
+          : TP.scenePathUpToElementPath(
+              focusedElementPath,
+              TP.elementPathForPath(path),
+              'dynamic-scene-path',
+            )
       const focusedRootElementPaths =
         matchingFocusPath == null
           ? []

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -131,7 +131,11 @@ export function getValidTemplatePathsFromElement(
     const matchingFocusedPathPart =
       focusedElementPath == null
         ? null
-        : TP.scenePathUpToElementPath(focusedElementPath, TP.elementPathForPath(path))
+        : TP.scenePathUpToElementPath(
+            focusedElementPath,
+            TP.elementPathForPath(path),
+            'static-scene-path',
+          )
 
     if (matchingFocusedPathPart != null) {
       paths = [

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -934,11 +934,14 @@ export function dynamicPathToStaticPath(path: TemplatePath): StaticTemplatePath 
   }
 }
 
-// TODO maybe delete me
-export function scenePathContainsElementPath(scene: ScenePath, elementPath: ElementPath): boolean {
-  return scene.sceneElementPaths.some((sceneElementPath) =>
-    elementPathsEqual(sceneElementPath, elementPath),
-  )
+export function scenePathContainsElementPath( // TODO rename me!
+  scene: ScenePath,
+  elementPath: ElementPath,
+): ScenePath | null {
+  const foundIndex = scene.sceneElementPaths.findIndex((sceneElementPath) => {
+    return elementPathsEqual(sceneElementPath, elementPath)
+  })
+  return foundIndex === -1 ? null : scenePath(scene.sceneElementPaths.slice(0, foundIndex + 1))
 }
 
 export function staticScenePathContainsElementPath( // TODO rename me!


### PR DESCRIPTION
**Problem:**
If the focusedElementPath contains a dynamic path (ie something with `~~~3` in the UID) the `staticScenePathContainsElementPath` would return false when comparing the static scene path with a dynamic element path. The reason `staticScenePathContainsElementPath` converts the scene path to static is because in the valid path generation step we don't have access to dynamic UIDs. But in `createOrderedTemplatePathsFromElements` for the Navigator, we need to compare the dynamic scene path with a dynamic element path. 

**Fix:**


**Commit Details:**
- Create a copy of `TP.staticScenePathContainsElementPath` called `TP. scenePathContainsElementPath` which skips the conversion to static scene path.
- Using `TP. scenePathContainsElementPath` in the Navigator and in `createOrderedTemplatePathsFromElements`
- Keeping `TP.staticScenePathContainsElementPath` for `getValidTemplatePathsFromElement`
