### PR TITLE
Fix Tag and Release Workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Set Explicit Tag Variable
         # If we have explicitly passed in a tag, use that
         if: ${{ github.event.inputs.tag-name != null }}
-        run: echo ::set-env name=NEW_TAG::${{ github.event.inputs.tag-name }}
+        run: echo "NEW_TAG=${{ github.event.inputs.tag-name }}" >> $GITHUB_ENV
       - name: Set Calculated Tag Variable
         # If we haven't explicitly passed in a tag, use the next patch version determined above
         if: ${{ github.event.inputs.tag-name == null }}
-        run: echo ::set-env name=NEW_TAG::${{ steps.get-next-tags.outputs.v_patch }}
+        run: echo "NEW_TAG=${{ steps.get-next-tags.outputs.v_patch }}" >> $GITHUB_ENV
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
The `set-env` command was disabled a while back, so this PR replaces them based on https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

We had to do exactly this in the deploys repo a while back, but this script was missed during that.