### PR TITLE
Do not check the open canvas file for highlights.

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -436,6 +436,7 @@ import {
   modifyUnderlyingTarget,
   BaseCanvasOffsetLeftPane,
   BaseCanvasOffset,
+  getHighlightBoundsForFile,
 } from '../store/editor-state'
 import { loadStoredState } from '../stored-state'
 import { applyMigrations } from './migrations/migrations'
@@ -4159,23 +4160,18 @@ export const UPDATE_FNS = {
     derived: DerivedState,
     dispatch: EditorDispatch,
   ): EditorModel => {
-    const currentlyOpenFile = getOpenTextFileKey(editor)
-    if (currentlyOpenFile === action.filePath) {
-      const allTemplatePaths = derived.navigatorTargets
-      const highlightBoundsForUids = getHighlightBoundsForUids(editor)
-      const newlySelectedElements = getTemplatePathsInBounds(
-        action.line,
-        highlightBoundsForUids,
-        allTemplatePaths,
-      )
-      return UPDATE_FNS.SELECT_COMPONENTS(
-        selectComponents(newlySelectedElements, false),
-        editor,
-        dispatch,
-      )
-    } else {
-      return editor
-    }
+    const allTemplatePaths = derived.navigatorTargets
+    const highlightBoundsForUids = getHighlightBoundsForFile(editor, action.filePath)
+    const newlySelectedElements = getTemplatePathsInBounds(
+      action.line,
+      highlightBoundsForUids,
+      allTemplatePaths,
+    )
+    return UPDATE_FNS.SELECT_COMPONENTS(
+      selectComponents(newlySelectedElements, false),
+      editor,
+      dispatch,
+    )
   },
   SEND_CODE_EDITOR_INITIALISATION: (
     action: SendCodeEditorInitialisation,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1781,6 +1781,17 @@ export function getHighlightBoundsForUids(editorState: EditorState): HighlightBo
   return null
 }
 
+export function getHighlightBoundsForFile(
+  editorState: EditorState,
+  fullPath: string,
+): HighlightBoundsForUids | null {
+  const file = getContentsTreeFileFromString(editorState.projectContents, fullPath)
+  if (isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
+    return getHighlightBoundsFromParseResult(file.fileContents.parsed)
+  }
+  return null
+}
+
 export function getHighlightBoundsForTemplatePath(
   path: TemplatePath,
   editorState: EditorState,


### PR DESCRIPTION
Fixes #1159

**Problem:**
The highlight bounds for non-storyboard files didn't show up.

**Fix:**
The open canvas file was being checked against for the highlight bounds, now highlight bounds are purely taken from the file path that came from VS Code.

**Commit Details:**
- Added `getHighlightBoundsForFile` to look up the highlight bounds
  given a specific file that we want the bounds for.
- `SELECT_FROM_FILE_AND_POSITION` action looks up the highlight
  bounds by the file from the action ignoring the open canvas file.
