### PR TITLE
handle the case when the Fragment's child is a null

### DIFF
--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -241,7 +241,14 @@ function uidsWithoutExoticUID(uids: string | null): string | null {
 
 const mangleExoticType = Utils.memoize(
   (type: React.ComponentType): React.FunctionComponent => {
-    function updateChild(child: React.ReactElement, dataUids: string | null, paths: string | null) {
+    function updateChild(
+      child: React.ReactElement | null,
+      dataUids: string | null,
+      paths: string | null,
+    ) {
+      if (child == null) {
+        return child
+      }
       const existingChildUIDs = child.props?.[UTOPIA_UIDS_KEY]
       const existingChildPaths = child.props?.[UTOPIA_PATHS_KEY]
       const appendedUIDString = appendToUidString(existingChildUIDs, dataUids)


### PR DESCRIPTION
Fixes #915

**Problem:**
If a fragment had a child which was `null`, our React Monkey Wrapper would throw an exception, bringing down the canvas with an unhelpful error message.

**Fix:**
Handle the possibility that in react, you can write valid code like this: `<>{null}</>`

**Commit Details:**
- Added simple nullcheck to `updateChild`