### PR TITLE
fixing the navigator showing unfocused targets as focused

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -187,13 +187,7 @@ function isFocused(focusedElementPath: ScenePath | null, path: TemplatePath): bo
   if (focusedElementPath == null || TP.isScenePath(path)) {
     return false
   } else {
-    return (
-      TP.scenePathUpToElementPath(
-        focusedElementPath,
-        TP.elementPathForPath(path),
-        'dynamic-scene-path',
-      ) != null
-    )
+    return TP.isPathAlongFocusedElementPath(path, focusedElementPath)
   }
 }
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -815,22 +815,18 @@ export const MetadataUtils = {
     const allPaths = Object.values(metadata).map((element) => element.templatePath)
     const children = MetadataUtils.getImmediateChildrenPaths(metadata, path)
 
-    const matchingFocusPath =
-      focusedElementPath == null
-        ? null
-        : TP.scenePathUpToElementPath(
-            focusedElementPath,
-            TP.elementPathForPath(path),
-            'dynamic-scene-path',
-          )
-    const focusedRootElementPaths =
-      matchingFocusPath == null
-        ? []
-        : allPaths.filter(
-            (p) =>
-              TP.depth(p) === 2 && // TODO this is actually pretty silly, TP.depth returns depth + 1 for legacy reasons
-              TP.scenePathsEqual(TP.scenePathPartOfTemplatePath(p), matchingFocusPath),
-          )
+    const isPathPrefixOfFocusedPath = TP.isPathAlongFocusedElementPath(path, focusedElementPath)
+
+    const focusedRootElementPaths = isPathPrefixOfFocusedPath
+      ? allPaths.filter(
+          (p) =>
+            TP.depth(p) === 2 && // TODO this is actually pretty silly, TP.depth returns depth + 1 for legacy reasons
+            TP.scenePathsEqual(
+              TP.scenePathPartOfTemplatePath(p),
+              TP.scenePathForElementAtPath(path),
+            ),
+        )
+      : []
 
     return { children: children, unfurledComponents: focusedRootElementPaths }
   },

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -1040,3 +1040,52 @@ export function outermostScenePathPart(path: TemplatePath): ScenePath {
     return asScenePath
   }
 }
+
+function toElementPathArray(path: TemplatePath | null): Array<ElementPath> | null {
+  if (path == null) {
+    return null
+  } else if (isScenePath(path)) {
+    return path.sceneElementPaths
+  } else {
+    return [...path.scene.sceneElementPaths, path.element]
+  }
+}
+
+function longestSharedElementPathArray(
+  l: Array<ElementPath> | null,
+  r: Array<ElementPath> | null,
+): Array<ElementPath> | null {
+  if (l === null || r === null) {
+    return null
+  } else if (l === r) {
+    return l
+  } else {
+    const matchedElements = longestCommonArray(l, r, elementPathsEqual)
+    if (matchedElements.length > 0) {
+      return matchedElements
+    } else {
+      return null
+    }
+  }
+}
+
+function isElementPathPrefixOfElementPath(
+  potentialPrefix: Array<ElementPath> | null,
+  target: Array<ElementPath> | null,
+): boolean {
+  const longestSharedArray = longestSharedElementPathArray(potentialPrefix, target)
+  return potentialPrefix != null && longestSharedArray?.length === potentialPrefix.length
+}
+
+export function isPathAlongFocusedElementPath(
+  path: TemplatePath,
+  focusedElementPath: ScenePath | null,
+): boolean {
+  const elementPathArrayForTarget = toElementPathArray(path) ?? []
+  return (
+    isElementPathPrefixOfElementPath(
+      elementPathArrayForTarget,
+      toElementPathArray(focusedElementPath),
+    ) && elementPathArrayForTarget.length > 1
+  )
+}


### PR DESCRIPTION
**Problem:**
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/2226774/114014690-2aae8300-9869-11eb-8ff8-fa91c19b90b8.png">
The Navigator would unfurl non-focused instances of a focused component. In the screenshot, LabelRow inside Scene 2 should not be unfurled.

**Fix:**
The problem is that the logic to determine if something is along the focused path (ie a _prefix_ of the focused path) was using `TP.scenePathUpToElementPath` which actually only finds the last elementPath's index inside the focused path, and returns the subpath up to that index. Which means it will match for all template paths with _any_ scene paths so long as the elementPath is in there. We accidentally used this function to also determine if something is along the focused path, but that is simply wrong for this purpose. 
I now wonder if the final usage of `TP.scenePathUpToElementPath` is also wrong and should instead use `longestSharedElementPathArray` 

**Commit Details:**
- Introduced `TP.isPathAlongFocusedElementPath` along with a handful of helper functions that treat a TemplatePath as an `Array<ElementPath>`
- Using `TP. isPathAlongFocusedElementPath` in `getAllChildrenIncludingUnfurledFocusedComponents` 
- Using `TP.isPathAlongFocusedElementPath` in `navigator-item@isFocused`
