### PR TITLE
fix(description) - adds description field, exposes it, always shows it

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -461,6 +461,11 @@ export interface SetProjectName {
   name: string
 }
 
+export interface SetProjectDescription {
+  action: 'SET_PROJECT_DESCRIPTION'
+  description: string
+}
+
 export interface RegenerateThumbnail {
   action: 'REGENERATE_THUMBNAIL'
 }
@@ -872,6 +877,7 @@ export type EditorAction =
   | UpdateCodeResultCache
   | SetCodeEditorVisibility
   | SetProjectName
+  | SetProjectDescription
   | RegenerateThumbnail
   | UpdateThumbnailGenerated
   | UpdatePreviewConnected

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -127,6 +127,7 @@ import type {
   SetPanelVisibility,
   SetProjectID,
   SetProjectName,
+  SetProjectDescription,
   SetProp,
   SetPropWithElementPath,
   SetRightMenuExpanded,
@@ -747,6 +748,13 @@ export function setProjectName(projectName: string): SetProjectName {
   return {
     action: 'SET_PROJECT_NAME',
     name: projectName,
+  }
+}
+
+export function setProjectDescription(projectDescription: string): SetProjectDescription {
+  return {
+    action: 'SET_PROJECT_DESCRIPTION',
+    description: projectDescription,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -115,6 +115,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UNWRAP_GROUP_OR_VIEW':
     case 'SET_CANVAS_FRAMES':
     case 'SET_PROJECT_NAME':
+    case 'SET_PROJECT_DESCRIPTION':
     case 'REGENERATE_THUMBNAIL':
     case 'UPDATE_THUMBNAIL_GENERATED':
     case 'ALIGN_SELECTED_VIEWS':

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -973,6 +973,7 @@ describe('LOAD', () => {
     const loadedModel: PersistentModel = {
       appID: null,
       projectVersion: CURRENT_PROJECT_VERSION,
+      projectDescription: '',
       projectContents: contentsToTree({
         [firstUIJSFile]: textFile(initialFileContents, null, 0),
         [secondUIJSFile]: textFile(initialFileContents, null, 0),

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -291,6 +291,7 @@ import {
   SetPanelVisibility,
   SetProjectID,
   SetProjectName,
+  SetProjectDescription,
   SetProp,
   SetPropWithElementPath,
   SetStoredFontSettings,
@@ -853,6 +854,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     id: currentEditor.id,
     appID: currentEditor.appID,
     projectName: currentEditor.projectName,
+    projectDescription: currentEditor.projectDescription,
     projectVersion: currentEditor.projectVersion,
     isLoaded: currentEditor.isLoaded,
     spyMetadata: poppedEditor.spyMetadata,
@@ -2977,6 +2979,13 @@ export const UPDATE_FNS = {
     return {
       ...editor,
       projectName: action.name,
+    }
+  },
+
+  SET_PROJECT_DESCRIPTION: (action: SetProjectDescription, editor: EditorModel): EditorModel => {
+    return {
+      ...editor,
+      projectDescription: action.description,
     }
   },
 

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -228,6 +228,7 @@ export interface EditorState {
   id: string | null
   appID: string | null
   projectName: string
+  projectDescription: string
   projectVersion: number
   isLoaded: boolean
   spyMetadata: ElementInstanceMetadataMap // this is coming from the canvas spy report.
@@ -970,6 +971,7 @@ function emptyDerivedState(editorState: EditorState): DerivedState {
 export interface PersistentModel {
   appID?: string | null
   projectVersion: number
+  projectDescription: string
   projectContents: ProjectContentTreeRoot
   exportsInfo: ReadonlyArray<ExportsInfo>
   lastUsedFont: FontSettings | null
@@ -1007,6 +1009,7 @@ export function mergePersistentModel(
   return {
     appID: second.appID,
     projectVersion: second.projectVersion,
+    projectDescription: second.projectDescription,
     projectContents: {
       ...first.projectContents,
       ...second.projectContents,
@@ -1049,6 +1052,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     id: null,
     appID: null,
     projectName: createNewProjectName(),
+    projectDescription: 'Made with Utopia',
     projectVersion: CURRENT_PROJECT_VERSION,
     isLoaded: false,
     spyMetadata: emptyJsxMetadata,
@@ -1275,6 +1279,7 @@ export function editorModelFromPersistentModel(
     id: null,
     appID: persistentModel.appID ?? null,
     projectName: createNewProjectName(),
+    projectDescription: persistentModel.projectDescription,
     projectVersion: persistentModel.projectVersion,
     isLoaded: false,
     spyMetadata: emptyJsxMetadata,
@@ -1402,6 +1407,7 @@ export function persistentModelFromEditorModel(editor: EditorState): PersistentM
   return {
     appID: editor.appID,
     projectVersion: editor.projectVersion,
+    projectDescription: editor.projectDescription,
     projectContents: editor.projectContents,
     exportsInfo: editor.codeResultCache.exportsInfo,
     lastUsedFont: editor.lastUsedFont,
@@ -1428,6 +1434,7 @@ export function persistentModelForProjectContents(
   return {
     appID: null,
     projectVersion: CURRENT_PROJECT_VERSION,
+    projectDescription: '',
     projectContents: projectContents,
     exportsInfo: [],
     codeEditorErrors: {

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -163,6 +163,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SET_CODE_EDITOR_VISIBILITY(action, state)
     case 'SET_PROJECT_NAME':
       return UPDATE_FNS.SET_PROJECT_NAME(action, state)
+    case 'SET_PROJECT_DESCRIPTION':
+      return UPDATE_FNS.SET_PROJECT_DESCRIPTION(action, state)
     case 'REGENERATE_THUMBNAIL':
       return UPDATE_FNS.REGENERATE_THUMBNAIL(action, state, dispatch)
     case 'UPDATE_THUMBNAIL_GENERATED':

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -33,6 +33,7 @@ import {
   clearSelection,
   regenerateThumbnail,
   setProjectName,
+  setProjectDescription,
 } from '../editor/actions/action-creators'
 import { InsertMenu } from '../editor/insertmenu'
 import { DerivedState, EditorState } from '../editor/store/editor-state'
@@ -574,6 +575,7 @@ const ProjectPane = betterReactMemo('ProjectSettingsPanel', () => {
   const {
     dispatch,
     projectName,
+    projectDescription,
     projectId,
     thumbnailLastGenerated,
     userState,
@@ -583,6 +585,7 @@ const ProjectPane = betterReactMemo('ProjectSettingsPanel', () => {
     return {
       dispatch: store.dispatch,
       projectName: store.editor.projectName,
+      projectDescription: store.editor.projectDescription,
       projectId: store.editor.id,
       thumbnailLastGenerated: store.editor.thumbnailLastGenerated,
       userState: store.userState,
@@ -592,6 +595,7 @@ const ProjectPane = betterReactMemo('ProjectSettingsPanel', () => {
   }, 'ProjectSettingsPanel')
 
   const [name, changeProjectName] = React.useState(projectName)
+  const [description, changeProjectDescription] = React.useState(projectDescription)
   const [requestingPreviewImage, setRequestingPreviewImage] = React.useState(false)
 
   const toggleMinimised = React.useCallback(() => {
@@ -601,6 +605,13 @@ const ProjectPane = betterReactMemo('ProjectSettingsPanel', () => {
   const updateProjectName = React.useCallback(
     (newProjectName: string) => {
       dispatch([setProjectName(newProjectName)])
+    },
+    [dispatch],
+  )
+
+  const updateProjectDescription = React.useCallback(
+    (newProjectDescription: string) => {
+      dispatch([setProjectDescription(newProjectDescription)])
     },
     [dispatch],
   )
@@ -620,11 +631,18 @@ const ProjectPane = betterReactMemo('ProjectSettingsPanel', () => {
     [dispatch, focusedPanel],
   )
 
-  const handleBlur = React.useCallback(
+  const handleBlurProjectName = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       updateProjectName(e.target.value)
     },
     [updateProjectName],
+  )
+
+  const handleBlurProjecDescription = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      updateProjectDescription(e.target.value)
+    },
+    [updateProjectDescription],
   )
 
   const handleKeyPress = React.useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -637,6 +655,13 @@ const ProjectPane = betterReactMemo('ProjectSettingsPanel', () => {
   const onChangeProjectName = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     changeProjectName(event.target.value)
   }, [])
+
+  const onChangeProjectDescription = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      changeProjectDescription(event.target.value)
+    },
+    [],
+  )
 
   const urlToRequest = `${thumbnailURL(projectId!)}?lastUpdated=${thumbnailLastGenerated}`
 
@@ -668,103 +693,110 @@ const ProjectPane = betterReactMemo('ProjectSettingsPanel', () => {
               </FlexRow>
             </SectionTitleRow>
             <SectionBodyArea minimised={minimised}>
-              {userState.loginState.type === 'NOT_LOGGED_IN' ? (
-                <span>Log in or sign up to see settings</span>
-              ) : (
-                <FlexColumn>
-                  <SectionBodyArea minimised={false}>
-                    <UIGridRow
-                      padded
-                      variant='<-------------1fr------------->'
-                      style={{
-                        height: 'inherit',
-                        wordWrap: 'normal',
-                        whiteSpace: 'normal',
-                        alignItems: 'flex-start',
-                        minHeight: 34,
-                        paddingTop: 8,
-                        paddingLeft: 8,
-                        paddingRight: 8,
-                        paddingBottom: 8,
-                        letterSpacing: 0.1,
-                        lineHeight: '17px',
-                        fontSize: '11px',
-                      }}
-                    >
-                      <Subdued>
-                        These help you organise your projects. We also use them when you embed or
-                        share your project on social media and chat apps.
-                      </Subdued>
-                    </UIGridRow>
-                    <UIGridRow padded variant='<---1fr--->|------172px-------|'>
-                      <span>Name</span>
+              <FlexColumn>
+                <SectionBodyArea minimised={false}>
+                  <UIGridRow
+                    padded
+                    variant='<-------------1fr------------->'
+                    style={{
+                      height: 'inherit',
+                      wordWrap: 'normal',
+                      whiteSpace: 'normal',
+                      alignItems: 'flex-start',
+                      minHeight: 34,
+                      paddingTop: 8,
+                      paddingLeft: 8,
+                      paddingRight: 8,
+                      paddingBottom: 8,
+                      letterSpacing: 0.1,
+                      lineHeight: '17px',
+                      fontSize: '11px',
+                    }}
+                  >
+                    <Subdued>
+                      These help you organise your projects. We also use them when you embed or
+                      share your project on social media and chat apps.
+                    </Subdued>
+                  </UIGridRow>
+                  <UIGridRow padded variant='<---1fr--->|------172px-------|'>
+                    <span>Name</span>
+                    {userState.loginState.type === 'NOT_LOGGED_IN' ? (
+                      <span>{name}</span>
+                    ) : (
                       <StringInput
                         testId='projectName'
                         value={name}
                         onChange={onChangeProjectName}
                         onKeyDown={handleKeyPress}
                         style={{ width: 150 }}
-                        onBlur={handleBlur}
+                        onBlur={handleBlurProjectName}
                       />
-                    </UIGridRow>
-                    <UIGridRow padded variant='<---1fr--->|------172px-------|'>
-                      <span> Description </span>
+                    )}
+                  </UIGridRow>
+                  <UIGridRow padded variant='<---1fr--->|------172px-------|'>
+                    <span> Description </span>
+                    {userState.loginState.type === 'NOT_LOGGED_IN' ? (
+                      <span>{description}</span>
+                    ) : (
                       <StringInput
                         testId='projectDescription'
-                        value={projectName}
+                        value={description}
+                        onChange={onChangeProjectDescription}
+                        onKeyDown={handleKeyPress}
+                        onBlur={handleBlurProjecDescription}
                         style={{ width: 150 }}
                       />
-                    </UIGridRow>
-                    <UIGridRow
-                      padded
-                      variant='<---1fr--->|------172px-------|'
-                      style={{ alignItems: 'start', height: 'initial', paddingTop: 8 }}
-                    >
-                      <span> Preview </span>
-                      <FlexColumn style={{ gap: 8 }}>
-                        <div
-                          css={{
-                            boxShadow: `inset 0 0 0 1px ${colorTheme.secondaryBorder.value}`,
-                            borderRadius: 1,
-                            display: 'block',
-                            justifySelf: 'stretch',
-                            aspectRatio: '16 / 9',
-                            backgroundImage: `url('${urlToRequest}')`,
-                            backgroundSize: 'cover',
-                            backgroundColor: colorTheme.canvasBackground.value,
-                          }}
-                        />
-                        <Button
-                          disabled={requestingPreviewImage}
-                          spotlight
-                          highlight
-                          onClick={triggerRegenerateThumbnail}
-                          css={{
-                            position: 'relative',
-                            textAlign: 'center',
-                            '&:before': {
-                              transition: requestingPreviewImage
-                                ? 'right 2.5s ease-in-out'
-                                : 'inherit',
-                              position: 'absolute',
-                              left: 0,
-                              top: 0,
-                              bottom: 0,
-                              right: requestingPreviewImage ? 0 : '100%',
-                              background: requestingPreviewImage
-                                ? UtopiaTheme.color.primary.value
-                                : 'transparent',
-                              content: '""',
-                            },
-                          }}
-                        >
-                          {requestingPreviewImage ? 'Refreshing' : 'Refresh'}
-                        </Button>
-                      </FlexColumn>
-                    </UIGridRow>
-                  </SectionBodyArea>
-                </FlexColumn>
-              )}
+                    )}
+                  </UIGridRow>
+                  <UIGridRow
+                    padded
+                    variant='<---1fr--->|------172px-------|'
+                    style={{ alignItems: 'start', height: 'initial', paddingTop: 8 }}
+                  >
+                    <span> Preview </span>
+                    <FlexColumn style={{ gap: 8 }}>
+                      <div
+                        css={{
+                          boxShadow: `inset 0 0 0 1px ${colorTheme.secondaryBorder.value}`,
+                          borderRadius: 1,
+                          display: 'block',
+                          justifySelf: 'stretch',
+                          aspectRatio: '16 / 9',
+                          backgroundImage: `url('${urlToRequest}')`,
+                          backgroundSize: 'cover',
+                          backgroundColor: colorTheme.canvasBackground.value,
+                        }}
+                      />
+                      <Button
+                        disabled={requestingPreviewImage}
+                        spotlight
+                        highlight
+                        onClick={triggerRegenerateThumbnail}
+                        css={{
+                          position: 'relative',
+                          textAlign: 'center',
+                          '&:before': {
+                            transition: requestingPreviewImage
+                              ? 'right 2.5s ease-in-out'
+                              : 'inherit',
+                            position: 'absolute',
+                            left: 0,
+                            top: 0,
+                            bottom: 0,
+                            right: requestingPreviewImage ? 0 : '100%',
+                            background: requestingPreviewImage
+                              ? UtopiaTheme.color.primary.value
+                              : 'transparent',
+                            content: '""',
+                          },
+                        }}
+                      >
+                        {requestingPreviewImage ? 'Refreshing' : 'Refresh'}
+                      </Button>
+                    </FlexColumn>
+                  </UIGridRow>
+                </SectionBodyArea>
+              </FlexColumn>
             </SectionBodyArea>
           </Section>
         )}


### PR DESCRIPTION
**Problem:**
1. We had a rogue description field in the UI that didn't do anything
2. We weren't showing the project description or title when logged out, which conflicts with the goal to learn more and fork it

**Fix:**
1. Added a field + action
2. Changed the UI to show the project name and description when logged out, but not editable

(this was prep work for showing more prominent "Sign In" and "Fork this project" panels. In the process I also stumbled upon the "we always fork the project immediately on opening" bug (#1202 )