### PR TITLE
adding new rule to disallow src/core/shared to reach the rest of the editor

### DIFF
--- a/editor/.dependency-cruiser.js
+++ b/editor/.dependency-cruiser.js
@@ -49,6 +49,25 @@ module.exports = {
       },
     },
     {
+      name: 'not-from-core-shared-to-outside',
+      comment:
+        'The core/shared files should not accidentally import from the rest of the codebase.',
+      severity: 'error',
+      from: {
+        path: 'src/core/shared/.*',
+      },
+      to: {
+        pathNot: [
+          'node_modules',
+          '../utopia-api/',
+          'src/core/shared/',
+          'src/common/',
+          'src/third-party/',
+        ],
+        reachable: true,
+      },
+    },
+    {
       name: 'no-deprecated-core',
       comment:
         'A module depends on a node core module that has been deprecated. Find an alternative - these are ' +


### PR DESCRIPTION
the branch has 39 dependency cruiser errors. 
some of these errors are valid and need fixing in the codebase
other errors are not valid and we need to tweak the ruleset a bit