### PR TITLE
spike(editor) Spiking the use of scenes as regular components

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -648,13 +648,14 @@ function walkScene(
       TP.isScenePath(scenePath) &&
       validPathsAttr != null
     ) {
+      const templatePath = TP.instancePathForElementAtScenePath(scenePath)
       const validPaths = validPathsAttr.value.split(' ')
       let cachedMetadata: ElementInstanceMetadata | null = null
       if (ObserversAvailable && invalidatedSceneIDsRef.current != null) {
         if (!invalidatedSceneIDsRef.current.has(sceneID)) {
           // we can use the cache, if it exists
           const elementFromCurrentMetadata = MetadataUtils.findElementMetadata(
-            scenePath,
+            templatePath,
             rootMetadataInStateRef.current,
           )
           if (elementFromCurrentMetadata != null) {
@@ -682,7 +683,7 @@ function walkScene(
 
         const sceneMetadata = collectMetadata(
           scene,
-          [scenePath],
+          [templatePath],
           canvasPoint({ x: 0, y: 0 }),
           rootElements,
           scale,
@@ -695,7 +696,7 @@ function walkScene(
         let rootMetadataAccumulator = [cachedMetadata]
         // Push the cached metadata for everything from this scene downwards
         Utils.fastForEach(rootMetadataInStateRef.current, (elem) => {
-          if (TP.isAncestorOf(elem.templatePath, scenePath)) {
+          if (TP.isAncestorOf(elem.templatePath, templatePath)) {
             rootMetadataAccumulator.push(elem)
           }
         })

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -830,9 +830,11 @@ export const MetadataUtils = {
         fastForEach(root.rootElements, (rootElement) => {
           walkAndAddKeys(rootElement, isCollapsed)
         })
-      } else {
-        return walkAndAddKeys(root.templatePath, false)
       }
+      // } else {
+
+      return walkAndAddKeys(root.templatePath, false)
+      // }
     })
 
     return {

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -384,6 +384,24 @@ function elementPathParent(path: ElementPath): ElementPath {
   return path.slice(0, path.length - 1)
 }
 
+function scenePathParent(path: ScenePath): ScenePath | null {
+  let mutatedSceneElementPaths = [...path.sceneElementPaths]
+  let lastElementPath = mutatedSceneElementPaths.pop()
+  if (lastElementPath == null) {
+    return null
+  } else {
+    const parentOfLastElementPath = elementPathParent(lastElementPath)
+    if (parentOfLastElementPath.length > 0) {
+      mutatedSceneElementPaths.push(parentOfLastElementPath)
+    }
+    if (mutatedSceneElementPaths.length > 0) {
+      return scenePath(mutatedSceneElementPaths)
+    } else {
+      return null
+    }
+  }
+}
+
 export function instancePathParent(path: StaticInstancePath): ScenePath | StaticInstancePath
 export function instancePathParent(path: InstancePath): TemplatePath
 export function instancePathParent(path: InstancePath): TemplatePath {
@@ -395,13 +413,13 @@ export function instancePathParent(path: InstancePath): TemplatePath {
   }
 }
 
-export function parentPath(path: ScenePath): null
+export function parentPath(path: ScenePath): ScenePath | null
 export function parentPath(path: StaticInstancePath): StaticTemplatePath
 export function parentPath(path: InstancePath): TemplatePath
 export function parentPath(path: TemplatePath): TemplatePath | null
 export function parentPath(path: TemplatePath): TemplatePath | null {
   if (isScenePath(path)) {
-    return null
+    return scenePathParent(path)
   } else {
     return instancePathParent(path)
   }


### PR DESCRIPTION
**Problem:**
Right now we have to define a `Scene` to render a component, and we do that by passing the component we want to render as a prop to it: `<Scene component={App} />`. Instead, we want to pass the component(s) to render as a child / children.

This spike hacks something together that kinda works, but exposes flaws in the current approach.