### PR TITLE
Feature/multifile elements inspector

### DIFF
--- a/editor/src/components/custom-code/code-file.test-utils.ts
+++ b/editor/src/components/custom-code/code-file.test-utils.ts
@@ -16,7 +16,7 @@ import { ProjectContentTreeRoot, contentsToTree, getContentsTreeFileFromString }
 import { DefaultPackageJson, StoryboardFilePath } from '../editor/store/editor-state'
 import * as TP from '../../core/shared/template-path'
 
-function createCodeFile(path: string, contents: string): TextFile {
+export function createCodeFile(path: string, contents: string): TextFile {
   const result = lintAndParse(path, contents)
   return textFile(textFileContents(contents, result, RevisionsState.CodeAhead), null, Date.now())
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -155,6 +155,7 @@ import {
   DerivedStateKeepDeepEquality,
   JSXMetadataKeepDeepEquality,
 } from './store-deep-equality-instances'
+import * as TP from '../../../core/shared/template-path'
 
 export const StoryboardFilePath: string = '/utopia/storyboard.js'
 
@@ -703,6 +704,37 @@ export function getOpenUtopiaJSXComponentsFromState(model: EditorState): Array<U
     return []
   } else {
     if (isParseSuccess(openUIJSFile.fileContents.parsed)) {
+      return getUtopiaJSXComponentsFromSuccess(openUIJSFile.fileContents.parsed)
+    } else {
+      return []
+    }
+  }
+}
+
+export function getOpenUtopiaJSXComponentsFromStateMultifile(
+  model: EditorState,
+  path: TemplatePath,
+): Array<UtopiaJSXComponent> {
+  const openUIJSFile = getOpenUIJSFile(model)
+  const openUIJSFilePath = getOpenUIJSFileKey(model)
+  if (openUIJSFile == null || openUIJSFilePath == null) {
+    return []
+  } else {
+    const normalisedResult = TP.isScenePath(path)
+      ? null
+      : normalisePathToUnderlyingTarget(
+          model.projectContents,
+          model.nodeModules.files,
+          openUIJSFilePath,
+          path,
+        )
+    if (
+      normalisedResult != null &&
+      normalisedResult.type === 'NORMALISE_PATH_SUCCESS' &&
+      isParseSuccess(normalisedResult.textFile.fileContents.parsed)
+    ) {
+      return getUtopiaJSXComponentsFromSuccess(normalisedResult.textFile.fileContents.parsed)
+    } else if (isParseSuccess(openUIJSFile.fileContents.parsed)) {
       return getUtopiaJSXComponentsFromSuccess(openUIJSFile.fileContents.parsed)
     } else {
       return []

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -155,8 +155,6 @@ import {
   DerivedStateKeepDeepEquality,
   JSXMetadataKeepDeepEquality,
 } from './store-deep-equality-instances'
-import * as TP from '../../../core/shared/template-path'
-import { importedFromWhere } from '../import-utils'
 
 export const StoryboardFilePath: string = '/utopia/storyboard.js'
 

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -925,8 +925,8 @@ export function useIsSubSectionVisible(sectionName: string): boolean {
 
   return useEditorState((store) => {
     const imports = getOpenImportsFromState(store.editor)
+    const rootComponents = getOpenUtopiaJSXComponentsFromStateMultifile(store.editor)
     const types = selectedViews.current.map((view) => {
-      const rootComponents = getOpenUtopiaJSXComponentsFromStateMultifile(store.editor, view)
       if (TP.isScenePath(view)) {
         return 'scene'
       }

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -6,6 +6,7 @@ import { PropertyControls } from 'utopia-api'
 import {
   getOpenImportsFromState,
   getOpenUtopiaJSXComponentsFromState,
+  getOpenUtopiaJSXComponentsFromStateMultifile,
 } from '../../../components/editor/store/editor-state'
 import { useEditorState } from '../../../components/editor/store/store-hook'
 import {
@@ -924,8 +925,8 @@ export function useIsSubSectionVisible(sectionName: string): boolean {
 
   return useEditorState((store) => {
     const imports = getOpenImportsFromState(store.editor)
-    const rootComponents = getOpenUtopiaJSXComponentsFromState(store.editor)
     const types = selectedViews.current.map((view) => {
+      const rootComponents = getOpenUtopiaJSXComponentsFromStateMultifile(store.editor, view)
       if (TP.isScenePath(view)) {
         return 'scene'
       }

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -758,13 +758,19 @@ export const InspectorContextProvider = betterReactMemo<{
   children: React.ReactNode
 }>('InspectorContextProvider', (props) => {
   const { selectedViews } = props
-  const { dispatch, jsxMetadataKILLME, rootComponents } = useEditorState((store) => {
+  const { dispatch, jsxMetadataKILLME } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
       jsxMetadataKILLME: store.editor.jsxMetadataKILLME,
-      rootComponents: getOpenUtopiaJSXComponentsFromStateMultifile(store.editor),
     }
   }, 'InspectorContextProvider')
+
+  const rootComponents = useKeepReferenceEqualityIfPossible(
+    useEditorState(
+      (store) => getOpenUtopiaJSXComponentsFromStateMultifile(store.editor),
+      'InspectorContextProvider rootComponents',
+    ),
+  )
 
   let newEditedMultiSelectedProps: JSXAttributes[] = []
   let newSpiedProps: Array<{ [key: string]: any }> = []

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -59,6 +59,7 @@ import { MiniMenu, MiniMenuItem } from '../editor/minimenu'
 import {
   getOpenImportsFromState,
   getOpenUtopiaJSXComponentsFromState,
+  getOpenUtopiaJSXComponentsFromStateMultifile,
   isOpenFileUiJs,
 } from '../editor/store/editor-state'
 import { useEditorState } from '../editor/store/store-hook'
@@ -92,6 +93,7 @@ import {
 import { Icn, colorTheme, InspectorSectionHeader, UtopiaTheme, FlexRow } from '../../uuiui'
 import { emptyComments } from '../../core/workers/parser-printer/parser-printer-comments'
 import { getElementsToTarget } from './common/inspector-utils'
+import { flatMapArray } from '../../core/shared/array-utils'
 
 export interface InspectorModel {
   layout?: ResolvedLayoutProps
@@ -293,7 +295,6 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
     aspectRatioLocked,
   } = useEditorState((store) => {
     const rootMetadata = store.editor.jsxMetadataKILLME
-    const rootComponents = getOpenUtopiaJSXComponentsFromState(store.editor)
     const imports = getOpenImportsFromState(store.editor)
     let anyComponentsInner: boolean = false
     let anyHTMLElementsInner: boolean = false
@@ -305,6 +306,7 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
         // TODO Scene Implementation
         return
       }
+      let rootComponents = getOpenUtopiaJSXComponentsFromStateMultifile(store.editor, view)
       anyComponentsInner =
         anyComponentsInner ||
         MetadataUtils.isComponentInstance(view, rootComponents, rootMetadata, imports)
@@ -761,7 +763,10 @@ export const InspectorContextProvider = betterReactMemo<{
     return {
       dispatch: store.dispatch,
       jsxMetadataKILLME: store.editor.jsxMetadataKILLME,
-      rootComponents: getOpenUtopiaJSXComponentsFromState(store.editor),
+      rootComponents: flatMapArray(
+        (view) => getOpenUtopiaJSXComponentsFromStateMultifile(store.editor, view),
+        store.editor.selectedViews,
+      ),
     }
   }, 'InspectorContextProvider')
 

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -93,7 +93,6 @@ import {
 import { Icn, colorTheme, InspectorSectionHeader, UtopiaTheme, FlexRow } from '../../uuiui'
 import { emptyComments } from '../../core/workers/parser-printer/parser-printer-comments'
 import { getElementsToTarget } from './common/inspector-utils'
-import { flatMapArray } from '../../core/shared/array-utils'
 
 export interface InspectorModel {
   layout?: ResolvedLayoutProps

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -296,6 +296,7 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
   } = useEditorState((store) => {
     const rootMetadata = store.editor.jsxMetadataKILLME
     const imports = getOpenImportsFromState(store.editor)
+    const rootComponents = getOpenUtopiaJSXComponentsFromStateMultifile(store.editor)
     let anyComponentsInner: boolean = false
     let anyHTMLElementsInner: boolean = false
     let anyUnknownElementsInner: boolean = false
@@ -306,7 +307,6 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
         // TODO Scene Implementation
         return
       }
-      let rootComponents = getOpenUtopiaJSXComponentsFromStateMultifile(store.editor, view)
       anyComponentsInner =
         anyComponentsInner ||
         MetadataUtils.isComponentInstance(view, rootComponents, rootMetadata, imports)
@@ -763,10 +763,7 @@ export const InspectorContextProvider = betterReactMemo<{
     return {
       dispatch: store.dispatch,
       jsxMetadataKILLME: store.editor.jsxMetadataKILLME,
-      rootComponents: flatMapArray(
-        (view) => getOpenUtopiaJSXComponentsFromStateMultifile(store.editor, view),
-        store.editor.selectedViews,
-      ),
+      rootComponents: getOpenUtopiaJSXComponentsFromStateMultifile(store.editor),
     }
   }, 'InspectorContextProvider')
 


### PR DESCRIPTION
**Problem:**
Inspector is empty for multifile elements.

**Fix:**
It is using the UtopiaJSXComponents to collect set style properties on the selected elements, from the ui file only. The fix is to make sure all UtopiaJSXComponents are available for the inspector collected from different files, starting from the UI file and going recursively based on the imports.

**Commit Details:**
- test
- getOpenUtopiaJSXComponentsFromStateMultifile
