### PR TITLE
Investigating wtf is happening with the render counts with a fixed dom-walker

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -645,7 +645,7 @@ function walkScene(
 
     if (sceneID != null && scenePath != null && TP.isScenePath(scenePath)) {
       let cachedMetadata: ElementInstanceMetadata | null = null
-      if (ObserversAvailable && invalidatedSceneIDsRef.current != null) {
+      if (invalidatedSceneIDsRef.current != null) {
         if (!invalidatedSceneIDsRef.current.has(sceneID)) {
           // we can use the cache, if it exists
           const elementFromCurrentMetadata = MetadataUtils.findElementMetadata(
@@ -687,6 +687,7 @@ function walkScene(
         )
         return [...rootMetadata, ...sceneMetadata]
       } else {
+        console.warn('using cache')
         let rootMetadataAccumulator = [cachedMetadata]
         // Push the cached metadata for everything from this scene downwards
         Utils.fastForEach(rootMetadataInStateRef.current, (elem) => {


### PR DESCRIPTION
**Problem:**
#1150  and #1140 both suffer from the same problem _independently_: the render count test spectacularly breaks:
```
    Expected: < 495
    Received:   1146
```
Now. I don't believe this is a real life issue, as the time-based performance tests are actually slightly better than master on these branches.
However, I also didn't just want to merge these to master with the bumped render counts, so I started to investigate why on earth this is happening.

This PR contains a minimum reproduction of the 1146 counted renders. What is amazing about this is that the dom-walker is actually returning a cached response, and somehow _that_ triggers rerenders elsewhere?

This is how far I could get today, I thought I'll make this little snapshot so we can pick up the investigation from here.