### PR TITLE
Underlying target lookup uses module resolution instead of file resolution.

### DIFF
--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -426,6 +426,7 @@ describe('normalisePathToUnderlyingTarget', () => {
   it('handles finding the target within the same file', () => {
     const actualResult = normalisePathToUnderlyingTarget(
       projectContents,
+      SampleNodeModules,
       StoryboardFilePath,
       instancePathFromString('storyboard-entity/scene-2-entity:same-file-app-div'),
     )
@@ -439,6 +440,7 @@ describe('normalisePathToUnderlyingTarget', () => {
   it('jumps across multiple files to reach the actual target', () => {
     const actualResult = normalisePathToUnderlyingTarget(
       projectContents,
+      SampleNodeModules,
       StoryboardFilePath,
       instancePathFromString(
         'storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div/card-inner-div',
@@ -454,6 +456,7 @@ describe('normalisePathToUnderlyingTarget', () => {
   it('returns the same path because there are no hops to take', () => {
     const actualResult = normalisePathToUnderlyingTarget(
       projectContents,
+      SampleNodeModules,
       '/src/card.js',
       instancePathFromString(':card-outer-div/card-inner-div'),
     )
@@ -467,6 +470,7 @@ describe('normalisePathToUnderlyingTarget', () => {
   it('gives an error when a file does not exist', () => {
     const actualResult = normalisePathToUnderlyingTarget(
       projectContents,
+      SampleNodeModules,
       '/src/nonexistant.js',
       instancePathFromString(':card-outer-div/card-inner-div'),
     )
@@ -476,6 +480,7 @@ describe('normalisePathToUnderlyingTarget', () => {
   it('skips attempting to traverse when confronted with an unparsed code file', () => {
     const actualResult = normalisePathToUnderlyingTarget(
       projectContents,
+      SampleNodeModules,
       '/utopia/unparsedstoryboard.js',
       instancePathFromString(
         'storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div/card-inner-div',
@@ -487,6 +492,7 @@ describe('normalisePathToUnderlyingTarget', () => {
   it('handles hitting an external dependency', () => {
     const actualResult = normalisePathToUnderlyingTarget(
       projectContents,
+      SampleNodeModules,
       StoryboardFilePath,
       instancePathFromString(
         'storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle:rectangle-inner-div',

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -44,7 +44,7 @@ import {
 } from '../../core/shared/element-template'
 import { findElementWithUID } from '../../core/shared/uid-utils'
 import { importedFromWhere } from '../editor/import-utils'
-import { absolutePathFromRelativePath } from '../../utils/path-utils'
+import { resolveModule } from '../../core/es-modules/package-manager/module-resolution'
 
 export interface CodeResult {
   exports: ModuleExportTypes
@@ -368,6 +368,7 @@ export function normalisePathSuccessOrThrowError(
 
 export function normalisePathToUnderlyingTarget(
   projectContents: ProjectContentTreeRoot,
+  nodeModules: NodeModules,
   currentFilePath: string,
   elementPath: InstancePath,
 ): NormalisePathResult {
@@ -432,18 +433,43 @@ export function normalisePathToUnderlyingTarget(
                       `Unable to handle Scene component definition for ${TP.toString(elementPath)}`,
                     )
                   }
-                } else if (importedFrom.includes('/')) {
-                  const absoluteImportedPath = absolutePathFromRelativePath(
+                } else {
+                  const resolutionResult = resolveModule(
+                    projectContents,
+                    nodeModules,
                     currentFilePath,
                     importedFrom,
                   )
-                  return normalisePathToUnderlyingTarget(
-                    projectContents,
-                    absoluteImportedPath,
-                    potentiallyDroppedFirstSceneElementResult.newPath,
-                  )
-                } else {
-                  return normalisePathEndsAtDependency(importedFrom)
+                  switch (resolutionResult.type) {
+                    case 'RESOLVE_SUCCESS':
+                      const successResult = resolutionResult.success
+                      // Avoid drilling into node_modules because we can't do anything useful with
+                      // the contents of files in there.
+                      if (successResult.path.startsWith('/node_modules/')) {
+                        const splitPath = successResult.path.split('/')
+                        return normalisePathEndsAtDependency(splitPath[2])
+                      } else {
+                        switch (successResult.file.type) {
+                          case 'ES_CODE_FILE':
+                            return normalisePathToUnderlyingTarget(
+                              projectContents,
+                              nodeModules,
+                              successResult.path,
+                              potentiallyDroppedFirstSceneElementResult.newPath,
+                            )
+                          case 'ES_REMOTE_DEPENDENCY_PLACEHOLDER':
+                            return normalisePathUnableToProceed(successResult.path)
+                          default:
+                            const _exhaustiveCheck: never = successResult.file
+                            throw new Error(`Unhandled case ${JSON.stringify(successResult.file)}`)
+                        }
+                      }
+                    case 'RESOLVE_NOT_PRESENT':
+                      return normalisePathError(`Unable to find resolve path at ${importedFrom}`)
+                    default:
+                      const _exhaustiveCheck: never = resolutionResult
+                      throw new Error(`Unhandled case ${JSON.stringify(resolutionResult)}`)
+                  }
                 }
               }
             }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1775,6 +1775,7 @@ export function modifyUnderlyingTarget(
 ): EditorState {
   const underlyingTarget = normalisePathToUnderlyingTarget(
     editorState.projectContents,
+    editorState.nodeModules.files,
     currentFilePath,
     target,
   )

--- a/editor/src/utils/path-utils.spec.ts
+++ b/editor/src/utils/path-utils.spec.ts
@@ -1,0 +1,28 @@
+import { absolutePathFromRelativePath } from './path-utils'
+
+describe('absolutePathFromRelativePath', () => {
+  it('returns an absolute path directly', () => {
+    const actualResult = absolutePathFromRelativePath('/src/app.js', false, '/src/card.js')
+    expect(actualResult).toEqual('/src/card.js')
+  })
+  it('handles a basic relative path from a file', () => {
+    const actualResult = absolutePathFromRelativePath('/src/app.js', false, './card.js')
+    expect(actualResult).toEqual('/src/card.js')
+  })
+  it('handles a basic relative path from a directory', () => {
+    const actualResult = absolutePathFromRelativePath('/src/', true, './card.js')
+    expect(actualResult).toEqual('/src/card.js')
+  })
+  it('handles a weird relative path from a file', () => {
+    const actualResult = absolutePathFromRelativePath(
+      '/src/app.js',
+      false,
+      './other/../path/.././card.js',
+    )
+    expect(actualResult).toEqual('/src/card.js')
+  })
+  it('handles a weird relative path from a directory', () => {
+    const actualResult = absolutePathFromRelativePath('/src/', true, './other/../path/.././card.js')
+    expect(actualResult).toEqual('/src/card.js')
+  })
+})

--- a/editor/src/utils/path-utils.ts
+++ b/editor/src/utils/path-utils.ts
@@ -1,6 +1,6 @@
 export function normalizePath(path: Array<string>): Array<string> {
   return path.reduce((pathSoFar: Array<string>, pathElem: string, index: number) => {
-    if (pathElem === '' && index !== 0) {
+    if (pathElem === '') {
       return pathSoFar
     }
     if (pathElem === '.') {
@@ -27,17 +27,31 @@ export function appendToPath(firstPart: string, secondPart: string): string {
   return `${left}/${right}`
 }
 
-// TODO!!! this should be replaced with a more comprehensive module resolution, a generic version of `resolveModule`.
-// The reason is that a user might import something like `src/folder/index.js` as `import { ComponentFromIndex } from "./folder"` and rely on JS module resolution to find index.js for them
+export function makePathFromParts(parts: Array<string>): string {
+  return `/${parts.join('/')}`
+}
 
-export function absolutePathFromRelativePath(origin: string, relativePath: string): string {
+export function getPartsFromPath(path: string): Array<string> {
+  return stripLeadingSlash(path).split('/')
+}
+
+export function absolutePathFromRelativePath(
+  origin: string,
+  originIsDir: boolean,
+  relativePath: string,
+): string {
   if (relativePath.startsWith('/')) {
     // Not actually relative in this case.
     return relativePath
   } else {
-    const joinedPath = appendToPath(origin, relativePath)
-    // TODO this is not calling normalizePath, but it seems like it should
-    const normalized = joinedPath.split('/')
-    return `/${normalized.join('/')}`
+    let originDir: string
+    if (originIsDir) {
+      originDir = origin
+    } else {
+      originDir = makePathFromParts(getPartsFromPath(origin).slice(0, -1))
+    }
+    const joinedPath = appendToPath(originDir, relativePath)
+    const normalized = normalizePath(joinedPath.split('/'))
+    return makePathFromParts(normalized)
   }
 }


### PR DESCRIPTION
**Problem:**
The original handling for identifying the underlying target of an element used imports purely to do conventional path adjustment, but that doesn't support the myriad ways that something can be imported including omitting a `.js` file extension for example.

**Fix:**
Replaced the call that was doing file path lookups with our existing module resolution logic.

**Commit Details:**
- `normalisePathToUnderlyingTarget` invokes `resolveModule` instead of
  `absolutePathFromRelativePath` keeping it inline with the actual behaviour
  of imports.
- Standardised some logic on `getPartsFromPath` and `makePathFromParts` avoiding
  a bunch of individual and varying ways of stripping apart and reassembling
  paths.
- Fixed a bug that arose from the path parts standardisation whereby an empty
  path element was assumed at the start of the path.
