### PR TITLE
preview connected: only dispatch if the value changes

### DIFF
--- a/editor/src/components/editor/preview-report-handler.ts
+++ b/editor/src/components/editor/preview-report-handler.ts
@@ -17,10 +17,15 @@ export function handlePreviewDisconnected() {
 }
 
 export function startPreviewConnectedMonitoring(dispatch: EditorDispatch) {
+  let previousPreviewConnected: boolean
+
   window.clearInterval(intervalId)
   intervalId = window.setInterval(() => {
     const stillConnected =
       lastReportFromPreviewTS > 0 && Date.now() - lastReportFromPreviewTS < timeout
-    dispatch([updatePreviewConnected(stillConnected)], 'everyone')
+    if (stillConnected !== previousPreviewConnected) {
+      dispatch([updatePreviewConnected(stillConnected)], 'everyone')
+    }
+    previousPreviewConnected = stillConnected
   }, 200)
 }


### PR DESCRIPTION
Fixes #1136 

**Problem:**
`startPreviewConnectedMonitoring` would dispatch an action every 200ms. This makes it very hard to debug actions because this creates a lot of noise. It is also unnecessarily spinning our update loop.

**Fix:**
Store locally the previous value for preview connectedness. Only dispatch if value changes

