### PR TITLE
fix canvas height for Safari

### DIFF
--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -60,6 +60,7 @@ export const CanvasWrapperComponent = betterReactMemo(
           justifyContent: 'stretch',
           alignItems: 'stretch',
           flexGrow: 1,
+          height: '100%',
           // ^ prevents Monaco from pushing the inspector out
         }}
       >


### PR DESCRIPTION
**Problem:**
The canvas was invisible on Safari. Turns out the height was 0.

**Fix:**
This fixes the height of the canvas for Safari. I'm gonna be honest here. I have no idea why. Malte told me to try this and it works! 
