### PR TITLE
Fix multifile canvas selection

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1749,6 +1749,7 @@ function getReparentTargetAtPosition(
   componentMeta: JSXMetadata,
   selectedViews: Array<TemplatePath>,
   hiddenInstances: Array<TemplatePath>,
+  focusedElementPath: ScenePath | null,
   canvasScale: number,
   canvasOffset: CanvasVector,
 ): TemplatePath | undefined {
@@ -1756,6 +1757,7 @@ function getReparentTargetAtPosition(
     componentMeta,
     selectedViews,
     hiddenInstances,
+    focusedElementPath,
     'no-filter',
     WindowMousePositionRaw,
     canvasScale,
@@ -1780,6 +1782,7 @@ export function getReparentTarget(
     editorState.jsxMetadataKILLME,
     selectedViews,
     editorState.hiddenInstances,
+    editorState.focusedElementPath,
     editorState.canvas.scale,
     editorState.canvas.realCanvasOffset,
   )

--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -12,6 +12,7 @@ import {
   TemplatePath,
   importDetails,
   importAlias,
+  ScenePath,
 } from '../../core/shared/project-file-types'
 import { CanvasMousePositionRaw } from '../../templates/editor-canvas'
 import Keyboard, {
@@ -87,6 +88,7 @@ const Canvas = {
   ],
   getFramesInCanvasContext(
     metadata: JSXMetadata,
+    focusedElementPath: ScenePath | null,
     useBoundingFrames: boolean,
   ): Array<FrameWithPath> {
     function recurseChildren(
@@ -107,7 +109,11 @@ const Canvas = {
       )
       const overflows = MetadataUtils.overflows(component)
       const includeClippedNext = useBoundingFrames && overflows
-      const children = MetadataUtils.getImmediateChildren(metadata, component.templatePath)
+      const children = MetadataUtils.getAllChildrenElementsIncludingUnfurledFocusedComponents(
+        component.templatePath,
+        metadata,
+        focusedElementPath,
+      )
       const childFrames = children.map((child) => {
         const recurseResults = recurseChildren(offsetFrame, child)
         const rectToBoundWith = includeClippedNext ? recurseResults.boundingRect : offsetFrame
@@ -278,6 +284,7 @@ const Canvas = {
     componentMetadata: JSXMetadata,
     selectedViews: Array<TemplatePath>,
     hiddenInstances: Array<TemplatePath>,
+    focusedElementPath: ScenePath | null,
     canvasPosition: CanvasPoint,
     searchTypes: Array<TargetSearchType>,
     useBoundingFrames: boolean,
@@ -285,7 +292,11 @@ const Canvas = {
   ): Array<{ templatePath: TemplatePath; canBeFilteredOut: boolean }> {
     const looseReparentThreshold = 5
     const targetFilters = Canvas.targetFilter(selectedViews, searchTypes)
-    const framesWithPaths = Canvas.getFramesInCanvasContext(componentMetadata, useBoundingFrames)
+    const framesWithPaths = Canvas.getFramesInCanvasContext(
+      componentMetadata,
+      focusedElementPath,
+      useBoundingFrames,
+    )
     const filteredFrames = framesWithPaths.filter((frameWithPath) => {
       const shouldUseLooseTargeting =
         looseTargetingForZeroSizedElements &&

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -15,7 +15,12 @@ import {
   getOpenUIJSFileKey,
   TransientCanvasState,
 } from '../../editor/store/editor-state'
-import { TemplatePath, InstancePath, Imports } from '../../../core/shared/project-file-types'
+import {
+  TemplatePath,
+  InstancePath,
+  Imports,
+  ScenePath,
+} from '../../../core/shared/project-file-types'
 import { CanvasPositions, CSSCursor } from '../canvas-types'
 import { SelectModeControlContainer } from './select-mode-control-container'
 import { InsertModeControlContainer } from './insert-mode-control-container'
@@ -82,6 +87,7 @@ export interface ControlProps {
   componentMetadata: JSXMetadata
   imports: Imports
   hiddenInstances: Array<TemplatePath>
+  focusedElementPath: ScenePath | null
   highlightsEnabled: boolean
   canvasOffset: CanvasPoint
   scale: number
@@ -322,6 +328,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       componentMetadata: componentMetadata,
       imports: imports,
       hiddenInstances: props.editor.hiddenInstances,
+      focusedElementPath: props.editor.focusedElementPath,
       highlightsEnabled: props.editor.canvas.highlightsEnabled,
       canvasOffset: props.canvasOffset,
       scale: props.editor.canvas.scale,

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -151,6 +151,7 @@ export class SelectModeControlContainer extends React.Component<
       this.props.componentMetadata,
       this.props.selectedViews,
       this.props.hiddenInstances,
+      this.props.focusedElementPath,
       'no-filter',
       WindowMousePositionRaw,
       this.props.scale,

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -112,6 +112,7 @@ export function getSelectableViews(
   componentMetadata: JSXMetadata,
   selectedViews: Array<TemplatePath>,
   hiddenInstances: Array<TemplatePath>,
+  focusedElementPath: ScenePath | null,
   allElementsDirectlySelectable: boolean,
   childrenSelectable: boolean,
 ): TemplatePath[] {
@@ -142,8 +143,12 @@ export function getSelectableViews(
     Utils.fastForEach(selectedViews, (view) => {
       const allPaths = childrenSelectable ? TP.allPaths(view) : TP.allPaths(TP.parentPath(view))
       Utils.fastForEach(allPaths, (ancestor) => {
-        const ancestorChildren = MetadataUtils.getImmediateChildren(componentMetadata, ancestor)
-        fastForEach(ancestorChildren, (child) => siblings.push(child.templatePath))
+        const ancestorChildren = MetadataUtils.getAllChildrenIncludingUnfurledFocusedComponents(
+          TP.dynamicPathToStaticPath(ancestor),
+          componentMetadata,
+          focusedElementPath,
+        )
+        fastForEach(ancestorChildren, (child) => siblings.push(child))
       })
     })
 
@@ -182,6 +187,7 @@ function useFindValidTarget(): (
       hiddenInstances: store.editor.hiddenInstances,
       canvasScale: store.editor.canvas.scale,
       canvasOffset: store.editor.canvas.realCanvasOffset,
+      focusedElementPath: store.editor.focusedElementPath,
     }
   })
 
@@ -191,6 +197,7 @@ function useFindValidTarget(): (
         selectedViews,
         componentMetadata,
         hiddenInstances,
+        focusedElementPath,
         canvasScale,
         canvasOffset,
       } = storeRef.current
@@ -198,6 +205,7 @@ function useFindValidTarget(): (
         componentMetadata,
         selectedViews,
         hiddenInstances,
+        focusedElementPath,
         selectableViews.map(TP.toString),
         mousePoint,
         canvasScale,
@@ -349,16 +357,23 @@ function useGetSelectableViewsForSelectMode() {
       componentMetadata: store.editor.jsxMetadataKILLME,
       selectedViews: store.editor.selectedViews,
       hiddenInstances: store.editor.hiddenInstances,
+      focusedElementPath: store.editor.focusedElementPath,
     }
   })
 
   return React.useCallback(
     (allElementsDirectlySelectable: boolean, childrenSelectable: boolean) => {
-      const { componentMetadata, selectedViews, hiddenInstances } = storeRef.current
+      const {
+        componentMetadata,
+        selectedViews,
+        hiddenInstances,
+        focusedElementPath,
+      } = storeRef.current
       const selectableViews = getSelectableViews(
         componentMetadata,
         selectedViews,
         hiddenInstances,
+        focusedElementPath,
         allElementsDirectlySelectable,
         childrenSelectable,
       )

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -12,7 +12,7 @@ import {
   windowPoint,
   WindowPoint,
 } from '../../core/shared/math-utils'
-import { TemplatePath } from '../../core/shared/project-file-types'
+import { ScenePath, TemplatePath } from '../../core/shared/project-file-types'
 import * as TP from '../../core/shared/template-path'
 import { getUIDsOnDomELement } from '../../core/shared/uid-utils'
 import Canvas, { TargetSearchType } from './canvas'
@@ -62,6 +62,7 @@ export function getValidTargetAtPoint(
   componentMetadata: JSXMetadata,
   selectedViews: Array<TemplatePath>,
   hiddenInstances: Array<TemplatePath>,
+  focusedElementPath: ScenePath | null,
   validTemplatePathsForLookup: Array<string> | 'no-filter',
   point: WindowPoint | null,
   canvasScale: number,
@@ -75,6 +76,7 @@ export function getValidTargetAtPoint(
       componentMetadata,
       selectedViews,
       hiddenInstances,
+      focusedElementPath,
       validTemplatePathsForLookup,
       point,
       canvasScale,
@@ -87,6 +89,7 @@ export function getAllTargetsAtPoint(
   componentMetadata: JSXMetadata,
   selectedViews: Array<TemplatePath>,
   hiddenInstances: Array<TemplatePath>,
+  focusedElementPath: ScenePath | null,
   validTemplatePathsForLookup: Array<string> | 'no-filter',
   point: WindowPoint | null,
   canvasScale: number,
@@ -100,6 +103,7 @@ export function getAllTargetsAtPoint(
     componentMetadata,
     selectedViews,
     hiddenInstances,
+    focusedElementPath,
     pointOnCanvas.canvasPositionRaw,
     [TargetSearchType.All],
     true,

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -466,6 +466,7 @@ export function handleKeyDown(
             editor.jsxMetadataKILLME,
             editor.selectedViews,
             editor.hiddenInstances,
+            editor.focusedElementPath,
             'no-filter',
             WindowMousePositionRaw,
             editor.canvas.scale,

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -279,10 +279,17 @@ export function staticScenePathForElementAtInstancePath(path: StaticInstancePath
   return staticScenePath([...path.scene.sceneElementPaths, path.element])
 }
 
+export function elementPathForPath(path: StaticScenePath): StaticElementPath
+export function elementPathForPath(path: ScenePath): ElementPath
 export function elementPathForPath(path: StaticInstancePath): StaticElementPath
 export function elementPathForPath(path: InstancePath): ElementPath
-export function elementPathForPath(path: InstancePath): ElementPath {
-  return path.element
+export function elementPathForPath(path: TemplatePath): ElementPath
+export function elementPathForPath(path: TemplatePath): ElementPath {
+  if (isScenePath(path)) {
+    return last(path.sceneElementPaths) ?? []
+  } else {
+    return path.element
+  }
 }
 
 export function filterScenes(paths: StaticTemplatePath[]): StaticInstancePath[]


### PR DESCRIPTION
**Problem:**
Focused elements from other files could be selected from the navigator, they would get a proper highlight / selection outline on the canvas, but clicking on them on the canvas could not select them. The problem is that the `select-mode-hooks@getSelectableViews` and `canvas@getAllTargetsAtPoint` would both rely on `MetadataUtils.getImmediateChildren` which only returned real children elements, and could not include the "unfurled" focused component's elements.

**Fix:**
I made a new function called `getAllChildrenIncludingUnfurledFocusedComponents` which returns the children + the focused elements.

**Commit Details:**
- Made new `getAllChildrenIncludingUnfurledFocusedComponents`
- Moved code from `createOrderedTemplatePathsFromElements` to avoid duplication
- Created new `getImmediateChildrenPaths` that returns the instance paths instead of the metadata to speed things up a little
- Also made a `getAllChildrenElementsIncludingUnfurledFocusedComponents` that returns `ElementInstanceMetadata[]` instead of instance paths.
