### PR TITLE
fix(navigator) fix editor scrolling

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -308,7 +308,7 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
           style={{
             position: 'absolute',
             top: TopMenuHeight,
-            height: 'calc(100% - 30px)',
+            height: `calc(100% - ${TopMenuHeight}px)`,
             left: getNavigatorLeft,
             width: LeftPaneDefaultWidth,
           }}


### PR DESCRIPTION
**Problem:**
Fix for navigator size, this was causing a problem where you can scroll the whole editor.

Fixes https://github.com/concrete-utopia/utopia/issues/1130.

