### PR TITLE
Prevent stack overflow on insert from same file.

### DIFF
--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -83,12 +83,6 @@ import {
 } from '../shared/project-components'
 import { ProjectContentTreeRoot } from '../assets'
 
-interface CurrentFileComponent {
-  componentName: string
-  defaultProps: { [prop: string]: unknown }
-  detectedProps: Array<string>
-}
-
 interface InsertMenuProps {
   lastFontSettings: FontSettings | null
   editorDispatch: EditorDispatch
@@ -96,7 +90,6 @@ interface InsertMenuProps {
   mode: Mode
   existingUIDs: Array<string>
   currentlyOpenFilename: string | null
-  currentFileComponents: Array<CurrentFileComponent>
   dependencies: Array<PossiblyUnversionedNpmDependency>
   packageStatus: PackageStatusMap
   propertyControlsInfo: PropertyControlsInfo
@@ -106,34 +99,7 @@ interface InsertMenuProps {
 export const InsertMenu = betterReactMemo('InsertMenu', () => {
   const props = useEditorState((store) => {
     const openFileFullPath = getOpenFilename(store.editor)
-    let currentlyOpenFilename: string | null = null
-    if (openFileFullPath != null) {
-      const splitFilename = openFileFullPath.split('/')
-      currentlyOpenFilename = defaultIfNull<string | null>(null, last(splitFilename))
-    }
-
-    let currentFileComponents: Array<CurrentFileComponent> = []
     const openUIJSFile = getOpenUIJSFile(store.editor)
-    if (openUIJSFile != null && openFileFullPath != null) {
-      forEachParseSuccess((fileContents) => {
-        Utils.fastForEach(fileContents.topLevelElements, (topLevelElement) => {
-          if (isUtopiaJSXComponent(topLevelElement)) {
-            const componentName = topLevelElement.name
-            const defaultProps = defaultPropertiesForComponentInFile(
-              componentName,
-              dropFileExtension(openFileFullPath),
-              store.editor.propertyControlsInfo,
-            )
-            const detectedProps = topLevelElement.propsUsed
-            currentFileComponents.push({
-              componentName: componentName,
-              defaultProps: defaultProps,
-              detectedProps: detectedProps,
-            })
-          }
-        })
-      }, openUIJSFile.fileContents.parsed)
-    }
 
     return {
       lastFontSettings: store.editor.lastUsedFont,
@@ -141,8 +107,7 @@ export const InsertMenu = betterReactMemo('InsertMenu', () => {
       selectedViews: store.editor.selectedViews,
       mode: store.editor.mode,
       existingUIDs: existingUIDs(openUIJSFile),
-      currentlyOpenFilename: currentlyOpenFilename,
-      currentFileComponents: currentFileComponents,
+      currentlyOpenFilename: openFileFullPath,
       packageStatus: store.editor.nodeModules.packageStatus,
       propertyControlsInfo: store.editor.propertyControlsInfo,
       projectContents: store.editor.projectContents,


### PR DESCRIPTION
Fixes #1082

**Problem:**
When attempting to insert something from the same file, a stack overflow was triggered pretty much instantly as the mouse drag started.

**Fix:**
When constructing the list of components to export the short file path was used for the originating path instead of the absolute path (`storyboard.js` versus `/utopia/storyboard.js`), which resulted in an import for the current file being included. As a result the canvas require function would stack overflow when attempting to resolve that import.

**Notes:**
I believe there's still some an underlying issue where the import/package resolution can fail in the same way if an import like this has been written in by hand.

**Commit Details:**
- Use the full path when constructing the imports to add to
  a file from the insert menu so that the check for same file
  imports correctly functions.
- Removed a field being constructed for the insert menu props
  as it was not being referenced or used.
