### PR TITLE
Natural Scenes Tidying Part 1

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -338,7 +338,7 @@ export function updateFramesOfScenesAndComponents(
 ): EditorState {
   let workingEditorState: EditorState = editorState
   Utils.fastForEach(framesAndTargets, (frameAndTarget) => {
-    const target = TP.instancePathForElementAtPath(frameAndTarget.target, true)
+    const target = TP.instancePathForElementAtPath(frameAndTarget.target)
 
     // Realign to aim at the static version, not the dynamic one.
     const originalTarget = target

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -338,526 +338,384 @@ export function updateFramesOfScenesAndComponents(
 ): EditorState {
   let workingEditorState: EditorState = editorState
   Utils.fastForEach(framesAndTargets, (frameAndTarget) => {
-    const { target } = frameAndTarget
-    if (TP.isScenePath(target)) {
-      switch (frameAndTarget.type) {
-        case 'PIN_FRAME_CHANGE':
-        case 'PIN_SIZE_CHANGE': {
-          // Update scene with pin based frame.
-          const sceneStaticpath = createSceneTemplatePath(target)
-          workingEditorState = modifyUnderlyingForOpenFile(
-            sceneStaticpath,
-            workingEditorState,
-            (sceneElement) => {
-              const sceneStyleUpdated = setJSXValuesAtPaths(sceneElement.props, [
-                {
-                  path: PP.create(['style']),
-                  value: jsxAttributeValue(
-                    {
-                      left: frameAndTarget.frame?.x,
-                      top: frameAndTarget.frame?.y,
-                      width: frameAndTarget.frame?.width,
-                      height: frameAndTarget.frame?.height,
-                    },
-                    emptyComments,
-                  ),
-                },
-              ])
-              return foldEither(
-                () => sceneElement,
-                (updatedProps) => {
-                  return {
-                    ...sceneElement,
-                    props: roundAttributeLayoutValues(updatedProps),
-                  }
-                },
-                sceneStyleUpdated,
-              )
-            },
-          )
-          break
-        }
-        case 'PIN_MOVE_CHANGE': {
-          const sceneStaticpath = createSceneTemplatePath(target)
-          workingEditorState = modifyUnderlyingForOpenFile(
-            sceneStaticpath,
-            workingEditorState,
-            (sceneElement) => {
-              const styleProps = jsxSimpleAttributeToValue(
-                getJSXAttributeAtPath(sceneElement.props, PP.create(['style'])).attribute,
-              )
-              if (isRight(styleProps)) {
-                let frameProps: { [k: string]: string | number | undefined } = {}
-                Utils.fastForEach(['PinnedLeft', 'PinnedTop'] as LayoutPinnedProp[], (p) => {
-                  const framePoint = framePointForPinnedProp(p)
-                  const value = getLayoutProperty(p, right(sceneElement.props))
-                  if (isLeft(value) || value.value != null) {
-                    frameProps[framePoint] = value.value
-                  }
-                })
-                let propsToSet = getPropsToSetToMoveElement(
-                  frameAndTarget.delta,
-                  [FramePoint.Top, FramePoint.Left],
-                  frameProps,
-                  null,
-                )
-                const sceneStyleUpdated = setJSXValuesAtPaths(sceneElement.props, propsToSet)
-                return foldEither(
-                  () => sceneElement,
-                  (updatedProps) => {
-                    return {
-                      ...sceneElement,
-                      props: roundAttributeLayoutValues(updatedProps),
-                    }
-                  },
-                  sceneStyleUpdated,
-                )
-              } else {
-                return sceneElement
-              }
-            },
-          )
-          break
-        }
-        case 'SINGLE_RESIZE':
-          const sceneStaticpath = createSceneTemplatePath(target)
-          workingEditorState = modifyUnderlyingForOpenFile(
-            sceneStaticpath,
-            workingEditorState,
-            (sceneElement) => {
-              const styleProps = jsxSimpleAttributeToValue(
-                getJSXAttributeAtPath(sceneElement.props, PP.create(['style'])).attribute,
-              )
-              if (isRight(styleProps)) {
-                let frameProps: { [k: string]: string | number | undefined } = {}
-                Utils.fastForEach(
-                  ['PinnedLeft', 'PinnedTop', 'Width', 'Height'] as LayoutPinnedProp[],
-                  (p) => {
-                    const framePoint = framePointForPinnedProp(p)
-                    const value = getLayoutProperty(p, right(sceneElement.props))
-                    if (isLeft(value) || value.value != null) {
-                      frameProps[framePoint] = value.value
-                    }
-                  },
-                )
-                let propsToSet = getPropsToSetToResizeElement(
-                  frameAndTarget.edgePosition,
-                  frameAndTarget.sizeDelta.x,
-                  frameAndTarget.sizeDelta.y,
-                  [FramePoint.Top, FramePoint.Left, FramePoint.Width, FramePoint.Height],
-                  frameProps,
-                  null,
-                )
-                const sceneStyleUpdated = setJSXValuesAtPaths(sceneElement.props, propsToSet)
-                return foldEither(
-                  () => sceneElement,
-                  (updatedProps) => {
-                    return {
-                      ...sceneElement,
-                      props: roundAttributeLayoutValues(updatedProps),
-                    }
-                  },
-                  sceneStyleUpdated,
-                )
-              } else {
-                return sceneElement
-              }
-            },
-          )
-          break
-        case 'FLEX_MOVE':
-        case 'FLEX_RESIZE':
-          throw new Error(
-            `Attempted to change a scene with a flex change ${JSON.stringify(target)}.`,
-          )
-        default:
-          const _exhaustiveCheck: never = frameAndTarget
-          throw new Error(`Unhandled type ${JSON.stringify(frameAndTarget)}`)
-      }
-    } else {
-      // Realign to aim at the static version, not the dynamic one.
-      const originalTarget = target
-      const staticTarget = MetadataUtils.dynamicPathToStaticPath(target)
-      if (staticTarget == null) {
-        return
-      }
+    const target = TP.instancePathForElementAtPath(frameAndTarget.target, true)
 
-      const element = withUnderlyingTargetFromEditorState(
-        staticTarget,
-        workingEditorState,
-        null,
-        (success, underlyingElement) => underlyingElement,
-      )
-      if (element == null) {
-        throw new Error(`Unexpected result when looking for element: ${element}`)
-      }
+    // Realign to aim at the static version, not the dynamic one.
+    const originalTarget = target
+    const staticTarget = MetadataUtils.dynamicPathToStaticPath(target)
+    if (staticTarget == null) {
+      return
+    }
 
-      const staticParentPath = TP.parentPath(staticTarget)
-      const parentElement = withUnderlyingTargetFromEditorState(
-        staticParentPath,
-        workingEditorState,
-        null,
-        (success, underlyingElement) => underlyingElement,
-      )
+    const element = withUnderlyingTargetFromEditorState(
+      staticTarget,
+      workingEditorState,
+      null,
+      (success, underlyingElement) => underlyingElement,
+    )
+    if (element == null) {
+      throw new Error(`Unexpected result when looking for element: ${element}`)
+    }
 
-      const isFlexContainer =
-        frameAndTarget.type !== 'PIN_FRAME_CHANGE' &&
-        frameAndTarget.type !== 'PIN_MOVE_CHANGE' &&
-        frameAndTarget.type !== 'PIN_SIZE_CHANGE' &&
-        frameAndTarget.type !== 'SINGLE_RESIZE' // TODO since now we are trusting the frameAndTarget.type, there is no point in having two switches
+    const staticParentPath = TP.parentPath(staticTarget)
+    const parentElement = withUnderlyingTargetFromEditorState(
+      staticParentPath,
+      workingEditorState,
+      null,
+      (success, underlyingElement) => underlyingElement,
+    )
 
-      let propsToSet: Array<ValueAtPath> = []
-      let propsToSkip: Array<PropertyPath> = []
-      if (isFlexContainer) {
-        if (TP.isInstancePath(staticParentPath)) {
-          switch (frameAndTarget.type) {
-            case 'PIN_FRAME_CHANGE': // this can never run now since frameAndTarget.type cannot be both PIN_FRAME_CHANGE and not PIN_FRAME_CHANGE
-            case 'PIN_SIZE_CHANGE': // this can never run now since frameAndTarget.type cannot be both PIN_FRAME_CHANGE and not PIN_FRAME_CHANGE
-            case 'PIN_MOVE_CHANGE': // this can never run now since frameAndTarget.type cannot be both PIN_FRAME_CHANGE and not PIN_FRAME_CHANGE
-            case 'SINGLE_RESIZE': // this can never run now since frameAndTarget.type cannot be both PIN_FRAME_CHANGE and not PIN_FRAME_CHANGE
-              throw new Error(
-                `Attempted to make a pin change against an element in a flex container ${JSON.stringify(
-                  staticParentPath,
-                )}.`,
-              )
-            case 'FLEX_MOVE':
-              workingEditorState = modifyUnderlyingForOpenFile(
-                originalTarget,
-                workingEditorState,
-                (elem) => elem,
-                (success, underlyingTarget) => {
-                  const components = getUtopiaJSXComponentsFromSuccess(success)
-                  if (underlyingTarget == null) {
-                    return success
-                  } else {
-                    const updatedComponents = reorderComponent(
-                      components,
-                      underlyingTarget,
-                      frameAndTarget.newIndex,
-                    )
-                    return {
-                      ...success,
-                      topLevelElements: applyUtopiaJSXComponentsChanges(
-                        success.topLevelElements,
-                        updatedComponents,
-                      ),
-                    }
-                  }
-                },
-              )
-              break
-            case 'FLEX_RESIZE':
-              if (staticParentPath == null) {
-                throw new Error(`No parent available for ${JSON.stringify(staticParentPath)}`)
-              } else {
-                if (parentElement == null) {
-                  throw new Error(`Unexpected result when looking for parent: ${parentElement}`)
-                }
-                // Flex based layout.
-                const possibleFlexProps = FlexLayoutHelpers.convertWidthHeightToFlex(
-                  frameAndTarget.newSize.width,
-                  frameAndTarget.newSize.height,
-                  element.props,
-                  right(parentElement.props),
-                  frameAndTarget.edgePosition,
-                )
-                forEachRight(possibleFlexProps, (flexProps) => {
-                  const { flexBasis, width, height } = flexProps
-                  if (flexBasis != null) {
-                    propsToSet.push({
-                      path: createLayoutPropertyPath('flexBasis'),
-                      value: jsxAttributeValue(flexBasis, emptyComments),
-                    })
-                  }
-                  if (width != null) {
-                    propsToSet.push({
-                      path: createLayoutPropertyPath('Width'),
-                      value: jsxAttributeValue(width, emptyComments),
-                    })
-                  }
-                  if (height != null) {
-                    propsToSet.push({
-                      path: createLayoutPropertyPath('Height'),
-                      value: jsxAttributeValue(height, emptyComments),
-                    })
-                  }
-                })
-              }
-              break
-            default:
-              const _exhaustiveCheck: never = frameAndTarget
-              throw new Error(`Unhandled type ${JSON.stringify(frameAndTarget)}`)
-          }
-        } else {
-          // Shouldn't happen, but the types force our hand here.
-          throw new Error(
-            `Attempted to use non-instance path ${JSON.stringify(
-              staticParentPath,
-            )} as a flex parent.`,
-          )
-        }
-      } else {
-        let parentFrame: CanvasRectangle | null = null
-        if (optionalParentFrame == null) {
-          const nonGroupParent = MetadataUtils.findNonGroupParent(
-            workingEditorState.jsxMetadata,
-            originalTarget,
-          )
-          parentFrame =
-            nonGroupParent == null
-              ? null
-              : MetadataUtils.getFrameInCanvasCoords(nonGroupParent, workingEditorState.jsxMetadata)
-        } else {
-          parentFrame = optionalParentFrame
-        }
-        const parentOffset =
-          parentFrame == null
-            ? ({ x: 0, y: 0 } as CanvasPoint)
-            : ({ x: parentFrame.x, y: parentFrame.y } as CanvasPoint)
+    const isFlexContainer =
+      frameAndTarget.type !== 'PIN_FRAME_CHANGE' &&
+      frameAndTarget.type !== 'PIN_MOVE_CHANGE' &&
+      frameAndTarget.type !== 'PIN_SIZE_CHANGE' &&
+      frameAndTarget.type !== 'SINGLE_RESIZE' // TODO since now we are trusting the frameAndTarget.type, there is no point in having two switches
 
+    let propsToSet: Array<ValueAtPath> = []
+    let propsToSkip: Array<PropertyPath> = []
+    if (isFlexContainer) {
+      if (TP.isInstancePath(staticParentPath)) {
         switch (frameAndTarget.type) {
-          case 'PIN_FRAME_CHANGE':
-          case 'PIN_SIZE_CHANGE':
-            if (frameAndTarget.frame != null) {
-              const newLocalFrame = Utils.getLocalRectangleInNewParentContext(
-                parentOffset,
-                frameAndTarget.frame,
-              )
-              const currentLocalFrame = MetadataUtils.getFrame(
-                target,
-                workingEditorState.jsxMetadata,
-              )
-              const currentFullFrame = optionalMap(Frame.getFullFrame, currentLocalFrame)
-              const fullFrame = Frame.getFullFrame(newLocalFrame)
-              const elementProps = element.props
-
-              // Pinning layout.
-              const frameProps = LayoutPinnedProps.filter((p) => {
-                const value = getLayoutProperty(p, right(elementProps))
-                return isLeft(value) || value.value != null
-              }).map(framePointForPinnedProp)
-
-              function whichPropsToUpdate() {
-                if (frameAndTarget.type === 'PIN_SIZE_CHANGE') {
-                  // only update left, top, right or bottom if the frame is expressed as left, top, right, bottom.
-                  // otherwise try to change width and height only
-                  let verticalPoints = frameProps.filter((p) => VerticalFramePoints.includes(p))
-                  let horizontalPoints = frameProps.filter((p) => HorizontalFramePoints.includes(p))
-                  if (verticalPoints.length < 2) {
-                    verticalPoints.push(FramePoint.Height)
-                  }
-                  if (horizontalPoints.length < 2) {
-                    horizontalPoints.push(FramePoint.Width)
-                  }
-
-                  return [...horizontalPoints, ...verticalPoints]
-                } else if (
-                  frameAndTarget.type === 'PIN_FRAME_CHANGE' &&
-                  frameAndTarget.edgePosition != null &&
-                  isEdgePositionOnSide(frameAndTarget.edgePosition)
-                ) {
-                  // if it has partial positioning points set and dragged on an edge only the dragged edge should be added while keeping the existing frame points.
-                  return extendPartialFramePointsForResize(frameProps, frameAndTarget.edgePosition)
+          case 'PIN_FRAME_CHANGE': // this can never run now since frameAndTarget.type cannot be both PIN_FRAME_CHANGE and not PIN_FRAME_CHANGE
+          case 'PIN_SIZE_CHANGE': // this can never run now since frameAndTarget.type cannot be both PIN_FRAME_CHANGE and not PIN_FRAME_CHANGE
+          case 'PIN_MOVE_CHANGE': // this can never run now since frameAndTarget.type cannot be both PIN_FRAME_CHANGE and not PIN_FRAME_CHANGE
+          case 'SINGLE_RESIZE': // this can never run now since frameAndTarget.type cannot be both PIN_FRAME_CHANGE and not PIN_FRAME_CHANGE
+            throw new Error(
+              `Attempted to make a pin change against an element in a flex container ${JSON.stringify(
+                staticParentPath,
+              )}.`,
+            )
+          case 'FLEX_MOVE':
+            workingEditorState = modifyUnderlyingForOpenFile(
+              originalTarget,
+              workingEditorState,
+              (elem) => elem,
+              (success, underlyingTarget) => {
+                const components = getUtopiaJSXComponentsFromSuccess(success)
+                if (underlyingTarget == null) {
+                  return success
                 } else {
-                  // The "Old" behavior, for PIN_FRAME_CHANGE
-                  return frameProps.length == 4
-                    ? frameProps
-                    : [FramePoint.Left, FramePoint.Top, FramePoint.Width, FramePoint.Height]
+                  const updatedComponents = reorderComponent(
+                    components,
+                    underlyingTarget,
+                    frameAndTarget.newIndex,
+                  )
+                  return {
+                    ...success,
+                    topLevelElements: applyUtopiaJSXComponentsChanges(
+                      success.topLevelElements,
+                      updatedComponents,
+                    ),
+                  }
                 }
+              },
+            )
+            break
+          case 'FLEX_RESIZE':
+            if (staticParentPath == null) {
+              throw new Error(`No parent available for ${JSON.stringify(staticParentPath)}`)
+            } else {
+              if (parentElement == null) {
+                throw new Error(`Unexpected result when looking for parent: ${parentElement}`)
               }
-
-              const propsToUpdate: Array<FramePoint> = whichPropsToUpdate()
-
-              Utils.fastForEach(propsToUpdate, (propToUpdate) => {
-                const absoluteValue = fullFrame[propToUpdate]
-                const previousValue =
-                  currentFullFrame == null ? null : currentFullFrame[propToUpdate]
-
-                const pinnedPropToUpdate = pinnedPropForFramePoint(propToUpdate)
-                const propPathToUpdate = createLayoutPropertyPath(pinnedPropToUpdate)
-                const existingProp = getLayoutProperty(pinnedPropToUpdate, right(elementProps))
-                if (absoluteValue === previousValue || isLeft(existingProp)) {
-                  // Only update pins that have actually changed or aren't set via code
-                  propsToSkip.push(propPathToUpdate)
-                } else {
-                  const pinIsPercentage =
-                    existingProp.value == null ? false : isPercentPin(existingProp.value)
-                  let valueToUse: string | number
-                  if (parentFrame == null) {
-                    valueToUse = absoluteValue
-                  } else {
-                    valueToUse = valueToUseForPin(
-                      propToUpdate,
-                      absoluteValue,
-                      pinIsPercentage,
-                      parentFrame,
-                    )
-                  }
+              // Flex based layout.
+              const possibleFlexProps = FlexLayoutHelpers.convertWidthHeightToFlex(
+                frameAndTarget.newSize.width,
+                frameAndTarget.newSize.height,
+                element.props,
+                right(parentElement.props),
+                frameAndTarget.edgePosition,
+              )
+              forEachRight(possibleFlexProps, (flexProps) => {
+                const { flexBasis, width, height } = flexProps
+                if (flexBasis != null) {
                   propsToSet.push({
-                    path: propPathToUpdate,
-                    value: jsxAttributeValue(valueToUse, emptyComments),
+                    path: createLayoutPropertyPath('flexBasis'),
+                    value: jsxAttributeValue(flexBasis, emptyComments),
+                  })
+                }
+                if (width != null) {
+                  propsToSet.push({
+                    path: createLayoutPropertyPath('Width'),
+                    value: jsxAttributeValue(width, emptyComments),
+                  })
+                }
+                if (height != null) {
+                  propsToSet.push({
+                    path: createLayoutPropertyPath('Height'),
+                    value: jsxAttributeValue(height, emptyComments),
                   })
                 }
               })
             }
             break
+          default:
+            const _exhaustiveCheck: never = frameAndTarget
+            throw new Error(`Unhandled type ${JSON.stringify(frameAndTarget)}`)
+        }
+      } else {
+        // Shouldn't happen, but the types force our hand here.
+        throw new Error(
+          `Attempted to use non-instance path ${JSON.stringify(
+            staticParentPath,
+          )} as a flex parent.`,
+        )
+      }
+    } else {
+      let parentFrame: CanvasRectangle | null = null
+      if (optionalParentFrame == null) {
+        const nonGroupParent = MetadataUtils.findNonGroupParent(
+          workingEditorState.jsxMetadata,
+          originalTarget,
+        )
+        parentFrame =
+          nonGroupParent == null
+            ? null
+            : MetadataUtils.getFrameInCanvasCoords(nonGroupParent, workingEditorState.jsxMetadata)
+      } else {
+        parentFrame = optionalParentFrame
+      }
+      const parentOffset =
+        parentFrame == null
+          ? ({ x: 0, y: 0 } as CanvasPoint)
+          : ({ x: parentFrame.x, y: parentFrame.y } as CanvasPoint)
 
-          case 'PIN_MOVE_CHANGE': {
-            let frameProps: { [k: string]: string | number | undefined } = {} // { FramePoint: value }
-            Utils.fastForEach(LayoutPinnedProps, (p) => {
-              const framePoint = framePointForPinnedProp(p)
-              if (framePoint !== FramePoint.Width && framePoint !== FramePoint.Height) {
-                const value = getLayoutProperty(p, right(element.props))
-                if (isLeft(value) || value.value != null) {
-                  frameProps[framePoint] = value.value
-                  propsToSkip.push(createLayoutPropertyPath(p))
+      switch (frameAndTarget.type) {
+        case 'PIN_FRAME_CHANGE':
+        case 'PIN_SIZE_CHANGE':
+          if (frameAndTarget.frame != null) {
+            const newLocalFrame = Utils.getLocalRectangleInNewParentContext(
+              parentOffset,
+              frameAndTarget.frame,
+            )
+            const currentLocalFrame = MetadataUtils.getFrame(target, workingEditorState.jsxMetadata)
+            const currentFullFrame = optionalMap(Frame.getFullFrame, currentLocalFrame)
+            const fullFrame = Frame.getFullFrame(newLocalFrame)
+            const elementProps = element.props
+
+            // Pinning layout.
+            const frameProps = LayoutPinnedProps.filter((p) => {
+              const value = getLayoutProperty(p, right(elementProps))
+              return isLeft(value) || value.value != null
+            }).map(framePointForPinnedProp)
+
+            function whichPropsToUpdate() {
+              if (frameAndTarget.type === 'PIN_SIZE_CHANGE') {
+                // only update left, top, right or bottom if the frame is expressed as left, top, right, bottom.
+                // otherwise try to change width and height only
+                let verticalPoints = frameProps.filter((p) => VerticalFramePoints.includes(p))
+                let horizontalPoints = frameProps.filter((p) => HorizontalFramePoints.includes(p))
+                if (verticalPoints.length < 2) {
+                  verticalPoints.push(FramePoint.Height)
                 }
+                if (horizontalPoints.length < 2) {
+                  horizontalPoints.push(FramePoint.Width)
+                }
+
+                return [...horizontalPoints, ...verticalPoints]
+              } else if (
+                frameAndTarget.type === 'PIN_FRAME_CHANGE' &&
+                frameAndTarget.edgePosition != null &&
+                isEdgePositionOnSide(frameAndTarget.edgePosition)
+              ) {
+                // if it has partial positioning points set and dragged on an edge only the dragged edge should be added while keeping the existing frame points.
+                return extendPartialFramePointsForResize(frameProps, frameAndTarget.edgePosition)
+              } else {
+                // The "Old" behavior, for PIN_FRAME_CHANGE
+                return frameProps.length == 4
+                  ? frameProps
+                  : [FramePoint.Left, FramePoint.Top, FramePoint.Width, FramePoint.Height]
+              }
+            }
+
+            const propsToUpdate: Array<FramePoint> = whichPropsToUpdate()
+
+            Utils.fastForEach(propsToUpdate, (propToUpdate) => {
+              const absoluteValue = fullFrame[propToUpdate]
+              const previousValue = currentFullFrame == null ? null : currentFullFrame[propToUpdate]
+
+              const pinnedPropToUpdate = pinnedPropForFramePoint(propToUpdate)
+              const propPathToUpdate = createLayoutPropertyPath(pinnedPropToUpdate)
+              const existingProp = getLayoutProperty(pinnedPropToUpdate, right(elementProps))
+              if (absoluteValue === previousValue || isLeft(existingProp)) {
+                // Only update pins that have actually changed or aren't set via code
+                propsToSkip.push(propPathToUpdate)
+              } else {
+                const pinIsPercentage =
+                  existingProp.value == null ? false : isPercentPin(existingProp.value)
+                let valueToUse: string | number
+                if (parentFrame == null) {
+                  valueToUse = absoluteValue
+                } else {
+                  valueToUse = valueToUseForPin(
+                    propToUpdate,
+                    absoluteValue,
+                    pinIsPercentage,
+                    parentFrame,
+                  )
+                }
+                propsToSet.push({
+                  path: propPathToUpdate,
+                  value: jsxAttributeValue(valueToUse, emptyComments),
+                })
               }
             })
-
-            let framePointsToUse: Array<FramePoint> = [...(Object.keys(frameProps) as FramePoint[])]
-            const horizontalExistingFramePoints = framePointsToUse.filter(
-              (p) => HorizontalFramePointsExceptSize.indexOf(p) > -1,
-            )
-            if (horizontalExistingFramePoints.length === 0) {
-              framePointsToUse.push(FramePoint.Left)
-            }
-            const verticalExistingFramePoints = framePointsToUse.filter(
-              (p) => VerticalFramePointsExceptSize.indexOf(p) > -1,
-            )
-            if (verticalExistingFramePoints.length === 0) {
-              framePointsToUse.push(FramePoint.Top)
-            }
-            propsToSet.push(
-              ...getPropsToSetToMoveElement(
-                frameAndTarget.delta,
-                framePointsToUse,
-                frameProps,
-                parentFrame,
-              ),
-            )
-            break
           }
-          case 'SINGLE_RESIZE':
-            let frameProps: { [k: string]: string | number | undefined } = {} // { FramePoint: value }
-            Utils.fastForEach(LayoutPinnedProps, (p) => {
-              const framePoint = framePointForPinnedProp(p)
+          break
+
+        case 'PIN_MOVE_CHANGE': {
+          let frameProps: { [k: string]: string | number | undefined } = {} // { FramePoint: value }
+          Utils.fastForEach(LayoutPinnedProps, (p) => {
+            const framePoint = framePointForPinnedProp(p)
+            if (framePoint !== FramePoint.Width && framePoint !== FramePoint.Height) {
               const value = getLayoutProperty(p, right(element.props))
               if (isLeft(value) || value.value != null) {
                 frameProps[framePoint] = value.value
                 propsToSkip.push(createLayoutPropertyPath(p))
               }
-            })
-
-            let framePointsToUse: Array<FramePoint> = Object.keys(frameProps) as FramePoint[]
-
-            if (isEdgePositionOnSide(frameAndTarget.edgePosition)) {
-              framePointsToUse = extendPartialFramePointsForResize(
-                framePointsToUse,
-                frameAndTarget.edgePosition,
-              )
-            } else {
-              let verticalPoints = framePointsToUse.filter((p) => VerticalFramePoints.includes(p))
-              let horizontalPoints = framePointsToUse.filter((p) =>
-                HorizontalFramePoints.includes(p),
-              )
-
-              if (verticalPoints.length < 2) {
-                if (verticalPoints.length === 0) {
-                  verticalPoints.push(FramePoint.Top)
-                }
-                verticalPoints.push(FramePoint.Height)
-              }
-              if (horizontalPoints.length < 2) {
-                if (horizontalPoints.length === 0) {
-                  horizontalPoints.push(FramePoint.Left)
-                }
-                horizontalPoints.push(FramePoint.Width)
-              }
-              framePointsToUse = Utils.uniq([...verticalPoints, ...horizontalPoints])
             }
+          })
 
-            propsToSet.push(
-              ...getPropsToSetToResizeElement(
-                frameAndTarget.edgePosition,
-                frameAndTarget.sizeDelta.x,
-                frameAndTarget.sizeDelta.y,
-                framePointsToUse,
-                frameProps,
-                parentFrame,
-              ),
-            )
-            break
-          case 'FLEX_MOVE':
-          case 'FLEX_RESIZE':
-            throw new Error(
-              `Attempted to make a flex change against a pinned element ${JSON.stringify(
-                staticParentPath,
-              )}.`,
-            )
-          default:
-            const _exhaustiveCheck: never = frameAndTarget
-            throw new Error(`Unhandled type ${JSON.stringify(frameAndTarget)}`)
+          let framePointsToUse: Array<FramePoint> = [...(Object.keys(frameProps) as FramePoint[])]
+          const horizontalExistingFramePoints = framePointsToUse.filter(
+            (p) => HorizontalFramePointsExceptSize.indexOf(p) > -1,
+          )
+          if (horizontalExistingFramePoints.length === 0) {
+            framePointsToUse.push(FramePoint.Left)
+          }
+          const verticalExistingFramePoints = framePointsToUse.filter(
+            (p) => VerticalFramePointsExceptSize.indexOf(p) > -1,
+          )
+          if (verticalExistingFramePoints.length === 0) {
+            framePointsToUse.push(FramePoint.Top)
+          }
+          propsToSet.push(
+            ...getPropsToSetToMoveElement(
+              frameAndTarget.delta,
+              framePointsToUse,
+              frameProps,
+              parentFrame,
+            ),
+          )
+          break
         }
-      }
-
-      if (propsToSet.length > 0) {
-        const propsToNotDelete = [...propsToSet.map((p) => p.path), ...propsToSkip]
-
-        workingEditorState = modifyUnderlyingForOpenFile(
-          originalTarget,
-          workingEditorState,
-          (elem) => {
-            // Remove the pinning and flex props first...
-            const propsToMaybeRemove =
-              frameAndTarget.type === 'PIN_MOVE_CHANGE'
-                ? PinningAndFlexPointsExceptSize // for PIN_MOVE_CHANGE, we don't want to remove the size props, we just keep them intact
-                : PinningAndFlexPoints
-            let propsToRemove: Array<PropertyPath> = []
-            function createPropPathForProp(prop: string): PropertyPath {
-              if (isFramePoint(prop)) {
-                return createLayoutPropertyPath(pinnedPropForFramePoint(prop))
-              } else {
-                return createLayoutPropertyPath(prop as LayoutProp)
-              }
+        case 'SINGLE_RESIZE':
+          let frameProps: { [k: string]: string | number | undefined } = {} // { FramePoint: value }
+          Utils.fastForEach(LayoutPinnedProps, (p) => {
+            const framePoint = framePointForPinnedProp(p)
+            const value = getLayoutProperty(p, right(element.props))
+            if (isLeft(value) || value.value != null) {
+              frameProps[framePoint] = value.value
+              propsToSkip.push(createLayoutPropertyPath(p))
             }
-            fastForEach(propsToMaybeRemove, (prop) => {
-              const propPath = createPropPathForProp(prop)
-              if (!PP.contains(propsToNotDelete, propPath)) {
-                propsToRemove.push(propPath)
+          })
+
+          let framePointsToUse: Array<FramePoint> = Object.keys(frameProps) as FramePoint[]
+
+          if (isEdgePositionOnSide(frameAndTarget.edgePosition)) {
+            framePointsToUse = extendPartialFramePointsForResize(
+              framePointsToUse,
+              frameAndTarget.edgePosition,
+            )
+          } else {
+            let verticalPoints = framePointsToUse.filter((p) => VerticalFramePoints.includes(p))
+            let horizontalPoints = framePointsToUse.filter((p) => HorizontalFramePoints.includes(p))
+
+            if (verticalPoints.length < 2) {
+              if (verticalPoints.length === 0) {
+                verticalPoints.push(FramePoint.Top)
               }
-            })
-            const layoutPropsRemoved = unsetJSXValuesAtPaths(elem.props, propsToRemove)
-            // ...Add in the updated properties.
+              verticalPoints.push(FramePoint.Height)
+            }
+            if (horizontalPoints.length < 2) {
+              if (horizontalPoints.length === 0) {
+                horizontalPoints.push(FramePoint.Left)
+              }
+              horizontalPoints.push(FramePoint.Width)
+            }
+            framePointsToUse = Utils.uniq([...verticalPoints, ...horizontalPoints])
+          }
 
-            const layoutPropsAdded = flatMapEither(
-              (props) => setJSXValuesAtPaths(props, propsToSet),
-              layoutPropsRemoved,
-            )
-
-            return foldEither(
-              (_) => elem,
-              (updatedProps) => {
-                return {
-                  ...elem,
-                  props: updatedProps,
-                }
-              },
-              layoutPropsAdded,
-            )
-          },
-        )
+          propsToSet.push(
+            ...getPropsToSetToResizeElement(
+              frameAndTarget.edgePosition,
+              frameAndTarget.sizeDelta.x,
+              frameAndTarget.sizeDelta.y,
+              framePointsToUse,
+              frameProps,
+              parentFrame,
+            ),
+          )
+          break
+        case 'FLEX_MOVE':
+        case 'FLEX_RESIZE':
+          throw new Error(
+            `Attempted to make a flex change against a pinned element ${JSON.stringify(
+              staticParentPath,
+            )}.`,
+          )
+        default:
+          const _exhaustiveCheck: never = frameAndTarget
+          throw new Error(`Unhandled type ${JSON.stringify(frameAndTarget)}`)
       }
-
-      // Round the frame details.
-      workingEditorState = modifyUnderlyingForOpenFile(
-        staticTarget,
-        workingEditorState,
-        roundJSXElementLayoutValues,
-      )
-      // TODO originalFrames is never being set, so we have a regression here, meaning keepChildrenGlobalCoords
-      // doesn't work. Once that is fixed we can re-implement keeping the children in place
     }
+
+    if (propsToSet.length > 0) {
+      const propsToNotDelete = [...propsToSet.map((p) => p.path), ...propsToSkip]
+
+      workingEditorState = modifyUnderlyingForOpenFile(
+        originalTarget,
+        workingEditorState,
+        (elem) => {
+          // Remove the pinning and flex props first...
+          const propsToMaybeRemove =
+            frameAndTarget.type === 'PIN_MOVE_CHANGE'
+              ? PinningAndFlexPointsExceptSize // for PIN_MOVE_CHANGE, we don't want to remove the size props, we just keep them intact
+              : PinningAndFlexPoints
+          let propsToRemove: Array<PropertyPath> = []
+          function createPropPathForProp(prop: string): PropertyPath {
+            if (isFramePoint(prop)) {
+              return createLayoutPropertyPath(pinnedPropForFramePoint(prop))
+            } else {
+              return createLayoutPropertyPath(prop as LayoutProp)
+            }
+          }
+          fastForEach(propsToMaybeRemove, (prop) => {
+            const propPath = createPropPathForProp(prop)
+            if (!PP.contains(propsToNotDelete, propPath)) {
+              propsToRemove.push(propPath)
+            }
+          })
+          const layoutPropsRemoved = unsetJSXValuesAtPaths(elem.props, propsToRemove)
+          // ...Add in the updated properties.
+
+          const layoutPropsAdded = flatMapEither(
+            (props) => setJSXValuesAtPaths(props, propsToSet),
+            layoutPropsRemoved,
+          )
+
+          return foldEither(
+            (_) => elem,
+            (updatedProps) => {
+              return {
+                ...elem,
+                props: updatedProps,
+              }
+            },
+            layoutPropsAdded,
+          )
+        },
+      )
+    }
+
+    // Round the frame details.
+    workingEditorState = modifyUnderlyingForOpenFile(
+      staticTarget,
+      workingEditorState,
+      roundJSXElementLayoutValues,
+    )
+    // TODO originalFrames is never being set, so we have a regression here, meaning keepChildrenGlobalCoords
+    // doesn't work. Once that is fixed we can re-implement keeping the children in place
   })
   return workingEditorState
 }

--- a/editor/src/components/canvas/controls/breadcrumb-trail.tsx
+++ b/editor/src/components/canvas/controls/breadcrumb-trail.tsx
@@ -39,23 +39,15 @@ export const BreadcrumbTrail = betterReactMemo('BreadcrumbTrail', () => {
       }
       let elements: Array<ElementPathElement> = []
       Utils.fastForEach(TP.allPaths(selectedViews[0]), (path) => {
-        // TODO Scene Implementation
-        if (TP.isInstancePath(path)) {
-          const component = MetadataUtils.getElementByInstancePathMaybe(jsxMetadata, path)
-          if (component != null) {
-            elements.push({
-              name: MetadataUtils.getElementLabel(path, jsxMetadata),
-              path: path,
-            })
-          }
-        } else {
-          const scene = MetadataUtils.findElementByTemplatePath(jsxMetadata, path)
-          if (scene != null) {
-            elements.push({
-              name: scene.label ?? undefined,
-              path: path,
-            })
-          }
+        const component = MetadataUtils.findElementByTemplatePathDontThrowOnScenes(
+          jsxMetadata,
+          path,
+        )
+        if (component != null) {
+          elements.push({
+            name: MetadataUtils.getElementLabel(path, jsxMetadata),
+            path: path,
+          })
         }
       })
       return elements

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -285,6 +285,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       const possibleMetadata = MetadataUtils.findElementByTemplatePath(
         componentMetadata,
         selectedView,
+        true,
       )
       return possibleMetadata == null
     })
@@ -301,7 +302,11 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
 
   const renderModeControlContainer = () => {
     const elementAspectRatioLocked = localSelectedViews.every((target) => {
-      const possibleElement = MetadataUtils.findElementByTemplatePath(componentMetadata, target)
+      const possibleElement = MetadataUtils.findElementByTemplatePath(
+        componentMetadata,
+        target,
+        true,
+      )
       if (possibleElement == null) {
         return false
       } else {

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -282,15 +282,11 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       return 'noninteractive'
     }
     const anyIncomprehensibleElementsSelected = selectedViews.some((selectedView) => {
-      if (TP.isScenePath(selectedView)) {
-        return false
-      }
-
-      const possibleMetadata = MetadataUtils.getElementByInstancePathMaybe(
+      const possibleMetadata = MetadataUtils.findElementByTemplatePath(
         componentMetadata,
         selectedView,
       )
-      return possibleMetadata == null || MetadataUtils.dynamicPathToStaticPath(selectedView) == null
+      return possibleMetadata == null
     })
     if (anyIncomprehensibleElementsSelected) {
       return 'disabled'
@@ -305,10 +301,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
 
   const renderModeControlContainer = () => {
     const elementAspectRatioLocked = localSelectedViews.every((target) => {
-      if (TP.isScenePath(target)) {
-        return false
-      }
-      const possibleElement = MetadataUtils.getElementByInstancePathMaybe(componentMetadata, target)
+      const possibleElement = MetadataUtils.findElementByTemplatePath(componentMetadata, target)
       if (possibleElement == null) {
         return false
       } else {

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -285,7 +285,6 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       const possibleMetadata = MetadataUtils.findElementByTemplatePath(
         componentMetadata,
         selectedView,
-        true,
       )
       return possibleMetadata == null
     })
@@ -302,11 +301,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
 
   const renderModeControlContainer = () => {
     const elementAspectRatioLocked = localSelectedViews.every((target) => {
-      const possibleElement = MetadataUtils.findElementByTemplatePath(
-        componentMetadata,
-        target,
-        true,
-      )
+      const possibleElement = MetadataUtils.findElementByTemplatePath(componentMetadata, target)
       if (possibleElement == null) {
         return false
       } else {

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -159,7 +159,11 @@ export const OutlineControls = (props: OutlineControlsProps) => {
     }
 
     const keyPrefix = TP.toComponentId(selectedView)
-    const instance = MetadataUtils.findElementByTemplatePath(props.componentMetadata, selectedView)
+    const instance = MetadataUtils.findElementByTemplatePath(
+      props.componentMetadata,
+      selectedView,
+      true,
+    )
     const createsYogaLayout = MetadataUtils.isFlexLayoutedContainer(instance)
     const selectionColor = selectionColors[index]
 

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -159,11 +159,7 @@ export const OutlineControls = (props: OutlineControlsProps) => {
     }
 
     const keyPrefix = TP.toComponentId(selectedView)
-    const instance = MetadataUtils.findElementByTemplatePath(
-      props.componentMetadata,
-      selectedView,
-      true,
-    )
+    const instance = MetadataUtils.findElementByTemplatePath(props.componentMetadata, selectedView)
     const createsYogaLayout = MetadataUtils.isFlexLayoutedContainer(instance)
     const selectionColor = selectionColors[index]
 

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -159,9 +159,7 @@ export const OutlineControls = (props: OutlineControlsProps) => {
     }
 
     const keyPrefix = TP.toComponentId(selectedView)
-    const instance = TP.isScenePath(selectedView)
-      ? null
-      : MetadataUtils.getElementByInstancePathMaybe(props.componentMetadata, selectedView)
+    const instance = MetadataUtils.findElementByTemplatePath(props.componentMetadata, selectedView)
     const createsYogaLayout = MetadataUtils.isFlexLayoutedContainer(instance)
     const selectionColor = selectionColors[index]
 

--- a/editor/src/components/canvas/controls/repositionable-control.tsx
+++ b/editor/src/components/canvas/controls/repositionable-control.tsx
@@ -3,17 +3,12 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import Utils from '../../../utils/utils'
 import * as TP from '../../../core/shared/template-path'
 import { ControlProps } from './new-canvas-controls'
-import { anyInstanceYogaLayouted } from './select-mode/yoga-utils'
 import { getSelectionColor } from './outline-control'
 
 const Size = 6
 
 export class RepositionableControl extends React.Component<ControlProps> {
   render() {
-    const anySelectedElementIsYogaLayouted = anyInstanceYogaLayouted(
-      this.props.componentMetadata,
-      this.props.selectedViews,
-    )
     const outlineOffset = 0.5 / this.props.scale
 
     let indicators: JSX.Element[] = []
@@ -23,10 +18,6 @@ export class RepositionableControl extends React.Component<ControlProps> {
         return
       }
 
-      const instance = TP.isScenePath(selectedView)
-        ? null
-        : MetadataUtils.getElementByInstancePathMaybe(this.props.componentMetadata, selectedView)
-      const createsYogaLayout = MetadataUtils.isFlexLayoutedContainer(instance)
       const selectionColor = getSelectionColor(
         selectedView,
         this.props.rootComponents,

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -192,12 +192,7 @@ export class SelectModeControlContainer extends React.Component<
 
     return TP.getAncestors(target).reduce(
       (frameIntersect: CanvasRectangle | null, current: TemplatePath) => {
-        if (TP.isScenePath(current)) {
-          // TODO Scene Implementation - should scenes act like they clip?
-          return frameIntersect
-        }
-
-        const currentInstance = MetadataUtils.getElementByInstancePathMaybe(
+        const currentInstance = MetadataUtils.findElementByTemplatePath(
           this.props.componentMetadata,
           current,
         )
@@ -459,20 +454,7 @@ export class SelectModeControlContainer extends React.Component<
 
   canResizeElements(): boolean {
     return this.props.selectedViews.every((target) => {
-      if (TP.isScenePath(target)) {
-        const scene = MetadataUtils.findElementByTemplatePath(this.props.componentMetadata, target)
-        let rootHasStyleProp = false
-        if (scene != null) {
-          rootHasStyleProp = scene.rootElements.some((rootElement) => {
-            return this.props.elementsThatRespectLayout.some((path) => {
-              return TP.pathsEqual(path, rootElement)
-            })
-          })
-        }
-        return MetadataUtils.isSceneTreatedAsGroup(scene) || rootHasStyleProp
-      } else {
-        return this.props.elementsThatRespectLayout.some((path) => TP.pathsEqual(path, target))
-      }
+      return this.props.elementsThatRespectLayout.some((path) => TP.pathsEqual(path, target))
     })
   }
 
@@ -492,12 +474,9 @@ export class SelectModeControlContainer extends React.Component<
 
     // TODO future span element should be included here
     let repositionOnly = false
-    if (this.props.selectedViews.length === 1 && !TP.isScenePath(this.props.selectedViews[0])) {
+    if (this.props.selectedViews.length === 1) {
       const path = this.props.selectedViews[0]
-      const element = MetadataUtils.getElementByInstancePathMaybe(
-        this.props.componentMetadata,
-        path,
-      )
+      const element = MetadataUtils.findElementByTemplatePath(this.props.componentMetadata, path)
       repositionOnly =
         element != null && MetadataUtils.isAutoSizingText(this.props.imports, element)
     }

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -195,6 +195,7 @@ export class SelectModeControlContainer extends React.Component<
         const currentInstance = MetadataUtils.findElementByTemplatePath(
           this.props.componentMetadata,
           current,
+          true,
         )
         if (currentInstance == null) {
           return frameIntersect
@@ -476,7 +477,11 @@ export class SelectModeControlContainer extends React.Component<
     let repositionOnly = false
     if (this.props.selectedViews.length === 1) {
       const path = this.props.selectedViews[0]
-      const element = MetadataUtils.findElementByTemplatePath(this.props.componentMetadata, path)
+      const element = MetadataUtils.findElementByTemplatePath(
+        this.props.componentMetadata,
+        path,
+        true,
+      )
       repositionOnly =
         element != null && MetadataUtils.isAutoSizingText(this.props.imports, element)
     }

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -195,7 +195,6 @@ export class SelectModeControlContainer extends React.Component<
         const currentInstance = MetadataUtils.findElementByTemplatePath(
           this.props.componentMetadata,
           current,
-          true,
         )
         if (currentInstance == null) {
           return frameIntersect
@@ -477,11 +476,7 @@ export class SelectModeControlContainer extends React.Component<
     let repositionOnly = false
     if (this.props.selectedViews.length === 1) {
       const path = this.props.selectedViews[0]
-      const element = MetadataUtils.findElementByTemplatePath(
-        this.props.componentMetadata,
-        path,
-        true,
-      )
+      const element = MetadataUtils.findElementByTemplatePath(this.props.componentMetadata, path)
       repositionOnly =
         element != null && MetadataUtils.isAutoSizingText(this.props.imports, element)
     }

--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.ts
@@ -27,16 +27,11 @@ function useGetHighlightableViewsForInsertMode() {
     }
     const allPaths = MetadataUtils.getAllPaths(componentMetadata)
     const insertTargets = allPaths.filter((path) => {
-      if (TP.isScenePath(path)) {
-        // TODO Scene Implementation
-        return false
-      } else {
-        return (
-          (insertionSubjectIsJSXElement(mode.subject) ||
-            insertionSubjectIsDragAndDrop(mode.subject)) &&
-          MetadataUtils.targetSupportsChildren(imports, componentMetadata, path)
-        )
-      }
+      return (
+        (insertionSubjectIsJSXElement(mode.subject) ||
+          insertionSubjectIsDragAndDrop(mode.subject)) &&
+        MetadataUtils.targetSupportsChildren(imports, componentMetadata, path)
+      )
     })
     return insertTargets
   }, [storeRef])

--- a/editor/src/components/canvas/controls/select-mode/move-utils.ts
+++ b/editor/src/components/canvas/controls/select-mode/move-utils.ts
@@ -71,7 +71,10 @@ export function determineElementsToOperateOnForDragging(
     ).map((view) => {
       const parentPath = TP.parentPath(view)
       if (parentPath != null && TP.isScenePath(parentPath)) {
-        const scene = MetadataUtils.findElementByTemplatePath(componentMetadata, parentPath)
+        const scene = MetadataUtils.findElementByTemplatePathDontThrowOnScenes(
+          componentMetadata,
+          parentPath,
+        )
         if (MetadataUtils.isSceneTreatedAsGroup(scene)) {
           return parentPath
         } else {
@@ -85,7 +88,10 @@ export function determineElementsToOperateOnForDragging(
     // Resizing.
     return flatMapArray<TemplatePath, TemplatePath>((view) => {
       if (TP.isScenePath(view)) {
-        const scene = MetadataUtils.findElementByTemplatePath(componentMetadata, view)
+        const scene = MetadataUtils.findElementByTemplatePathDontThrowOnScenes(
+          componentMetadata,
+          view,
+        )
         if (scene != null && MetadataUtils.isSceneTreatedAsGroup(scene)) {
           return scene.rootElements
         } else {

--- a/editor/src/components/canvas/controls/size-box-label.tsx
+++ b/editor/src/components/canvas/controls/size-box-label.tsx
@@ -78,7 +78,7 @@ const ResizeLabel = (props: SizeBoxLabelProps) => {
       true,
     )
     Utils.fastForEach(targets, (target) => {
-      const element = MetadataUtils.findElementByTemplatePath(metadata, target)
+      const element = MetadataUtils.findElementByTemplatePath(metadata, target, true)
       if (element != null) {
         const jsxElement = eitherToMaybe(element.element)
         if (jsxElement != null && isJSXElement(jsxElement)) {

--- a/editor/src/components/canvas/controls/size-box-label.tsx
+++ b/editor/src/components/canvas/controls/size-box-label.tsx
@@ -78,19 +78,13 @@ const ResizeLabel = (props: SizeBoxLabelProps) => {
       true,
     )
     Utils.fastForEach(targets, (target) => {
-      if (TP.isScenePath(target)) {
-        const element = MetadataUtils.findElementByTemplatePath(metadata, target)
-        if (element != null) {
-          names.push(element.label ?? 'Scene')
-        }
-      } else {
-        const element = MetadataUtils.getElementByInstancePathMaybe(metadata, target)
-        if (element != null) {
-          const jsxElement = eitherToMaybe(element.element)
-          if (jsxElement != null && isJSXElement(jsxElement)) {
-            names.push(getJSXElementNameAsString(jsxElement.name))
-            properties = LayoutHelpers.getElementSizePropertyPaths(element)
-          }
+      const element = MetadataUtils.findElementByTemplatePath(metadata, target)
+      if (element != null) {
+        const jsxElement = eitherToMaybe(element.element)
+        if (jsxElement != null && isJSXElement(jsxElement)) {
+          const labelFromProps = MetadataUtils.getElementLabelFromProps(element)
+          names.push(labelFromProps ?? getJSXElementNameAsString(jsxElement.name))
+          properties = LayoutHelpers.getElementSizePropertyPaths(element)
         }
       }
     })

--- a/editor/src/components/canvas/controls/size-box-label.tsx
+++ b/editor/src/components/canvas/controls/size-box-label.tsx
@@ -78,7 +78,7 @@ const ResizeLabel = (props: SizeBoxLabelProps) => {
       true,
     )
     Utils.fastForEach(targets, (target) => {
-      const element = MetadataUtils.findElementByTemplatePath(metadata, target, true)
+      const element = MetadataUtils.findElementByTemplatePath(metadata, target)
       if (element != null) {
         const jsxElement = eitherToMaybe(element.element)
         if (jsxElement != null && isJSXElement(jsxElement)) {

--- a/editor/src/components/canvas/controls/yoga-control.tsx
+++ b/editor/src/components/canvas/controls/yoga-control.tsx
@@ -120,13 +120,8 @@ export class YogaControls extends React.Component<YogaControlsProps> {
 
     let color: string = ''
     if (showResizeControl) {
-      const selectedView = targets[0]
-      const instance = TP.isScenePath(selectedView)
-        ? null
-        : MetadataUtils.getElementByInstancePathMaybe(this.props.componentMetadata, selectedView)
-      const createsYogaLayout = MetadataUtils.isFlexLayoutedContainer(instance)
       color = getSelectionColor(
-        selectedView,
+        targets[0],
         this.props.rootComponents,
         this.props.componentMetadata,
         this.props.imports,

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -394,7 +394,7 @@ function collectMetadata(
   return pathsForElement.map((path) => {
     const rootsOrChildrenToAdd = pathsForElement
       .filter((otherPath) => TP.isParentOf(path, otherPath))
-      .map((p) => TP.instancePathForElementAtPath(p, true))
+      .map(TP.instancePathForElementAtPath)
     const unfilteredChildrenPaths = allUnfilteredChildrenPaths.concat(rootsOrChildrenToAdd)
 
     let filteredChildPaths: InstancePath[] = []

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -367,10 +367,6 @@ function collectMetadataForElement(
   }
 }
 
-function isRootElement(path: InstancePath): boolean {
-  return TP.isScenePath(TP.parentPath(path))
-}
-
 function collectMetadata(
   element: HTMLElement,
   pathsForElement: Array<TemplatePath>,
@@ -405,7 +401,7 @@ function collectMetadata(
     let filteredRootElements: InstancePath[] = []
     fastForEach(unfilteredChildrenPaths, (childPath) => {
       if (TP.isParentOf(path, childPath)) {
-        if (isRootElement(childPath)) {
+        if (TP.isTopLevelInstancePath(childPath)) {
           filteredRootElements.push(childPath)
         } else {
           filteredChildPaths.push(childPath)

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -394,7 +394,7 @@ function collectMetadata(
   return pathsForElement.map((path) => {
     const rootsOrChildrenToAdd = pathsForElement
       .filter((otherPath) => TP.isParentOf(path, otherPath))
-      .map(TP.instancePathForElementAtPath)
+      .map((p) => TP.instancePathForElementAtPath(p, true))
     const unfilteredChildrenPaths = allUnfilteredChildrenPaths.concat(rootsOrChildrenToAdd)
 
     let filteredChildPaths: InstancePath[] = []

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -408,7 +408,9 @@ export function handleKeyDown(
         if (modeType === 'select') {
           const textTarget = getTextEditorTarget(editor)
           if (textTarget != null) {
-            return [EditorActions.openTextEditor(TP.instancePathForElementAtPath(textTarget), null)]
+            return [
+              EditorActions.openTextEditor(TP.instancePathForElementAtPath(textTarget, true), null),
+            ]
           } else {
             const childToSelect = Canvas.getFirstChild(editor.selectedViews, editor.jsxMetadata)
             if (childToSelect != null) {

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -174,15 +174,11 @@ function jumpToParentActions(selectedViews: Array<TemplatePath>): Array<EditorAc
   }
 }
 
-function getTextEditorTarget(editor: EditorState): InstancePath | null {
+function getTextEditorTarget(editor: EditorState): TemplatePath | null {
   if (editor.canvas.dragState != null || editor.selectedViews.length !== 1) {
     return null
   } else {
     const target = editor.selectedViews[0]
-    if (TP.isScenePath(target)) {
-      return null
-    }
-
     const components = getOpenUtopiaJSXComponentsFromState(editor)
     const imports = getOpenImportsFromState(editor)
     const element = findElementAtPath(target, components)
@@ -412,7 +408,7 @@ export function handleKeyDown(
         if (modeType === 'select') {
           const textTarget = getTextEditorTarget(editor)
           if (textTarget != null) {
-            return [EditorActions.openTextEditor(textTarget, null)]
+            return [EditorActions.openTextEditor(TP.instancePathForElementAtPath(textTarget), null)]
           } else {
             const childToSelect = Canvas.getFirstChild(editor.selectedViews, editor.jsxMetadata)
             if (childToSelect != null) {

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -408,9 +408,7 @@ export function handleKeyDown(
         if (modeType === 'select') {
           const textTarget = getTextEditorTarget(editor)
           if (textTarget != null) {
-            return [
-              EditorActions.openTextEditor(TP.instancePathForElementAtPath(textTarget, true), null),
-            ]
+            return [EditorActions.openTextEditor(TP.instancePathForElementAtPath(textTarget), null)]
           } else {
             const childToSelect = Canvas.getFirstChild(editor.selectedViews, editor.jsxMetadata)
             if (childToSelect != null) {

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -515,6 +515,12 @@ export function editorDispatch(
     storedState.workers.initWatchdogWorker(frozenEditorState.id)
   }
 
+  if (frozenEditorState.selectedViews.some(TP.isScenePath)) {
+    throw new Error(
+      `Scene path selected: ${frozenEditorState.selectedViews.map(TP.toString).join(', ')}`,
+    )
+  }
+
   return {
     editor: frozenEditorState,
     derived: frozenDerivedState,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -708,7 +708,7 @@ export function getJSXComponentsAndImportsForPath(
     projectContents,
     nodeModules,
     currentFilePath,
-    TP.instancePathForElementAtPath(path),
+    TP.instancePathForElementAtPathDontThrowOnScene(path),
   )
   const elementFilePath =
     underlying.type === 'NORMALISE_PATH_SUCCESS' ? underlying.filePath : currentFilePath
@@ -1890,7 +1890,7 @@ export function modifyUnderlyingTarget(
   } else if (TP.isInstancePath(target)) {
     instanceTarget = target
   } else {
-    instanceTarget = TP.instancePathForElementAtPath(target)
+    instanceTarget = TP.instancePathForElementAtPathDontThrowOnScene(target)
   }
   const underlyingTarget = normalisePathToUnderlyingTarget(
     editorState.projectContents,
@@ -1989,7 +1989,7 @@ export function withUnderlyingTarget<T>(
   } else if (TP.isInstancePath(target)) {
     instanceTarget = target
   } else {
-    instanceTarget = TP.instancePathForElementAtPath(target)
+    instanceTarget = TP.instancePathForElementAtPathDontThrowOnScene(target)
   }
   const underlyingTarget = normalisePathToUnderlyingTarget(
     projectContents,

--- a/editor/src/components/inspector/common/inspector-utils.ts
+++ b/editor/src/components/inspector/common/inspector-utils.ts
@@ -188,9 +188,9 @@ export function clampString(value: string, maxLength: number) {
 export function getElementsToTarget(paths: Array<TemplatePath>): Array<InstancePath> {
   let result: Array<InstancePath> = []
   Utils.fastForEach(paths, (path) => {
-    // TODO Scene Implementation
-    if (!TP.isScenePath(path) && !TP.containsPath(path, result)) {
-      result.push(path)
+    const asInstancePath = TP.instancePathForElementAtPath(path)
+    if (!TP.containsPath(asInstancePath, result)) {
+      result.push(asInstancePath)
     }
   })
   return result

--- a/editor/src/components/inspector/common/inspector-utils.ts
+++ b/editor/src/components/inspector/common/inspector-utils.ts
@@ -188,7 +188,7 @@ export function clampString(value: string, maxLength: number) {
 export function getElementsToTarget(paths: Array<TemplatePath>): Array<InstancePath> {
   let result: Array<InstancePath> = []
   Utils.fastForEach(paths, (path) => {
-    const asInstancePath = TP.instancePathForElementAtPath(path, true)
+    const asInstancePath = TP.instancePathForElementAtPath(path)
     if (!TP.containsPath(asInstancePath, result)) {
       result.push(asInstancePath)
     }

--- a/editor/src/components/inspector/common/inspector-utils.ts
+++ b/editor/src/components/inspector/common/inspector-utils.ts
@@ -188,7 +188,7 @@ export function clampString(value: string, maxLength: number) {
 export function getElementsToTarget(paths: Array<TemplatePath>): Array<InstancePath> {
   let result: Array<InstancePath> = []
   Utils.fastForEach(paths, (path) => {
-    const asInstancePath = TP.instancePathForElementAtPath(path)
+    const asInstancePath = TP.instancePathForElementAtPath(path, true)
     if (!TP.containsPath(asInstancePath, result)) {
       result.push(asInstancePath)
     }

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -304,7 +304,7 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
       anyComponentsInner =
         anyComponentsInner ||
         MetadataUtils.isComponentInstance(view, rootComponents, rootMetadata, imports)
-      const possibleElement = MetadataUtils.findElementByTemplatePath(rootMetadata, view, true)
+      const possibleElement = MetadataUtils.findElementByTemplatePath(rootMetadata, view)
       if (possibleElement != null) {
         // Slightly coarse in definition, but element metadata is in a weird little world of
         // its own compared to the props.
@@ -343,7 +343,7 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
     }
   }, 'Inspector')
   const instancePaths = useKeepReferenceEqualityIfPossible(
-    selectedViews.map((p) => TP.instancePathForElementAtPath(p, true)),
+    selectedViews.map(TP.instancePathForElementAtPath),
   )
 
   const onFocus = React.useCallback(
@@ -590,7 +590,10 @@ export const SingleInspectorEntryPoint: React.FunctionComponent<{
 
       let elements: Array<ElementPathElement> = []
       Utils.fastForEach(TP.allPaths(selectedViews[0]), (path) => {
-        const component = MetadataUtils.findElementByTemplatePath(jsxMetadata, path)
+        const component = MetadataUtils.findElementByTemplatePathDontThrowOnScenes(
+          jsxMetadata,
+          path,
+        )
         if (component != null) {
           elements.push({
             name: MetadataUtils.getElementLabel(path, jsxMetadata),
@@ -734,7 +737,7 @@ export const InspectorContextProvider = betterReactMemo<{
   let newAttributeMetadatas: Array<StyleAttributeMetadata> = []
 
   Utils.fastForEach(selectedViews, (path) => {
-    const elementMetadata = MetadataUtils.findElementByTemplatePath(jsxMetadata, path, true)
+    const elementMetadata = MetadataUtils.findElementByTemplatePath(jsxMetadata, path)
     if (elementMetadata != null) {
       if (elementMetadata.computedStyle == null || elementMetadata.attributeMetadatada == null) {
         /**

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -304,7 +304,7 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
       anyComponentsInner =
         anyComponentsInner ||
         MetadataUtils.isComponentInstance(view, rootComponents, rootMetadata, imports)
-      const possibleElement = MetadataUtils.findElementByTemplatePath(rootMetadata, view)
+      const possibleElement = MetadataUtils.findElementByTemplatePath(rootMetadata, view, true)
       if (possibleElement != null) {
         // Slightly coarse in definition, but element metadata is in a weird little world of
         // its own compared to the props.
@@ -343,7 +343,7 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
     }
   }, 'Inspector')
   const instancePaths = useKeepReferenceEqualityIfPossible(
-    selectedViews.map(TP.instancePathForElementAtPath),
+    selectedViews.map((p) => TP.instancePathForElementAtPath(p, true)),
   )
 
   const onFocus = React.useCallback(
@@ -590,23 +590,12 @@ export const SingleInspectorEntryPoint: React.FunctionComponent<{
 
       let elements: Array<ElementPathElement> = []
       Utils.fastForEach(TP.allPaths(selectedViews[0]), (path) => {
-        // TODO Scene Implementation
-        if (TP.isInstancePath(path)) {
-          const component = MetadataUtils.getElementByInstancePathMaybe(jsxMetadata, path)
-          if (component != null) {
-            elements.push({
-              name: MetadataUtils.getElementLabel(path, jsxMetadata),
-              path: path,
-            })
-          }
-        } else {
-          const scene = MetadataUtils.findElementByTemplatePath(jsxMetadata, path)
-          if (scene != null) {
-            elements.push({
-              name: scene.label ?? undefined,
-              path: path,
-            })
-          }
+        const component = MetadataUtils.findElementByTemplatePath(jsxMetadata, path)
+        if (component != null) {
+          elements.push({
+            name: MetadataUtils.getElementLabel(path, jsxMetadata),
+            path: path,
+          })
         }
       })
       return elements
@@ -745,7 +734,7 @@ export const InspectorContextProvider = betterReactMemo<{
   let newAttributeMetadatas: Array<StyleAttributeMetadata> = []
 
   Utils.fastForEach(selectedViews, (path) => {
-    const elementMetadata = MetadataUtils.findElementByTemplatePath(jsxMetadata, path)
+    const elementMetadata = MetadataUtils.findElementByTemplatePath(jsxMetadata, path, true)
     if (elementMetadata != null) {
       if (elementMetadata.computedStyle == null || elementMetadata.attributeMetadatada == null) {
         /**

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -67,7 +67,7 @@ const navigatorItemWrapperSelectorFactory = (templatePath: TemplatePath) =>
         projectContents,
         nodeModules,
         forceNotNull('Should be a file path.', currentFilePath),
-        TP.instancePathForElementAtPath(templatePath),
+        TP.instancePathForElementAtPathDontThrowOnScene(templatePath),
       )
       const elementFilePath =
         underlying.type === 'NORMALISE_PATH_SUCCESS' ? underlying.filePath : currentFilePath

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -38,7 +38,6 @@ export const NavigatorComponent = betterReactMemo(
   ({ style: navigatorStyle }) => {
     const editorSliceRef = useRefEditorState((store) => {
       const dragSelections = createDragSelections(
-        store.editor.jsxMetadata,
         store.derived.navigatorTargets,
         store.editor.selectedViews,
       )

--- a/editor/src/core/layout/layout-utils.spec.browser.ts
+++ b/editor/src/core/layout/layout-utils.spec.browser.ts
@@ -71,7 +71,7 @@ describe('maybeSwitchLayoutProps', () => {
     )
     const elementPath = TP.instancePath(TestScenePath, [NewUID])
 
-    const sceneElementPath = TP.instancePathForElementAtPath(TestScenePath)
+    const sceneElementPath = TP.instancePathForElementAtPathDontThrowOnScene(TestScenePath)
 
     const metadata: ElementInstanceMetadataMap = {
       [TP.toString(sceneElementPath)]: {

--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -554,9 +554,7 @@ describe('getting the root paths', () => {
 
   it('getAllStoryboardChildrenPathsScenesOnly returns paths of only the scene children of the storyboard', () => {
     const actualResult = MetadataUtils.getAllStoryboardChildrenPathsScenesOnly(testJsxMetadata)
-    const expectedResult: Array<ScenePath> = [
-      TP.scenePathForElementAtInstancePath(testComponentSceneElement.templatePath),
-    ]
+    const expectedResult: Array<InstancePath> = [testComponentSceneElement.templatePath]
     expect(actualResult).toEqual(expectedResult)
   })
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -168,11 +168,12 @@ export const MetadataUtils = {
   findElementByTemplatePath(
     elementMap: ElementInstanceMetadataMap,
     path: TemplatePath | null,
+    throwOnScenePath: boolean = false,
   ): ElementInstanceMetadata | null {
     if (path == null) {
       return null
     } else {
-      const targetPath = TP.instancePathForElementAtPath(path)
+      const targetPath = TP.instancePathForElementAtPath(path, throwOnScenePath)
       return elementMap[TP.toString(targetPath)] ?? null
     }
   },
@@ -1358,8 +1359,8 @@ export const MetadataUtils = {
     } else {
       const duplicatedElementPath = duplicateElementMetadata(
         originalMetadata,
-        TP.instancePathForElementAtPath(oldPath),
-        TP.instancePathForElementAtPath(newPath),
+        TP.instancePathForElementAtPath(oldPath, true),
+        TP.instancePathForElementAtPath(newPath, true),
         newElement,
       )
       const updatedElements = this.updateParentWithNewChildPath(

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -99,6 +99,7 @@ import {
 import { EmptyScenePathForStoryboard, ResizesContentProp } from './scene-utils'
 import { fastForEach } from '../shared/utils'
 import { omit } from '../shared/object-utils'
+import { UTOPIA_LABEL_KEY } from './utopia-constants'
 const ObjectPathImmutable: any = OPI
 
 type MergeCandidate = These<ElementInstanceMetadata, ElementInstanceMetadata>
@@ -961,6 +962,14 @@ export const MetadataUtils = {
       )
     }
   },
+  getElementLabelFromProps(element: ElementInstanceMetadata): string | null {
+    const dataLabelProp = element.props[UTOPIA_LABEL_KEY]
+    if (dataLabelProp != null && typeof dataLabelProp === 'string' && dataLabelProp.length > 0) {
+      return dataLabelProp
+    } else {
+      return null
+    }
+  },
   getElementLabel(
     path: TemplatePath,
     metadata: ElementInstanceMetadataMap,
@@ -968,9 +977,9 @@ export const MetadataUtils = {
   ): string {
     const element = this.findElementByTemplatePath(metadata, path)
     if (element != null) {
-      const sceneLabel = element.label
-      const dataLabelProp = element.props['data-label']
-      if (dataLabelProp != null && typeof dataLabelProp === 'string' && dataLabelProp.length > 0) {
+      const sceneLabel = element.label // KILLME?
+      const dataLabelProp = MetadataUtils.getElementLabelFromProps(element)
+      if (dataLabelProp != null) {
         return dataLabelProp
       } else if (sceneLabel != null) {
         return sceneLabel

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -312,7 +312,14 @@ function instancePathForElementPaths(elementPaths: ElementPath[]): InstancePath 
   }
 }
 
-export function instancePathForElementAtPath(path: TemplatePath): InstancePath {
+export function instancePathForElementAtPath(
+  path: TemplatePath,
+  throwOnScenePath: boolean = false,
+): InstancePath {
+  if (throwOnScenePath && isScenePath(path)) {
+    throw new Error(`Encountered Scene Path ${toString(path)}`)
+  }
+
   return isInstancePath(path) ? path : instancePathForElementPaths(path.sceneElementPaths)
 }
 

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -269,12 +269,12 @@ export function isStoryboardPath(path: InstancePath): boolean {
 }
 
 export function isStoryboardDescendant(path: TemplatePath): boolean {
-  const asInstancePath = instancePathForElementAtPath(path)
+  const asInstancePath = instancePathForElementAtPathDontThrowOnScene(path)
   return isEmptyScenePath(asInstancePath.scene) && !isStoryboardPath(asInstancePath)
 }
 
 export function isStoryboardChild(path: TemplatePath): boolean {
-  const asInstancePath = instancePathForElementAtPath(path)
+  const asInstancePath = instancePathForElementAtPathDontThrowOnScene(path)
   return isEmptyScenePath(asInstancePath.scene) && asInstancePath.element.length === 2
 }
 
@@ -312,15 +312,16 @@ function instancePathForElementPaths(elementPaths: ElementPath[]): InstancePath 
   }
 }
 
-export function instancePathForElementAtPath(
-  path: TemplatePath,
-  throwOnScenePath: boolean = false,
-): InstancePath {
-  if (throwOnScenePath && isScenePath(path)) {
+export function instancePathForElementAtPathDontThrowOnScene(path: TemplatePath): InstancePath {
+  return isInstancePath(path) ? path : instancePathForElementPaths(path.sceneElementPaths)
+}
+
+export function instancePathForElementAtPath(path: TemplatePath): InstancePath {
+  if (isScenePath(path)) {
     throw new Error(`Encountered Scene Path ${toString(path)}`)
   }
 
-  return isInstancePath(path) ? path : instancePathForElementPaths(path.sceneElementPaths)
+  return instancePathForElementAtPathDontThrowOnScene(path)
 }
 
 export function scenePathForElementAtInstancePath(path: InstancePath): ScenePath {
@@ -468,9 +469,11 @@ export function parentPath(path: TemplatePath): TemplatePath | null {
 }
 
 export function isParentOf(maybeParent: TemplatePath, maybeChild: TemplatePath): boolean {
-  const maybeChildAsInstancePath = instancePathForElementAtPath(maybeChild)
-  const maybeParentAsInstancePath = instancePathForElementAtPath(maybeParent)
-  const actualParent = instancePathForElementAtPath(parentPath(maybeChildAsInstancePath))
+  const maybeChildAsInstancePath = instancePathForElementAtPathDontThrowOnScene(maybeChild)
+  const maybeParentAsInstancePath = instancePathForElementAtPathDontThrowOnScene(maybeParent)
+  const actualParent = instancePathForElementAtPathDontThrowOnScene(
+    parentPath(maybeChildAsInstancePath),
+  )
   return pathsEqual(actualParent, maybeParentAsInstancePath)
 }
 

--- a/editor/src/templates/editor-canvas.ts
+++ b/editor/src/templates/editor-canvas.ts
@@ -796,10 +796,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
 
   getElementAspectRatioLocked(): boolean {
     return this.props.editor.selectedViews.every((target) => {
-      if (TP.isScenePath(target)) {
-        return false
-      }
-      const possibleElement = MetadataUtils.getElementByInstancePathMaybe(
+      const possibleElement = MetadataUtils.findElementByTemplatePath(
         this.props.editor.jsxMetadata,
         target,
       )

--- a/editor/src/templates/editor-canvas.ts
+++ b/editor/src/templates/editor-canvas.ts
@@ -799,6 +799,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
       const possibleElement = MetadataUtils.findElementByTemplatePath(
         this.props.editor.jsxMetadata,
         target,
+        true,
       )
       if (possibleElement == null) {
         return false

--- a/editor/src/templates/editor-canvas.ts
+++ b/editor/src/templates/editor-canvas.ts
@@ -799,7 +799,6 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
       const possibleElement = MetadataUtils.findElementByTemplatePath(
         this.props.editor.jsxMetadata,
         target,
-        true,
       )
       if (possibleElement == null) {
         return false

--- a/editor/src/templates/editor-navigator.ts
+++ b/editor/src/templates/editor-navigator.ts
@@ -4,29 +4,18 @@ import { DerivedState, EditorState } from '../components/editor/store/editor-sta
 import { LocalNavigatorAction } from '../components/navigator/actions'
 import { DragSelection } from '../components/navigator/navigator-item/navigator-item-dnd-container'
 import * as TP from '../core/shared/template-path'
-import { ElementInstanceMetadataMap } from '../core/shared/element-template'
 import Utils from '../utils/utils'
-import { MetadataUtils } from '../core/model/element-metadata-utils'
 
 export function createDragSelections(
-  components: ElementInstanceMetadataMap,
   templatePaths: TemplatePath[],
   selectedViews: TemplatePath[],
 ): Array<DragSelection> {
   let selections: Array<DragSelection> = []
   Utils.fastForEach(selectedViews, (selectedView) => {
-    const metadata = TP.isScenePath(selectedView)
-      ? null // TODO Scene Implementation?
-      : MetadataUtils.getElementByInstancePathMaybe(components, selectedView)
-    if (metadata != null) {
-      // FIXME It seems nobody really knows why we have this `null` check here, so
-      // we need to add some tests around this and consider removing it, or finding
-      // out what disconnected logic (if any) depends on it
-      selections.push({
-        templatePath: selectedView,
-        index: templatePaths.findIndex((tp) => TP.pathsEqual(tp, selectedView)),
-      })
-    }
+    selections.push({
+      templatePath: selectedView,
+      index: templatePaths.findIndex((tp) => TP.pathsEqual(tp, selectedView)),
+    })
   })
   selections.sort((a, b) => b.index - a.index)
   return selections

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -168,12 +168,7 @@ export function createClipboardDataFromSelectionNewWorld(
   })
   const utopiaComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
   const jsxElements = filteredSelectedViews.map((view) => {
-    if (TP.isScenePath(view)) {
-      const path = createSceneTemplatePath(view)
-      return findJSXElementChildAtPath(utopiaComponents, path)
-    } else {
-      return findElementAtPath(view, utopiaComponents)
-    }
+    return findElementAtPath(view, utopiaComponents)
   })
   return {
     data: [


### PR DESCRIPTION
**Problem:**
Ridding the world of the old style scenes left over a lot of code that is either unreachable or in some cases undesirable.

**Fix:**
The first step in trying to rid us of this code is to remove explicit uses of `ScenePath`s where they shouldn't be used anymore. To tackle this I've been targeting code that forks if a path is an `InstancePath` or `ScenePath` and then attempts to use metadata if the path is an `InstancePath` - I have been replacing these forks with a use of the function `findElementByTemplatePath`, and ~have added a boolean flag to that to~ [updated] have added two versions of the function, one of which will throw an error in cases where it should absolutely not be called with a `ScenePath`.

I have also added a `throw` into the `editorDispatch` if we ever end up somehow selecting a `ScenePath`, since this should now be impossible. I've been testing and have been unable to cause any of these to throw.
