### PR TITLE
fix scene-level DOM-walker caching

### DIFF
--- a/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/dom-walker.spec.browser.tsx.snap
@@ -124,6 +124,7 @@ Object {
     "props": Object {
       "data-paths": ":utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa",
+      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "height": 812,
@@ -890,6 +891,7 @@ Object {
     "props": Object {
       "data-paths": ":utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa",
+      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "height": 812,
@@ -1335,6 +1337,7 @@ Object {
     "props": Object {
       "data-paths": ":utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa",
+      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "height": 812,
@@ -2046,6 +2049,7 @@ Object {
     "props": Object {
       "data-paths": ":utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa",
+      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "height": 812,
@@ -2758,6 +2762,7 @@ Object {
     "props": Object {
       "data-paths": ":utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa",
+      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "height": 812,

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -7,6 +7,7 @@ exports[`UiJsxCanvas #747 - DOM object constructor cannot be called as a functio
   data-utopia-valid-paths=\\":sb :sb/scene :sb/scene/app\\"
 >
   <div
+    data-utopia-scene-id=\\"sb/scene\\"
     data-paths=\\":sb/scene :sb\\"
     style=\\"
       position: absolute;

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -7,6 +7,7 @@ exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -689,6 +690,7 @@ exports[`UiJsxCanvas render Label carried through for normal elements 1`] = `
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -930,6 +932,7 @@ exports[`UiJsxCanvas render Renders input tag without errors 1`] = `
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:567\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -1072,6 +1075,7 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -1798,6 +1802,7 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -4376,6 +4381,7 @@ exports[`UiJsxCanvas render class component is available from arbitrary block in
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -4797,6 +4803,7 @@ exports[`UiJsxCanvas render console logging does not do anything bizarre 1`] = `
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -5023,6 +5030,7 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are not the ap
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -5902,6 +5910,7 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are undefined 
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -6781,6 +6790,7 @@ exports[`UiJsxCanvas render function component is available from arbitrary block
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -7230,6 +7240,7 @@ exports[`UiJsxCanvas render function component works inside a map 1`] = `
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -7679,6 +7690,7 @@ exports[`UiJsxCanvas render handles a component that destructures its props obje
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -8301,6 +8313,7 @@ exports[`UiJsxCanvas render handles a component that renames its props object 1`
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -8910,6 +8923,7 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -9622,6 +9636,7 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -10334,6 +10349,7 @@ exports[`UiJsxCanvas render handles chaining dependencies into the appropriate o
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -10475,6 +10491,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834 utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999 utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999/000\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -15584,6 +15601,7 @@ exports[`UiJsxCanvas render props can be accessed inside the arbitrary js block 
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -16095,6 +16113,7 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a class 
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -16288,6 +16307,7 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a functi
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -16570,6 +16590,7 @@ exports[`UiJsxCanvas render renderrs correctly when a component is passed in via
   data-utopia-valid-paths=\\":eee :eee/fff :eee/fff/app-entity eee/fff/app-entity:aaa eee/fff/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"eee/fff\\"
     data-paths=\\":eee/fff :eee\\"
     style=\\"
       position: absolute;
@@ -17023,6 +17044,7 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59 utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59/dd5\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -17702,6 +17724,7 @@ exports[`UiJsxCanvas render renders a canvas defined by a utopia storyboard comp
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -18181,6 +18204,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -19060,6 +19084,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -19943,6 +19968,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block with 
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -20829,6 +20855,7 @@ exports[`UiJsxCanvas render renders a component with a fragment at the root 1`] 
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -21073,6 +21100,7 @@ exports[`UiJsxCanvas render renders correctly with a context 1`] = `
   data-utopia-valid-paths=\\":ccc :ccc/ddd :ccc/ddd/app-entity ccc/ddd/app-entity:aaa ccc/ddd/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"ccc/ddd\\"
     data-paths=\\":ccc/ddd :ccc\\"
     style=\\"
       position: absolute;
@@ -21450,6 +21478,7 @@ exports[`UiJsxCanvas render renders correctly with a nested context in another c
   data-utopia-valid-paths=\\":ccc :ccc/ddd :ccc/ddd/app-entity ccc/ddd/app-entity:card\\"
 >
   <div
+    data-utopia-scene-id=\\"ccc/ddd\\"
     data-paths=\\":ccc/ddd :ccc\\"
     style=\\"
       position: absolute;
@@ -21592,6 +21621,7 @@ exports[`UiJsxCanvas render renders fine with two circularly referencing arbitra
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene :utopia-storyboard-uid/scene/app-entity utopia-storyboard-uid/scene/app-entity:aaa\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene\\"
     data-paths=\\":utopia-storyboard-uid/scene :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -21881,6 +21911,7 @@ exports[`UiJsxCanvas render renders fine with two components that reference each
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene :utopia-storyboard-uid/scene/app-entity utopia-storyboard-uid/scene/app-entity:BBB\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene\\"
     data-paths=\\":utopia-storyboard-uid/scene :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -22027,6 +22058,7 @@ exports[`UiJsxCanvas render renders fragments correctly 1`] = `
   data-utopia-valid-paths=\\":eee :eee/fff :eee/fff/app eee/fff/app:aaa eee/fff/app:aaa/bbb eee/fff/app:aaa/bbb/ccc eee/fff/app:aaa/ddd\\"
 >
   <div
+    data-utopia-scene-id=\\"eee/fff\\"
     data-paths=\\":eee/fff :eee\\"
     style=\\"
       position: absolute;
@@ -22999,6 +23031,7 @@ exports[`UiJsxCanvas render renders img tag 1`] = `
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -23331,6 +23364,7 @@ exports[`UiJsxCanvas render respects a jsx pragma 1`] = `
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     data-factory-function-works=\\"true\\"
     style=\\"
@@ -23477,6 +23511,7 @@ exports[`UiJsxCanvas render supports passing down the scope to children of compo
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb/ccc\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -24880,6 +24915,7 @@ exports[`UiJsxCanvas render the spy wrapper is compatible with React.cloneElemen
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner/cloned\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -25369,6 +25405,7 @@ exports[`UiJsxCanvas render the utopia jsx pragma (and layout prop) works well 1
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -25513,6 +25550,7 @@ exports[`UiJsxCanvas render the utopia jsx pragma supports emotion CSS prop 1`] 
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;
@@ -25658,6 +25696,7 @@ exports[`UiJsxCanvas runtime errors React.useEffect at the root fails usefully 1
   data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity\\"
 >
   <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
     data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
     style=\\"
       position: absolute;

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -4,6 +4,7 @@ import { getUtopiaID } from '../../../core/model/element-template-utils'
 import { isSceneElementIgnoringImports } from '../../../core/model/scene-utils'
 import {
   UTOPIA_PATHS_KEY,
+  UTOPIA_SCENE_ID_KEY,
   UTOPIA_SCENE_PATH,
   UTOPIA_UIDS_KEY,
   UTOPIA_UID_ORIGINAL_PARENTS_KEY,
@@ -296,15 +297,24 @@ function renderJSXElement(
     !elementIsScene && elementFromScopeOrImport == null && isIntrinsicElement(jsx.name)
   const elementIsBaseHTML = elementIsIntrinsic && isIntrinsicHTMLElement(jsx.name)
   const FinalElement = elementIsIntrinsic ? jsx.name.baseVariable : elementOrScene
+
   const scenePathForElement = optionalMap(TP.scenePathForElementAtInstancePath, templatePath)
+
   const elementPropsWithScenePath =
     isComponentRendererComponent(FinalElement) && scenePathForElement != null
       ? { ...elementProps, [UTOPIA_SCENE_PATH]: scenePathForElement }
       : elementProps
+
+  const elementPropsWithSceneID =
+    elementIsScene && scenePathForElement != null
+      ? { ...elementPropsWithScenePath, [UTOPIA_SCENE_ID_KEY]: TP.toString(scenePathForElement) }
+      : elementPropsWithScenePath
+
   const finalProps =
     elementIsIntrinsic && !elementIsBaseHTML
-      ? filterDataProps(elementPropsWithScenePath)
-      : elementPropsWithScenePath
+      ? filterDataProps(elementPropsWithSceneID)
+      : elementPropsWithSceneID
+
   const finalPropsIcludingTemplatePath = {
     ...finalProps,
     [UTOPIA_PATHS_KEY]: optionalMap(TP.toString, templatePath),

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
@@ -161,9 +161,7 @@ describe('Spy Wrapper Template Path Tests', () => {
     expect(sanitizedDomMetadata).toMatchInlineSnapshot(`
       Object {
         ":storyboard": Object {
-          "children": Array [
-            ":storyboard/scene",
-          ],
+          "children": Array [],
           "name": "Storyboard",
           "rootElements": Array [],
         },
@@ -342,9 +340,7 @@ describe('Spy Wrapper Template Path Tests', () => {
     expect(sanitizedDomMetadata).toMatchInlineSnapshot(`
       Object {
         ":storyboard": Object {
-          "children": Array [
-            ":storyboard/scene",
-          ],
+          "children": Array [],
           "name": "Storyboard",
           "rootElements": Array [],
         },
@@ -581,9 +577,7 @@ describe('Spy Wrapper Template Path Tests', () => {
     expect(sanitizedDomMetadata).toMatchInlineSnapshot(`
       Object {
         ":storyboard": Object {
-          "children": Array [
-            ":storyboard/scene",
-          ],
+          "children": Array [],
           "name": "Storyboard",
           "rootElements": Array [],
         },
@@ -834,9 +828,7 @@ describe('Spy Wrapper Template Path Tests', () => {
     expect(sanitizedDomMetadata).toMatchInlineSnapshot(`
       Object {
         ":storyboard": Object {
-          "children": Array [
-            ":storyboard/scene",
-          ],
+          "children": Array [],
           "name": "Storyboard",
           "rootElements": Array [],
         },
@@ -1094,10 +1086,7 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
     expect(sanitizedDomMetadata).toMatchInlineSnapshot(`
       Object {
         ":storyboard-entity": Object {
-          "children": Array [
-            ":storyboard-entity/scene-1-entity",
-            ":storyboard-entity/scene-2-entity",
-          ],
+          "children": Array [],
           "name": "Storyboard",
           "rootElements": Array [],
         },

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1189,6 +1189,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
         data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       >
         <div
+          data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
           data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
           style=\\"
             position: absolute;
@@ -1284,6 +1285,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
         data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       >
         <div
+          data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
           data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
           style=\\"
             position: absolute;
@@ -1351,6 +1353,7 @@ export var storyboard = (
         data-utopia-valid-paths=\\":storyboard :storyboard/scene :storyboard/scene/app-entity storyboard/scene/app-entity:aaa storyboard/scene/app-entity:aaa/antd-date-picker\\"
       >
         <div
+          data-utopia-scene-id=\\"storyboard/scene\\"
           data-paths=\\":storyboard/scene :storyboard\\"
           style=\\"
             position: absolute;
@@ -2110,6 +2113,7 @@ describe('UiJsxCanvas render multifile projects', () => {
         data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/inner-div\\"
       >
         <div
+          data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
           data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
           style=\\"
             position: absolute;
@@ -2193,6 +2197,7 @@ describe('UiJsxCanvas render multifile projects', () => {
         data-utopia-valid-paths=\\":utopia-storyboard-uid :utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/card-instance utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/card-instance/card-content\\"
       >
         <div
+          data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
           data-paths=\\":utopia-storyboard-uid/scene-aaa :utopia-storyboard-uid\\"
           style=\\"
             position: absolute;

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -1108,6 +1108,17 @@ export function outermostScenePathPart(path: TemplatePath): ScenePath {
   }
 }
 
+export function createBackwardsCompatibleScenePath(path: TemplatePath): ScenePath | null {
+  const scenePathElements = isScenePath(path)
+    ? path.sceneElementPaths[0]
+    : path.scene.sceneElementPaths[0]
+  if (scenePathElements != null) {
+    return scenePath([scenePathElements.slice(0, 2)]) // we only return the FIRST TWO elements (storyboard, scene), this is a horrible, horrible hack
+  } else {
+    return null
+  }
+}
+
 export function isFocused(focusedElementPath: ScenePath | null, path: TemplatePath): boolean {
   if (focusedElementPath == null || isStoryboardDescendant(path)) {
     return false


### PR DESCRIPTION
**Problem:**
The new Natural Scenes worked removed the `data-utopia-scene-id` field from Scenes. This had the unintended consequence of breaking the caching in DOM-walker.

**Commit Details:**
- Restore `data-utopia-scene-id` on the scenes.
- Created a sinful `TP.createBackwardsCompatibleScenePath` function which takes the first two elements of the first element path of a scene path of a path. Long story short: for this path: `storyboard/scene-1/app-instance:app-root/card-instance` it will return `storyboard/scene-1`. This is horrible, and really bad, but the alternative was to change the keying of the dom walker caching which has zero test coverage, and I will probably just break it if I touch it.
