### PR TITLE
Fix Template Path isDescendantOf check

### DIFF
--- a/editor/src/core/shared/template-path.spec.ts
+++ b/editor/src/core/shared/template-path.spec.ts
@@ -37,6 +37,56 @@ describe('serialization', function () {
   })
 })
 
+describe('isDescendantOf', () => {
+  it('returns true if it is a descendant from the same instance', () => {
+    const result = TP.isDescendantOf(
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X', 'Y']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
+    )
+    chaiExpect(result).to.be.true
+  })
+
+  it('returns true if it is a descendant from a higher instance', () => {
+    const result = TP.isDescendantOf(
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X', 'Y']),
+      TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]),
+    )
+    chaiExpect(result).to.be.true
+  })
+
+  it('returns true if it is a descendant of a descendant from a higher instance', () => {
+    const result = TP.isDescendantOf(
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X', 'Y']),
+      TP.scenePath([[BakedInStoryboardUID]]),
+    )
+    chaiExpect(result).to.be.true
+  })
+
+  it('returns false if it is the same path', () => {
+    const result = TP.isDescendantOf(
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
+    )
+    chaiExpect(result).to.be.false
+  })
+
+  it('returns false if not a descendant', () => {
+    const result = TP.isDescendantOf(
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['Y']),
+    )
+    chaiExpect(result).to.be.false
+  })
+
+  it('returns false if it is a parent of the target', () => {
+    const result = TP.isDescendantOf(
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X']),
+      TP.instancePath(TP.scenePath([[BakedInStoryboardUID, 'scene-aaa']]), ['X', 'Y']),
+    )
+    chaiExpect(result).to.be.false
+  })
+})
+
 describe('isAncestorOf', () => {
   it('is not an ancestor', () => {
     const result = TP.isAncestorOf(

--- a/editor/src/core/shared/template-path.ts
+++ b/editor/src/core/shared/template-path.ts
@@ -638,13 +638,17 @@ export function isSiblingOf(l: TemplatePath | null, r: TemplatePath | null): boo
   return l != null && r != null && pathsEqual(parentPath(l), parentPath(r))
 }
 
-function elementIsDescendent(l: ElementPath, r: ElementPath): boolean {
-  if (l.length < r.length) {
-    return false
-  }
-
+function slicedPathsEqual(l: ElementPath, r: ElementPath): boolean {
   const slicedL = l.slice(0, r.length)
   return elementPathsEqual(slicedL, r)
+}
+
+function elementIsDescendant(l: ElementPath, r: ElementPath): boolean {
+  return l.length > r.length && slicedPathsEqual(l, r)
+}
+
+function elementIsDescendantOrEqualTo(l: ElementPath, r: ElementPath): boolean {
+  return l.length >= r.length && slicedPathsEqual(l, r)
 }
 
 function scenePathIsDescendent(path: ScenePath, targetAncestor: ScenePath): boolean {
@@ -673,9 +677,13 @@ export function isAncestorOf(
   } else if (isScenePath(targetAncestor)) {
     return scenePathIsDescendent(path.scene, targetAncestor)
   } else {
+    const elementPathCompare = includePathsEqual
+      ? elementIsDescendantOrEqualTo
+      : elementIsDescendant
+
     return (
       scenePathIsDescendent(path.scene, targetAncestor.scene) &&
-      elementIsDescendent(path.element, targetAncestor.element)
+      elementPathCompare(path.element, targetAncestor.element)
     )
   }
 }
@@ -688,23 +696,22 @@ function fullElementPathForPath(path: TemplatePath): ElementPath[] {
   }
 }
 
-export function isDescendantOf(
-  target: TemplatePath,
-  maybeAncestor: TemplatePath,
-  includePathsEqual: boolean = true,
-): boolean {
+export function isDescendantOf(target: TemplatePath, maybeAncestor: TemplatePath): boolean {
   const targetElementPath = fullElementPathForPath(target)
   const maybeAncestorElementPath = fullElementPathForPath(maybeAncestor)
-  if (fullElementPathsEqual(targetElementPath, maybeAncestorElementPath)) {
-    return includePathsEqual
-  } else if (targetElementPath.length >= maybeAncestorElementPath.length) {
+  if (targetElementPath.length >= maybeAncestorElementPath.length) {
     const partsToCheck = targetElementPath.slice(0, maybeAncestorElementPath.length)
     return partsToCheck.every((elementPath, i) => {
-      // all parts up to the last must match, and the last must be a descendent
+      // all parts up to the last must match, and the last must be a descendant
       if (i < maybeAncestorElementPath.length - 1) {
         return elementPathsEqual(elementPath, maybeAncestorElementPath[i])
       } else {
-        return elementIsDescendent(elementPath, maybeAncestorElementPath[i])
+        const finalPartComparison =
+          targetElementPath.length === maybeAncestorElementPath.length
+            ? elementIsDescendant
+            : elementIsDescendantOrEqualTo
+
+        return finalPartComparison(elementPath, maybeAncestorElementPath[i])
       }
     })
   } else {


### PR DESCRIPTION
**Problem:**
When checking if one `TemplatePath` was a descendant of another, we were incorrectly defaulting to also return true if the paths matched. This manifested it in the DOM walker returning cached data that was different to the previous result because it would include duplicated results, triggering a re-render. This is partially responsible for the issue Balazs discovered in #1151 

**Fix:**
Change `isDescendantOf` to return false if the paths match, since it is currently only used in the DOM walker.
