### PR TITLE
Fixing the missing styles in the default project

### DIFF
--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -76,7 +76,7 @@ import { Scene, Storyboard, jsx } from 'utopia-api'
 import { App } from '/src/app.js'
 
 export var SameFileApp = (props) => {
-  return <div data-uid='same-file-app-div' />
+  return <div data-uid='same-file-app-div' style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF' }} />
 }
 
 export var storyboard = (
@@ -103,9 +103,14 @@ import * as React from 'react'
 import { jsx } from 'utopia-api'
 import { Card } from '/src/card.js'
 export var App = (props) => {
-  return <div data-uid='app-outer-div'>
-    <Card data-uid='card-instance' />
-  </div>
+  return (
+    <div
+      data-uid='app-outer-div'
+      style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
+    >
+      <Card data-uid='card-instance' style={{ position: 'absolute', left: 0, top: 0, width: 200, height: 300}} />
+    </div>
+  )
 }`,
     ),
     '/src/card.js': createCodeFile(
@@ -114,9 +119,9 @@ export var App = (props) => {
 import * as React from 'react'
 import { jsx, Rectangle } from 'utopia-api'
 export var Card = (props) => {
-  return <div data-uid='card-outer-div'>
-    <div data-uid='card-inner-div' style={{ position: 'absolute', left: 0, top: 0, width: 50, height: 50, backgroundColor: 'red'}} />
-    <Rectangle data-uid='card-inner-rectangle' style={{ position: 'absolute', left: 200, top: 300, width: 50, height: 50, backgroundColor: 'blue'}} /> 
+  return <div data-uid='card-outer-div' style={{...props.style}}>
+    <div data-uid='card-inner-div' style={{ position: 'absolute', left: 0, top: 0, width: 50, height: 50, backgroundColor: 'red' }} />
+    <Rectangle data-uid='card-inner-rectangle' style={{ position: 'absolute', left: 100, top: 200, width: 50, height: 50, backgroundColor: 'blue' }} />
   </div>
 }`,
     ),


### PR DESCRIPTION
**Problem:**
The new multifile default project did not have style props for most of the elements, which made the Navigator show yellow warning triangles and the canvas selection a bit awkward.

**Simple fix:**
I sprinkled some style props over the new default project