### PR TITLE
Errors with code should clear their entry from nodeModules.

### DIFF
--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateCodeResultCache,
+  incorporateBuildResult,
   normalisePathEndsAtDependency,
   normalisePathSuccess,
   normalisePathToUnderlyingTarget,
@@ -26,6 +27,7 @@ import {
   getTextFileByPath,
   SampleNodeModules,
 } from './code-file.test-utils'
+import { NodeModules } from '../../core/shared/project-file-types'
 
 function transpileCode(
   rootFilenames: Array<string>,
@@ -442,6 +444,17 @@ describe('Creating require function', () => {
     )
 
     expect(() => codeResultCache.requireFn('/', 'foo', false)).toThrowErrorMatchingSnapshot()
+  })
+})
+
+describe('incorporateBuildResult', () => {
+  it('should remove a value if there is no transpiled code', () => {
+    let nodeModules: NodeModules = {}
+    incorporateBuildResult(nodeModules, SampleSingleFileBuildResult)
+    incorporateBuildResult(nodeModules, {
+      ['/app.js']: { errors: [], transpiledCode: null, sourceMap: null },
+    })
+    expect(nodeModules).toMatchInlineSnapshot(`Object {}`)
   })
 })
 

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -183,7 +183,9 @@ export function incorporateBuildResult(
   // Mutates nodeModules.
   fastForEach(Object.keys(buildResult), (moduleKey) => {
     const modulesFile = buildResult[moduleKey]
-    if (modulesFile.transpiledCode != null) {
+    if (modulesFile.transpiledCode == null) {
+      delete nodeModules[moduleKey]
+    } else {
       nodeModules[moduleKey] = esCodeFile(modulesFile.transpiledCode, 'NODE_MODULES', moduleKey)
     }
   })


### PR DESCRIPTION
Fixes #1175.

**Problem:**
If a change was made to the code of a dependency of the storyboard which previously compiled so that it now does not parse, the original transpiled code was held in the `nodeModules` part of the `CodeResultCache`. Which resulted in the canvas contents continuing to appear with no relevant error being shown.

**Fix:**
Modified `incorporateBuiltdResult` to clear out entries instead of just updating them, removing the entry if there's no transpiled code for it.

**Commit Details:**
- Fixes #1175.
- `incorporateBuildResult` on encountering a build result that lacks some
  transpiled code should delete the previous entry held in the
  node modules object.
