### PR TITLE
types(icons) - adds 'colourful', uses it

### DIFF
--- a/editor/src/uuiui/icn.tsx
+++ b/editor/src/uuiui/icn.tsx
@@ -14,6 +14,7 @@ export type IcnColor =
   | 'purple'
   | 'red'
   | 'orange'
+  | 'colourful'
 
 export interface IcnPropsBase {
   category?: string

--- a/editor/src/uuiui/icons.tsx
+++ b/editor/src/uuiui/icons.tsx
@@ -61,6 +61,13 @@ export const LargerIcons = {
     width: 21,
     height: 21,
   }),
+  NpmLogo: makeIcon({
+    category: 'special',
+    type: 'npm',
+    color: 'colourful',
+    width: 28,
+    height: 11,
+  }),
 }
 
 export const SmallerIcons = {


### PR DESCRIPTION
**Problem:**
The NPM logo isn't ours, and comes in One Colour Only. This creates an icon for it using the `colourful` colour name, so we can use it for other things that don't neatly fit into the monochromatic colour scheme.

**Fix:**
Added `colourful` to type, added new icon `Icons.NpmLogo`
