### PR TITLE
Multi-file Movement

### DIFF
--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -10544,9 +10544,9 @@
       "dev": true
     },
     "electron": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-6.1.7.tgz",
-      "integrity": "sha512-QhBA/fcYJit2XJGkD2xEfxlWTtTaWYu7qkKVohtVWXpELFqkpel2DCDxet5BTo0qs8ukuZHxlQPnIonODnl2bw==",
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-6.1.12.tgz",
+      "integrity": "sha512-RUPM8xJfTcm53V9EKMBhvpLu1+CQkmuvWDmVCypR5XbUG1OOrOLiKl0CqUZ9+tEDuOmC+DmzmJP2MZXScBU5IA==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",
@@ -10555,9 +10555,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.26",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
-          "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw==",
+          "version": "10.17.56",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
+          "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w==",
           "dev": true
         }
       }
@@ -10580,9 +10580,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"

--- a/editor/package.json
+++ b/editor/package.json
@@ -255,7 +255,7 @@
     "csstype": "3.0.3",
     "dependency-cruiser": "^9.17.1",
     "diff": "5.0.0",
-    "electron": "6.1.7",
+    "electron": "6.1.12",
     "enzyme": "3.3.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.9.0",

--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser.ts
@@ -580,6 +580,7 @@ describe('moving a scene/rootview on the canvas', () => {
 })
 
 describe('resizing a scene/rootview on the canvas', () => {
+  beforeAll(setElectronWindow)
   it('resizing a dynamic scene’s root view sets the root view size', async () => {
     const testCode = Prettier.format(
       `/** @jsx jsx */

--- a/editor/src/components/canvas/canvas-utils-unit-tests.spec.ts
+++ b/editor/src/components/canvas/canvas-utils-unit-tests.spec.ts
@@ -3,19 +3,19 @@ import {
   getTestParseSuccess,
   makeTestProjectCodeWithSnippet,
   TestScenePath,
-  testPrintCode,
+  testPrintCodeFromEditorState,
+  getEditorState,
 } from './ui-jsx.test-utils'
 import { singleResizeChange, EdgePosition } from './canvas-types'
 import { CanvasVector, canvasRectangle } from '../../core/shared/math-utils'
 import { updateFramesOfScenesAndComponents } from './canvas-utils'
 import { ParseSuccess } from '../../core/shared/project-file-types'
 import { getComponentsFromTopLevelElements } from '../../core/model/project-file-utils'
-import { createFakeMetadataForParseSuccess } from '../../utils/utils.test-utils'
 import { applyUtopiaJSXComponentsChanges } from '../editor/store/editor-state'
 
 describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   it('a simple TLWH pin change works', async () => {
-    const testProject = getTestParseSuccess(
+    const testProject = getEditorState(
       makeTestProjectCodeWithSnippet(`
     <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
@@ -33,22 +33,13 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       { x: 60, y: 40 } as CanvasVector,
     )
 
-    const transformedComponents = updateFramesOfScenesAndComponents(
-      getComponentsFromTopLevelElements(testProject.topLevelElements),
-      createFakeMetadataForParseSuccess(testProject),
+    const updatedProject = updateFramesOfScenesAndComponents(
+      testProject,
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
 
-    const updatedProject: ParseSuccess = {
-      ...testProject,
-      topLevelElements: applyUtopiaJSXComponentsChanges(
-        testProject.topLevelElements,
-        transformedComponents,
-      ),
-    }
-
-    expect(testPrintCode(updatedProject)).toEqual(
+    expect(testPrintCodeFromEditorState(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
@@ -61,7 +52,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
     )
   })
   it('TLW, missing H resizing from bottom right edge adds height', async () => {
-    const testProject = getTestParseSuccess(
+    const testProject = getEditorState(
       makeTestProjectCodeWithSnippet(`
     <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
@@ -79,22 +70,13 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       { x: 40, y: 30 } as CanvasVector,
     )
 
-    const transformedComponents = updateFramesOfScenesAndComponents(
-      getComponentsFromTopLevelElements(testProject.topLevelElements),
-      createFakeMetadataForParseSuccess(testProject),
+    const updatedProject = updateFramesOfScenesAndComponents(
+      testProject,
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
 
-    const updatedProject: ParseSuccess = {
-      ...testProject,
-      topLevelElements: applyUtopiaJSXComponentsChanges(
-        testProject.topLevelElements,
-        transformedComponents,
-      ),
-    }
-
-    expect(testPrintCode(updatedProject)).toEqual(
+    expect(testPrintCodeFromEditorState(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
@@ -107,7 +89,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
     )
   })
   it('TLWHBR, too many frame points work', async () => {
-    const testProject = getTestParseSuccess(
+    const testProject = getEditorState(
       makeTestProjectCodeWithSnippet(`
     <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
@@ -125,22 +107,13 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       { x: 50, y: 50 } as CanvasVector,
     )
 
-    const transformedComponents = updateFramesOfScenesAndComponents(
-      getComponentsFromTopLevelElements(testProject.topLevelElements),
-      createFakeMetadataForParseSuccess(testProject),
+    const updatedProject = updateFramesOfScenesAndComponents(
+      testProject,
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
 
-    const updatedProject: ParseSuccess = {
-      ...testProject,
-      topLevelElements: applyUtopiaJSXComponentsChanges(
-        testProject.topLevelElements,
-        transformedComponents,
-      ),
-    }
-
-    expect(testPrintCode(updatedProject)).toEqual(
+    expect(testPrintCodeFromEditorState(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
@@ -162,7 +135,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   })
 
   it('TLRB pin change works, dragged from topleft point', async () => {
-    const testProject = getTestParseSuccess(
+    const testProject = getEditorState(
       makeTestProjectCodeWithSnippet(`
     <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
@@ -180,22 +153,13 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       { x: 50, y: 20 } as CanvasVector,
     )
 
-    const transformedComponents = updateFramesOfScenesAndComponents(
-      getComponentsFromTopLevelElements(testProject.topLevelElements),
-      createFakeMetadataForParseSuccess(testProject),
+    const updatedProject = updateFramesOfScenesAndComponents(
+      testProject,
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
 
-    const updatedProject: ParseSuccess = {
-      ...testProject,
-      topLevelElements: applyUtopiaJSXComponentsChanges(
-        testProject.topLevelElements,
-        transformedComponents,
-      ),
-    }
-
-    expect(testPrintCode(updatedProject)).toEqual(
+    expect(testPrintCodeFromEditorState(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
@@ -208,7 +172,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
     )
   })
   it('TLRB pin change works, dragged from bottom right point', async () => {
-    const testProject = getTestParseSuccess(
+    const testProject = getEditorState(
       makeTestProjectCodeWithSnippet(`
     <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
@@ -226,22 +190,13 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       { x: 80, y: -10 } as CanvasVector,
     )
 
-    const transformedComponents = updateFramesOfScenesAndComponents(
-      getComponentsFromTopLevelElements(testProject.topLevelElements),
-      createFakeMetadataForParseSuccess(testProject),
+    const updatedProject = updateFramesOfScenesAndComponents(
+      testProject,
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
 
-    const updatedProject: ParseSuccess = {
-      ...testProject,
-      topLevelElements: applyUtopiaJSXComponentsChanges(
-        testProject.topLevelElements,
-        transformedComponents,
-      ),
-    }
-
-    expect(testPrintCode(updatedProject)).toEqual(
+    expect(testPrintCodeFromEditorState(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
@@ -255,7 +210,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
   })
 
   it('TLCxCy pin change works, dragged from topleft point', async () => {
-    const testProject = getTestParseSuccess(
+    const testProject = getEditorState(
       makeTestProjectCodeWithSnippet(`
     <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
@@ -273,22 +228,13 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       { x: 40, y: 30 } as CanvasVector,
     )
 
-    const transformedComponents = updateFramesOfScenesAndComponents(
-      getComponentsFromTopLevelElements(testProject.topLevelElements),
-      createFakeMetadataForParseSuccess(testProject),
+    const updatedProject = updateFramesOfScenesAndComponents(
+      testProject,
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
 
-    const updatedProject: ParseSuccess = {
-      ...testProject,
-      topLevelElements: applyUtopiaJSXComponentsChanges(
-        testProject.topLevelElements,
-        transformedComponents,
-      ),
-    }
-
-    expect(testPrintCode(updatedProject)).toEqual(
+    expect(testPrintCodeFromEditorState(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
@@ -301,7 +247,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
     )
   })
   it('TLCxCy pin change works, dragged from bottomright point', async () => {
-    const testProject = getTestParseSuccess(
+    const testProject = getEditorState(
       makeTestProjectCodeWithSnippet(`
     <View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
       <View
@@ -319,22 +265,13 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       { x: 40, y: 30 } as CanvasVector,
     )
 
-    const transformedComponents = updateFramesOfScenesAndComponents(
-      getComponentsFromTopLevelElements(testProject.topLevelElements),
-      createFakeMetadataForParseSuccess(testProject),
+    const updatedProject = updateFramesOfScenesAndComponents(
+      testProject,
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
 
-    const updatedProject: ParseSuccess = {
-      ...testProject,
-      topLevelElements: applyUtopiaJSXComponentsChanges(
-        testProject.topLevelElements,
-        transformedComponents,
-      ),
-    }
-
-    expect(testPrintCode(updatedProject)).toEqual(
+    expect(testPrintCodeFromEditorState(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
         <View
@@ -347,7 +284,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
     )
   })
   it('a simple TLWH pin change with values in string pixels', async () => {
-    const testProject = getTestParseSuccess(
+    const testProject = getEditorState(
       makeTestProjectCodeWithSnippet(`
     <View style={{ ...(props.style || {}) }} data-uid='aaa'>
       <View
@@ -364,22 +301,13 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       { x: 60, y: 40 } as CanvasVector,
     )
 
-    const transformedComponents = updateFramesOfScenesAndComponents(
-      getComponentsFromTopLevelElements(testProject.topLevelElements),
-      createFakeMetadataForParseSuccess(testProject),
+    const updatedProject = updateFramesOfScenesAndComponents(
+      testProject,
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
 
-    const updatedProject: ParseSuccess = {
-      ...testProject,
-      topLevelElements: applyUtopiaJSXComponentsChanges(
-        testProject.topLevelElements,
-        transformedComponents,
-      ),
-    }
-
-    expect(testPrintCode(updatedProject)).toEqual(
+    expect(testPrintCodeFromEditorState(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
         <View
@@ -391,7 +319,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
     )
   })
   it('a simple TLWH pin change with expression, the expression is not changed', async () => {
-    const testProject = getTestParseSuccess(
+    const testProject = getEditorState(
       makeTestProjectCodeWithSnippet(`
     <View style={{ ...(props.style || {}) }} data-uid='aaa'>
       <View
@@ -408,22 +336,13 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       { x: 60, y: 40 } as CanvasVector,
     )
 
-    const transformedComponents = updateFramesOfScenesAndComponents(
-      getComponentsFromTopLevelElements(testProject.topLevelElements),
-      createFakeMetadataForParseSuccess(testProject),
+    const updatedProject = updateFramesOfScenesAndComponents(
+      testProject,
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
 
-    const updatedProject: ParseSuccess = {
-      ...testProject,
-      topLevelElements: applyUtopiaJSXComponentsChanges(
-        testProject.topLevelElements,
-        transformedComponents,
-      ),
-    }
-
-    expect(testPrintCode(updatedProject)).toEqual(
+    expect(testPrintCodeFromEditorState(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
         <View
@@ -435,7 +354,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
     )
   })
   it('a simple TLWH pin change with values in exotic units', async () => {
-    const testProject = getTestParseSuccess(
+    const testProject = getEditorState(
       makeTestProjectCodeWithSnippet(`
     <View style={{ ...(props.style || {}) }} data-uid='aaa'>
       <View
@@ -452,22 +371,13 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
       { x: 60, y: 40 } as CanvasVector,
     )
 
-    const transformedComponents = updateFramesOfScenesAndComponents(
-      getComponentsFromTopLevelElements(testProject.topLevelElements),
-      createFakeMetadataForParseSuccess(testProject),
+    const updatedProject = updateFramesOfScenesAndComponents(
+      testProject,
       [pinChange],
       canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     )
 
-    const updatedProject: ParseSuccess = {
-      ...testProject,
-      topLevelElements: applyUtopiaJSXComponentsChanges(
-        testProject.topLevelElements,
-        transformedComponents,
-      ),
-    }
-
-    expect(testPrintCode(updatedProject)).toEqual(
+    expect(testPrintCodeFromEditorState(updatedProject)).toEqual(
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
         <View

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -295,6 +295,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
 })
 
 describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
+  beforeAll(setElectronWindow)
   it('only TL pins work', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
@@ -779,6 +780,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
 })
 
 describe('updateFramesOfScenesAndComponents - pinSizeChange -', () => {
+  beforeAll(setElectronWindow)
   it('only TL pins work', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(
@@ -885,6 +887,7 @@ describe('updateFramesOfScenesAndComponents - pinSizeChange -', () => {
 })
 
 describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
+  beforeAll(setElectronWindow)
   it('TLWH, but W and H are percentage works', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
@@ -953,6 +956,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
 })
 
 describe('moveTemplate', () => {
+  beforeAll(setElectronWindow)
   it('wraps in 1 element', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
@@ -1290,6 +1294,14 @@ describe('moveTemplate', () => {
   })
 
   it('reparents a pinned element to flex using magic?', async () => {
+    //const currentWindow = require('electron').remote.getCurrentWindow()
+    //currentWindow.show()
+    //currentWindow.setPosition(500, 200)
+    //currentWindow.setSize(2200, 1000)
+    //currentWindow.openDevTools()
+    // This is necessary because the test code races against the Electron process
+    // opening the window it would appear.
+    //await wait(10000)
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
         <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>
@@ -2064,6 +2076,7 @@ describe('moveTemplate', () => {
       await dispatchDone
     })
 
+    //await wait(600000)
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...props.style }} layout={{ layoutSystem: 'pinSystem' }} data-uid='aaa'>

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -52,6 +52,7 @@ import {
   setUtopiaID,
   transformJSXComponentAtPath,
   findJSXElementChildAtPath,
+  transformJSXComponentAtElementPath,
 } from '../../core/model/element-template-utils'
 import { generateUID } from '../../core/shared/uid-utils'
 import {
@@ -127,6 +128,11 @@ import {
   modifyUnderlyingTarget,
   modifyParseSuccessAtPath,
   getOpenUIJSFileKey,
+  withUnderlyingTarget,
+  modifyUnderlyingForOpenFile,
+  TransientFilesState,
+  forUnderlyingTarget,
+  TransientFileState,
 } from '../editor/store/editor-state'
 import * as Frame from '../frame'
 import { getImageSizeFromMetadata, MultipliersForImages, scaleImageDimensions } from '../images'
@@ -174,11 +180,14 @@ import {
 import { forceNotNull, optionalMap } from '../../core/shared/optional-utils'
 import { fastForEach } from '../../core/shared/utils'
 import { UiJsxCanvasContextData } from './ui-jsx-canvas'
-import { addFileToProjectContents, contentsToTree } from '../assets'
+import { addFileToProjectContents, contentsToTree, ProjectContentTreeRoot } from '../assets'
 import { emptyComments } from '../../core/workers/parser-printer/parser-printer-comments'
 import { getAllTargetsAtPoint } from './dom-lookup'
 import { WindowMousePositionRaw } from '../../templates/editor-canvas'
 import { parseCSSLengthPercent } from '../inspector/common/css-utils'
+import { normalisePathToUnderlyingTargetForced } from '../custom-code/code-file'
+import { addToMapOfArraysUnique } from '../../core/shared/array-utils'
+import { mapValues } from '../../core/shared/object-utils'
 
 export function getOriginalFrames(
   selectedViews: Array<TemplatePath>,
@@ -268,6 +277,27 @@ export function getOriginalCanvasFrames(
   return originalFrames
 }
 
+function applyTransientFilesState(
+  producedTransientFilesState: TransientFilesState | null,
+  result: EditorState,
+): EditorState {
+  let workingState = result
+  if (producedTransientFilesState != null) {
+    for (const filePath of Object.keys(producedTransientFilesState)) {
+      const producedTransientFileState = producedTransientFilesState[filePath]
+      workingState = modifyParseSuccessAtPath(filePath, workingState, (success) => {
+        let parseSuccessResult: ParseSuccess = {
+          ...success,
+          imports: producedTransientFileState.imports,
+          topLevelElements: producedTransientFileState.topLevelElementsIncludingScenes,
+        }
+        return parseSuccessResult
+      })
+    }
+  }
+  return workingState
+}
+
 export function clearDragState(
   model: EditorState,
   derived: DerivedState,
@@ -281,19 +311,7 @@ export function clearDragState(
       false,
     )
     const producedTransientFilesState = producedTransientCanvasState.filesState
-    if (producedTransientFilesState != null) {
-      for (const filePath of Object.keys(producedTransientFilesState)) {
-        const producedTransientFileState = producedTransientFilesState[filePath]
-        result = modifyParseSuccessAtPath(filePath, result, (success) => {
-          let parseSuccessResult: ParseSuccess = {
-            ...success,
-            imports: producedTransientFileState.imports,
-            topLevelElements: producedTransientFileState.topLevelElementsIncludingScenes,
-          }
-          return parseSuccessResult
-        })
-      }
-    }
+    result = applyTransientFilesState(producedTransientFilesState, result)
   }
 
   return {
@@ -314,12 +332,11 @@ export function canvasFrameToNormalisedFrame(frame: CanvasRectangle): Normalised
 }
 
 export function updateFramesOfScenesAndComponents(
-  components: Array<UtopiaJSXComponent>,
-  metadata: ElementInstanceMetadataMap,
+  editorState: EditorState,
   framesAndTargets: Array<PinOrFlexFrameChange>,
   optionalParentFrame: CanvasRectangle | null,
-): Array<UtopiaJSXComponent> {
-  let workingComponentsResult = [...components]
+): EditorState {
+  let workingEditorState: EditorState = editorState
   Utils.fastForEach(framesAndTargets, (frameAndTarget) => {
     const { target } = frameAndTarget
     if (TP.isScenePath(target)) {
@@ -328,9 +345,9 @@ export function updateFramesOfScenesAndComponents(
         case 'PIN_SIZE_CHANGE': {
           // Update scene with pin based frame.
           const sceneStaticpath = createSceneTemplatePath(target)
-          workingComponentsResult = transformJSXComponentAtPath(
-            workingComponentsResult,
+          workingEditorState = modifyUnderlyingForOpenFile(
             sceneStaticpath,
+            workingEditorState,
             (sceneElement) => {
               const sceneStyleUpdated = setJSXValuesAtPaths(sceneElement.props, [
                 {
@@ -362,9 +379,9 @@ export function updateFramesOfScenesAndComponents(
         }
         case 'PIN_MOVE_CHANGE': {
           const sceneStaticpath = createSceneTemplatePath(target)
-          workingComponentsResult = transformJSXComponentAtPath(
-            workingComponentsResult,
+          workingEditorState = modifyUnderlyingForOpenFile(
             sceneStaticpath,
+            workingEditorState,
             (sceneElement) => {
               const styleProps = jsxSimpleAttributeToValue(
                 getJSXAttributeAtPath(sceneElement.props, PP.create(['style'])).attribute,
@@ -404,9 +421,9 @@ export function updateFramesOfScenesAndComponents(
         }
         case 'SINGLE_RESIZE':
           const sceneStaticpath = createSceneTemplatePath(target)
-          workingComponentsResult = transformJSXComponentAtPath(
-            workingComponentsResult,
+          workingEditorState = modifyUnderlyingForOpenFile(
             sceneStaticpath,
+            workingEditorState,
             (sceneElement) => {
               const styleProps = jsxSimpleAttributeToValue(
                 getJSXAttributeAtPath(sceneElement.props, PP.create(['style'])).attribute,
@@ -465,13 +482,23 @@ export function updateFramesOfScenesAndComponents(
         return
       }
 
-      const element = findJSXElementAtPath(staticTarget, workingComponentsResult)
+      const element = withUnderlyingTarget(
+        staticTarget,
+        workingEditorState,
+        null,
+        (success, underlyingElement) => underlyingElement,
+      )
       if (element == null) {
         throw new Error(`Unexpected result when looking for element: ${element}`)
       }
 
       const staticParentPath = TP.parentPath(staticTarget)
-      const parentElement = findJSXElementAtPath(staticParentPath, workingComponentsResult)
+      const parentElement = withUnderlyingTarget(
+        staticParentPath,
+        workingEditorState,
+        null,
+        (success, underlyingElement) => underlyingElement,
+      )
 
       const isFlexContainer =
         frameAndTarget.type !== 'PIN_FRAME_CHANGE' &&
@@ -494,10 +521,29 @@ export function updateFramesOfScenesAndComponents(
                 )}.`,
               )
             case 'FLEX_MOVE':
-              workingComponentsResult = reorderComponent(
-                workingComponentsResult,
+              workingEditorState = modifyUnderlyingForOpenFile(
                 originalTarget,
-                frameAndTarget.newIndex,
+                workingEditorState,
+                (elem) => elem,
+                (success, underlyingTarget) => {
+                  const components = getUtopiaJSXComponentsFromSuccess(success)
+                  if (underlyingTarget == null) {
+                    return success
+                  } else {
+                    const updatedComponents = reorderComponent(
+                      components,
+                      underlyingTarget,
+                      frameAndTarget.newIndex,
+                    )
+                    return {
+                      ...success,
+                      topLevelElements: applyUtopiaJSXComponentsChanges(
+                        success.topLevelElements,
+                        updatedComponents,
+                      ),
+                    }
+                  }
+                },
               )
               break
             case 'FLEX_RESIZE':
@@ -553,11 +599,14 @@ export function updateFramesOfScenesAndComponents(
       } else {
         let parentFrame: CanvasRectangle | null = null
         if (optionalParentFrame == null) {
-          const nonGroupParent = MetadataUtils.findNonGroupParent(metadata, originalTarget)
+          const nonGroupParent = MetadataUtils.findNonGroupParent(
+            workingEditorState.jsxMetadata,
+            originalTarget,
+          )
           parentFrame =
             nonGroupParent == null
               ? null
-              : MetadataUtils.getFrameInCanvasCoords(nonGroupParent, metadata)
+              : MetadataUtils.getFrameInCanvasCoords(nonGroupParent, workingEditorState.jsxMetadata)
         } else {
           parentFrame = optionalParentFrame
         }
@@ -574,7 +623,10 @@ export function updateFramesOfScenesAndComponents(
                 parentOffset,
                 frameAndTarget.frame,
               )
-              const currentLocalFrame = MetadataUtils.getFrame(target, metadata)
+              const currentLocalFrame = MetadataUtils.getFrame(
+                target,
+                workingEditorState.jsxMetadata,
+              )
               const currentFullFrame = optionalMap(Frame.getFullFrame, currentLocalFrame)
               const fullFrame = Frame.getFullFrame(newLocalFrame)
               const elementProps = element.props
@@ -751,10 +803,11 @@ export function updateFramesOfScenesAndComponents(
 
       if (propsToSet.length > 0) {
         const propsToNotDelete = [...propsToSet.map((p) => p.path), ...propsToSkip]
-        workingComponentsResult = transformJSXComponentAtPath(
-          workingComponentsResult,
-          staticTarget,
-          (e: JSXElement) => {
+
+        workingEditorState = modifyUnderlyingForOpenFile(
+          originalTarget,
+          workingEditorState,
+          (elem) => {
             // Remove the pinning and flex props first...
             const propsToMaybeRemove =
               frameAndTarget.type === 'PIN_MOVE_CHANGE'
@@ -774,7 +827,7 @@ export function updateFramesOfScenesAndComponents(
                 propsToRemove.push(propPath)
               }
             })
-            const layoutPropsRemoved = unsetJSXValuesAtPaths(e.props, propsToRemove)
+            const layoutPropsRemoved = unsetJSXValuesAtPaths(elem.props, propsToRemove)
             // ...Add in the updated properties.
 
             const layoutPropsAdded = flatMapEither(
@@ -783,10 +836,10 @@ export function updateFramesOfScenesAndComponents(
             )
 
             return foldEither(
-              (_) => e,
+              (_) => elem,
               (updatedProps) => {
                 return {
-                  ...e,
+                  ...elem,
                   props: updatedProps,
                 }
               },
@@ -797,16 +850,16 @@ export function updateFramesOfScenesAndComponents(
       }
 
       // Round the frame details.
-      workingComponentsResult = transformJSXComponentAtPath(
-        workingComponentsResult,
+      workingEditorState = modifyUnderlyingForOpenFile(
         staticTarget,
+        workingEditorState,
         roundJSXElementLayoutValues,
       )
       // TODO originalFrames is never being set, so we have a regression here, meaning keepChildrenGlobalCoords
       // doesn't work. Once that is fixed we can re-implement keeping the children in place
     }
   })
-  return workingComponentsResult
+  return workingEditorState
 }
 
 function updateFrameValueForProp(
@@ -1424,9 +1477,43 @@ export function getCursorFromDragState(editorState: EditorState): CSSCursor | nu
   }
 }
 
+function getTransientCanvasStateFromFrameChanges(
+  editorState: EditorState,
+  framesAndTargets: Array<PinOrFlexFrameChange>,
+  preventAnimations: boolean,
+  elementsToTarget: Array<TemplatePath>,
+): TransientCanvasState {
+  let workingEditorState: EditorState = editorState
+  let successByFilename: { [filename: string]: ParseSuccess } = {}
+
+  if (preventAnimations) {
+    // We don't want animations included in the transient state, except for the case where we're about to apply that to the final state
+    workingEditorState = preventAnimationsOnTargets(workingEditorState, elementsToTarget)
+  }
+  workingEditorState = updateFramesOfScenesAndComponents(workingEditorState, framesAndTargets, null)
+
+  for (const frameAndTarget of framesAndTargets) {
+    forUnderlyingTarget(
+      frameAndTarget.target,
+      workingEditorState,
+      (success, underlyingElement, underlyingTarget, underlyingFilePath) => {
+        successByFilename[underlyingFilePath] = success
+        return success
+      },
+    )
+  }
+
+  return transientCanvasState(
+    editorState.selectedViews,
+    editorState.highlightedViews,
+    mapValues((success) => {
+      return transientFileState(success.topLevelElements, success.imports)
+    }, successByFilename),
+  )
+}
+
 export function produceResizeCanvasTransientState(
   editorState: EditorState,
-  parseSuccess: ParseSuccess,
   dragState: ResizeDragState,
   preventAnimations: boolean,
 ): TransientCanvasState {
@@ -1451,69 +1538,54 @@ export function produceResizeCanvasTransientState(
     return transientCanvasState(dragState.draggedElements, editorState.highlightedViews, null)
   } else {
     Utils.fastForEach(elementsToTarget, (target) => {
-      const originalFrame = getOriginalFrameInCanvasCoords(dragState.originalFrames, target)
-      if (originalFrame != null) {
-        const newTargetFrame = Utils.transformFrameUsingBoundingBox(
-          newSize,
-          boundingBox,
-          originalFrame,
-        )
-        const roundedFrame = {
-          x: Math.floor(newTargetFrame.x),
-          y: Math.floor(newTargetFrame.y),
-          width: Math.ceil(newTargetFrame.width),
-          height: Math.ceil(newTargetFrame.height),
-        } as CanvasRectangle
-        const isFlexContainer = MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
-          target,
-          editorState.jsxMetadata,
-        )
-        if (isFlexContainer) {
-          framesAndTargets.push(flexResizeChange(target, roundedFrame, dragState.edgePosition))
-        } else {
-          framesAndTargets.push(pinFrameChange(target, roundedFrame, dragState.edgePosition))
-        }
-      }
+      forUnderlyingTarget(
+        target,
+        editorState,
+        (success, element, underlyingTarget, underlyingFilePath) => {
+          const originalFrame = getOriginalFrameInCanvasCoords(dragState.originalFrames, target)
+          if (originalFrame != null) {
+            const newTargetFrame = Utils.transformFrameUsingBoundingBox(
+              newSize,
+              boundingBox,
+              originalFrame,
+            )
+            const roundedFrame = {
+              x: Math.floor(newTargetFrame.x),
+              y: Math.floor(newTargetFrame.y),
+              width: Math.ceil(newTargetFrame.width),
+              height: Math.ceil(newTargetFrame.height),
+            } as CanvasRectangle
+            const isFlexContainer = MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
+              target,
+              editorState.jsxMetadata,
+            )
+
+            let change: PinOrFlexFrameChange
+            if (isFlexContainer) {
+              framesAndTargets.push(
+                flexResizeChange(underlyingTarget, roundedFrame, dragState.edgePosition),
+              )
+            } else {
+              framesAndTargets.push(
+                pinFrameChange(underlyingTarget, roundedFrame, dragState.edgePosition),
+              )
+            }
+          }
+        },
+      )
     })
 
-    // We don't want animations included in the transient state, except for the case where we're about to apply that to the final state
-    const untouchedOpenComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
-    const openComponents = preventAnimations
-      ? preventAnimationsOnTargets(untouchedOpenComponents, elementsToTarget)
-      : untouchedOpenComponents
-
-    const componentsIncludingFakeUtopiaScene = openComponents
-
-    const updatedScenesAndComponents = updateFramesOfScenesAndComponents(
-      componentsIncludingFakeUtopiaScene,
-      editorState.jsxMetadata,
+    return getTransientCanvasStateFromFrameChanges(
+      editorState,
       framesAndTargets,
-      null,
-    )
-
-    // Sync these back up.
-    const topLevelElementsIncludingScenes = applyUtopiaJSXComponentsChanges(
-      parseSuccess.topLevelElements,
-      updatedScenesAndComponents,
-    )
-
-    return transientCanvasState(
-      editorState.selectedViews,
-      editorState.highlightedViews,
-      // FIXME: Should handle multiple file edit situations.
-      {
-        [forceNotNull(
-          'Should be an open file',
-          getOpenUIJSFileKey(editorState),
-        )]: transientFileState(topLevelElementsIncludingScenes, parseSuccess.imports),
-      },
+      preventAnimations,
+      elementsToTarget,
     )
   }
 }
 
 export function produceResizeSingleSelectCanvasTransientState(
   editorState: EditorState,
-  parseSuccess: ParseSuccess,
   dragState: ResizeDragState,
   preventAnimations: boolean,
 ): TransientCanvasState {
@@ -1533,62 +1605,49 @@ export function produceResizeSingleSelectCanvasTransientState(
   let globalFrame = getOriginalFrameInCanvasCoords(dragState.originalFrames, elementToTarget)
   const originalFrame = getOriginalFrameInCanvasCoords(dragState.originalFrames, elementToTarget)
   if (originalFrame != null && globalFrame != null) {
-    const newTargetFrame = Utils.transformFrameUsingBoundingBox(newSize, globalFrame, originalFrame)
-    const roundedFrame = {
-      x: Math.floor(newTargetFrame.x),
-      y: Math.floor(newTargetFrame.y),
-      width: Math.ceil(newTargetFrame.width),
-      height: Math.ceil(newTargetFrame.height),
-    } as CanvasRectangle
-    const isFlexContainer = MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
+    const nonNullGlobalFrame = globalFrame
+    forUnderlyingTarget(
       elementToTarget,
-      editorState.jsxMetadata,
+      editorState,
+      (success, element, underlyingTarget, underlyingFilePath) => {
+        const newTargetFrame = Utils.transformFrameUsingBoundingBox(
+          newSize,
+          nonNullGlobalFrame,
+          originalFrame,
+        )
+        const roundedFrame = {
+          x: Math.floor(newTargetFrame.x),
+          y: Math.floor(newTargetFrame.y),
+          width: Math.ceil(newTargetFrame.width),
+          height: Math.ceil(newTargetFrame.height),
+        } as CanvasRectangle
+        const isFlexContainer = MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
+          elementToTarget,
+          editorState.jsxMetadata,
+        )
+        if (isFlexContainer) {
+          framesAndTargets.push(
+            flexResizeChange(elementToTarget, roundedFrame, dragState.edgePosition),
+          )
+        } else {
+          const edgePosition = dragState.centerBasedResize
+            ? ({ x: 0.5, y: 0.5 } as EdgePosition)
+            : dragState.edgePosition
+          const sizeChange = {
+            x: roundedFrame.width - originalFrame.width,
+            y: roundedFrame.height - originalFrame.height,
+          } as CanvasVector
+          framesAndTargets.push(singleResizeChange(elementToTarget, edgePosition, sizeChange))
+        }
+      },
     )
-    if (isFlexContainer) {
-      framesAndTargets.push(flexResizeChange(elementToTarget, roundedFrame, dragState.edgePosition))
-    } else {
-      const edgePosition = dragState.centerBasedResize
-        ? ({ x: 0.5, y: 0.5 } as EdgePosition)
-        : dragState.edgePosition
-      const sizeChange = {
-        x: roundedFrame.width - originalFrame.width,
-        y: roundedFrame.height - originalFrame.height,
-      } as CanvasVector
-      framesAndTargets.push(singleResizeChange(elementToTarget, edgePosition, sizeChange))
-    }
   }
 
-  // We don't want animations included in the transient state, except for the case where we're about to apply that to the final state
-  const untouchedOpenComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
-  const openComponents = preventAnimations
-    ? preventAnimationsOnTargets(untouchedOpenComponents, elementsToTarget)
-    : untouchedOpenComponents
-
-  const componentsIncludingFakeUtopiaScene = openComponents
-
-  const updatedScenesAndComponents = updateFramesOfScenesAndComponents(
-    componentsIncludingFakeUtopiaScene,
-    editorState.jsxMetadata,
+  return getTransientCanvasStateFromFrameChanges(
+    editorState,
     framesAndTargets,
-    null,
-  )
-
-  // Sync these back up.
-  const topLevelElementsIncludingScenes = applyUtopiaJSXComponentsChanges(
-    parseSuccess.topLevelElements,
-    updatedScenesAndComponents,
-  )
-
-  return transientCanvasState(
-    editorState.selectedViews,
-    editorState.highlightedViews,
-    // FIXME: Should handle multiple file edit situations.
-    {
-      [forceNotNull('Should be an open file', getOpenUIJSFileKey(editorState))]: transientFileState(
-        topLevelElementsIncludingScenes,
-        parseSuccess.imports,
-      ),
-    },
+    preventAnimations,
+    elementsToTarget,
   )
 }
 
@@ -1655,45 +1714,35 @@ export function produceCanvasTransientState(
           editorState.canvas.dragState.drag != null
         ) {
           const dragState = editorState.canvas.dragState
-          const openUIFile = getOpenUIJSFile(editorState)
-          if (openUIFile != null) {
-            const parsed = openUIFile.fileContents.parsed
-            if (isParseSuccess(parsed)) {
-              const parseSuccess: ParseSuccess = parsed
-              switch (dragState.type) {
-                case 'MOVE_DRAG_STATE':
-                  transientState = produceMoveTransientCanvasState(
-                    previousCanvasTransientSelectedViews,
-                    editorState,
-                    dragState,
-                    parseSuccess,
-                    preventAnimations,
-                  )
-                  break
-                case 'RESIZE_DRAG_STATE':
-                  if (dragState.isMultiSelect) {
-                    transientState = produceResizeCanvasTransientState(
-                      editorState,
-                      parseSuccess,
-                      dragState,
-                      preventAnimations,
-                    )
-                  } else {
-                    transientState = produceResizeSingleSelectCanvasTransientState(
-                      editorState,
-                      parseSuccess,
-                      dragState,
-                      preventAnimations,
-                    )
-                  }
-                  break
-                case 'INSERT_DRAG_STATE':
-                  throw new Error(`Unable to use insert drag state in select mode.`)
-                default:
-                  const _exhaustiveCheck: never = dragState
-                  throw new Error(`Unhandled drag state type ${JSON.stringify(dragState)}`)
+          switch (dragState.type) {
+            case 'MOVE_DRAG_STATE':
+              transientState = produceMoveTransientCanvasState(
+                previousCanvasTransientSelectedViews,
+                editorState,
+                dragState,
+                preventAnimations,
+              )
+              break
+            case 'RESIZE_DRAG_STATE':
+              if (dragState.isMultiSelect) {
+                transientState = produceResizeCanvasTransientState(
+                  editorState,
+                  dragState,
+                  preventAnimations,
+                )
+              } else {
+                transientState = produceResizeSingleSelectCanvasTransientState(
+                  editorState,
+                  dragState,
+                  preventAnimations,
+                )
               }
-            }
+              break
+            case 'INSERT_DRAG_STATE':
+              throw new Error(`Unable to use insert drag state in select mode.`)
+            default:
+              const _exhaustiveCheck: never = dragState
+              throw new Error(`Unhandled drag state type ${JSON.stringify(dragState)}`)
           }
         }
         break
@@ -1838,11 +1887,8 @@ export function getReparentTarget(
 }
 
 export interface MoveTemplateResult {
-  utopiaComponentsIncludingScenes: Array<UtopiaJSXComponent>
+  updatedEditorState: EditorState
   newPath: TemplatePath | null
-  metadata: ElementInstanceMetadataMap
-  selectedViews: Array<TemplatePath>
-  highlightedViews: Array<TemplatePath>
 }
 
 export function getFrameChange(
@@ -1864,7 +1910,7 @@ export function moveTemplate(
   indexPosition: IndexPosition,
   newParentPath: TemplatePath | null,
   parentFrame: CanvasRectangle | null,
-  utopiaComponentsIncludingScenes: Array<UtopiaJSXComponent>,
+  editorState: EditorState,
   componentMetadata: ElementInstanceMetadataMap,
   selectedViews: Array<TemplatePath>,
   highlightedViews: Array<TemplatePath>,
@@ -1872,11 +1918,8 @@ export function moveTemplate(
 ): MoveTemplateResult {
   function noChanges(): MoveTemplateResult {
     return {
-      utopiaComponentsIncludingScenes: utopiaComponentsIncludingScenes,
+      updatedEditorState: editorState,
       newPath: target,
-      metadata: componentMetadata,
-      selectedViews: selectedViews,
-      highlightedViews: highlightedViews,
     }
   }
   if (TP.isScenePath(target)) {
@@ -1884,28 +1927,27 @@ export function moveTemplate(
     if (newFrame === SkipFrameChange || newFrame == null) {
       return noChanges()
     } else {
-      const updatedComponentsIncludingScenes = transformJSXComponentAtPath(
-        utopiaComponentsIncludingScenes,
+      const updatedEditorState = modifyUnderlyingForOpenFile(
         createSceneTemplatePath(target),
-        (sceneElement): JSXElement => {
+        editorState,
+        (element, underlyingTarget, underlyingFilePath) => {
           const updatedPropsResult = setJSXValueAtPath(
-            sceneElement.props,
+            element.props,
             PathForSceneStyle,
             jsxAttributeValue(canvasFrameToNormalisedFrame(newFrame), emptyComments),
           )
           return foldEither(
-            () => sceneElement,
-            (updatedProps) => ({ ...sceneElement, props: updatedProps }),
+            () => element,
+            (updatedProps) => {
+              return { ...element, props: updatedProps }
+            },
             updatedPropsResult,
           )
         },
       )
       return {
-        utopiaComponentsIncludingScenes: updatedComponentsIncludingScenes,
+        updatedEditorState: updatedEditorState,
         newPath: target,
-        metadata: componentMetadata,
-        selectedViews: selectedViews,
-        highlightedViews: highlightedViews,
       }
     }
   } else {
@@ -1918,165 +1960,224 @@ export function moveTemplate(
       // TODO Scene Implementation
       return noChanges()
     } else {
-      const {
-        components: withLayoutUpdatedForNewContext,
-        componentMetadata: withMetadataUpdatedForNewContext,
-        didSwitch,
-      } = maybeSwitchLayoutProps(
+      return withUnderlyingTarget(
         target,
-        originalPath,
-        newParentPath,
-        componentMetadata,
-        componentMetadata,
-        utopiaComponentsIncludingScenes,
-        utopiaComponentsIncludingScenes,
-        parentFrame,
-        newParentLayoutSystem,
-      )
-
-      const jsxElement = findElementAtPath(target, withLayoutUpdatedForNewContext)
-      if (jsxElement == null) {
-        return noChanges()
-      } else {
-        let updatedUtopiaComponents: Array<UtopiaJSXComponent> = utopiaComponentsIncludingScenes
-        let newPath: TemplatePath | null = null
-        let updatedComponentMetadata: ElementInstanceMetadataMap = withMetadataUpdatedForNewContext
-
-        flexContextChanged = flexContextChanged || didSwitch
-
-        const withTargetRemoved: Array<UtopiaJSXComponent> = removeElementAtPath(
-          target,
-          withLayoutUpdatedForNewContext,
-        )
-
-        updatedUtopiaComponents = insertElementAtPath(
-          newParentPath,
-          jsxElement,
-          withTargetRemoved,
-          indexPosition,
-        )
-        if (newParentPath == null) {
-          newIndex = updatedUtopiaComponents.findIndex(
-            (exported) => exported.rootElement === jsxElement,
-          )
-          if (newIndex === -1) {
-            throw new Error('Invalid root element index.')
-          }
-        } else {
-          const parent = findElementAtPath(newParentPath, updatedUtopiaComponents)
-          if (parent == null || !isJSXElement(parent)) {
-            throw new Error(`Couldn't find parent ${JSON.stringify(newParentPath)}`)
-          } else {
-            newIndex = parent.children.indexOf(jsxElement)
-            if (newIndex === -1) {
-              throw new Error('Invalid child element index.')
-            }
-          }
-        }
-
-        newPath = TP.appendToPath(newParentPath, targetID)
-        newInstancePath = newPath
-
-        // Need to make these changes ahead of updating the frame.
-        const elementMetadata = MetadataUtils.getElementByInstancePathMaybe(
-          updatedComponentMetadata,
-          target,
-        )
-
-        if (elementMetadata != null) {
-          updatedComponentMetadata = MetadataUtils.removeElementMetadataChild(
-            target,
-            updatedComponentMetadata,
-          )
-
-          updatedComponentMetadata = MetadataUtils.insertElementMetadataChild(
-            newParentPath,
-            elementMetadata,
-            updatedComponentMetadata,
-            indexPosition,
-          )
-
-          updatedComponentMetadata = MetadataUtils.transformAllPathsInMetadata(
-            updatedComponentMetadata,
-            target,
-            newInstancePath,
-          )
-        }
-
-        if (
-          newFrame !== SkipFrameChange &&
-          newFrame != null &&
-          newInstancePath != null &&
-          !flexContextChanged
-        ) {
-          const isParentFlex = MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
+        editorState,
+        noChanges(),
+        (underlyingElementSuccess, underlyingElement, underlyingTarget, underlyingFilePath) => {
+          return withUnderlyingTarget(
             originalPath,
-            componentMetadata,
+            editorState,
+            noChanges(),
+            (
+              originalPathSuccess,
+              underlyingOriginalElement,
+              underlyingOriginalPath,
+              underlyingOriginalFilePath,
+            ) => {
+              return withUnderlyingTarget(
+                newParentPath,
+                editorState,
+                noChanges(),
+                (
+                  newParentSuccess,
+                  underlyingNewParentElement,
+                  underlyingNewParentPath,
+                  underlyingNewParentFilePath,
+                ) => {
+                  const utopiaComponentsIncludingScenes = getUtopiaJSXComponentsFromSuccess(
+                    newParentSuccess,
+                  )
+                  const {
+                    components: withLayoutUpdatedForNewContext,
+                    componentMetadata: withMetadataUpdatedForNewContext,
+                    didSwitch,
+                  } = maybeSwitchLayoutProps(
+                    target,
+                    originalPath,
+                    newParentPath,
+                    componentMetadata,
+                    componentMetadata,
+                    utopiaComponentsIncludingScenes,
+                    parentFrame,
+                    newParentLayoutSystem,
+                  )
+                  const updatedUnderlyingElement = findElementAtPath(
+                    underlyingTarget,
+                    withLayoutUpdatedForNewContext,
+                  )
+                  if (updatedUnderlyingElement == null) {
+                    return noChanges()
+                  } else {
+                    let workingEditorState: EditorState = editorState
+
+                    let updatedUtopiaComponents: Array<UtopiaJSXComponent> = withLayoutUpdatedForNewContext
+                    let newPath: TemplatePath | null = null
+
+                    flexContextChanged = flexContextChanged || didSwitch
+
+                    // Remove and then insert again at the new location.
+                    workingEditorState = modifyParseSuccessAtPath(
+                      underlyingNewParentFilePath,
+                      workingEditorState,
+                      (workingSuccess) => {
+                        updatedUtopiaComponents = removeElementAtPath(
+                          underlyingTarget,
+                          updatedUtopiaComponents,
+                        )
+
+                        updatedUtopiaComponents = insertElementAtPath(
+                          underlyingNewParentPath,
+                          updatedUnderlyingElement,
+                          updatedUtopiaComponents,
+                          indexPosition,
+                        )
+
+                        return {
+                          ...workingSuccess,
+                          topLevelElements: applyUtopiaJSXComponentsChanges(
+                            workingSuccess.topLevelElements,
+                            updatedUtopiaComponents,
+                          ),
+                        }
+                      },
+                    )
+
+                    // Validate the result of the re-insertion.
+                    if (newParentPath == null) {
+                      newIndex = updatedUtopiaComponents.findIndex(
+                        (exported) => exported.rootElement === updatedUnderlyingElement,
+                      )
+                      if (newIndex === -1) {
+                        throw new Error('Invalid root element index.')
+                      }
+                    } else {
+                      // Can't rely on underlyingNewParentElement as that will now be out of date.
+                      const updatedUnderlyingNewParentElement = forceNotNull(
+                        'Element should exist',
+                        findJSXElementAtPath(underlyingNewParentPath, updatedUtopiaComponents),
+                      )
+                      newIndex = updatedUnderlyingNewParentElement.children.indexOf(
+                        updatedUnderlyingElement,
+                      )
+                      if (newIndex === -1) {
+                        throw new Error('Invalid child element index.')
+                      }
+                    }
+
+                    newPath = TP.appendToPath(newParentPath, targetID)
+                    newInstancePath = newPath
+
+                    let updatedComponentMetadata: ElementInstanceMetadataMap = withMetadataUpdatedForNewContext
+                    // Need to make these changes ahead of updating the frame.
+                    const elementMetadata = MetadataUtils.getElementByInstancePathMaybe(
+                      updatedComponentMetadata,
+                      target,
+                    )
+
+                    if (elementMetadata != null) {
+                      updatedComponentMetadata = MetadataUtils.removeElementMetadataChild(
+                        target,
+                        updatedComponentMetadata,
+                      )
+
+                      updatedComponentMetadata = MetadataUtils.insertElementMetadataChild(
+                        newParentPath,
+                        elementMetadata,
+                        updatedComponentMetadata,
+                        indexPosition,
+                      )
+
+                      updatedComponentMetadata = MetadataUtils.transformAllPathsInMetadata(
+                        updatedComponentMetadata,
+                        target,
+                        newInstancePath,
+                      )
+                    }
+                    workingEditorState.jsxMetadata = updatedComponentMetadata
+
+                    if (
+                      newFrame !== SkipFrameChange &&
+                      newFrame != null &&
+                      newInstancePath != null &&
+                      !flexContextChanged
+                    ) {
+                      const isParentFlex = MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
+                        originalPath,
+                        componentMetadata,
+                      )
+                      const frameChanges: Array<PinOrFlexFrameChange> = [
+                        getFrameChange(newInstancePath, newFrame, isParentFlex),
+                      ]
+
+                      workingEditorState = updateFramesOfScenesAndComponents(
+                        workingEditorState,
+                        frameChanges,
+                        parentFrame,
+                      )
+                    }
+
+                    const newSelectedViews = selectedViews.map((v) => {
+                      if (TP.pathsEqual(v, target)) {
+                        return newInstancePath
+                      } else {
+                        return v
+                      }
+                    })
+
+                    const newHighlightedViews =
+                      newParentPath == null
+                        ? highlightedViews.map((t) =>
+                            TP.pathsEqual(t, target) ? newInstancePath : t,
+                          )
+                        : [newParentPath]
+
+                    const updatedEditorState: EditorState = {
+                      ...workingEditorState,
+                      selectedViews: filterMultiSelectScenes(Utils.stripNulls(newSelectedViews)),
+                      highlightedViews: Utils.stripNulls(newHighlightedViews),
+                    }
+
+                    return {
+                      updatedEditorState: updatedEditorState,
+                      newPath: newInstancePath,
+                    }
+                  }
+                },
+              )
+            },
           )
-          const frameChanges: Array<PinOrFlexFrameChange> = [
-            getFrameChange(newInstancePath, newFrame, isParentFlex),
-          ]
-
-          const frameChangeResult = updateFramesOfScenesAndComponents(
-            updatedUtopiaComponents,
-            updatedComponentMetadata,
-            frameChanges,
-            parentFrame,
-          )
-
-          updatedUtopiaComponents = frameChangeResult
-        }
-
-        const newSelectedViews = selectedViews.map((v) => {
-          if (TP.pathsEqual(v, target)) {
-            return newInstancePath
-          } else {
-            return v
-          }
-        })
-
-        const newHighlightedViews =
-          newParentPath == null
-            ? highlightedViews.map((t) => (TP.pathsEqual(t, target) ? newInstancePath : t))
-            : [newParentPath]
-
-        return {
-          utopiaComponentsIncludingScenes: updatedUtopiaComponents,
-          newPath: newInstancePath,
-          metadata: updatedComponentMetadata,
-          selectedViews: filterMultiSelectScenes(Utils.stripNulls(newSelectedViews)),
-          highlightedViews: Utils.stripNulls(newHighlightedViews),
-        }
-      }
+        },
+      )
     }
   }
 }
 
 function preventAnimationsOnTargets(
-  components: UtopiaJSXComponent[],
+  editorState: EditorState,
   targets: TemplatePath[],
-): UtopiaJSXComponent[] {
-  let workingComponentsResult = [...components]
+): EditorState {
+  let workingEditorState = editorState
   Utils.fastForEach(targets, (target) => {
     const staticPath = TP.isScenePath(target)
       ? createSceneTemplatePath(target)
       : MetadataUtils.dynamicPathToStaticPath(target)
     if (staticPath != null) {
-      workingComponentsResult = transformJSXComponentAtPath(
-        workingComponentsResult,
+      workingEditorState = modifyUnderlyingForOpenFile(
         staticPath,
-        (element) => {
-          const styleUpdated = setJSXValuesAtPaths(element.props, [
+        editorState,
+        (underlyingElement) => {
+          const styleUpdated = setJSXValuesAtPaths(underlyingElement.props, [
             {
               path: PP.create(['style', 'transition']),
               value: jsxAttributeValue('none', emptyComments),
             },
           ])
           return foldEither(
-            () => element,
+            () => underlyingElement,
             (updatedProps) => {
               return {
-                ...element,
+                ...underlyingElement,
                 props: updatedProps,
               }
             },
@@ -2086,44 +2187,41 @@ function preventAnimationsOnTargets(
       )
     }
   })
-  return workingComponentsResult
+  return workingEditorState
 }
 
 function produceMoveTransientCanvasState(
   previousCanvasTransientSelectedViews: Array<TemplatePath>,
   editorState: EditorState,
   dragState: MoveDragState,
-  parseSuccess: ParseSuccess,
   preventAnimations: boolean,
 ): TransientCanvasState {
   let selectedViews: Array<TemplatePath> = dragState.draggedElements
-  let metadata: ElementInstanceMetadataMap = editorState.jsxMetadata
   let originalFrames: Array<CanvasFrameAndTarget> = dragState.originalFrames
-  let highlightedViews: Array<TemplatePath> = editorState.highlightedViews
 
-  const elementsToTarget = determineElementsToOperateOnForDragging(
+  let elementsToTarget = determineElementsToOperateOnForDragging(
     selectedViews,
-    metadata,
+    editorState.jsxMetadata,
     true,
     false,
   )
 
-  // We don't want animations included in the transient state, except for the case where we're about to apply that to the final state
-  const untouchedOpenComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
-  let utopiaComponentsIncludingScenes = preventAnimations
-    ? preventAnimationsOnTargets(untouchedOpenComponents, elementsToTarget)
-    : untouchedOpenComponents
+  let workingEditorState: EditorState = editorState
+  if (preventAnimations) {
+    // We don't want animations included in the transient state, except for the case where we're about to apply that to the final state
+    workingEditorState = preventAnimationsOnTargets(workingEditorState, elementsToTarget)
+  }
 
   if (dragState.reparent) {
     const reparentTarget = getReparentTarget(
       previousCanvasTransientSelectedViews,
-      editorState,
+      workingEditorState,
       elementsToTarget,
       dragState.canvasPosition,
     )
 
     if (reparentTarget.shouldReparent) {
-      Utils.fastForEach(elementsToTarget, (target) => {
+      elementsToTarget = elementsToTarget.map((target) => {
         const frame = originalFrames.find((originalFrameAndTarget) => {
           return TP.pathsEqual(originalFrameAndTarget.target, target)
         })?.frame
@@ -2134,16 +2232,13 @@ function produceMoveTransientCanvasState(
           { type: 'front' },
           reparentTarget.newParent,
           null,
-          utopiaComponentsIncludingScenes,
-          metadata,
+          workingEditorState,
+          workingEditorState.jsxMetadata,
           selectedViews,
-          highlightedViews,
+          workingEditorState.highlightedViews,
           null,
         )
-        highlightedViews = reparentResult.highlightedViews
-        selectedViews = reparentResult.selectedViews
-        metadata = reparentResult.metadata
-        utopiaComponentsIncludingScenes = reparentResult.utopiaComponentsIncludingScenes
+        selectedViews = reparentResult.updatedEditorState.selectedViews
         // As it has moved, we need to synchronise the paths.
         originalFrames = originalFrames.map((originalFrame) => {
           if (reparentResult.newPath != null && TP.pathsEqual(originalFrame.target, target)) {
@@ -2155,24 +2250,29 @@ function produceMoveTransientCanvasState(
             return originalFrame
           }
         })
+
+        workingEditorState = reparentResult.updatedEditorState
+        return reparentResult.newPath ?? target
       })
     }
   } else if (dragState.duplicate) {
     const parentTarget = MetadataUtils.getDuplicationParentTargets(selectedViews)
-    const duplicateResult = duplicate(elementsToTarget, parentTarget, editorState)
+    const duplicateResult = duplicate(elementsToTarget, parentTarget, workingEditorState)
     if (duplicateResult != null) {
-      utopiaComponentsIncludingScenes = duplicateResult.utopiaComponents
-      selectedViews = duplicateResult.selectedViews
-      metadata = duplicateResult.metadata
+      workingEditorState = duplicateResult.updatedEditorState
+      selectedViews = duplicateResult.updatedEditorState.selectedViews
       if (duplicateResult.originalFrames != null) {
         originalFrames = duplicateResult.originalFrames
       }
     }
   }
 
-  const moveGuidelines = collectParentAndSiblingGuidelines(metadata, selectedViews)
+  const moveGuidelines = collectParentAndSiblingGuidelines(
+    workingEditorState.jsxMetadata,
+    selectedViews,
+  )
   const framesAndTargets = dragComponent(
-    metadata,
+    workingEditorState.jsxMetadata,
     selectedViews,
     originalFrames,
     moveGuidelines,
@@ -2181,33 +2281,29 @@ function produceMoveTransientCanvasState(
     Utils.defaultIfNull(Utils.zeroPoint as CanvasPoint, dragState.drag),
     dragState.enableSnapping,
     dragState.constrainDragAxis,
-    editorState.canvas.scale,
+    workingEditorState.canvas.scale,
   )
 
-  const componentsIncludingFakeUtopiaScene = utopiaComponentsIncludingScenes
+  workingEditorState = updateFramesOfScenesAndComponents(workingEditorState, framesAndTargets, null)
 
-  const updatedScenesAndComponents = updateFramesOfScenesAndComponents(
-    componentsIncludingFakeUtopiaScene,
-    metadata,
-    framesAndTargets,
-    null,
-  )
-
-  // Sync these back up.
-  const topLevelElementsIncludingScenes = applyUtopiaJSXComponentsChanges(
-    parseSuccess.topLevelElements,
-    updatedScenesAndComponents,
-  )
+  let transientFilesState: TransientFilesState = {}
+  for (const elementToTarget of elementsToTarget) {
+    forUnderlyingTarget(
+      elementToTarget,
+      workingEditorState,
+      (success, underlyingElement, underlyingTarget, underlyingFilePath) => {
+        transientFilesState[underlyingFilePath] = {
+          topLevelElementsIncludingScenes: success.topLevelElements,
+          imports: success.imports,
+        }
+        return success
+      },
+    )
+  }
   return transientCanvasState(
     selectedViews,
-    highlightedViews,
-    // FIXME: Should handle multiple file edit situations.
-    {
-      [forceNotNull('Should be an open file', getOpenUIJSFileKey(editorState))]: transientFileState(
-        topLevelElementsIncludingScenes,
-        parseSuccess.imports,
-      ),
-    },
+    workingEditorState.highlightedViews,
+    transientFilesState,
   )
 }
 
@@ -2326,9 +2422,7 @@ export function focusPointForZoom(
 }
 
 export interface DuplicateResult {
-  utopiaComponents: Array<UtopiaJSXComponent>
-  selectedViews: Array<TemplatePath>
-  metadata: ElementInstanceMetadataMap
+  updatedEditorState: EditorState
   originalFrames: Array<CanvasFrameAndTarget> | null
 }
 
@@ -2337,140 +2431,154 @@ export function duplicate(
   newParentPath: TemplatePath | null,
   editor: EditorState,
 ): DuplicateResult | null {
-  const uiFile = getOpenUIJSFile(editor)
-  if (uiFile == null) {
-    return null
-  } else {
-    return foldParsedTextFile(
-      (_) => null,
-      (parseSuccess) => {
-        let metadata = editor.jsxMetadata
-        let utopiaComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
-        let duplicateNewUIDs: Array<DuplicateNewUID> = []
-        let newOriginalFrames: Array<CanvasFrameAndTarget> | null = null
-        if (
-          editor.canvas.dragState != null &&
-          editor.canvas.dragState.type === 'MOVE_DRAG_STATE' &&
-          editor.canvas.dragState.duplicateNewUIDs != null
-        ) {
-          duplicateNewUIDs = editor.canvas.dragState.duplicateNewUIDs
-          newOriginalFrames = editor.canvas.dragState.originalFrames
+  let duplicateNewUIDs: Array<DuplicateNewUID> = []
+  let newOriginalFrames: Array<CanvasFrameAndTarget> | null = null
+  if (
+    editor.canvas.dragState != null &&
+    editor.canvas.dragState.type === 'MOVE_DRAG_STATE' &&
+    editor.canvas.dragState.duplicateNewUIDs != null
+  ) {
+    duplicateNewUIDs = editor.canvas.dragState.duplicateNewUIDs
+    newOriginalFrames = editor.canvas.dragState.originalFrames
+  }
+
+  let newSelectedViews: Array<TemplatePath> = []
+  let workingEditorState: EditorState = editor
+  for (const path of paths) {
+    let metadataUpdate: (metadata: ElementInstanceMetadataMap) => ElementInstanceMetadataMap = (
+      metadata,
+    ) => metadata
+    workingEditorState = modifyUnderlyingForOpenFile(
+      path,
+      workingEditorState,
+      (elem) => elem,
+      (success, underlyingInstancePath, underlyingFilePath) => {
+        let utopiaComponents = getUtopiaJSXComponentsFromSuccess(success)
+        let newElement: JSXElementChild | null = null
+        let jsxElement: JSXElementChild | null = null
+        if (TP.isScenePath(path)) {
+          const scenepath = createSceneTemplatePath(path)
+          jsxElement = findJSXElementChildAtPath(utopiaComponents, scenepath)
+        } else {
+          jsxElement = findElementAtPath(underlyingInstancePath, utopiaComponents)
         }
-        let newSelectedViews: Array<TemplatePath> = []
-        for (const path of paths) {
-          let newElement: JSXElementChild | null = null
-          let jsxElement: JSXElementChild | null = null
-          if (TP.isScenePath(path)) {
-            const scenepath = createSceneTemplatePath(path)
-            jsxElement = findJSXElementChildAtPath(utopiaComponents, scenepath)
+        let uid: string
+        if (jsxElement == null) {
+          console.warn(`Could not find element ${TP.toVarSafeComponentId(path)}`)
+          return success
+        } else {
+          const duplicateNewUID: DuplicateNewUID | undefined = duplicateNewUIDs.find((entry) =>
+            TP.pathsEqual(entry.originalPath, path),
+          )
+          const existingIDs = getAllUniqueUids(utopiaComponents)
+          if (duplicateNewUID === undefined) {
+            newElement = guaranteeUniqueUids([jsxElement], existingIDs)[0]
+            uid = getUtopiaID(newElement)
           } else {
-            jsxElement = findElementAtPath(path, utopiaComponents)
+            // Helps to keep the model consistent because otherwise the dom walker
+            // goes into a frenzy.
+            newElement = setUtopiaID(jsxElement, duplicateNewUID.newUID)
+            if (isJSXElement(newElement)) {
+              newElement = {
+                ...newElement,
+                children: guaranteeUniqueUids(newElement.children, [
+                  ...existingIDs,
+                  duplicateNewUID.newUID,
+                ]),
+              }
+            }
+            uid = duplicateNewUID.newUID
           }
-          let uid: string
-          if (jsxElement == null) {
-            console.warn(`Could not find element ${TP.toVarSafeComponentId(path)}`)
-            return null
-          } else {
-            const duplicateNewUID: DuplicateNewUID | undefined = duplicateNewUIDs.find((entry) =>
-              TP.pathsEqual(entry.originalPath, path),
+          let newPath: TemplatePath
+          if (newParentPath == null) {
+            const storyboardUID = Utils.forceNotNull(
+              'Could not find storyboard element',
+              getStoryboardUID(utopiaComponents),
             )
-            const existingIDs = getAllUniqueUids(utopiaComponents)
-            if (duplicateNewUID === undefined) {
-              newElement = guaranteeUniqueUids([jsxElement], existingIDs)[0]
-              uid = getUtopiaID(newElement)
-            } else {
-              // Helps to keep the model consistent because otherwise the dom walker
-              // goes into a frenzy.
-              newElement = setUtopiaID(jsxElement, duplicateNewUID.newUID)
-              if (isJSXElement(newElement)) {
-                newElement = {
-                  ...newElement,
-                  children: guaranteeUniqueUids(newElement.children, [
-                    ...existingIDs,
-                    duplicateNewUID.newUID,
-                  ]),
+            newPath = TP.scenePath([[storyboardUID, uid]])
+          } else {
+            newPath = TP.appendToPath(newParentPath, uid)
+          }
+          // Update the original frames to be the duplicate ones.
+          if (newOriginalFrames != null && newPath != null) {
+            newOriginalFrames = newOriginalFrames.map((originalFrame) => {
+              if (TP.pathsEqual(originalFrame.target, path)) {
+                return {
+                  frame: originalFrame.frame,
+                  target: newPath as TemplatePath,
                 }
+              } else {
+                return originalFrame
               }
-              uid = duplicateNewUID.newUID
-            }
-            let newPath: TemplatePath
-            if (newParentPath == null) {
-              const storyboardUID = Utils.forceNotNull(
-                'Could not find storyboard element',
-                getStoryboardUID(utopiaComponents),
-              )
-              newPath = TP.scenePath([[storyboardUID, uid]])
-            } else {
-              newPath = TP.appendToPath(newParentPath, uid)
-            }
-            // Update the original frames to be the duplicate ones.
-            if (newOriginalFrames != null && newPath != null) {
-              newOriginalFrames = newOriginalFrames.map((originalFrame) => {
-                if (TP.pathsEqual(originalFrame.target, path)) {
-                  return {
-                    frame: originalFrame.frame,
-                    target: newPath as TemplatePath,
-                  }
-                } else {
-                  return originalFrame
-                }
-              })
-            }
-            if (TP.isScenePath(path) && isJSXElement(jsxElement)) {
-              const numberOfScenes = getNumberOfScenes(editor)
-              const newSceneLabel = `Scene ${numberOfScenes}`
-              let props = setJSXAttributesAttribute(
-                jsxElement.props,
-                'data-label',
-                jsxAttributeValue(newSceneLabel, emptyComments),
-              )
-              props = setJSXAttributesAttribute(
-                props,
-                'data-uid',
-                jsxAttributeValue(getUtopiaID(newElement), emptyComments),
-              )
+            })
+          }
+          if (TP.isScenePath(path) && isJSXElement(jsxElement)) {
+            const numberOfScenes = getNumberOfScenes(editor)
+            const newSceneLabel = `Scene ${numberOfScenes}`
+            let props = setJSXAttributesAttribute(
+              jsxElement.props,
+              'data-label',
+              jsxAttributeValue(newSceneLabel, emptyComments),
+            )
+            props = setJSXAttributesAttribute(
+              props,
+              'data-uid',
+              jsxAttributeValue(getUtopiaID(newElement), emptyComments),
+            )
 
-              const newSceneElement = {
-                ...jsxElement,
-                props: props,
-              }
-              utopiaComponents = addSceneToJSXComponents(utopiaComponents, newSceneElement)
-            } else {
-              utopiaComponents = insertElementAtPath(
-                newParentPath,
-                newElement,
-                utopiaComponents,
-                null,
-              )
+            const newSceneElement = {
+              ...jsxElement,
+              props: props,
             }
+            utopiaComponents = addSceneToJSXComponents(utopiaComponents, newSceneElement)
+          } else {
+            utopiaComponents = insertElementAtPath(
+              newParentPath,
+              newElement,
+              utopiaComponents,
+              null,
+            )
+          }
 
-            if (newElement == null) {
-              console.warn(`Could not duplicate ${TP.toVarSafeComponentId(path)}`)
-              return null
-            } else {
-              newSelectedViews.push(newPath)
-              // duplicating and inserting the metadata to ensure we're not working with stale metadata
-              // this is used for drag + duplicate on the canvas
-              metadata = MetadataUtils.duplicateElementMetadataAtPath(
+          if (newElement == null) {
+            console.warn(`Could not duplicate ${TP.toVarSafeComponentId(path)}`)
+            return success
+          } else {
+            newSelectedViews.push(newPath)
+            // duplicating and inserting the metadata to ensure we're not working with stale metadata
+            // this is used for drag + duplicate on the canvas
+            const nonNullNewElement: JSXElementChild = newElement
+            metadataUpdate = (metadata) =>
+              MetadataUtils.duplicateElementMetadataAtPath(
                 path,
                 newPath,
-                right(newElement),
+                right(nonNullNewElement),
                 metadata,
               )
+
+            return {
+              ...success,
+              topLevelElements: applyUtopiaJSXComponentsChanges(
+                success.topLevelElements,
+                utopiaComponents,
+              ),
             }
           }
         }
-
-        return {
-          utopiaComponents: utopiaComponents,
-          metadata: metadata,
-          selectedViews: newSelectedViews,
-          originalFrames: newOriginalFrames,
-        }
       },
-      (_) => null,
-      uiFile.fileContents.parsed,
     )
+    workingEditorState = {
+      ...workingEditorState,
+      jsxMetadata: metadataUpdate(workingEditorState.jsxMetadata),
+    }
+  }
+
+  return {
+    updatedEditorState: {
+      ...workingEditorState,
+      selectedViews: newSelectedViews,
+    },
+    originalFrames: newOriginalFrames,
   }
 }
 

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -257,10 +257,6 @@ function useStartDragState(): (
         entireEditorStoreRef.current.editor,
       )
 
-      const elementsThatRespectLayout = selectElementsThatRespectLayout(
-        entireEditorStoreRef.current,
-      )
-
       const duplicate = event.altKey
       const duplicateNewUIDs = duplicate
         ? createDuplicationNewUIDs(selectedViews, componentMetadata, rootComponents)
@@ -269,14 +265,8 @@ function useStartDragState(): (
       const isTargetSelected = selectedViews.some((sv) => TP.pathsEqual(sv, target))
       const selection =
         isTargetSelected && TP.areAllElementsInSameScene(selectedViews) ? selectedViews : [target]
-      const moveTargets = selection.filter(
-        (view) =>
-          TP.isScenePath(view) ||
-          TP.isStoryboardDescendant(view) || // FIXME This must go in the bin when we separate the Scene from the component it renders
-          elementsThatRespectLayout.some((path) => TP.pathsEqual(path, view)),
-      )
 
-      let originalFrames = getOriginalCanvasFrames(moveTargets, componentMetadata)
+      let originalFrames = getOriginalCanvasFrames(selection, componentMetadata)
       originalFrames = originalFrames.filter((f) => f.frame != null)
 
       const selectionArea = boundingRectangleArray(
@@ -300,7 +290,7 @@ function useStartDragState(): (
             duplicateNewUIDs,
             start,
             componentMetadata,
-            moveTargets,
+            selection,
           ),
         ),
       ])

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -263,6 +263,9 @@ function useStartDragState(): (
         : null
 
       const isTargetSelected = selectedViews.some((sv) => TP.pathsEqual(sv, target))
+
+      // FIXME: Re-establish filtering based on `selectElementsThatRespectLayout`.
+      // https://github.com/concrete-utopia/utopia/pull/1088/files/460e68fb6b4156833744a5441c9e56d662c8b51d#r614029462
       const selection =
         isTargetSelected && TP.areAllElementsInSameScene(selectedViews) ? selectedViews : [target]
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -86,7 +86,7 @@ export function createComponentRendererComponent(params: {
 
     if (utopiaJsxComponent == null) {
       // If this element cannot be found, we want to purposefully cause a 'ReferenceError' to notify the user.
-      throw new ReferenceError(`${params.topLevelElementName} is not defined in ${params.filePath}`)
+      throw new ReferenceError(`${params.topLevelElementName} is not defined`)
     }
 
     const appliedProps = optionalMap(

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -27,7 +27,10 @@ import {
   isUnparsed,
   ParsedTextFile,
   ParseSuccess,
+  RevisionsState,
+  textFile,
   TextFile,
+  textFileContents,
 } from '../../core/shared/project-file-types'
 import { PrettierConfig } from '../../core/workers/parser-printer/prettier-utils'
 import {
@@ -47,6 +50,7 @@ import { editorDispatch } from '../editor/store/dispatch'
 import {
   createEditorState,
   deriveState,
+  EditorState,
   EditorStore,
   PersistentModel,
   persistentModelForProjectContents,
@@ -60,8 +64,9 @@ import { emptyUiJsxCanvasContextData } from './ui-jsx-canvas'
 import { testParseCode } from '../../core/workers/parser-printer/parser-printer.test-utils'
 import { printCode, printCodeOptions } from '../../core/workers/parser-printer/parser-printer'
 import { setPropertyControlsIFrameAvailable } from '../../core/property-controls/property-controls-utils'
-import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../assets'
+import { contentsToTree, getContentsTreeFileFromString, ProjectContentTreeRoot } from '../assets'
 import { testStaticScenePath } from '../../core/shared/template-path.test-utils'
+import { createFakeMetadataForParseSuccess } from '../../utils/utils.test-utils'
 
 process.on('unhandledRejection', (reason, promise) => {
   console.warn('Unhandled promise rejection:', promise, 'reason:', (reason as any)?.stack || reason)
@@ -277,7 +282,38 @@ export function getTestParseSuccess(fileContents: string): ParseSuccess {
   }
 }
 
-export function testPrintCode(parseSuccess: ParseSuccess): string {
+export function getEditorState(fileContents: string): EditorState {
+  const success = getTestParseSuccess(fileContents)
+  const storyboardFile = textFile(
+    textFileContents('', success, RevisionsState.ParsedAhead),
+    null,
+    0,
+  )
+  return {
+    ...createEditorState(NO_OP),
+    projectContents: contentsToTree({
+      [StoryboardFilePath]: storyboardFile,
+    }),
+    jsxMetadata: createFakeMetadataForParseSuccess(success),
+  }
+}
+
+export function editorStateToParseSuccess(editorState: EditorState): ParseSuccess {
+  const file = getContentsTreeFileFromString(editorState.projectContents, StoryboardFilePath)
+  if (file == null) {
+    throw new Error(`Cannot find storyboard file.`)
+  } else if (isTextFile(file)) {
+    if (isParseSuccess(file.fileContents.parsed)) {
+      return file.fileContents.parsed
+    } else {
+      throw new Error(`Parsed storyboard is not a parse success.`)
+    }
+  } else {
+    throw new Error(`Storyboard file was not a text file.`)
+  }
+}
+
+export function testPrintCodeFromParseSuccess(parseSuccess: ParseSuccess): string {
   return printCode(
     printCodeOptions(false, true, true),
     parseSuccess.imports,
@@ -287,10 +323,15 @@ export function testPrintCode(parseSuccess: ParseSuccess): string {
   )
 }
 
+export function testPrintCodeFromEditorState(editorState: EditorState): string {
+  const parseSuccess = editorStateToParseSuccess(editorState)
+  return testPrintCodeFromParseSuccess(parseSuccess)
+}
+
 export function testPrintParsedTextFile(parsedTextFile: ParsedTextFile): string {
   return foldParsedTextFile(
     (_) => 'FAILURE',
-    testPrintCode,
+    testPrintCodeFromParseSuccess,
     (_) => 'UNPARSED',
     parsedTextFile,
   )

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -298,8 +298,11 @@ export function getEditorState(fileContents: string): EditorState {
   }
 }
 
-export function editorStateToParseSuccess(editorState: EditorState): ParseSuccess {
-  const file = getContentsTreeFileFromString(editorState.projectContents, StoryboardFilePath)
+export function editorStateToParseSuccess(
+  editorState: EditorState,
+  filePath: string = StoryboardFilePath,
+): ParseSuccess {
+  const file = getContentsTreeFileFromString(editorState.projectContents, filePath)
   if (file == null) {
     throw new Error(`Cannot find storyboard file.`)
   } else if (isTextFile(file)) {
@@ -323,8 +326,11 @@ export function testPrintCodeFromParseSuccess(parseSuccess: ParseSuccess): strin
   )
 }
 
-export function testPrintCodeFromEditorState(editorState: EditorState): string {
-  const parseSuccess = editorStateToParseSuccess(editorState)
+export function testPrintCodeFromEditorState(
+  editorState: EditorState,
+  filePath: string = StoryboardFilePath,
+): string {
+  const parseSuccess = editorStateToParseSuccess(editorState, filePath)
   return testPrintCodeFromParseSuccess(parseSuccess)
 }
 

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -20,6 +20,7 @@ import {
   jsxAttributesFromMap,
   emptyAttributeMetadatada,
   jsxAttributeOtherJavaScript,
+  JSXElementChild,
 } from '../../../core/shared/element-template'
 import { getModifiableJSXAttributeAtPath } from '../../../core/shared/jsx-attributes'
 import {
@@ -70,7 +71,6 @@ import { getLayoutPropertyOr } from '../../../core/layout/getLayoutProperty'
 import {
   ScenePathForTestUiJsFile,
   ScenePath1ForTestUiJsFile,
-  sampleDefaultImports,
   sampleImportsForTests,
 } from '../../../core/model/test-ui-js-file.test-utils'
 import {
@@ -84,99 +84,109 @@ import { CURRENT_PROJECT_VERSION } from './migrations/migrations'
 import { generateCodeResultCache } from '../../custom-code/code-file'
 import { contentsToTree, getContentsTreeFileFromString } from '../../assets'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
+import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 const chaiExpect = Chai.expect
 
-describe('SET_PROP', () => {
-  const originalModel = deepFreeze(
-    parseSuccess(
-      addImport(
-        'utopia-api',
-        null,
-        [importAlias('View'), importAlias('Scene'), importAlias('Storyboard')],
-        null,
-        emptyImports(),
+function storyboardComponent(numberOfScenes: number): UtopiaJSXComponent {
+  let scenes: Array<JSXElement> = []
+  for (let sceneIndex = 0; sceneIndex < numberOfScenes; sceneIndex++) {
+    scenes.push(
+      jsxElement(
+        'Scene',
+        jsxAttributesFromMap({
+          component: jsxAttributeOtherJavaScript(
+            `MyView${sceneIndex + 1}`,
+            `return MyView${sceneIndex + 1}`,
+            [`MyView${sceneIndex + 1}`],
+            null,
+          ),
+          'data-uid': jsxAttributeValue(`scene-${sceneIndex}`, emptyComments),
+        }),
+        [],
       ),
-      [
-        utopiaJSXComponent(
-          'MyView',
-          true,
-          'var',
-          'block',
-          defaultPropsParam,
-          [],
-          jsxElement(
-            jsxElementName('View', []),
-            jsxAttributesFromMap({
-              'data-uid': jsxAttributeValue('aaa', emptyComments),
-            }),
-            [
-              jsxElement(
-                jsxElementName('View', []),
-                jsxAttributesFromMap({
-                  test: jsxAttributeNestedObjectSimple(
-                    jsxAttributesFromMap({ prop: jsxAttributeValue(5, emptyComments) }),
-                    emptyComments,
-                  ),
-                  'data-uid': jsxAttributeValue('bbb', emptyComments),
-                }),
-                [],
-              ),
-            ],
-          ),
-          null,
-          false,
-          emptyComments,
-        ),
-        utopiaJSXComponent(
-          BakedInStoryboardVariableName,
-          false,
-          'var',
-          'block',
-          null,
-          [],
-          jsxElement(
-            'Storyboard',
-            jsxAttributesFromMap({
-              'data-uid': jsxAttributeValue(BakedInStoryboardUID, emptyComments),
-            }),
-            [
-              jsxElement(
-                'Scene',
-                jsxAttributesFromMap({
-                  component: jsxAttributeOtherJavaScript(
-                    'MyView',
-                    `return MyView`,
-                    ['MyView'],
-                    null,
-                  ),
-                  'data-uid': jsxAttributeValue('scene-0', emptyComments),
-                }),
-                [],
-              ),
-            ],
-          ),
-          null,
-          false,
-          emptyComments,
-        ),
-      ],
-      {},
-      null,
-      null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+    )
+  }
+  return utopiaJSXComponent(
+    BakedInStoryboardVariableName,
+    false,
+    'var',
+    'block',
+    null,
+    [],
+    jsxElement(
+      'Storyboard',
+      jsxAttributesFromMap({
+        'data-uid': jsxAttributeValue(BakedInStoryboardUID, emptyComments),
+      }),
+      scenes,
     ),
+    null,
+    false,
+    emptyComments,
   )
-  const testEditor: EditorState = deepFreeze({
-    ...createEditorState(NO_OP),
-    projectContents: contentsToTree({
-      [StoryboardFilePath]: textFile(
-        textFileContents('', originalModel, RevisionsState.ParsedAhead),
+}
+
+const originalModel = deepFreeze(
+  parseSuccess(
+    addImport(
+      'utopia-api',
+      null,
+      [importAlias('View'), importAlias('Scene'), importAlias('Storyboard')],
+      null,
+      sampleImportsForTests,
+    ),
+    [
+      utopiaJSXComponent(
+        'MyView1',
+        true,
+        'var',
+        'block',
+        defaultPropsParam,
+        [],
+        jsxElement(
+          jsxElementName('View', []),
+          jsxAttributesFromMap({
+            'data-uid': jsxAttributeValue('aaa', emptyComments),
+          }),
+          [
+            jsxElement(
+              jsxElementName('View', []),
+              jsxAttributesFromMap({
+                test: jsxAttributeNestedObjectSimple(
+                  jsxAttributesFromMap({ prop: jsxAttributeValue(5, emptyComments) }),
+                  emptyComments,
+                ),
+                'data-uid': jsxAttributeValue('bbb', emptyComments),
+              }),
+              [],
+            ),
+          ],
+        ),
         null,
-        0,
+        false,
+        emptyComments,
       ),
-    }),
-    jsxMetadata: createFakeMetadataForComponents(originalModel.topLevelElements),
-  })
+      storyboardComponent(1),
+    ],
+    {},
+    null,
+    null,
+    addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+  ),
+)
+const testEditor: EditorState = deepFreeze({
+  ...createEditorState(NO_OP),
+  projectContents: contentsToTree({
+    [StoryboardFilePath]: textFile(
+      textFileContents('', originalModel, RevisionsState.ParsedAhead),
+      null,
+      0,
+    ),
+  }),
+  jsxMetadata: createFakeMetadataForComponents(originalModel.topLevelElements),
+})
+
+describe('SET_PROP', () => {
   it('updates a simple value property', () => {
     const action = setProp_UNSAFE(
       TP.instancePath(ScenePathForTestUiJsFile, ['aaa', 'bbb']),
@@ -208,76 +218,6 @@ describe('SET_PROP', () => {
 })
 
 describe('SET_CANVAS_FRAMES', () => {
-  // Annoyingly, to test this properly we'd need the spy functions to run, so right now
-  // we're making do with having everything zero offset
-  const components = [
-    utopiaJSXComponent(
-      'MyView',
-      true,
-      'var',
-      'block',
-      defaultPropsParam,
-      [],
-      jsxElement(
-        jsxElementName('View', []),
-        jsxAttributesFromMap({
-          layout: jsxAttributeNestedObjectSimple(
-            jsxAttributesFromMap({
-              top: jsxAttributeValue(0, emptyComments),
-              left: jsxAttributeValue(0, emptyComments),
-              width: jsxAttributeValue(100, emptyComments),
-              height: jsxAttributeValue(100, emptyComments),
-            }),
-            emptyComments,
-          ),
-          'data-uid': jsxAttributeValue('aaa', emptyComments),
-        }),
-        [
-          jsxElement(
-            jsxElementName('View', []),
-            jsxAttributesFromMap({
-              layout: jsxAttributeNestedObjectSimple(
-                jsxAttributesFromMap({
-                  top: jsxAttributeValue(0, emptyComments),
-                  left: jsxAttributeValue(0, emptyComments),
-                  width: jsxAttributeValue(10, emptyComments),
-                  height: jsxAttributeValue(10, emptyComments),
-                }),
-                emptyComments,
-              ),
-              'data-uid': jsxAttributeValue('bbb', emptyComments),
-            }),
-            [],
-          ),
-        ],
-      ),
-      null,
-      false,
-      emptyComments,
-    ),
-  ]
-
-  const originalModel = deepFreeze(
-    parseSuccess(
-      emptyImports(),
-      components,
-      {},
-      null,
-      null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
-    ),
-  )
-  const testEditor: EditorState = deepFreeze({
-    ...createEditorState(NO_OP),
-    projectContents: contentsToTree({
-      [StoryboardFilePath]: textFile(
-        textFileContents('', originalModel, RevisionsState.ParsedAhead),
-        null,
-        0,
-      ),
-    }),
-    jsxMetadata: createFakeMetadataForComponents(originalModel.topLevelElements),
-  })
   const derivedState = deriveState(testEditor, null)
   it('Updates the frame of the child correctly', () => {
     const action = setCanvasFrames(
@@ -321,21 +261,25 @@ describe('moveTemplate', () => {
   function fileModel(rootElements: Array<JSXElement>): Readonly<ParseSuccess> {
     return deepFreeze(
       parseSuccess(
-        emptyImports(),
-        rootElements.map((element, index) =>
-          utopiaJSXComponent(
-            `MyView${index}`,
-            true,
-            'var',
-            'block',
-            defaultPropsParam,
-            [],
-            element,
-            null,
-            false,
-            emptyComments,
-          ),
-        ),
+        sampleImportsForTests,
+        [
+          storyboardComponent(rootElements.length),
+          ...rootElements.map((element, index) => {
+            const componentName = `MyView${index + 1}`
+            return utopiaJSXComponent(
+              componentName,
+              true,
+              'var',
+              'block',
+              defaultPropsParam,
+              [],
+              element,
+              null,
+              false,
+              emptyComments,
+            )
+          }),
+        ],
         {},
         null,
         null,
@@ -399,7 +343,7 @@ describe('moveTemplate', () => {
     )
   }
 
-  function testEditor(uiFile: Readonly<ParseSuccess>): EditorState {
+  function testEditorFromParseSuccess(uiFile: Readonly<ParseSuccess>): EditorState {
     let editor: EditorState = {
       ...createEditorState(NO_OP),
       projectContents: contentsToTree({
@@ -419,7 +363,7 @@ describe('moveTemplate', () => {
     const view1 = view('bbb')
     const view2 = view('ccc')
     const root = view('aaa', [view1, view2])
-    const editor = testEditor(fileModel([root]))
+    const editor = testEditorFromParseSuccess(fileModel([root]))
 
     const newEditor = editorMoveTemplate(
       TP.instancePath(ScenePathForTestUiJsFile, ['aaa', 'ccc']),
@@ -438,9 +382,10 @@ describe('moveTemplate', () => {
     ) as TextFile
     expect(isTextFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents.parsed)).toBeTruthy()
-    const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.parsed as ParseSuccess)
-      .topLevelElements
-    const updatedRoot = newTopLevelElements[0] as UtopiaJSXComponent
+    const newComponents = getUtopiaJSXComponentsFromSuccess(
+      newUiJsFile.fileContents.parsed as ParseSuccess,
+    )
+    const updatedRoot = newComponents[1] as UtopiaJSXComponent
     expect(isUtopiaJSXComponent(updatedRoot)).toBeTruthy()
     expect(Utils.pathOr([], ['rootElement', 'children'], updatedRoot)).toHaveLength(1)
     const expectedView2 = Utils.path(['rootElement', 'children', 0, 'children', 0], updatedRoot)
@@ -452,7 +397,7 @@ describe('moveTemplate', () => {
     const view1 = view('bbb', [], 5, 5, 100, 100)
     const view2 = view('ccc', [], 15, 15, 100, 100)
     const root = view('aaa', [view1, view2], 10, 10, 100, 100)
-    const editor = testEditor(fileModel([root]))
+    const editor = testEditorFromParseSuccess(fileModel([root]))
 
     const newEditor = editorMoveTemplate(
       TP.instancePath(ScenePathForTestUiJsFile, ['aaa', 'ccc']),
@@ -500,7 +445,7 @@ describe('moveTemplate', () => {
     const view1 = view('bbb', [], '5%', '5%', 100, 100, 'BBB')
     const view2 = view('ccc', [], '15%', '15%', 100, 100, 'CCC')
     const root = view('aaa', [view1, view2], 10, 10, 100, 100, 'AAA')
-    const editor = testEditor(fileModel([root]))
+    const editor = testEditorFromParseSuccess(fileModel([root]))
 
     const newEditor = editorMoveTemplate(
       TP.instancePath(ScenePathForTestUiJsFile, ['aaa', 'ccc']),
@@ -529,9 +474,10 @@ describe('moveTemplate', () => {
     ) as TextFile
     expect(isTextFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents.parsed)).toBeTruthy()
-    const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.parsed as ParseSuccess)
-      .topLevelElements
-    const updatedRoot = newTopLevelElements[0] as UtopiaJSXComponent
+    const newComponents = getUtopiaJSXComponentsFromSuccess(
+      newUiJsFile.fileContents.parsed as ParseSuccess,
+    )
+    const updatedRoot = newComponents[1] as UtopiaJSXComponent
     expect(isUtopiaJSXComponent(updatedRoot)).toBeTruthy()
     expect(Utils.pathOr([], ['rootElement', 'children'], updatedRoot)).toHaveLength(1)
     const actual = Utils.path(['rootElement', 'children', 0, 'children', 0], updatedRoot)
@@ -543,7 +489,7 @@ describe('moveTemplate', () => {
     const view2 = view('ccc')
     const view1 = view('bbb', [view2])
     const root = view('aaa', [view1])
-    const editor = testEditor(fileModel([root]))
+    const editor = testEditorFromParseSuccess(fileModel([root]))
 
     const newEditor = editorMoveTemplate(
       TP.instancePath(ScenePathForTestUiJsFile, ['aaa', 'bbb', 'ccc']),
@@ -562,9 +508,10 @@ describe('moveTemplate', () => {
     ) as TextFile
     expect(isTextFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents.parsed)).toBeTruthy()
-    const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.parsed as ParseSuccess)
-      .topLevelElements
-    const updatedRoot = newTopLevelElements[0] as UtopiaJSXComponent
+    const newComponents = getUtopiaJSXComponentsFromSuccess(
+      newUiJsFile.fileContents.parsed as ParseSuccess,
+    )
+    const updatedRoot = newComponents[1] as UtopiaJSXComponent
     expect(isUtopiaJSXComponent(updatedRoot)).toBeTruthy()
     expect(Utils.pathOr([], ['rootElement', 'children'], updatedRoot)).toHaveLength(2)
     const actual = Utils.path(['rootElement', 'children', 1], updatedRoot)
@@ -575,7 +522,7 @@ describe('moveTemplate', () => {
     const view2 = view('ccc')
     const view1 = view('bbb', [view2])
     const root = view('aaa', [view1])
-    const editor = testEditor(fileModel([root]))
+    const editor = testEditorFromParseSuccess(fileModel([root]))
 
     const newEditor = editorMoveTemplate(
       TP.instancePath(ScenePathForTestUiJsFile, ['aaa', 'bbb', 'ccc']),
@@ -594,9 +541,10 @@ describe('moveTemplate', () => {
     ) as TextFile
     expect(isTextFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents.parsed)).toBeTruthy()
-    const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.parsed as ParseSuccess)
-      .topLevelElements
-    const updatedRoot = newTopLevelElements[0] as UtopiaJSXComponent
+    const newComponents = getUtopiaJSXComponentsFromSuccess(
+      newUiJsFile.fileContents.parsed as ParseSuccess,
+    )
+    const updatedRoot = newComponents[1] as UtopiaJSXComponent
     expect(isUtopiaJSXComponent(updatedRoot)).toBeTruthy()
     expect(Utils.pathOr([], ['rootElement', 'children'], updatedRoot)).toHaveLength(2)
     const actual = Utils.path(['rootElement', 'children', 0], updatedRoot)
@@ -608,7 +556,7 @@ describe('moveTemplate', () => {
     const view1 = view('bbb', [view2])
     const view3 = view('ddd')
     const root = view('aaa', [view1, view3])
-    const editor = testEditor(fileModel([root]))
+    const editor = testEditorFromParseSuccess(fileModel([root]))
 
     const newEditor = editorMoveTemplate(
       TP.instancePath(ScenePathForTestUiJsFile, ['aaa', 'bbb', 'ccc']),
@@ -627,9 +575,10 @@ describe('moveTemplate', () => {
     ) as TextFile
     expect(isTextFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents.parsed)).toBeTruthy()
-    const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.parsed as ParseSuccess)
-      .topLevelElements
-    const updatedRoot = newTopLevelElements[0] as UtopiaJSXComponent
+    const newComponents = getUtopiaJSXComponentsFromSuccess(
+      newUiJsFile.fileContents.parsed as ParseSuccess,
+    )
+    const updatedRoot = newComponents[1] as UtopiaJSXComponent
     expect(isUtopiaJSXComponent(updatedRoot)).toBeTruthy()
     expect(Utils.pathOr([], ['rootElement', 'children'], updatedRoot)).toHaveLength(3)
     const actual = Utils.path(['rootElement', 'children', 1], updatedRoot)
@@ -640,7 +589,7 @@ describe('moveTemplate', () => {
     const view1 = view('bbb')
     const root1 = view('aaa', [view1])
     const root2 = view('ccc', [])
-    const editor = testEditor(fileModel([root1, root2]))
+    const editor = testEditorFromParseSuccess(fileModel([root1, root2]))
 
     const newEditor = editorMoveTemplate(
       TP.instancePath(ScenePathForTestUiJsFile, ['aaa', 'bbb']),
@@ -659,12 +608,13 @@ describe('moveTemplate', () => {
     ) as TextFile
     expect(isTextFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents.parsed)).toBeTruthy()
-    const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.parsed as ParseSuccess)
-      .topLevelElements
-    const updatedRoot1 = newTopLevelElements[0] as UtopiaJSXComponent
+    const newComponents = getUtopiaJSXComponentsFromSuccess(
+      newUiJsFile.fileContents.parsed as ParseSuccess,
+    )
+    const updatedRoot1 = newComponents[1] as UtopiaJSXComponent
     expect(isUtopiaJSXComponent(updatedRoot1)).toBeTruthy()
     expect(Utils.pathOr([], ['rootElement', 'children'], updatedRoot1)).toHaveLength(0)
-    const updatedRoot2 = newTopLevelElements[1] as UtopiaJSXComponent
+    const updatedRoot2 = newComponents[2] as UtopiaJSXComponent
     expect(isUtopiaJSXComponent(updatedRoot2)).toBeTruthy()
     expect(Utils.pathOr([], ['rootElement', 'children'], updatedRoot2)).toHaveLength(1)
     const actual = Utils.path(['rootElement', 'children', 0], updatedRoot2)
@@ -689,7 +639,7 @@ describe('moveTemplate', () => {
     )
     const group1 = group('ddd', [], -10, -10, 100, 100, 'Group')
     const root1 = view('aaa', [view1])
-    const editor = testEditor(fileModel([root1, group1]))
+    const editor = testEditorFromParseSuccess(fileModel([root1, group1]))
     const groupFrame = canvasRectangle({ x: -10, y: -10, width: 100, height: 100 })
 
     const newEditor = editorMoveTemplate(
@@ -709,9 +659,10 @@ describe('moveTemplate', () => {
     ) as TextFile
     expect(isTextFile(newUiJsFile)).toBeTruthy()
     expect(isParseSuccess(newUiJsFile.fileContents.parsed)).toBeTruthy()
-    const newTopLevelElements: TopLevelElement[] = (newUiJsFile.fileContents.parsed as ParseSuccess)
-      .topLevelElements
-    const updatedGroup = newTopLevelElements[1] as UtopiaJSXComponent
+    const newComponents = getUtopiaJSXComponentsFromSuccess(
+      newUiJsFile.fileContents.parsed as ParseSuccess,
+    )
+    const updatedGroup = newComponents[2] as UtopiaJSXComponent
     expect(isUtopiaJSXComponent(updatedGroup)).toBeTruthy()
     expect(Utils.pathOr([], ['rootElement', 'children'], updatedGroup)).toHaveLength(1)
     const actual: any = Utils.path(['rootElement', 'children', 0], updatedGroup)
@@ -748,7 +699,7 @@ describe('moveTemplate', () => {
       }),
       [],
     )
-    const editor = testEditor(fileModel([flexView, group1]))
+    const editor = testEditorFromParseSuccess(fileModel([flexView, group1]))
 
     const newEditor = editorMoveTemplate(
       TP.instancePath(ScenePath1ForTestUiJsFile, ['ddd', 'bbb']),
@@ -799,7 +750,7 @@ describe('moveTemplate', () => {
     )
     const group1 = group('ddd', [view1], 50, 50, 100, 100, 'Group')
     const root1 = view('aaa', [], 0, 0, 200, 200)
-    const editor = testEditor(fileModel([root1, group1]))
+    const editor = testEditorFromParseSuccess(fileModel([root1, group1]))
 
     const newEditor = editorMoveTemplate(
       TP.instancePath(ScenePathForTestUiJsFile, ['ddd', 'bbb']),

--- a/editor/src/core/layout/layout-utils.ts
+++ b/editor/src/core/layout/layout-utils.ts
@@ -61,7 +61,6 @@ export function maybeSwitchChildrenLayoutProps(
   target: InstancePath,
   targetOriginalContextMetadata: ElementInstanceMetadataMap,
   currentContextMetadata: ElementInstanceMetadataMap,
-  originalComponents: UtopiaJSXComponent[],
   components: UtopiaJSXComponent[],
 ): LayoutPropChangeResult {
   const children = MetadataUtils.getChildrenHandlingGroups(
@@ -82,7 +81,6 @@ export function maybeSwitchChildrenLayoutProps(
         target,
         targetOriginalContextMetadata,
         currentContextMetadata,
-        originalComponents,
         workingComponents,
         null,
         null,
@@ -104,7 +102,6 @@ export function maybeSwitchLayoutProps(
   newParentPath: InstancePath,
   targetOriginalContextMetadata: ElementInstanceMetadataMap,
   currentContextMetadata: ElementInstanceMetadataMap,
-  originalComponents: UtopiaJSXComponent[],
   components: UtopiaJSXComponent[],
   parentFrame: CanvasRectangle | null,
   parentLayoutSystem: SettableLayoutSystem | null,


### PR DESCRIPTION
**Problem:**
Previously none of the logic around moving/resizing was multi-file editing aware so would be unable to handle an element defined deeply within other files.

**Fix:**
A lot of functions involved taking arrays of components and component metadata, transforming those and returning them again. Many of those have now been switched to taking `EditorState` as an input and returning it again as an output. This also means that some of the logic produces the transient state from an `EditorState`, instead of from the individual parts as it previously did.

**Limitations:**
- It appears there's still an issue with resizing in that the controls aren't showing up for deeply nested components, but I thought given that pretty much everything is in place at this point I'd rather get the PR done then investigate that afterwards.

**Commit Details:**
- Removed some filtering around the targets of `useStartDragState`.
- Speculatively upgraded electron to 6.1.12 to see if it would result in console logging making an appearance for browser tests on Linux systems.
- Added a `beforeAll` inside a few `describe` calls of browser tests so they run properly when run alone.
- Tests in `canvas-utils-unit-tests.spec.ts` switched to using `EditorState` instead of `ParseSuccess` for their test data.
- Implemented `applyTransientFilesState` to extract out the logic of taking the values held within `TransientFilesState` to the `EditorState`.
- Much of the logic in `canvas-utils.ts` now uses functions like `withUnderlyingTarget` and `modifyUnderlyingForOpenFile` to reach down into or transform the `EditorState`.
- `getTransientCanvasStateFromFrameChanges` implemented to produce the transient state from an `EditorState`.
- `NormalisePathImportNotFound` now includes what it couldn't find.