### PR TITLE
fix(parser) fix highlightbounds

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -1286,7 +1286,10 @@ export function parseCode(
           if (isLeft(parsedContents) || (isFunction && isLeft(parsedFunctionParam))) {
             pushArbitraryNode(topLevelElement)
           } else {
-            highlightBounds = parsedContents.value.highlightBounds
+            highlightBounds = {
+              ...highlightBounds,
+              ...parsedContents.value.highlightBounds,
+            }
             const contents = parsedContents.value.value
             // If propsUsed is already populated, it's because the user used destructuring, so we can
             // use that. Otherwise, we have to use the list retrieved during parsing


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/1128

**Problem:**
Code following only works for one component in the majestic broker example project. Highlightbounds are missing for some elements from the parsed project contents.
In the parser only the last parsed element's highlighbounds are used. Instead of capturing only the last element it is now extending the current highlightbounds map.

