### PR TITLE
feature(canvas) clicking into element sets focus mode for components without children passed in

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -26,6 +26,7 @@ import {
 } from '../../../editor/actions/action-creators'
 import {
   EditorState,
+  getJSXComponentsAndImportsForPathInnerComponentFromState,
   getOpenUtopiaJSXComponentsFromState,
 } from '../../../editor/store/editor-state'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
@@ -470,6 +471,11 @@ export function useSelectModeSelectAndHover(
     getSelectableViewsForSelectMode,
   )
 
+  const editorStoreRef = useRefEditorState((store) => ({
+    editor: store.editor,
+    derived: store.derived,
+  }))
+
   const onMouseDown = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       const doubleClick = event.detail > 1 // we interpret a triple click as two double clicks, a quadruple click as three double clicks, etc  // TODO TEST ME
@@ -497,6 +503,26 @@ export function useSelectModeSelectAndHover(
           updatedSelection = foundTarget != null ? [foundTarget.templatePath] : []
         }
 
+        if (foundTarget != null && TP.isInstancePath(foundTarget.templatePath)) {
+          // for components without passed children doubleclicking enters focus mode
+          const { components, imports } = getJSXComponentsAndImportsForPathInnerComponentFromState(
+            foundTarget.templatePath,
+            editorStoreRef.current.editor,
+            editorStoreRef.current.derived,
+          )
+          const isFocusableLeaf = MetadataUtils.isFocusableLeafComponent(
+            foundTarget.templatePath,
+            components,
+            editorStoreRef.current.editor.jsxMetadata,
+            imports,
+          )
+          if (isFocusableLeaf) {
+            dispatch([
+              setFocusedElement(TP.scenePathForElementAtInstancePath(foundTarget.templatePath)),
+            ])
+          }
+        }
+
         if (!(foundTarget?.isSelected ?? false)) {
           // first we only set the selected views for the canvas controls
           setSelectedViewsForCanvasControlsOnly(updatedSelection)
@@ -521,6 +547,7 @@ export function useSelectModeSelectAndHover(
       startDragStateAfterDragExceedsThreshold,
       setSelectedViewsForCanvasControlsOnly,
       getSelectableViewsForSelectMode,
+      editorStoreRef,
     ],
   )
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1578,11 +1578,7 @@ export const MetadataUtils = {
     metadata: ElementInstanceMetadataMap,
     imports: Imports,
   ): boolean {
-    if (MetadataUtils.getChildrenPaths(metadata, path).length > 0) {
-      return false
-    } else {
-      return MetadataUtils.isFocusableComponent(path, components, metadata, imports)
-    }
+    return MetadataUtils.getChildrenPaths(metadata, path).length === 0 && MetadataUtils.isFocusableComponent(path, components, metadata, imports)
   },
 }
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1572,6 +1572,18 @@ export const MetadataUtils = {
       return false
     }
   },
+  isFocusableLeafComponent(
+    path: TemplatePath,
+    components: UtopiaJSXComponent[],
+    metadata: ElementInstanceMetadataMap,
+    imports: Imports,
+  ): boolean {
+    if (MetadataUtils.getChildrenPaths(metadata, path).length > 0) {
+      return false
+    } else {
+      return MetadataUtils.isFocusableComponent(path, components, metadata, imports)
+    }
+  },
 }
 
 export function findElementAtPath(

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1578,7 +1578,10 @@ export const MetadataUtils = {
     metadata: ElementInstanceMetadataMap,
     imports: Imports,
   ): boolean {
-    return MetadataUtils.getChildrenPaths(metadata, path).length === 0 && MetadataUtils.isFocusableComponent(path, components, metadata, imports)
+    return (
+      MetadataUtils.getChildrenPaths(metadata, path).length === 0 &&
+      MetadataUtils.isFocusableComponent(path, components, metadata, imports)
+    )
   },
 }
 


### PR DESCRIPTION
**Problem:**
Entering component editing mode is possible only from the context-menu, component's inner children are not selectable without it. This is not matching with the idea for if an element is editable and visible with some doubleclicking it should become selected. It is allowed focusing on instances only with inner children, without direct props.children.

**Commit Details:**
- extending `useSelectModeSelectAndHover` to set focused element when the foundTarget is a focusable leaf component
- a helper in `metadata-utils`
