### PR TITLE
Feature/scroll to element contextmenu

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -3,13 +3,7 @@
 exports[`UiJsxCanvas #747 - DOM object constructor cannot be called as a function 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":8a6 :8a6/088\\"
 >
   <div

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -3,13 +3,7 @@
 exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -673,13 +667,7 @@ Object {
 exports[`UiJsxCanvas render Label carried through for normal elements 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -918,13 +906,7 @@ Object {
 exports[`UiJsxCanvas render Renders input tag without errors 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -1061,13 +1043,7 @@ Object {
 exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbitrary jsx block 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -1762,13 +1738,7 @@ Object {
 exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbitrary jsx block inside an element inside an arbitrary jsx block 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -4241,13 +4211,7 @@ Object {
 exports[`UiJsxCanvas render class component is available from arbitrary block in JSX element 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -4651,13 +4615,7 @@ Object {
 exports[`UiJsxCanvas render console logging does not do anything bizarre 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -4881,13 +4839,7 @@ Object {
 exports[`UiJsxCanvas render does not crash if the metadata scenes are not the appropriate value 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -5732,13 +5684,7 @@ Object {
 exports[`UiJsxCanvas render does not crash if the metadata scenes are undefined 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -6588,13 +6534,7 @@ Object {
 exports[`UiJsxCanvas render function component is available from arbitrary block in JSX element 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -7024,13 +6964,7 @@ Object {
 exports[`UiJsxCanvas render function component works inside a map 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -7460,13 +7394,7 @@ Object {
 exports[`UiJsxCanvas render handles a component that destructures its props object 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
 >
   <div
@@ -8074,13 +8002,7 @@ Array [
 exports[`UiJsxCanvas render handles a component that renames its props object 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
 >
   <div
@@ -8671,13 +8593,7 @@ Object {
 exports[`UiJsxCanvas render handles a component with a props object written by someone that wants to watch the world burn 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
 >
   <div
@@ -9375,13 +9291,7 @@ Object {
 exports[`UiJsxCanvas render handles a component with a props object written by someone that wants to watch the world burn and also loves defaults 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
 >
   <div
@@ -10079,13 +9989,7 @@ Object {
 exports[`UiJsxCanvas render handles chaining dependencies into the appropriate order 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -10222,13 +10126,7 @@ Object {
 exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -15193,13 +15091,7 @@ export var storyboard = (props) => {
 exports[`UiJsxCanvas render props can be accessed inside the arbitrary js block inside a text range 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -15691,13 +15583,7 @@ Object {
 exports[`UiJsxCanvas render refs are handled and triggered correctly in a class component 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -15884,13 +15770,7 @@ Object {
 exports[`UiJsxCanvas render refs are handled and triggered correctly in a functional component 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -16169,13 +16049,7 @@ Object {
 exports[`UiJsxCanvas render renderrs correctly when a component is passed in via a prop 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":eee :eee/fff\\"
 >
   <div
@@ -16623,13 +16497,7 @@ export var storyboard = (
 exports[`UiJsxCanvas render renders a 1st party component with uids correctly, using the passed uid instead inside App 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -17298,13 +17166,7 @@ Object {
 exports[`UiJsxCanvas render renders a canvas defined by a utopia storyboard component 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
 >
   <div
@@ -17771,13 +17633,7 @@ Object {
 exports[`UiJsxCanvas render renders a component used in an arbitrary block correctly 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -18622,13 +18478,7 @@ Object {
 exports[`UiJsxCanvas render renders a component used in an arbitrary block correctly, with an HTML element name as a parameter name 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -19477,13 +19327,7 @@ Object {
 exports[`UiJsxCanvas render renders a component used in an arbitrary block with eye-stabbingly awful nested destructuring correctly 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -20335,13 +20179,7 @@ Object {
 exports[`UiJsxCanvas render renders a component with a fragment at the root 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -20573,13 +20411,7 @@ Object {
 exports[`UiJsxCanvas render renders correctly with a context 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":ccc :ccc/ddd\\"
 >
   <div
@@ -20953,13 +20785,7 @@ export var storyboard = (
 exports[`UiJsxCanvas render renders correctly with a nested context in another component 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":ccc :ccc/ddd\\"
 >
   <div
@@ -21099,13 +20925,7 @@ Object {
 exports[`UiJsxCanvas render renders fine with two circularly referencing arbitrary blocks 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene\\"
 >
   <div
@@ -21393,13 +21213,7 @@ export var storyboard = (
 exports[`UiJsxCanvas render renders fine with two components that reference each other 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene\\"
 >
   <div
@@ -21540,13 +21354,7 @@ Object {
 exports[`UiJsxCanvas render renders fragments correctly 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":eee :eee/fff\\"
 >
   <div
@@ -22165,13 +21973,7 @@ export var storyboard = (
 exports[`UiJsxCanvas render renders img tag 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -22497,13 +22299,7 @@ Object {
 exports[`UiJsxCanvas render respects a jsx pragma 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -22643,13 +22439,7 @@ Object {
 exports[`UiJsxCanvas render supports passing down the scope to children of components 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -23997,13 +23787,7 @@ Object {
 exports[`UiJsxCanvas render the spy wrapper is compatible with React.cloneElement 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -24475,13 +24259,7 @@ Object {
 exports[`UiJsxCanvas render the utopia jsx pragma (and layout prop) works well 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -24623,13 +24401,7 @@ Object {
 exports[`UiJsxCanvas render the utopia jsx pragma supports emotion CSS prop 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div
@@ -24772,13 +24544,7 @@ Object {
 exports[`UiJsxCanvas runtime errors React.useEffect at the root fails usefully 1`] = `
 "<div
   id=\\"canvas-container\\"
-  style=\\"
-    all: initial;
-    position: absolute;
-    zoom: 100%;
-    transform: translate3d(0px, 0px, 0);
-    transition: initial;
-  \\"
+  style=\\"all: initial; position: absolute;\\"
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
 >
   <div

--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -48,15 +48,27 @@ export const CanvasComponentEntry = betterReactMemo(
       return null
     } else {
       return (
-        <CanvasErrorBoundary
-          fileCode={canvasProps.uiFileCode}
-          filePath={canvasProps.uiFilePath}
-          reportError={onRuntimeError}
-          requireFn={canvasProps.requireFn}
-          key={`canvas-error-boundary-${canvasProps.mountCount}`}
+        <div
+          id='canvas-container-outer'
+          style={{
+            position: 'absolute',
+            zoom: canvasProps.scale >= 1 ? `${canvasProps.scale * 100}%` : 1,
+            transform:
+              (canvasProps.scale < 1 ? `scale(${canvasProps.scale})` : '') +
+              ` translate3d(${canvasProps.offset.x}px, ${canvasProps.offset.y}px, 0)`,
+            transition: canvasProps.scrollAnimation ? 'transform 0.3s ease-in-out' : 'initial',
+          }}
         >
-          <UiJsxCanvas {...canvasProps} clearErrors={clearRuntimeErrors} />
-        </CanvasErrorBoundary>
+          <CanvasErrorBoundary
+            fileCode={canvasProps.uiFileCode}
+            filePath={canvasProps.uiFilePath}
+            reportError={onRuntimeError}
+            requireFn={canvasProps.requireFn}
+            key={`canvas-error-boundary-${canvasProps.mountCount}`}
+          >
+            <UiJsxCanvas {...canvasProps} clearErrors={clearRuntimeErrors} />
+          </CanvasErrorBoundary>
+        </div>
       )
     }
   },

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1118,13 +1118,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
     expect(printedDom).toMatchInlineSnapshot(`
       "<div
         id=\\"canvas-container\\"
-        style=\\"
-          all: initial;
-          position: absolute;
-          zoom: 100%;
-          transform: translate3d(0px, 0px, 0);
-          transition: initial;
-        \\"
+        style=\\"all: initial; position: absolute;\\"
         data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
       >
         <div
@@ -1213,13 +1207,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
     expect(printedDom).toMatchInlineSnapshot(`
       "<div
         id=\\"canvas-container\\"
-        style=\\"
-          all: initial;
-          position: absolute;
-          zoom: 100%;
-          transform: translate3d(0px, 0px, 0);
-          transition: initial;
-        \\"
+        style=\\"all: initial; position: absolute;\\"
         data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa\\"
       >
         <div
@@ -1281,13 +1269,7 @@ export var storyboard = (
     expect(printedDom).toMatchInlineSnapshot(`
       "<div
         id=\\"canvas-container\\"
-        style=\\"
-          all: initial;
-          position: absolute;
-          zoom: 100%;
-          transform: translate3d(0px, 0px, 0);
-          transition: initial;
-        \\"
+        style=\\"all: initial; position: absolute;\\"
         data-utopia-valid-paths=\\":storyboard :storyboard/scene\\"
       >
         <div
@@ -2028,13 +2010,7 @@ describe('UiJsxCanvas render multifile projects', () => {
     expect(printedDom).toMatchInlineSnapshot(`
       "<div
         id=\\"canvas-container\\"
-        style=\\"
-          all: initial;
-          position: absolute;
-          zoom: 100%;
-          transform: translate3d(0px, 0px, 0);
-          transition: initial;
-        \\"
+        style=\\"all: initial; position: absolute;\\"
         data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
       >
         <div
@@ -2107,13 +2083,7 @@ describe('UiJsxCanvas render multifile projects', () => {
     expect(printedDom).toMatchInlineSnapshot(`
       "<div
         id=\\"canvas-container\\"
-        style=\\"
-          all: initial;
-          position: absolute;
-          zoom: 100%;
-          transform: translate3d(0px, 0px, 0);
-          transition: initial;
-        \\"
+        style=\\"all: initial; position: absolute;\\"
         data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-0\\"
       >
         <div

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -491,6 +491,7 @@ const CanvasContainer: React.FunctionComponent<React.PropsWithChildren<CanvasCon
       ref={containerRef}
       style={{
         all: 'initial',
+        position: 'absolute',
       }}
       data-utopia-valid-paths={props.validRootPaths.map(TP.toString).join(' ')}
     >

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -497,7 +497,7 @@ const CanvasContainer: React.FunctionComponent<React.PropsWithChildren<CanvasCon
         zoom: scale >= 1 ? `${scale * 100}%` : 1,
         transform:
           (scale < 1 ? `scale(${scale})` : '') + ` translate3d(${offset.x}px, ${offset.y}px, 0)`,
-        transition: props.scrollAnimation ? 'transform .2s ease-in-out' : 'initial',
+        transition: 'all 900ms ease-in-out',
       }}
       data-utopia-valid-paths={props.validRootPaths.map(TP.toString).join(' ')}
     >

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -485,7 +485,6 @@ const CanvasContainer: React.FunctionComponent<React.PropsWithChildren<CanvasCon
   // eslint-disable-next-line react-hooks/rules-of-hooks
   let containerRef = props.walkDOM ? useDomWalker(props) : React.useRef<HTMLDivElement>(null)
 
-  const { scale, offset } = props
   return (
     <div
       id={CanvasContainerID}
@@ -493,11 +492,6 @@ const CanvasContainer: React.FunctionComponent<React.PropsWithChildren<CanvasCon
       ref={containerRef}
       style={{
         all: 'initial',
-        position: 'absolute',
-        zoom: scale >= 1 ? `${scale * 100}%` : 1,
-        transform:
-          (scale < 1 ? `scale(${scale})` : '') + ` translate3d(${offset.x}px, ${offset.y}px, 0)`,
-        transition: 'all 900ms ease-in-out',
       }}
       data-utopia-valid-paths={props.validRootPaths.map(TP.toString).join(' ')}
     >

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -142,7 +142,20 @@ export const setAsFocusedElement: ContextMenuItem<CanvasData> = {
       const sv = data.selectedViews[0]
       requireDispatch(dispatch)([
         EditorActions.setFocusedElement(TP.scenePathForElementAtInstancePath(sv)),
-        EditorActions.scrollToElement(TP.scenePathForElementAtInstancePath(sv)),
+        EditorActions.scrollToElement(TP.scenePathForElementAtInstancePath(sv), true),
+      ])
+    }
+  },
+}
+
+export const scrollToElement: ContextMenuItem<CanvasData> = {
+  name: 'Scroll to',
+  enabled: true,
+  action: (data, dispatch?: EditorDispatch) => {
+    if (data.selectedViews.length > 0) {
+      const sv = data.selectedViews[0]
+      requireDispatch(dispatch)([
+        EditorActions.scrollToElement(TP.scenePathForElementAtInstancePath(sv), false),
       ])
     }
   },

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -812,6 +812,7 @@ export interface SetFocusedElement {
 export interface ScrollToElement {
   action: 'SCROLL_TO_ELEMENT'
   target: TemplatePath
+  keepScrollPositionIfVisible: boolean
 }
 
 export interface SetScrollAnimation {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1282,10 +1282,14 @@ export function setFocusedElement(focusedElementTemplatePath: ScenePath | null):
   }
 }
 
-export function scrollToElement(focusedElementTemplatePath: TemplatePath): ScrollToElement {
+export function scrollToElement(
+  focusedElementTemplatePath: TemplatePath,
+  keepScrollPositionIfVisible: boolean,
+): ScrollToElement {
   return {
     action: 'SCROLL_TO_ELEMENT',
     target: focusedElementTemplatePath,
+    keepScrollPositionIfVisible: keepScrollPositionIfVisible,
   }
 }
 

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4252,7 +4252,7 @@ export const UPDATE_FNS = {
         clearTimeout(canvasScrollAnimationTimer)
         canvasScrollAnimationTimer = undefined
         dispatch([setScrollAnimation(false)], 'everyone')
-      }, 700)
+      }, 500)
     }
     return {
       ...editor,

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -170,6 +170,7 @@ import {
   WindowPoint,
   canvasRectangle,
   Rectangle,
+  rectangleIntersection,
 } from '../../../core/shared/math-utils'
 import {
   addFileToProjectContents,
@@ -4217,8 +4218,24 @@ export const UPDATE_FNS = {
       editor.jsxMetadata,
     )
     if (targetElementCoords != null) {
-      const baseCanvasOffset =
-        editor.navigator.position === 'right' ? BaseCanvasOffsetLeftPane : BaseCanvasOffset
+      const isNavigatorOnTop = editor.navigator.position === 'right'
+      const containerRootDiv = document.getElementById('canvas-root')
+      if (action.keepScrollPositionIfVisible && containerRootDiv != null) {
+        const containerDivBoundingRect = containerRootDiv.getBoundingClientRect()
+        const navigatorOffset = isNavigatorOnTop ? LeftPaneDefaultWidth : 0
+        const containerRectangle = {
+          x: navigatorOffset - editor.canvas.realCanvasOffset.x,
+          y: -editor.canvas.realCanvasOffset.y,
+          width: containerDivBoundingRect.width,
+          height: containerDivBoundingRect.height,
+        } as CanvasRectangle
+        const isVisible = rectangleIntersection(containerRectangle, targetElementCoords)
+        // when the element is on screen no scrolling is needed
+        if (isVisible) {
+          return editor
+        }
+      }
+      const baseCanvasOffset = isNavigatorOnTop ? BaseCanvasOffsetLeftPane : BaseCanvasOffset
       const newCanvasOffset = Utils.pointDifference(targetElementCoords, baseCanvasOffset)
 
       return UPDATE_FNS.SET_SCROLL_ANIMATION(

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -20,6 +20,7 @@ import {
   ContextMenuItem,
   CanvasData,
   setAsFocusedElement,
+  scrollToElement,
 } from './context-menu-items'
 import { ContextMenuInnerProps, MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState } from './editor/store/store-hook'
@@ -44,6 +45,7 @@ interface ElementContextMenuProps {
 
 const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
   setAsFocusedElement,
+  scrollToElement,
   cutElements,
   copyElements,
   duplicateElement,


### PR DESCRIPTION
**Problem:**
The on focus scrolling is too much when the element is on screen already and extra contextmenu item that always scrolls, called `Scroll to`

**Commit Details:**
- moved animation to outside of the canvas error boundary as mountcount remounting can eat animations
- new context-menu item called `Scroll to` that always scrolls, even when the element is on screen
- changed the context-menu behavior for `Focus Element` to scroll to element only when it is out of screen
- changed the timers a little