### PR TITLE
Merge ComponentMetadata into ElementInstanceMetadata (part 1)

### DIFF
--- a/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
@@ -4,35 +4,6 @@ exports[`DOM Walker tests Label carried through for generated elements 1`] = `
 Object {
   "components": Array [
     Object {
-      "component": "storyboard",
-      "globalFrame": null,
-      "label": "Storyboard",
-      "rootElements": Array [
-        Object {
-          "element": Array [
-            "utopia-storyboard-uid",
-          ],
-          "scene": Object {
-            "sceneElementPaths": Array [],
-            "type": "scenepath",
-          },
-        },
-      ],
-      "scenePath": Object {
-        "sceneElementPaths": Array [],
-        "type": "scenepath",
-      },
-      "sceneResizesContent": false,
-      "style": Object {},
-      "templatePath": Object {
-        "element": Array [],
-        "scene": Object {
-          "sceneElementPaths": Array [],
-          "type": "scenepath",
-        },
-      },
-    },
-    Object {
       "component": "App",
       "globalFrame": Object {
         "height": 812,
@@ -714,35 +685,6 @@ exports[`DOM Walker tests Label carried through for normal elements 1`] = `
 Object {
   "components": Array [
     Object {
-      "component": "storyboard",
-      "globalFrame": null,
-      "label": "Storyboard",
-      "rootElements": Array [
-        Object {
-          "element": Array [
-            "utopia-storyboard-uid",
-          ],
-          "scene": Object {
-            "sceneElementPaths": Array [],
-            "type": "scenepath",
-          },
-        },
-      ],
-      "scenePath": Object {
-        "sceneElementPaths": Array [],
-        "type": "scenepath",
-      },
-      "sceneResizesContent": false,
-      "style": Object {},
-      "templatePath": Object {
-        "element": Array [],
-        "scene": Object {
-          "sceneElementPaths": Array [],
-          "type": "scenepath",
-        },
-      },
-    },
-    Object {
       "component": "App",
       "globalFrame": Object {
         "height": 812,
@@ -1108,35 +1050,6 @@ Object {
 exports[`DOM Walker tests Simple Project with divs 1`] = `
 Object {
   "components": Array [
-    Object {
-      "component": "storyboard",
-      "globalFrame": null,
-      "label": "Storyboard",
-      "rootElements": Array [
-        Object {
-          "element": Array [
-            "utopia-storyboard-uid",
-          ],
-          "scene": Object {
-            "sceneElementPaths": Array [],
-            "type": "scenepath",
-          },
-        },
-      ],
-      "scenePath": Object {
-        "sceneElementPaths": Array [],
-        "type": "scenepath",
-      },
-      "sceneResizesContent": false,
-      "style": Object {},
-      "templatePath": Object {
-        "element": Array [],
-        "scene": Object {
-          "sceneElementPaths": Array [],
-          "type": "scenepath",
-        },
-      },
-    },
     Object {
       "component": "App",
       "globalFrame": Object {
@@ -1766,35 +1679,6 @@ exports[`DOM Walker tests Simple Project with flex parent 1`] = `
 Object {
   "components": Array [
     Object {
-      "component": "storyboard",
-      "globalFrame": null,
-      "label": "Storyboard",
-      "rootElements": Array [
-        Object {
-          "element": Array [
-            "utopia-storyboard-uid",
-          ],
-          "scene": Object {
-            "sceneElementPaths": Array [],
-            "type": "scenepath",
-          },
-        },
-      ],
-      "scenePath": Object {
-        "sceneElementPaths": Array [],
-        "type": "scenepath",
-      },
-      "sceneResizesContent": false,
-      "style": Object {},
-      "templatePath": Object {
-        "element": Array [],
-        "scene": Object {
-          "sceneElementPaths": Array [],
-          "type": "scenepath",
-        },
-      },
-    },
-    Object {
       "component": "App",
       "globalFrame": Object {
         "height": 812,
@@ -2423,35 +2307,6 @@ Object {
 exports[`DOM Walker tests Simple Project with one child View 1`] = `
 Object {
   "components": Array [
-    Object {
-      "component": "storyboard",
-      "globalFrame": null,
-      "label": "Storyboard",
-      "rootElements": Array [
-        Object {
-          "element": Array [
-            "utopia-storyboard-uid",
-          ],
-          "scene": Object {
-            "sceneElementPaths": Array [],
-            "type": "scenepath",
-          },
-        },
-      ],
-      "scenePath": Object {
-        "sceneElementPaths": Array [],
-        "type": "scenepath",
-      },
-      "sceneResizesContent": false,
-      "style": Object {},
-      "templatePath": Object {
-        "element": Array [],
-        "scene": Object {
-          "sceneElementPaths": Array [],
-          "type": "scenepath",
-        },
-      },
-    },
     Object {
       "component": "App",
       "globalFrame": Object {

--- a/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
@@ -102,6 +102,7 @@ Object {
         },
       ],
       "componentInstance": true,
+      "componentName": null,
       "computedStyle": Object {},
       "element": Object {
         "type": "LEFT",
@@ -114,6 +115,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 0,
         "width": 0,
@@ -124,6 +126,7 @@ Object {
         "data-uid": "utopia-storyboard-uid",
         "skipDeepFreeze": true,
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 0,
         "clientWidth": 0,
@@ -187,6 +190,7 @@ Object {
         },
       ],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -199,13 +203,24 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 812,
         "width": 375,
         "x": 0,
         "y": 0,
       },
-      "props": Object {},
+      "props": Object {
+        "data-uid": "scene-aaa",
+        "style": Object {
+          "height": 812,
+          "left": 0,
+          "position": "relative",
+          "top": 0,
+          "width": 375,
+        },
+      },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -311,6 +326,7 @@ Object {
         },
       ],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -323,6 +339,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 812,
         "width": 375,
@@ -359,6 +376,7 @@ Object {
           "width": undefined,
         },
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -422,6 +440,7 @@ Object {
       "attributeMetadatada": null,
       "children": Array [],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -434,6 +453,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 0,
         "width": 375,
@@ -445,6 +465,7 @@ Object {
         "data-uid": "bbb~~~1",
         "skipDeepFreeze": true,
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 0,
         "clientWidth": 375,
@@ -509,6 +530,7 @@ Object {
       "attributeMetadatada": null,
       "children": Array [],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -521,6 +543,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 0,
         "width": 375,
@@ -532,6 +555,7 @@ Object {
         "data-uid": "bbb~~~2",
         "skipDeepFreeze": true,
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 0,
         "clientWidth": 375,
@@ -596,6 +620,7 @@ Object {
       "attributeMetadatada": null,
       "children": Array [],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -608,6 +633,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 0,
         "width": 375,
@@ -619,6 +645,7 @@ Object {
         "data-uid": "bbb~~~3",
         "skipDeepFreeze": true,
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 0,
         "clientWidth": 375,
@@ -785,6 +812,7 @@ Object {
         },
       ],
       "componentInstance": true,
+      "componentName": null,
       "computedStyle": Object {},
       "element": Object {
         "type": "LEFT",
@@ -797,6 +825,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 0,
         "width": 0,
@@ -807,6 +836,7 @@ Object {
         "data-uid": "utopia-storyboard-uid",
         "skipDeepFreeze": true,
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 0,
         "clientWidth": 0,
@@ -870,6 +900,7 @@ Object {
         },
       ],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -882,13 +913,24 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 812,
         "width": 375,
         "x": 0,
         "y": 0,
       },
-      "props": Object {},
+      "props": Object {
+        "data-uid": "scene-aaa",
+        "style": Object {
+          "height": 812,
+          "left": 0,
+          "position": "relative",
+          "top": 0,
+          "width": 375,
+        },
+      },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -948,6 +990,7 @@ Object {
       "attributeMetadatada": null,
       "children": Array [],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -960,6 +1003,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 812,
         "width": 375,
@@ -997,6 +1041,7 @@ Object {
           "width": undefined,
         },
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -1162,6 +1207,7 @@ Object {
         },
       ],
       "componentInstance": true,
+      "componentName": null,
       "computedStyle": Object {},
       "element": Object {
         "type": "LEFT",
@@ -1174,6 +1220,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 0,
         "width": 0,
@@ -1184,6 +1231,7 @@ Object {
         "data-uid": "utopia-storyboard-uid",
         "skipDeepFreeze": true,
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 0,
         "clientWidth": 0,
@@ -1247,6 +1295,7 @@ Object {
         },
       ],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -1259,13 +1308,24 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 812,
         "width": 375,
         "x": 0,
         "y": 0,
       },
-      "props": Object {},
+      "props": Object {
+        "data-uid": "scene-aaa",
+        "style": Object {
+          "height": 812,
+          "left": 0,
+          "position": "relative",
+          "top": 0,
+          "width": 375,
+        },
+      },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -1341,6 +1401,7 @@ Object {
         },
       ],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -1353,6 +1414,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 812,
         "width": 375,
@@ -1390,6 +1452,7 @@ Object {
           "width": undefined,
         },
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -1470,6 +1533,7 @@ Object {
         },
       ],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -1482,6 +1546,7 @@ Object {
         "y": 98,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 164,
         "width": 306,
@@ -1520,6 +1585,7 @@ Object {
           "width": 266,
         },
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 164,
         "clientWidth": 306,
@@ -1579,6 +1645,7 @@ Object {
       "attributeMetadatada": null,
       "children": Array [],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -1591,6 +1658,7 @@ Object {
         "y": 125,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 70,
         "width": 125,
@@ -1628,6 +1696,7 @@ Object {
           "width": 125,
         },
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 70,
         "clientWidth": 125,
@@ -1795,6 +1864,7 @@ Object {
         },
       ],
       "componentInstance": true,
+      "componentName": null,
       "computedStyle": Object {},
       "element": Object {
         "type": "LEFT",
@@ -1807,6 +1877,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 0,
         "width": 0,
@@ -1817,6 +1888,7 @@ Object {
         "data-uid": "utopia-storyboard-uid",
         "skipDeepFreeze": true,
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 0,
         "clientWidth": 0,
@@ -1880,6 +1952,7 @@ Object {
         },
       ],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -1892,13 +1965,24 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 812,
         "width": 375,
         "x": 0,
         "y": 0,
       },
-      "props": Object {},
+      "props": Object {
+        "data-uid": "scene-aaa",
+        "style": Object {
+          "height": 812,
+          "left": 0,
+          "position": "relative",
+          "top": 0,
+          "width": 375,
+        },
+      },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -1974,6 +2058,7 @@ Object {
         },
       ],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -1986,6 +2071,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 812,
         "width": 375,
@@ -2024,6 +2110,7 @@ Object {
           "width": undefined,
         },
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -2104,6 +2191,7 @@ Object {
         },
       ],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -2116,6 +2204,7 @@ Object {
         "y": 98,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 164,
         "width": 306,
@@ -2154,6 +2243,7 @@ Object {
           "width": 266,
         },
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 164,
         "clientWidth": 306,
@@ -2213,6 +2303,7 @@ Object {
       "attributeMetadatada": null,
       "children": Array [],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -2225,6 +2316,7 @@ Object {
         "y": 125,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 70,
         "width": 125,
@@ -2262,6 +2354,7 @@ Object {
           "width": 125,
         },
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 70,
         "clientWidth": 125,
@@ -2429,6 +2522,7 @@ Object {
         },
       ],
       "componentInstance": true,
+      "componentName": null,
       "computedStyle": Object {},
       "element": Object {
         "type": "LEFT",
@@ -2441,6 +2535,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 0,
         "width": 0,
@@ -2451,6 +2546,7 @@ Object {
         "data-uid": "utopia-storyboard-uid",
         "skipDeepFreeze": true,
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 0,
         "clientWidth": 0,
@@ -2514,6 +2610,7 @@ Object {
         },
       ],
       "componentInstance": false,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -2526,13 +2623,24 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 812,
         "width": 375,
         "x": 0,
         "y": 0,
       },
-      "props": Object {},
+      "props": Object {
+        "data-uid": "scene-aaa",
+        "style": Object {
+          "height": 812,
+          "left": 0,
+          "position": "relative",
+          "top": 0,
+          "width": 375,
+        },
+      },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -2608,6 +2716,7 @@ Object {
         },
       ],
       "componentInstance": true,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -2620,6 +2729,7 @@ Object {
         "y": 0,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 812,
         "width": 375,
@@ -2657,6 +2767,7 @@ Object {
           "width": undefined,
         },
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -2737,6 +2848,7 @@ Object {
         },
       ],
       "componentInstance": true,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -2749,6 +2861,7 @@ Object {
         "y": 98,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 124,
         "width": 266,
@@ -2786,6 +2899,7 @@ Object {
           "width": 266,
         },
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 124,
         "clientWidth": 266,
@@ -2850,6 +2964,7 @@ Object {
       "attributeMetadatada": null,
       "children": Array [],
       "componentInstance": true,
+      "componentName": null,
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -2862,6 +2977,7 @@ Object {
         "y": 125,
       },
       "isEmotionOrStyledComponent": false,
+      "label": null,
       "localFrame": Object {
         "height": 70,
         "width": 125,
@@ -2899,6 +3015,7 @@ Object {
           "width": 125,
         },
       },
+      "rootElements": Array [],
       "specialSizeMeasurements": Object {
         "clientHeight": 70,
         "clientWidth": 125,

--- a/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
@@ -220,7 +220,22 @@ Object {
           "width": 375,
         },
       },
-      "rootElements": Array [],
+      "rootElements": Array [
+        Object {
+          "element": Array [
+            "aaa",
+          ],
+          "scene": Object {
+            "sceneElementPaths": Array [
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
+            ],
+            "type": "scenepath",
+          },
+        },
+      ],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -930,7 +945,22 @@ Object {
           "width": 375,
         },
       },
-      "rootElements": Array [],
+      "rootElements": Array [
+        Object {
+          "element": Array [
+            "aaa",
+          ],
+          "scene": Object {
+            "sceneElementPaths": Array [
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
+            ],
+            "type": "scenepath",
+          },
+        },
+      ],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -1325,7 +1355,22 @@ Object {
           "width": 375,
         },
       },
-      "rootElements": Array [],
+      "rootElements": Array [
+        Object {
+          "element": Array [
+            "05c",
+          ],
+          "scene": Object {
+            "sceneElementPaths": Array [
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
+            ],
+            "type": "scenepath",
+          },
+        },
+      ],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -1982,7 +2027,22 @@ Object {
           "width": 375,
         },
       },
-      "rootElements": Array [],
+      "rootElements": Array [
+        Object {
+          "element": Array [
+            "05c",
+          ],
+          "scene": Object {
+            "sceneElementPaths": Array [
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
+            ],
+            "type": "scenepath",
+          },
+        },
+      ],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,
@@ -2640,7 +2700,22 @@ Object {
           "width": 375,
         },
       },
-      "rootElements": Array [],
+      "rootElements": Array [
+        Object {
+          "element": Array [
+            "05c",
+          ],
+          "scene": Object {
+            "sceneElementPaths": Array [
+              Array [
+                "utopia-storyboard-uid",
+                "scene-aaa",
+              ],
+            ],
+            "type": "scenepath",
+          },
+        },
+      ],
       "specialSizeMeasurements": Object {
         "clientHeight": 812,
         "clientWidth": 375,

--- a/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
@@ -190,7 +190,7 @@ Object {
         },
       ],
       "componentInstance": false,
-      "componentName": null,
+      "componentName": "App",
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -915,7 +915,7 @@ Object {
         },
       ],
       "componentInstance": false,
-      "componentName": null,
+      "componentName": "App",
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -1325,7 +1325,7 @@ Object {
         },
       ],
       "componentInstance": false,
-      "componentName": null,
+      "componentName": "App",
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -1997,7 +1997,7 @@ Object {
         },
       ],
       "componentInstance": false,
-      "componentName": null,
+      "componentName": "App",
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",
@@ -2670,7 +2670,7 @@ Object {
         },
       ],
       "componentInstance": false,
-      "componentName": null,
+      "componentName": "App",
       "computedStyle": null,
       "element": Object {
         "type": "LEFT",

--- a/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
@@ -173,22 +173,7 @@ Object {
     },
     ":utopia-storyboard-uid/scene-aaa": Object {
       "attributeMetadatada": null,
-      "children": Array [
-        Object {
-          "element": Array [
-            "aaa",
-          ],
-          "scene": Object {
-            "sceneElementPaths": Array [
-              Array [
-                "utopia-storyboard-uid",
-                "scene-aaa",
-              ],
-            ],
-            "type": "scenepath",
-          },
-        },
-      ],
+      "children": Array [],
       "componentInstance": false,
       "componentName": "App",
       "computedStyle": null,
@@ -898,22 +883,7 @@ Object {
     },
     ":utopia-storyboard-uid/scene-aaa": Object {
       "attributeMetadatada": null,
-      "children": Array [
-        Object {
-          "element": Array [
-            "aaa",
-          ],
-          "scene": Object {
-            "sceneElementPaths": Array [
-              Array [
-                "utopia-storyboard-uid",
-                "scene-aaa",
-              ],
-            ],
-            "type": "scenepath",
-          },
-        },
-      ],
+      "children": Array [],
       "componentInstance": false,
       "componentName": "App",
       "computedStyle": null,
@@ -1308,22 +1278,7 @@ Object {
     },
     ":utopia-storyboard-uid/scene-aaa": Object {
       "attributeMetadatada": null,
-      "children": Array [
-        Object {
-          "element": Array [
-            "05c",
-          ],
-          "scene": Object {
-            "sceneElementPaths": Array [
-              Array [
-                "utopia-storyboard-uid",
-                "scene-aaa",
-              ],
-            ],
-            "type": "scenepath",
-          },
-        },
-      ],
+      "children": Array [],
       "componentInstance": false,
       "componentName": "App",
       "computedStyle": null,
@@ -1980,22 +1935,7 @@ Object {
     },
     ":utopia-storyboard-uid/scene-aaa": Object {
       "attributeMetadatada": null,
-      "children": Array [
-        Object {
-          "element": Array [
-            "05c",
-          ],
-          "scene": Object {
-            "sceneElementPaths": Array [
-              Array [
-                "utopia-storyboard-uid",
-                "scene-aaa",
-              ],
-            ],
-            "type": "scenepath",
-          },
-        },
-      ],
+      "children": Array [],
       "componentInstance": false,
       "componentName": "App",
       "computedStyle": null,
@@ -2653,22 +2593,7 @@ Object {
     },
     ":utopia-storyboard-uid/scene-aaa": Object {
       "attributeMetadatada": null,
-      "children": Array [
-        Object {
-          "element": Array [
-            "05c",
-          ],
-          "scene": Object {
-            "sceneElementPaths": Array [
-              Array [
-                "utopia-storyboard-uid",
-                "scene-aaa",
-              ],
-            ],
-            "type": "scenepath",
-          },
-        },
-      ],
+      "children": Array [],
       "componentInstance": false,
       "componentName": "App",
       "computedStyle": null,

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -44,6 +44,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -250,6 +251,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
@@ -281,6 +283,7 @@ Object {
         "width": undefined,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -334,6 +337,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -382,12 +386,14 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-label": "Plane",
       "data-uid": "bbb~~~1",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -442,6 +448,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -490,12 +497,14 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-label": "Plane",
       "data-uid": "bbb~~~2",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -550,6 +559,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -598,12 +608,14 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-label": "Plane",
       "data-uid": "bbb~~~3",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -698,6 +710,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -814,6 +827,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-label": "Hat",
@@ -846,6 +860,7 @@ Object {
         "width": undefined,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -935,6 +950,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -968,6 +984,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "567 scene-aaa",
@@ -985,6 +1002,7 @@ Object {
       },
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -1078,6 +1096,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -1245,11 +1264,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -1303,6 +1324,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -1385,11 +1407,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~1",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -1444,6 +1468,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -1526,11 +1551,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~2",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -1585,6 +1612,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -1667,11 +1695,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~3",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -1778,6 +1808,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -2058,11 +2089,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -2116,6 +2149,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -2296,11 +2330,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~1",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -2355,6 +2391,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -2443,11 +2480,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -2503,6 +2542,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -2591,11 +2631,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -2651,6 +2693,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -2739,11 +2782,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -2799,6 +2844,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -2979,11 +3025,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~2",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -3038,6 +3086,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -3126,11 +3175,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -3186,6 +3237,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -3274,11 +3326,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -3334,6 +3388,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -3422,11 +3477,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -3482,6 +3539,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -3662,11 +3720,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~3",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -3721,6 +3781,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -3809,11 +3870,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -3869,6 +3932,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -3957,11 +4021,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -4017,6 +4083,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -4105,11 +4172,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -4235,6 +4304,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -4323,11 +4393,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -4381,6 +4453,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -4414,11 +4487,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -4473,6 +4548,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -4506,11 +4582,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -4604,6 +4682,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -4707,6 +4786,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
@@ -4738,6 +4818,7 @@ Object {
         "width": undefined,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -4831,6 +4912,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -5007,11 +5089,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -5065,6 +5149,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -5154,6 +5239,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
@@ -5199,6 +5285,7 @@ Object {
       },
       "title": "n1",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -5253,6 +5340,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -5342,6 +5430,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
@@ -5387,6 +5476,7 @@ Object {
       },
       "title": "n2",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -5441,6 +5531,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -5530,6 +5621,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
@@ -5575,6 +5667,7 @@ Object {
       },
       "title": "n3",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -5669,6 +5762,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -5847,11 +5941,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -5905,6 +6001,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -5995,6 +6092,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
@@ -6040,6 +6138,7 @@ Object {
       },
       "title": "n1",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6094,6 +6193,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -6184,6 +6284,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
@@ -6229,6 +6330,7 @@ Object {
       },
       "title": "n2",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6283,6 +6385,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -6373,6 +6476,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
@@ -6418,6 +6522,7 @@ Object {
       },
       "title": "n3",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6542,6 +6647,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -6630,11 +6736,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6688,6 +6796,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -6721,6 +6830,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
@@ -6739,6 +6849,7 @@ Object {
       },
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6793,6 +6904,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -6826,6 +6938,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
@@ -6844,6 +6957,7 @@ Object {
       },
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6937,6 +7051,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -7056,11 +7171,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -7114,6 +7231,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -7147,6 +7265,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~1",
@@ -7165,6 +7284,7 @@ Object {
       },
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -7219,6 +7339,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -7252,6 +7373,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa~~~2",
@@ -7270,6 +7392,7 @@ Object {
       },
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -7391,6 +7514,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -7624,6 +7748,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-0",
@@ -7656,6 +7781,7 @@ Object {
         "width": "100%",
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -7709,6 +7835,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -7819,6 +7946,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
@@ -7865,6 +7993,7 @@ Object {
       },
       "title": "Hi there!",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -7993,6 +8122,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -8226,6 +8356,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-0",
@@ -8258,6 +8389,7 @@ Object {
         "width": "100%",
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -8311,6 +8443,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -8421,6 +8554,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
@@ -8467,6 +8601,7 @@ Object {
       },
       "title": "Hi there!",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -8588,6 +8723,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -8869,6 +9005,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-0",
@@ -8901,6 +9038,7 @@ Object {
         "width": "100%",
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -8954,6 +9092,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -9112,6 +9251,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
@@ -9164,6 +9304,7 @@ Object {
         },
       ],
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -9285,6 +9426,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -9566,6 +9708,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-0",
@@ -9598,6 +9741,7 @@ Object {
         "width": "100%",
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -9651,6 +9795,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -9809,6 +9954,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
@@ -9861,6 +10007,7 @@ Object {
         },
       ],
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -9951,6 +10098,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -9984,6 +10132,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb scene-aaa",
@@ -10001,6 +10150,7 @@ Object {
       },
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -10155,6 +10305,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -11234,6 +11385,7 @@ export var storyboard = (props) => {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
@@ -11269,6 +11421,7 @@ export var storyboard = (props) => {
         "width": 376,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -11322,6 +11475,7 @@ export var storyboard = (props) => {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -12074,6 +12228,7 @@ export var storyboard = (props) => {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "03a",
@@ -12118,6 +12273,7 @@ export var storyboard = (props) => {
         "width": undefined,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -12172,6 +12328,7 @@ export var storyboard = (props) => {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -12447,12 +12604,14 @@ export var storyboard = (props) => {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-label": "Copy",
       "data-uid": "834~~~1",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -12508,6 +12667,7 @@ export var storyboard = (props) => {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -12783,12 +12943,14 @@ export var storyboard = (props) => {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-label": "Paste",
       "data-uid": "834~~~3",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -12844,6 +13006,7 @@ export var storyboard = (props) => {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -13119,12 +13282,14 @@ export var storyboard = (props) => {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-label": "Cut",
       "data-uid": "834~~~5",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -13180,6 +13345,7 @@ export var storyboard = (props) => {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -13487,6 +13653,7 @@ export var storyboard = (props) => {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-label": Array [
@@ -13497,6 +13664,7 @@ export var storyboard = (props) => {
       "data-uid": "999~~~2",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -13552,6 +13720,7 @@ export var storyboard = (props) => {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -13708,6 +13877,7 @@ export var storyboard = (props) => {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "000",
@@ -13733,6 +13903,7 @@ export var storyboard = (props) => {
       ],
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -13789,6 +13960,7 @@ export var storyboard = (props) => {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -14096,12 +14268,14 @@ export var storyboard = (props) => {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-label": "⌘⎇V",
       "data-uid": "999~~~4",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -14157,6 +14331,7 @@ export var storyboard = (props) => {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -14313,6 +14488,7 @@ export var storyboard = (props) => {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "000",
@@ -14334,6 +14510,7 @@ export var storyboard = (props) => {
       "shortcut": "⌘⎇V",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -14390,6 +14567,7 @@ export var storyboard = (props) => {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -14697,12 +14875,14 @@ export var storyboard = (props) => {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-label": "⌘⎇C",
       "data-uid": "999~~~6",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -14758,6 +14938,7 @@ export var storyboard = (props) => {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -14914,6 +15095,7 @@ export var storyboard = (props) => {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "000",
@@ -14935,6 +15117,7 @@ export var storyboard = (props) => {
       "shortcut": "⌘⎇C",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -15077,6 +15260,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -15195,11 +15379,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -15253,6 +15439,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -15301,6 +15488,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa",
@@ -15320,6 +15508,7 @@ Object {
       "name": "World!",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -15374,6 +15563,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -15422,6 +15612,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
@@ -15441,6 +15632,7 @@ Object {
       "name": "Dolly!",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -15531,6 +15723,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -15626,11 +15819,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -15723,6 +15918,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -15881,6 +16077,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
@@ -15912,6 +16109,7 @@ Object {
         "width": undefined,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -16028,6 +16226,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -16179,6 +16378,7 @@ export var storyboard = (
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa fff",
@@ -16189,6 +16389,7 @@ export var storyboard = (
         "width": "100%",
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -16242,6 +16443,7 @@ export var storyboard = (
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -16339,6 +16541,7 @@ export var storyboard = (
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
@@ -16358,6 +16561,7 @@ export var storyboard = (
       "skipDeepFreeze": true,
       "thing": "REACT_ELEMENT",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -16509,6 +16713,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -16657,6 +16862,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
@@ -16666,6 +16872,7 @@ Object {
         "position": "absolute",
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -16736,6 +16943,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -16838,6 +17046,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "d59",
@@ -16882,6 +17091,7 @@ Object {
         "width": 221,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -16936,6 +17146,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -16990,6 +17201,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "dd5",
@@ -17022,6 +17234,7 @@ Object {
         "width": 193,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -17139,6 +17352,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -17317,6 +17531,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-0",
@@ -17349,6 +17564,7 @@ Object {
         "width": "100%",
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -17402,6 +17618,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -17458,6 +17675,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
@@ -17489,6 +17707,7 @@ Object {
         "width": undefined,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -17583,6 +17802,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -17759,11 +17979,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -17817,6 +18039,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -17906,6 +18129,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
@@ -17951,6 +18175,7 @@ Object {
       },
       "title": "n1",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -18005,6 +18230,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -18094,6 +18320,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
@@ -18139,6 +18366,7 @@ Object {
       },
       "title": "n2",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -18193,6 +18421,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -18282,6 +18511,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
@@ -18327,6 +18557,7 @@ Object {
       },
       "title": "n3",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -18421,6 +18652,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -18598,11 +18830,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -18656,6 +18890,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -18746,6 +18981,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
@@ -18791,6 +19027,7 @@ Object {
       },
       "title": "n1",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -18845,6 +19082,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -18935,6 +19173,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
@@ -18980,6 +19219,7 @@ Object {
       },
       "title": "n2",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -19034,6 +19274,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -19124,6 +19365,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
@@ -19169,6 +19411,7 @@ Object {
       },
       "title": "n3",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -19263,6 +19506,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -19446,11 +19690,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -19504,6 +19750,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -19593,6 +19840,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
@@ -19638,6 +19886,7 @@ Object {
       },
       "title": "n1",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -19692,6 +19941,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -19781,6 +20031,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
@@ -19826,6 +20077,7 @@ Object {
       },
       "title": "n2",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -19880,6 +20132,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -19969,6 +20222,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
@@ -20014,6 +20268,7 @@ Object {
       },
       "title": "n3",
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -20105,6 +20360,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -20144,11 +20400,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -20202,6 +20460,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -20241,11 +20500,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -20354,6 +20615,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -20495,6 +20757,7 @@ export var storyboard = (
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa ddd",
@@ -20503,6 +20766,7 @@ export var storyboard = (
         "current": Object {},
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -20556,6 +20820,7 @@ export var storyboard = (
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -20608,6 +20873,7 @@ export var storyboard = (
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb ddd",
@@ -20618,6 +20884,7 @@ export var storyboard = (
         "width": "100%",
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -20711,6 +20978,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -20744,6 +21012,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "card ddd",
@@ -20761,6 +21030,7 @@ Object {
       },
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -20855,6 +21125,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -21041,6 +21312,7 @@ export var storyboard = (
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene",
@@ -21051,6 +21323,7 @@ export var storyboard = (
         "width": "100%",
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -21140,6 +21413,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -21188,12 +21462,14 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "BBB scene",
       "skipDeepFreeze": true,
       "x": 5,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -21323,6 +21599,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -21656,6 +21933,7 @@ export var storyboard = (
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa fff",
@@ -21688,6 +21966,7 @@ export var storyboard = (
         "width": undefined,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -21741,6 +22020,7 @@ export var storyboard = (
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -21780,6 +22060,7 @@ export var storyboard = (
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "ddd",
@@ -21811,6 +22092,7 @@ export var storyboard = (
         "width": undefined,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -21922,6 +22204,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -21998,11 +22281,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -22056,6 +22341,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -22104,6 +22390,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb",
@@ -22136,6 +22423,7 @@ Object {
         "width": undefined,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -22228,6 +22516,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -22261,6 +22550,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-factory-function-works": "true",
@@ -22279,6 +22569,7 @@ Object {
       },
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -22372,6 +22663,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -22577,11 +22869,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -22635,6 +22929,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -22748,6 +23043,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~1",
@@ -22779,6 +23075,7 @@ Object {
         "width": undefined,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -22833,6 +23130,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -22918,11 +23216,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "ccc",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -22978,6 +23278,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -23091,6 +23392,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~2",
@@ -23122,6 +23424,7 @@ Object {
         "width": undefined,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -23176,6 +23479,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -23261,11 +23565,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "ccc",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -23321,6 +23627,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -23434,6 +23741,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "bbb~~~3",
@@ -23465,6 +23773,7 @@ Object {
         "width": undefined,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -23519,6 +23828,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -23604,11 +23914,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "ccc",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -23720,6 +24032,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -23815,11 +24128,13 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "zzz scene-aaa",
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -23890,6 +24205,7 @@ Object {
       },
     ],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -23957,6 +24273,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "cloner",
@@ -23975,6 +24292,7 @@ Object {
       },
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -24029,6 +24347,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -24068,6 +24387,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "cloned",
@@ -24077,6 +24397,7 @@ Object {
         "fontWeight": 800,
       },
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -24173,6 +24494,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -24206,6 +24528,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
@@ -24223,6 +24546,7 @@ Object {
       },
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -24318,6 +24642,7 @@ Object {
     "attributeMetadatada": Object {},
     "children": Array [],
     "componentInstance": false,
+    "componentName": null,
     "computedStyle": Object {},
     "element": Object {
       "type": "RIGHT",
@@ -24351,6 +24676,7 @@ Object {
     },
     "globalFrame": null,
     "isEmotionOrStyledComponent": false,
+    "label": null,
     "localFrame": null,
     "props": Object {
       "data-uid": "aaa scene-aaa",
@@ -24368,6 +24694,7 @@ Object {
       },
       "skipDeepFreeze": true,
     },
+    "rootElements": Array [],
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,

--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
@@ -217,7 +217,7 @@ describe('moving a scene/rootview on the canvas', () => {
     await renderResult.dispatch([selectComponents([TestScenePath], false)], false)
 
     const areaControl = renderResult.renderedDOM.getByTestId(
-      'label-control-utopia-storyboard-uid/scene-aaa',
+      'label-control-:utopia-storyboard-uid/scene-aaa',
     )
 
     const areaControlBounds = areaControl.getBoundingClientRect()
@@ -311,7 +311,7 @@ describe('moving a scene/rootview on the canvas', () => {
         return (
           <Storyboard data-uid='utopia-storyboard-uid'>
             <Scene
-              style={{ position: 'absolute', top: 20, left: 40 }}
+              style={{ position: 'absolute', left: 40, top: 20 }}
               component={App}
               data-uid='scene-aaa'
               resizeContent
@@ -471,7 +471,7 @@ describe('moving a scene/rootview on the canvas', () => {
     await renderResult.dispatch([selectComponents([TestScenePath], false)], false)
 
     const areaControl = renderResult.renderedDOM.getByTestId(
-      'label-control-utopia-storyboard-uid/scene-aaa',
+      'label-control-:utopia-storyboard-uid/scene-aaa',
     )
 
     const areaControlBounds = areaControl.getBoundingClientRect()

--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
@@ -217,7 +217,7 @@ describe('moving a scene/rootview on the canvas', () => {
     await renderResult.dispatch([selectComponents([TestScenePath], false)], false)
 
     const areaControl = renderResult.renderedDOM.getByTestId(
-      'label-control-:utopia-storyboard-uid/scene-aaa',
+      'label-control-utopia-storyboard-uid/scene-aaa',
     )
 
     const areaControlBounds = areaControl.getBoundingClientRect()
@@ -311,7 +311,7 @@ describe('moving a scene/rootview on the canvas', () => {
         return (
           <Storyboard data-uid='utopia-storyboard-uid'>
             <Scene
-              style={{ position: 'absolute', left: 40, top: 20 }}
+              style={{ position: 'absolute', top: 20, left: 40 }}
               component={App}
               data-uid='scene-aaa'
               resizeContent
@@ -471,7 +471,7 @@ describe('moving a scene/rootview on the canvas', () => {
     await renderResult.dispatch([selectComponents([TestScenePath], false)], false)
 
     const areaControl = renderResult.renderedDOM.getByTestId(
-      'label-control-:utopia-storyboard-uid/scene-aaa',
+      'label-control-utopia-storyboard-uid/scene-aaa',
     )
 
     const areaControlBounds = areaControl.getBoundingClientRect()

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1457,7 +1457,7 @@ describe('moveTemplate', () => {
       new MouseEvent('mousedown', {
         bubbles: true,
         cancelable: true,
-        metaKey: false,
+        metaKey: true,
         clientX: areaControlBounds.left + 5,
         clientY: areaControlBounds.top + 5,
         buttons: 1,

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1457,7 +1457,7 @@ describe('moveTemplate', () => {
       new MouseEvent('mousedown', {
         bubbles: true,
         cancelable: true,
-        metaKey: true,
+        metaKey: false,
         clientX: areaControlBounds.left + 5,
         clientY: areaControlBounds.top + 5,
         buttons: 1,

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2508,7 +2508,7 @@ export function cullSpyCollector(
   let scenePaths: Set<string> = Utils.emptySet()
   fastForEach(domMetadata, (element) => {
     let workingPath: TemplatePath | null = element.templatePath
-    while (workingPath != null) {
+    while (workingPath != null && !TP.isEmptyPath(workingPath)) {
       const pathAsString = TP.toString(workingPath)
       if (TP.isScenePath(workingPath)) {
         elementPaths.add(TP.toString(TP.instancePathForElementAtScenePath(workingPath)))

--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -137,7 +137,7 @@ const Canvas = {
       }
     }
 
-    const storyboardEntryPoint = MetadataUtils.getAllStoryboardDescendants(metadata)
+    const storyboardEntryPoint = MetadataUtils.getAllStoryboardChildren(metadata)
     return storyboardEntryPoint.flatMap((storyboardRoot) => {
       return recurseChildren({ x: 0, y: 0 } as CanvasVector, storyboardRoot).frames
     })

--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -131,7 +131,7 @@ const Canvas = {
       }
     }
 
-    const storyboardEntryPoint = MetadataUtils.getAllStoryboardAncestors(metadata)
+    const storyboardEntryPoint = MetadataUtils.getAllStoryboardDescendants(metadata)
     return storyboardEntryPoint.flatMap((storyboardRoot) => {
       return recurseChildren({ x: 0, y: 0 } as CanvasVector, storyboardRoot).frames
     })

--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -138,7 +138,7 @@ const Canvas = {
     if (storyboardComponent != null) {
       const storyboardEntryPoint = MetadataUtils.getImmediateChildren(
         metadata,
-        storyboardComponent.scenePath,
+        storyboardComponent.rootElements[0], // FIXME WAT
       )
       return storyboardEntryPoint.flatMap((storyboardRoot) => {
         return recurseChildren({ x: 0, y: 0 } as CanvasVector, storyboardRoot).frames

--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -131,21 +131,10 @@ const Canvas = {
       }
     }
 
-    const storyboardComponent = metadata.components.find((c) =>
-      TP.pathsEqual(c.scenePath, EmptyScenePathForStoryboard),
-    )
-
-    if (storyboardComponent != null) {
-      const storyboardEntryPoint = MetadataUtils.getImmediateChildren(
-        metadata,
-        storyboardComponent.rootElements[0], // FIXME WAT
-      )
-      return storyboardEntryPoint.flatMap((storyboardRoot) => {
-        return recurseChildren({ x: 0, y: 0 } as CanvasVector, storyboardRoot).frames
-      })
-    } else {
-      return []
-    }
+    const storyboardEntryPoint = MetadataUtils.getAllStoryboardAncestors(metadata)
+    return storyboardEntryPoint.flatMap((storyboardRoot) => {
+      return recurseChildren({ x: 0, y: 0 } as CanvasVector, storyboardRoot).frames
+    })
   },
   jumpToParent(selectedViews: Array<TemplatePath>): TemplatePath | 'CLEAR' | null {
     switch (selectedViews.length) {

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -660,7 +660,7 @@ export class InsertModeControlContainer extends React.Component<
   }
 
   render() {
-    const roots = MetadataUtils.getAllStoryboardDescendantPathsScenesOnly(
+    const roots = MetadataUtils.getAllStoryboardChildrenPathsScenesOnly(
       this.props.componentMetadata,
     )
     const dragFrame = this.state.dragFrame

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -660,7 +660,7 @@ export class InsertModeControlContainer extends React.Component<
   }
 
   render() {
-    const roots = MetadataUtils.getAllScenePaths(this.props.componentMetadata.components)
+    const roots = MetadataUtils.getAllStoryboardAncestorPaths(this.props.componentMetadata.elements)
     const dragFrame = this.state.dragFrame
 
     return (

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -660,7 +660,9 @@ export class InsertModeControlContainer extends React.Component<
   }
 
   render() {
-    const roots = MetadataUtils.getAllStoryboardAncestorPaths(this.props.componentMetadata.elements)
+    const roots = MetadataUtils.getAllStoryboardAncestorPathsScenesOnly(
+      this.props.componentMetadata,
+    )
     const dragFrame = this.state.dragFrame
 
     return (

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -660,7 +660,7 @@ export class InsertModeControlContainer extends React.Component<
   }
 
   render() {
-    const roots = MetadataUtils.getAllStoryboardAncestorPathsScenesOnly(
+    const roots = MetadataUtils.getAllStoryboardDescendantPathsScenesOnly(
       this.props.componentMetadata,
     )
     const dragFrame = this.state.dragFrame

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -496,7 +496,7 @@ export class SelectModeControlContainer extends React.Component<
   render() {
     const cmdPressed = this.props.keysPressed['cmd'] || false
     const allElementsDirectlySelectable = cmdPressed && !this.props.isDragging
-    const roots = MetadataUtils.getAllStoryboardAncestorPathsScenesOnly(
+    const roots = MetadataUtils.getAllStoryboardDescendantPathsScenesOnly(
       this.props.componentMetadata,
     )
     let labelDirectlySelectable = this.props.highlightsEnabled

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -31,6 +31,7 @@ import { RightMenuTab } from '../right-menu'
 import { getSelectableViews } from './select-mode/select-mode-hooks'
 import { getAllTargetsAtPoint } from '../dom-lookup'
 import { WindowMousePositionRaw } from '../../../templates/editor-canvas'
+import { mapDropNulls } from '../../../core/shared/array-utils'
 
 export const SnappingThreshold = 5
 
@@ -495,8 +496,14 @@ export class SelectModeControlContainer extends React.Component<
   render() {
     const cmdPressed = this.props.keysPressed['cmd'] || false
     const allElementsDirectlySelectable = cmdPressed && !this.props.isDragging
-    const roots = MetadataUtils.getAllStoryboardAncestorPaths(this.props.componentMetadata.elements)
-    const rootsAsScenes = roots.map(TP.scenePathForElementAtInstancePath) // FIXME Bin this after separating Scene from the component it renders
+    const rootElements = MetadataUtils.getAllStoryboardAncestors(this.props.componentMetadata)
+    const roots = mapDropNulls(
+      (e) =>
+        MetadataUtils.elementIsScene(e)
+          ? TP.scenePathForElementAtInstancePath(e.templatePath) // FIXME Use the instance path after we separate Scene from the component it renders
+          : null,
+      rootElements,
+    )
     let labelDirectlySelectable = this.props.highlightsEnabled
 
     // TODO future span element should be included here
@@ -524,7 +531,7 @@ export class SelectModeControlContainer extends React.Component<
         }}
         onContextMenu={this.onContextMenu}
       >
-        {rootsAsScenes.map((root) => {
+        {roots.map((root) => {
           return (
             <React.Fragment key={`${TP.toComponentId(root)}}-root-controls`}>
               {this.renderLabel(root, allElementsDirectlySelectable || labelDirectlySelectable)}

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -497,7 +497,7 @@ export class SelectModeControlContainer extends React.Component<
   render() {
     const cmdPressed = this.props.keysPressed['cmd'] || false
     const allElementsDirectlySelectable = cmdPressed && !this.props.isDragging
-    const roots = MetadataUtils.getAllStoryboardDescendantPathsScenesOnly(
+    const roots = MetadataUtils.getAllStoryboardChildrenPathsScenesOnly(
       this.props.componentMetadata,
     )
     let labelDirectlySelectable = this.props.highlightsEnabled

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -496,13 +496,8 @@ export class SelectModeControlContainer extends React.Component<
   render() {
     const cmdPressed = this.props.keysPressed['cmd'] || false
     const allElementsDirectlySelectable = cmdPressed && !this.props.isDragging
-    const rootElements = MetadataUtils.getAllStoryboardAncestors(this.props.componentMetadata)
-    const roots = mapDropNulls(
-      (e) =>
-        MetadataUtils.elementIsScene(e)
-          ? TP.scenePathForElementAtInstancePath(e.templatePath) // FIXME Use the instance path after we separate Scene from the component it renders
-          : null,
-      rootElements,
+    const roots = MetadataUtils.getAllStoryboardAncestorPathsScenesOnly(
+      this.props.componentMetadata,
     )
     let labelDirectlySelectable = this.props.highlightsEnabled
 

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -496,6 +496,7 @@ export class SelectModeControlContainer extends React.Component<
     const cmdPressed = this.props.keysPressed['cmd'] || false
     const allElementsDirectlySelectable = cmdPressed && !this.props.isDragging
     const roots = MetadataUtils.getAllStoryboardAncestorPaths(this.props.componentMetadata.elements)
+    const rootsAsScenes = roots.map(TP.scenePathForElementAtInstancePath) // FIXME Bin this after separating Scene from the component it renders
     let labelDirectlySelectable = this.props.highlightsEnabled
 
     // TODO future span element should be included here
@@ -523,7 +524,7 @@ export class SelectModeControlContainer extends React.Component<
         }}
         onContextMenu={this.onContextMenu}
       >
-        {roots.map((root) => {
+        {rootsAsScenes.map((root) => {
           return (
             <React.Fragment key={`${TP.toComponentId(root)}}-root-controls`}>
               {this.renderLabel(root, allElementsDirectlySelectable || labelDirectlySelectable)}

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -495,7 +495,7 @@ export class SelectModeControlContainer extends React.Component<
   render() {
     const cmdPressed = this.props.keysPressed['cmd'] || false
     const allElementsDirectlySelectable = cmdPressed && !this.props.isDragging
-    const roots = MetadataUtils.getAllScenePaths(this.props.componentMetadata.components)
+    const roots = MetadataUtils.getAllStoryboardAncestorPaths(this.props.componentMetadata.elements)
     let labelDirectlySelectable = this.props.highlightsEnabled
 
     // TODO future span element should be included here

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -256,7 +256,7 @@ function useStartDragState(): (
       const moveTargets = selection.filter(
         (view) =>
           TP.isScenePath(view) ||
-          TP.isStoryboardAncestor(view) ||
+          TP.isStoryboardAncestor(view) || // FIXME This must go in the bin when we separate the Scene from the component it renders
           elementsThatRespectLayout.some((path) => TP.pathsEqual(path, view)),
       )
 

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -120,7 +120,7 @@ export function getSelectableViews(
   if (allElementsDirectlySelectable) {
     candidateViews = MetadataUtils.getAllPaths(componentMetadata)
   } else {
-    const scenes = MetadataUtils.getAllStoryboardAncestorPaths(componentMetadata.elements)
+    const scenes = MetadataUtils.getAllStoryboardAncestorPathsScenesOnly(componentMetadata)
     let rootElementsToFilter: TemplatePath[] = []
     let dynamicScenesWithFragmentRootViews: TemplatePath[] = []
     Utils.fastForEach(scenes, (path) => {

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -120,9 +120,9 @@ export function getSelectableViews(
   if (allElementsDirectlySelectable) {
     candidateViews = MetadataUtils.getAllPaths(componentMetadata)
   } else {
-    const scenes = MetadataUtils.getAllScenePaths(componentMetadata.components)
+    const scenes = MetadataUtils.getAllStoryboardAncestorPaths(componentMetadata.elements)
     let rootElementsToFilter: TemplatePath[] = []
-    let dynamicScenesWithFragmentRootViews: ScenePath[] = []
+    let dynamicScenesWithFragmentRootViews: TemplatePath[] = []
     Utils.fastForEach(scenes, (path) => {
       const scene = MetadataUtils.findSceneByTemplatePath(componentMetadata.components, path)
       const rootElements = scene?.rootElements
@@ -256,6 +256,7 @@ function useStartDragState(): (
       const moveTargets = selection.filter(
         (view) =>
           TP.isScenePath(view) ||
+          TP.isStoryboardAncestor(view) ||
           elementsThatRespectLayout.some((path) => TP.pathsEqual(path, view)),
       )
 

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -121,7 +121,7 @@ export function getSelectableViews(
   if (allElementsDirectlySelectable) {
     candidateViews = MetadataUtils.getAllPaths(componentMetadata)
   } else {
-    const scenes = MetadataUtils.getAllStoryboardDescendantPathsScenesOnly(componentMetadata)
+    const scenes = MetadataUtils.getAllStoryboardChildrenPathsScenesOnly(componentMetadata)
     let rootElementsToFilter: TemplatePath[] = []
     let dynamicScenesWithFragmentRootViews: TemplatePath[] = []
     Utils.fastForEach(scenes, (path) => {

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -120,7 +120,7 @@ export function getSelectableViews(
   if (allElementsDirectlySelectable) {
     candidateViews = MetadataUtils.getAllPaths(componentMetadata)
   } else {
-    const scenes = MetadataUtils.getAllStoryboardAncestorPathsScenesOnly(componentMetadata)
+    const scenes = MetadataUtils.getAllStoryboardDescendantPathsScenesOnly(componentMetadata)
     let rootElementsToFilter: TemplatePath[] = []
     let dynamicScenesWithFragmentRootViews: TemplatePath[] = []
     Utils.fastForEach(scenes, (path) => {
@@ -256,7 +256,7 @@ function useStartDragState(): (
       const moveTargets = selection.filter(
         (view) =>
           TP.isScenePath(view) ||
-          TP.isStoryboardAncestor(view) || // FIXME This must go in the bin when we separate the Scene from the component it renders
+          TP.isStoryboardDescendant(view) || // FIXME This must go in the bin when we separate the Scene from the component it renders
           elementsThatRespectLayout.some((path) => TP.pathsEqual(path, view)),
       )
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -419,11 +419,9 @@ function collectMetadata(
       if (TP.pathsEqual(path, TP.parentPath(childPath))) {
         if (isRootElement(childPath)) {
           filteredRootElements.push(childPath)
+        } else {
+          filteredChildPaths.push(childPath)
         }
-
-        // FIXME We shouldn't include root elements in with the children, but right now a lot of
-        // logic relies on that implicitly
-        filteredChildPaths.push(childPath)
       }
     })
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -421,11 +421,14 @@ function collectMetadata(
       globalFrame,
       localFrame,
       filteredChildPaths,
+      [],
       false,
       false,
       specialSizeMeasurementsObject,
       computedStyle,
       attributeMetadata,
+      null,
+      null,
     )
   })
 }
@@ -613,11 +616,14 @@ function walkCanvasRootFragment(
       { x: 0, y: 0, width: 0, height: 0 } as CanvasRectangle,
       { x: 0, y: 0, width: 0, height: 0 } as LocalRectangle,
       rootElements,
+      [], // FIXME This should be rootElements and the children should be the actual children
       false,
       false,
       emptySpecialSizeMeasurements,
       emptyComputedStyle,
       emptyAttributeMetadatada,
+      null,
+      null,
     )
     return [...rootMetadata, metadata]
   }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-root.tsx
@@ -82,18 +82,36 @@ function useRunSpy(
     style: props.style ?? {},
   }
   if (shouldIncludeCanvasRootInTheSpy) {
+    let capturedProps: {
+      resizesContent?: boolean
+      style?: React.CSSProperties
+      'data-uid'?: string
+    } = {}
+    if (resizesContent) {
+      capturedProps.resizesContent = true
+    }
+    if (props.style != null) {
+      capturedProps.style = props.style
+    }
+    if (props['data-uid'] != null) {
+      capturedProps['data-uid'] = props['data-uid']
+    }
+
     metadataContext.current.spyValues.metadata[TP.toComponentId(templatePath)] = {
       element: left('Scene'),
       templatePath: templatePath,
-      props: {},
+      props: capturedProps,
       globalFrame: null,
       localFrame: null,
       children: [],
+      rootElements: [],
       componentInstance: false,
       isEmotionOrStyledComponent: false,
       specialSizeMeasurements: emptySpecialSizeMeasurements,
       computedStyle: emptyComputedStyle,
       attributeMetadatada: emptyAttributeMetadatada,
+      componentName: componentName,
+      label: props['data-label'] ?? null,
     }
   }
 }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
@@ -67,6 +67,19 @@ export var storyboard = (
 );
 `
 
+function extractTemplatePathStuffFromElement(elementMetadata: ElementInstanceMetadata) {
+  return {
+    name: foldEither(
+      (name) => name,
+      (element) =>
+        isJSXElement(element) ? getJSXElementNameAsString(element.name) : 'not-jsx-element',
+      elementMetadata.element,
+    ),
+    children: elementMetadata.children.map(TP.toString),
+    rootElements: elementMetadata.rootElements.map(TP.toString),
+  }
+}
+
 function extractTemplatePathStuffFromElementInstanceMetadata(metadata: JSXMetadata) {
   const sanitizedSpyData = objectMap((elementMetadata, key) => {
     const templatePathAsReportedBySpy = TP.toString(elementMetadata.templatePath)
@@ -74,15 +87,7 @@ function extractTemplatePathStuffFromElementInstanceMetadata(metadata: JSXMetada
       fail(`The reported template path should match what was used as key`)
     }
 
-    return {
-      name: foldEither(
-        (name) => name,
-        (element) =>
-          isJSXElement(element) ? getJSXElementNameAsString(element.name) : 'not-jsx-element',
-        elementMetadata.element,
-      ),
-      children: elementMetadata.children.map(TP.toString),
-    }
+    return extractTemplatePathStuffFromElement(elementMetadata)
   }, metadata.elements)
   return sanitizedSpyData
 }
@@ -91,17 +96,7 @@ function extractTemplatePathStuffFromDomWalkerMetadata(metadata: Array<ElementIn
   return mapArrayToDictionary(
     metadata,
     (elementMetadata: ElementInstanceMetadata) => TP.toString(elementMetadata.templatePath),
-    (elementMetadata: ElementInstanceMetadata) => {
-      return {
-        name: foldEither(
-          (name) => name,
-          (element) =>
-            isJSXElement(element) ? getJSXElementNameAsString(element.name) : 'not-jsx-element',
-          elementMetadata.element,
-        ),
-        children: elementMetadata.children.map(TP.toString),
-      }
-    },
+    extractTemplatePathStuffFromElement,
   )
 }
 
@@ -127,26 +122,31 @@ describe('Spy Wrapper Template Path Tests', () => {
             ":storyboard/scene",
           ],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard/scene": Object {
           "children": Array [],
           "name": "Scene",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
         },
       }
     `)
@@ -156,28 +156,33 @@ describe('Spy Wrapper Template Path Tests', () => {
         ":storyboard": Object {
           "children": Array [],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard/scene": Object {
-          "children": Array [
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
             "storyboard/scene:app-root",
           ],
-          "name": "div",
         },
         "storyboard/scene:app-root": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
       }
     `)
@@ -189,28 +194,33 @@ describe('Spy Wrapper Template Path Tests', () => {
             ":storyboard/scene",
           ],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard/scene": Object {
-          "children": Array [
+          "children": Array [],
+          "name": "Scene",
+          "rootElements": Array [
             "storyboard/scene:app-root",
           ],
-          "name": "Scene",
         },
         "storyboard/scene:app-root": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
         },
       }
     `)
@@ -250,42 +260,51 @@ describe('Spy Wrapper Template Path Tests', () => {
             ":storyboard/scene",
           ],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard/scene": Object {
           "children": Array [],
           "name": "Scene",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance": Object {
           "children": Array [],
           "name": "Button",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
       }
     `)
@@ -295,28 +314,33 @@ describe('Spy Wrapper Template Path Tests', () => {
         ":storyboard": Object {
           "children": Array [],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard/scene": Object {
-          "children": Array [
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
             "storyboard/scene:app-root",
           ],
-          "name": "div",
         },
         "storyboard/scene:app-root": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance": Object {
           "children": Array [
@@ -325,18 +349,22 @@ describe('Spy Wrapper Template Path Tests', () => {
             "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
       }
     `)
@@ -348,28 +376,33 @@ describe('Spy Wrapper Template Path Tests', () => {
             ":storyboard/scene",
           ],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard/scene": Object {
-          "children": Array [
+          "children": Array [],
+          "name": "Scene",
+          "rootElements": Array [
             "storyboard/scene:app-root",
           ],
-          "name": "Scene",
         },
         "storyboard/scene:app-root": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance": Object {
           "children": Array [
@@ -378,18 +411,22 @@ describe('Spy Wrapper Template Path Tests', () => {
             "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3",
           ],
           "name": "Button",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
       }
     `)
@@ -430,46 +467,56 @@ describe('Spy Wrapper Template Path Tests', () => {
             ":storyboard/scene",
           ],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard/scene": Object {
           "children": Array [],
           "name": "Scene",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance": Object {
           "children": Array [],
           "name": "Button",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance:button-root": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
       }
     `)
@@ -479,28 +526,33 @@ describe('Spy Wrapper Template Path Tests', () => {
         ":storyboard": Object {
           "children": Array [],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard/scene": Object {
-          "children": Array [
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
             "storyboard/scene:app-root",
           ],
-          "name": "div",
         },
         "storyboard/scene:app-root": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance": Object {
           "children": Array [
@@ -509,22 +561,27 @@ describe('Spy Wrapper Template Path Tests', () => {
             "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance:button-root": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
       }
     `)
@@ -536,28 +593,33 @@ describe('Spy Wrapper Template Path Tests', () => {
             ":storyboard/scene",
           ],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard/scene": Object {
-          "children": Array [
+          "children": Array [],
+          "name": "Scene",
+          "rootElements": Array [
             "storyboard/scene:app-root",
           ],
-          "name": "Scene",
         },
         "storyboard/scene:app-root": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance": Object {
           "children": Array [
@@ -566,22 +628,27 @@ describe('Spy Wrapper Template Path Tests', () => {
             "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3",
           ],
           "name": "Button",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance:button-root": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
       }
     `)
@@ -622,46 +689,56 @@ describe('Spy Wrapper Template Path Tests', () => {
             ":storyboard/scene",
           ],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard/scene": Object {
           "children": Array [],
           "name": "Scene",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance": Object {
           "children": Array [],
           "name": "Button",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~2:hi-element-root": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
       }
     `)
@@ -671,28 +748,33 @@ describe('Spy Wrapper Template Path Tests', () => {
         ":storyboard": Object {
           "children": Array [],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard/scene": Object {
-          "children": Array [
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
             "storyboard/scene:app-root",
           ],
-          "name": "div",
         },
         "storyboard/scene:app-root": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance": Object {
           "children": Array [
@@ -701,22 +783,27 @@ describe('Spy Wrapper Template Path Tests', () => {
             "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~2:hi-element-root": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
       }
     `)
@@ -728,28 +815,33 @@ describe('Spy Wrapper Template Path Tests', () => {
             ":storyboard/scene",
           ],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard/scene": Object {
-          "children": Array [
+          "children": Array [],
+          "name": "Scene",
+          "rootElements": Array [
             "storyboard/scene:app-root",
           ],
-          "name": "Scene",
         },
         "storyboard/scene:app-root": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div": Object {
           "children": Array [
             "storyboard/scene:app-root/inner-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance": Object {
           "children": Array [
@@ -758,22 +850,27 @@ describe('Spy Wrapper Template Path Tests', () => {
             "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3",
           ],
           "name": "Button",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~2:hi-element-root": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard/scene:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
         },
       }
     `)
@@ -818,24 +915,29 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
             ":storyboard-entity/scene-2-entity",
           ],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard-entity/scene-1-entity": Object {
           "children": Array [],
           "name": "Scene",
+          "rootElements": Array [],
         },
         ":storyboard-entity/scene-2-entity": Object {
           "children": Array [],
           "name": "Scene",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div": Object {
           "children": Array [
             "storyboard-entity/scene-1-entity:app-outer-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div/card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div": Object {
           "children": Array [
@@ -843,18 +945,22 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
             "storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div/card-inner-div": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle": Object {
           "children": Array [],
           "name": "Rectangle",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-2-entity:same-file-app-div": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
       }
     `)
@@ -864,28 +970,33 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
         ":storyboard-entity": Object {
           "children": Array [],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard-entity/scene-1-entity": Object {
-          "children": Array [
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
             "storyboard-entity/scene-1-entity:app-outer-div",
           ],
-          "name": "div",
         },
         ":storyboard-entity/scene-2-entity": Object {
-          "children": Array [
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
             "storyboard-entity/scene-2-entity:same-file-app-div",
           ],
-          "name": "div",
         },
         "storyboard-entity/scene-1-entity:app-outer-div": Object {
           "children": Array [
             "storyboard-entity/scene-1-entity:app-outer-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div/card-instance": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div": Object {
           "children": Array [
@@ -893,18 +1004,22 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
             "storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div/card-inner-div": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-2-entity:same-file-app-div": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
       }
     `)
@@ -917,28 +1032,33 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
             ":storyboard-entity/scene-2-entity",
           ],
           "name": "Storyboard",
+          "rootElements": Array [],
         },
         ":storyboard-entity/scene-1-entity": Object {
-          "children": Array [
+          "children": Array [],
+          "name": "Scene",
+          "rootElements": Array [
             "storyboard-entity/scene-1-entity:app-outer-div",
           ],
-          "name": "Scene",
         },
         ":storyboard-entity/scene-2-entity": Object {
-          "children": Array [
+          "children": Array [],
+          "name": "Scene",
+          "rootElements": Array [
             "storyboard-entity/scene-2-entity:same-file-app-div",
           ],
-          "name": "Scene",
         },
         "storyboard-entity/scene-1-entity:app-outer-div": Object {
           "children": Array [
             "storyboard-entity/scene-1-entity:app-outer-div/card-instance",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div/card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div": Object {
           "children": Array [
@@ -946,18 +1066,22 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
             "storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle",
           ],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div/card-inner-div": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-1-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle": Object {
           "children": Array [],
           "name": "Rectangle",
+          "rootElements": Array [],
         },
         "storyboard-entity/scene-2-entity:same-file-app-div": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
         },
       }
     `)

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -46,11 +46,14 @@ export function buildSpyWrappedElement(
       globalFrame: null,
       localFrame: null,
       children: childrenTemplatePaths,
+      rootElements: [],
       componentInstance: false,
       isEmotionOrStyledComponent: isEmotionComponent || isStyledComponent,
       specialSizeMeasurements: emptySpecialSizeMeasurements, // This is not the nicest, but the results from the DOM walker will override this anyways
       computedStyle: emptyComputedStyle,
       attributeMetadatada: emptyAttributeMetadatada,
+      componentName: null,
+      label: null,
     }
     const isChildOfRootScene = TP.pathsEqual(
       TP.scenePathPartOfTemplatePath(templatePath),

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -865,11 +865,14 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
     localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
     children: [childElementPath],
+    rootElements: [],
     componentInstance: false,
     isEmotionOrStyledComponent: false,
     specialSizeMeasurements: emptySpecialSizeMeasurements,
     computedStyle: emptyComputedStyle,
     attributeMetadatada: emptyAttributeMetadatada,
+    componentName: null,
+    label: null,
   }
 
   const childElementMetadata: ElementInstanceMetadata = {
@@ -887,11 +890,14 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     globalFrame: canvasRectangle({ x: 0, y: 0, width: 200, height: 300 }),
     localFrame: localRectangle({ x: 0, y: 0, width: 200, height: 300 }),
     children: [],
+    rootElements: [],
     componentInstance: false,
     isEmotionOrStyledComponent: false,
     specialSizeMeasurements: emptySpecialSizeMeasurements,
     computedStyle: emptyComputedStyle,
     attributeMetadatada: emptyAttributeMetadatada,
+    componentName: null,
+    label: null,
   }
 
   const elementMetadataMap: ElementInstanceMetadataMap = {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -1064,7 +1064,7 @@ function deleteElements(targets: TemplatePath[], editor: EditorModel): EditorMod
 
       return element.children.every((childPath) => {
         const child = MetadataUtils.getElementByInstancePathMaybe(metadata.elements, childPath)
-        child == null || isElementToBeDeleted(child) || isEmptyOrContainsDeleted(child)
+        return child == null || isElementToBeDeleted(child) || isEmptyOrContainsDeleted(child)
       })
     }
     const emptyGroups = MetadataUtils.findElements(

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -72,18 +72,15 @@ import {
   combine6EqualityCalls,
   nullableDeepEquality,
   createCallWithTripleEquals,
-  combine9EqualityCalls,
   objectDeepEquality,
-  mapKeepDeepEqualityResult,
   combine5EqualityCalls,
   arrayDeepEquality,
-  combine1EqualityCall,
   combine2EqualityCalls,
   combine7EqualityCalls,
   combine8EqualityCalls,
   undefinableDeepEquality,
   combine4EqualityCalls,
-  combine11EqualityCalls,
+  combine14EqualityCalls,
 } from '../../../utils/deep-equality'
 import {
   TemplatePathArrayKeepDeepEquality,
@@ -646,7 +643,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
 export function ElementInstanceMetadataKeepDeepEquality(): KeepDeepEqualityCall<
   ElementInstanceMetadata
 > {
-  return combine11EqualityCalls(
+  return combine14EqualityCalls(
     (metadata) => metadata.templatePath,
     InstancePathKeepDeepEquality,
     (metadata) => metadata.element,
@@ -659,6 +656,8 @@ export function ElementInstanceMetadataKeepDeepEquality(): KeepDeepEqualityCall<
     nullableDeepEquality(LocalRectangleKeepDeepEquality),
     (metadata) => metadata.children,
     InstancePathArrayKeepDeepEquality,
+    (metadata) => metadata.rootElements,
+    InstancePathArrayKeepDeepEquality,
     (metadata) => metadata.componentInstance,
     createCallWithTripleEquals(),
     (metadata) => metadata.isEmotionOrStyledComponent,
@@ -669,6 +668,10 @@ export function ElementInstanceMetadataKeepDeepEquality(): KeepDeepEqualityCall<
     nullableDeepEquality(objectDeepEquality(createCallWithTripleEquals())),
     (metadata) => metadata.attributeMetadatada,
     nullableDeepEquality(objectDeepEquality(createCallWithTripleEquals())),
+    (metadata) => metadata.componentName,
+    nullableDeepEquality(createCallWithTripleEquals()),
+    (metadata) => metadata.label,
+    nullableDeepEquality(createCallWithTripleEquals()),
     elementInstanceMetadata,
   )
 }

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -433,36 +433,23 @@ export const InspectorEntryPoint: React.FunctionComponent = betterReactMemo(
       (store) => store.editor.selectedViews,
       'InspectorEntryPoint selectedViews',
     )
-    const rootViewsForScene: Array<TemplatePath> = useEditorState(
-      (store) => {
-        const possibleRootComponent = store.editor.jsxMetadataKILLME.components.find((m) =>
-          TP.pathsEqual(m.scenePath, selectedViews[0]),
-        )
-        if (possibleRootComponent != null) {
-          return possibleRootComponent.rootElements
-        } else {
-          return []
-        }
-      },
+    const rootViewsForSelectedElement: Array<TemplatePath> = useEditorState(
+      (store) =>
+        MetadataUtils.getRootViews(store.editor.jsxMetadataKILLME.elements, selectedViews[0]),
       'InspectorEntryPoint',
       (oldTemplatePaths, newTemplatePaths) => {
         return arrayEquals(oldTemplatePaths, newTemplatePaths, TP.pathsEqual)
       },
     )
 
-    const showSceneInspector =
-      selectedViews[0] != null &&
-      TP.depth(selectedViews[0]) === 1 &&
-      TP.isScenePath(selectedViews[0])
-
-    if (showSceneInspector) {
+    if (selectedViews.length === 1 && rootViewsForSelectedElement.length > 0) {
       return (
         <>
           <SingleInspectorEntryPoint selectedViews={selectedViews} />
           <InspectorSectionHeader style={{ paddingTop: UtopiaTheme.layout.rowHeight.small }}>
             Root View
           </InspectorSectionHeader>
-          <SingleInspectorEntryPoint selectedViews={rootViewsForScene} />
+          <SingleInspectorEntryPoint selectedViews={rootViewsForSelectedElement} />
         </>
       )
     } else {

--- a/editor/src/core/layout/layout-utils.spec.browser.ts
+++ b/editor/src/core/layout/layout-utils.spec.browser.ts
@@ -89,6 +89,7 @@ describe('maybeSwitchLayoutProps', () => {
         globalFrame: { x: 0, y: 0, width: 375, height: 812 } as CanvasRectangle,
         localFrame: { x: 0, y: 0, width: 375, height: 812 } as LocalRectangle,
         children: [],
+        rootElements: [],
         componentInstance: true,
         isEmotionOrStyledComponent: false,
         specialSizeMeasurements: specialSizeMeasurements(
@@ -114,6 +115,8 @@ describe('maybeSwitchLayoutProps', () => {
         ),
         computedStyle: emptyComputedStyle,
         attributeMetadatada: emptyAttributeMetadatada,
+        componentName: null,
+        label: null,
       },
     }
 

--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -50,11 +50,14 @@ const testComponentMetadataChild1: ElementInstanceMetadata = {
   props: {},
   element: right(jsxTestElement('View', [], [])),
   children: [],
+  rootElements: [],
   componentInstance: false,
   isEmotionOrStyledComponent: false,
   specialSizeMeasurements: emptySpecialSizeMeasurements,
   computedStyle: emptyComputedStyle,
   attributeMetadatada: emptyAttributeMetadatada,
+  componentName: null,
+  label: null,
 }
 const testComponentMetadataChild2: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
@@ -66,11 +69,14 @@ const testComponentMetadataChild2: ElementInstanceMetadata = {
   props: {},
   element: right(jsxTestElement('View', [], [])),
   children: [],
+  rootElements: [],
   componentInstance: false,
   isEmotionOrStyledComponent: false,
   specialSizeMeasurements: emptySpecialSizeMeasurements,
   computedStyle: emptyComputedStyle,
   attributeMetadatada: emptyAttributeMetadatada,
+  componentName: null,
+  label: null,
 }
 
 const testComponentMetadataGrandchild: ElementInstanceMetadata = {
@@ -86,11 +92,14 @@ const testComponentMetadataGrandchild: ElementInstanceMetadata = {
   },
   element: right(jsxTestElement('View', [], [])),
   children: [],
+  rootElements: [],
   componentInstance: false,
   isEmotionOrStyledComponent: false,
   specialSizeMeasurements: emptySpecialSizeMeasurements,
   computedStyle: emptyComputedStyle,
   attributeMetadatada: emptyAttributeMetadatada,
+  componentName: null,
+  label: null,
 }
 
 const testComponentMetadataChild3: ElementInstanceMetadata = {
@@ -103,11 +112,14 @@ const testComponentMetadataChild3: ElementInstanceMetadata = {
   props: {},
   element: right(jsxTestElement('View', [], [])),
   children: [testComponentMetadataGrandchild.templatePath],
+  rootElements: [],
   componentInstance: false,
   isEmotionOrStyledComponent: false,
   specialSizeMeasurements: emptySpecialSizeMeasurements,
   computedStyle: emptyComputedStyle,
   attributeMetadatada: emptyAttributeMetadatada,
+  componentName: null,
+  label: null,
 }
 
 const testComponentRoot1: ElementInstanceMetadata = {
@@ -121,11 +133,14 @@ const testComponentRoot1: ElementInstanceMetadata = {
     testComponentMetadataChild2.templatePath,
     testComponentMetadataChild3.templatePath,
   ],
+  rootElements: [],
   componentInstance: false,
   isEmotionOrStyledComponent: false,
   specialSizeMeasurements: emptySpecialSizeMeasurements,
   computedStyle: emptyComputedStyle,
   attributeMetadatada: emptyAttributeMetadatada,
+  componentName: null,
+  label: null,
 }
 
 const testComponentScene: ComponentMetadata = {
@@ -229,11 +244,14 @@ describe('targetElementSupportsChildren', () => {
       props: {},
       element: right(jsxTestElement(elementName, [], [])),
       children: [],
+      rootElements: [],
       componentInstance: false,
       isEmotionOrStyledComponent: false,
       specialSizeMeasurements: emptySpecialSizeMeasurements,
       computedStyle: emptyComputedStyle,
       attributeMetadatada: emptyAttributeMetadatada,
+      componentName: null,
+      label: null,
     }
   }
 
@@ -359,11 +377,14 @@ describe('getElementLabel', () => {
     zeroRectangle as CanvasRectangle,
     zeroRectangle as LocalRectangle,
     [],
+    [],
     false,
     false,
     emptySpecialSizeMeasurements,
     emptyComputedStyle,
     emptyAttributeMetadatada,
+    null,
+    null,
   )
   const divElement = jsxElement(
     'div',
@@ -379,11 +400,14 @@ describe('getElementLabel', () => {
     zeroRectangle as CanvasRectangle,
     zeroRectangle as LocalRectangle,
     [spanElementMetadata.templatePath],
+    [],
     false,
     false,
     emptySpecialSizeMeasurements,
     emptyComputedStyle,
     emptyAttributeMetadatada,
+    null,
+    null,
   )
   const elements: ElementInstanceMetadataMap = {
     [TP.toString(spanElementMetadata.templatePath)]: spanElementMetadata,

--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -6,7 +6,7 @@ import {
   LocalRectangle,
   CanvasRectangle,
 } from '../shared/math-utils'
-import { right } from '../shared/either'
+import { left, right } from '../shared/either'
 import { MetadataUtils } from './element-metadata-utils'
 import {
   ComponentMetadata,
@@ -161,6 +161,28 @@ const testComponentScene: ComponentMetadata = {
   },
 }
 
+const testComponentSceneElement: ElementInstanceMetadata = {
+  globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
+  localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
+  templatePath: TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID, TestScenePath]),
+  props: {
+    style: {
+      width: 100,
+      height: 100,
+    },
+  },
+  element: left('Scene'),
+  children: [],
+  rootElements: [testComponentRoot1.templatePath],
+  componentInstance: false,
+  isEmotionOrStyledComponent: false,
+  specialSizeMeasurements: emptySpecialSizeMeasurements,
+  computedStyle: emptyComputedStyle,
+  attributeMetadatada: emptyAttributeMetadatada,
+  componentName: 'MyView',
+  label: null,
+}
+
 const testComponentMetadata: Array<ComponentMetadata> = [testComponentScene]
 const testElementMetadataMap: ElementInstanceMetadataMap = {
   [TP.toString(testComponentMetadataChild1.templatePath)]: testComponentMetadataChild1,
@@ -168,6 +190,7 @@ const testElementMetadataMap: ElementInstanceMetadataMap = {
   [TP.toString(testComponentMetadataChild3.templatePath)]: testComponentMetadataChild3,
   [TP.toString(testComponentMetadataGrandchild.templatePath)]: testComponentMetadataGrandchild,
   [TP.toString(testComponentRoot1.templatePath)]: testComponentRoot1,
+  [TP.toString(testComponentSceneElement.templatePath)]: testComponentSceneElement,
 }
 
 const testJsxMetadata = jsxMetadata(testComponentMetadata, testElementMetadataMap)

--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -183,6 +183,23 @@ const testComponentSceneElement: ElementInstanceMetadata = {
   label: null,
 }
 
+const testStoryboardElement: ElementInstanceMetadata = {
+  globalFrame: canvasRectangle({ x: 0, y: 0, width: 0, height: 0 }),
+  localFrame: localRectangle({ x: 0, y: 0, width: 0, height: 0 }),
+  templatePath: TP.instancePath(TP.emptyScenePath, [BakedInStoryboardUID]),
+  props: {},
+  element: right(jsxTestElement('Storyboard', [], [])),
+  children: [testComponentSceneElement.templatePath],
+  rootElements: [],
+  componentInstance: true,
+  isEmotionOrStyledComponent: false,
+  specialSizeMeasurements: emptySpecialSizeMeasurements,
+  computedStyle: emptyComputedStyle,
+  attributeMetadatada: emptyAttributeMetadatada,
+  componentName: null,
+  label: null,
+}
+
 const testComponentMetadata: Array<ComponentMetadata> = [testComponentScene]
 const testElementMetadataMap: ElementInstanceMetadataMap = {
   [TP.toString(testComponentMetadataChild1.templatePath)]: testComponentMetadataChild1,
@@ -191,6 +208,7 @@ const testElementMetadataMap: ElementInstanceMetadataMap = {
   [TP.toString(testComponentMetadataGrandchild.templatePath)]: testComponentMetadataGrandchild,
   [TP.toString(testComponentRoot1.templatePath)]: testComponentRoot1,
   [TP.toString(testComponentSceneElement.templatePath)]: testComponentSceneElement,
+  [TP.toString(testStoryboardElement.templatePath)]: testStoryboardElement,
 }
 
 const testJsxMetadata = jsxMetadata(testComponentMetadata, testElementMetadataMap)
@@ -466,7 +484,7 @@ describe('getAllPaths', () => {
   it('returns the paths in a depth first manner', () => {
     const actualResult = MetadataUtils.getAllPaths(testJsxMetadata)
     const expectedResult: Array<TemplatePath> = [
-      testComponentScene.scenePath,
+      testComponentSceneElement.templatePath,
       testComponentRoot1.templatePath,
       testComponentMetadataChild1.templatePath,
       testComponentMetadataChild2.templatePath,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -96,7 +96,6 @@ import { isGivenUtopiaAPIElement, isUtopiaAPIComponent } from './project-file-ut
 import { EmptyScenePathForStoryboard } from './scene-utils'
 import { fastForEach } from '../shared/utils'
 import { omit } from '../shared/object-utils'
-import { childPaths } from 'utopia-vscode-common'
 const ObjectPathImmutable: any = OPI
 
 type MergeCandidate = These<ElementInstanceMetadata, ElementInstanceMetadata>

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -817,9 +817,8 @@ export const MetadataUtils = {
 
     const reverseCanvasRoots = MetadataUtils.getAllStoryboardAncestors(metadata).reverse()
     fastForEach(reverseCanvasRoots, (root) => {
-      const rootPath = root.templatePath
-      if (TP.isStoryboardAncestor(rootPath)) {
-        const rootScenePath = TP.scenePathForElementAtInstancePath(rootPath)
+      if (MetadataUtils.elementIsScene(root)) {
+        const rootScenePath = TP.scenePathForElementAtInstancePath(root.templatePath)
         const isCollapsed = TP.containsPath(rootScenePath, collapsedViews)
         navigatorTargets.push(rootScenePath)
         visibleNavigatorTargets.push(rootScenePath)

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -96,6 +96,7 @@ import { isGivenUtopiaAPIElement, isUtopiaAPIComponent } from './project-file-ut
 import { EmptyScenePathForStoryboard } from './scene-utils'
 import { fastForEach } from '../shared/utils'
 import { omit } from '../shared/object-utils'
+import { childPaths } from 'utopia-vscode-common'
 const ObjectPathImmutable: any = OPI
 
 type MergeCandidate = These<ElementInstanceMetadata, ElementInstanceMetadata>
@@ -552,8 +553,9 @@ export const MetadataUtils = {
     target: TemplatePath,
   ): Array<InstancePath> {
     const element = MetadataUtils.findElementByTemplatePath(elements, target)
-    const paths = TP.isScenePath(target) ? element?.rootElements : element?.children
-    return paths ?? []
+    const rootElements = element?.rootElements ?? []
+    const children = element?.children ?? []
+    return [...rootElements, ...children]
   },
   getImmediateChildren(
     metadata: JSXMetadata,
@@ -605,63 +607,6 @@ export const MetadataUtils = {
     return storyboardMetadata == null
       ? []
       : MetadataUtils.getImmediateChildrenPaths(metadata, storyboardMetadata.templatePath)
-  },
-  getCanvasRootScenesAndElements(
-    metadata: JSXMetadata,
-  ): Array<ComponentMetadata | ElementInstanceMetadata> {
-    const rootChildrenPathsOfStoryboard = MetadataUtils.getAllStoryboardAncestorPaths(
-      metadata.elements,
-    )
-    return MetadataUtils.getElementsByInstancePath(metadata.elements, rootChildrenPathsOfStoryboard)
-    // return rootChildrenOfStoryboard.map(path => MetadataUtils
-    // const rootChildrenOfStoryboard = flatMapArray(
-    //   (path) => MetadataUtils.getImmediateChildren(metadata, path),
-    //   rootChildrenPathsOfStoryboard,
-    // )
-    // return rootChildrenOfStoryboard.map((child) => {
-    //   if (isLeft(child.element) && child.element.value === 'Scene') {
-    //     const foundScenePath = TP.scenePath([child.templatePath.element])
-    //     const realSceneRoot = MetadataUtils.findSceneByTemplatePath(
-    //       metadata.components,
-    //       foundScenePath,
-    //     )
-    //     if (realSceneRoot != null) {
-    //       return realSceneRoot
-    //     }
-    //   }
-    //   return child
-    // })
-
-    // The spy metadata has a new special scene (its scene path is _empty array_ 🤯)
-    // which represents the "Storyboard" element (nee Canvas Metadata).
-    // We want to show the scene- and non-scene-children of Storyboard as the root elements
-    // Scenes are already the roots in this `scenes` array, we want to take the non-scene
-    // children of Storyboard and put them right next to the scene roots as siblings.
-    // We want to filter out the Storyboard element itself, and hide the "Storyboard Scene".
-    // We also want to show the scene and non-scene siblings in their original order, not the order determined by the spy
-
-    // const storyboardRoot = this.findStoryboardRoot(metadata.components)
-    // if (storyboardRoot == null) {
-    //   return []
-    // } else {
-    //   const rootChildrenOfStoryboard = flatMapArray(
-    //     (path) => MetadataUtils.getImmediateChildren(metadata, path),
-    //     storyboardRoot.rootElements,
-    //   )
-    //   return rootChildrenOfStoryboard.map((child) => {
-    //     if (isLeft(child.element) && child.element.value === 'Scene') {
-    //       const foundScenePath = TP.scenePath([child.templatePath.element])
-    //       const realSceneRoot = MetadataUtils.findSceneByTemplatePath(
-    //         metadata.components,
-    //         foundScenePath,
-    //       )
-    //       if (realSceneRoot != null) {
-    //         return realSceneRoot
-    //       }
-    //     }
-    //     return child
-    //   })
-    // }
   },
   getAllCanvasRootPaths(metadata: JSXMetadata): TemplatePath[] {
     const rootScenesAndElements = MetadataUtils.getAllStoryboardAncestors(metadata)

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -612,6 +612,17 @@ export const MetadataUtils = {
       ? []
       : MetadataUtils.getImmediateChildrenPaths(metadata, storyboardMetadata.templatePath)
   },
+  getAllStoryboardAncestorPathsScenesOnly(metadata: JSXMetadata): ScenePath[] {
+    // FIXME Use the instance path after we separate Scene from the component it renders
+    const ancestors = MetadataUtils.getAllStoryboardAncestors(metadata)
+    return mapDropNulls(
+      (e) =>
+        MetadataUtils.elementIsScene(e)
+          ? TP.scenePathForElementAtInstancePath(e.templatePath)
+          : null,
+      ancestors,
+    )
+  },
   getAllCanvasRootPaths(metadata: JSXMetadata): TemplatePath[] {
     const rootScenesAndElements = MetadataUtils.getAllStoryboardAncestors(metadata)
     return flatMapArray<ElementInstanceMetadata, TemplatePath>((root) => {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -648,7 +648,6 @@ export const MetadataUtils = {
       const element = MetadataUtils.findElementByTemplatePath(metadata.elements, rootInstance)
       if (element != null) {
         result.push(rootInstance)
-        // element.children.forEach(recurseElement)
         element.rootElements.forEach(recurseElement)
       }
     })

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -548,6 +548,10 @@ export const MetadataUtils = {
     })
     return jsxMetadata(metadata.components, elements)
   },
+  getRootViews(elements: ElementInstanceMetadataMap, target: TemplatePath): Array<InstancePath> {
+    const element = MetadataUtils.findElementByTemplatePath(elements, target)
+    return element?.rootElements ?? []
+  },
   getImmediateChildrenPaths(
     elements: ElementInstanceMetadataMap,
     target: TemplatePath,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -600,31 +600,31 @@ export const MetadataUtils = {
   getStoryboardMetadata(metadata: ElementInstanceMetadataMap): ElementInstanceMetadata | null {
     return Object.values(metadata).find((e) => TP.isStoryboardPath(e.templatePath)) ?? null
   },
-  getAllStoryboardAncestors(metadata: JSXMetadata): ElementInstanceMetadata[] {
+  getAllStoryboardDescendants(metadata: JSXMetadata): ElementInstanceMetadata[] {
     const storyboardMetadata = MetadataUtils.getStoryboardMetadata(metadata.elements)
     return storyboardMetadata == null
       ? []
       : MetadataUtils.getImmediateChildren(metadata, storyboardMetadata.templatePath)
   },
-  getAllStoryboardAncestorPaths(metadata: ElementInstanceMetadataMap): InstancePath[] {
+  getAllStoryboardDescendantPaths(metadata: ElementInstanceMetadataMap): InstancePath[] {
     const storyboardMetadata = MetadataUtils.getStoryboardMetadata(metadata)
     return storyboardMetadata == null
       ? []
       : MetadataUtils.getImmediateChildrenPaths(metadata, storyboardMetadata.templatePath)
   },
-  getAllStoryboardAncestorPathsScenesOnly(metadata: JSXMetadata): ScenePath[] {
+  getAllStoryboardDescendantPathsScenesOnly(metadata: JSXMetadata): ScenePath[] {
     // FIXME Use the instance path after we separate Scene from the component it renders
-    const ancestors = MetadataUtils.getAllStoryboardAncestors(metadata)
+    const descendants = MetadataUtils.getAllStoryboardDescendants(metadata)
     return mapDropNulls(
       (e) =>
         MetadataUtils.elementIsScene(e)
           ? TP.scenePathForElementAtInstancePath(e.templatePath)
           : null,
-      ancestors,
+      descendants,
     )
   },
   getAllCanvasRootPaths(metadata: JSXMetadata): TemplatePath[] {
-    const rootScenesAndElements = MetadataUtils.getAllStoryboardAncestors(metadata)
+    const rootScenesAndElements = MetadataUtils.getAllStoryboardDescendants(metadata)
     return flatMapArray<ElementInstanceMetadata, TemplatePath>((root) => {
       if (root.rootElements.length > 0) {
         return root.rootElements
@@ -642,7 +642,7 @@ export const MetadataUtils = {
       fastForEach(element?.children ?? [], recurseElement)
     }
 
-    const rootInstances = this.getAllStoryboardAncestorPaths(metadata.elements)
+    const rootInstances = this.getAllStoryboardDescendantPaths(metadata.elements)
 
     fastForEach(rootInstances, (rootInstance) => {
       const element = MetadataUtils.findElementByTemplatePath(metadata.elements, rootInstance)
@@ -825,7 +825,7 @@ export const MetadataUtils = {
       })
     }
 
-    const reverseCanvasRoots = MetadataUtils.getAllStoryboardAncestors(metadata).reverse()
+    const reverseCanvasRoots = MetadataUtils.getAllStoryboardDescendants(metadata).reverse()
     fastForEach(reverseCanvasRoots, (root) => {
       if (MetadataUtils.elementIsScene(root)) {
         const rootScenePath = TP.scenePathForElementAtInstancePath(root.templatePath)

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -615,7 +615,7 @@ export const MetadataUtils = {
   getAllCanvasRootPaths(metadata: JSXMetadata): TemplatePath[] {
     const rootScenesAndElements = MetadataUtils.getAllStoryboardAncestors(metadata)
     return flatMapArray<ElementInstanceMetadata, TemplatePath>((root) => {
-      if (root.rootElements != null) {
+      if (root.rootElements.length > 0) {
         return root.rootElements
       } else {
         return [root.templatePath]
@@ -1108,6 +1108,9 @@ export const MetadataUtils = {
   getDuplicationParentTargets(targets: TemplatePath[]): TemplatePath | null {
     return TP.getCommonParent(targets)
   },
+  elementIsScene(element: ElementInstanceMetadata): boolean {
+    return isLeft(element.element) && element.element.value === 'Scene'
+  },
   mergeComponentMetadata(
     elementsByUID: ElementsByUID,
     fromSpy: JSXMetadata,
@@ -1154,7 +1157,7 @@ export const MetadataUtils = {
       } else {
         let componentInstance = spyElem.componentInstance || domElem.componentInstance
         let jsxElement = alternativeEither(spyElem.element, domElem.element)
-        if (isLeft(spyElem.element) && spyElem.element.value === 'Scene') {
+        if (MetadataUtils.elementIsScene(spyElem)) {
           // We have some weird special casing for Scenes (see https://github.com/concrete-utopia/utopia/pull/671)
           jsxElement = spyElem.element
         } else {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -786,7 +786,7 @@ export const MetadataUtils = {
     focusedElementPath: ScenePath | null,
   ): Array<InstancePath> {
     const allPaths = Object.values(metadata.elements).map((element) => element.templatePath)
-    const children = MetadataUtils.getImmediateChildrenPaths(metadata, path)
+    const children = MetadataUtils.getImmediateChildrenPaths(metadata.elements, path)
 
     const matchingFocusPath =
       focusedElementPath == null

--- a/editor/src/core/shared/element-template.tsx
+++ b/editor/src/core/shared/element-template.tsx
@@ -1294,11 +1294,14 @@ export interface ElementInstanceMetadata {
   globalFrame: CanvasRectangle | null
   localFrame: LocalRectangle | null
   children: Array<InstancePath>
+  rootElements: Array<InstancePath>
   componentInstance: boolean
   isEmotionOrStyledComponent: boolean
   specialSizeMeasurements: SpecialSizeMeasurements
   computedStyle: ComputedStyle | null
   attributeMetadatada: StyleAttributeMetadata | null
+  componentName: string | null
+  label: string | null
 }
 
 export function elementInstanceMetadata(
@@ -1308,11 +1311,14 @@ export function elementInstanceMetadata(
   globalFrame: CanvasRectangle | null,
   localFrame: LocalRectangle | null,
   children: Array<InstancePath>,
+  rootElements: Array<InstancePath>,
   componentInstance: boolean,
   isEmotionOrStyledComponent: boolean,
   sizeMeasurements: SpecialSizeMeasurements,
   computedStyle: ComputedStyle | null,
   attributeMetadatada: StyleAttributeMetadata | null,
+  componentName: string | null,
+  label: string | null,
 ): ElementInstanceMetadata {
   return {
     templatePath: templatePath,
@@ -1321,11 +1327,14 @@ export function elementInstanceMetadata(
     globalFrame: globalFrame,
     localFrame: localFrame,
     children: children,
+    rootElements: rootElements,
     componentInstance: componentInstance,
     isEmotionOrStyledComponent: isEmotionOrStyledComponent,
     specialSizeMeasurements: sizeMeasurements,
     computedStyle: computedStyle,
     attributeMetadatada: attributeMetadatada,
+    componentName: componentName,
+    label: label,
   }
 }
 

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -257,6 +257,7 @@ export function scenePathPartOfTemplatePath(path: TemplatePath): ScenePath {
 }
 
 export function instancePathForElementAtScenePath(path: ScenePath): StaticInstancePath {
+  // FIXME This should be returning a regular InstancePath, not a StaticInstancePath
   // Uses the last `ElementPath` in a `ScenePath` to create an `InstancePath` pointing to that element
   const staticScene = dynamicScenePathToStaticScenePath(path)
   const lastElementPath = last(staticScene.sceneElementPaths)
@@ -267,6 +268,10 @@ export function instancePathForElementAtScenePath(path: ScenePath): StaticInstan
     const targetScenePath = staticScenePath(targetSceneElementPaths)
     return staticInstancePath(targetScenePath, lastElementPath)
   }
+}
+
+export function instancePathForElementAtPath(path: TemplatePath): InstancePath {
+  return isInstancePath(path) ? path : instancePathForElementAtScenePath(path)
 }
 
 export function scenePathForElementAtInstancePath(path: InstancePath): ScenePath {

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -178,6 +178,14 @@ export const emptyScenePath: StaticScenePath = {
   sceneElementPaths: [],
 }
 
+function isEmptyElementPathsArray(elementPaths: ElementPath[]): boolean {
+  return elementPaths.length === 0 || (elementPaths.length === 1 && elementPaths[0].length === 0)
+}
+
+function isEmptyScenePath(scene: ScenePath): boolean {
+  return isEmptyElementPathsArray(scene.sceneElementPaths)
+}
+
 function newInstancePath(scene: ScenePath, elementPath: ElementPath): InstancePath {
   return {
     scene: scene,
@@ -191,7 +199,7 @@ export const emptyInstancePath: StaticInstancePath = {
 }
 
 export function scenePath(elementPaths: ElementPath[]): ScenePath {
-  if (elementPaths.length === 0 || (elementPaths.length === 1 && elementPaths[0].length === 0)) {
+  if (isEmptyElementPathsArray(elementPaths)) {
     return emptyScenePath
   }
 
@@ -245,6 +253,14 @@ export function isInstancePath(path: TemplatePath): path is InstancePath {
 
 export function isTopLevelInstancePath(path: TemplatePath): path is InstancePath {
   return isInstancePath(path) && path.element.length === 1
+}
+
+export function isStoryboardPath(path: InstancePath): boolean {
+  return isEmptyScenePath(path.scene) && isTopLevelInstancePath(path)
+}
+
+export function isStoryboardAncestor(path: InstancePath): boolean {
+  return isEmptyScenePath(path.scene) && !isStoryboardPath(path)
 }
 
 export function scenePathPartOfTemplatePath(path: TemplatePath): ScenePath {

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -267,7 +267,7 @@ export function isStoryboardPath(path: InstancePath): boolean {
   return isEmptyScenePath(path.scene) && isTopLevelInstancePath(path)
 }
 
-export function isStoryboardAncestor(path: InstancePath): boolean {
+export function isStoryboardDescendant(path: InstancePath): boolean {
   return isEmptyScenePath(path.scene) && !isStoryboardPath(path)
 }
 

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -300,6 +300,10 @@ export function staticScenePathForElementAtInstancePath(path: StaticInstancePath
   return staticScenePath([...path.scene.sceneElementPaths, path.element])
 }
 
+export function scenePathForElementAtPath(path: TemplatePath): ScenePath {
+  return isScenePath(path) ? path : scenePathForElementAtInstancePath(path)
+}
+
 export function elementPathForPath(path: StaticInstancePath): StaticElementPath
 export function elementPathForPath(path: InstancePath): ElementPath
 export function elementPathForPath(path: InstancePath): ElementPath {

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -186,6 +186,14 @@ function isEmptyScenePath(scene: ScenePath): boolean {
   return isEmptyElementPathsArray(scene.sceneElementPaths)
 }
 
+export function isEmptyPath(path: TemplatePath): boolean {
+  if (isScenePath(path)) {
+    return isEmptyScenePath(path)
+  } else {
+    return path.element.length === 0 && isEmptyScenePath(path.scene)
+  }
+}
+
 function newInstancePath(scene: ScenePath, elementPath: ElementPath): InstancePath {
   return {
     scene: scene,

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -38,6 +38,7 @@ export const UtopiaApiComponents: DependencyBoundDescriptors = {
       createBasicUtopiaComponent('Rectangle', 'Rectangle', StyleObjectProps),
       createBasicUtopiaComponent('Text', 'Text', StyleObjectProps),
       createBasicUtopiaComponent('View', 'View', StyleObjectProps),
+      // createBasicUtopiaComponent('Scene', 'Scene', StyleObjectProps), // FIXME Uncomment when we separate Scene from the component it renders
     ],
   },
 }

--- a/editor/src/utils/deep-equality.ts
+++ b/editor/src/utils/deep-equality.ts
@@ -494,6 +494,106 @@ export function combine11EqualityCalls<A, B, C, D, E, F, G, H, I, J, K, X>(
   }
 }
 
+export function combine14EqualityCalls<A, B, C, D, E, F, G, H, I, J, K, L, M, N, X>(
+  getAValue: (x: X) => A,
+  callA: KeepDeepEqualityCall<A>,
+  getBValue: (x: X) => B,
+  callB: KeepDeepEqualityCall<B>,
+  getCValue: (x: X) => C,
+  callC: KeepDeepEqualityCall<C>,
+  getDValue: (x: X) => D,
+  callD: KeepDeepEqualityCall<D>,
+  getEValue: (x: X) => E,
+  callE: KeepDeepEqualityCall<E>,
+  getFValue: (x: X) => F,
+  callF: KeepDeepEqualityCall<F>,
+  getGValue: (x: X) => G,
+  callG: KeepDeepEqualityCall<G>,
+  getHValue: (x: X) => H,
+  callH: KeepDeepEqualityCall<H>,
+  getIValue: (x: X) => I,
+  callI: KeepDeepEqualityCall<I>,
+  getJValue: (x: X) => J,
+  callJ: KeepDeepEqualityCall<J>,
+  getKValue: (x: X) => K,
+  callK: KeepDeepEqualityCall<K>,
+  getLValue: (x: X) => L,
+  callL: KeepDeepEqualityCall<L>,
+  getMValue: (x: X) => M,
+  callM: KeepDeepEqualityCall<M>,
+  getNValue: (x: X) => N,
+  callN: KeepDeepEqualityCall<N>,
+  combine: (
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+  ) => X,
+): KeepDeepEqualityCall<X> {
+  return (oldValue, newValue) => {
+    const resultA = callA(getAValue(oldValue), getAValue(newValue))
+    const resultB = callB(getBValue(oldValue), getBValue(newValue))
+    const resultC = callC(getCValue(oldValue), getCValue(newValue))
+    const resultD = callD(getDValue(oldValue), getDValue(newValue))
+    const resultE = callE(getEValue(oldValue), getEValue(newValue))
+    const resultF = callF(getFValue(oldValue), getFValue(newValue))
+    const resultG = callG(getGValue(oldValue), getGValue(newValue))
+    const resultH = callH(getHValue(oldValue), getHValue(newValue))
+    const resultI = callI(getIValue(oldValue), getIValue(newValue))
+    const resultJ = callJ(getJValue(oldValue), getJValue(newValue))
+    const resultK = callK(getKValue(oldValue), getKValue(newValue))
+    const resultL = callL(getLValue(oldValue), getLValue(newValue))
+    const resultM = callM(getMValue(oldValue), getMValue(newValue))
+    const resultN = callN(getNValue(oldValue), getNValue(newValue))
+    const areEqual =
+      resultA.areEqual &&
+      resultB.areEqual &&
+      resultC.areEqual &&
+      resultD.areEqual &&
+      resultE.areEqual &&
+      resultF.areEqual &&
+      resultG.areEqual &&
+      resultH.areEqual &&
+      resultI.areEqual &&
+      resultJ.areEqual &&
+      resultK.areEqual &&
+      resultL.areEqual &&
+      resultM.areEqual &&
+      resultN.areEqual
+    if (areEqual) {
+      return keepDeepEqualityResult(oldValue, true)
+    } else {
+      const value = combine(
+        resultA.value,
+        resultB.value,
+        resultC.value,
+        resultD.value,
+        resultE.value,
+        resultF.value,
+        resultG.value,
+        resultH.value,
+        resultI.value,
+        resultJ.value,
+        resultK.value,
+        resultL.value,
+        resultM.value,
+        resultN.value,
+      )
+      return keepDeepEqualityResult(value, false)
+    }
+  }
+}
+
 export function createCallWithTripleEquals<T>(): KeepDeepEqualityCall<T> {
   return (oldValue, newValue) => {
     const areEqual = oldValue === newValue

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -292,11 +292,14 @@ function createFakeMetadataForJSXElement(
       globalFrame: Utils.zeroRectangle as CanvasRectangle, // this could be parametrized to be able to set real rectangles
       localFrame: Utils.zeroRectangle as LocalRectangle,
       children: childPaths,
+      rootElements: [],
       componentInstance: false,
       isEmotionOrStyledComponent: false,
       specialSizeMeasurements: emptySpecialSizeMeasurements,
       computedStyle: emptyComputedStyle,
       attributeMetadatada: emptyAttributeMetadatada,
+      componentName: null,
+      label: null,
     })
     elements.push(...children)
   } else if (isJSXFragment(element)) {


### PR DESCRIPTION
**Problem:**
We no longer want or need the distinction between `ComponentMetadata` and `ElementInstanceMetadata`

**Fix:**
Move everything we need into `ElementInstanceMetadata` and start using that instead.

**Commit Details:**

- Added `rootElements`, `componentName`, and `label` to `ElementInstanceMetadata` so that we can capture the information that is being captured by `ComponentMetadata`
- Updated the metadata capturing in `scene-root.tsx` to include those values, as well as capture other props from the scene (`resizesContent`, `style` and the UID)
- Added functions to `template-path.ts` for checking if an `InstancePath` is the path for the Storyboard's instance, or a descendant of it. Also added functions for converting a given `TemplatePath` to an `InstancePath` or a `ScenePath`, again underlining the fact that really we don't need the distinction anymore.
- Replaced the multitude of ways that we get the root paths we are interested in to only use the `ElementInstanceMetadata`, in `element-metadata-utils.ts`, and added tests to cover the new functions
- Added a helper function for determining if the instance metadata is for a scene or not, based on previous usage (checking that the element is `left('Scene')` unfortunately, but at least this means we can fix this horrible hack that we're using when capturing the metadata)
- Updated the metadata merging (spy + dom walker data) to include the new props added to the instance metadata
- Updated and fixed the tests

I'm pretty convinced after having done this that:

1. `rootElements` should just be merged back with the `children`, since we can distinguish between which is which based on the `TemplatePath`s of them
2. We should absolutely bin off the concept of a separate `ScenePath` and `InstancePath`, but not right now because that will be quite the undertaking :grimacing: 