### PR TITLE
Multi-file insertion.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -83,7 +83,7 @@ export function createComponentRendererComponent(params: {
 
     if (utopiaJsxComponent == null) {
       // If this element cannot be found, we want to purposefully cause a 'ReferenceError' to notify the user.
-      throw new ReferenceError(`${params.topLevelElementName} is not defined`)
+      throw new ReferenceError(`${params.topLevelElementName} is not defined in ${params.filePath}`)
     }
 
     const appliedProps = optionalMap(

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
@@ -6,7 +6,11 @@ import { Either, left } from '../../../core/shared/either'
 import type { TopLevelElement, UtopiaJSXComponent } from '../../../core/shared/element-template'
 import type { InstancePath, ScenePath, TemplatePath } from '../../../core/shared/project-file-types'
 import { ProjectContentTreeRoot } from '../../assets'
-import type { TransientFileState, UIFileBase64Blobs } from '../../editor/store/editor-state'
+import type {
+  TransientFilesState,
+  TransientFileState,
+  UIFileBase64Blobs,
+} from '../../editor/store/editor-state'
 
 export interface MutableUtopiaContextProps {
   [filePath: string]: {
@@ -49,7 +53,7 @@ RerenderUtopiaContext.displayName = 'RerenderUtopiaContext'
 interface UtopiaProjectContextProps {
   projectContents: ProjectContentTreeRoot
   openStoryboardFilePathKILLME: string | null
-  transientFileState: TransientFileState | null
+  transientFilesState: TransientFilesState | null
   resolve: (importOrigin: string, toImport: string) => Either<string, string>
 }
 const EmptyResolve = (importOrigin: string, toImport: string): Either<string, string> => {
@@ -59,7 +63,7 @@ const EmptyResolve = (importOrigin: string, toImport: string): Either<string, st
 export const UtopiaProjectContext = createContext<UtopiaProjectContextProps>({
   projectContents: {},
   openStoryboardFilePathKILLME: null,
-  transientFileState: null,
+  transientFilesState: null,
   resolve: EmptyResolve,
 })
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.ts
@@ -10,6 +10,7 @@ import { ProjectContentTreeRoot } from '../../assets'
 import { importResultFromImports } from '../../editor/npm-dependency/npm-dependency'
 import {
   CanvasBase64Blobs,
+  TransientFilesState,
   TransientFileState,
   UIFileBase64Blobs,
 } from '../../editor/store/editor-state'
@@ -41,7 +42,7 @@ export function createExecutionScope(
   >,
   projectContents: ProjectContentTreeRoot,
   openStoryboardFileNameKILLME: string | null,
-  transientFileStateKILLME: TransientFileState | null,
+  transientFilesStateKILLME: TransientFilesState | null,
   fileBlobs: CanvasBase64Blobs,
   hiddenInstances: TemplatePath[],
   metadataContext: UiJsxCanvasContextData,
@@ -65,12 +66,7 @@ export function createExecutionScope(
     imports,
     jsxFactoryFunction,
     combinedTopLevelArbitraryBlock,
-  } = getParseSuccessOrTransientForFilePath(
-    filePath,
-    projectContents,
-    openStoryboardFileNameKILLME,
-    transientFileStateKILLME,
-  )
+  } = getParseSuccessOrTransientForFilePath(filePath, projectContents, transientFilesStateKILLME)
   const requireResult: MapLike<any> = importResultFromImports(filePath, imports, customRequire)
 
   const userRequireFn = (toImport: string) => customRequire(filePath, toImport) // TODO this was a React usecallback

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements.ts
@@ -2,7 +2,7 @@ import { useContextSelector } from 'use-context-selector'
 import { ArbitraryJSBlock, TopLevelElement } from '../../../core/shared/element-template'
 import { Imports, isParseSuccess, isTextFile } from '../../../core/shared/project-file-types'
 import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../../assets'
-import { TransientFileState } from '../../editor/store/editor-state'
+import { TransientFilesState, TransientFileState } from '../../editor/store/editor-state'
 import { UtopiaProjectContext } from './ui-jsx-canvas-contexts'
 
 interface GetParseSuccessOrTransientResult {
@@ -22,25 +22,27 @@ const EmptyResult: GetParseSuccessOrTransientResult = {
 export function getParseSuccessOrTransientForFilePath(
   filePath: string,
   projectContents: ProjectContentTreeRoot,
-  openStoryboardFileNameKILLME: string | null,
-  transientFileState: TransientFileState | null,
+  transientFilesState: TransientFilesState | null,
 ): GetParseSuccessOrTransientResult {
   const projectFile = getContentsTreeFileFromString(projectContents, filePath)
   if (isTextFile(projectFile) && isParseSuccess(projectFile.fileContents.parsed)) {
     const parseSuccess = projectFile.fileContents.parsed
-    if (openStoryboardFileNameKILLME === filePath && transientFileState != null) {
+    const transientFileState: TransientFileState | null =
+      transientFilesState == null ? null : transientFilesState[filePath] ?? null
+    if (transientFileState == null) {
+      return {
+        topLevelElements: parseSuccess.topLevelElements,
+        imports: parseSuccess.imports,
+        jsxFactoryFunction: parseSuccess.jsxFactoryFunction,
+        combinedTopLevelArbitraryBlock: parseSuccess.combinedTopLevelArbitraryBlock,
+      }
+    } else {
       return {
         topLevelElements: transientFileState.topLevelElementsIncludingScenes,
         imports: transientFileState.imports,
         jsxFactoryFunction: parseSuccess.jsxFactoryFunction,
         combinedTopLevelArbitraryBlock: parseSuccess.combinedTopLevelArbitraryBlock,
       }
-    }
-    return {
-      topLevelElements: parseSuccess.topLevelElements,
-      imports: parseSuccess.imports,
-      jsxFactoryFunction: parseSuccess.jsxFactoryFunction,
-      combinedTopLevelArbitraryBlock: parseSuccess.combinedTopLevelArbitraryBlock,
     }
   } else {
     return EmptyResult
@@ -51,12 +53,12 @@ export function useGetTopLevelElements(filePath: string | null): TopLevelElement
   return useContextSelector(UtopiaProjectContext, (c) => {
     if (filePath == null) {
       return EmptyResult.topLevelElements
+    } else {
+      return getParseSuccessOrTransientForFilePath(
+        filePath,
+        c.projectContents,
+        c.transientFilesState,
+      ).topLevelElements
     }
-    return getParseSuccessOrTransientForFilePath(
-      filePath,
-      c.projectContents,
-      c.openStoryboardFilePathKILLME,
-      c.transientFileState,
-    ).topLevelElements
   })
 }

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -221,7 +221,7 @@ export function renderCanvasReturnResultAndError(
       linkTags: '',
       focusedElementPath: null,
       projectContents: storeHookForTest.api.getState().editor.projectContents,
-      transientFileState: storeHookForTest.api.getState().derived.canvas.transientState.fileState,
+      transientFilesState: storeHookForTest.api.getState().derived.canvas.transientState.filesState,
     }
   } else {
     canvasProps = {
@@ -242,7 +242,7 @@ export function renderCanvasReturnResultAndError(
       linkTags: '',
       focusedElementPath: null,
       projectContents: storeHookForTest.api.getState().editor.projectContents,
-      transientFileState: storeHookForTest.api.getState().derived.canvas.transientState.fileState,
+      transientFilesState: storeHookForTest.api.getState().derived.canvas.transientState.filesState,
     }
   }
 

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -43,8 +43,8 @@ import {
   UIFileBase64Blobs,
   ConsoleLog,
   getIndexHtmlFileFromEditorState,
-  TransientFileState,
   CanvasBase64Blobs,
+  TransientFilesState,
 } from '../editor/store/editor-state'
 import { proxyConsole } from './console-proxy'
 import { useDomWalker } from './dom-walker'
@@ -137,7 +137,7 @@ export interface UiJsxCanvasProps {
   linkTags: string
   focusedElementPath: ScenePath | null
   projectContents: ProjectContentTreeRoot
-  transientFileState: TransientFileState | null
+  transientFilesState: TransientFilesState | null
 }
 
 export interface CanvasReactReportErrorCallback {
@@ -169,8 +169,7 @@ export function pickUiJsxCanvasProps(
     const { imports: imports_KILLME } = getParseSuccessOrTransientForFilePath(
       uiFilePath,
       editor.projectContents,
-      uiFilePath,
-      derived.canvas.transientState.fileState,
+      derived.canvas.transientState.filesState,
     )
 
     const requireFn = editor.codeResultCache.requireFn
@@ -214,7 +213,7 @@ export function pickUiJsxCanvasProps(
       linkTags: linkTags,
       focusedElementPath: editor.focusedElementPath,
       projectContents: editor.projectContents,
-      transientFileState: derived.canvas.transientState.fileState,
+      transientFilesState: derived.canvas.transientState.filesState,
     }
   }
 }
@@ -250,7 +249,7 @@ export const UiJsxCanvas = betterReactMemo(
       linkTags,
       base64FileBlobs,
       projectContents,
-      transientFileState,
+      transientFilesState,
       shouldIncludeCanvasRootInTheSpy,
     } = props
 
@@ -296,7 +295,7 @@ export const UiJsxCanvas = betterReactMemo(
                   topLevelComponentRendererComponents,
                   projectContents,
                   uiFilePath,
-                  transientFileState,
+                  transientFilesState,
                   base64FileBlobs,
                   hiddenInstances,
                   metadataContext,
@@ -335,7 +334,7 @@ export const UiJsxCanvas = betterReactMemo(
           requireFn,
           resolve,
           projectContents,
-          transientFileState,
+          transientFilesState,
           uiFilePath,
           base64FileBlobs,
           hiddenInstances,
@@ -351,7 +350,7 @@ export const UiJsxCanvas = betterReactMemo(
         topLevelComponentRendererComponents,
         props.projectContents,
         uiFilePath, // this is the storyboard filepath
-        props.transientFileState,
+        props.transientFilesState,
         base64FileBlobs,
         hiddenInstances,
         metadataContext,
@@ -390,7 +389,7 @@ export const UiJsxCanvas = betterReactMemo(
               <UtopiaProjectContext.Provider
                 value={{
                   projectContents: props.projectContents,
-                  transientFileState: props.transientFileState,
+                  transientFilesState: props.transientFilesState,
                   openStoryboardFilePathKILLME: props.uiFilePath,
                   resolve: props.resolve,
                 }}

--- a/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
+++ b/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
@@ -259,6 +259,93 @@ Array [
     "type": "UTOPIA_JSX_COMPONENT",
     "usedInReactDOMRender": false,
   },
+  Object {
+    "arbitraryJSBlock": null,
+    "blockOrExpression": "block",
+    "declarationSyntax": "var",
+    "isFunction": false,
+    "name": "storyboard",
+    "param": null,
+    "propsUsed": Array [],
+    "returnStatementComments": Object {
+      "leadingComments": Array [],
+      "trailingComments": Array [],
+    },
+    "rootElement": Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "Scene",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "component",
+              "value": Object {
+                "definedElsewhere": Array [
+                  "App",
+                ],
+                "javascript": "App",
+                "sourceMap": null,
+                "transpiledJavascript": "return App",
+                "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
+                "uniqueID": "",
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "data-uid",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "scene-0",
+              },
+            },
+          ],
+          "type": "JSX_ELEMENT",
+        },
+      ],
+      "name": Object {
+        "baseVariable": "Storyboard",
+        "propertyPath": Object {
+          "propertyElements": Array [],
+        },
+      },
+      "props": Array [
+        Object {
+          "comments": Object {
+            "leadingComments": Array [],
+            "trailingComments": Array [],
+          },
+          "key": "data-uid",
+          "value": Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "type": "ATTRIBUTE_VALUE",
+            "value": "utopia-storyboard-uid",
+          },
+        },
+      ],
+      "type": "JSX_ELEMENT",
+    },
+    "type": "UTOPIA_JSX_COMPONENT",
+    "usedInReactDOMRender": false,
+  },
 ]
 `;
 
@@ -473,6 +560,93 @@ Array [
             },
             "type": "ATTRIBUTE_VALUE",
             "value": Object {},
+          },
+        },
+      ],
+      "type": "JSX_ELEMENT",
+    },
+    "type": "UTOPIA_JSX_COMPONENT",
+    "usedInReactDOMRender": false,
+  },
+  Object {
+    "arbitraryJSBlock": null,
+    "blockOrExpression": "block",
+    "declarationSyntax": "var",
+    "isFunction": false,
+    "name": "storyboard",
+    "param": null,
+    "propsUsed": Array [],
+    "returnStatementComments": Object {
+      "leadingComments": Array [],
+      "trailingComments": Array [],
+    },
+    "rootElement": Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "Scene",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "component",
+              "value": Object {
+                "definedElsewhere": Array [
+                  "App",
+                ],
+                "javascript": "App",
+                "sourceMap": null,
+                "transpiledJavascript": "return App",
+                "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
+                "uniqueID": "",
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "data-uid",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "scene-0",
+              },
+            },
+          ],
+          "type": "JSX_ELEMENT",
+        },
+      ],
+      "name": Object {
+        "baseVariable": "Storyboard",
+        "propertyPath": Object {
+          "propertyElements": Array [],
+        },
+      },
+      "props": Array [
+        Object {
+          "comments": Object {
+            "leadingComments": Array [],
+            "trailingComments": Array [],
+          },
+          "key": "data-uid",
+          "value": Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "type": "ATTRIBUTE_VALUE",
+            "value": "utopia-storyboard-uid",
           },
         },
       ],

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -19,6 +19,7 @@ import {
   ElementInstanceMetadataMap,
   jsxAttributesFromMap,
   emptyAttributeMetadatada,
+  jsxAttributeOtherJavaScript,
 } from '../../../core/shared/element-template'
 import { getModifiableJSXAttributeAtPath } from '../../../core/shared/jsx-attributes'
 import {
@@ -33,8 +34,13 @@ import {
   unparsed,
   addModifierExportToDetail,
   EmptyExportsDetail,
+  importAlias,
 } from '../../../core/shared/project-file-types'
-import { emptyImports, parseSuccess } from '../../../core/workers/common/project-file-utils'
+import {
+  addImport,
+  emptyImports,
+  parseSuccess,
+} from '../../../core/workers/common/project-file-utils'
 import { deepFreeze } from '../../../utils/deep-freeze'
 import { right, forceRight, left, isRight } from '../../../core/shared/either'
 import { createFakeMetadataForComponents } from '../../../utils/utils.test-utils'
@@ -65,8 +71,12 @@ import {
   ScenePathForTestUiJsFile,
   ScenePath1ForTestUiJsFile,
   sampleDefaultImports,
+  sampleImportsForTests,
 } from '../../../core/model/test-ui-js-file.test-utils'
-import { BakedInStoryboardUID } from '../../../core/model/scene-utils'
+import {
+  BakedInStoryboardUID,
+  BakedInStoryboardVariableName,
+} from '../../../core/model/scene-utils'
 import { getDefaultUIJsFile, sampleCode } from '../../../core/model/new-project-files'
 import { TestScenePath } from '../../canvas/ui-jsx.test-utils'
 import { NO_OP } from '../../../core/shared/utils'
@@ -79,7 +89,13 @@ const chaiExpect = Chai.expect
 describe('SET_PROP', () => {
   const originalModel = deepFreeze(
     parseSuccess(
-      emptyImports(),
+      addImport(
+        'utopia-api',
+        null,
+        [importAlias('View'), importAlias('Scene'), importAlias('Storyboard')],
+        null,
+        emptyImports(),
+      ),
       [
         utopiaJSXComponent(
           'MyView',
@@ -102,6 +118,38 @@ describe('SET_PROP', () => {
                     emptyComments,
                   ),
                   'data-uid': jsxAttributeValue('bbb', emptyComments),
+                }),
+                [],
+              ),
+            ],
+          ),
+          null,
+          false,
+          emptyComments,
+        ),
+        utopiaJSXComponent(
+          BakedInStoryboardVariableName,
+          false,
+          'var',
+          'block',
+          null,
+          [],
+          jsxElement(
+            'Storyboard',
+            jsxAttributesFromMap({
+              'data-uid': jsxAttributeValue(BakedInStoryboardUID, emptyComments),
+            }),
+            [
+              jsxElement(
+                'Scene',
+                jsxAttributesFromMap({
+                  component: jsxAttributeOtherJavaScript(
+                    'MyView',
+                    `return MyView`,
+                    ['MyView'],
+                    null,
+                  ),
+                  'data-uid': jsxAttributeValue('scene-0', emptyComments),
                 }),
                 [],
               ),
@@ -818,12 +866,39 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     false,
     emptyComments,
   )
+  const storyboard = utopiaJSXComponent(
+    BakedInStoryboardVariableName,
+    false,
+    'var',
+    'block',
+    null,
+    [],
+    jsxElement(
+      'Storyboard',
+      jsxAttributesFromMap({
+        'data-uid': jsxAttributeValue(BakedInStoryboardUID, emptyComments),
+      }),
+      [
+        jsxElement(
+          'Scene',
+          jsxAttributesFromMap({
+            component: jsxAttributeOtherJavaScript('App', `return App`, ['App'], null),
+            'data-uid': jsxAttributeValue('scene-0', emptyComments),
+          }),
+          [],
+        ),
+      ],
+    ),
+    null,
+    false,
+    emptyComments,
+  )
   const fileForUI = textFile(
     textFileContents(
       '',
       parseSuccess(
-        sampleDefaultImports,
-        [firstTopLevelElement],
+        sampleImportsForTests,
+        [firstTopLevelElement, storyboard],
         {},
         null,
         null,

--- a/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
@@ -20,23 +20,25 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
     const state: TransientCanvasState = transientCanvasState(
       [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
       [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
-      transientFileState(
-        [
-          utopiaJSXComponent(
-            'App',
-            false,
-            'var',
-            'block',
-            null,
-            [],
-            jsxElement('div', [], []),
-            null,
-            false,
-            emptyComments,
-          ),
-        ],
-        emptyImports(),
-      ),
+      {
+        ['/utopia/app.js']: transientFileState(
+          [
+            utopiaJSXComponent(
+              'App',
+              false,
+              'var',
+              'block',
+              null,
+              [],
+              jsxElement('div', [], []),
+              null,
+              false,
+              emptyComments,
+            ),
+          ],
+          emptyImports(),
+        ),
+      },
     )
 
     const result = TransientCanvasStateKeepDeepEquality()(state, state)
@@ -47,44 +49,48 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
     const oldState: TransientCanvasState = transientCanvasState(
       [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
       [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
-      transientFileState(
-        [
-          utopiaJSXComponent(
-            'App',
-            false,
-            'var',
-            'block',
-            null,
-            [],
-            jsxElement('div', [], []),
-            null,
-            false,
-            emptyComments,
-          ),
-        ],
-        emptyImports(),
-      ),
+      {
+        ['/utopia/app.js']: transientFileState(
+          [
+            utopiaJSXComponent(
+              'App',
+              false,
+              'var',
+              'block',
+              null,
+              [],
+              jsxElement('div', [], []),
+              null,
+              false,
+              emptyComments,
+            ),
+          ],
+          emptyImports(),
+        ),
+      },
     )
     const newState: TransientCanvasState = transientCanvasState(
       [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
       [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
-      transientFileState(
-        [
-          utopiaJSXComponent(
-            'App',
-            false,
-            'var',
-            'block',
-            null,
-            [],
-            jsxElement('div', [], []),
-            null,
-            false,
-            emptyComments,
-          ),
-        ],
-        emptyImports(),
-      ),
+      {
+        ['/utopia/app.js']: transientFileState(
+          [
+            utopiaJSXComponent(
+              'App',
+              false,
+              'var',
+              'block',
+              null,
+              [],
+              jsxElement('div', [], []),
+              null,
+              false,
+              emptyComments,
+            ),
+          ],
+          emptyImports(),
+        ),
+      },
     )
 
     const result = TransientCanvasStateKeepDeepEquality()(oldState, newState)
@@ -95,51 +101,55 @@ describe('TransientCanvasStateKeepDeepEquality', () => {
     const oldState: TransientCanvasState = transientCanvasState(
       [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
       [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
-      transientFileState(
-        [
-          utopiaJSXComponent(
-            'App',
-            false,
-            'var',
-            'block',
-            null,
-            [],
-            jsxElement('span', [], []),
-            null,
-            false,
-            emptyComments,
-          ),
-        ],
-        emptyImports(),
-      ),
+      {
+        ['/utopia/app.js']: transientFileState(
+          [
+            utopiaJSXComponent(
+              'App',
+              false,
+              'var',
+              'block',
+              null,
+              [],
+              jsxElement('span', [], []),
+              null,
+              false,
+              emptyComments,
+            ),
+          ],
+          emptyImports(),
+        ),
+      },
     )
     const newState: TransientCanvasState = transientCanvasState(
       [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ddd'])],
       [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
-      transientFileState(
-        [
-          utopiaJSXComponent(
-            'App',
-            false,
-            'var',
-            'block',
-            null,
-            [],
-            jsxElement('div', [], []),
-            null,
-            false,
-            emptyComments,
-          ),
-        ],
-        emptyImports(),
-      ),
+      {
+        ['/utopia/app.js']: transientFileState(
+          [
+            utopiaJSXComponent(
+              'App',
+              false,
+              'var',
+              'block',
+              null,
+              [],
+              jsxElement('div', [], []),
+              null,
+              false,
+              emptyComments,
+            ),
+          ],
+          emptyImports(),
+        ),
+      },
     )
 
     const result = TransientCanvasStateKeepDeepEquality()(oldState, newState)
     expect(result.value).toEqual(newState)
     expect(result.value.selectedViews).toEqual(newState.selectedViews)
     expect(result.value.highlightedViews).toBe(oldState.highlightedViews)
-    expect(result.value.fileState).toEqual(newState.fileState)
+    expect(result.value.filesState).toEqual(newState.filesState)
     expect(result.areEqual).toEqual(false)
   })
 })
@@ -155,23 +165,25 @@ describe('DerivedStateKeepDeepEquality', () => {
         transientState: transientCanvasState(
           [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
           [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
-          transientFileState(
-            [
-              utopiaJSXComponent(
-                'App',
-                false,
-                'var',
-                'block',
-                null,
-                [],
-                jsxElement('div', [], []),
-                null,
-                false,
-                emptyComments,
-              ),
-            ],
-            emptyImports(),
-          ),
+          {
+            ['/utopia/app.js']: transientFileState(
+              [
+                utopiaJSXComponent(
+                  'App',
+                  false,
+                  'var',
+                  'block',
+                  null,
+                  [],
+                  jsxElement('div', [], []),
+                  null,
+                  false,
+                  emptyComments,
+                ),
+              ],
+              emptyImports(),
+            ),
+          },
         ),
       },
       elementWarnings: addToComplexMap(
@@ -195,23 +207,25 @@ describe('DerivedStateKeepDeepEquality', () => {
         transientState: transientCanvasState(
           [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
           [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
-          transientFileState(
-            [
-              utopiaJSXComponent(
-                'App',
-                false,
-                'var',
-                'block',
-                null,
-                [],
-                jsxElement('div', [], []),
-                null,
-                false,
-                emptyComments,
-              ),
-            ],
-            emptyImports(),
-          ),
+          {
+            ['/utopia/app.js']: transientFileState(
+              [
+                utopiaJSXComponent(
+                  'App',
+                  false,
+                  'var',
+                  'block',
+                  null,
+                  [],
+                  jsxElement('div', [], []),
+                  null,
+                  false,
+                  emptyComments,
+                ),
+              ],
+              emptyImports(),
+            ),
+          },
         ),
       },
       elementWarnings: addToComplexMap(
@@ -230,23 +244,25 @@ describe('DerivedStateKeepDeepEquality', () => {
         transientState: transientCanvasState(
           [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
           [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
-          transientFileState(
-            [
-              utopiaJSXComponent(
-                'App',
-                false,
-                'var',
-                'block',
-                null,
-                [],
-                jsxElement('div', [], []),
-                null,
-                false,
-                emptyComments,
-              ),
-            ],
-            emptyImports(),
-          ),
+          {
+            ['/utopia/app.js']: transientFileState(
+              [
+                utopiaJSXComponent(
+                  'App',
+                  false,
+                  'var',
+                  'block',
+                  null,
+                  [],
+                  jsxElement('div', [], []),
+                  null,
+                  false,
+                  emptyComments,
+                ),
+              ],
+              emptyImports(),
+            ),
+          },
         ),
       },
       elementWarnings: addToComplexMap(
@@ -270,23 +286,25 @@ describe('DerivedStateKeepDeepEquality', () => {
         transientState: transientCanvasState(
           [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'bbb'])],
           [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
-          transientFileState(
-            [
-              utopiaJSXComponent(
-                'App',
-                false,
-                'var',
-                'block',
-                null,
-                [],
-                jsxElement('div', [], []),
-                null,
-                false,
-                emptyComments,
-              ),
-            ],
-            emptyImports(),
-          ),
+          {
+            ['/utopia/app.js']: transientFileState(
+              [
+                utopiaJSXComponent(
+                  'App',
+                  false,
+                  'var',
+                  'block',
+                  null,
+                  [],
+                  jsxElement('div', [], []),
+                  null,
+                  false,
+                  emptyComments,
+                ),
+              ],
+              emptyImports(),
+            ),
+          },
         ),
       },
       elementWarnings: addToComplexMap(
@@ -305,23 +323,25 @@ describe('DerivedStateKeepDeepEquality', () => {
         transientState: transientCanvasState(
           [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ddd'])],
           [TP.instancePath(TP.scenePath([['scene']]), ['aaa', 'ccc'])],
-          transientFileState(
-            [
-              utopiaJSXComponent(
-                'App',
-                false,
-                'var',
-                'block',
-                null,
-                [],
-                jsxElement('div', [], []),
-                null,
-                false,
-                emptyComments,
-              ),
-            ],
-            emptyImports(),
-          ),
+          {
+            ['/utopia/app.js']: transientFileState(
+              [
+                utopiaJSXComponent(
+                  'App',
+                  false,
+                  'var',
+                  'block',
+                  null,
+                  [],
+                  jsxElement('div', [], []),
+                  null,
+                  false,
+                  emptyComments,
+                ),
+              ],
+              emptyImports(),
+            ),
+          },
         ),
       },
       elementWarnings: addToComplexMap(

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -94,7 +94,7 @@ import {
 import { createCallFromIntrospectiveKeepDeep } from '../../../utils/react-performance'
 import {
   TransientCanvasState,
-  TransientFileState,
+  TransientFilesState,
   transientCanvasState,
   DerivedState,
 } from './editor-state'
@@ -105,8 +105,8 @@ export function TransientCanvasStateKeepDeepEquality(): KeepDeepEqualityCall<Tra
     TemplatePathArrayKeepDeepEquality,
     (state) => state.highlightedViews,
     TemplatePathArrayKeepDeepEquality,
-    (state) => state.fileState,
-    createCallFromIntrospectiveKeepDeep<TransientFileState | null>(),
+    (state) => state.filesState,
+    createCallFromIntrospectiveKeepDeep<TransientFilesState | null>(),
     transientCanvasState,
   )
 }

--- a/editor/src/core/model/test-ui-js-file.test-utils.ts
+++ b/editor/src/core/model/test-ui-js-file.test-utils.ts
@@ -30,6 +30,7 @@ const sampleIncludedElementTypes: Array<string> = [
   'Storyboard',
   'Text',
   'View',
+  'Scene',
 ]
 
 export const onlyImportReact: Imports = {

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -1006,14 +1006,19 @@ export function isScenePathEmpty(path: TemplatePath): boolean {
 }
 
 interface DropFirstScenePathElementResultType {
-  newPath: InstancePath
+  newPath: InstancePath | null
   droppedScenePathElements: StaticElementPath | null
 }
 
 export function dropFirstScenePathElement(
-  path: StaticInstancePath,
+  path: StaticInstancePath | null,
 ): DropFirstScenePathElementResultType {
-  if (isScenePathEmpty(path)) {
+  if (path == null) {
+    return {
+      newPath: null,
+      droppedScenePathElements: null,
+    }
+  } else if (isScenePathEmpty(path)) {
     return {
       newPath: path,
       droppedScenePathElements: null,

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -102,7 +102,7 @@ function otherFn(n) {
       "sourcesContent": Array [
         "import { cake } from 'cake'
 import * as React from 'react'
-import { UtopiaUtils, Ellipse, Image, Rectangle, Storyboard, Text, View } from 'utopia-api'
+import { UtopiaUtils, Ellipse, Image, Rectangle, Storyboard, Text, View, Scene } from 'utopia-api'
 function cakeFn(n) {
   return n
 }
@@ -202,6 +202,10 @@ return { cakeFn: cakeFn, otherFn: otherFn };",
           "alias": "View",
           "name": "View",
         },
+        Object {
+          "alias": "Scene",
+          "name": "Scene",
+        },
       ],
       "importedWithName": null,
     },
@@ -247,9 +251,10 @@ return { cakeFn: cakeFn, otherFn: otherFn };",
         "Storyboard",
         "Text",
         "View",
+        "Scene",
       ],
       "module": "utopia-api",
-      "rawCode": "import { UtopiaUtils, Ellipse, Image, Rectangle, Storyboard, Text, View } from 'utopia-api'",
+      "rawCode": "import { UtopiaUtils, Ellipse, Image, Rectangle, Storyboard, Text, View, Scene } from 'utopia-api'",
       "type": "IMPORT_STATEMENT",
     },
     Object {
@@ -285,7 +290,7 @@ return { cakeFn: cakeFn, otherFn: otherFn };",
         "sourcesContent": Array [
           "import { cake } from 'cake'
 import * as React from 'react'
-import { UtopiaUtils, Ellipse, Image, Rectangle, Storyboard, Text, View } from 'utopia-api'
+import { UtopiaUtils, Ellipse, Image, Rectangle, Storyboard, Text, View, Scene } from 'utopia-api'
 function cakeFn(n) {
   return n
 }
@@ -343,7 +348,7 @@ return { cakeFn: cakeFn };",
         "sourcesContent": Array [
           "import { cake } from 'cake'
 import * as React from 'react'
-import { UtopiaUtils, Ellipse, Image, Rectangle, Storyboard, Text, View } from 'utopia-api'
+import { UtopiaUtils, Ellipse, Image, Rectangle, Storyboard, Text, View, Scene } from 'utopia-api'
 function cakeFn(n) {
   return n
 }
@@ -447,7 +452,7 @@ return { otherFn: otherFn };",
                     "sourcesContent": Array [
                       "import { cake } from 'cake'
 import * as React from 'react'
-import { UtopiaUtils, Ellipse, Image, Rectangle, Storyboard, Text, View } from 'utopia-api'
+import { UtopiaUtils, Ellipse, Image, Rectangle, Storyboard, Text, View, Scene } from 'utopia-api'
 function cakeFn(n) {
   return n
 }
@@ -803,7 +808,7 @@ Object {
     "javascript": "const a = \\"cake\\"",
     "sourceMap": Object {
       "file": "code.tsx",
-      "mappings": "AAUCA,IAAMC,CAACC,GAAGC,MAAVH",
+      "mappings": "AAWCA,IAAMC,CAACC,GAAGC,MAAVH",
       "names": Array [
         "const",
         "a",
@@ -822,7 +827,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from \\"utopia-api\\";
 const a = \\"cake\\"
 export var App = (props) => <View data-uid='bbb'>
@@ -848,9 +854,9 @@ return { a: a };",
   "highlightBounds": Object {
     "bbb": Object {
       "endCol": 7,
-      "endLine": 13,
+      "endLine": 14,
       "startCol": 28,
-      "startLine": 11,
+      "startLine": 12,
       "uid": "bbb",
     },
   },
@@ -891,6 +897,10 @@ return { a: a };",
           "alias": "View",
           "name": "View",
         },
+        Object {
+          "alias": "Scene",
+          "name": "Scene",
+        },
       ],
       "importedWithName": null,
     },
@@ -921,6 +931,7 @@ return { a: a };",
         "Storyboard",
         "Text",
         "View",
+        "Scene",
       ],
       "module": "utopia-api",
       "rawCode": "import {
@@ -930,7 +941,8 @@ return { a: a };",
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from \\"utopia-api\\";",
       "type": "IMPORT_STATEMENT",
     },
@@ -950,7 +962,7 @@ return { a: a };",
       "javascript": "const a = \\"cake\\"",
       "sourceMap": Object {
         "file": "code.tsx",
-        "mappings": "AAUCA,IAAMC,CAACC,GAAGC,MAAVH",
+        "mappings": "AAWCA,IAAMC,CAACC,GAAGC,MAAVH",
         "names": Array [
           "const",
           "a",
@@ -969,7 +981,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from \\"utopia-api\\";
 const a = \\"cake\\"
 export var App = (props) => <View data-uid='bbb'>
@@ -1032,7 +1045,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from \\"utopia-api\\";
 const a = \\"cake\\"
 export var App = (props) => <View data-uid='bbb'>
@@ -1091,9 +1105,9 @@ exports[`getHighlightBounds gets some bounds 1`] = `
 Array [
   Object {
     "endCol": 15,
-    "endLine": 28,
+    "endLine": 29,
     "startCol": 8,
-    "startLine": 17,
+    "startLine": 18,
   },
 ]
 `;
@@ -1104,13 +1118,13 @@ Object {
   "errorMessage": null,
   "errorMessages": Array [
     Object {
-      "codeSnippet": "  15 |       return (
-  16 |         <View
-> 17 |           style={{ backgroundColor: \\"darkgrey\\", position: \\"absolute\\" }, ...hello}
+      "codeSnippet": "  16 |       return (
+  17 |         <View
+> 18 |           style={{ backgroundColor: \\"darkgrey\\", position: \\"absolute\\" }, ...hello}
      |                                                                         ^
-  18 |         >
-  19 |         </View>
-  20 |       )",
+  19 |         >
+  20 |         </View>
+  21 |       )",
       "endColumn": undefined,
       "endLine": undefined,
       "errorCode": null,
@@ -1120,7 +1134,7 @@ Object {
       "severity": "fatal",
       "source": "eslint",
       "startColumn": 73,
-      "startLine": 17,
+      "startLine": 18,
       "type": "fatal",
     },
   ],

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -78,7 +78,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export var whatever = (props) => <View data-uid='aaa'>
@@ -136,7 +137,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export var whatever = () => <View data-uid='aaa'>
@@ -189,7 +191,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export function whatever(props) {
@@ -251,7 +254,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export function whatever() {
@@ -308,7 +312,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export default function whatever(props) {
@@ -370,7 +375,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export default function whatever() {
@@ -427,7 +433,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import cake from 'cake'
 import './style.css'
@@ -487,7 +494,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import cake, { cake2 } from 'cake'
 export var whatever = (props) => <View data-uid='aaa'>
@@ -559,7 +567,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake as cake2 } from 'cake'
 export var whatever = (props) => <View data-uid='aaa'>
@@ -623,7 +632,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export var whatever = (props) => <View data-uid='aaa'>
@@ -697,7 +707,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export var whatever = (props) => <View data-uid='aaa'>
@@ -764,7 +775,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 function getSizing(n) {
@@ -901,7 +913,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export default function getSizing(n) {
@@ -984,7 +997,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export function getSizing(n) {
@@ -1083,7 +1097,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export default (n) => {
@@ -1166,7 +1181,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 var spacing = 20
@@ -1751,7 +1767,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 var count = 10
@@ -1829,7 +1846,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 var use20 = true
@@ -1908,7 +1926,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 var mySet = new Set()
 export var whatever = (props) => <View data-uid='aaa'>
@@ -1967,7 +1986,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 var spacing = 20
@@ -2046,7 +2066,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 var MyComp = props => {
   return React.createElement(
@@ -2145,7 +2166,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 var MyComp = (props) => {
   return (
@@ -2283,7 +2305,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 export var Whatever = (props) => <View>
   <MyComp layout={{left: 100}} />
@@ -2340,7 +2363,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export var whatever = (props) => <View data-uid='aaa'>
@@ -2407,7 +2431,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 import { cake } from 'cake'
 export var whatever = <View data-uid='aaa'>
@@ -2460,7 +2485,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 export var App = (props) => <View data-uid='bbb'>
   {}
@@ -2507,7 +2533,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 const a = "cake"
 export var App = (props) => <View data-uid='bbb'>
@@ -2739,7 +2766,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 function cakeFn(n) {
   return n
@@ -2771,6 +2799,7 @@ import {
   Storyboard,
   Text,
   View,
+  Scene
 } from 'utopia-api'
 
 export var whatever = props => {
@@ -3011,7 +3040,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 export var whatever = props => {
   function test(n) {
@@ -3206,7 +3236,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 export var App = props => {
   return (
@@ -3277,7 +3308,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 export var App = props => {
   return (
@@ -3322,7 +3354,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 export var App = props => {
   return (
@@ -3467,7 +3500,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 export var App = props => {
   const a = 20;
@@ -3640,7 +3674,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 export var App = props => {
   return (
@@ -3687,7 +3722,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 export var whatever = props => {
   return <View data-uid="aaa" booleanProperty />;
@@ -3734,7 +3770,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 export var whatever = props => {
   return <View data-uid="aaa" booleanProperty={false} />;
@@ -4261,7 +4298,8 @@ import {
   Rectangle,
   Storyboard,
   Text,
-  View
+  View,
+  Scene
 } from "utopia-api";
 
 console.log('hello!') // line 12 char 9
@@ -4306,7 +4344,7 @@ export var App = props => {
 
     const position = consumer.getOriginalPosition(transpiledLine, transpiledCharacter)
 
-    expect(position).toEqual(expect.objectContaining({ line: 12, column: 9 }))
+    expect(position).toEqual(expect.objectContaining({ line: 13, column: 9 }))
   })
 
   it('maps an arbitraryJSBlock inside a utopiaJSXComponent', () => {
@@ -4332,7 +4370,7 @@ export var App = props => {
 
     const position = consumer.getOriginalPosition(transpiledLine, transpiledCharacter)
 
-    expect(position).toEqual(expect.objectContaining({ line: 16, column: 10 }))
+    expect(position).toEqual(expect.objectContaining({ line: 17, column: 10 }))
   })
 
   it('maps a jsxAttributeOtherJavaScript correctly', () => {
@@ -4365,7 +4403,7 @@ export var App = props => {
 
     const position = consumer.getOriginalPosition(transpiledLine, transpiledCharacter)
 
-    expect(position).toEqual(expect.objectContaining({ line: 28, column: 26 }))
+    expect(position).toEqual(expect.objectContaining({ line: 29, column: 26 }))
   })
 })
 
@@ -4380,7 +4418,8 @@ describe('getHighlightBounds', () => {
       Image,
       Rectangle,
       Text,
-      View
+      View,
+      Scene
     } from "utopia-api";
     
     console.log('hello!') // line 18 char 9
@@ -4420,7 +4459,8 @@ describe('lintAndParse', () => {
       Image,
       Rectangle,
       Text,
-      View
+      View,
+      Scene
     } from "utopia-api";
     
     export var App = props => {


### PR DESCRIPTION
**Problem:**
Insertion has no concept that the result of insertion might be that the change will go into something other than what is shown on the canvas.

**Fix:**
As changes potentially to any file in the entire project those changes are now tracked against the files they need to change. The new infrastructural code around modifying the underlying target of a change was implemented into multiple place that didn't currently handle that.

**Limitations:**
- The canvas is potentially presenting too many targets which results in one level of nesting being applied (changes going into `/src/app.js` instead of `/src/card.js` for example in the dev project). This appears to be an issue with focusing that should be fixed separately.

**Commit Details:**
- Applying the transient state changes in `clearDragState` now handles
  the changes potentially hitting multiple files.
- Functions for handling move and resize transient canvas state shimmed to
  work with the multiple file handling transient state.
- `produceCanvasTransientState` refactored to transform the underlying
  target for insertion.
- Canvas components use `TransientFilesState` instead of `TransientFileState`.
- `normalisePathToUnderlyingTarget` supports returning a null
  element path to allow for root insertion.
- Added storyboard components to some test data, as they previously didn't
  have one and relied on faked metadata which did include data for
  the storyboard component.
- `INSERT_JSX_ELEMENT` action uses `modifyUnderlyingTarget` to perform the
  insertion.
- `modifyOpenJsxElementAtPath` and `modifyOpenJsxElementAtStaticPath` also
  now utilise `modifyUnderlyingTarget`.
- `TransientCanvasState` now holds a `TransientFilesState` instance which
  holds a `TransientFileState` for each file that is changing.
- Widened the type of the `target` parameter for `modifyUnderlyingTarget`.
- `navigatorItemWrapperSelectorFactory` reworked to lookup the underlying
  element so that the correct transient file state can be obtained.
- Added `Scene` to `sampleIncludedElementTypes` and fixed the mountain of
  snapshots and tests which used that.
- `dropFirstScenePathElement` now allows for a null `path` parameter.
- Fixed `createFakeMetadataForComponents` such that fake values are inserted
  for anything in the `definedElsewhere` value and removed the `parentProps`
  parameter which was never used.
