### PR TITLE
Poll logged in state

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -49,6 +49,7 @@ import { Notice } from '../common/notice'
 import { BuildType } from '../../core/workers/ts/ts-worker'
 import { ParseResult } from '../../utils/value-parser-utils'
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
+import type { LoginState } from '../../common/user'
 export { isLoggedIn, loggedInUser, LoginState, notLoggedIn, UserDetails } from '../../common/user'
 
 export interface PropertyTarget {
@@ -798,6 +799,11 @@ export interface UpdateConfigFromVSCode {
   config: UtopiaVSCodeConfig
 }
 
+export interface SetLoginState {
+  action: 'SET_LOGIN_STATE'
+  loginState: LoginState
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -929,6 +935,7 @@ export type EditorAction =
   | SetScrollAnimation
   | SetFollowSelectionEnabled
   | UpdateConfigFromVSCode
+  | SetLoginState
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1,5 +1,6 @@
 import { LayoutSystem } from 'utopia-api' // TODO fixme this imports utopia-api
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
+import type { LoginState } from '../../../common/user'
 import type { revertFile, saveFile } from '../../../core/model/project-file-utils'
 import type { foldEither } from '../../../core/shared/either'
 import type {
@@ -180,6 +181,7 @@ import type {
   SetScrollAnimation,
   UpdateConfigFromVSCode,
   SetFollowSelectionEnabled,
+  SetLoginState,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -1266,5 +1268,12 @@ export function updateConfigFromVSCode(config: UtopiaVSCodeConfig): UpdateConfig
   return {
     action: 'UPDATE_CONFIG_FROM_VSCODE',
     config: config,
+  }
+}
+
+export function setLoginState(loginState: LoginState): SetLoginState {
+  return {
+    action: 'SET_LOGIN_STATE',
+    loginState: loginState,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -87,6 +87,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_SCROLL_ANIMATION':
     case 'SET_FOLLOW_SELECTION_ENABLED':
     case 'UPDATE_CONFIG_FROM_VSCODE':
+    case 'SET_LOGIN_STATE':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -348,6 +348,7 @@ import {
   SetScrollAnimation,
   SetFollowSelectionEnabled,
   UpdateConfigFromVSCode,
+  SetLoginState,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -421,6 +422,7 @@ import {
   modifyUnderlyingForOpenFile,
   forUnderlyingTargetFromEditorState,
   getHighlightBoundsForFile,
+  EditorStore,
 } from '../store/editor-state'
 import { loadStoredState } from '../stored-state'
 import { applyMigrations } from './migrations/migrations'
@@ -4056,6 +4058,12 @@ export const UPDATE_FNS = {
     return {
       ...editor,
       config: action.config,
+    }
+  },
+  SET_LOGIN_STATE: (action: SetLoginState, userState: UserState): UserState => {
+    return {
+      ...userState,
+      loginState: action.loginState,
     }
   },
 }

--- a/editor/src/components/editor/notification-bar.tsx
+++ b/editor/src/components/editor/notification-bar.tsx
@@ -26,8 +26,12 @@ export const EditorOfflineBar = betterReactMemo('EditorOfflineBar', () => {
 export const LoginStatusBar = betterReactMemo('LoginStatusBar', () => {
   const loginState = useEditorState((store) => store.userState.loginState, 'LoginStatusBar')
 
-  const onClickCallback = React.useCallback(() => {
+  const onClickLoginSameTab = React.useCallback(() => {
     setRedirectUrl(window.top.location.pathname).then(() => window.top.location.replace(auth0Url))
+  }, [])
+
+  const onClickLoginNewTab = React.useCallback(() => {
+    window.open(auth0Url, '_blank')
   }, [])
 
   switch (loginState.type) {
@@ -38,7 +42,7 @@ export const LoginStatusBar = betterReactMemo('LoginStatusBar', () => {
         <NotificationBar
           level='PRIMARY'
           message={'Welcome to Utopia. Click here to sign in and save your projects.'}
-          onClick={onClickCallback}
+          onClick={onClickLoginSameTab}
           style={{ cursor: 'pointer' }}
         />
       )
@@ -47,7 +51,7 @@ export const LoginStatusBar = betterReactMemo('LoginStatusBar', () => {
         <NotificationBar
           level='ERROR'
           message={'You were logged out. Click here to log in again.'}
-          onClick={onClickCallback}
+          onClick={onClickLoginNewTab}
           style={{ cursor: 'pointer' }}
         />
       )

--- a/editor/src/components/editor/notification-bar.tsx
+++ b/editor/src/components/editor/notification-bar.tsx
@@ -50,7 +50,7 @@ export const LoginStatusBar = betterReactMemo('LoginStatusBar', () => {
       return (
         <NotificationBar
           level='ERROR'
-          message={'You were logged out. Click here to log in again.'}
+          message={'You have been logged out. Click here to log in again and save your changes.'}
           onClick={onClickLoginNewTab}
           style={{ cursor: 'pointer' }}
         />

--- a/editor/src/components/editor/notification-bar.tsx
+++ b/editor/src/components/editor/notification-bar.tsx
@@ -30,17 +30,30 @@ export const LoginStatusBar = betterReactMemo('LoginStatusBar', () => {
     setRedirectUrl(window.top.location.pathname).then(() => window.top.location.replace(auth0Url))
   }, [])
 
-  if (isLoggedIn(loginState)) {
-    return null
-  } else {
-    return (
-      <NotificationBar
-        level='PRIMARY'
-        message={'Welcome to Utopia. Click here to sign in and save your projects.'}
-        onClick={onClickCallback}
-        style={{ cursor: 'pointer' }}
-      />
-    )
+  switch (loginState.type) {
+    case 'LOGGED_IN':
+      return null
+    case 'NOT_LOGGED_IN':
+      return (
+        <NotificationBar
+          level='PRIMARY'
+          message={'Welcome to Utopia. Click here to sign in and save your projects.'}
+          onClick={onClickCallback}
+          style={{ cursor: 'pointer' }}
+        />
+      )
+    case 'LOGIN_LOST':
+      return (
+        <NotificationBar
+          level='ERROR'
+          message={'You were logged out. Click here to log in again.'}
+          onClick={onClickCallback}
+          style={{ cursor: 'pointer' }}
+        />
+      )
+    default:
+      const _exhaustiveCheck: never = loginState
+      throw new Error(`Unhandled login state ${loginState}`)
   }
 })
 LoginStatusBar.displayName = 'LoginStatusBar'

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -1,6 +1,7 @@
 import { UTOPIA_BACKEND } from '../../common/env-vars'
 import {
   assetURL,
+  getLoginState,
   HEADERS,
   MODE,
   projectURL,
@@ -14,6 +15,8 @@ import { LoginState } from '../../uuiui-deps'
 import urljoin = require('url-join')
 import * as JSZip from 'jszip'
 import { addFileToProjectContents, walkContentsTree } from '../assets'
+import type { EditorDispatch } from './action-types'
+import { setLoginState } from './actions/action-creators'
 
 export { fetchProjectList, fetchShowcaseProjects, getLoginState } from '../../common/server'
 
@@ -385,4 +388,18 @@ export async function downloadGithubRepo(
       `Download github repo request failed: ${response.statusText}`,
     )
   }
+}
+
+export function startPollingLoginState(
+  dispatch: EditorDispatch,
+  initialLoginState: LoginState,
+): void {
+  let previousLoginState: LoginState = initialLoginState
+  setInterval(async () => {
+    const loginState = await getLoginState('no-cache')
+    if (previousLoginState.type !== loginState.type) {
+      dispatch([setLoginState(loginState)])
+    }
+    previousLoginState = loginState
+  }, 5000)
 }

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -344,6 +344,7 @@ export async function getUserConfiguration(loginState: LoginState): Promise<User
         throw new Error(`server responded with ${response.status} ${response.statusText}`)
       }
     case 'NOT_LOGGED_IN':
+    case 'LOGIN_LOST':
       return emptyUserConfiguration()
     default:
       const _exhaustiveCheck: never = loginState

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -16,7 +16,9 @@ import urljoin = require('url-join')
 import * as JSZip from 'jszip'
 import { addFileToProjectContents, walkContentsTree } from '../assets'
 import type { EditorDispatch } from './action-types'
-import { setLoginState } from './actions/action-creators'
+import { setLoginState, showToast } from './actions/action-creators'
+import { isLoginLost } from '../../common/user'
+import { notice } from '../common/notice'
 
 export { fetchProjectList, fetchShowcaseProjects, getLoginState } from '../../common/server'
 
@@ -400,6 +402,9 @@ export function startPollingLoginState(
     const loginState = await getLoginState('no-cache')
     if (previousLoginState.type !== loginState.type) {
       dispatch([setLoginState(loginState)])
+      if (isLoginLost(loginState)) {
+        dispatch([showToast(notice(`You have been logged out.`, 'ERROR', true))])
+      }
     }
     previousLoginState = loginState
   }, 5000)

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -403,7 +403,7 @@ export function startPollingLoginState(
     if (previousLoginState.type !== loginState.type) {
       dispatch([setLoginState(loginState)])
       if (isLoginLost(loginState)) {
-        dispatch([showToast(notice(`You have been logged out.`, 'ERROR', true))])
+        dispatch([showToast(notice(`You have been logged out. You can continue working, but your work won't be saved until you log in again.`, 'ERROR', true))])
       }
     }
     previousLoginState = loginState

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -403,7 +403,15 @@ export function startPollingLoginState(
     if (previousLoginState.type !== loginState.type) {
       dispatch([setLoginState(loginState)])
       if (isLoginLost(loginState)) {
-        dispatch([showToast(notice(`You have been logged out. You can continue working, but your work won't be saved until you log in again.`, 'ERROR', true))])
+        dispatch([
+          showToast(
+            notice(
+              `You have been logged out. You can continue working, but your work won't be saved until you log in again.`,
+              'ERROR',
+              true,
+            ),
+          ),
+        ])
       }
     }
     previousLoginState = loginState

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -129,6 +129,11 @@ function processAction(
       ...working,
       userState: UPDATE_FNS.SET_SHORTCUT(action, working.userState),
     }
+  } else if (action.action === 'SET_LOGIN_STATE') {
+    return {
+      ...working,
+      userState: UPDATE_FNS.SET_LOGIN_STATE(action, working.userState),
+    }
   } else {
     // Process action on the JS side.
     const editorAfterUpdateFunction = runLocalEditorAction(

--- a/editor/src/templates/editor-entry-point.tsx
+++ b/editor/src/templates/editor-entry-point.tsx
@@ -9,7 +9,7 @@
 import { getLoginState } from '../common/server'
 import { triggerHashedAssetsUpdate, preloadPrioritizedAssets } from '../utils/hashed-assets'
 
-getLoginState()
+getLoginState('no-cache')
 triggerHashedAssetsUpdate().then(() => preloadPrioritizedAssets())
 
 import { addStyleSheetToPage } from '../core/shared/dom-utils'

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -41,6 +41,7 @@ import {
   getLoginState,
   getUserConfiguration,
   isRequestFailure,
+  startPollingLoginState,
 } from '../components/editor/server'
 import {
   DispatchResult,
@@ -211,7 +212,8 @@ export class Editor {
       handleHeartbeatRequestMessage(e.data),
     )
 
-    getLoginState().then((loginState) => {
+    getLoginState('cache').then((loginState) => {
+      startPollingLoginState(this.boundDispatch, loginState)
       this.storedState.userState.loginState = loginState
       getUserConfiguration(loginState).then((shortcutConfiguration) => {
         this.storedState.userState = {

--- a/editor/src/uuiui/styles/theme.ts
+++ b/editor/src/uuiui/styles/theme.ts
@@ -522,14 +522,41 @@ const backgroundURLs = {
 
 // see type AlertLevel in editor-state.ts
 
-const noticeStyles = {
-  success: { background: backgroundURLs.green, color: 'white' },
-  info: { background: '#f1f1f1', color: colorTheme.darkPrimary.value },
-  primary: { background: backgroundURLs.blue, color: 'white' },
-  notice: { background: backgroundURLs.paleblue, color: 'white' },
-  warning: { background: backgroundURLs.red, color: 'white' },
-  error: { background: backgroundURLs.almostBlack, color: 'white' },
-  disconnected: { background: backgroundURLs.noise, color: 'white' },
+const noticeStyles: { [styleName: string]: React.CSSProperties } = {
+  success: {
+    backgroundColor: base.neongreen.value,
+    backgroundImage: backgroundURLs.green,
+    color: 'white',
+  },
+  info: {
+    backgroundColor: '#f1f1f1',
+    color: colorTheme.darkPrimary.value,
+  },
+  primary: {
+    backgroundColor: base.blue.value,
+    backgroundImage: backgroundURLs.blue,
+    color: 'white',
+  },
+  notice: {
+    backgroundColor: base.blue.value,
+    backgroundImage: backgroundURLs.paleblue,
+    color: 'white',
+  },
+  warning: {
+    backgroundColor: base.red.value,
+    backgroundImage: backgroundURLs.red,
+    color: 'white',
+  },
+  error: {
+    backgroundColor: base.almostBlack.value,
+    backgroundImage: backgroundURLs.almostBlack,
+    color: 'white',
+  },
+  disconnected: {
+    backgroundColor: base.almostBlack.value,
+    backgroundImage: backgroundURLs.noise,
+    color: 'white',
+  },
 }
 
 const textNoticeStyles = {

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -65,7 +65,7 @@ type AuthenticateAPI = "authenticate" :> QueryParam "code" Text :> Get '[HTML] (
 
 type LogoutAPI = "logout" :> Get '[HTML] (SetSessionCookies H.Html)
 
-type GetUserAPI = "v1" :> "user" :> Get '[JSON] UserResponse
+type GetUserAPI = "v1" :> "user" :> Get '[JSON] User Response
 
 type EmptyProjectPageAPI = "p" :> BranchNameParam :> Get '[HTML] H.Html
 

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -65,7 +65,7 @@ type AuthenticateAPI = "authenticate" :> QueryParam "code" Text :> Get '[HTML] (
 
 type LogoutAPI = "logout" :> Get '[HTML] (SetSessionCookies H.Html)
 
-type GetUserAPI = "v1" :> "user" :> Get '[JSON] User Response
+type GetUserAPI = "v1" :> "user" :> Get '[JSON] UserResponse
 
 type EmptyProjectPageAPI = "p" :> BranchNameParam :> Get '[HTML] H.Html
 

--- a/website/src/common/server.ts
+++ b/website/src/common/server.ts
@@ -1,6 +1,6 @@
 import { UTOPIA_BACKEND, THUMBNAIL_ENDPOINT, ASSET_ENDPOINT, BASE_URL } from './env-vars'
 import { ProjectListing } from './persistence'
-import { isLoggedIn, isNotLoggedIn, loginLost, LoginState, notLoggedIn } from './user'
+import { isLoggedIn, isLoginLost, isNotLoggedIn, loginLost, LoginState, notLoggedIn } from './user'
 // Stupid style of import because the website and editor are different
 // and so there's no style of import which works with both projects.
 const urljoin = require('url-join')
@@ -101,7 +101,10 @@ function getLoginStateFromResponse(
   response: any,
   previousLoginState: LoginState | null,
 ): LoginState {
-  if (isNotLoggedIn(response) && isLoggedIn(previousLoginState)) {
+  if (
+    !isLoggedIn(response) &&
+    (isLoggedIn(previousLoginState) || isLoginLost(previousLoginState))
+  ) {
     // if we used to be logged in but we are not anymore, return a LoginLost
     return loginLost
   } else {

--- a/website/src/common/server.ts
+++ b/website/src/common/server.ts
@@ -62,8 +62,8 @@ export function userConfigURL(): string {
 
 let CachedLoginStatePromise: Promise<LoginState> | null = null
 
-export async function getLoginState(): Promise<LoginState> {
-  if (CachedLoginStatePromise != null) {
+export async function getLoginState(useCache: 'cache' | 'no-cache'): Promise<LoginState> {
+  if (useCache === 'cache' && CachedLoginStatePromise != null) {
     return CachedLoginStatePromise
   } else {
     const promise = createGetLoginStatePromise()
@@ -73,19 +73,24 @@ export async function getLoginState(): Promise<LoginState> {
 }
 
 async function createGetLoginStatePromise(): Promise<LoginState> {
-  const url = UTOPIA_BACKEND + 'user'
-  const response = await fetch(url, {
-    method: 'GET',
-    credentials: 'include',
-    headers: HEADERS,
-    mode: MODE,
-  })
-  if (response.ok) {
-    const result = await response.json()
-    return result
-  } else {
-    // FIXME Client should show an error if server requests fail
-    console.error(`Fetch user details failed (${response.status}): ${response.statusText}`)
+  try {
+    const url = UTOPIA_BACKEND + 'user'
+    const response = await fetch(url, {
+      method: 'GET',
+      credentials: 'include',
+      headers: HEADERS,
+      mode: MODE,
+    })
+    if (response.ok) {
+      const result = await response.json()
+      return result
+    } else {
+      // FIXME Client should show an error if server requests fail
+      console.error(`Fetch user details failed (${response.status}): ${response.statusText}`)
+      return notLoggedIn
+    }
+  } catch (e) {
+    console.error(`Fetch user details failed: ${e}`)
     return notLoggedIn
   }
 }

--- a/website/src/common/user.ts
+++ b/website/src/common/user.ts
@@ -42,3 +42,7 @@ export function isLoggedIn(loginState: unknown): loginState is LoggedInUser {
 export const loginLost: LoginLost = {
   type: 'LOGIN_LOST',
 }
+
+export function isLoginLost(loginState: unknown): loginState is LoginLost {
+  return (loginState as Partial<LoginState>)?.type === 'LOGIN_LOST'
+}

--- a/website/src/common/user.ts
+++ b/website/src/common/user.ts
@@ -14,7 +14,11 @@ interface NotLoggedIn {
   type: 'NOT_LOGGED_IN'
 }
 
-export type LoginState = LoggedInUser | NotLoggedIn
+interface LoginLost {
+  type: 'LOGIN_LOST'
+}
+
+export type LoginState = LoggedInUser | NotLoggedIn | LoginLost
 
 export function loggedInUser(user: UserDetails): LoggedInUser {
   return {
@@ -27,6 +31,14 @@ export const notLoggedIn: NotLoggedIn = {
   type: 'NOT_LOGGED_IN',
 }
 
-export function isLoggedIn(loginState: LoginState): loginState is LoggedInUser {
-  return loginState.type === 'LOGGED_IN'
+export function isNotLoggedIn(loginState: unknown): loginState is NotLoggedIn {
+  return (loginState as Partial<LoginState>)?.type === 'NOT_LOGGED_IN'
+}
+
+export function isLoggedIn(loginState: unknown): loginState is LoggedInUser {
+  return (loginState as Partial<LoginState>)?.type === 'LOGGED_IN'
+}
+
+export const loginLost: LoginLost = {
+  type: 'LOGIN_LOST',
 }


### PR DESCRIPTION
Fixes #186

<img width="1626" alt="image" src="https://user-images.githubusercontent.com/2226774/117035565-bef2f500-ad04-11eb-93b1-a8ae68c0eaef.png">

**Problem:**
The editor would not tell users if they lost their login for any reason.

**Fix:**
Poll login status (I set it to every 5 seconds), and if the login status changes, dispatch an action. Show a toast. 
I also made a new kind of black status bar for users that were loggin in but are not logged in anymore. This new status bar opens the login screen in a new tab to avoid data loss.

**Commit Details:**
- Login status polling function
- I also wrapped the login status fetch to a try-catch to avoid an unhandled promise rejection error
- new `LOGIN_LOST` UserState to indicate a user that was logged in but not anymore
- a new `getLoginStateFromResponse` which sometimes returns the real login state coming from the server, or LoginLost (because LoginLost is not coming from the server, that is a UserState internal to the editor)
- I also noticed that if the server/internet is down, the black background png of the status bar can never load, so I changed it to have a backgroundColor and backgroundImage as well