### PR TITLE
Fix/canvas shortcuts multifile

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -426,6 +426,7 @@ import {
   forUnderlyingTargetFromEditorState,
   getHighlightBoundsForFile,
   modifyParseSuccessAtPath,
+  withUnderlyingTarget,
 } from '../store/editor-state'
 import { loadStoredState } from '../stored-state'
 import { applyMigrations } from './migrations/migrations'
@@ -1049,11 +1050,17 @@ function indexPositionForAdjustment(
       return { type: 'front' }
     case 'backward':
     case 'forward':
-      const openUIJSFile = getOpenUIJSFile(editor)
-      if (openUIJSFile != null && isParseSuccess(openUIJSFile.fileContents.parsed)) {
-        const current = getZIndexOfElement(
-          openUIJSFile.fileContents.parsed.topLevelElements,
-          EP.asStatic(target),
+      const openUIJSFileKey = getOpenUIJSFileKey(editor)
+      if (openUIJSFileKey != null) {
+        const current = withUnderlyingTarget(
+          target,
+          editor.projectContents,
+          editor.nodeModules.files,
+          openUIJSFileKey,
+          0,
+          (success) => {
+            return getZIndexOfElement(success.topLevelElements, EP.asStatic(target))
+          },
         )
         return {
           type: 'absolute',
@@ -1866,8 +1873,8 @@ export const UPDATE_FNS = {
       editorForAction,
       false,
       (editor) => {
-        const uiFile = getOpenUIJSFile(editor)
-        if (uiFile == null || !isParseSuccess(uiFile.fileContents.parsed)) {
+        const uiFileKey = getOpenUIJSFileKey(editor)
+        if (uiFileKey == null) {
           return editor
         }
 
@@ -1894,27 +1901,40 @@ export const UPDATE_FNS = {
           }
 
           let viewPath: ElementPath | null = null
-          const withWrapperViewAddedNoFrame = modifyOpenParseSuccess((parseSuccess) => {
-            const elementToInsert: JSXElement = defaultTransparentViewElement(newUID)
-            const utopiaJSXComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
-            const withTargetAdded: Array<UtopiaJSXComponent> = insertElementAtPath(
-              editor.projectContents,
-              editor.canvas.openFile?.filename ?? null,
-              parentPath,
-              elementToInsert,
-              utopiaJSXComponents,
-              null,
-            )
 
-            viewPath = EP.appendToPath(parentPath, newUID)
+          const underlyingTarget = normalisePathToUnderlyingTarget(
+            editor.projectContents,
+            editor.nodeModules.files,
+            uiFileKey,
+            parentPath,
+          )
+          const targetSuccess = normalisePathSuccessOrThrowError(underlyingTarget)
 
-            return modifyParseSuccessWithSimple((success: SimpleParseSuccess) => {
-              return {
-                ...success,
-                utopiaComponents: withTargetAdded,
-              }
-            }, parseSuccess)
-          }, editor)
+          const withWrapperViewAddedNoFrame = modifyParseSuccessAtPath(
+            targetSuccess.filePath,
+            editor,
+            (parseSuccess) => {
+              const elementToInsert: JSXElement = defaultTransparentViewElement(newUID)
+              const utopiaJSXComponents = getUtopiaJSXComponentsFromSuccess(parseSuccess)
+              const withTargetAdded: Array<UtopiaJSXComponent> = insertElementAtPath(
+                editor.projectContents,
+                editor.canvas.openFile?.filename ?? null,
+                parentPath,
+                elementToInsert,
+                utopiaJSXComponents,
+                null,
+              )
+
+              viewPath = EP.appendToPath(parentPath, newUID)
+
+              return modifyParseSuccessWithSimple((success: SimpleParseSuccess) => {
+                return {
+                  ...success,
+                  utopiaComponents: withTargetAdded,
+                }
+              }, parseSuccess)
+            },
+          )
 
           if (viewPath == null) {
             return editor

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -143,8 +143,10 @@ import {
   codeFile,
   unparsed,
   ParseSuccess,
+  importAlias,
 } from '../../../core/shared/project-file-types'
 import {
+  addImport,
   codeNeedsParsing,
   codeNeedsPrinting,
   mergeImports,
@@ -1931,6 +1933,13 @@ export const UPDATE_FNS = {
                 return {
                   ...success,
                   utopiaComponents: withTargetAdded,
+                  imports: addImport(
+                    'utopia-api',
+                    null,
+                    [importAlias('View')],
+                    null,
+                    success.imports,
+                  ),
                 }
               }, parseSuccess)
             },


### PR DESCRIPTION
**Problem:**
This PR fixes 2 more canvas contextmenu and shortcut items: wrap in view and changing the z index.

**Fix:**
These features were missing multifile support.

**Commit Details:**
- update `indexPositionForAdjustment` to work with filepath
- change `WRAP_IN_VIEW` to use normalizedPath
- added a test for wrapping in views
