### PR TITLE
fix(dom-walker) invalidate selected parent scene for focused components

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -265,7 +265,7 @@ function useInvalidateScenesWhenSelectedViewChanges(
     (store) => store.editor.selectedViews,
     (newSelectedViews) => {
       newSelectedViews.forEach((sv) => {
-        const scenePath = TP.scenePathPartOfTemplatePath(sv)
+        const scenePath = TP.outermostScenePathPart(sv)
         const sceneID = TP.toString(scenePath)
         invalidatedSceneIDsRef.current.add(sceneID)
         invalidatedPathsForStylesheetCacheRef.current.add(TP.toString(sv))

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -985,3 +985,15 @@ export function dropFirstScenePathElement(
     }
   }
 }
+
+export function outermostScenePathPart(path: TemplatePath): ScenePath {
+  const asScenePath = isScenePath(path) ? path : scenePathPartOfTemplatePath(path)
+  if (asScenePath.sceneElementPaths.length > 1) {
+    return {
+      ...asScenePath,
+      sceneElementPaths: asScenePath.sceneElementPaths.slice(0, 1),
+    }
+  } else {
+    return asScenePath
+  }
+}


### PR DESCRIPTION
**Problem:**
When selecting elements inside a focused component the inspector can be empty because only the focused element scenepath is invalidated on selection change, this causes the dom-walker to return the cached metadata for the scene, skips walking the focused element children.

**Commit Details:**
- adding the first scenepath to `invalidatedSceneIDsRef` instead of the full focused component path
