### PR TITLE
Chore/component renderer no context

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
@@ -110,7 +110,7 @@ function useGetValidTemplatePaths(
 ): Array<InstancePath> {
   const uiFilePath = useContextSelector(UtopiaProjectContext, (c) => c.openStoryboardFilePathKILLME)
 
-  const topLevelElements = useGetTopLevelElements(uiFilePath ?? '')
+  const topLevelElements = useGetTopLevelElements(uiFilePath)
   let topLevelJSXComponents: Map<string, UtopiaJSXComponent> = new Map()
   fastForEach(topLevelElements, (topLevelElement) => {
     if (isUtopiaJSXComponent(topLevelElement)) {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -6,7 +6,7 @@ import { JSXElementChild, isJSXFragment } from '../../../core/shared/element-tem
 import { forceNotNull, optionalMap } from '../../../core/shared/optional-utils'
 import { UiJsxCanvasContext, UiJsxCanvasContextData } from '../ui-jsx-canvas'
 import {
-  MutableUtopiaContext,
+  MutableUtopiaContextProps,
   RerenderUtopiaContext,
   SceneLevelUtopiaContext,
 } from './ui-jsx-canvas-contexts'
@@ -40,6 +40,7 @@ export function isComponentRendererComponent(
 
 export function createComponentRendererComponent(params: {
   topLevelElementName: string
+  mutableContextRef: React.MutableRefObject<MutableUtopiaContextProps>
 }): ComponentRendererComponent {
   const Component = (realPassedPropsIncludingUtopiaSpecialStuff: any) => {
     const {
@@ -49,7 +50,8 @@ export function createComponentRendererComponent(params: {
 
     const scenePath: ScenePath | null = TP.isScenePath(scenePathAny) ? scenePathAny : null
 
-    const { current: mutableContext } = React.useContext(MutableUtopiaContext)
+    const mutableContext = params.mutableContextRef.current
+
     const utopiaJsxComponent = useContextSelector(RerenderUtopiaContext, (c) =>
       c.topLevelElements.get(params.topLevelElementName),
     )

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -30,6 +30,7 @@ import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/workers/parser-pr
 import { useEditorState } from '../../editor/store/store-hook'
 import { getFileForName } from '../../editor/store/editor-state'
 import { mapDropNulls } from '../../../core/shared/array-utils'
+import { getTopLevelElements } from './ui-jsx-canvas-top-level-elements'
 
 export type ComponentRendererComponent = React.ComponentType<{ [UTOPIA_SCENE_PATH]: ScenePath }> & {
   topLevelElementName: string
@@ -62,20 +63,16 @@ export function createComponentRendererComponent(params: {
     const mutableContext = params.mutableContextRef.current
 
     const utopiaJsxComponent = useEditorState((store) => {
-      const projectFile = getFileForName(params.filePath, store.editor)
-      if (isTextFile(projectFile) && isParseSuccess(projectFile.fileContents.parsed)) {
-        return (
-          mapDropNulls((elem) => {
-            if (isUtopiaJSXComponent(elem) && elem.name === params.topLevelElementName) {
-              return elem
-            } else {
-              return null
-            }
-          }, projectFile.fileContents.parsed.topLevelElements)[0] ?? null
-        )
-      } else {
-        return null
-      }
+      const topLevelElements = getTopLevelElements(params.filePath, store.editor, store.derived)
+      return (
+        mapDropNulls((elem) => {
+          if (isUtopiaJSXComponent(elem) && elem.name === params.topLevelElementName) {
+            return elem
+          } else {
+            return null
+          }
+        }, topLevelElements)[0] ?? null
+      )
     }, 'createComponentRendererComponent utopiaJsxComponent')
     const shouldIncludeCanvasRootInTheSpy = useContextSelector(
       RerenderUtopiaContext,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -30,7 +30,7 @@ import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/workers/parser-pr
 import { useEditorState } from '../../editor/store/store-hook'
 import { getFileForName } from '../../editor/store/editor-state'
 import { mapDropNulls } from '../../../core/shared/array-utils'
-import { getTopLevelElements } from './ui-jsx-canvas-top-level-elements'
+import { getTopLevelElements, useGetTopLevelElements } from './ui-jsx-canvas-top-level-elements'
 
 export type ComponentRendererComponent = React.ComponentType<{ [UTOPIA_SCENE_PATH]: ScenePath }> & {
   topLevelElementName: string
@@ -62,18 +62,13 @@ export function createComponentRendererComponent(params: {
 
     const mutableContext = params.mutableContextRef.current
 
-    const utopiaJsxComponent = useEditorState((store) => {
-      const topLevelElements = getTopLevelElements(params.filePath, store.editor, store.derived)
-      return (
-        mapDropNulls((elem) => {
-          if (isUtopiaJSXComponent(elem) && elem.name === params.topLevelElementName) {
-            return elem
-          } else {
-            return null
-          }
-        }, topLevelElements)[0] ?? null
-      )
-    }, 'createComponentRendererComponent utopiaJsxComponent')
+    const topLevelElements = useGetTopLevelElements(params.filePath)
+
+    const utopiaJsxComponent: UtopiaJSXComponent | null =
+      topLevelElements.find((elem): elem is UtopiaJSXComponent => {
+        return isUtopiaJSXComponent(elem) && elem.name === params.topLevelElementName
+      }) ?? null
+
     const shouldIncludeCanvasRootInTheSpy = useContextSelector(
       RerenderUtopiaContext,
       (c) => c.shouldIncludeCanvasRootInTheSpy,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
@@ -2,9 +2,10 @@ import * as React from 'react'
 import type { MapLike } from 'typescript'
 import { createContext } from 'use-context-selector'
 import { EmptyScenePathForStoryboard } from '../../../core/model/scene-utils'
-import type { UtopiaJSXComponent } from '../../../core/shared/element-template'
+import type { TopLevelElement, UtopiaJSXComponent } from '../../../core/shared/element-template'
 import type { InstancePath, ScenePath, TemplatePath } from '../../../core/shared/project-file-types'
-import type { UIFileBase64Blobs } from '../../editor/store/editor-state'
+import { ProjectContentTreeRoot } from '../../assets'
+import type { TransientFileState, UIFileBase64Blobs } from '../../editor/store/editor-state'
 
 export interface MutableUtopiaContextProps {
   requireResult: MapLike<any>
@@ -44,6 +45,17 @@ export const RerenderUtopiaContext = createContext<RerenderUtopiaContextProps>({
   focusedElementPath: null,
 })
 RerenderUtopiaContext.displayName = 'RerenderUtopiaContext'
+
+interface UtopiaProjectContextProps {
+  projectContents: ProjectContentTreeRoot
+  openStoryboardFilePathKILLME: string | null
+  transientFileState: TransientFileState | null
+}
+export const UtopiaProjectContext = createContext<UtopiaProjectContextProps>({
+  projectContents: {},
+  openStoryboardFilePathKILLME: null,
+  transientFileState: null,
+})
 
 interface SceneLevelContextProps {
   validPaths: Array<InstancePath>

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
@@ -31,7 +31,6 @@ export function updateMutableUtopiaContextWithNewProps(
 }
 
 interface RerenderUtopiaContextProps {
-  topLevelElements: ReadonlyMap<string, UtopiaJSXComponent>
   hiddenInstances: Array<TemplatePath>
   canvasIsLive: boolean
   shouldIncludeCanvasRootInTheSpy: boolean
@@ -39,7 +38,6 @@ interface RerenderUtopiaContextProps {
 }
 
 export const RerenderUtopiaContext = createContext<RerenderUtopiaContextProps>({
-  topLevelElements: new Map(),
   hiddenInstances: [],
   canvasIsLive: false,
   shouldIncludeCanvasRootInTheSpy: false,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements.ts
@@ -43,8 +43,11 @@ export function getTopLevelElements(
   }
 }
 
-export function useGetTopLevelElements(filePath: string): TopLevelElement[] {
+export function useGetTopLevelElements(filePath: string | null): TopLevelElement[] {
   return useContextSelector(UtopiaProjectContext, (c) => {
+    if (filePath == null) {
+      return EmptyProjectContents
+    }
     return getTopLevelElements(
       filePath,
       c.projectContents,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements.ts
@@ -1,25 +1,55 @@
+import { useContextSelector } from 'use-context-selector'
 import { TopLevelElement } from '../../../core/shared/element-template'
 import { isParseSuccess, isTextFile } from '../../../core/shared/project-file-types'
+import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../../assets'
 import {
   DerivedState,
   EditorState,
   getFileForName,
   getOpenUIJSFileKey,
+  TransientFileState,
 } from '../../editor/store/editor-state'
+import { useEditorState } from '../../editor/store/store-hook'
+import { UtopiaProjectContext } from './ui-jsx-canvas-contexts'
 
-export function getTopLevelElements(
+export function getTopLevelElementsFromEditorState(
   filePath: string,
   editor: EditorState,
   derived: DerivedState,
 ): TopLevelElement[] {
-  const projectFile = getFileForName(filePath, editor)
-  const uiFilePath = getOpenUIJSFileKey(editor)
+  return getTopLevelElements(
+    filePath,
+    editor.projectContents,
+    getOpenUIJSFileKey(editor),
+    derived.canvas.transientState.fileState,
+  )
+}
+
+const EmptyProjectContents: TopLevelElement[] = []
+export function getTopLevelElements(
+  filePath: string,
+  projectContents: ProjectContentTreeRoot,
+  openStoryboardFileNameKILLME: string | null,
+  transientFileState: TransientFileState | null,
+): TopLevelElement[] {
+  const projectFile = getContentsTreeFileFromString(projectContents, filePath)
   if (isTextFile(projectFile) && isParseSuccess(projectFile.fileContents.parsed)) {
-    if (uiFilePath === filePath && derived.canvas.transientState.fileState != null) {
-      return derived.canvas.transientState.fileState.topLevelElementsIncludingScenes
+    if (openStoryboardFileNameKILLME === filePath && transientFileState != null) {
+      return transientFileState.topLevelElementsIncludingScenes
     }
     return projectFile.fileContents.parsed.topLevelElements
   } else {
-    return []
+    return EmptyProjectContents
   }
+}
+
+export function useGetTopLevelElements(filePath: string): TopLevelElement[] {
+  return useContextSelector(UtopiaProjectContext, (c) => {
+    return getTopLevelElements(
+      filePath,
+      c.projectContents,
+      c.openStoryboardFilePathKILLME,
+      c.transientFileState,
+    )
+  })
 }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements.ts
@@ -1,0 +1,25 @@
+import { TopLevelElement } from '../../../core/shared/element-template'
+import { isParseSuccess, isTextFile } from '../../../core/shared/project-file-types'
+import {
+  DerivedState,
+  EditorState,
+  getFileForName,
+  getOpenUIJSFileKey,
+} from '../../editor/store/editor-state'
+
+export function getTopLevelElements(
+  filePath: string,
+  editor: EditorState,
+  derived: DerivedState,
+): TopLevelElement[] {
+  const projectFile = getFileForName(filePath, editor)
+  const uiFilePath = getOpenUIJSFileKey(editor)
+  if (isTextFile(projectFile) && isParseSuccess(projectFile.fileContents.parsed)) {
+    if (uiFilePath === filePath && derived.canvas.transientState.fileState != null) {
+      return derived.canvas.transientState.fileState.topLevelElementsIncludingScenes
+    }
+    return projectFile.fileContents.parsed.topLevelElements
+  } else {
+    return []
+  }
+}

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -18,12 +18,20 @@ import {
 } from '../../core/shared/element-template'
 import { canvasPoint } from '../../core/shared/math-utils'
 import { RequireFn } from '../../core/shared/npm-dependency-types'
-import { Imports, foldParsedTextFile } from '../../core/shared/project-file-types'
+import {
+  Imports,
+  foldParsedTextFile,
+  codeFile,
+  textFile,
+  textFileContents,
+  RevisionsState,
+  ProjectContents,
+} from '../../core/shared/project-file-types'
 import { emptyImports } from '../../core/workers/common/project-file-utils'
 import { testParseCode } from '../../core/workers/parser-printer/parser-printer.test-utils'
 import { Utils } from '../../uuiui-deps'
 import { normalizeName } from '../custom-code/custom-code-utils'
-import { ConsoleLog } from '../editor/store/editor-state'
+import { ConsoleLog, deriveState } from '../editor/store/editor-state'
 import {
   UiJsxCanvasProps,
   UiJsxCanvasContextData,
@@ -37,6 +45,8 @@ import { CanvasErrorBoundary } from './canvas-component-entry'
 import { EditorStateContext } from '../editor/store/store-hook'
 import { getStoreHook } from '../inspector/common/inspector.test-utils'
 import { NO_OP } from '../../core/shared/utils'
+import { directory } from '../../core/model/project-file-utils'
+import { contentsToTree } from '../assets'
 
 export interface PartialCanvasProps {
   offset: UiJsxCanvasProps['offset']
@@ -186,6 +196,31 @@ export function renderCanvasReturnResultAndError(
   }
 
   const storeHookForTest = getStoreHook(NO_OP)
+  storeHookForTest.updateStore((store) => {
+    const projectContents: ProjectContents = {
+      utopia: directory(),
+      [uiFilePath]: textFile(
+        textFileContents(code, parsedCode, RevisionsState.BothMatch),
+        null,
+        1000,
+      ),
+    }
+    const updatedEditor = {
+      ...store.editor,
+      canvas: {
+        ...store.editor.canvas,
+        openFile: {
+          filename: uiFilePath,
+        },
+      },
+      projectContents: contentsToTree(projectContents),
+    }
+    return {
+      ...store,
+      editor: updatedEditor,
+      derived: deriveState(updatedEditor, store.derived),
+    }
+  })
 
   let formattedSpyEnabled
   let errorsReportedSpyEnabled = []

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -136,6 +136,33 @@ export function renderCanvasReturnResultAndError(
     parsedCode,
   )
 
+  const storeHookForTest = getStoreHook(NO_OP)
+  storeHookForTest.updateStore((store) => {
+    const projectContents: ProjectContents = {
+      utopia: directory(),
+      [uiFilePath]: textFile(
+        textFileContents(code, parsedCode, RevisionsState.BothMatch),
+        null,
+        1000,
+      ),
+    }
+    const updatedEditor = {
+      ...store.editor,
+      canvas: {
+        ...store.editor.canvas,
+        openFile: {
+          filename: uiFilePath,
+        },
+      },
+      projectContents: contentsToTree(projectContents),
+    }
+    return {
+      ...store,
+      editor: updatedEditor,
+      derived: deriveState(updatedEditor, store.derived),
+    }
+  })
+
   function clearConsoleLogs(): void {
     consoleLogs = []
   }
@@ -166,6 +193,8 @@ export function renderCanvasReturnResultAndError(
       linkTags: '',
       combinedTopLevelArbitraryBlock: combinedTopLevelArbitraryBlock,
       focusedElementPath: null,
+      projectContents: storeHookForTest.api.getState().editor.projectContents,
+      transientFileState: storeHookForTest.api.getState().derived.canvas.transientState.fileState,
     }
   } else {
     canvasProps = {
@@ -187,6 +216,8 @@ export function renderCanvasReturnResultAndError(
       linkTags: '',
       combinedTopLevelArbitraryBlock: combinedTopLevelArbitraryBlock,
       focusedElementPath: null,
+      projectContents: storeHookForTest.api.getState().editor.projectContents,
+      transientFileState: storeHookForTest.api.getState().derived.canvas.transientState.fileState,
     }
   }
 
@@ -194,33 +225,6 @@ export function renderCanvasReturnResultAndError(
     ...canvasProps,
     spyEnabled: false,
   }
-
-  const storeHookForTest = getStoreHook(NO_OP)
-  storeHookForTest.updateStore((store) => {
-    const projectContents: ProjectContents = {
-      utopia: directory(),
-      [uiFilePath]: textFile(
-        textFileContents(code, parsedCode, RevisionsState.BothMatch),
-        null,
-        1000,
-      ),
-    }
-    const updatedEditor = {
-      ...store.editor,
-      canvas: {
-        ...store.editor.canvas,
-        openFile: {
-          filename: uiFilePath,
-        },
-      },
-      projectContents: contentsToTree(projectContents),
-    }
-    return {
-      ...store,
-      editor: updatedEditor,
-      derived: deriveState(updatedEditor, store.derived),
-    }
-  })
 
   let formattedSpyEnabled
   let errorsReportedSpyEnabled = []

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -317,7 +317,10 @@ export const UiJsxCanvas = betterReactMemo(
           if (!(topLevelElement.name in topLevelComponentRendererComponents.current)) {
             topLevelComponentRendererComponents.current[
               topLevelElement.name
-            ] = createComponentRendererComponent({ topLevelElementName: topLevelElement.name })
+            ] = createComponentRendererComponent({
+              topLevelElementName: topLevelElement.name,
+              mutableContextRef: mutableContextRef,
+            })
           }
         }
       })

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -34,6 +34,7 @@ import {
   UIFileBase64Blobs,
   ConsoleLog,
   getIndexHtmlFileFromEditorState,
+  TransientFileState,
 } from '../editor/store/editor-state'
 import { proxyConsole } from './console-proxy'
 import { useDomWalker } from './dom-walker'
@@ -61,6 +62,7 @@ import {
   RerenderUtopiaContext,
   SceneLevelUtopiaContext,
   updateMutableUtopiaContextWithNewProps,
+  UtopiaProjectContext,
 } from './ui-jsx-canvas-renderer/ui-jsx-canvas-contexts'
 import { runBlockUpdatingScope } from './ui-jsx-canvas-renderer/ui-jsx-canvas-scope-utils'
 import { CanvasContainerID } from './canvas-types'
@@ -73,7 +75,11 @@ import {
   utopiaCanvasJSXLookup,
 } from './ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../core/workers/parser-printer/parser-printer-utils'
-import { getTopLevelElements } from './ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements'
+import {
+  getTopLevelElements,
+  getTopLevelElementsFromEditorState,
+} from './ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements'
+import { ProjectContentTreeRoot } from '../assets'
 
 const emptyFileBlobs: UIFileBase64Blobs = {}
 
@@ -126,6 +132,8 @@ export interface UiJsxCanvasProps {
   linkTags: string
   combinedTopLevelArbitraryBlock: ArbitraryJSBlock | null
   focusedElementPath: ScenePath | null
+  projectContents: ProjectContentTreeRoot
+  transientFileState: TransientFileState | null
 }
 
 export interface CanvasReactReportErrorCallback {
@@ -167,7 +175,11 @@ export function pickUiJsxCanvasProps(
     let jsxFactoryFunction: string | null = null
     let combinedTopLevelArbitraryBlock: ArbitraryJSBlock | null = null
 
-    const topLevelElementsIncludingScenes = getTopLevelElements(uiFilePath, editor, derived)
+    const topLevelElementsIncludingScenes = getTopLevelElementsFromEditorState(
+      uiFilePath,
+      editor,
+      derived,
+    )
     if (uiFile != null && isParseSuccess(uiFile.fileContents.parsed)) {
       const success = uiFile.fileContents.parsed
       const transientCanvasState = derived.canvas.transientState
@@ -221,6 +233,8 @@ export function pickUiJsxCanvasProps(
       linkTags: linkTags,
       combinedTopLevelArbitraryBlock: combinedTopLevelArbitraryBlock,
       focusedElementPath: editor.focusedElementPath,
+      projectContents: editor.projectContents,
+      transientFileState: derived.canvas.transientState.fileState,
     }
   }
 }
@@ -390,27 +404,35 @@ export const UiJsxCanvas = betterReactMemo(
                 focusedElementPath: props.focusedElementPath,
               }}
             >
-              <CanvasContainer
-                mountCount={props.mountCount}
-                walkDOM={walkDOM}
-                scale={scale}
-                offset={offset}
-                onDomReport={onDomReport}
-                validRootPaths={rootValidPaths}
-                canvasRootElementTemplatePath={storyboardRootElementPath}
+              <UtopiaProjectContext.Provider
+                value={{
+                  projectContents: props.projectContents,
+                  transientFileState: props.transientFileState,
+                  openStoryboardFilePathKILLME: props.uiFilePath,
+                }}
               >
-                <SceneLevelUtopiaContext.Provider value={{ validPaths: rootValidPaths }}>
-                  <ParentLevelUtopiaContext.Provider
-                    value={{
-                      templatePath: storyboardRootElementPath,
-                    }}
-                  >
-                    {StoryboardRootComponent == null ? null : (
-                      <StoryboardRootComponent {...{ [UTOPIA_SCENE_PATH]: rootScenePath }} />
-                    )}
-                  </ParentLevelUtopiaContext.Provider>
-                </SceneLevelUtopiaContext.Provider>
-              </CanvasContainer>
+                <CanvasContainer
+                  mountCount={props.mountCount}
+                  walkDOM={walkDOM}
+                  scale={scale}
+                  offset={offset}
+                  onDomReport={onDomReport}
+                  validRootPaths={rootValidPaths}
+                  canvasRootElementTemplatePath={storyboardRootElementPath}
+                >
+                  <SceneLevelUtopiaContext.Provider value={{ validPaths: rootValidPaths }}>
+                    <ParentLevelUtopiaContext.Provider
+                      value={{
+                        templatePath: storyboardRootElementPath,
+                      }}
+                    >
+                      {StoryboardRootComponent == null ? null : (
+                        <StoryboardRootComponent {...{ [UTOPIA_SCENE_PATH]: rootScenePath }} />
+                      )}
+                    </ParentLevelUtopiaContext.Provider>
+                  </SceneLevelUtopiaContext.Provider>
+                </CanvasContainer>
+              </UtopiaProjectContext.Provider>
             </RerenderUtopiaContext.Provider>
           </MutableUtopiaContext.Provider>
         </>

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -320,6 +320,7 @@ export const UiJsxCanvas = betterReactMemo(
             ] = createComponentRendererComponent({
               topLevelElementName: topLevelElement.name,
               mutableContextRef: mutableContextRef,
+              filePath: uiFilePath,
             })
           }
         }
@@ -385,7 +386,6 @@ export const UiJsxCanvas = betterReactMemo(
             <RerenderUtopiaContext.Provider
               value={{
                 hiddenInstances: hiddenInstances,
-                topLevelElements: topLevelElementsMap,
                 canvasIsLive: canvasIsLive,
                 shouldIncludeCanvasRootInTheSpy: props.shouldIncludeCanvasRootInTheSpy,
                 focusedElementPath: props.focusedElementPath,

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -73,6 +73,7 @@ import {
   utopiaCanvasJSXLookup,
 } from './ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../core/workers/parser-printer/parser-printer-utils'
+import { getTopLevelElements } from './ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements'
 
 const emptyFileBlobs: UIFileBase64Blobs = {}
 
@@ -163,21 +164,19 @@ export function pickUiJsxCanvasProps(
     )
 
     let imports: Imports = emptyImports
-    let topLevelElementsIncludingScenes: Array<TopLevelElement> = emptyTopLevelElements
     let jsxFactoryFunction: string | null = null
     let combinedTopLevelArbitraryBlock: ArbitraryJSBlock | null = null
 
+    const topLevelElementsIncludingScenes = getTopLevelElements(uiFilePath, editor, derived)
     if (uiFile != null && isParseSuccess(uiFile.fileContents.parsed)) {
       const success = uiFile.fileContents.parsed
       const transientCanvasState = derived.canvas.transientState
       imports = uiFile.fileContents.parsed.imports
-      topLevelElementsIncludingScenes = success.topLevelElements
       jsxFactoryFunction = success.jsxFactoryFunction
       combinedTopLevelArbitraryBlock = success.combinedTopLevelArbitraryBlock
       const transientFileState = transientCanvasState.fileState
       if (transientFileState != null) {
         imports = transientFileState.imports
-        topLevelElementsIncludingScenes = transientFileState.topLevelElementsIncludingScenes
       }
     }
     const requireFn = editor.codeResultCache.requireFn

--- a/editor/src/core/shared/equality-utils.ts
+++ b/editor/src/core/shared/equality-utils.ts
@@ -18,6 +18,22 @@ export function abstractEquals(
   if (typeof objA !== 'object' || objA === null || typeof objB !== 'object' || objB === null) {
     return false
   }
+
+  // code from https://github.com/epoberezkin/fast-deep-equal/blob/a33d49ab5cc659e331ff445109f35dd323230d41/src/index.jst#L25-L39
+  if (objA instanceof Map && objB instanceof Map) {
+    if (objA.size !== objB.size) return false
+    for (const i of objA.entries()) if (!objB.has(i[0])) return false
+    for (const i of objA.entries())
+      if (!nestedEqualityFn(i[1], objB.get(i[0]), debugMode)) return false
+    return true
+  }
+
+  if (objA instanceof Set && objB instanceof Set) {
+    if (objA.size !== objB.size) return false
+    for (const i of objA.entries()) if (!objB.has(i[0])) return false
+    return true
+  }
+
   const keysA = Object.keys(objA)
   const keysB = Object.keys(objB)
   if (keysA.length !== keysB.length) return false


### PR DESCRIPTION
**Problem:**
For the multifile focus element feature the canvas context needs to handle different topLevelElements from different files with their own scopes. This PR is the first step, it clears the topLevelElements from the canvas context and replaces it with searching for the element from the editorstate based on filename.

