### PR TITLE
Ux/leftpane alongside not above

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -264,6 +264,18 @@ export const EditorComponentInner = betterReactMemo(
             >
               <Menubar />
             </SimpleFlexColumn>
+            <div
+              className='LeftPaneShell'
+              style={{
+                height: '100%',
+                transition: 'all .1s linear',
+                width: leftMenuExpanded ? LeftPaneDefaultWidth : 0,
+                overflowX: 'scroll',
+                backgroundColor: UtopiaTheme.color.leftPaneBackground.value,
+              }}
+            >
+              {delayedLeftMenuExpanded ? <LeftPaneComponent /> : null}
+            </div>
             <SimpleFlexRow
               className='editor-shell'
               style={{
@@ -286,19 +298,6 @@ export const EditorComponentInner = betterReactMemo(
               </SimpleFlexRow>
               {/* insert more columns here */}
 
-              <div
-                className='LeftPaneShell'
-                style={{
-                  height: '100%',
-                  transition: 'all .1s linear',
-                  position: 'absolute',
-                  width: leftMenuExpanded ? LeftPaneDefaultWidth : 0,
-                  overflowX: 'scroll',
-                  backgroundColor: UtopiaTheme.color.leftPaneBackground.value,
-                }}
-              >
-                {delayedLeftMenuExpanded ? <LeftPaneComponent /> : null}
-              </div>
               {previewVisible ? (
                 <ResizableFlexColumn
                   style={{ borderLeft: `1px solid ${colorTheme.secondaryBorder.value}` }}


### PR DESCRIPTION
**Problem:**
We made the left panel slide on top of the code editor to save space, but this got tedious, and also obscures messages #1146. I reverted this. It predictably sucks on smaller screens, but overall feels better. 


https://user-images.githubusercontent.com/2945037/116408789-1f78c280-a82b-11eb-9ebf-003a38acd909.mp4

