### PR TITLE
fix(upload behaviour)

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -210,19 +210,15 @@ export const EditorComponentInner = betterReactMemo(
         const draggedTypes = event.nativeEvent?.dataTransfer?.types
         const isDraggedFile =
           draggedTypes != null && draggedTypes.length === 1 && draggedTypes[0] === 'Files'
-        const currentMode = editorStoreRef.current.editor.mode
-        if (isDraggedFile && (isSelectMode(currentMode) || isLiveMode(currentMode))) {
+        if (isDraggedFile) {
           const actions = [
-            EditorActions.switchEditorMode(
-              EditorModes.insertMode(false, dragAndDropInsertionSubject(null)),
-            ),
             EditorActions.setPanelVisibility('leftmenu', true),
             EditorActions.setLeftMenuTab(LeftMenuTab.Contents),
           ]
           dispatch(actions, 'everyone')
         }
       },
-      [dispatch, editorStoreRef],
+      [dispatch],
     )
 
     React.useEffect(() => {


### PR DESCRIPTION
Fixes #1073 and #1075 

**Problem:**
Image upload had two problematic behaviours:
- it kicks the canvas into image insert mode, but then fails to actually insert (#1075)
- it (silently) prevents further uploads while in insert mode, causing [attribution](https://en.wikipedia.org/wiki/Learned_helplessness) of the perceived failure to everything from "my file name must have the wrong extension" to "I just uploaded an image, maybe it's still tired" all the way to "it's a conspiracy, They do not wish to host my collection of artistic photographs" (#1073)

**Fix:**
Yoink. As in, _removes the feature that sets automatic insert mode_ . Now you get to upload your files one or many at a time, and either can drop them directly onto the canvas (which still works), or the file browser (which now works 97% of the time, all of the time) and then drag them from the file browser onto the canvas (which still works as well).