### PR TITLE
Fix/canvas shortcut copy elements

### DIFF
--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -114,7 +114,7 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.PASTE_JSX_ELEMENTS(action, state, dispatch)
     case 'COPY_SELECTION_TO_CLIPBOARD':
       // side effect 😟
-      setClipboardData(createClipboardDataFromSelectionNewWorld(state, derivedState))
+      setClipboardData(createClipboardDataFromSelectionNewWorld(state))
       return UPDATE_FNS.COPY_SELECTION_TO_CLIPBOARD(action, state, dispatch)
     case 'OPEN_TEXT_EDITOR':
       return UPDATE_FNS.OPEN_TEXT_EDITOR(action, state)

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -3,10 +3,7 @@ import { EditorAction, EditorDispatch } from '../action-types'
 import { UPDATE_FNS } from '../actions/actions'
 
 import { StateHistory } from '../history'
-import {
-  setClipboardData,
-  createClipboardDataFromSelection,
-} from '../../../utils/clipboard'
+import { setClipboardData, createClipboardDataFromSelection } from '../../../utils/clipboard'
 import { UtopiaTsWorkers } from '../../../core/workers/common/worker-types'
 import { UiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
 

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -5,7 +5,7 @@ import { UPDATE_FNS } from '../actions/actions'
 import { StateHistory } from '../history'
 import {
   setClipboardData,
-  createClipboardDataFromSelectionNewWorld,
+  createClipboardDataFromSelection,
 } from '../../../utils/clipboard'
 import { UtopiaTsWorkers } from '../../../core/workers/common/worker-types'
 import { UiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
@@ -114,7 +114,7 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.PASTE_JSX_ELEMENTS(action, state, dispatch)
     case 'COPY_SELECTION_TO_CLIPBOARD':
       // side effect 😟
-      setClipboardData(createClipboardDataFromSelectionNewWorld(state))
+      setClipboardData(createClipboardDataFromSelection(state))
       return UPDATE_FNS.COPY_SELECTION_TO_CLIPBOARD(action, state, dispatch)
     case 'OPEN_TEXT_EDITOR':
       return UPDATE_FNS.OPEN_TEXT_EDITOR(action, state)

--- a/editor/src/utils/clipboard.spec.ts
+++ b/editor/src/utils/clipboard.spec.ts
@@ -1,0 +1,83 @@
+import { contentsToTree } from '../components/assets'
+import {
+  renderTestEditorWithProjectContent,
+  TestAppUID,
+  TestScenePath,
+  TestSceneUID,
+} from '../components/canvas/ui-jsx.test-utils'
+import { createCodeFile } from '../components/custom-code/code-file.test-utils'
+import { selectComponents } from '../components/editor/actions/action-creators'
+import { DefaultPackageJson, StoryboardFilePath } from '../components/editor/store/editor-state'
+import { directory } from '../core/model/project-file-utils'
+import { BakedInStoryboardUID } from '../core/model/scene-utils'
+import {
+  ProjectContents,
+  RevisionsState,
+  textFile,
+  textFileContents,
+  unparsed,
+} from '../core/shared/project-file-types'
+import * as EP from '../core/shared/element-path'
+import { createClipboardDataFromSelectionNewWorld } from './clipboard'
+
+describe('copy to clipboard', () => {
+  it('creates copy data multifile elements', async () => {
+    const appFilePath = '/src/app.js'
+    let projectContents: ProjectContents = {
+      '/package.json': textFile(
+        textFileContents(
+          JSON.stringify(DefaultPackageJson, null, 2),
+          unparsed,
+          RevisionsState.BothMatch,
+        ),
+        null,
+        0,
+      ),
+      '/src': directory(),
+      '/utopia': directory(),
+      [StoryboardFilePath]: createCodeFile(
+        StoryboardFilePath,
+        `
+import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+import { App } from '/src/app.js'
+export var storyboard = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <Scene
+      data-uid='${TestSceneUID}'
+      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+    >
+      <App data-uid='${TestAppUID}' />
+    </Scene>
+  </Storyboard>
+)`,
+      ),
+      [appFilePath]: createCodeFile(
+        appFilePath,
+        `
+import * as React from 'react'
+export var App = (props) => {
+  return <div data-uid='app-outer-div' style={{position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF'}}>
+    <div data-uid='app-inner-div-to-copy'/>
+  </div>
+}`,
+      ),
+    }
+    const renderResult = await renderTestEditorWithProjectContent(contentsToTree(projectContents))
+    const targetPath1 = EP.appendNewElementPath(TestScenePath, [
+      'app-outer-div',
+      'app-inner-div-to-copy',
+    ])
+
+    await renderResult.dispatch([selectComponents([targetPath1], false)], false)
+    const clipboardData = createClipboardDataFromSelectionNewWorld(
+      renderResult.getEditorState().editor,
+    )
+
+    expect(clipboardData?.data.length).toEqual(1)
+    expect(clipboardData?.data[0].type).toEqual('ELEMENT_COPY')
+    expect(clipboardData?.data[0].elements).toMatchInlineSnapshot(
+      `"[{type:\\"JSX_ELEMENT\\",name:{baseVariable:\\"div\\",propertyPath:{propertyElements:[]}},props:[{key:\\"data-uid\\",value:{type:\\"ATTRIBUTE_VALUE\\",value:\\"app-inner-div-to-copy\\",comments:{leadingComments:[],trailingComments:[]}},comments:{leadingComments:[],trailingComments:[]}}],children:[]}]"`,
+    )
+  })
+})

--- a/editor/src/utils/clipboard.spec.ts
+++ b/editor/src/utils/clipboard.spec.ts
@@ -18,7 +18,7 @@ import {
   unparsed,
 } from '../core/shared/project-file-types'
 import * as EP from '../core/shared/element-path'
-import { createClipboardDataFromSelectionNewWorld } from './clipboard'
+import { createClipboardDataFromSelection } from './clipboard'
 
 describe('copy to clipboard', () => {
   it('creates copy data multifile elements', async () => {
@@ -70,7 +70,7 @@ export var App = (props) => {
     ])
 
     await renderResult.dispatch([selectComponents([targetPath1], false)], false)
-    const clipboardData = createClipboardDataFromSelectionNewWorld(
+    const clipboardData = createClipboardDataFromSelection(
       renderResult.getEditorState().editor,
     )
 

--- a/editor/src/utils/clipboard.spec.ts
+++ b/editor/src/utils/clipboard.spec.ts
@@ -70,9 +70,7 @@ export var App = (props) => {
     ])
 
     await renderResult.dispatch([selectComponents([targetPath1], false)], false)
-    const clipboardData = createClipboardDataFromSelection(
-      renderResult.getEditorState().editor,
-    )
+    const clipboardData = createClipboardDataFromSelection(renderResult.getEditorState().editor)
 
     expect(clipboardData?.data.length).toEqual(1)
     expect(clipboardData?.data[0].type).toEqual('ELEMENT_COPY')

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -5,7 +5,7 @@ import { EditorModes } from '../components/editor/editor-modes'
 import {
   DerivedState,
   EditorState,
-  getOpenUIJSFile,
+  getOpenUIJSFileKey,
   withUnderlyingTarget,
 } from '../components/editor/store/editor-state'
 import { getFrameAndMultiplier } from '../components/images'
@@ -13,7 +13,12 @@ import * as EP from '../core/shared/element-path'
 import { findElementAtPath, MetadataUtils } from '../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap } from '../core/shared/element-template'
 import { getUtopiaJSXComponentsFromSuccess } from '../core/model/project-file-utils'
-import { isParseSuccess, NodeModules, ElementPath } from '../core/shared/project-file-types'
+import {
+  isParseSuccess,
+  NodeModules,
+  ElementPath,
+  isTextFile,
+} from '../core/shared/project-file-types'
 import { encodeUtopiaDataToHtml, parsePasteEvent, PasteResult } from './clipboard-utils'
 import { setLocalClipboardData } from './local-clipboard'
 import Utils from './utils'
@@ -22,7 +27,12 @@ import { CanvasPoint } from '../core/shared/math-utils'
 import json5 = require('json5')
 import { fastForEach } from '../core/shared/utils'
 import urljoin = require('url-join')
-import { ProjectContentTreeRoot } from '../components/assets'
+import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../components/assets'
+import {
+  normalisePathSuccessOrThrowError,
+  normalisePathToUnderlyingTarget,
+} from '../components/custom-code/code-file'
+import { stripNulls } from '../core/shared/array-utils'
 // tslint:disable-next-line:no-var-requires
 const ClipboardPolyfill = require('clipboard-polyfill') // stupid .d.ts is malformatted
 
@@ -156,22 +166,34 @@ export function createClipboardDataFromSelectionNewWorld(
   imageFilenames: Array<string>
   plaintext: string
 } | null {
-  const openUIJSFile = getOpenUIJSFile(editor)
-  if (
-    openUIJSFile == null ||
-    !isParseSuccess(openUIJSFile.fileContents.parsed) ||
-    editor.selectedViews.length === 0
-  ) {
+  const openUIJSFileKey = getOpenUIJSFileKey(editor)
+  if (openUIJSFileKey == null || editor.selectedViews.length === 0) {
     return null
   }
-  const parseSuccess = openUIJSFile.fileContents.parsed
   const filteredSelectedViews = editor.selectedViews.filter((view) => {
     return R.none((otherView) => EP.isDescendantOf(view, otherView), editor.selectedViews)
   })
-  const utopiaComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
-  const jsxElements = filteredSelectedViews.map((view) => {
-    return findElementAtPath(view, utopiaComponents)
-  })
+  const jsxElements = stripNulls(
+    filteredSelectedViews.map((target) => {
+      const underlyingTarget = normalisePathToUnderlyingTarget(
+        editor.projectContents,
+        editor.nodeModules.files,
+        openUIJSFileKey,
+        target,
+      )
+      const targetPathSuccess = normalisePathSuccessOrThrowError(underlyingTarget)
+      const projectFile = getContentsTreeFileFromString(
+        editor.projectContents,
+        targetPathSuccess.filePath,
+      )
+      if (isTextFile(projectFile) && isParseSuccess(projectFile.fileContents.parsed)) {
+        const components = getUtopiaJSXComponentsFromSuccess(projectFile.fileContents.parsed)
+        return findElementAtPath(target, components)
+      } else {
+        return null
+      }
+    }),
+  )
   return {
     data: [
       {

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -160,7 +160,6 @@ export function createDirectInsertImageActions(
 
 export function createClipboardDataFromSelectionNewWorld(
   editor: EditorState,
-  derived: DerivedState,
 ): {
   data: Array<JSXElementCopyData>
   imageFilenames: Array<string>


### PR DESCRIPTION
Fixes #1189

**Problem:**
Cut/copy/paste doesn't work on non-storyboard elements. The element copied to the clipboard is a `null`.

**Fix:**
Updating `createClipboardDataFromSelectionNewWorld` to handle different files.

**Commit Details:**
- using `normalisePathToUnderlyingTarget` to find the filepath for templatepath
- added a test
