### PR TITLE
fix(dom-walker) remove depending on uids on htmlelements

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -784,60 +784,55 @@ function walkElements(
   }
   if (element instanceof HTMLElement) {
     // Determine the uid of this element if it has one.
-    const uids = getUIDsOnDomELement(element)
+    const uids = getUIDsOnDomELement(element) ?? []
 
-    if (uids != null) {
-      const doNotTraverseAttribute = getDOMAttribute(element, UTOPIA_DO_NOT_TRAVERSE_KEY)
+    const doNotTraverseAttribute = getDOMAttribute(element, UTOPIA_DO_NOT_TRAVERSE_KEY)
+    const traverseChildren: boolean = doNotTraverseAttribute !== 'true'
 
-      const traverseChildren: boolean = doNotTraverseAttribute !== 'true'
+    const globalFrame = globalFrameForElement(element, scale, containerRectLazy)
 
-      const globalFrame = globalFrameForElement(element, scale, containerRectLazy)
+    // Check this is a path we're interested in, otherwise skip straight to the children
+    const foundValidPaths = mapDropNulls((uid) => findValidPath(uid, validPaths), uids)
 
-      // Check this is a path we're interested in, otherwise skip straight to the children
-      const foundValidPaths = mapDropNulls((uid) => findValidPath(uid, validPaths), uids)
+    // Build the metadata for the children of this DOM node.
+    let childPaths: Array<InstancePath> = []
+    let rootMetadataAccumulator: ReadonlyArray<ElementInstanceMetadata> = []
+    if (traverseChildren) {
+      element.childNodes.forEach((child, childIndex) => {
+        const { childPaths: childNodePaths, rootMetadata: rootMetadataInner } = walkElements(
+          child,
+          childIndex,
+          depth + 1,
+          globalFrame,
+          validPaths,
+          rootMetadataInStateRef,
+          invalidatedSceneIDsRef,
+          invalidatedPathsForStylesheetCacheRef,
+          selectedViews,
+          initComplete,
+          scale,
+          containerRectLazy,
+        )
+        childPaths.push(...childNodePaths)
+        rootMetadataAccumulator = [...rootMetadataAccumulator, ...rootMetadataInner]
+      })
+    }
 
-      // Build the metadata for the children of this DOM node.
-      let childPaths: Array<InstancePath> = []
-      let rootMetadataAccumulator: ReadonlyArray<ElementInstanceMetadata> = []
-      if (traverseChildren) {
-        element.childNodes.forEach((child, childIndex) => {
-          const { childPaths: childNodePaths, rootMetadata: rootMetadataInner } = walkElements(
-            child,
-            childIndex,
-            depth + 1,
-            globalFrame,
-            validPaths,
-            rootMetadataInStateRef,
-            invalidatedSceneIDsRef,
-            invalidatedPathsForStylesheetCacheRef,
-            selectedViews,
-            initComplete,
-            scale,
-            containerRectLazy,
-          )
-          childPaths.push(...childNodePaths)
-          rootMetadataAccumulator = [...rootMetadataAccumulator, ...rootMetadataInner]
-        })
-      }
+    const collectedMetadata = collectMetadata(
+      element,
+      foundValidPaths,
+      parentPoint,
+      childPaths,
+      scale,
+      containerRectLazy,
+      invalidatedPathsForStylesheetCacheRef,
+      selectedViews,
+    )
 
-      const collectedMetadata = collectMetadata(
-        element,
-        foundValidPaths,
-        parentPoint,
-        childPaths,
-        scale,
-        containerRectLazy,
-        invalidatedPathsForStylesheetCacheRef,
-        selectedViews,
-      )
-
-      rootMetadataAccumulator = [...rootMetadataAccumulator, ...collectedMetadata]
-      return {
-        rootMetadata: rootMetadataAccumulator,
-        childPaths: collectedMetadata.map((metadata) => metadata.templatePath), // TODO why not extract childPaths from the metadata?
-      }
-    } else {
-      return { childPaths: [], rootMetadata: [] }
+    rootMetadataAccumulator = [...rootMetadataAccumulator, ...collectedMetadata]
+    return {
+      rootMetadata: rootMetadataAccumulator,
+      childPaths: collectedMetadata.map((metadata) => metadata.templatePath), // TODO why not extract childPaths from the metadata?
     }
   } else {
     return { childPaths: [], rootMetadata: [] }


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/1020

**Problem:**
Imported third-party components can appear as a simple `Element` in the navigator.

**Fix:**
The current dom-walker stopped traversing children when it found an element without uids. For this issue the `antd` `DatePicker` component has div wrappers around the component, our data-uid tags can be found on non-direct descendants.

**Commit Details:**
- Removed nullcheck for uids for the children dom walking
- lots of indentation changes
