### PR TITLE
Fix over eager selection following in code editor

### DIFF
--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -265,6 +265,11 @@ function cursorPositionChanged(event: vscode.TextEditorSelectionChangeEvent): vo
   sendMessage(editorCursorPositionChanged(filename, position.line, position.character))
 }
 
+function rangesIntersectLinesOnly(first: vscode.Range, second: vscode.Range): boolean {
+  // For the case when we only care if the lines overlap, and don't care about the columns
+  return first.start.line <= second.end.line && second.start.line <= first.end.line
+}
+
 async function revealRangeIfPossible(
   workspaceRootUri: vscode.Uri,
   boundsInFile: BoundsInFile,
@@ -279,7 +284,7 @@ async function revealRangeIfPossible(
     }
   } else {
     const rangeToReveal = getVSCodeRangeForScrolling(boundsInFile)
-    const alreadySelected = rangeToReveal.contains(visibleEditor.selection)
+    const alreadySelected = rangesIntersectLinesOnly(visibleEditor.selection, rangeToReveal)
     const alreadyVisible = visibleEditor.visibleRanges.some((r) =>
       r.contains(visibleEditor.selection),
     )


### PR DESCRIPTION
**Problem:**
When selecting multiple lines in that spanned multiple elements in the code editor, we would instantly change your selection due to an over-eager check that the was based on whether the selection was entirely contained within the range of an element.

**Fix:**
Instead, we now check that the ranges intersect, only taking into account the line numbers and not the columns (otherwise it would cause an issue with 2 elements used on a single line).