### PR TITLE
Remove some of the single file functions.

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -55,8 +55,7 @@
     "moduleNameMapper": {
       "^domtoimage$": "<rootDir>/src/components/editor/dom-to-image-stub.ts",
       "\\.(css)$": "<rootDir>/test/jest/__mocks__/styleMock.js"
-    },
-    "verbose": true
+    }
   },
   "husky": {
     "hooks": {

--- a/editor/package.json
+++ b/editor/package.json
@@ -55,7 +55,8 @@
     "moduleNameMapper": {
       "^domtoimage$": "<rootDir>/src/components/editor/dom-to-image-stub.ts",
       "\\.(css)$": "<rootDir>/test/jest/__mocks__/styleMock.js"
-    }
+    },
+    "verbose": true
   },
   "husky": {
     "hooks": {

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -5,6 +5,10 @@ import {
   Directory,
   TextFile,
   AssetFile,
+  ParseSuccess,
+  isParsedTextFile,
+  isTextFile,
+  isParseSuccess,
 } from '../core/shared/project-file-types'
 import { isDirectory, directory, isImageFile } from '../core/model/project-file-utils'
 import Utils from '../utils/utils'
@@ -218,6 +222,17 @@ export function walkContentsTree(
       default:
         const _exhaustiveCheck: never = treeElement
         throw new Error(`Unhandled tree element ${JSON.stringify(treeElement)}`)
+    }
+  })
+}
+
+export function walkContentsTreeForParseSuccess(
+  tree: ProjectContentTreeRoot,
+  onElement: (fullPath: string, parseSuccess: ParseSuccess) => void,
+): void {
+  walkContentsTree(tree, (fullPath, file) => {
+    if (isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
+      onElement(fullPath, file.fileContents.parsed)
     }
   })
 }

--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -38,12 +38,7 @@ import {
   defaultViewElement,
 } from '../editor/defaults'
 import { EditorModes, Mode } from '../editor/editor-modes'
-import {
-  DerivedState,
-  EditorState,
-  getOpenImportsFromState,
-  getOpenUtopiaJSXComponentsFromState,
-} from '../editor/store/editor-state'
+import { DerivedState, EditorState } from '../editor/store/editor-state'
 import {
   toggleBorder,
   toggleShadow,

--- a/editor/src/components/canvas/controls/breadcrumb-trail.tsx
+++ b/editor/src/components/canvas/controls/breadcrumb-trail.tsx
@@ -6,7 +6,6 @@ import {
 } from '../../../utils/react-performance'
 import { Utils } from '../../../uuiui-deps'
 import * as TP from '../../../core/shared/template-path'
-import { getOpenUtopiaJSXComponentsFromState } from '../../editor/store/editor-state'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { selectComponents } from '../../../components/editor/actions/action-creators'
 import { Icons, UIRow, UtopiaTheme } from '../../../uuiui'
@@ -18,11 +17,10 @@ interface ElementPathElement {
 }
 
 export const BreadcrumbTrail = betterReactMemo('BreadcrumbTrail', () => {
-  const { dispatch, jsxMetadata, rootComponents, selectedViews } = useEditorState((store) => {
+  const { dispatch, jsxMetadata, selectedViews } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
       jsxMetadata: store.editor.jsxMetadata,
-      rootComponents: getOpenUtopiaJSXComponentsFromState(store.editor),
       selectedViews: store.editor.selectedViews,
     }
   }, 'TopMenuContextProvider')

--- a/editor/src/components/canvas/controls/component-area-control.tsx
+++ b/editor/src/components/canvas/controls/component-area-control.tsx
@@ -37,7 +37,6 @@ interface ComponentAreaControlProps {
   keysPressed: KeysPressed
   windowToCanvasPosition: (event: MouseEvent) => CanvasPositions
   selectedViews: TemplatePath[]
-  imports: Imports
   showAdditionalControls: boolean
   testID?: string
 }

--- a/editor/src/components/canvas/controls/constraints-control.tsx
+++ b/editor/src/components/canvas/controls/constraints-control.tsx
@@ -21,22 +21,13 @@ export class ConstraintsControls extends React.Component<ConstraintsControlProps
       this.props.componentMetadata,
       this.props.selectedViews,
     )
-    const anyUnknownElements = this.props.selectedViews.some((selectedView) => {
-      const elementOriginType = withUnderlyingTarget<ElementOriginType>(
-        selectedView,
-        this.props.projectContents,
-        this.props.nodeModules,
-        this.props.openFile,
-        'unknown-element',
-        (success, element, underlyingTarget, underlyingFilePath) => {
-          return MetadataUtils.getElementOriginType(
-            getUtopiaJSXComponentsFromSuccess(success),
-            underlyingTarget,
-          )
-        },
-      )
-      return isUnknownOrGeneratedElement(elementOriginType)
-    })
+    const anyUnknownElements = MetadataUtils.anyUnknownOrGeneratedElements(
+      this.props.projectContents,
+      this.props.nodeModules,
+      this.props.openFile,
+      this.props.selectedViews,
+    )
+
     const validResizeDragState =
       this.props.dragState == null || this.props.dragState.type === 'RESIZE_DRAG_STATE'
 

--- a/editor/src/components/canvas/controls/constraints-control.tsx
+++ b/editor/src/components/canvas/controls/constraints-control.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
+import {
+  ElementOriginType,
+  isUnknownOrGeneratedElement,
+} from '../../../core/shared/project-file-types'
+import { withUnderlyingTarget } from '../../editor/store/editor-state'
 import { DragState } from '../canvas-types'
 import { MultiselectResizeControl } from './multiselect-resize-control'
 import { ControlProps } from './new-canvas-controls'
@@ -15,10 +21,22 @@ export class ConstraintsControls extends React.Component<ConstraintsControlProps
       this.props.componentMetadata,
       this.props.selectedViews,
     )
-    const anyUnknownElements = MetadataUtils.anyUnknownOrGeneratedElements(
-      this.props.rootComponents,
-      this.props.selectedViews,
-    )
+    const anyUnknownElements = this.props.selectedViews.some((selectedView) => {
+      const elementOriginType = withUnderlyingTarget<ElementOriginType>(
+        selectedView,
+        this.props.projectContents,
+        this.props.nodeModules,
+        this.props.openFile,
+        'unknown-element',
+        (success, element, underlyingTarget, underlyingFilePath) => {
+          return MetadataUtils.getElementOriginType(
+            getUtopiaJSXComponentsFromSuccess(success),
+            underlyingTarget,
+          )
+        },
+      )
+      return isUnknownOrGeneratedElement(elementOriginType)
+    })
     const validResizeDragState =
       this.props.dragState == null || this.props.dragState.type === 'RESIZE_DRAG_STATE'
 

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -54,6 +54,7 @@ import { createLayoutPropertyPath } from '../../../core/layout/layout-helpers-ne
 import { getStoryboardTemplatePath } from '../../../core/model/scene-utils'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
 import { isSceneAgainstImports } from '../../../core/model/project-file-utils'
+import { withUnderlyingTarget } from '../../editor/store/editor-state'
 
 // I feel comfortable having this function confined to this file only, since we absolutely shouldn't be trying
 // to set values that would fail whilst inserting elements. If that ever changes, this function should be binned
@@ -221,7 +222,6 @@ export class InsertModeControlContainer extends React.Component<
         keysPressed={this.props.keysPressed}
         windowToCanvasPosition={this.props.windowToCanvasPosition}
         selectedViews={this.props.selectedViews}
-        imports={this.props.imports}
         showAdditionalControls={this.props.showAdditionalControls}
       />
     )
@@ -470,7 +470,7 @@ export class InsertModeControlContainer extends React.Component<
       let element = null
       const parentPath =
         safeIndex(this.props.highlightedViews, 0) ??
-        getStoryboardTemplatePath(this.props.rootComponents)
+        getStoryboardTemplatePath(this.props.projectContents, this.props.openFile)
       let extraActions: EditorAction[] = []
 
       if (
@@ -659,14 +659,30 @@ export class InsertModeControlContainer extends React.Component<
 
   render() {
     const storyboardChildren = MetadataUtils.getAllStoryboardChildren(this.props.componentMetadata)
-    const roots = mapDropNulls(
-      (child) =>
-        MetadataUtils.elementIsOldStyleScene(child) ||
-        (isRight(child.element) && isSceneAgainstImports(child.element.value, this.props.imports))
-          ? child.templatePath
-          : null,
-      storyboardChildren,
-    )
+    const roots = mapDropNulls((child) => {
+      if (MetadataUtils.elementIsOldStyleScene(child)) {
+        return child.templatePath
+      } else if (isRight(child.element)) {
+        const childElement = child.element.value
+        const isScene = withUnderlyingTarget(
+          child.templatePath,
+          this.props.projectContents,
+          this.props.nodeModules,
+          this.props.openFile,
+          false,
+          (success) => {
+            return isSceneAgainstImports(childElement, success.imports)
+          },
+        )
+        if (isScene) {
+          return child.templatePath
+        } else {
+          return null
+        }
+      } else {
+        return null
+      }
+    }, storyboardChildren)
     const dragFrame = this.state.dragFrame
 
     return (

--- a/editor/src/components/canvas/controls/multiselect-resize-control.tsx
+++ b/editor/src/components/canvas/controls/multiselect-resize-control.tsx
@@ -63,7 +63,6 @@ export class MultiselectResizeControl extends React.Component<
       return []
     } else {
       return collectGuidelines(
-        this.props.imports,
         this.props.componentMetadata,
         draggedElements,
         this.props.scale,

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -8,13 +8,12 @@ import { EditorDispatch } from '../../editor/action-types'
 import {
   DerivedState,
   EditorState,
-  getOpenUtopiaJSXComponentsFromState,
-  getOpenImportsFromState,
   getMetadata,
   EditorStore,
   getOpenUIJSFileKey,
   TransientCanvasState,
   getJSXComponentsAndImportsForPathInnerComponentFromState,
+  TransientFilesState,
 } from '../../editor/store/editor-state'
 import {
   TemplatePath,
@@ -43,7 +42,7 @@ import { forceNotNull } from '../../../core/shared/optional-utils'
 import { flatMapArray } from '../../../core/shared/array-utils'
 import { targetRespectsLayout } from '../../../core/layout/layout-helpers'
 import { createSelector } from 'reselect'
-import { PropertyControlsInfo } from '../../custom-code/code-file'
+import { PropertyControlsInfo, ResolveFn } from '../../custom-code/code-file'
 import { colorTheme } from '../../../uuiui'
 import { betterReactMemo } from '../../../uuiui-deps'
 import {
@@ -89,9 +88,10 @@ function useLocalSelectedHighlightedViews(
 export interface ControlProps {
   selectedViews: Array<TemplatePath>
   highlightedViews: Array<TemplatePath>
-  rootComponents: Array<UtopiaJSXComponent>
   componentMetadata: ElementInstanceMetadataMap
-  imports: Imports
+  projectContents: ProjectContentTreeRoot
+  nodeModules: NodeModules
+  openFile: string | null
   hiddenInstances: Array<TemplatePath>
   focusedElementPath: ScenePath | null
   highlightsEnabled: boolean
@@ -106,6 +106,8 @@ export interface ControlProps {
   showAdditionalControls: boolean
   elementsThatRespectLayout: Array<TemplatePath>
   maybeClearHighlightsOnHoverEnd: () => void
+  transientState: TransientCanvasState
+  resolve: ResolveFn
 }
 
 interface NewCanvasControlsProps {
@@ -308,19 +310,14 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
         return isAspectRatioLockedNew(possibleElement)
       }
     })
-    const imports = getOpenImportsFromState(props.editor)
     const imageMultiplier: number | null = MetadataUtils.getImageMultiplier(
-      imports,
       componentMetadata,
       localSelectedViews,
     )
-    const rootComponents = getOpenUtopiaJSXComponentsFromState(props.editor)
     const controlProps: ControlProps = {
       selectedViews: localSelectedViews,
       highlightedViews: localHighlightedViews,
-      rootComponents: rootComponents,
       componentMetadata: componentMetadata,
-      imports: imports,
       hiddenInstances: props.editor.hiddenInstances,
       focusedElementPath: props.editor.focusedElementPath,
       highlightsEnabled: props.editor.canvas.highlightsEnabled,
@@ -335,6 +332,11 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       showAdditionalControls: props.editor.interfaceDesigner.additionalControls,
       elementsThatRespectLayout: elementsThatRespectLayout,
       maybeClearHighlightsOnHoverEnd: maybeClearHighlightsOnHoverEnd,
+      projectContents: props.editor.projectContents,
+      nodeModules: props.editor.nodeModules.files,
+      openFile: props.editor.canvas.openFile?.filename ?? null,
+      transientState: props.derived.canvas.transientState,
+      resolve: props.editor.codeResultCache.resolve,
     }
     const dragState = props.editor.canvas.dragState
     switch (props.editor.mode.type) {

--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { getOpenUtopiaJSXComponentsFromState } from '../../editor/store/editor-state'
 import { useEditorState } from '../../editor/store/store-hook'
 import { usePropControlledRef_DANGEROUS } from '../../inspector/common/inspector-utils'
 import { InstancePath, TemplatePath } from '../../../core/shared/project-file-types'

--- a/editor/src/components/canvas/controls/repositionable-control.tsx
+++ b/editor/src/components/canvas/controls/repositionable-control.tsx
@@ -4,6 +4,7 @@ import Utils from '../../../utils/utils'
 import * as TP from '../../../core/shared/template-path'
 import { ControlProps } from './new-canvas-controls'
 import { getSelectionColor } from './outline-control'
+import { getJSXComponentsAndImportsForPathInnerComponent } from '../../editor/store/editor-state'
 
 const Size = 6
 
@@ -18,11 +19,19 @@ export class RepositionableControl extends React.Component<ControlProps> {
         return
       }
 
+      const { components, imports } = getJSXComponentsAndImportsForPathInnerComponent(
+        selectedView,
+        this.props.openFile,
+        this.props.projectContents,
+        this.props.nodeModules,
+        this.props.transientState.filesState,
+        this.props.resolve,
+      )
       const selectionColor = getSelectionColor(
         selectedView,
-        this.props.rootComponents,
+        components,
         this.props.componentMetadata,
-        this.props.imports,
+        imports,
         this.props.focusedElementPath,
       )
 

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.ts
@@ -26,8 +26,8 @@ import {
 } from '../../../editor/actions/action-creators'
 import {
   EditorState,
+  getJSXComponentsAndImportsForPathInnerComponent,
   getJSXComponentsAndImportsForPathInnerComponentFromState,
-  getOpenUtopiaJSXComponentsFromState,
 } from '../../../editor/store/editor-state'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
@@ -254,16 +254,17 @@ function useStartDragState(): (
       const componentMetadata = entireEditorStoreRef.current.editor.jsxMetadata
       const selectedViews = entireEditorStoreRef.current.editor.selectedViews
 
-      const rootComponents = getOpenUtopiaJSXComponentsFromState(
-        entireEditorStoreRef.current.editor,
-      )
       const elementsThatRespectLayout = selectElementsThatRespectLayout(
         entireEditorStoreRef.current,
       )
 
       const duplicate = event.altKey
       const duplicateNewUIDs = duplicate
-        ? createDuplicationNewUIDs(selectedViews, componentMetadata, rootComponents)
+        ? createDuplicationNewUIDs(
+            selectedViews,
+            componentMetadata,
+            entireEditorStoreRef.current.editor.projectContents,
+          )
         : null
 
       const isTargetSelected = selectedViews.some((sv) => TP.pathsEqual(sv, target))

--- a/editor/src/components/canvas/controls/yoga-control.tsx
+++ b/editor/src/components/canvas/controls/yoga-control.tsx
@@ -3,7 +3,11 @@ import { FlexStretch, Sides } from 'utopia-api'
 import { LayoutHelpers } from '../../../core/layout/layout-helpers'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadata } from '../../../core/shared/element-template'
-import { InstancePath } from '../../../core/shared/project-file-types'
+import {
+  ElementOriginType,
+  InstancePath,
+  isUnknownOrGeneratedElement,
+} from '../../../core/shared/project-file-types'
 import { defaultEither, mapEither } from '../../../core/shared/either'
 import Utils from '../../../utils/utils'
 import { CanvasRectangle, canvasRectangle } from '../../../core/shared/math-utils'
@@ -14,6 +18,11 @@ import { getOriginalFrames } from '../canvas-utils'
 import { ControlProps } from './new-canvas-controls'
 import { getSelectionColor } from './outline-control'
 import { ResizeRectangle } from './size-box'
+import {
+  getJSXComponentsAndImportsForPathInnerComponent,
+  withUnderlyingTarget,
+} from '../../editor/store/editor-state'
+import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 interface YogaResizeControlProps extends ControlProps {
   targetElement: ElementInstanceMetadata
   target: InstancePath
@@ -25,7 +34,7 @@ class YogaResizeControl extends React.Component<YogaResizeControlProps> {
   getTargetStretch = (): FlexStretch => {
     const target = this.props.targetElement
     const parentPath = TP.parentPath(this.props.target)
-    const sceneMetadataOrElementMetadata = MetadataUtils.findElementByTemplatePath(
+    const sceneMetadataOrElementMetadata = MetadataUtils.findElementByTemplatePathDontThrowOnScenes(
       this.props.componentMetadata,
       parentPath,
     )
@@ -42,10 +51,18 @@ class YogaResizeControl extends React.Component<YogaResizeControlProps> {
 
   getYogaSize = (visualSize: CanvasRectangle): CanvasRectangle => {
     const childStretch = this.getTargetStretch()
+    const { components } = getJSXComponentsAndImportsForPathInnerComponent(
+      this.props.target,
+      this.props.openFile,
+      this.props.projectContents,
+      this.props.nodeModules,
+      this.props.transientState.filesState,
+      this.props.resolve,
+    )
     const yogaSize = MetadataUtils.getYogaSizeProps(
       this.props.target,
       this.props.componentMetadata,
-      this.props.rootComponents,
+      components,
     )
 
     return canvasRectangle({
@@ -111,21 +128,45 @@ export class YogaControls extends React.Component<YogaControlsProps> {
         this.props.componentMetadata,
       )
     })
-    const unknownElementsSelected = MetadataUtils.anyUnknownOrGeneratedElements(
-      this.props.rootComponents,
-      this.props.selectedViews,
-    )
+
+    const unknownElementsSelected = this.props.selectedViews.some((selectedView) => {
+      const elementOriginType = withUnderlyingTarget<ElementOriginType>(
+        selectedView,
+        this.props.projectContents,
+        this.props.nodeModules,
+        this.props.openFile,
+        'unknown-element',
+        (success, element, underlyingTarget, underlyingFilePath) => {
+          return MetadataUtils.getElementOriginType(
+            getUtopiaJSXComponentsFromSuccess(success),
+            underlyingTarget,
+          )
+        },
+      )
+      return isUnknownOrGeneratedElement(elementOriginType)
+    })
+
     const showResizeControl =
       targets.length === 1 && everyThingIsYogaLayouted && !unknownElementsSelected
 
     let color: string = ''
-    if (showResizeControl) {
-      color = getSelectionColor(
-        targets[0],
-        this.props.rootComponents,
-        this.props.componentMetadata,
-        this.props.imports,
-        this.props.focusedElementPath,
+    if (showResizeControl && targets.length > 0) {
+      const selectedView = targets[0]
+      color = withUnderlyingTarget<string>(
+        selectedView,
+        this.props.projectContents,
+        this.props.nodeModules,
+        this.props.openFile,
+        '',
+        (success, element, underlyingTarget, underlyingFilePath) => {
+          return getSelectionColor(
+            underlyingTarget,
+            getUtopiaJSXComponentsFromSuccess(success),
+            this.props.componentMetadata,
+            success.imports,
+            this.props.focusedElementPath,
+          )
+        },
       )
     }
 

--- a/editor/src/components/canvas/controls/yoga-control.tsx
+++ b/editor/src/components/canvas/controls/yoga-control.tsx
@@ -129,22 +129,12 @@ export class YogaControls extends React.Component<YogaControlsProps> {
       )
     })
 
-    const unknownElementsSelected = this.props.selectedViews.some((selectedView) => {
-      const elementOriginType = withUnderlyingTarget<ElementOriginType>(
-        selectedView,
-        this.props.projectContents,
-        this.props.nodeModules,
-        this.props.openFile,
-        'unknown-element',
-        (success, element, underlyingTarget, underlyingFilePath) => {
-          return MetadataUtils.getElementOriginType(
-            getUtopiaJSXComponentsFromSuccess(success),
-            underlyingTarget,
-          )
-        },
-      )
-      return isUnknownOrGeneratedElement(elementOriginType)
-    })
+    const unknownElementsSelected = MetadataUtils.anyUnknownOrGeneratedElements(
+      this.props.projectContents,
+      this.props.nodeModules,
+      this.props.openFile,
+      this.props.selectedViews,
+    )
 
     const showResizeControl =
       targets.length === 1 && everyThingIsYogaLayouted && !unknownElementsSelected

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
@@ -48,7 +48,7 @@ export var App = (props) => {
       }}
     >
       <div data-uid="inner-div">
-        <Card data-uid="card-instance" />
+        <Card data-uid="other-card-instance" />
         
       </div>
     </div>
@@ -145,12 +145,12 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene/app:app-root/inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance",
+            "storyboard/scene/app:app-root/inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/card-instance": Object {
+        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
           "rootElements": Array [],
@@ -188,12 +188,12 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene/app:app-root/inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance",
+            "storyboard/scene/app:app-root/inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/card-instance": Object {
+        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
@@ -233,12 +233,12 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene/app:app-root/inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance",
+            "storyboard/scene/app:app-root/inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/card-instance": Object {
+        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
           "rootElements": Array [],
@@ -304,34 +304,14 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene/app:app-root/inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance",
+            "storyboard/scene/app:app-root/inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/card-instance": Object {
+        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance": Object {
-          "children": Array [],
-          "name": "Button",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
-          "children": Array [],
-          "name": "HiElement",
           "rootElements": Array [],
         },
       }
@@ -367,38 +347,12 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene/app:app-root/inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance",
+            "storyboard/scene/app:app-root/inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/card-instance": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance",
-          ],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance": Object {
-          "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1",
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2",
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3",
-          ],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
+        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
@@ -438,40 +392,14 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene/app:app-root/inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance",
+            "storyboard/scene/app:app-root/inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/card-instance": Object {
+        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
-          "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance",
-          ],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance": Object {
-          "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1",
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2",
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3",
-          ],
-          "name": "Button",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
-          "children": Array [],
-          "name": "HiElement",
           "rootElements": Array [],
         },
       }
@@ -536,39 +464,14 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene/app:app-root/inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance",
+            "storyboard/scene/app:app-root/inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/card-instance": Object {
+        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance": Object {
-          "children": Array [],
-          "name": "Button",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance:button-root": Object {
-          "children": Array [],
-          "name": "div",
           "rootElements": Array [],
         },
       }
@@ -604,45 +507,12 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene/app:app-root/inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance",
+            "storyboard/scene/app:app-root/inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/card-instance": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance",
-          ],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance": Object {
-          "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1",
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2",
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3",
-          ],
-          "name": "div",
-          "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance:button-root",
-          ],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance:button-root": Object {
+        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
@@ -682,47 +552,14 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene/app:app-root/inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance",
+            "storyboard/scene/app:app-root/inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/card-instance": Object {
+        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
-          "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance",
-          ],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance": Object {
-          "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1",
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2",
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3",
-          ],
-          "name": "Button",
-          "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance:button-root",
-          ],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance:button-root": Object {
-          "children": Array [],
-          "name": "div",
           "rootElements": Array [],
         },
       }
@@ -787,39 +624,14 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene/app:app-root/inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance",
+            "storyboard/scene/app:app-root/inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/card-instance": Object {
+        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance": Object {
-          "children": Array [],
-          "name": "Button",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
-          "children": Array [],
-          "name": "HiElement",
           "rootElements": Array [],
         },
       }
@@ -855,45 +667,12 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene/app:app-root/inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance",
+            "storyboard/scene/app:app-root/inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/card-instance": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance",
-          ],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance": Object {
-          "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1",
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2",
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3",
-          ],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2:hi-element-root",
-          ],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
+        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
@@ -933,47 +712,14 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene/app:app-root/inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance",
+            "storyboard/scene/app:app-root/inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/card-instance": Object {
+        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
-          "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance",
-          ],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance": Object {
-          "children": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1",
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2",
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3",
-          ],
-          "name": "Button",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~1": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2": Object {
-          "children": Array [],
-          "name": "HiElement",
-          "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2:hi-element-root",
-          ],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~2:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/card-instance:button-instance/hi-element~~~3": Object {
-          "children": Array [],
-          "name": "HiElement",
           "rootElements": Array [],
         },
       }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
@@ -1,9 +1,8 @@
 import { mapArrayToDictionary } from '../../../core/shared/array-utils'
-import { bimapEither, foldEither, mapEither } from '../../../core/shared/either'
+import { foldEither } from '../../../core/shared/either'
 import {
   ElementInstanceMetadata,
   getJSXElementNameAsString,
-  getJSXElementNameNoPathName,
   isJSXElement,
   ElementInstanceMetadataMap,
 } from '../../../core/shared/element-template'
@@ -21,18 +20,10 @@ import { lintAndParse } from '../../../core/workers/parser-printer/parser-printe
 import { defaultProject } from '../../../sample-projects/sample-project-utils'
 import { wait } from '../../../utils/utils.test-utils'
 import { addFileToProjectContents } from '../../assets'
-import { defaultProjectContentsForNormalising } from '../../custom-code/code-file.test-utils'
 import { setFocusedElement } from '../../editor/actions/action-creators'
-import {
-  persistentModelForProjectContents,
-  StoryboardFilePath,
-} from '../../editor/store/editor-state'
+import { StoryboardFilePath } from '../../editor/store/editor-state'
 import CanvasActions from '../canvas-actions'
-import {
-  renderTestEditorWithCode,
-  renderTestEditorWithModel,
-  renderTestEditorWithProjectContent,
-} from '../ui-jsx.test-utils'
+import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
 
 const exampleProject = `/** @jsx jsx */
 import * as React from "react";
@@ -77,13 +68,13 @@ export var SameFileApp = (props) => {
 export var storyboard = (
   <Storyboard data-uid="storyboard">
     <Scene
-      data-uid="scene"
+      data-uid="scene-1"
       style={{ position: "absolute", left: 0, top: 0, width: 375, height: 812 }}
     >
       <SameFileApp data-uid="app" />
     </Scene>
     <Scene
-      data-uid="scene"
+      data-uid="scene-2"
       style={{ position: "absolute", left: 400, top: 0, width: 375, height: 812 }}
     >
       <App data-uid="app2" />
@@ -179,16 +170,7 @@ export const Card = () => {
 
 describe('Spy Wrapper Template Path Tests', () => {
   it('a simple component in a regular scene', async () => {
-    // Code kept commented for any future person who needs it.
-    const currentWindow = require('electron').remote.getCurrentWindow()
-    currentWindow.show()
-    currentWindow.setPosition(500, 200)
-    currentWindow.setSize(2200, 1000)
-    currentWindow.openDevTools()
-    // This is necessary because the test code races against the Electron process
-    // opening the window it would appear.
-    await wait(20000)
-    const { getEditorState } = await createExampleProject().catch(() => wait(60000))
+    const { getEditorState } = await createExampleProject()
 
     await wait(20000)
     const spiedMetadata = getEditorState().editor.spyMetadata
@@ -206,51 +188,63 @@ describe('Spy Wrapper Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
+          "name": "SameFileApp",
           "rootElements": Array [],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
+          "children": Array [],
+          "name": "Card",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
           "children": Array [],
           "name": "Card",
           "rootElements": Array [],
@@ -265,47 +259,61 @@ describe('Spy Wrapper Template Path Tests', () => {
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene": Object {
-          "children": Array [
-            ":storyboard/scene/app",
-          ],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-1/app:other-app-root",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            ":storyboard/scene-2/app2",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        ":storyboard/scene-2/app2": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div",
+          ],
+        },
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
+          "children": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
@@ -317,53 +325,67 @@ describe('Spy Wrapper Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
-          "rootElements": Array [],
+          "name": "SameFileApp",
+          "rootElements": Array [
+            "storyboard/scene-1/app:other-app-root",
+          ],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-2/app2:app-outer-div",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
+          "children": Array [],
+          "name": "Card",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
           "children": Array [],
           "name": "Card",
           "rootElements": Array [],
@@ -378,8 +400,8 @@ describe('Spy Wrapper Template Path Tests', () => {
       [
         setFocusedElement(
           TP.scenePath([
-            ['storyboard', 'scene', 'app'],
-            ['app-root', 'inner-div', 'other-card-instance'],
+            ['storyboard', 'scene-1', 'app'],
+            ['other-app-root', 'other-inner-div', 'other-card-instance'],
           ]),
         ),
       ],
@@ -403,73 +425,85 @@ describe('Spy Wrapper Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
+          "name": "SameFileApp",
           "rootElements": Array [],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance": Object {
           "children": Array [],
           "name": "Button",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
           "rootElements": Array [],
         },
       }
@@ -482,73 +516,87 @@ describe('Spy Wrapper Template Path Tests', () => {
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene": Object {
-          "children": Array [
-            ":storyboard/scene/app",
-          ],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-1/app:other-app-root",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            ":storyboard/scene-2/app2",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
-          "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
-          ],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance",
+            "storyboard/scene-2/app2:app-outer-div",
           ],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1",
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2",
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
+          "children": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance",
+          ],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance": Object {
+          "children": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
@@ -560,81 +608,95 @@ describe('Spy Wrapper Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
-          "rootElements": Array [],
+          "name": "SameFileApp",
+          "rootElements": Array [
+            "storyboard/scene-1/app:other-app-root",
+          ],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-2/app2:app-outer-div",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
           "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance",
           ],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1",
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2",
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3",
           ],
           "name": "Button",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
           "rootElements": Array [],
         },
       }
@@ -647,9 +709,9 @@ describe('Spy Wrapper Template Path Tests', () => {
       [
         setFocusedElement(
           TP.scenePath([
-            ['storyboard', 'scene', 'app'],
-            ['app-root', 'inner-div', 'other-card-instance'],
-            ['button-instance'],
+            ['storyboard', 'scene-1', 'app'],
+            ['other-app-root', 'other-inner-div', 'other-card-instance'],
+            ['other-button-instance'],
           ]),
         ),
       ],
@@ -673,78 +735,90 @@ describe('Spy Wrapper Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
+          "name": "SameFileApp",
           "rootElements": Array [],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance": Object {
           "children": Array [],
           "name": "Button",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance:button-root": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance:other-button-root": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
           "rootElements": Array [],
         },
       }
@@ -757,80 +831,94 @@ describe('Spy Wrapper Template Path Tests', () => {
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene": Object {
-          "children": Array [
-            ":storyboard/scene/app",
-          ],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-1/app:other-app-root",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            ":storyboard/scene-2/app2",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
-          "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
-          ],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance",
+            "storyboard/scene-2/app2:app-outer-div",
           ],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1",
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2",
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
+          "children": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance",
+          ],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance": Object {
+          "children": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3",
           ],
           "name": "div",
           "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance:button-root",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance:other-button-root",
           ],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance:button-root": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance:other-button-root": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
@@ -842,88 +930,102 @@ describe('Spy Wrapper Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
-          "rootElements": Array [],
+          "name": "SameFileApp",
+          "rootElements": Array [
+            "storyboard/scene-1/app:other-app-root",
+          ],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-2/app2:app-outer-div",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
           "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance",
           ],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1",
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2",
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3",
           ],
           "name": "Button",
           "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance:button-root",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance:other-button-root",
           ],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance:button-root": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance:other-button-root": Object {
           "children": Array [],
           "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
           "rootElements": Array [],
         },
       }
@@ -936,9 +1038,9 @@ describe('Spy Wrapper Template Path Tests', () => {
       [
         setFocusedElement(
           TP.scenePath([
-            ['storyboard', 'scene', 'app'],
-            ['app-root', 'inner-div', 'other-card-instance'],
-            ['button-instance', 'hi-element~~~2'],
+            ['storyboard', 'scene-1', 'app'],
+            ['other-app-root', 'other-inner-div', 'other-card-instance'],
+            ['other-button-instance', 'other-hi-element~~~2'],
           ]),
         ),
       ],
@@ -962,78 +1064,90 @@ describe('Spy Wrapper Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
+          "name": "SameFileApp",
           "rootElements": Array [],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance": Object {
           "children": Array [],
           "name": "Button",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2:hi-element-root": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:other-hi-element-root": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
           "rootElements": Array [],
         },
       }
@@ -1046,80 +1160,94 @@ describe('Spy Wrapper Template Path Tests', () => {
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene": Object {
-          "children": Array [
-            ":storyboard/scene/app",
-          ],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-1/app:other-app-root",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            ":storyboard/scene-2/app2",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
-          "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
-          ],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance",
+            "storyboard/scene-2/app2:app-outer-div",
           ],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1",
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2",
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1": Object {
-          "children": Array [],
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
+          "children": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
+          ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2:hi-element-root",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance",
           ],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2:hi-element-root": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance": Object {
+          "children": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:other-hi-element-root",
+          ],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:other-hi-element-root": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
@@ -1131,88 +1259,102 @@ describe('Spy Wrapper Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
-          "rootElements": Array [],
+          "name": "SameFileApp",
+          "rootElements": Array [
+            "storyboard/scene-1/app:other-app-root",
+          ],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-2/app2:app-outer-div",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
           "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance",
           ],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1",
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2",
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3",
           ],
           "name": "Button",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~1": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2:hi-element-root",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:other-hi-element-root",
           ],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~2:hi-element-root": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:other-hi-element-root": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance:button-instance/hi-element~~~3": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
           "rootElements": Array [],
         },
       }
@@ -1227,8 +1369,8 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
       [
         setFocusedElement(
           TP.scenePath([
-            ['storyboard', 'scene', 'app2'],
-            ['app-root', 'inner-div', 'card-instance'],
+            ['storyboard', 'scene-2', 'app2'],
+            ['app-outer-div', 'card-instance'],
           ]),
         ),
       ],
@@ -1252,53 +1394,85 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
+          "name": "SameFileApp",
           "rootElements": Array [],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance": Object {
+          "children": Array [],
+          "name": "Button",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
+          "children": Array [],
+          "name": "HiElement",
           "rootElements": Array [],
         },
       }
@@ -1311,47 +1485,87 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene": Object {
-          "children": Array [
-            ":storyboard/scene/app",
-          ],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-1/app:other-app-root",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            ":storyboard/scene-2/app2",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        ":storyboard/scene-2/app2": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div",
+          ],
+        },
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
+          "children": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance",
+          ],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1",
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2",
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
@@ -1363,55 +1577,95 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
-          "rootElements": Array [],
+          "name": "SameFileApp",
+          "rootElements": Array [
+            "storyboard/scene-1/app:other-app-root",
+          ],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-2/app2:app-outer-div",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance",
+          ],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1",
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2",
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3",
+          ],
+          "name": "Button",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
+          "children": Array [],
+          "name": "HiElement",
           "rootElements": Array [],
         },
       }
@@ -1424,8 +1678,8 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
       [
         setFocusedElement(
           TP.scenePath([
-            ['storyboard', 'scene', 'app2'],
-            ['app-root', 'inner-div', 'card-instance'],
+            ['storyboard', 'scene-2', 'app2'],
+            ['app-outer-div', 'card-instance'],
             ['button-instance'],
           ]),
         ),
@@ -1450,53 +1704,90 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
+          "name": "SameFileApp",
           "rootElements": Array [],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance": Object {
+          "children": Array [],
+          "name": "Button",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance:button-root": Object {
+          "children": Array [],
+          "name": "div",
           "rootElements": Array [],
         },
       }
@@ -1509,47 +1800,94 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene": Object {
-          "children": Array [
-            ":storyboard/scene/app",
-          ],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-1/app:other-app-root",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            ":storyboard/scene-2/app2",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        ":storyboard/scene-2/app2": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div",
+          ],
+        },
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
+          "children": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance",
+          ],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1",
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2",
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3",
+          ],
+          "name": "div",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance:button-root",
+          ],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance:button-root": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
@@ -1561,55 +1899,102 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
-          "rootElements": Array [],
+          "name": "SameFileApp",
+          "rootElements": Array [
+            "storyboard/scene-1/app:other-app-root",
+          ],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-2/app2:app-outer-div",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance",
+          ],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1",
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2",
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3",
+          ],
+          "name": "Button",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance:button-root",
+          ],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance:button-root": Object {
+          "children": Array [],
+          "name": "div",
           "rootElements": Array [],
         },
       }
@@ -1622,8 +2007,8 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
       [
         setFocusedElement(
           TP.scenePath([
-            ['storyboard', 'scene', 'app2'],
-            ['app-root', 'inner-div', 'card-instance'],
+            ['storyboard', 'scene-2', 'app2'],
+            ['app-outer-div', 'card-instance'],
             ['button-instance', 'hi-element~~~2'],
           ]),
         ),
@@ -1648,53 +2033,90 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
+          "name": "SameFileApp",
           "rootElements": Array [],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance": Object {
+          "children": Array [],
+          "name": "Button",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2:hi-element-root": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
+          "children": Array [],
+          "name": "HiElement",
           "rootElements": Array [],
         },
       }
@@ -1707,47 +2129,94 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene": Object {
-          "children": Array [
-            ":storyboard/scene/app",
-          ],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-1/app:other-app-root",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            ":storyboard/scene-2/app2",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        ":storyboard/scene-2/app2": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div",
+          ],
+        },
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
+          "children": Array [
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance",
+          ],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1",
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2",
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2:hi-element-root",
+          ],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2:hi-element-root": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
@@ -1759,55 +2228,102 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
       Object {
         ":storyboard": Object {
           "children": Array [
-            ":storyboard/scene",
-            ":storyboard/f51",
+            ":storyboard/scene-1",
+            ":storyboard/scene-2",
           ],
           "name": "Storyboard",
           "rootElements": Array [],
         },
-        ":storyboard/f51": Object {
+        ":storyboard/scene-1": Object {
           "children": Array [
-            ":storyboard/f51/app2",
+            ":storyboard/scene-1/app",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/f51/app2": Object {
+        ":storyboard/scene-1/app": Object {
           "children": Array [],
-          "name": "App2",
-          "rootElements": Array [],
+          "name": "SameFileApp",
+          "rootElements": Array [
+            "storyboard/scene-1/app:other-app-root",
+          ],
         },
-        ":storyboard/scene": Object {
+        ":storyboard/scene-2": Object {
           "children": Array [
-            ":storyboard/scene/app",
+            ":storyboard/scene-2/app2",
           ],
           "name": "Scene",
           "rootElements": Array [],
         },
-        ":storyboard/scene/app": Object {
+        ":storyboard/scene-2/app2": Object {
           "children": Array [],
           "name": "App",
           "rootElements": Array [
-            "storyboard/scene/app:app-root",
+            "storyboard/scene-2/app2:app-outer-div",
           ],
         },
-        "storyboard/scene/app:app-root": Object {
+        "storyboard/scene-1/app:other-app-root": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div",
+            "storyboard/scene-1/app:other-app-root/other-inner-div",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div": Object {
           "children": Array [
-            "storyboard/scene/app:app-root/inner-div/other-card-instance",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance",
           ],
           "name": "div",
           "rootElements": Array [],
         },
-        "storyboard/scene/app:app-root/inner-div/other-card-instance": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance": Object {
           "children": Array [],
           "name": "Card",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance",
+          ],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance": Object {
+          "children": Array [],
+          "name": "Card",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance",
+          ],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance": Object {
+          "children": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1",
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2",
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3",
+          ],
+          "name": "Button",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
+          "children": Array [],
+          "name": "HiElement",
+          "rootElements": Array [
+            "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2:hi-element-root",
+          ],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2:hi-element-root": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
+          "children": Array [],
+          "name": "HiElement",
           "rootElements": Array [],
         },
       }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
@@ -138,7 +138,7 @@ const HiElement = (props) => {
 const Button = (props) => {
   return <div data-uid="button-root">{props.children}</div>;
 };
-const Card = () => {
+export const Card = () => {
   return (
     <Button data-uid="button-instance">
       {[0, 1, 2].map(i => (

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -157,11 +157,10 @@ export const setAsFocusedElement: ContextMenuItem<CanvasData> = {
       return data.selectedViews.every((view) => {
         const { components, imports } = getJSXComponentsAndImportsForPathInnerComponent(
           view,
-          data.currentFilePath!,
+          data.currentFilePath,
           data.projectContents,
           data.nodeModules,
           data.transientFilesState,
-          data.jsxMetadata,
           data.resolve,
         )
         return MetadataUtils.isFocusableComponent(view, components, data.jsxMetadata, imports)
@@ -172,14 +171,13 @@ export const setAsFocusedElement: ContextMenuItem<CanvasData> = {
     return data.selectedViews.every((view) => {
       const { components } = getJSXComponentsAndImportsForPathInnerComponent(
         view,
-        data.currentFilePath!,
+        data.currentFilePath,
         data.projectContents,
         data.nodeModules,
         data.transientFilesState,
-        data.jsxMetadata,
         data.resolve,
       )
-      const elementName = MetadataUtils.getJSXElementName(view, components, data.jsxMetadata)
+      const elementName = MetadataUtils.getJSXElementName(view, components)
       return elementName != null ? isIntrinsicHTMLElement(elementName) : true
     })
   },

--- a/editor/src/components/custom-code/code-file.test-utils.ts
+++ b/editor/src/components/custom-code/code-file.test-utils.ts
@@ -18,6 +18,7 @@ import { ProjectContentTreeRoot, contentsToTree, getContentsTreeFileFromString }
 import { DefaultPackageJson, StoryboardFilePath } from '../editor/store/editor-state'
 import * as TP from '../../core/shared/template-path'
 import { createComplexDefaultProjectContents } from '../../sample-projects/sample-project-utils'
+import { replaceAll } from '../../core/shared/string-utils'
 
 export const SampleNodeModules: NodeModules = {
   '/node_modules/utopia-api/index.js': esCodeFile(
@@ -70,12 +71,15 @@ export function createCodeFile(path: string, contents: string): TextFile {
 export function defaultProjectContentsForNormalising(): ProjectContentTreeRoot {
   const defaultProjectContents = createComplexDefaultProjectContents()
 
+  const unparsedCode = replaceAll(
+    (defaultProjectContents[StoryboardFilePath] as TextFile).fileContents.code,
+    `data-uid='`,
+    `data-uid='unparse-`,
+  )
+
   const projectContents: ProjectContents = {
     ...defaultProjectContents,
-    '/utopia/unparsedstoryboard.js': createCodeFile(
-      '/utopia/unparsedstoryboard.js',
-      (defaultProjectContents[StoryboardFilePath] as TextFile).fileContents.code,
-    ),
+    '/utopia/unparsedstoryboard.js': createCodeFile('/utopia/unparsedstoryboard.js', unparsedCode),
   }
 
   return contentsToTree(projectContents)

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -75,13 +75,15 @@ export type PropertyControlsInfo = {
   [filenameNoExtension: string]: { [componentName: string]: PropertyControls }
 }
 
+export type ResolveFn = (importOrigin: string, toImport: string) => Either<string, string>
+
 export type CodeResultCache = {
   skipDeepFreeze: true
   cache: { [filename: string]: CodeResult }
   exportsInfo: ReadonlyArray<ExportsInfo>
   error: Error | null
   requireFn: UtopiaRequireFn
-  resolve: (importOrigin: string, toImport: string) => Either<string, string>
+  resolve: ResolveFn
   projectModules: MultiFileBuildResult
   evaluationCache: EvaluationCache
 }

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -61,7 +61,6 @@ import {
   EditorState,
   reconstructJSXMetadata,
   getOpenUIJSFile,
-  getOpenUtopiaJSXComponentsFromState,
   PersistentModel,
   StoryboardFilePath,
 } from '../store/editor-state'
@@ -793,6 +792,19 @@ describe('moveTemplate', () => {
   })
 })
 
+function getOpenFileComponents(editor: EditorState): Array<UtopiaJSXComponent> {
+  const openFile = getOpenUIJSFile(editor)
+  if (openFile == null) {
+    return []
+  } else {
+    if (isParseSuccess(openFile.fileContents.parsed)) {
+      return getUtopiaJSXComponentsFromSuccess(openFile.fileContents.parsed)
+    } else {
+      return []
+    }
+  }
+}
+
 describe('SWITCH_LAYOUT_SYSTEM', () => {
   const childElement = jsxElement(
     'View',
@@ -942,18 +954,14 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
   it('switches from pins to flex correctly', () => {
     const switchActionToFlex = switchLayoutSystem('flex')
     const result = UPDATE_FNS.SWITCH_LAYOUT_SYSTEM(switchActionToFlex, testEditorWithPins)
-    expect(
-      getOpenUtopiaJSXComponentsFromState(result).map(clearTopLevelElementUniqueIDs),
-    ).toMatchSnapshot()
+    expect(getOpenFileComponents(result).map(clearTopLevelElementUniqueIDs)).toMatchSnapshot()
   })
   it('switches from flex to pins correctly', () => {
     const switchActionToFlex = switchLayoutSystem('flex')
     let result = UPDATE_FNS.SWITCH_LAYOUT_SYSTEM(switchActionToFlex, testEditorWithPins)
     const switchActionToPins = switchLayoutSystem(LayoutSystem.PinSystem)
     result = UPDATE_FNS.SWITCH_LAYOUT_SYSTEM(switchActionToPins, result)
-    expect(
-      getOpenUtopiaJSXComponentsFromState(result).map(clearTopLevelElementUniqueIDs),
-    ).toMatchSnapshot()
+    expect(getOpenFileComponents(result).map(clearTopLevelElementUniqueIDs)).toMatchSnapshot()
   })
 })
 

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -127,6 +127,7 @@ export const EditorComponentInner = betterReactMemo(
         handleKeyDown(
           event,
           editorStoreRef.current.editor,
+          editorStoreRef.current.derived,
           namesByKey,
           editorStoreRef.current.dispatch,
         )

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -111,11 +111,10 @@ import {
   ShortcutNamesByKey,
 } from './shortcut-definitions'
 import {
+  DerivedState,
   EditorState,
+  getJSXComponentsAndImportsForPathFromState,
   getOpenFile,
-  getOpenImportsFromState,
-  getOpenUtopiaJSXComponentsFromState,
-  UserState,
 } from './store/editor-state'
 
 function updateKeysPressed(
@@ -174,13 +173,16 @@ function jumpToParentActions(selectedViews: Array<TemplatePath>): Array<EditorAc
   }
 }
 
-function getTextEditorTarget(editor: EditorState): TemplatePath | null {
+function getTextEditorTarget(editor: EditorState, derived: DerivedState): TemplatePath | null {
   if (editor.canvas.dragState != null || editor.selectedViews.length !== 1) {
     return null
   } else {
     const target = editor.selectedViews[0]
-    const components = getOpenUtopiaJSXComponentsFromState(editor)
-    const imports = getOpenImportsFromState(editor)
+    const { components, imports } = getJSXComponentsAndImportsForPathFromState(
+      target,
+      editor,
+      derived,
+    )
     const element = findElementAtPath(target, components)
     if (element != null && isUtopiaAPITextElement(element, imports)) {
       return target
@@ -326,6 +328,7 @@ export function preventBrowserShortcuts(editor: EditorState, event: KeyboardEven
 export function handleKeyDown(
   event: KeyboardEvent,
   editor: EditorState,
+  derived: DerivedState,
   namesByKey: ShortcutNamesByKey,
   dispatch: EditorDispatch,
 ): void {
@@ -406,7 +409,7 @@ export function handleKeyDown(
       },
       [FIRST_CHILD_OR_EDIT_TEXT_SHORTCUT]: () => {
         if (modeType === 'select') {
-          const textTarget = getTextEditorTarget(editor)
+          const textTarget = getTextEditorTarget(editor, derived)
           if (textTarget != null) {
             return [EditorActions.openTextEditor(TP.instancePathForElementAtPath(textTarget), null)]
           } else {
@@ -589,8 +592,7 @@ export function handleKeyDown(
       },
       [INSERT_RECTANGLE_SHORTCUT]: () => {
         if (modeType === 'select' || modeType === 'insert') {
-          const utopiaComponents = getOpenUtopiaJSXComponentsFromState(editor)
-          const newUID = generateUidWithExistingComponents(utopiaComponents)
+          const newUID = generateUidWithExistingComponents(editor.projectContents)
           return [
             EditorActions.enableInsertModeForJSXElement(
               defaultRectangleElement(newUID),
@@ -607,8 +609,7 @@ export function handleKeyDown(
       },
       [INSERT_ELLIPSE_SHORTCUT]: () => {
         if (modeType === 'select' || modeType === 'insert') {
-          const utopiaComponents = getOpenUtopiaJSXComponentsFromState(editor)
-          const newUID = generateUidWithExistingComponents(utopiaComponents)
+          const newUID = generateUidWithExistingComponents(editor.projectContents)
           return [
             EditorActions.enableInsertModeForJSXElement(
               defaultEllipseElement(newUID),
@@ -634,8 +635,7 @@ export function handleKeyDown(
       },
       [INSERT_TEXT_SHORTCUT]: () => {
         if (modeType === 'select' || modeType === 'insert') {
-          const utopiaComponents = getOpenUtopiaJSXComponentsFromState(editor)
-          const newUID = generateUidWithExistingComponents(utopiaComponents)
+          const newUID = generateUidWithExistingComponents(editor.projectContents)
           return [
             EditorActions.enableInsertModeForJSXElement(
               defaultTextElement(newUID),
@@ -650,8 +650,7 @@ export function handleKeyDown(
       },
       [INSERT_VIEW_SHORTCUT]: () => {
         if (modeType === 'select' || modeType === 'insert') {
-          const utopiaComponents = getOpenUtopiaJSXComponentsFromState(editor)
-          const newUID = generateUidWithExistingComponents(utopiaComponents)
+          const newUID = generateUidWithExistingComponents(editor.projectContents)
           return [
             EditorActions.enableInsertModeForJSXElement(
               defaultViewElement(newUID),

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -31,7 +31,6 @@ import {
   defaultDivElement,
 } from './defaults'
 import { FontSettings } from '../inspector/common/css-utils'
-import { existingUIDs } from '../navigator/left-pane'
 import { EditorAction, EditorDispatch } from './action-types'
 import { enableInsertModeForJSXElement, enableInsertModeForScene } from './actions/action-creators'
 import {
@@ -82,6 +81,7 @@ import {
   getInsertableGroupPackageStatus,
 } from '../shared/project-components'
 import { ProjectContentTreeRoot } from '../assets'
+import { generateUidWithExistingComponents } from '../../core/model/element-template-utils'
 
 interface CurrentFileComponent {
   componentName: string
@@ -94,7 +94,6 @@ interface InsertMenuProps {
   editorDispatch: EditorDispatch
   selectedViews: Array<TemplatePath>
   mode: Mode
-  existingUIDs: Array<string>
   currentlyOpenFilename: string | null
   currentFileComponents: Array<CurrentFileComponent>
   dependencies: Array<PossiblyUnversionedNpmDependency>
@@ -140,7 +139,6 @@ export const InsertMenu = betterReactMemo('InsertMenu', () => {
       editorDispatch: store.dispatch,
       selectedViews: store.editor.selectedViews,
       mode: store.editor.mode,
-      existingUIDs: existingUIDs(openUIJSFile),
       currentlyOpenFilename: currentlyOpenFilename,
       currentFileComponents: currentFileComponents,
       packageStatus: store.editor.nodeModules.packageStatus,
@@ -238,8 +236,10 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
     this.props.editorDispatch([enableInsertModeForScene('scene')], 'everyone')
   }
 
+  getNewUID = () => generateUidWithExistingComponents(this.props.projectContents)
+
   divInsertMode = () => {
-    const newUID = generateUID(this.props.existingUIDs)
+    const newUID = this.getNewUID()
     this.props.editorDispatch(
       [enableInsertModeForJSXElement(defaultDivElement(newUID), newUID, {}, null)],
       'everyone',
@@ -251,7 +251,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
   }
 
   textInsertMode = () => {
-    const newUID = generateUID(this.props.existingUIDs)
+    const newUID = this.getNewUID()
     this.props.editorDispatch(
       [
         enableInsertModeForJSXElement(
@@ -266,7 +266,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
   }
 
   animatedDivInsertMode = () => {
-    const newUID = generateUID(this.props.existingUIDs)
+    const newUID = this.getNewUID()
     this.props.editorDispatch(
       [
         enableInsertModeForJSXElement(
@@ -281,7 +281,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
   }
 
   ellipseInsertMode = () => {
-    const newUID = generateUID(this.props.existingUIDs)
+    const newUID = this.getNewUID()
     this.props.editorDispatch(
       [
         enableInsertModeForJSXElement(
@@ -296,7 +296,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
   }
 
   rectangleInsertMode = () => {
-    const newUID = generateUID(this.props.existingUIDs)
+    const newUID = this.getNewUID()
     this.props.editorDispatch(
       [
         enableInsertModeForJSXElement(
@@ -361,7 +361,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
           >
             {insertableGroup.insertableComponents.map((component, componentIndex) => {
               const insertItemOnMouseDown = () => {
-                const newUID = generateUID(this.props.existingUIDs)
+                const newUID = this.getNewUID()
                 const newElement = {
                   ...component.element,
                   props: setJSXAttributesAttribute(

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -60,7 +60,6 @@ import {
   getAllErrorsFromFiles,
   getAllLintErrors,
   getHighlightBoundsForUids,
-  getOpenUtopiaJSXComponentsFromState,
   persistentModelFromEditorModel,
   reconstructJSXMetadata,
   storedEditorStateFromEditorState,
@@ -616,7 +615,7 @@ function editorDispatchInner(
     }
 
     const actionNames = dispatchedActions.map((action) => action.action).join(',')
-    getAllUniqueUids(getOpenUtopiaJSXComponentsFromState(frozenEditorState), actionNames)
+    getAllUniqueUids(frozenEditorState.projectContents, actionNames)
 
     if (!PRODUCTION_ENV) {
       if (typeof window.performance.mark === 'function') {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -110,6 +110,7 @@ import {
   normalisePathSuccessOrThrowError,
   normalisePathToUnderlyingTarget,
   PropertyControlsInfo,
+  ResolveFn,
 } from '../../custom-code/code-file'
 import { EditorModes, Mode } from '../editor-modes'
 import { FontSettings } from '../../inspector/common/css-utils'
@@ -625,19 +626,6 @@ export function modifyOpenJsxElementAtStaticPath(
   )
 }
 
-export function getOpenUtopiaJSXComponentsFromState(model: EditorState): Array<UtopiaJSXComponent> {
-  const openUIJSFile = getOpenUIJSFile(model)
-  if (openUIJSFile == null) {
-    return []
-  } else {
-    if (isParseSuccess(openUIJSFile.fileContents.parsed)) {
-      return getUtopiaJSXComponentsFromSuccess(openUIJSFile.fileContents.parsed)
-    } else {
-      return []
-    }
-  }
-}
-
 function getImportedUtopiaJSXComponents(
   filePath: string,
   model: EditorState,
@@ -733,35 +721,33 @@ export function getJSXComponentsAndImportsForPathInnerComponentFromState(
   imports: Imports
 } {
   const storyboardFilePath = getOpenUIJSFileKey(model)
-  if (storyboardFilePath == null) {
-    return {
-      components: [],
-      imports: {},
-    }
-  }
   return getJSXComponentsAndImportsForPathInnerComponent(
     path,
     storyboardFilePath,
     model.projectContents,
     model.nodeModules.files,
     derived.canvas.transientState.filesState,
-    model.jsxMetadata,
     model.codeResultCache.resolve,
   )
 }
 
 export function getJSXComponentsAndImportsForPathInnerComponent(
   path: TemplatePath,
-  currentFilePath: string,
+  currentFilePath: string | null | undefined,
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
   transientFilesState: TransientFilesState | null,
-  metadata: ElementInstanceMetadataMap,
-  resolve: (importOrigin: string, toImport: string) => Either<string, string>,
+  resolve: ResolveFn,
 ): {
   components: UtopiaJSXComponent[]
   imports: Imports
 } {
+  if (currentFilePath == null) {
+    return {
+      components: [],
+      imports: {},
+    }
+  }
   const resultForPath = getJSXComponentsAndImportsForPath(
     path,
     currentFilePath,
@@ -770,7 +756,7 @@ export function getJSXComponentsAndImportsForPathInnerComponent(
     transientFilesState,
   )
 
-  const elementName = MetadataUtils.getJSXElementTagName(path, resultForPath.components, metadata)
+  const elementName = MetadataUtils.getJSXElementTagName(path, resultForPath.components)
   if (elementName != null) {
     const importSource = importedFromWhere(
       resultForPath.underlyingFilePath,
@@ -850,12 +836,20 @@ export function getSceneElementsFromParseSuccess(success: ParseSuccess): JSXElem
 
 export function addNewScene(model: EditorState, newSceneElement: JSXElement): EditorState {
   return modifyOpenScenes_INTERNAL(
-    (components) => addSceneToJSXComponents(components, newSceneElement),
+    (components) =>
+      addSceneToJSXComponents(
+        model.projectContents,
+        model.canvas.openFile?.filename ?? null,
+        components,
+        newSceneElement,
+      ),
     model,
   )
 }
 
 export function addSceneToJSXComponents(
+  projectContents: ProjectContentTreeRoot,
+  openFile: string | null,
   components: UtopiaJSXComponent[],
   newSceneElement: JSXElement,
 ): UtopiaJSXComponent[] {
@@ -869,7 +863,14 @@ export function addSceneToJSXComponents(
       staticScenePath([staticElementPath([storyboardComponentUID])]),
       staticElementPath([storyboardComponentUID]),
     )
-    return insertJSXElementChild(storyboardComponentTemplatePath, newSceneElement, components, null)
+    return insertJSXElementChild(
+      projectContents,
+      openFile,
+      storyboardComponentTemplatePath,
+      newSceneElement,
+      components,
+      null,
+    )
   } else {
     return components
   }
@@ -882,26 +883,6 @@ export function removeScene(model: EditorState, path: ScenePath): EditorState {
 }
 
 const emptyImports: Imports = {}
-
-export function getOpenImportsFromState(model: EditorState): Imports {
-  const openUIJSFile = getOpenUIJSFile(model)
-  if (openUIJSFile == null) {
-    return {}
-  } else {
-    return foldParsedTextFile(
-      (_) => {
-        return emptyImports
-      },
-      (r) => {
-        return r.imports
-      },
-      (_) => {
-        return emptyImports
-      },
-      openUIJSFile.fileContents.parsed,
-    )
-  }
-}
 
 export function removeElementAtPath(
   target: InstancePath,
@@ -916,13 +897,22 @@ export function removeElementAtPath(
 }
 
 export function insertElementAtPath(
+  projectContents: ProjectContentTreeRoot,
+  openFile: string | null,
   targetParent: TemplatePath | null,
   elementToInsert: JSXElementChild,
   components: Array<UtopiaJSXComponent>,
   indexPosition: IndexPosition | null,
 ): Array<UtopiaJSXComponent> {
   const staticTarget = MetadataUtils.templatePathToStaticTemplatePath(targetParent)
-  return insertJSXElementChild(staticTarget, elementToInsert, components, indexPosition)
+  return insertJSXElementChild(
+    projectContents,
+    openFile,
+    staticTarget,
+    elementToInsert,
+    components,
+    indexPosition,
+  )
 }
 
 export function transformElementAtPath(
@@ -1652,16 +1642,20 @@ export function areGeneratedElementsTargeted(
   targets: Array<TemplatePath>,
   editor: EditorState,
 ): boolean {
-  const components = getOpenUtopiaJSXComponentsFromState(editor)
   return targets.some((target) => {
-    const originType = MetadataUtils.getElementOriginType(components, target)
-    switch (originType) {
-      case 'unknown-element':
-      case 'generated-static-definition-present':
-        return true
-      default:
-        return false
-    }
+    return withUnderlyingTargetFromEditorState(target, editor, false, (success) => {
+      const originType = MetadataUtils.getElementOriginType(
+        getUtopiaJSXComponentsFromSuccess(success),
+        target,
+      )
+      switch (originType) {
+        case 'unknown-element':
+        case 'generated-static-definition-present':
+          return true
+        default:
+          return false
+      }
+    })
   })
 }
 
@@ -1768,8 +1762,10 @@ export function reconstructJSXMetadata(editor: EditorState): ElementInstanceMeta
 export function getStoryboardTemplatePathFromEditorState(
   editorState: EditorState,
 ): StaticTemplatePath | null {
-  const openComponents = getOpenUtopiaJSXComponentsFromState(editorState)
-  return getStoryboardTemplatePath(openComponents)
+  return getStoryboardTemplatePath(
+    editorState.projectContents,
+    editorState.canvas.openFile?.filename ?? null,
+  )
 }
 
 export function getHighlightBoundsForUids(editorState: EditorState): HighlightBoundsForUids | null {
@@ -1970,10 +1966,10 @@ export function modifyUnderlyingForOpenFile(
 }
 
 export function withUnderlyingTarget<T>(
-  target: TemplatePath | null,
+  target: TemplatePath | null | undefined,
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
-  openFile: string | null,
+  openFile: string | null | undefined,
   defaultValue: T,
   withTarget: (
     success: ParseSuccess,
@@ -2043,7 +2039,7 @@ export function withUnderlyingTargetFromEditorState<T>(
   )
 }
 
-export function forUnderlyingTarget(
+export function forUnderlyingTargetFromEditorState(
   target: TemplatePath | null,
   editorState: EditorState,
   withTarget: (
@@ -2054,4 +2050,19 @@ export function forUnderlyingTarget(
   ) => void,
 ): void {
   withUnderlyingTargetFromEditorState<any>(target, editorState, {}, withTarget)
+}
+
+export function forUnderlyingTarget(
+  target: TemplatePath | null,
+  projectContents: ProjectContentTreeRoot,
+  nodeModules: NodeModules,
+  openFile: string | null | undefined,
+  withTarget: (
+    success: ParseSuccess,
+    element: JSXElement,
+    underlyingTarget: StaticInstancePath,
+    underlyingFilePath: string,
+  ) => void,
+): void {
+  withUnderlyingTarget<any>(target, projectContents, nodeModules, openFile, {}, withTarget)
 }

--- a/editor/src/components/editor/store/editor-update.spec.ts
+++ b/editor/src/components/editor/store/editor-update.spec.ts
@@ -51,9 +51,9 @@ import {
 import * as History from '../history'
 import {
   EditorState,
-  getOpenUtopiaJSXComponentsFromState,
   defaultUserState,
   StoryboardFilePath,
+  getJSXComponentsAndImportsForPathFromState,
 } from './editor-state'
 import { runLocalEditorAction } from './editor-update'
 import { getLayoutPropertyOr } from '../../../core/layout/getLayoutProperty'
@@ -435,9 +435,9 @@ describe('action DUPLICATE_SPECIFIC_ELEMENTS', () => {
       isTextFile(mainUIJSFile) &&
       isParseSuccess(mainUIJSFile.fileContents.parsed)
     ) {
-      const updatedComponents = getOpenUtopiaJSXComponentsFromState(updatedEditor)
+      const updatedComponents = getUtopiaJSXComponentsFromSuccess(mainUIJSFile.fileContents.parsed)
       const updatedChildren = Utils.pathOr([], [0, 'rootElement', 'children'], updatedComponents)
-      const originalComponents = getOpenUtopiaJSXComponentsFromState(editor)
+      const originalComponents = getUtopiaJSXComponentsFromSuccess(oldUIJSFile.fileContents.parsed)
       const originalChildren = Utils.pathOr([], [0, 'rootElement', 'children'], originalComponents)
       expect(updatedChildren).toHaveLength(originalChildren.length + 2)
       expect(updatedEditor.selectedViews).toHaveLength(2)
@@ -534,7 +534,7 @@ describe('INSERT_JSX_ELEMENT', () => {
     const { editor, derivedState, dispatch } = createEditorStates()
 
     const parentBeforeInsert = findJSXElementChildAtPath(
-      getOpenUtopiaJSXComponentsFromState(editor),
+      getJSXComponentsAndImportsForPathFromState(parentPath, editor, derivedState).components,
       parentPath,
     )
 
@@ -556,7 +556,11 @@ describe('INSERT_JSX_ELEMENT', () => {
       dispatch,
       emptyUiJsxCanvasContextData(),
     )
-    const updatedComponents = getOpenUtopiaJSXComponentsFromState(updatedEditor)
+    const updatedComponents = getJSXComponentsAndImportsForPathFromState(
+      parentPath,
+      updatedEditor,
+      derivedState,
+    ).components
     const parentAfterInsert = findJSXElementChildAtPath(updatedComponents, parentPath)
     const insertedElement = findJSXElementChildAtPath(
       updatedComponents,
@@ -592,7 +596,11 @@ describe('INSERT_JSX_ELEMENT', () => {
       highlightedViews: [],
     }
 
-    const componentsBeforeInsert = getOpenUtopiaJSXComponentsFromState(editorWithNoHighlighted)
+    const componentsBeforeInsert = getJSXComponentsAndImportsForPathFromState(
+      testStaticInstancePath(ScenePathForTestUiJsFile, []),
+      editor,
+      derivedState,
+    ).components
 
     const elementToInsert = jsxElement(
       jsxElementName('View', []),
@@ -612,7 +620,12 @@ describe('INSERT_JSX_ELEMENT', () => {
       dispatch,
       emptyUiJsxCanvasContextData(),
     )
-    const updatedComponents = getOpenUtopiaJSXComponentsFromState(updatedEditor)
+    const updatedComponents = getJSXComponentsAndImportsForPathFromState(
+      testStaticInstancePath(ScenePathForTestUiJsFile, []),
+      updatedEditor,
+      derivedState,
+    ).components
+
     const insertedElement = findJSXElementChildAtPath(
       updatedComponents,
       testStaticInstancePath(ScenePathForTestUiJsFile, ['TestView']),

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -229,11 +229,11 @@ export function runSimpleLocalEditorAction(
     case 'DELETE_VIEWS':
       return UPDATE_FNS.DELETE_VIEWS(action, state, dispatch)
     case 'DELETE_SELECTED':
-      return UPDATE_FNS.DELETE_SELECTED(action, state, dispatch)
+      return UPDATE_FNS.DELETE_SELECTED(action, state, derivedState, dispatch)
     case 'WRAP_IN_VIEW':
       return UPDATE_FNS.WRAP_IN_VIEW(action, state, derivedState, dispatch)
     case 'UNWRAP_GROUP_OR_VIEW':
-      return UPDATE_FNS.UNWRAP_GROUP_OR_VIEW(action, state, dispatch)
+      return UPDATE_FNS.UNWRAP_GROUP_OR_VIEW(action, state, derivedState, dispatch)
     case 'INSERT_IMAGE_INTO_UI':
       return UPDATE_FNS.INSERT_IMAGE_INTO_UI(action, state, derivedState)
     case 'SET_SCENE_PROP':
@@ -243,9 +243,9 @@ export function runSimpleLocalEditorAction(
     case 'WRAP_IN_LAYOUTABLE':
       return UPDATE_FNS.WRAP_IN_LAYOUTABLE(action, state)
     case 'UNWRAP_LAYOUTABLE':
-      return UPDATE_FNS.UNWRAP_LAYOUTABLE(action, state)
+      return UPDATE_FNS.UNWRAP_LAYOUTABLE(action, state, derivedState)
     case 'UPDATE_JSX_ELEMENT_NAME':
-      return UPDATE_FNS.UPDATE_JSX_ELEMENT_NAME(action, state)
+      return UPDATE_FNS.UPDATE_JSX_ELEMENT_NAME(action, state, derivedState)
     case 'ADD_IMPORTS':
       return UPDATE_FNS.ADD_IMPORTS(action, state)
     case 'SET_ASPECT_RATIO_LOCK':

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -199,7 +199,7 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
   const componentUIDs = useEditorState((store) => {
     const uiFile = getOpenUIJSFile(store.editor)
     return uiFile != null && isParseSuccess(uiFile.fileContents.parsed)
-      ? getAllUniqueUids(getUtopiaJSXComponentsFromSuccess(uiFile.fileContents.parsed))
+      ? getAllUniqueUids(store.editor.projectContents)
       : []
   }, 'FileBrowserItems componentUIDs')
   const componentUIDsWithStableRef = useKeepReferenceEqualityIfPossible(componentUIDs)

--- a/editor/src/components/inspector/common/layout-property-path-hooks.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.ts
@@ -25,7 +25,6 @@ import { InstancePath } from '../../../core/shared/project-file-types'
 import * as TP from '../../../core/shared/template-path'
 import Utils from '../../../utils/utils'
 import { resetPins, setProp_UNSAFE, unsetProperty } from '../../editor/actions/action-creators'
-import { getOpenUtopiaJSXComponentsFromState } from '../../editor/store/editor-state'
 import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 import { getFullFrame } from '../../frame'
 import {
@@ -39,6 +38,7 @@ import React = require('react')
 import { usePropControlledRef_DANGEROUS } from './inspector-utils'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
 import { CSSNumber, cssNumberToString } from './css-utils'
+import { getJSXComponentsAndImportsForPathFromState } from '../../editor/store/editor-state'
 
 const HorizontalPinPreference = [
   FramePoint.Left,
@@ -294,11 +294,14 @@ export function usePinToggling(): UsePinTogglingResult {
 
   const elementFrames = useEditorState(
     (store): ReadonlyArray<Frame> => {
-      const rootComponents = getOpenUtopiaJSXComponentsFromState(store.editor)
-
-      const jsxElements = TP.filterScenes(selectedViewsRef.current).map((path) =>
-        findElementAtPath(path, rootComponents),
-      )
+      const jsxElements = TP.filterScenes(selectedViewsRef.current).map((path) => {
+        const rootComponents = getJSXComponentsAndImportsForPathFromState(
+          path,
+          store.editor,
+          store.derived,
+        ).components
+        return findElementAtPath(path, rootComponents)
+      })
 
       return jsxElements.map((elem) => {
         if (elem != null && isJSXElement(elem)) {

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -164,7 +164,7 @@ export function createElementIconProps(
       height: 18,
     }
   }
-  const elementName = MetadataUtils.getJSXElementName(path, components, metadata)
+  const elementName = MetadataUtils.getJSXElementName(path, components)
   if (elementName != null && isImg(elementName)) {
     return {
       category: 'element',
@@ -208,7 +208,7 @@ function createComponentIconProps(
   metadata: ElementInstanceMetadataMap,
   imports: Imports,
 ): IcnPropsBase | null {
-  const elementName = MetadataUtils.getJSXElementName(path, components, metadata)
+  const elementName = MetadataUtils.getJSXElementName(path, components)
   const element = MetadataUtils.findElementByTemplatePath(metadata, path)
   if (isProbablySceneFromMetadata(metadata, path)) {
     return null

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -94,25 +94,6 @@ export function setLeftMenuTabFromFocusedPanel(editorState: EditorState): Editor
   }
 }
 
-function getExistingUIDs(projectFile: ProjectFile | null): Array<string> {
-  if (projectFile == null) {
-    return []
-  } else {
-    if (isTextFile(projectFile)) {
-      if (isParseSuccess(projectFile.fileContents.parsed)) {
-        const components = getUtopiaJSXComponentsFromSuccess(projectFile.fileContents.parsed)
-        return getAllUniqueUids(components)
-      } else {
-        return []
-      }
-    } else {
-      return []
-    }
-  }
-}
-
-export const existingUIDs = Utils.memoize(getExistingUIDs)
-
 export const LeftPaneMinimumWidth = 5
 
 export const LeftPaneDefaultWidth = 260

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -16,7 +16,6 @@ import {
 } from './navigator-item-dnd-container'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import {
-  getOpenImportsFromState,
   defaultElementWarnings,
   EditorStore,
   TransientFileState,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -324,7 +324,7 @@ export const MetadataUtils = {
     components: Array<UtopiaJSXComponent>,
     metadata: ElementInstanceMetadataMap,
   ): boolean {
-    const elementName = MetadataUtils.getJSXElementName(target, components, metadata)
+    const elementName = MetadataUtils.getJSXElementName(target, components)
     if (
       elementName != null &&
       PP.depth(elementName.propertyPath) === 0 &&
@@ -817,7 +817,6 @@ export const MetadataUtils = {
   },
   // TODO update this to work with the natural width / height
   getImageMultiplier(
-    imports: Imports,
     metadata: ElementInstanceMetadataMap,
     targets: Array<TemplatePath>,
   ): number | null {
@@ -1068,7 +1067,6 @@ export const MetadataUtils = {
   getJSXElementName(
     path: TemplatePath,
     components: Array<UtopiaJSXComponent>,
-    metadata: ElementInstanceMetadataMap,
   ): JSXElementName | null {
     const jsxElement = findElementAtPath(path, components)
     if (jsxElement != null) {
@@ -1081,11 +1079,7 @@ export const MetadataUtils = {
       return null
     }
   },
-  getJSXElementBaseName(
-    path: TemplatePath,
-    components: Array<UtopiaJSXComponent>,
-    metadata: ElementInstanceMetadataMap,
-  ): string | null {
+  getJSXElementBaseName(path: TemplatePath, components: Array<UtopiaJSXComponent>): string | null {
     const jsxElement = findElementAtPath(path, components)
     if (jsxElement != null) {
       if (isJSXElement(jsxElement)) {
@@ -1097,55 +1091,13 @@ export const MetadataUtils = {
       return null
     }
   },
-  getJSXElementTagName(
-    path: TemplatePath,
-    components: Array<UtopiaJSXComponent>,
-    metadata: ElementInstanceMetadataMap,
-  ): string | null {
+  getJSXElementTagName(path: TemplatePath, components: Array<UtopiaJSXComponent>): string | null {
     const jsxElement = findElementAtPath(path, components)
     if (jsxElement != null) {
       if (isJSXElement(jsxElement)) {
         return getJSXElementNameAsString(jsxElement.name)
       } else {
         return null
-      }
-    } else {
-      return null
-    }
-  },
-  getTargetParentForPaste: function (
-    imports: Imports,
-    selectedViews: Array<TemplatePath>,
-    metadata: ElementInstanceMetadataMap,
-    pasteTargetsToIgnore: TemplatePath[],
-  ): TemplatePath | null {
-    if (selectedViews.length > 0) {
-      const parentTarget = TP.getCommonParent(selectedViews, true)
-      if (parentTarget == null) {
-        return null
-      } else {
-        // we should not paste the source into itself
-        const insertingSourceIntoItself = TP.containsPath(parentTarget, pasteTargetsToIgnore)
-
-        if (TP.isScenePath(parentTarget)) {
-          return insertingSourceIntoItself ? null : parentTarget
-        } else if (
-          this.targetSupportsChildren(imports, metadata, parentTarget) &&
-          !insertingSourceIntoItself
-        ) {
-          return parentTarget
-        } else {
-          const parentOfSelected = TP.instancePathParent(parentTarget)
-          if (TP.isScenePath(parentOfSelected)) {
-            return parentOfSelected
-          } else {
-            if (this.targetSupportsChildren(imports, metadata, parentOfSelected)) {
-              return parentOfSelected
-            } else {
-              return null
-            }
-          }
-        }
       }
     } else {
       return null
@@ -1234,14 +1186,9 @@ export const MetadataUtils = {
 
     return workingElements
   },
-  staticElementsOnly(
-    elements: Array<UtopiaJSXComponent>,
-    targets: Array<TemplatePath>,
-  ): Array<TemplatePath> {
-    return targets.filter((target) => {
-      const originType = this.getElementOriginType(elements, target)
-      return originType === 'statically-defined' || originType === 'scene'
-    })
+  isStaticElement(elements: Array<UtopiaJSXComponent>, target: TemplatePath): boolean {
+    const originType = this.getElementOriginType(elements, target)
+    return originType === 'statically-defined' || originType === 'scene'
   },
   removeElementMetadataChild(
     target: InstancePath,
@@ -1560,7 +1507,7 @@ export const MetadataUtils = {
     metadata: ElementInstanceMetadataMap,
     imports: Imports,
   ): boolean {
-    const elementName = MetadataUtils.getJSXElementName(path, components, metadata)
+    const elementName = MetadataUtils.getJSXElementName(path, components)
     const element = MetadataUtils.findElementByTemplatePathDontThrowOnScenes(metadata, path)
     if (element?.isEmotionOrStyledComponent) {
       return false

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -4,6 +4,8 @@ import {
   StaticInstancePath,
   ScenePath,
   PropertyPath,
+  isTextFile,
+  isParseSuccess,
 } from '../shared/project-file-types'
 import {
   UtopiaJSXComponent,
@@ -43,6 +45,8 @@ import { isPercentPin } from 'utopia-api'
 import { UTOPIA_UIDS_KEY } from './utopia-constants'
 import { getUtopiaID } from './element-template-utils'
 import { emptyComments } from '../workers/parser-printer/parser-printer-comments'
+import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../../components/assets'
+import { getUtopiaJSXComponentsFromSuccess } from './project-file-utils'
 
 export const EmptyScenePathForStoryboard = TP.emptyScenePath
 
@@ -323,14 +327,20 @@ export function getStoryboardUID(openComponents: UtopiaJSXComponent[]): string |
 }
 
 export function getStoryboardTemplatePath(
-  openComponents: UtopiaJSXComponent[],
+  projectContents: ProjectContentTreeRoot,
+  openFile: string | null,
 ): StaticInstancePath | null {
-  const possiblyStoryboard = openComponents.find(
-    (component) => component.name === BakedInStoryboardVariableName,
-  )
-  if (possiblyStoryboard != null) {
-    const uid = getUtopiaID(possiblyStoryboard.rootElement)
-    return TP.staticInstancePath(EmptyScenePathForStoryboard, TP.staticElementPath([uid]))
+  if (openFile != null) {
+    const file = getContentsTreeFileFromString(projectContents, openFile)
+    if (isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
+      const possiblyStoryboard = getUtopiaJSXComponentsFromSuccess(file.fileContents.parsed).find(
+        (component) => component.name === BakedInStoryboardVariableName,
+      )
+      if (possiblyStoryboard != null) {
+        const uid = getUtopiaID(possiblyStoryboard.rootElement)
+        return TP.staticInstancePath(EmptyScenePathForStoryboard, TP.staticElementPath([uid]))
+      }
+    }
   }
   return null
 }

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -117,7 +117,7 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(485) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(495)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(495) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(500)
   })
 })

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -39,8 +39,6 @@ import {
   TemplatePath,
 } from '../shared/project-file-types'
 import {
-  getOpenImportsFromState,
-  getOpenUtopiaJSXComponentsFromState,
   getOpenUIJSFileKey,
   EditorState,
   withUnderlyingTarget,

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -544,4 +544,11 @@ export type ElementOriginType =
   // Something from somewhere, for which we probably have access to the bounds.
   | 'unknown-element'
 
+export function isUnknownOrGeneratedElement(elementOriginType: ElementOriginType): boolean {
+  return (
+    elementOriginType === 'unknown-element' ||
+    elementOriginType === 'generated-static-definition-present'
+  )
+}
+
 export type LayoutWrapper = 'Layoutable' | 'Positionable' | 'Resizeable'

--- a/editor/src/core/workers/parser-printer/parser-printer-uids.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-uids.spec.ts
@@ -12,11 +12,18 @@ import {
   jsxElement,
   utopiaJSXComponent,
 } from '../../shared/element-template'
-import { foldParsedTextFile } from '../../shared/project-file-types'
+import {
+  foldParsedTextFile,
+  RevisionsState,
+  textFile,
+  textFileContents,
+} from '../../shared/project-file-types'
 import { parseCode, printCode, printCodeOptions } from './parser-printer'
 import { emptyComments } from './parser-printer-comments'
 import { testParseCode } from './parser-printer.test-utils'
 import { applyPrettier } from 'utopia-vscode-common'
+import { addFileToProjectContents } from '../../../components/assets'
+import { StoryboardFilePath } from '../../../components/editor/store/editor-state'
 
 describe('parseCode', () => {
   it('produces unique IDs for every element', () => {
@@ -24,10 +31,16 @@ describe('parseCode', () => {
     foldParsedTextFile(
       (_) => fail('Is a failure.'),
       (success) => {
-        const uniqueIDs = getAllUniqueUids(
-          getComponentsFromTopLevelElements(success.topLevelElements),
-          'Unique IDs failure.',
+        const projectContents = addFileToProjectContents(
+          {},
+          StoryboardFilePath,
+          textFile(
+            textFileContents(MajesticBrokerTestCaseCode, success, RevisionsState.BothMatch),
+            null,
+            0,
+          ),
         )
+        const uniqueIDs = getAllUniqueUids(projectContents, 'Unique IDs failure.')
         expect(uniq(uniqueIDs).length).toMatchInlineSnapshot(`77`)
       },
       (_) => fail('Is unparsed.'),

--- a/editor/src/templates/editor-canvas.ts
+++ b/editor/src/templates/editor-canvas.ts
@@ -39,9 +39,7 @@ import {
   ConsoleLog,
   DerivedState,
   EditorState,
-  getOpenImportsFromState,
   isOpenFileUiJs,
-  getOpenUtopiaJSXComponentsFromState,
 } from '../components/editor/store/editor-state'
 import {
   didWeHandleMouseMoveForThisFrame,
@@ -1101,10 +1099,11 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         // on macOS it seems like alt prevents the 'paste' event from being ever fired, so this is dead code here
         // needs testing if it's any help for other platforms
       } else {
-        const imports = getOpenImportsFromState(editor)
         parseClipboardData(event.clipboardData).then((result) => {
           const actions = getActionsForClipboardItems(
-            imports,
+            editor.projectContents,
+            editor.nodeModules.files,
+            editor.canvas.openFile?.filename ?? null,
             result.utopiaData,
             result.files,
             selectedViews,


### PR DESCRIPTION
**Problem:**
There was some old functions like `getOpenUtopiaComponentsFromState`, which doesn't handle nested components from other files at all.

**Fix:**
The above function and `getOpenImportsFromState` have been removed altogether and multi-file compatible alternatives have been used. In the process of making these changes the `getAllUniqueUids` logic was also replaced to have it walk the project contents and not just look at one file.

**Commit Details:**
- Removed `getOpenUtopiaComponentsFromState` and
  `getOpenImportsFromState` altogether.
- Renamed `forUnderlyingTarget` to `forUnderlyingTargetFromEditorState`
  and added added a new `forUnderlyingTarget` that take the fields
  individually.
- Added `walkContentsTreeForParseSuccess`.
- Numerous functions to use the new utility functions and often bringing
  in `ProjectContentsTreeRoot instead of just an array of components.
- Moved `getTargetParentForPaste` to `clipboard.ts` as that makes a little
  more sense it being in there.
