### PR TITLE
Path-based dom selection

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -32,7 +32,7 @@ import CanvasActions from '../../canvas-actions'
 import { DragState, moveDragState } from '../../canvas-types'
 import { createDuplicationNewUIDs, getOriginalCanvasFrames } from '../../canvas-utils'
 import {
-  findFirstParentWithValidUID,
+  findFirstParentWithValidTemplatePath,
   getAllTargetsAtPoint,
   getValidTargetAtPoint,
 } from '../../dom-lookup'
@@ -213,7 +213,7 @@ function useFindValidTarget(): (
         selectedViews,
         hiddenInstances,
         focusedElementPath,
-        selectableViews.map(TP.toString),
+        selectableViews,
         mousePoint,
         canvasScale,
         canvasOffset,

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -34,7 +34,7 @@ export function findParentSceneValidPaths(target: Element): Array<TemplatePath> 
 export function findFirstParentWithValidTemplatePath(
   validTemplatePathsForLookup: Array<TemplatePath> | 'no-filter',
   target: Element,
-): InstancePath | null {
+): TemplatePath | null {
   const templatePaths = getPathsOnDomElement(target)
   const validTemplatePathsForScene = findParentSceneValidPaths(target) ?? []
   const validTemplatePaths =
@@ -42,8 +42,8 @@ export function findFirstParentWithValidTemplatePath(
       ? validTemplatePathsForScene
       : R.intersection(validTemplatePathsForLookup, validTemplatePathsForScene)
 
-  const filteredValidPaths = templatePaths.filter((tp) =>
-    validTemplatePaths.some((validPath) => TP.pathsEqual(validPath, tp)),
+  const filteredValidPaths = validTemplatePaths.filter((validPath) =>
+    templatePaths.some((tp) => TP.pathsEqual(validPath, tp)),
   )
 
   if (filteredValidPaths.length > 0) {

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -14,7 +14,7 @@ import {
 } from '../../core/shared/math-utils'
 import { InstancePath, ScenePath, TemplatePath } from '../../core/shared/project-file-types'
 import * as TP from '../../core/shared/template-path'
-import { getPathsOnDomElement, getUIDsOnDomELement } from '../../core/shared/uid-utils'
+import { getPathsOnDomElement } from '../../core/shared/uid-utils'
 import Canvas, { TargetSearchType } from './canvas'
 import { CanvasPositions } from './canvas-types'
 

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -12,16 +12,16 @@ import {
   windowPoint,
   WindowPoint,
 } from '../../core/shared/math-utils'
-import { ScenePath, TemplatePath } from '../../core/shared/project-file-types'
+import { InstancePath, ScenePath, TemplatePath } from '../../core/shared/project-file-types'
 import * as TP from '../../core/shared/template-path'
-import { getUIDsOnDomELement } from '../../core/shared/uid-utils'
+import { getPathsOnDomElement, getUIDsOnDomELement } from '../../core/shared/uid-utils'
 import Canvas, { TargetSearchType } from './canvas'
 import { CanvasPositions } from './canvas-types'
 
-export function findParentSceneValidPaths(target: Element): Array<string> | null {
+export function findParentSceneValidPaths(target: Element): Array<TemplatePath> | null {
   const validPaths = getDOMAttribute(target, 'data-utopia-valid-paths')
   if (validPaths != null) {
-    return validPaths.split(' ')
+    return validPaths.split(' ').map(TP.fromString)
   } else {
     if (target.parentElement != null) {
       return findParentSceneValidPaths(target.parentElement)
@@ -31,27 +31,26 @@ export function findParentSceneValidPaths(target: Element): Array<string> | null
   }
 }
 
-export function findFirstParentWithValidUID(
-  validTemplatePathsForLookup: Array<string> | 'no-filter',
+export function findFirstParentWithValidTemplatePath(
+  validTemplatePathsForLookup: Array<TemplatePath> | 'no-filter',
   target: Element,
-): string | null {
-  const uids = getUIDsOnDomELement(target)
-  const originalUid = getDOMAttribute(target, 'data-utopia-original-uid') // TODO BALAZS What's up with original-uid?
+): InstancePath | null {
+  const templatePaths = getPathsOnDomElement(target)
   const validTemplatePathsForScene = findParentSceneValidPaths(target) ?? []
   const validTemplatePaths =
     validTemplatePathsForLookup === 'no-filter'
       ? validTemplatePathsForScene
       : R.intersection(validTemplatePathsForLookup, validTemplatePathsForScene)
-  if (originalUid != null && validTemplatePaths.find((tp) => tp.endsWith(originalUid))) {
-    return last(validTemplatePaths.filter((tp) => tp.endsWith(originalUid))) ?? null
-  } else if (
-    uids != null &&
-    validTemplatePaths.find((tp) => uids.some((uid) => tp.endsWith(uid)))
-  ) {
-    return last(validTemplatePaths.filter((tp) => uids.some((uid) => tp.endsWith(uid)))) ?? null
+
+  const filteredValidPaths = templatePaths.filter((tp) =>
+    validTemplatePaths.some((validPath) => TP.pathsEqual(validPath, tp)),
+  )
+
+  if (filteredValidPaths.length > 0) {
+    return last(filteredValidPaths) ?? null
   } else {
     if (target.parentElement != null) {
-      return findFirstParentWithValidUID(validTemplatePaths, target.parentElement)
+      return findFirstParentWithValidTemplatePath(validTemplatePaths, target.parentElement)
     } else {
       return null
     }
@@ -63,7 +62,7 @@ export function getValidTargetAtPoint(
   selectedViews: Array<TemplatePath>,
   hiddenInstances: Array<TemplatePath>,
   focusedElementPath: ScenePath | null,
-  validTemplatePathsForLookup: Array<string> | 'no-filter',
+  validTemplatePathsForLookup: Array<TemplatePath> | 'no-filter',
   point: WindowPoint | null,
   canvasScale: number,
   canvasOffset: CanvasVector,
@@ -90,7 +89,7 @@ export function getAllTargetsAtPoint(
   selectedViews: Array<TemplatePath>,
   hiddenInstances: Array<TemplatePath>,
   focusedElementPath: ScenePath | null,
-  validTemplatePathsForLookup: Array<string> | 'no-filter',
+  validTemplatePathsForLookup: Array<TemplatePath> | 'no-filter',
   point: WindowPoint | null,
   canvasScale: number,
   canvasOffset: CanvasVector,
@@ -112,12 +111,12 @@ export function getAllTargetsAtPoint(
   const elementsUnderPoint = document.elementsFromPoint(point.x, point.y)
   const elementsFromDOM = stripNulls(
     elementsUnderPoint.map((element) => {
-      const foundValidtemplatePath = findFirstParentWithValidUID(
+      const foundValidtemplatePath = findFirstParentWithValidTemplatePath(
         validTemplatePathsForLookup,
         element,
       )
       if (foundValidtemplatePath != null) {
-        return TP.fromString(foundValidtemplatePath)
+        return foundValidtemplatePath
       } else {
         return null
       }

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -47,22 +47,17 @@ import { PRODUCTION_ENV } from '../../common/env-vars'
 import { CanvasContainerID } from './canvas-types'
 import { emptySet } from '../../core/shared/set-utils'
 import { useForceUpdate } from '../editor/hook-utils'
-import { extractOriginalUidFromIndexedUid, getUIDsOnDomELement } from '../../core/shared/uid-utils'
+import {
+  extractOriginalUidFromIndexedUid,
+  getPathsOnDomElement,
+  getUIDsOnDomELement,
+} from '../../core/shared/uid-utils'
 import { mapDropNulls } from '../../core/shared/array-utils'
 import { optionalMap } from '../../core/shared/optional-utils'
 import { fastForEach } from '../../core/shared/utils'
 
 const MutationObserverConfig = { attributes: true, childList: true, subtree: true }
 const ObserversAvailable = (window as any).MutationObserver != null && ResizeObserver != null
-
-export function getPathsOnDomElement(element: Element): Array<InstancePath> {
-  const pathsAttribute = getDOMAttribute(element, UTOPIA_PATHS_KEY)
-  return (
-    optionalMap((pathsString: string) => {
-      return pathsString.split(' ').map(TP.fromString) as Array<InstancePath>
-    }, pathsAttribute) ?? []
-  )
-}
 
 function elementLayoutSystem(computedStyle: CSSStyleDeclaration | null): DetectedLayoutSystem {
   if (computedStyle == null) {

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -47,11 +47,7 @@ import { PRODUCTION_ENV } from '../../common/env-vars'
 import { CanvasContainerID } from './canvas-types'
 import { emptySet } from '../../core/shared/set-utils'
 import { useForceUpdate } from '../editor/hook-utils'
-import {
-  extractOriginalUidFromIndexedUid,
-  getPathsOnDomElement,
-  getUIDsOnDomELement,
-} from '../../core/shared/uid-utils'
+import { getPathsOnDomElement } from '../../core/shared/uid-utils'
 import { mapDropNulls } from '../../core/shared/array-utils'
 import { optionalMap } from '../../core/shared/optional-utils'
 import { fastForEach } from '../../core/shared/utils'

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -19,12 +19,14 @@ import {
   setJSXValueAtPath,
 } from './jsx-attributes'
 import * as PP from './property-path'
+import * as TP from './template-path'
 import { objectMap, objectValues } from './object-utils'
 import { emptyComments } from '../workers/parser-printer/parser-printer-comments'
 import { getDOMAttribute } from './dom-utils'
-import { UTOPIA_UIDS_KEY } from '../model/utopia-constants'
+import { UTOPIA_PATHS_KEY, UTOPIA_UIDS_KEY } from '../model/utopia-constants'
 import { optionalMap } from './optional-utils'
 import { addAllUniquely } from './array-utils'
+import { InstancePath } from './project-file-types'
 
 export const UtopiaIDPropertyPath = PP.create(['data-uid'])
 
@@ -256,6 +258,15 @@ export function appendToUidString(
 export function getUIDsOnDomELement(element: Element): Array<string> | null {
   const uidsAttribute = getDOMAttribute(element, UTOPIA_UIDS_KEY)
   return optionalMap(uidsFromString, uidsAttribute)
+}
+
+export function getPathsOnDomElement(element: Element): Array<InstancePath> {
+  const pathsAttribute = getDOMAttribute(element, UTOPIA_PATHS_KEY)
+  return (
+    optionalMap((pathsString: string) => {
+      return pathsString.split(' ').map(TP.fromString).filter(TP.isInstancePath)
+    }, pathsAttribute) ?? []
+  )
 }
 
 export function findElementWithUID(

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -255,11 +255,6 @@ export function appendToUidString(
   }
 }
 
-export function getUIDsOnDomELement(element: Element): Array<string> | null {
-  const uidsAttribute = getDOMAttribute(element, UTOPIA_UIDS_KEY)
-  return optionalMap(uidsFromString, uidsAttribute)
-}
-
 export function getPathsOnDomElement(element: Element): Array<InstancePath> {
   const pathsAttribute = getDOMAttribute(element, UTOPIA_PATHS_KEY)
   return (


### PR DESCRIPTION
This is a follow-up to https://github.com/concrete-utopia/utopia/pull/1072

Instead of relying on the uids and backsolving a template path based on the valid paths, I've updated the `dom-lookup` functions to use the printed `data-utopia-paths` attribute, and find a valid selection target based on that.

This makes selection more robust to some edge cases where the UID based representation was ambiguous. 