### PR TITLE
useExecutionScope -> createExecutionScope

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -80,7 +80,7 @@ import {
   getTopLevelElementsFromEditorState,
 } from './ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements'
 import { ProjectContentTreeRoot } from '../assets'
-import { useExecutionScope } from './ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope'
+import { createExecutionScope } from './ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope'
 
 const emptyFileBlobs: UIFileBase64Blobs = {}
 
@@ -291,6 +291,10 @@ export const UiJsxCanvas = betterReactMemo(
       },
     })
 
+    let topLevelComponentRendererComponents = React.useRef<
+      MapLike<MapLike<ComponentRendererComponent>>
+    >({})
+
     if (clearErrors != null) {
       // a new canvas render, a new chance at having no errors
       // FIXME This is illegal! The line below is triggering a re-render
@@ -303,10 +307,11 @@ export const UiJsxCanvas = betterReactMemo(
         [requireFn],
       )
 
-      const { scope, requireResult, topLevelJsxComponents } = useExecutionScope(
+      const { scope, requireResult, topLevelJsxComponents } = createExecutionScope(
         uiFilePath,
         customRequire,
         mutableContextRef,
+        topLevelComponentRendererComponents,
         props.projectContents,
         uiFilePath, // this is the storyboard filepath
         props.transientFileState,


### PR DESCRIPTION
We realized that useExecutionScope is not good in a hook form as it should be running per file.
Changes:
- topLevelComponentRendererComponents ref passed in from ui-jsx-canvas
- rename useExecutionScope to createExecutionScope
