### PR TITLE
fix(canvas) prevent opening contextmenu when nothing is selected

### DIFF
--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -150,10 +150,12 @@ export class SelectModeControlContainer extends React.Component<
   onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation()
     event.preventDefault()
-    this.props.dispatch(
-      [EditorActions.showContextMenu('context-menu-canvas', event.nativeEvent)],
-      'canvas',
-    )
+    if (this.props.selectedViews.length > 0) {
+      this.props.dispatch(
+        [EditorActions.showContextMenu('context-menu-canvas', event.nativeEvent)],
+        'canvas',
+      )
+    }
   }
 
   getTargetViews(): Array<TemplatePath> {


### PR DESCRIPTION
**Problem:**
Canvas context-menu can be opened on empty areas but on the context-menu items are not usable.

Fix is to only open it when there are elements selected.
