### PR TITLE
fix(storyboard list) - if no storyboard exists, don't show one in a list

### DIFF
--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -186,10 +186,10 @@ const StoryboardsPane = betterReactMemo('StoryboardsPane', () => {
     dispatch([EditorActions.setPanelVisibility('canvas', true)])
   }, [dispatch])
 
-  const storyboardList = [StoryboardFilePath]
-
   const noStoryboardFileAvailable =
     getContentsTreeFileFromString(projectContents, StoryboardFilePath) == null
+
+  const storyboardList = noStoryboardFileAvailable ? [] : [StoryboardFilePath]
 
   return (
     <FlexColumn


### PR DESCRIPTION
Fixes #1145 

**Problem:**
If you delete (or don't have) `storyboard.js`, we still show it in the left menu, but (obvs) clicking on it doesn't do anything.

**Fix:**
A one-liner to not show it if there isn't one. 

I deliberately didn't touch all the places where we make or don't make assumptions about ontology, epistemology, or taxonomy of storyboards ("Are storyboards real? How can we know they exist? How are storyboards different from non-storyboards").