### PR TITLE
Fix cyclic import handling when creating execution scopes

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -283,38 +283,47 @@ export const UiJsxCanvas = betterReactMemo(
 
     // TODO after merge requireFn can never be null
     if (requireFn != null) {
+      let resolvedFiles: string[] = []
       const customRequire = React.useCallback(
         (importOrigin: string, toImport: string) => {
           const filePathResolveResult = resolve(importOrigin, toImport)
           const resolvedParseSuccess: Either<string, MapLike<any>> = flatMapEither(
             (resolvedFilePath) => {
-              const projectFile = getContentsTreeFileFromString(projectContents, resolvedFilePath)
-              if (isTextFile(projectFile) && isParseSuccess(projectFile.fileContents.parsed)) {
-                const { scope } = createExecutionScope(
-                  resolvedFilePath,
-                  customRequire,
-                  mutableContextRef,
-                  topLevelComponentRendererComponents,
-                  projectContents,
-                  uiFilePath,
-                  transientFilesState,
-                  base64FileBlobs,
-                  hiddenInstances,
-                  metadataContext,
-                  shouldIncludeCanvasRootInTheSpy,
-                )
-                const exportsDetail = projectFile.fileContents.parsed.exportsDetail
-                let filteredScope: MapLike<any> = {}
-                for (const s of Object.keys(scope)) {
-                  if (s in exportsDetail.namedExports) {
-                    filteredScope[s] = scope[s]
-                  } else if (s === exportsDetail.defaultExport?.name) {
-                    filteredScope[s] = scope[s]
-                  }
-                }
-                return right(filteredScope)
+              if (resolvedFiles.includes(resolvedFilePath)) {
+                // We're inside a cyclic dependency, so bail and the outer call will create the execution scope
+                return left('Ignoring inner cyclic dependency')
               } else {
-                return left(`File ${resolvedFilePath} is not a ParseSuccess`)
+                resolvedFiles.push(resolvedFilePath)
+                const projectFile = getContentsTreeFileFromString(projectContents, resolvedFilePath)
+                if (isTextFile(projectFile) && isParseSuccess(projectFile.fileContents.parsed)) {
+                  const { scope } = createExecutionScope(
+                    resolvedFilePath,
+                    customRequire,
+                    // (innerImportOrigin: string, innerToImport: string) =>
+                    //   requireFn(innerImportOrigin, innerToImport, false),
+                    mutableContextRef,
+                    topLevelComponentRendererComponents,
+                    projectContents,
+                    uiFilePath,
+                    transientFilesState,
+                    base64FileBlobs,
+                    hiddenInstances,
+                    metadataContext,
+                    shouldIncludeCanvasRootInTheSpy,
+                  )
+                  const exportsDetail = projectFile.fileContents.parsed.exportsDetail
+                  let filteredScope: MapLike<any> = {}
+                  for (const s of Object.keys(scope)) {
+                    if (s in exportsDetail.namedExports) {
+                      filteredScope[s] = scope[s]
+                    } else if (s === exportsDetail.defaultExport?.name) {
+                      filteredScope[s] = scope[s]
+                    }
+                  }
+                  return right(filteredScope)
+                } else {
+                  return left(`File ${resolvedFilePath} is not a ParseSuccess`)
+                }
               }
             },
             filePathResolveResult,
@@ -335,6 +344,7 @@ export const UiJsxCanvas = betterReactMemo(
         [
           requireFn,
           resolve,
+          resolvedFiles,
           projectContents,
           transientFilesState,
           uiFilePath,

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -299,8 +299,6 @@ export const UiJsxCanvas = betterReactMemo(
                   const { scope } = createExecutionScope(
                     resolvedFilePath,
                     customRequire,
-                    // (innerImportOrigin: string, innerToImport: string) =>
-                    //   requireFn(innerImportOrigin, innerToImport, false),
                     mutableContextRef,
                     topLevelComponentRendererComponents,
                     projectContents,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -609,6 +609,7 @@ export function modifyOpenJsxElementAtStaticPath(
 function getImportedUtopiaJSXComponents(
   filePath: string,
   model: EditorState,
+  pathsToFilter: string[],
 ): Array<UtopiaJSXComponent> {
   const file = getContentsTreeFileFromString(model.projectContents, filePath)
   if (isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
@@ -616,10 +617,13 @@ function getImportedUtopiaJSXComponents(
       .map((toImport) => model.codeResultCache.resolve(filePath, toImport))
       .filter(isRight)
       .map((r) => r.value)
+      .filter((v) => !pathsToFilter.includes(v))
 
     return [
       ...getUtopiaJSXComponentsFromSuccess(file.fileContents.parsed),
-      ...resolvedFilePaths.flatMap((path) => getImportedUtopiaJSXComponents(path, model)),
+      ...resolvedFilePaths.flatMap((path) =>
+        getImportedUtopiaJSXComponents(path, model, [...pathsToFilter, ...resolvedFilePaths]),
+      ),
     ]
   } else {
     return []
@@ -633,7 +637,7 @@ export function getOpenUtopiaJSXComponentsFromStateMultifile(
   if (openUIJSFilePath == null) {
     return []
   } else {
-    return getImportedUtopiaJSXComponents(openUIJSFilePath, model)
+    return getImportedUtopiaJSXComponents(openUIJSFilePath, model, [])
   }
 }
 


### PR DESCRIPTION
Fixes #1131 

**Problem:**
Cyclic imports were tripping the editor in two places: when creating execution scopes for the canvas, and when fetching all (transitively) imported `UtopiaJSXComponent`s.

**Fix:**
In both cases filter paths that have already been resolved. 

**Commit Details:**
- In `ui-jsx-canvas.tsx` if we encounter an already resolved file when creating the execution scope, we return a `left` to indicate that the outer call will handle the execution scope creation
- Updated `getImportedUtopiaJSXComponents` to take an array of paths to filter, filling it with the already resolved file paths
- Added a test to ensure the canvas still renders, and that we can still correctly focus on an element coming from a file with a cyclic dependency
- Moved some useful testing functions for extracting a simplified version of the recorded metadata to `utils.test-utils.ts` so that they can be used in other tests
