### PR TITLE
Allow the component section for utopia-api components.

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -295,8 +295,7 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
         store.derived,
       )
       anyComponentsInner =
-        anyComponentsInner ||
-        MetadataUtils.isComponentInstance(view, rootComponents, rootMetadata, imports)
+        anyComponentsInner || MetadataUtils.isComponentInstance(view, rootComponents)
       const possibleElement = MetadataUtils.findElementByTemplatePath(rootMetadata, view)
       if (possibleElement != null) {
         // Slightly coarse in definition, but element metadata is in a weird little world of

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1380,27 +1380,12 @@ export const MetadataUtils = {
       return optionalMap((element) => (isJSXElement(element) ? element.name : null), jsxElement)
     }
   },
-  isComponentInstance(
-    path: TemplatePath,
-    rootElements: Array<UtopiaJSXComponent>,
-    metadata: ElementInstanceMetadataMap,
-    imports: Imports,
-  ): boolean {
+  isComponentInstance(path: TemplatePath, rootElements: Array<UtopiaJSXComponent>): boolean {
     if (TP.isScenePath(path)) {
       return false
     } else {
       const elementName = MetadataUtils.getStaticElementName(path, rootElements)
-      const instanceMetadata = MetadataUtils.getElementByInstancePathMaybe(metadata, path)
-      return (
-        elementName != null &&
-        instanceMetadata != null &&
-        !MetadataUtils.isGivenUtopiaAPIElementFromImports(
-          imports,
-          instanceMetadata,
-          getJSXElementNameLastPart(elementName),
-        ) &&
-        !isIntrinsicElement(elementName)
-      )
+      return elementName != null && !isIntrinsicElement(elementName)
     }
   },
   isPinnedAndNotAbsolutePositioned(

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -60,8 +60,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(310) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(320)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(340) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(360)
   })
 
   it('Changing the selected view', async () => {
@@ -117,7 +117,7 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(405) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(410)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(440) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(450)
   })
 })


### PR DESCRIPTION
**Problem:**
The component section in the inspector no longer showed up for components imported from `utopia-api`. It was showing from before https://github.com/concrete-utopia/utopia/commit/86903699cc92e4edb456342939e779c7cbef47a4 because the check for those elements was failing as the imports and root components were from the wrong file. In getting those components and imports from the correct place it was causing the check to validly trip preventing the component section from showing.

**Fix:**
The check to see if something was coming from `utopia-api` was removed as it was determined that we no longer wanted it.

**Commit Details:**
- Removed the `isGivenUtopiaAPIElementFromImports` check from
  `isComponentInstance` and then removed the lookup and parameters
  which the check required as they are no longer used by anything.
