### PR TITLE
Make the default project more like a CRA project.

### DIFF
--- a/editor/src/bundled-dependencies/codeBundle.ts
+++ b/editor/src/bundled-dependencies/codeBundle.ts
@@ -4,6 +4,23 @@ import { ExportsInfo } from '../core/workers/ts/ts-worker'
 // 'Update Saved Bundle' and change the test function from xit(... to it(... to enable it
 
 export const SampleFileBuildResult = JSON.parse(`{
+  "/src/app.js": {
+    "errors": [],
+    "transpiledCode": "\\"use strict\\";\\n\\nObject.defineProperty(exports, \\"__esModule\\", {\\n  value: true\\n});\\nexports.storyboard = void 0;\\n\\nvar utopia_api_1 = require(\\"utopia-api\\");\\n\\nvar app_js_1 = require(\\"/src/app.js\\");\\n\\nexports.storyboard = utopia_api_1.jsx(utopia_api_1.Storyboard, null, utopia_api_1.jsx(utopia_api_1.Scene, {\\n  style: {\\n    position: 'absolute',\\n    left: 0,\\n    top: 0,\\n    width: 375,\\n    height: 812\\n  }\\n}, utopia_api_1.jsx(app_js_1.App, null))); //# sourceMappingURL=app.js.map",
+    "sourceMap": {
+      "version": 3,
+      "sources": [
+        "../../src/app.js"
+      ],
+      "names": [],
+      "mappings": ";;;;;;;AAEA,IAAA,YAAA,GAAA,OAAA,CAAA,YAAA,CAAA;;AACA,IAAA,QAAA,GAAA,OAAA,CAAA,aAAA,CAAA;;AACW,OAAA,CAAA,UAAA,GACT,YAAA,CAAA,GAAA,CAAC,YAAA,CAAA,UAAD,EAAW,IAAX,EACE,YAAA,CAAA,GAAA,CAAC,YAAA,CAAA,KAAD,EAAM;AACJ,EAAA,KAAK,EAAE;AAAE,IAAA,QAAQ,EAAE,UAAZ;AAAwB,IAAA,IAAI,EAAE,CAA9B;AAAiC,IAAA,GAAG,EAAE,CAAtC;AAAyC,IAAA,KAAK,EAAE,GAAhD;AAAqD,IAAA,MAAM,EAAE;AAA7D;AADH,CAAN,EAGE,YAAA,CAAA,GAAA,CAAC,QAAA,CAAA,GAAD,EAAI,IAAJ,CAHF,CADF,CADS,C",
+      "sourcesContent": [
+        "/** @jsx jsx */\\nimport * as React from 'react'\\nimport { Scene, Storyboard, jsx } from 'utopia-api'\\nimport { App } from '/src/app.js'\\nexport var storyboard = (\\n  <Storyboard>\\n    <Scene\\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\\n    >\\n      <App />\\n    </Scene>\\n  </Storyboard>\\n)\\n\\n"
+      ],
+      "sourceRoot": "",
+      "file": "app.js"
+    }
+  },
   "/src/index.js": {
     "errors": [],
     "transpiledCode": "\\"use strict\\";\\n\\nvar __createBinding = this && this.__createBinding || (Object.create ? function (o, m, k, k2) {\\n  if (k2 === undefined) k2 = k;\\n  Object.defineProperty(o, k2, {\\n    enumerable: true,\\n    get: function get() {\\n      return m[k];\\n    }\\n  });\\n} : function (o, m, k, k2) {\\n  if (k2 === undefined) k2 = k;\\n  o[k2] = m[k];\\n});\\n\\nvar __setModuleDefault = this && this.__setModuleDefault || (Object.create ? function (o, v) {\\n  Object.defineProperty(o, \\"default\\", {\\n    enumerable: true,\\n    value: v\\n  });\\n} : function (o, v) {\\n  o[\\"default\\"] = v;\\n});\\n\\nvar __importStar = this && this.__importStar || function (mod) {\\n  if (mod && mod.__esModule) return mod;\\n  var result = {};\\n  if (mod != null) for (var k in mod) {\\n    if (k !== \\"default\\" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);\\n  }\\n\\n  __setModuleDefault(result, mod);\\n\\n  return result;\\n};\\n\\nObject.defineProperty(exports, \\"__esModule\\", {\\n  value: true\\n});\\n\\nvar React = __importStar(require(\\"react\\"));\\n\\nvar ReactDOM = __importStar(require(\\"react-dom\\"));\\n\\nvar app_1 = require(\\"../src/app\\");\\n\\nvar root = document.getElementById(\\"root\\");\\n\\nif (root != null) {\\n  ReactDOM.render(React.createElement(app_1.App, null), root);\\n} //# sourceMappingURL=index.js.map",
@@ -23,16 +40,16 @@ export const SampleFileBuildResult = JSON.parse(`{
   },
   "/utopia/storyboard.js": {
     "errors": [],
-    "transpiledCode": "\\"use strict\\";\\n\\nObject.defineProperty(exports, \\"__esModule\\", {\\n  value: true\\n});\\nexports.storyboard = exports.App = void 0;\\n\\nvar utopia_api_1 = require(\\"utopia-api\\");\\n\\nexports.App = function (props) {\\n  return utopia_api_1.jsx(\\"div\\", {\\n    style: {\\n      width: '100%',\\n      height: '100%',\\n      backgroundColor: '#FFFFFF',\\n      position: 'relative'\\n    }\\n  });\\n};\\n\\nexports.storyboard = utopia_api_1.jsx(utopia_api_1.Storyboard, null, utopia_api_1.jsx(utopia_api_1.Scene, {\\n  style: {\\n    position: 'absolute',\\n    left: 0,\\n    top: 0,\\n    width: 375,\\n    height: 812\\n  }\\n}, utopia_api_1.jsx(exports.App, null))); //# sourceMappingURL=storyboard.js.map",
+    "transpiledCode": "\\"use strict\\";\\n\\nObject.defineProperty(exports, \\"__esModule\\", {\\n  value: true\\n});\\nexports.storyboard = void 0;\\n\\nvar utopia_api_1 = require(\\"utopia-api\\");\\n\\nvar app_js_1 = require(\\"/src/app.js\\");\\n\\nexports.storyboard = utopia_api_1.jsx(utopia_api_1.Storyboard, null, utopia_api_1.jsx(utopia_api_1.Scene, {\\n  style: {\\n    position: 'absolute',\\n    left: 0,\\n    top: 0,\\n    width: 375,\\n    height: 812\\n  }\\n}, utopia_api_1.jsx(app_js_1.App, null))); //# sourceMappingURL=storyboard.js.map",
     "sourceMap": {
       "version": 3,
       "sources": [
         "../../utopia/storyboard.js"
       ],
       "names": [],
-      "mappings": ";;;;;;;AAEA,IAAA,YAAA,GAAA,OAAA,CAAA,YAAA,CAAA;;AACW,OAAA,CAAA,GAAA,GAAM,UAAC,KAAD,EAAU;AACzB,SACE,YAAA,CAAA,GAAA,CAAA,KAAA,EAAA;AACE,IAAA,KAAK,EAAE;AAAE,MAAA,KAAK,EAAE,MAAT;AAAiB,MAAA,MAAM,EAAE,MAAzB;AAAiC,MAAA,eAAe,EAAE,SAAlD;AAA6D,MAAA,QAAQ,EAAE;AAAvE;AADT,GAAA,CADF;AAKD,CANU;;AAOA,OAAA,CAAA,UAAA,GACT,YAAA,CAAA,GAAA,CAAC,YAAA,CAAA,UAAD,EAAW,IAAX,EACE,YAAA,CAAA,GAAA,CAAC,YAAA,CAAA,KAAD,EAAM;AACJ,EAAA,KAAK,EAAE;AAAE,IAAA,QAAQ,EAAE,UAAZ;AAAwB,IAAA,IAAI,EAAE,CAA9B;AAAiC,IAAA,GAAG,EAAE,CAAtC;AAAyC,IAAA,KAAK,EAAE,GAAhD;AAAqD,IAAA,MAAM,EAAE;AAA7D;AADH,CAAN,EAGE,YAAA,CAAA,GAAA,CAAC,OAAA,CAAA,GAAD,EAAI,IAAJ,CAHF,CADF,CADS,C",
+      "mappings": ";;;;;;;AAEA,IAAA,YAAA,GAAA,OAAA,CAAA,YAAA,CAAA;;AACA,IAAA,QAAA,GAAA,OAAA,CAAA,aAAA,CAAA;;AACW,OAAA,CAAA,UAAA,GACT,YAAA,CAAA,GAAA,CAAC,YAAA,CAAA,UAAD,EAAW,IAAX,EACE,YAAA,CAAA,GAAA,CAAC,YAAA,CAAA,KAAD,EAAM;AACJ,EAAA,KAAK,EAAE;AAAE,IAAA,QAAQ,EAAE,UAAZ;AAAwB,IAAA,IAAI,EAAE,CAA9B;AAAiC,IAAA,GAAG,EAAE,CAAtC;AAAyC,IAAA,KAAK,EAAE,GAAhD;AAAqD,IAAA,MAAM,EAAE;AAA7D;AADH,CAAN,EAGE,YAAA,CAAA,GAAA,CAAC,QAAA,CAAA,GAAD,EAAI,IAAJ,CAHF,CADF,CADS,C",
       "sourcesContent": [
-        "/** @jsx jsx */\\nimport * as React from 'react'\\nimport { Scene, Storyboard, jsx } from 'utopia-api'\\nexport var App = (props) => {\\n  return (\\n    <div\\n      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}\\n    />\\n  )\\n}\\nexport var storyboard = (\\n  <Storyboard>\\n    <Scene\\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\\n    >\\n      <App />\\n    </Scene>\\n  </Storyboard>\\n)\\n\\n"
+        "/** @jsx jsx */\\nimport * as React from 'react'\\nimport { Scene, Storyboard, jsx } from 'utopia-api'\\nimport { App } from '/src/app.js'\\nexport var storyboard = (\\n  <Storyboard>\\n    <Scene\\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\\n    >\\n      <App />\\n    </Scene>\\n  </Storyboard>\\n)\\n\\n"
       ],
       "sourceRoot": "",
       "file": "storyboard.js"
@@ -42,27 +59,25 @@ export const SampleFileBuildResult = JSON.parse(`{
 
 export const SampleFileBundledExportsInfo: Array<ExportsInfo> = JSON.parse(`[
   {
+    "filename": "/src/app.js",
+    "code": "/** @jsx jsx */\\nimport * as React from 'react'\\nimport { Scene, Storyboard, jsx } from 'utopia-api'\\nimport { App } from '/src/app.js'\\nexport var storyboard = (\\n  <Storyboard>\\n    <Scene\\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\\n    >\\n      <App />\\n    </Scene>\\n  </Storyboard>\\n)\\n\\n",
+    "exportTypes": {
+      "storyboard": {
+        "type": "Element",
+        "functionInfo": null,
+        "reactClassInfo": null
+      }
+    }
+  },
+  {
     "filename": "/src/index.js",
     "code": "import * as React from \\"react\\";\\nimport * as ReactDOM from \\"react-dom\\";\\nimport { App } from \\"../src/app\\";\\n\\nconst root = document.getElementById(\\"root\\");\\nif (root != null) {\\n  ReactDOM.render(<App />, root);\\n}",
     "exportTypes": {}
   },
   {
     "filename": "/utopia/storyboard.js",
-    "code": "/** @jsx jsx */\\nimport * as React from 'react'\\nimport { Scene, Storyboard, jsx } from 'utopia-api'\\nexport var App = (props) => {\\n  return (\\n    <div\\n      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}\\n    />\\n  )\\n}\\nexport var storyboard = (\\n  <Storyboard>\\n    <Scene\\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\\n    >\\n      <App />\\n    </Scene>\\n  </Storyboard>\\n)\\n\\n",
+    "code": "/** @jsx jsx */\\nimport * as React from 'react'\\nimport { Scene, Storyboard, jsx } from 'utopia-api'\\nimport { App } from '/src/app.js'\\nexport var storyboard = (\\n  <Storyboard>\\n    <Scene\\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\\n    >\\n      <App />\\n    </Scene>\\n  </Storyboard>\\n)\\n\\n",
     "exportTypes": {
-      "App": {
-        "type": "(props: any) => Element",
-        "functionInfo": [
-          {
-            "name": "props",
-            "memberInfo": {
-              "type": "any",
-              "members": {}
-            }
-          }
-        ],
-        "reactClassInfo": null
-      },
       "storyboard": {
         "type": "Element",
         "functionInfo": null,

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -16,21 +16,17 @@ Array [
           "props": Array [],
           "type": "JSX_ELEMENT",
         },
-        "importsToAdd": Object {
-          "/utopia/storyboard.js": Object {
-            "importedAs": null,
-            "importedFromWithin": Array [
-              Object {
-                "alias": "App",
-                "name": "App",
-              },
-            ],
-            "importedWithName": null,
-          },
-        },
+        "importsToAdd": Object {},
         "name": "App",
       },
     ],
+    "source": Object {
+      "path": "/src/app.js",
+      "type": "PROJECT_COMPONENT_GROUP",
+    },
+  },
+  Object {
+    "insertableComponents": Array [],
     "source": Object {
       "path": "/utopia/storyboard.js",
       "type": "PROJECT_COMPONENT_GROUP",

--- a/editor/src/core/model/new-project-files.ts
+++ b/editor/src/core/model/new-project-files.ts
@@ -7,6 +7,22 @@ import {
 } from '../shared/project-file-types'
 import { lintAndParse } from '../workers/parser-printer/parser-printer'
 
+export const sampleAppJSCode = `/** @jsx jsx */
+import * as React from 'react'
+import { jsx } from 'utopia-api'
+export var App = (props) => {
+  return (
+    <div
+      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}
+    />
+  )
+}`
+
+export function appJSFile(): TextFile {
+  const result = lintAndParse('/src/app.js', sampleAppJSCode, null)
+  return textFile(textFileContents(sampleCode, result, RevisionsState.BothMatch), null, Date.now())
+}
+
 export function getDefaultUIJsFile(): TextFile {
   const result = lintAndParse('code.tsx', sampleCode, null)
   return textFile(textFileContents(sampleCode, result, RevisionsState.BothMatch), null, Date.now())
@@ -15,13 +31,7 @@ export function getDefaultUIJsFile(): TextFile {
 export const sampleCode = `/** @jsx jsx */
 import * as React from 'react'
 import { Scene, Storyboard, jsx } from 'utopia-api'
-export var App = (props) => {
-  return (
-    <div
-      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}
-    />
-  )
-}
+import { App } from '/src/app.js'
 export var storyboard = (
   <Storyboard>
     <Scene

--- a/editor/src/core/shared/project-contents-dependencies.spec.ts
+++ b/editor/src/core/shared/project-contents-dependencies.spec.ts
@@ -27,6 +27,12 @@ describe('getDirectReverseDependencies', () => {
       simpleDefaultProject().projectContents,
       SampleNodeModules,
     )
-    expect(actualResult).toMatchInlineSnapshot(`Object {}`)
+    expect(actualResult).toMatchInlineSnapshot(`
+      Object {
+        "/src/app.js": Array [
+          "/utopia/storyboard.js",
+        ],
+      }
+    `)
   })
 })

--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -6,6 +6,7 @@ import {
   StoryboardFilePath,
 } from '../components/editor/store/editor-state'
 import {
+  appJSFile,
   getDefaultUIJsFile,
   getSamplePreviewFile,
   getSamplePreviewHTMLFile,
@@ -36,6 +37,7 @@ export function simpleDefaultProject(): PersistentModel {
       0,
     ),
     '/src': directory(),
+    '/src/app.js': appJSFile(),
     [StoryboardFilePath]: getDefaultUIJsFile(),
     '/assets': directory(),
     '/public': directory(),


### PR DESCRIPTION
Fixes #1117

**Problem:**
Our default project doesn't look very similar to a Create React App project.

**Fix:**
Split out some code from the storyboard file so that the default project looks more like a CRA project with a single additional file.

**Commit Details:**
- Put the `App` component into the file `/src/app.js`.
- Storyboard now imports the `App` component from this new file.
