### PR TITLE
fix(canvas) only doubleclick triggers focusmode

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -496,7 +496,7 @@ export function useSelectModeSelectAndHover(
           updatedSelection = foundTarget != null ? [foundTarget.templatePath] : []
         }
 
-        if (foundTarget != null && TP.isInstancePath(foundTarget.templatePath)) {
+        if (foundTarget != null && TP.isInstancePath(foundTarget.templatePath) && doubleClick) {
           // for components without passed children doubleclicking enters focus mode
           const { components, imports } = getJSXComponentsAndImportsForPathInnerComponentFromState(
             foundTarget.templatePath,


### PR DESCRIPTION
**Fix:**
Only double-click should trigger component focused editing. The problem is that it works with cmd+click too.
