### PR TITLE
Feature/context menu focus menuitem changes

### DIFF
--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -148,22 +148,8 @@ export class SelectModeControlContainer extends React.Component<
   onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation()
     event.preventDefault()
-    const elementsUnderCursor = getAllTargetsAtPoint(
-      this.props.componentMetadata,
-      this.props.selectedViews,
-      this.props.hiddenInstances,
-      this.props.focusedElementPath,
-      'no-filter',
-      WindowMousePositionRaw,
-      this.props.scale,
-      this.props.canvasOffset,
-    )
     this.props.dispatch(
-      [
-        EditorActions.showContextMenu('context-menu-canvas', event.nativeEvent, {
-          elementsUnderCursor,
-        }),
-      ],
+      [EditorActions.showContextMenu('context-menu-canvas', event.nativeEvent)],
       'canvas',
     )
   }

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -149,7 +149,7 @@ export const toggleShadowItem: ContextMenuItem<CanvasData> = {
 }
 
 export const setAsFocusedElement: ContextMenuItem<CanvasData> = {
-  name: 'Set As Focused Element',
+  name: 'Edit Component',
   enabled: (data) => {
     if (data.currentFilePath == null) {
       return false

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -2,9 +2,14 @@ import * as R from 'ramda'
 import { TriggerEvent } from 'react-contexify'
 import { MetadataUtils } from '../core/model/element-metadata-utils'
 import { Either } from '../core/shared/either'
-import { ElementInstanceMetadataMap } from '../core/shared/element-template'
+import { ElementInstanceMetadataMap, isIntrinsicHTMLElement } from '../core/shared/element-template'
 import { CanvasPoint } from '../core/shared/math-utils'
-import { InstancePath, NodeModules } from '../core/shared/project-file-types'
+import {
+  InstancePath,
+  NodeModules,
+  ScenePath,
+  TemplatePath,
+} from '../core/shared/project-file-types'
 import * as PP from '../core/shared/property-path'
 import * as TP from '../core/shared/template-path'
 import RU from '../utils/react-utils'
@@ -36,15 +41,7 @@ export interface ContextMenuItem<T> {
   submenuName?: string | null
   shortcut?: string
   isSeparator?: boolean
-  isHidden?: ({
-    props,
-    data,
-    triggerEvent,
-  }: {
-    props: any
-    data: T
-    triggerEvent: TriggerEvent
-  }) => boolean
+  isHidden?: (data: T) => boolean
   action: (data: T, dispatch?: EditorDispatch, event?: MouseEvent) => void
 }
 
@@ -57,6 +54,9 @@ export interface CanvasData {
   nodeModules: NodeModules
   transientFilesState: TransientFilesState | null
   resolve: (importOrigin: string, toImport: string) => Either<string, string>
+  focusedElementPath: ScenePath | null
+  hiddenInstances: TemplatePath[]
+  scale: number
 }
 
 export function requireDispatch(dispatch: EditorDispatch | null | undefined): EditorDispatch {
@@ -167,6 +167,21 @@ export const setAsFocusedElement: ContextMenuItem<CanvasData> = {
         return MetadataUtils.isFocusableComponent(view, components, data.jsxMetadata, imports)
       })
     }
+  },
+  isHidden: (data) => {
+    return data.selectedViews.every((view) => {
+      const { components } = getJSXComponentsAndImportsForPathInnerComponent(
+        view,
+        data.currentFilePath!,
+        data.projectContents,
+        data.nodeModules,
+        data.transientFilesState,
+        data.jsxMetadata,
+        data.resolve,
+      )
+      const elementName = MetadataUtils.getJSXElementName(view, components, data.jsxMetadata)
+      return elementName != null ? isIntrinsicHTMLElement(elementName) : true
+    })
   },
   action: (data, dispatch?: EditorDispatch) => {
     if (data.selectedViews.length > 0) {

--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -25,15 +25,10 @@ export interface ContextMenuWrapperProps<T> {
   providerStyle?: React.CSSProperties
 }
 
-export interface ContextMenuInnerProps {
-  elementsUnderCursor: Array<TemplatePath>
-}
-
-export function openMenu(id: string, nativeEvent: MouseEvent, props: ContextMenuInnerProps | null) {
+export function openMenu(id: string, nativeEvent: MouseEvent) {
   contextMenu.show({
     id: id,
     event: nativeEvent,
-    props: props,
   })
 }
 
@@ -88,7 +83,17 @@ export class MomentumContextMenu<T> extends ReactComponent<ContextMenuProps<T>> 
     return splitItems
   }
 
-  isHidden = (): boolean => false
+  isHidden = (item: ContextMenuItem<T>): (() => boolean) => {
+    return () => {
+      if (item.isHidden == null) {
+        return false
+      } else if (typeof item.isHidden === 'function') {
+        return item.isHidden(this.props.getData())
+      } else {
+        return item.isHidden
+      }
+    }
+  }
 
   isDisabled = (item: ContextMenuItem<T>): (() => boolean) => {
     return () => {
@@ -111,7 +116,7 @@ export class MomentumContextMenu<T> extends ReactComponent<ContextMenuProps<T>> 
           item.action(this.props.getData(), this.props.dispatch, event.nativeEvent)
           contextMenu.hideAll()
         }}
-        hidden={item.isHidden ?? this.isHidden}
+        hidden={this.isHidden(item)}
         style={{ height: item.isSeparator ? 9 : 24, display: 'flex', alignItems: 'center' }}
       >
         <span style={{ flexGrow: 1, flexShrink: 0 }} className='react-contexify-span'>

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -51,7 +51,6 @@ import {
 } from './store/editor-state'
 import { Notice } from '../common/notice'
 import { BuildType } from '../../core/workers/ts/ts-worker'
-import { ContextMenuInnerProps } from '../../uuiui-deps'
 import { ParseResult } from '../../utils/value-parser-utils'
 export { isLoggedIn, loggedInUser, LoginState, notLoggedIn, UserDetails } from '../../common/user'
 
@@ -515,7 +514,6 @@ export interface ShowContextMenu {
   action: 'SHOW_CONTEXT_MENU'
   menuName: ElementContextMenuInstance
   event: MouseEvent
-  props: ContextMenuInnerProps | null
 }
 
 export interface SetCursorOverlay {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -36,7 +36,7 @@ import type {
 import type { BuildType } from '../../../core/workers/ts/ts-worker'
 import type { Key, KeysPressed } from '../../../utils/keyboard'
 import type { objectKeyParser, parseString } from '../../../utils/value-parser-utils'
-import type { ContextMenuInnerProps, CSSCursor } from '../../../uuiui-deps'
+import type { CSSCursor } from '../../../uuiui-deps'
 import type {
   addFileToProjectContents,
   getContentsTreeFileFromString,
@@ -807,13 +807,11 @@ export function distributeSelectedViews(distribution: Distribution): DistributeS
 export function showContextMenu(
   menuName: ElementContextMenuInstance,
   event: MouseEvent,
-  props: ContextMenuInnerProps | null,
 ): ShowContextMenu {
   return {
     action: 'SHOW_CONTEXT_MENU',
     menuName: menuName,
     event: event,
-    props: props,
   }
 }
 

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3176,7 +3176,7 @@ export const UPDATE_FNS = {
   },
   SHOW_CONTEXT_MENU: (action: ShowContextMenu, editor: EditorModel): EditorModel => {
     // side effect!
-    openMenu(action.menuName, action.event, action.props)
+    openMenu(action.menuName, action.event)
     return editor
   },
   SEND_PREVIEW_MODEL: (action: SendPreviewModel, editor: EditorModel): EditorModel => {

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -503,7 +503,7 @@ export const ComponentSectionInner = betterReactMemo(
     const onResetClicked = React.useCallback(
       (event: React.MouseEvent<HTMLElement>) => {
         dispatch(
-          [showContextMenu('context-menu-instance-inspector', event.nativeEvent, null)],
+          [showContextMenu('context-menu-instance-inspector', event.nativeEvent)],
           'everyone',
         )
       },

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -73,7 +73,7 @@ export const NavigatorComponent = betterReactMemo(
 
     const onContextMenu = React.useCallback(
       (event: React.MouseEvent<HTMLElement>) => {
-        dispatch([showContextMenu('context-menu-navigator', event.nativeEvent, null)], 'everyone')
+        dispatch([showContextMenu('context-menu-navigator', event.nativeEvent)], 'everyone')
       },
       [dispatch],
     )


### PR DESCRIPTION
**Problem:**
Focus component in the context-menu should be hidden for elements.

**Commit Details:**
- change label from `Set As Focused Element` to `Edit Component`
- `isHidden` callback for focus context-menu item
- update existing isHidden for element list, this was using data from props which is unusual because we use the data in other cases
