### PR TITLE
fix(preview) SafeReactDOM in preview

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3267,7 +3267,7 @@ export const UPDATE_FNS = {
           return packageStatus
         }, {})
 
-        fetchNodeModules(deps).then((fetchNodeModulesResult) => {
+        fetchNodeModules(deps, 'canvas').then((fetchNodeModulesResult) => {
           const loadedPackagesStatus = createLoadedPackageStatusMapFromDependencies(
             deps,
             fetchNodeModulesResult.dependenciesWithError,
@@ -4474,7 +4474,7 @@ export async function newProject(
 ): Promise<void> {
   const defaultPersistentModel = defaultProject()
   const npmDependencies = dependenciesWithEditorRequirements(defaultPersistentModel.projectContents)
-  const fetchNodeModulesResult = await fetchNodeModules(npmDependencies)
+  const fetchNodeModulesResult = await fetchNodeModules(npmDependencies, 'canvas')
 
   const nodeModules: NodeModules = fetchNodeModulesResult.nodeModules
   const packageResult: PackageStatusMap = createLoadedPackageStatusMapFromDependencies(
@@ -4537,7 +4537,11 @@ export async function load(
   // this action is now async!
   const migratedModel = applyMigrations(model)
   const npmDependencies = dependenciesWithEditorRequirements(migratedModel.projectContents)
-  const fetchNodeModulesResult = await fetchNodeModules(npmDependencies, retryFetchNodeModules)
+  const fetchNodeModulesResult = await fetchNodeModules(
+    npmDependencies,
+    'canvas',
+    retryFetchNodeModules,
+  )
 
   const nodeModules: NodeModules = fetchNodeModulesResult.nodeModules
   const packageResult: PackageStatusMap = createLoadedPackageStatusMapFromDependencies(

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -194,7 +194,7 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
 
       this.props.editorDispatch([EditorActions.updatePackageJson(npmDependencies)])
 
-      fetchNodeModules(npmDependencies).then((fetchNodeModulesResult) => {
+      fetchNodeModules(npmDependencies, 'canvas').then((fetchNodeModulesResult) => {
         if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
           this.packagesUpdateFailed(
             `Failed to download the following dependencies: ${JSON.stringify(
@@ -352,7 +352,10 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
                 EditorActions.setPackageStatus(editedPackageName, loadingOrUpdating),
                 EditorActions.updatePackageJson(updatedNpmDeps),
               ])
-              fetchNodeModules([requestedNpmDependency(editedPackageName, editedPackageVersion!)])
+              fetchNodeModules(
+                [requestedNpmDependency(editedPackageName, editedPackageVersion!)],
+                'canvas',
+              )
                 .then((fetchNodeModulesResult) => {
                   if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
                     this.packagesUpdateFailed(

--- a/editor/src/core/es-modules/package-manager/built-in-dependencies.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies.ts
@@ -42,17 +42,27 @@ function builtInDependency(
 
 // Prevent ReactDOM.render from running in the canvas/editor because it's
 // entirely likely to cause either havoc or just break.
-export const SafeReactDOM = {
-  ...ReactDOM,
-  render: NO_OP,
+export const SafeReactDOM = (isPreview: boolean) => {
+  if (isPreview) {
+    return ReactDOM
+  } else {
+    return {
+      ...ReactDOM,
+      render: NO_OP,
+    }
+  }
 }
 
-const BuiltInDependencies: Array<BuiltInDependency> = [
+const BuiltInDependencies = (isPreview: boolean): Array<BuiltInDependency> => [
   builtInDependency('utopia-api', UtopiaAPI, utopiaAPIPackageJSON.version),
   builtInDependency('uuiui', UUIUI, editorPackageJSON.version),
   builtInDependency('uuiui-deps', UUIUIDeps, editorPackageJSON.version),
   builtInDependency('react', React, editorPackageJSON.dependencies.react),
-  builtInDependency('react-dom', SafeReactDOM, editorPackageJSON.dependencies['react-dom']),
+  builtInDependency(
+    'react-dom',
+    SafeReactDOM(isPreview),
+    editorPackageJSON.dependencies['react-dom'],
+  ),
   builtInDependency(
     '@emotion/react',
     EmotionReact,
@@ -70,18 +80,21 @@ const BuiltInDependencies: Array<BuiltInDependency> = [
   ),
 ]
 
-function findBuiltInForName(moduleName: string): BuiltInDependency | undefined {
-  return BuiltInDependencies.find((builtIn) => builtIn.moduleName === moduleName)
+function findBuiltInForName(moduleName: string, isPreview: boolean): BuiltInDependency | undefined {
+  return BuiltInDependencies(isPreview).find((builtIn) => builtIn.moduleName === moduleName)
 }
 
-export function isBuiltInDependency(moduleName: string): boolean {
-  return findBuiltInForName(moduleName) != null
+export function isBuiltInDependency(moduleName: string, isPreview: boolean): boolean {
+  return findBuiltInForName(moduleName, isPreview) != null
 }
 
-export function resolveBuiltInDependency(moduleName: string): any | undefined {
-  return findBuiltInForName(moduleName)?.nodeModule
+export function resolveBuiltInDependency(moduleName: string, isPreview: boolean): any | undefined {
+  return findBuiltInForName(moduleName, isPreview)?.nodeModule
 }
 
-export function versionForBuiltInDependency(moduleName: string): string | undefined {
-  return findBuiltInForName(moduleName)?.version
+export function versionForBuiltInDependency(
+  moduleName: string,
+  isPreview: boolean,
+): string | undefined {
+  return findBuiltInForName(moduleName, isPreview)?.version
 }

--- a/editor/src/core/es-modules/package-manager/built-in-dependencies.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies.ts
@@ -42,27 +42,23 @@ function builtInDependency(
 
 // Prevent ReactDOM.render from running in the canvas/editor because it's
 // entirely likely to cause either havoc or just break.
-export const SafeReactDOM = (isPreview: boolean) => {
-  if (isPreview) {
-    return ReactDOM
-  } else {
+export const SafeReactDOM = (mode: 'preview' | 'canvas') => {
+  if (mode === 'canvas') {
     return {
       ...ReactDOM,
       render: NO_OP,
     }
+  } else {
+    return ReactDOM
   }
 }
 
-const BuiltInDependencies = (isPreview: boolean): Array<BuiltInDependency> => [
+const BuiltInDependencies = (mode: 'preview' | 'canvas'): Array<BuiltInDependency> => [
   builtInDependency('utopia-api', UtopiaAPI, utopiaAPIPackageJSON.version),
   builtInDependency('uuiui', UUIUI, editorPackageJSON.version),
   builtInDependency('uuiui-deps', UUIUIDeps, editorPackageJSON.version),
   builtInDependency('react', React, editorPackageJSON.dependencies.react),
-  builtInDependency(
-    'react-dom',
-    SafeReactDOM(isPreview),
-    editorPackageJSON.dependencies['react-dom'],
-  ),
+  builtInDependency('react-dom', SafeReactDOM(mode), editorPackageJSON.dependencies['react-dom']),
   builtInDependency(
     '@emotion/react',
     EmotionReact,
@@ -80,21 +76,27 @@ const BuiltInDependencies = (isPreview: boolean): Array<BuiltInDependency> => [
   ),
 ]
 
-function findBuiltInForName(moduleName: string, isPreview: boolean): BuiltInDependency | undefined {
-  return BuiltInDependencies(isPreview).find((builtIn) => builtIn.moduleName === moduleName)
+function findBuiltInForName(
+  moduleName: string,
+  mode: 'preview' | 'canvas',
+): BuiltInDependency | undefined {
+  return BuiltInDependencies(mode).find((builtIn) => builtIn.moduleName === moduleName)
 }
 
-export function isBuiltInDependency(moduleName: string, isPreview: boolean): boolean {
-  return findBuiltInForName(moduleName, isPreview) != null
+export function isBuiltInDependency(moduleName: string, mode: 'preview' | 'canvas'): boolean {
+  return findBuiltInForName(moduleName, mode) != null
 }
 
-export function resolveBuiltInDependency(moduleName: string, isPreview: boolean): any | undefined {
-  return findBuiltInForName(moduleName, isPreview)?.nodeModule
+export function resolveBuiltInDependency(
+  moduleName: string,
+  mode: 'preview' | 'canvas',
+): any | undefined {
+  return findBuiltInForName(moduleName, mode)?.nodeModule
 }
 
 export function versionForBuiltInDependency(
   moduleName: string,
-  isPreview: boolean,
+  mode: 'preview' | 'canvas',
 ): string | undefined {
-  return findBuiltInForName(moduleName, isPreview)?.version
+  return findBuiltInForName(moduleName, mode)?.version
 }

--- a/editor/src/core/es-modules/package-manager/fetch-packages.ts
+++ b/editor/src/core/es-modules/package-manager/fetch-packages.ts
@@ -195,8 +195,8 @@ function failError(dependency: RequestedNpmDependency): DependencyFetchError {
 
 export async function fetchNodeModules(
   newDeps: Array<RequestedNpmDependency>,
+  mode: 'canvas' | 'preview',
   shouldRetry: boolean = true,
-  mode: 'canvas' | 'preview' = 'canvas',
 ): Promise<NodeFetchResult> {
   const dependenciesToDownload = newDeps.filter((d) => !isBuiltInDependency(d.name, mode))
   const nodeModulesArr = await Promise.all(

--- a/editor/src/core/es-modules/package-manager/fetch-packages.ts
+++ b/editor/src/core/es-modules/package-manager/fetch-packages.ts
@@ -196,8 +196,9 @@ function failError(dependency: RequestedNpmDependency): DependencyFetchError {
 export async function fetchNodeModules(
   newDeps: Array<RequestedNpmDependency>,
   shouldRetry: boolean = true,
+  isPreview: boolean = false,
 ): Promise<NodeFetchResult> {
-  const dependenciesToDownload = newDeps.filter((d) => !isBuiltInDependency(d.name))
+  const dependenciesToDownload = newDeps.filter((d) => !isBuiltInDependency(d.name, isPreview))
   const nodeModulesArr = await Promise.all(
     dependenciesToDownload.map(
       async (newDep): Promise<Either<DependencyFetchError, NodeModules>> => {

--- a/editor/src/core/es-modules/package-manager/fetch-packages.ts
+++ b/editor/src/core/es-modules/package-manager/fetch-packages.ts
@@ -196,9 +196,9 @@ function failError(dependency: RequestedNpmDependency): DependencyFetchError {
 export async function fetchNodeModules(
   newDeps: Array<RequestedNpmDependency>,
   shouldRetry: boolean = true,
-  isPreview: boolean = false,
+  mode: 'canvas' | 'preview' = 'canvas',
 ): Promise<NodeFetchResult> {
-  const dependenciesToDownload = newDeps.filter((d) => !isBuiltInDependency(d.name, isPreview))
+  const dependenciesToDownload = newDeps.filter((d) => !isBuiltInDependency(d.name, mode))
   const nodeModulesArr = await Promise.all(
     dependenciesToDownload.map(
       async (newDep): Promise<Either<DependencyFetchError, NodeModules>> => {

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -181,9 +181,10 @@ describe('ES Dependency Manager — Real-life packages', () => {
         }
       },
     )
-    const fetchNodeModulesResult = await fetchNodeModules([
-      requestedNpmDependency('react-spring', '8.0.27'),
-    ])
+    const fetchNodeModulesResult = await fetchNodeModules(
+      [requestedNpmDependency('react-spring', '8.0.27')],
+      'canvas',
+    )
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
       fail(`Expected successful nodeModules fetch`)
     }
@@ -209,7 +210,10 @@ describe('ES Dependency Manager — Real-life packages', () => {
         }
       },
     )
-    const fetchNodeModulesResult = await fetchNodeModules([requestedNpmDependency('antd', '4.2.5')])
+    const fetchNodeModulesResult = await fetchNodeModules(
+      [requestedNpmDependency('antd', '4.2.5')],
+      'canvas',
+    )
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
       fail(`Expected successful nodeModules fetch`)
     }
@@ -261,9 +265,10 @@ describe('ES Dependency Manager — d.ts', () => {
       },
     )
 
-    const fetchNodeModulesResult = await fetchNodeModules([
-      requestedNpmDependency('react-spring', '8.0.27'),
-    ])
+    const fetchNodeModulesResult = await fetchNodeModules(
+      [requestedNpmDependency('react-spring', '8.0.27')],
+      'canvas',
+    )
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
       fail(`Expected successful nodeModules fetch`)
     }
@@ -295,9 +300,10 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
         }
       },
     )
-    const fetchNodeModulesResult = await fetchNodeModules([
-      requestedNpmDependency('mypackage', '0.0.1'),
-    ])
+    const fetchNodeModulesResult = await fetchNodeModules(
+      [requestedNpmDependency('mypackage', '0.0.1')],
+      'canvas',
+    )
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
       fail(`Expected successful nodeModules fetch`)
     }
@@ -352,7 +358,7 @@ describe('ES Dependency manager - retry behavior', () => {
       },
     )
 
-    fetchNodeModules([requestedNpmDependency('react-spring', '8.0.27')]).then(
+    fetchNodeModules([requestedNpmDependency('react-spring', '8.0.27')], 'canvas').then(
       (fetchNodeModulesResult) => {
         if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
           fail(`Expected successful nodeModule fetch`)
@@ -373,7 +379,7 @@ describe('ES Dependency manager - retry behavior', () => {
       },
     )
 
-    fetchNodeModules([requestedNpmDependency('react-spring', '8.0.27')]).then(
+    fetchNodeModules([requestedNpmDependency('react-spring', '8.0.27')], 'canvas').then(
       (fetchNodeModulesResult) => {
         expect(fetchNodeModulesResult.dependenciesWithError).toHaveLength(1)
         expect(fetchNodeModulesResult.dependenciesWithError[0].name).toBe('react-spring')
@@ -400,7 +406,7 @@ describe('ES Dependency manager - retry behavior', () => {
       },
     )
 
-    fetchNodeModules([requestedNpmDependency('react-spring', '8.0.27')], false).then(
+    fetchNodeModules([requestedNpmDependency('react-spring', '8.0.27')], 'canvas', false).then(
       (fetchNodeModulesResult) => {
         expect(fetchNodeModulesResult.dependenciesWithError).toHaveLength(1)
         expect(fetchNodeModulesResult.dependenciesWithError[0].name).toBe('react-spring')

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -58,6 +58,7 @@ describe('ES Dependency Package Manager', () => {
         fileNoImports as PackagerServerResponse,
       ),
       {},
+      false,
     )
     const requireResult = reqFn('/src/index.js', 'mypackage')
     expect(requireResult).toHaveProperty('hello')
@@ -70,6 +71,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
       {},
+      false,
     )
     const requireResult = reqFn('/src/index.js', 'mypackage')
     expect(requireResult).toHaveProperty('hello')
@@ -82,6 +84,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithLocalImport),
       {},
+      false,
     )
     const requireResult = reqFn('/src/index.js', 'mypackage')
     expect(requireResult).toHaveProperty('hello')
@@ -94,6 +97,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
       {},
+      false,
     )
     reqFn('/src/index.js', 'mypackage/simple.css')
 
@@ -107,6 +111,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
       {},
+      false,
     )
     reqFn('/src/index.js', 'mypackage/simple.css')
 
@@ -122,6 +127,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
       {},
+      false,
     )
 
     const requireResult = reqFn('/src/index.js', 'mypackage/simple.svg')
@@ -138,6 +144,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
       {},
+      false,
     )
     const test = () => reqFn('/src/index.js', 'mypackage2')
     expect(test).toThrowError(`Could not find dependency: 'mypackage2' relative to '/src/index.js`)
@@ -152,6 +159,7 @@ describe('ES Dependency Manager — Cycles', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
       {},
+      false,
       spyEvaluator,
     )
     const requireResult = reqFn('/src/index.js', 'mypackage/moduleA')
@@ -181,7 +189,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
     }
     const nodeModules = fetchNodeModulesResult.nodeModules
     const onRemoteModuleDownload = jest.fn()
-    const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {})
+    const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {}, false)
     const reactSpring = req('/src/index.js', 'react-spring')
     expect(Object.keys(reactSpring)).not.toHaveLength(0)
     expect(onRemoteModuleDownload).toBeCalledTimes(0)
@@ -216,6 +224,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
         {},
         updatedNodeModules,
         {},
+        false,
         spyEvaluator,
       )
 
@@ -231,7 +240,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
       done()
     }
 
-    const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {}, spyEvaluator)
+    const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {}, false, spyEvaluator)
     const antd = req('/src/index.js', 'antd')
     expect(Object.keys(antd)).not.toHaveLength(0)
     expect(antd).toHaveProperty('Button')
@@ -298,7 +307,13 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
       const downloadedModules = await moduleDownload
       const updatedNodeModules = { ...nodeModules, ...downloadedModules }
       const innerOnRemoteModuleDownload = jest.fn()
-      const updatedReq = getRequireFn(innerOnRemoteModuleDownload, {}, updatedNodeModules, {})
+      const updatedReq = getRequireFn(
+        innerOnRemoteModuleDownload,
+        {},
+        updatedNodeModules,
+        {},
+        false,
+      )
 
       // this is like calling `import 'mypackage/dist/style.css';`, we only care about the side effect
       updatedReq('/src/index.js', 'mypackage/dist/style.css')
@@ -313,7 +328,7 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
       done()
     }
 
-    const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {})
+    const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {}, false)
     const styleCss = req('/src/index.js', 'mypackage/dist/style.css')
     expect(Object.keys(styleCss)).toHaveLength(0)
   })

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -58,7 +58,7 @@ describe('ES Dependency Package Manager', () => {
         fileNoImports as PackagerServerResponse,
       ),
       {},
-      false,
+      'canvas',
     )
     const requireResult = reqFn('/src/index.js', 'mypackage')
     expect(requireResult).toHaveProperty('hello')
@@ -71,7 +71,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
       {},
-      false,
+      'canvas',
     )
     const requireResult = reqFn('/src/index.js', 'mypackage')
     expect(requireResult).toHaveProperty('hello')
@@ -84,7 +84,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithLocalImport),
       {},
-      false,
+      'canvas',
     )
     const requireResult = reqFn('/src/index.js', 'mypackage')
     expect(requireResult).toHaveProperty('hello')
@@ -97,7 +97,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
       {},
-      false,
+      'canvas',
     )
     reqFn('/src/index.js', 'mypackage/simple.css')
 
@@ -111,7 +111,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
       {},
-      false,
+      'canvas',
     )
     reqFn('/src/index.js', 'mypackage/simple.css')
 
@@ -127,7 +127,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
       {},
-      false,
+      'canvas',
     )
 
     const requireResult = reqFn('/src/index.js', 'mypackage/simple.svg')
@@ -144,7 +144,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
       {},
-      false,
+      'canvas',
     )
     const test = () => reqFn('/src/index.js', 'mypackage2')
     expect(test).toThrowError(`Could not find dependency: 'mypackage2' relative to '/src/index.js`)
@@ -159,7 +159,7 @@ describe('ES Dependency Manager — Cycles', () => {
       {},
       extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
       {},
-      false,
+      'canvas',
       spyEvaluator,
     )
     const requireResult = reqFn('/src/index.js', 'mypackage/moduleA')
@@ -189,7 +189,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
     }
     const nodeModules = fetchNodeModulesResult.nodeModules
     const onRemoteModuleDownload = jest.fn()
-    const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {}, false)
+    const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {}, 'canvas')
     const reactSpring = req('/src/index.js', 'react-spring')
     expect(Object.keys(reactSpring)).not.toHaveLength(0)
     expect(onRemoteModuleDownload).toBeCalledTimes(0)
@@ -224,7 +224,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
         {},
         updatedNodeModules,
         {},
-        false,
+        'canvas',
         spyEvaluator,
       )
 
@@ -240,7 +240,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
       done()
     }
 
-    const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {}, false, spyEvaluator)
+    const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {}, 'canvas', spyEvaluator)
     const antd = req('/src/index.js', 'antd')
     expect(Object.keys(antd)).not.toHaveLength(0)
     expect(antd).toHaveProperty('Button')
@@ -312,7 +312,7 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
         {},
         updatedNodeModules,
         {},
-        false,
+        'canvas',
       )
 
       // this is like calling `import 'mypackage/dist/style.css';`, we only care about the side effect
@@ -328,7 +328,7 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
       done()
     }
 
-    const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {}, false)
+    const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {}, 'canvas')
     const styleCss = req('/src/index.js', 'mypackage/dist/style.css')
     expect(Object.keys(styleCss)).toHaveLength(0)
   })

--- a/editor/src/core/es-modules/package-manager/package-manager.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.ts
@@ -49,7 +49,7 @@ export const getEditorRequireFn = (
       dispatch([updateNodeModulesContents(modulesToAdd, 'incremental')]),
     )
   }
-  return getRequireFn(onRemoteModuleDownload, projectContents, nodeModules, evaluationCache)
+  return getRequireFn(onRemoteModuleDownload, projectContents, nodeModules, evaluationCache, false)
 }
 
 export function getRequireFn(
@@ -57,10 +57,11 @@ export function getRequireFn(
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
   evaluationCache: EvaluationCache,
+  isPreview: boolean,
   injectedEvaluator = evaluator,
 ): RequireFn {
   return function require(importOrigin, toImport): unknown {
-    const builtInDependency = resolveBuiltInDependency(toImport)
+    const builtInDependency = resolveBuiltInDependency(toImport, isPreview)
     if (builtInDependency != null) {
       return builtInDependency
     }

--- a/editor/src/core/es-modules/package-manager/package-manager.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.ts
@@ -49,7 +49,13 @@ export const getEditorRequireFn = (
       dispatch([updateNodeModulesContents(modulesToAdd, 'incremental')]),
     )
   }
-  return getRequireFn(onRemoteModuleDownload, projectContents, nodeModules, evaluationCache, false)
+  return getRequireFn(
+    onRemoteModuleDownload,
+    projectContents,
+    nodeModules,
+    evaluationCache,
+    'canvas',
+  )
 }
 
 export function getRequireFn(
@@ -57,11 +63,11 @@ export function getRequireFn(
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
   evaluationCache: EvaluationCache,
-  isPreview: boolean,
+  mode: 'canvas' | 'preview',
   injectedEvaluator = evaluator,
 ): RequireFn {
   return function require(importOrigin, toImport): unknown {
-    const builtInDependency = resolveBuiltInDependency(toImport, isPreview)
+    const builtInDependency = resolveBuiltInDependency(toImport, mode)
     if (builtInDependency != null) {
       return builtInDependency
     }

--- a/editor/src/core/property-controls/property-controls-processor.ts
+++ b/editor/src/core/property-controls/property-controls-processor.ts
@@ -75,6 +75,7 @@ export const initPropertyControlsProcessor = (
       projectContents,
       currentNodeModules,
       evaluationCache,
+      false,
     )
 
     const exportValues = getExportValuesFromAllModules(bundledProjectFiles, requireFn)

--- a/editor/src/core/property-controls/property-controls-processor.ts
+++ b/editor/src/core/property-controls/property-controls-processor.ts
@@ -75,7 +75,7 @@ export const initPropertyControlsProcessor = (
       projectContents,
       currentNodeModules,
       evaluationCache,
-      false,
+      'canvas',
     )
 
     const exportValues = getExportValuesFromAllModules(bundledProjectFiles, requireFn)

--- a/editor/src/core/third-party/third-party-components.ts
+++ b/editor/src/core/third-party/third-party-components.ts
@@ -62,7 +62,7 @@ export function resolvedDependencyVersions(
 ): Array<PossiblyUnversionedNpmDependency> {
   let result: Array<PossiblyUnversionedNpmDependency> = []
   fastForEach(dependencies, (dependency) => {
-    const builtInVersion = versionForBuiltInDependency(dependency.name, false)
+    const builtInVersion = versionForBuiltInDependency(dependency.name, 'canvas')
     const version = builtInVersion ?? parseDependencyVersionFromNodeModules(files, dependency.name)
     if (version == null) {
       result.push(unversionedNpmDependency(dependency.name))

--- a/editor/src/core/third-party/third-party-components.ts
+++ b/editor/src/core/third-party/third-party-components.ts
@@ -62,7 +62,7 @@ export function resolvedDependencyVersions(
 ): Array<PossiblyUnversionedNpmDependency> {
   let result: Array<PossiblyUnversionedNpmDependency> = []
   fastForEach(dependencies, (dependency) => {
-    const builtInVersion = versionForBuiltInDependency(dependency.name)
+    const builtInVersion = versionForBuiltInDependency(dependency.name, false)
     const version = builtInVersion ?? parseDependencyVersionFromNodeModules(files, dependency.name)
     if (version == null) {
       result.push(unversionedNpmDependency(dependency.name))

--- a/editor/src/templates/preview.tsx
+++ b/editor/src/templates/preview.tsx
@@ -211,7 +211,7 @@ const initPreview = () => {
       if (fastDeepEquals(lastDependencies, npmDependencies)) {
         nodeModules = { ...cachedDependencies }
       } else {
-        const fetchNodeModulesResult = await fetchNodeModules(npmDependencies, true, 'preview')
+        const fetchNodeModulesResult = await fetchNodeModules(npmDependencies, 'preview', true)
 
         if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
           const errorToThrow = Error(

--- a/editor/src/templates/preview.tsx
+++ b/editor/src/templates/preview.tsx
@@ -211,7 +211,7 @@ const initPreview = () => {
       if (fastDeepEquals(lastDependencies, npmDependencies)) {
         nodeModules = { ...cachedDependencies }
       } else {
-        const fetchNodeModulesResult = await fetchNodeModules(npmDependencies)
+        const fetchNodeModulesResult = await fetchNodeModules(npmDependencies, true, true)
 
         if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
           const errorToThrow = Error(
@@ -248,7 +248,7 @@ const initPreview = () => {
 
     incorporateBuildResult(nodeModules, bundledProjectFiles)
 
-    const requireFn = getRequireFn(onRemoteModuleDownload, projectContents, nodeModules, {})
+    const requireFn = getRequireFn(onRemoteModuleDownload, projectContents, nodeModules, {}, true)
 
     // replacing the document body first
     const previewHTMLFileName = getMainHTMLFilename(projectContents)

--- a/editor/src/templates/preview.tsx
+++ b/editor/src/templates/preview.tsx
@@ -211,7 +211,7 @@ const initPreview = () => {
       if (fastDeepEquals(lastDependencies, npmDependencies)) {
         nodeModules = { ...cachedDependencies }
       } else {
-        const fetchNodeModulesResult = await fetchNodeModules(npmDependencies, true, true)
+        const fetchNodeModulesResult = await fetchNodeModules(npmDependencies, true, 'preview')
 
         if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
           const errorToThrow = Error(
@@ -248,7 +248,13 @@ const initPreview = () => {
 
     incorporateBuildResult(nodeModules, bundledProjectFiles)
 
-    const requireFn = getRequireFn(onRemoteModuleDownload, projectContents, nodeModules, {}, true)
+    const requireFn = getRequireFn(
+      onRemoteModuleDownload,
+      projectContents,
+      nodeModules,
+      {},
+      'preview',
+    )
 
     // replacing the document body first
     const previewHTMLFileName = getMainHTMLFilename(projectContents)


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/1134

**Problem:**
ReactDOM.render was missing from the preview because it uses a safe version as the canvas.

**Fix:**
Extended `fetchNodeModules` and `getRequireFn` to have a isPreview flag
