### PR TITLE
Strip UIDs when printing code in production environments

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -250,9 +250,8 @@ function maybeRequestModelUpdate(
         codeNeedsPrinting(file.fileContents.revisionsState) &&
         isParseSuccess(file.fileContents.parsed)
       ) {
-        const stripUIDs = PRODUCTION_ENV
         filesToUpdate.push(
-          createPrintCode(fullPath, file.fileContents.parsed, stripUIDs, file.lastRevisedTime),
+          createPrintCode(fullPath, file.fileContents.parsed, true, file.lastRevisedTime),
         )
       }
     }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -251,7 +251,12 @@ function maybeRequestModelUpdate(
         isParseSuccess(file.fileContents.parsed)
       ) {
         filesToUpdate.push(
-          createPrintCode(fullPath, file.fileContents.parsed, true, file.lastRevisedTime),
+          createPrintCode(
+            fullPath,
+            file.fileContents.parsed,
+            isBrowserEnvironment,
+            file.lastRevisedTime,
+          ),
         )
       }
     }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -250,8 +250,9 @@ function maybeRequestModelUpdate(
         codeNeedsPrinting(file.fileContents.revisionsState) &&
         isParseSuccess(file.fileContents.parsed)
       ) {
+        const stripUIDs = process.env.NODE_ENV === 'production'
         filesToUpdate.push(
-          createPrintCode(fullPath, file.fileContents.parsed, false, file.lastRevisedTime),
+          createPrintCode(fullPath, file.fileContents.parsed, stripUIDs, file.lastRevisedTime),
         )
       }
     }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -251,12 +251,7 @@ function maybeRequestModelUpdate(
         isParseSuccess(file.fileContents.parsed)
       ) {
         filesToUpdate.push(
-          createPrintCode(
-            fullPath,
-            file.fileContents.parsed,
-            isBrowserEnvironment,
-            file.lastRevisedTime,
-          ),
+          createPrintCode(fullPath, file.fileContents.parsed, PRODUCTION_ENV, file.lastRevisedTime),
         )
       }
     }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -250,7 +250,7 @@ function maybeRequestModelUpdate(
         codeNeedsPrinting(file.fileContents.revisionsState) &&
         isParseSuccess(file.fileContents.parsed)
       ) {
-        const stripUIDs = process.env.NODE_ENV === 'production'
+        const stripUIDs = PRODUCTION_ENV
         filesToUpdate.push(
           createPrintCode(fullPath, file.fileContents.parsed, stripUIDs, file.lastRevisedTime),
         )


### PR DESCRIPTION
Fixes #1119 

**Problem:**
We were no longer stripping UIDs because of a hard coded flag that was presumably left in from development.

**Fix:**
Use the environment to determine if UIDs should be stripped, meaning they will be removed in all production environments (including staging)