### PR TITLE
feature(canvas) scroll animation on canvas

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -8,6 +8,7 @@ exports[`UiJsxCanvas #747 - DOM object constructor cannot be called as a functio
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":8a6 :8a6/088\\"
 >

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -8,6 +8,7 @@ exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -677,6 +678,7 @@ exports[`UiJsxCanvas render Label carried through for normal elements 1`] = `
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -921,6 +923,7 @@ exports[`UiJsxCanvas render Renders input tag without errors 1`] = `
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -1063,6 +1066,7 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -1763,6 +1767,7 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -4241,6 +4246,7 @@ exports[`UiJsxCanvas render class component is available from arbitrary block in
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -4650,6 +4656,7 @@ exports[`UiJsxCanvas render console logging does not do anything bizarre 1`] = `
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -4879,6 +4886,7 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are not the ap
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -5729,6 +5737,7 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are undefined 
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -6584,6 +6593,7 @@ exports[`UiJsxCanvas render function component is available from arbitrary block
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -7019,6 +7029,7 @@ exports[`UiJsxCanvas render function component works inside a map 1`] = `
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -7454,6 +7465,7 @@ exports[`UiJsxCanvas render handles a component that destructures its props obje
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
 >
@@ -8067,6 +8079,7 @@ exports[`UiJsxCanvas render handles a component that renames its props object 1`
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
 >
@@ -8663,6 +8676,7 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
 >
@@ -9366,6 +9380,7 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
 >
@@ -10069,6 +10084,7 @@ exports[`UiJsxCanvas render handles chaining dependencies into the appropriate o
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -10211,6 +10227,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -15181,6 +15198,7 @@ exports[`UiJsxCanvas render props can be accessed inside the arbitrary js block 
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -15678,6 +15696,7 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a class 
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -15870,6 +15889,7 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a functi
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -16154,6 +16174,7 @@ exports[`UiJsxCanvas render renderrs correctly when a component is passed in via
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":eee :eee/fff\\"
 >
@@ -16607,6 +16628,7 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -17281,6 +17303,7 @@ exports[`UiJsxCanvas render renders a canvas defined by a utopia storyboard comp
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
 >
@@ -17753,6 +17776,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -18603,6 +18627,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -19457,6 +19482,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block with 
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -20314,6 +20340,7 @@ exports[`UiJsxCanvas render renders a component with a fragment at the root 1`] 
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -20551,6 +20578,7 @@ exports[`UiJsxCanvas render renders correctly with a context 1`] = `
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":ccc :ccc/ddd\\"
 >
@@ -20930,6 +20958,7 @@ exports[`UiJsxCanvas render renders correctly with a nested context in another c
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":ccc :ccc/ddd\\"
 >
@@ -21075,6 +21104,7 @@ exports[`UiJsxCanvas render renders fine with two circularly referencing arbitra
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene\\"
 >
@@ -21368,6 +21398,7 @@ exports[`UiJsxCanvas render renders fine with two components that reference each
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene\\"
 >
@@ -21514,6 +21545,7 @@ exports[`UiJsxCanvas render renders fragments correctly 1`] = `
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":eee :eee/fff\\"
 >
@@ -22138,6 +22170,7 @@ exports[`UiJsxCanvas render renders img tag 1`] = `
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -22469,6 +22502,7 @@ exports[`UiJsxCanvas render respects a jsx pragma 1`] = `
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -22614,6 +22648,7 @@ exports[`UiJsxCanvas render supports passing down the scope to children of compo
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -23967,6 +24002,7 @@ exports[`UiJsxCanvas render the spy wrapper is compatible with React.cloneElemen
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -24444,6 +24480,7 @@ exports[`UiJsxCanvas render the utopia jsx pragma (and layout prop) works well 1
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -24591,6 +24628,7 @@ exports[`UiJsxCanvas render the utopia jsx pragma supports emotion CSS prop 1`] 
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
@@ -24739,6 +24777,7 @@ exports[`UiJsxCanvas runtime errors React.useEffect at the root fails usefully 1
     position: absolute;
     zoom: 100%;
     transform: translate3d(0px, 0px, 0);
+    transition: initial;
   \\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -137,6 +137,11 @@ export const NewCanvasControls = betterReactMemo(
       setSelectedViewsLocally,
     } = useLocalSelectedHighlightedViews(canvasControlProps.transientCanvasState)
 
+    const canvasScrollAnimation = useEditorState(
+      (store) => store.editor.canvas.scrollAnimation,
+      'NewCanvasControls scrollAnimation',
+    )
+
     // Somehow this being setup and hooked into the div makes the `onDrop` call
     // work properly in `editor-canvas.ts`. I blame React DnD for this.
     const dropSpec: DropTargetHookSpec<FileBrowserItemProps, 'CANVAS', unknown> = {
@@ -176,6 +181,7 @@ export const NewCanvasControls = betterReactMemo(
             height: `100%`,
             zoom: canvasControlProps.scale >= 1 ? `${canvasControlProps.scale * 100}%` : 1,
             cursor: props.cursor,
+            visibility: canvasScrollAnimation ? 'hidden' : 'initial',
           }}
         >
           <div

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1123,6 +1123,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
           position: absolute;
           zoom: 100%;
           transform: translate3d(0px, 0px, 0);
+          transition: initial;
         \\"
         data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
       >
@@ -1217,6 +1218,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
           position: absolute;
           zoom: 100%;
           transform: translate3d(0px, 0px, 0);
+          transition: initial;
         \\"
         data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
       >
@@ -1284,6 +1286,7 @@ export var storyboard = (
           position: absolute;
           zoom: 100%;
           transform: translate3d(0px, 0px, 0);
+          transition: initial;
         \\"
         data-utopia-valid-paths=\\":storyboard :storyboard/scene\\"
       >
@@ -2030,6 +2033,7 @@ describe('UiJsxCanvas render multifile projects', () => {
           position: absolute;
           zoom: 100%;
           transform: translate3d(0px, 0px, 0);
+          transition: initial;
         \\"
         data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
       >
@@ -2108,6 +2112,7 @@ describe('UiJsxCanvas render multifile projects', () => {
           position: absolute;
           zoom: 100%;
           transform: translate3d(0px, 0px, 0);
+          transition: initial;
         \\"
         data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
       >

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -222,6 +222,7 @@ export function renderCanvasReturnResultAndError(
       focusedElementPath: null,
       projectContents: storeHookForTest.api.getState().editor.projectContents,
       transientFileState: storeHookForTest.api.getState().derived.canvas.transientState.fileState,
+      scrollAnimation: false,
     }
   } else {
     canvasProps = {
@@ -243,6 +244,7 @@ export function renderCanvasReturnResultAndError(
       focusedElementPath: null,
       projectContents: storeHookForTest.api.getState().editor.projectContents,
       transientFileState: storeHookForTest.api.getState().derived.canvas.transientState.fileState,
+      scrollAnimation: false,
     }
   }
 

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -138,6 +138,7 @@ export interface UiJsxCanvasProps {
   focusedElementPath: ScenePath | null
   projectContents: ProjectContentTreeRoot
   transientFileState: TransientFileState | null
+  scrollAnimation: boolean
 }
 
 export interface CanvasReactReportErrorCallback {
@@ -215,6 +216,7 @@ export function pickUiJsxCanvasProps(
       focusedElementPath: editor.focusedElementPath,
       projectContents: editor.projectContents,
       transientFileState: derived.canvas.transientState.fileState,
+      scrollAnimation: editor.canvas.scrollAnimation,
     }
   }
 }
@@ -403,6 +405,7 @@ export const UiJsxCanvas = betterReactMemo(
                   onDomReport={onDomReport}
                   validRootPaths={rootValidPaths}
                   canvasRootElementTemplatePath={storyboardRootElementPath}
+                  scrollAnimation={props.scrollAnimation}
                 >
                   <SceneLevelUtopiaContext.Provider value={{ validPaths: rootValidPaths }}>
                     <ParentLevelUtopiaContext.Provider
@@ -473,6 +476,7 @@ export interface CanvasContainerProps {
   canvasRootElementTemplatePath: TemplatePath
   validRootPaths: Array<InstancePath>
   mountCount: number
+  scrollAnimation: boolean
 }
 
 const CanvasContainer: React.FunctionComponent<React.PropsWithChildren<CanvasContainerProps>> = (
@@ -493,6 +497,7 @@ const CanvasContainer: React.FunctionComponent<React.PropsWithChildren<CanvasCon
         zoom: scale >= 1 ? `${scale * 100}%` : 1,
         transform:
           (scale < 1 ? `scale(${scale})` : '') + ` translate3d(${offset.x}px, ${offset.y}px, 0)`,
+        transition: props.scrollAnimation ? 'transform .2s ease-in-out' : 'initial',
       }}
       data-utopia-valid-paths={props.validRootPaths.map(TP.toString).join(' ')}
     >

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -809,6 +809,11 @@ export interface SetFocusedElement {
   focusedElementPath: ScenePath | null
 }
 
+export interface SetScrollAnimation {
+  action: 'SET_SCROLL_ANIMATION'
+  value: boolean
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -941,6 +946,7 @@ export type EditorAction =
   | SelectFromFileAndPosition
   | SendCodeEditorInitialisation
   | SetFocusedElement
+  | SetScrollAnimation
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -184,6 +184,7 @@ import type {
   AddImports,
   WorkerCodeUpdate,
   WorkerParsedUpdate,
+  SetScrollAnimation,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -1277,5 +1278,12 @@ export function setFocusedElement(focusedElementTemplatePath: ScenePath | null):
   return {
     action: 'SET_FOCUSED_ELEMENT',
     focusedElementPath: focusedElementTemplatePath,
+  }
+}
+
+export function setScrollAnimation(value: boolean): SetScrollAnimation {
+  return {
+    action: 'SET_SCROLL_ANIMATION',
+    value: value,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -83,6 +83,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SELECT_FROM_FILE_AND_POSITION':
     case 'SEND_CODE_EDITOR_INITIALISATION':
     case 'SET_FOCUSED_ELEMENT':
+    case 'SET_SCROLL_ANIMATION':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4207,6 +4207,9 @@ export const UPDATE_FNS = {
     dispatch: EditorDispatch,
   ): EditorModel => {
     if (action.value) {
+      if (canvasScrollAnimationTimer != null) {
+        clearTimeout(canvasScrollAnimationTimer)
+      }
       canvasScrollAnimationTimer = window.setTimeout(() => {
         clearTimeout(canvasScrollAnimationTimer)
         canvasScrollAnimationTimer = undefined

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -356,6 +356,7 @@ import {
   SendCodeEditorInitialisation,
   SetFocusedElement,
   AddImports,
+  SetScrollAnimation,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -487,6 +488,7 @@ import {
   selectComponents,
   markVSCodeBridgeReady,
   addImports,
+  setScrollAnimation,
 } from './action-creators'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
 import { getAllTargetsAtPoint } from '../../canvas/dom-lookup'
@@ -966,6 +968,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
       base64Blobs: {},
       mountCount: currentEditor.canvas.mountCount + 1,
       openFile: currentEditor.canvas.openFile,
+      scrollAnimation: currentEditor.canvas.scrollAnimation,
     },
     inspector: {
       visible: currentEditor.inspector.visible,
@@ -1368,6 +1371,7 @@ function toastOnGeneratedElementsTargeted(
 }
 
 let checkpointTimeoutId: number | undefined = undefined
+let canvasScrollAnimationTimer: number | undefined = undefined
 
 // JS Editor Actions:
 export const UPDATE_FNS = {
@@ -4194,6 +4198,26 @@ export const UPDATE_FNS = {
       canvas: {
         ...editor.canvas,
         mountCount: editor.canvas.mountCount + 1,
+      },
+    }
+  },
+  SET_SCROLL_ANIMATION: (
+    action: SetScrollAnimation,
+    editor: EditorModel,
+    dispatch: EditorDispatch,
+  ): EditorModel => {
+    if (action.value === true) {
+      canvasScrollAnimationTimer = window.setTimeout(() => {
+        clearTimeout(canvasScrollAnimationTimer)
+        canvasScrollAnimationTimer = undefined
+        dispatch([setScrollAnimation(false)], 'everyone')
+      }, 700)
+    }
+    return {
+      ...editor,
+      canvas: {
+        ...editor.canvas,
+        scrollAnimation: action.value,
       },
     }
   },

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4206,7 +4206,7 @@ export const UPDATE_FNS = {
     editor: EditorModel,
     dispatch: EditorDispatch,
   ): EditorModel => {
-    if (action.value === true) {
+    if (action.value) {
       canvasScrollAnimationTimer = window.setTimeout(() => {
         clearTimeout(canvasScrollAnimationTimer)
         canvasScrollAnimationTimer = undefined

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -295,6 +295,7 @@ export interface EditorState {
     base64Blobs: CanvasBase64Blobs
     mountCount: number
     openFile: DesignerFile | null
+    scrollAnimation: boolean
   }
   inspector: {
     visible: boolean
@@ -1085,6 +1086,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
       openFile: {
         filename: StoryboardFilePath,
       },
+      scrollAnimation: false,
     },
     inspector: {
       visible: true,
@@ -1337,6 +1339,7 @@ export function editorModelFromPersistentModel(
       openFile: {
         filename: StoryboardFilePath,
       },
+      scrollAnimation: false,
     },
     inspector: {
       visible: true,

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -292,6 +292,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.MARK_VSCODE_BRIDGE_READY(action, state)
     case 'SET_FOCUSED_ELEMENT':
       return UPDATE_FNS.SET_FOCUSED_ELEMENT(action, state)
+    case 'SET_SCROLL_ANIMATION':
+      return UPDATE_FNS.SET_SCROLL_ANIMATION(action, state, dispatch)
     default:
       return state
   }


### PR DESCRIPTION
**Problem:**
There are no animations on the canvas.

**Fix:**
Adding animation for the scroll to element feature. While the canvas animations are enabled the canvas controls are not visible.

**Commit Details:**
- new action, nem variable in editorstate
- hide canvas controls while animations are enabled
- add css `transition` for transform property while animations are enabled to the canvas-container
