### PR TITLE
Use setInterval instead of setTimeout.

### DIFF
--- a/utopia-vscode-common/src/fs/fs-utils.ts
+++ b/utopia-vscode-common/src/fs/fs-utils.ts
@@ -404,7 +404,6 @@ async function polledWatch(): Promise<void> {
   })
 
   await Promise.all(promises)
-  watchTimeout = setTimeout(polledWatch, POLLING_TIMEOUT) as any
 }
 
 export async function watch(
@@ -429,7 +428,7 @@ export async function watch(
     targets.forEach(startWatchingPath)
 
     if (watchTimeout == null) {
-      watchTimeout = setTimeout(polledWatch, POLLING_TIMEOUT) as any
+      watchTimeout = setInterval(polledWatch, POLLING_TIMEOUT) as any
     }
   }
 }


### PR DESCRIPTION
Fixes #1070

**Problem:**
The way `polledWatch` is implemented appears to be creating a near infinite chain of async calls by the use of `setTimeout`.

**Fix:**
Switch the starting call to using `setInterval`.

**Commit Details:**
- Use `setInterval` in the `watch` function, negating the
  need for repeatedly calling `setTimeout`.
