### PR TITLE
Prevent an error about overwriting files in VS Code.

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -449,7 +449,7 @@ import {
   getStoryboardTemplatePath,
 } from '../../../core/model/scene-utils'
 import { getFrameAndMultiplier } from '../../images'
-import { arrayToMaybe, forceNotNull } from '../../../core/shared/optional-utils'
+import { arrayToMaybe, forceNotNull, optionalMap } from '../../../core/shared/optional-utils'
 
 import {
   updateRightMenuExpanded,
@@ -1358,9 +1358,13 @@ export const UPDATE_FNS = {
       migratedModel.projectContents,
       (filename: string, file: TextFile) => {
         const parseResult = lintAndParse(filename, file.fileContents.code)
+        const lastSavedFileContents = optionalMap((lastSaved) => {
+          const lastSavedParseResult = lintAndParse(filename, lastSaved.code)
+          return textFileContents(lastSaved.code, lastSavedParseResult, RevisionsState.BothMatch)
+        }, file.lastSavedContents)
         return textFile(
           textFileContents(file.fileContents.code, parseResult, RevisionsState.BothMatch),
-          null,
+          lastSavedFileContents,
           Date.now(),
         )
       },


### PR DESCRIPTION
**Problem:**
After reloading the editor sometimes saving a file in VS Code would cause a warning about overwriting files even potentially with no change shown in the diff view that is presented.

**Fix:**
Now only files that are different to those in IndexedDB are actually updated during startup, this was the underlying issue where files would just be overwritten during startup and as a result to VS Code their modification times would indicate that those files had been updated by something else. There was also an issue where the `TextFile.lastSavedContents` field was being obliterated on load which also triggered that saving with some loss of data as well.

**Bugs:**
An additional issue was found whereby saving in VS Code, refreshing the page, getting the warning pop-up and cancelling it followed by reloading it completely loses any changes made prior to the save. This is currently an issue on master and not a regression.

**Commit Details:**
- Added in some protection against writing a file to IndexedDB
  when writing the project contents during startup. The files
  from `projectContents` are compared against those stored in
  IndexedDB and if they match then no change is made.
- Fixed a bug where `lastSavedContents` was thrown away on load
  which meant that the file would get overwritten in `writeProjectContents`.
