### PR TITLE
Include source file name in hashed object when generating UIDs

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -21,8 +21,8 @@ exports[`UiJsxCanvas #747 - DOM object constructor cannot be called as a functio
     data-uid=\\"scene sb\\"
   >
     <div
-      data-uid=\\"comment-root 031~~~1 app\\"
-      data-paths=\\"031~~~1:comment-root :031~~~1 :sb/scene/app\\"
+      data-uid=\\"comment-root 1d1~~~1 app\\"
+      data-paths=\\"1d1~~~1:comment-root :1d1~~~1 :sb/scene/app\\"
     >
       hat
     </div>

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -946,9 +946,9 @@ exports[`UiJsxCanvas render Renders input tag without errors 1`] = `
     data-uid=\\"scene-aaa utopia-storyboard-uid\\"
   >
     <input
-      data-uid=\\"9e8 567 app-entity\\"
+      data-uid=\\"5f4 567 app-entity\\"
       style=\\"top: 10px;\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:567:9e8 utopia-storyboard-uid/scene-aaa/app-entity:567 :utopia-storyboard-uid/scene-aaa/app-entity\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:567:5f4 utopia-storyboard-uid/scene-aaa/app-entity:567 :utopia-storyboard-uid/scene-aaa/app-entity\\"
     />
   </div>
 </div>
@@ -21925,8 +21925,8 @@ exports[`UiJsxCanvas render renders fine with two components that reference each
     data-uid=\\"scene utopia-storyboard-uid\\"
   >
     <div
-      data-uid=\\"2a2~~~1 aaa-unparsed-no-template-path bbb-unparsed-no-template-path BBB app-entity\\"
-      data-paths=\\":2a2~~~1 utopia-storyboard-uid/scene/app-entity:BBB :utopia-storyboard-uid/scene/app-entity\\"
+      data-uid=\\"1a9~~~1 aaa-unparsed-no-template-path bbb-unparsed-no-template-path BBB app-entity\\"
+      data-paths=\\":1a9~~~1 utopia-storyboard-uid/scene/app-entity:BBB :utopia-storyboard-uid/scene/app-entity\\"
     >
       great
     </div>
@@ -23379,8 +23379,8 @@ exports[`UiJsxCanvas render respects a jsx pragma 1`] = `
     data-uid=\\"scene-aaa utopia-storyboard-uid\\"
   >
     <div
-      data-uid=\\"fa7 aaa app-entity\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:fa7 utopia-storyboard-uid/scene-aaa/app-entity:aaa :utopia-storyboard-uid/scene-aaa/app-entity\\"
+      data-uid=\\"4cf aaa app-entity\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:4cf utopia-storyboard-uid/scene-aaa/app-entity:aaa :utopia-storyboard-uid/scene-aaa/app-entity\\"
       data-factory-function-works=\\"true\\"
     >
       Utopia
@@ -25419,8 +25419,8 @@ exports[`UiJsxCanvas render the utopia jsx pragma (and layout prop) works well 1
     data-uid=\\"scene-aaa utopia-storyboard-uid\\"
   >
     <div
-      data-uid=\\"56b aaa app-entity\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:56b utopia-storyboard-uid/scene-aaa/app-entity:aaa :utopia-storyboard-uid/scene-aaa/app-entity\\"
+      data-uid=\\"45b aaa app-entity\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:45b utopia-storyboard-uid/scene-aaa/app-entity:aaa :utopia-storyboard-uid/scene-aaa/app-entity\\"
       style=\\"width: 50px; height: 50px; left: 15px; top: 15px;\\"
     >
       Utopia
@@ -25564,8 +25564,8 @@ exports[`UiJsxCanvas render the utopia jsx pragma supports emotion CSS prop 1`] 
     data-uid=\\"scene-aaa utopia-storyboard-uid\\"
   >
     <div
-      data-uid=\\"6b9 aaa app-entity\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:6b9 utopia-storyboard-uid/scene-aaa/app-entity:aaa :utopia-storyboard-uid/scene-aaa/app-entity\\"
+      data-uid=\\"a0e aaa app-entity\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:a0e utopia-storyboard-uid/scene-aaa/app-entity:aaa :utopia-storyboard-uid/scene-aaa/app-entity\\"
       class=\\"css-f9xk9e\\"
       style=\\"width: 50px; height: 50px; left: 15px; top: 15px;\\"
     >

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser.ts
@@ -206,7 +206,7 @@ describe('Select Mode Advanced Cases', () => {
     await waitForAnimationFrame()
 
     expect(renderResult.getEditorState().editor.selectedViews).toEqual([
-      TP.fromString('sb/scene-2/Card-instance:Card-Root/d63/Card-Button-3'),
+      TP.fromString('sb/scene-2/Card-instance:Card-Root/Card-Row-Buttons/Card-Button-3'),
     ])
   })
 
@@ -259,7 +259,7 @@ describe('Select Mode Advanced Cases', () => {
     await doubleClick()
 
     expect(renderResult.getEditorState().editor.selectedViews).toEqual([
-      TP.fromString('sb/scene-2/Card-instance:Card-Root/d63/Card-Button-3'),
+      TP.fromString('sb/scene-2/Card-instance:Card-Root/Card-Row-Buttons/Card-Button-3'),
     ])
   })
 
@@ -331,7 +331,7 @@ describe('Select Mode Advanced Cases', () => {
 
     expect(renderResult.getEditorState().editor.selectedViews).toEqual([
       TP.fromString(
-        'sb/scene-CardList/CardList-instance:CardList-Root/CardList-Col/CardList-Card~~~1:Card-Root/d63/Card-Button-3',
+        'sb/scene-CardList/CardList-instance:CardList-Root/CardList-Col/CardList-Card~~~1:Card-Root/Card-Row-Buttons/Card-Button-3',
       ),
     ])
   })
@@ -454,7 +454,7 @@ export const Card = (props) => (
       />
       <LabelRow data-uid="Card-LabelRow" />
     </Row>
-    <Row style={{ minHeight: 40, gap: 12 }} data-uid="Card-Row">
+    <Row style={{ minHeight: 40, gap: 12 }} data-uid="Card-Row-Buttons">
       <Button data-uid="Card-Button-1">Hello</Button>
       <Button data-uid="Card-Button-2">Button</Button>
       <Button data-uid="Card-Button-3">Button</Button>

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1300,8 +1300,8 @@ export var ${BakedInStoryboardVariableName} = (props) => {
         >
           <div
             id=\\"nasty-div\\"
-            data-uid=\\"2a7~~~1 150~~~2 2f5~~~1 aaa app-entity\\"
-            data-paths=\\":150~~~2/2a7~~~1 :150~~~2 :2f5~~~1 utopia-storyboard-uid/scene-aaa/app-entity:aaa :utopia-storyboard-uid/scene-aaa/app-entity\\"
+            data-uid=\\"8cd~~~1 833~~~2 65e~~~1 aaa app-entity\\"
+            data-paths=\\":833~~~2/8cd~~~1 :833~~~2 :65e~~~1 utopia-storyboard-uid/scene-aaa/app-entity:aaa :utopia-storyboard-uid/scene-aaa/app-entity\\"
           >
             huhahuha
           </div>

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.ts
@@ -1063,8 +1063,8 @@ export var storyboard = (
       expect(results.alone).toMatchInlineSnapshot(`
         Object {
           "elements": Array [
-            "cc6",
-            "bc4",
+            "219",
+            "971",
           ],
           "js": "function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
 
@@ -1086,7 +1086,7 @@ export var storyboard = (
             babelHelpers.createClass(Picker, [{
               key: \\"renderPicker\\",
               value: function renderPicker(locale) {
-                return utopiaCanvasJSXLookup(\\"cc6\\", {
+                return utopiaCanvasJSXLookup(\\"971\\", {
                   locale: locale,
                   React: React,
                   utopiaCanvasJSXLookup: utopiaCanvasJSXLookup,
@@ -1096,7 +1096,7 @@ export var storyboard = (
             }, {
               key: \\"render\\",
               value: function render() {
-                return utopiaCanvasJSXLookup(\\"bc4\\", {
+                return utopiaCanvasJSXLookup(\\"219\\", {
                   callerThis: this
                 });
               }
@@ -1114,8 +1114,8 @@ export var storyboard = (
       expect(results.combined).toMatchInlineSnapshot(`
         Object {
           "elements": Array [
-            "150",
-            "2f5",
+            "833",
+            "65e",
           ],
           "js": "function _createSuper(Derived) { return function () { var Super = babelHelpers.getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = babelHelpers.getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return babelHelpers.possibleConstructorReturn(this, result); }; }
 
@@ -1158,7 +1158,7 @@ export var storyboard = (
             babelHelpers.createClass(Picker, [{
               key: \\"renderPicker\\",
               value: function renderPicker(locale) {
-                return utopiaCanvasJSXLookup(\\"150\\", {
+                return utopiaCanvasJSXLookup(\\"833\\", {
                   locale: locale,
                   React: React,
                   utopiaCanvasJSXLookup: utopiaCanvasJSXLookup,
@@ -1168,7 +1168,7 @@ export var storyboard = (
             }, {
               key: \\"render\\",
               value: function render() {
-                return utopiaCanvasJSXLookup(\\"2f5\\", {
+                return utopiaCanvasJSXLookup(\\"65e\\", {
                   callerThis: this
                 });
               }

--- a/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
@@ -168,9 +168,9 @@ describe('Parsing and printing code with comments', () => {
             {
               /* Comment at start of JSX expression */
               true /* Comment inside JSX expression */ ? (
-                <div data-uid='fa7' />
+                <div data-uid='4cf' />
               ) : (
-                <div data-uid='36e' />
+                <div data-uid='b93' />
               ) /* Comment at end of JSX expression */
             }
           </div>

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -1560,6 +1560,7 @@ function forciblyUpdateDataUID(
   alreadyExistingUIDs: Set<string>,
 ): WithParserMetadata<JSXAttributes> {
   const hash = Hash({
+    fileName: sourceFile.fileName,
     name: name,
     props: clearAttributesSourceMaps(clearAttributesUniqueIDs(props)),
   })

--- a/editor/src/core/workers/parser-printer/uid-fix.spec.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.spec.ts
@@ -9,10 +9,10 @@ describe('fixParseSuccessUIDs', () => {
     const newFile = lintAndParse('test.js', baseFileContents, baseFile)
     expect(getUidTree(newFile)).toEqual(getUidTree(baseFile))
     expect(getUidTree(newFile)).toMatchInlineSnapshot(`
-      "c94
+      "4ed
         random-uuid
-      93b
-        c8a
+      a04
+        ce5
       storyboard
         scene
           component"
@@ -24,12 +24,12 @@ describe('fixParseSuccessUIDs', () => {
     const newFileFixed = lintAndParse('test.js', baseFileWithTwoTopLevelComponents, baseFile)
     expect(getUidTree(newFileFixed)).toEqual(getUidTree(newFile))
     expect(getUidTree(newFileFixed)).toMatchInlineSnapshot(`
-      "c94
+      "4ed
         random-uuid
-      7f2
-        8de
-      93b
-        c8a
+      6f6
+        edd
+      a04
+        ce5
       storyboard
         scene
           component"
@@ -40,10 +40,10 @@ describe('fixParseSuccessUIDs', () => {
     const newFile = lintAndParse('test.js', fileWithSingleUpdateContents, baseFile)
     expect(getUidTree(newFile)).toEqual(getUidTree(baseFile))
     expect(getUidTree(newFile)).toMatchInlineSnapshot(`
-      "c94
+      "4ed
         random-uuid
-      93b
-        c8a
+      a04
+        ce5
       storyboard
         scene
           component"
@@ -53,11 +53,11 @@ describe('fixParseSuccessUIDs', () => {
   it('avoids uid shifting caused by single prepending insertion', () => {
     const newFile = lintAndParse('test.js', fileWithOneInsertedView, baseFile)
     expect(getUidTree(newFile)).toMatchInlineSnapshot(`
-      "c94
+      "4ed
         random-uuid
-      93b
-        8de
-        c8a
+      a04
+        edd
+        ce5
       storyboard
         scene
           component"
@@ -67,12 +67,12 @@ describe('fixParseSuccessUIDs', () => {
   it('double duplication', () => {
     const newFile = lintAndParse('test.js', fileWithTwoDuplicatedViews, baseFile)
     expect(getUidTree(newFile)).toMatchInlineSnapshot(`
-      "c94
+      "4ed
         random-uuid
-      93b
-        c8a
-        af7
-        a72
+      a04
+        ce5
+        0b4
+        e78
       storyboard
         scene
           component"
@@ -83,13 +83,13 @@ describe('fixParseSuccessUIDs', () => {
     const threeViews = lintAndParse('test.js', fileWithTwoDuplicatedViews, null)
     const fourViews = lintAndParse('test.js', fileWithTwoDuplicatesAndInsertion, threeViews)
     expect(getUidTree(fourViews)).toMatchInlineSnapshot(`
-      "c94
+      "4ed
         random-uuid
-      93b
-        578
-        c8a
-        af7
-        a72
+      a04
+        395
+        ce5
+        0b4
+        e78
       storyboard
         scene
           component"


### PR DESCRIPTION
Fixes #1127 

**Problem:**
UIDs generated from hashes don't take into account the existence of UIDs from other source files.

**Fix:**
This fix is really a partial fix - for a full fix we would need to change the parsing to apply to the entire project, so that we could pass along the existing UIDs. Rather than doing that, this fix includes the source file's name in the object that we hash when generating those UIDs, meaning that copying and pasting code across multiple files won't result in clashing UIDs.

I've also fixed a duplicate hand written UID in the `TestProjectAlpineClimb` test code.