### PR TITLE
fix(parser) exported arbitrary added to exports

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -984,7 +984,10 @@ return { getSizing: getSizing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      setModifierDefaultExportInDetail(
+        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+        'getSizing',
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1084,7 +1087,10 @@ return { getSizing: getSizing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      addModifierExportToDetail(
+        addModifierExportToDetail(EmptyExportsDetail, 'getSizing'),
+        'whatever',
+      ),
     )
     expect(actualResult).toEqual(expectedResult)
   })

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -1285,6 +1285,14 @@ export function parseCode(
           }
           if (isLeft(parsedContents) || (isFunction && isLeft(parsedFunctionParam))) {
             pushArbitraryNode(topLevelElement)
+            if (isExported(topLevelElement)) {
+              const defaultExport = isDefaultExport(topLevelElement)
+              if (defaultExport) {
+                detailOfExports = setModifierDefaultExportInDetail(detailOfExports, name)
+              } else {
+                detailOfExports = addModifierExportToDetail(detailOfExports, name)
+              }
+            }
           } else {
             highlightBounds = parsedContents.value.highlightBounds
             const contents = parsedContents.value.value


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/1129

**Problem:**
Multifile styled components are missing from the canvas. Only parsed elements are part of the exportsDetails, and Styled components are arbitrary js. The canvas scope contains exported elements based on the exportsDetails.
This effected not just styled components but any non react element variable exports from other files imported to the storyboard.

**Fix:**
Changing the parser to include all exported elements in the exportsDetails.

