### PR TITLE
integrate redux devtools, if available

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -81,6 +81,7 @@ import {
   identifyFilesThatHaveChanged,
 } from '../../../core/shared/project-contents-dependencies'
 import { CodeResultCache, generateCodeResultCache } from '../../custom-code/code-file'
+import { updateReduxDevtools } from '../../../core/shared/redux-devtools'
 
 export interface DispatchResult extends EditorStore {
   nothingChanged: boolean
@@ -422,7 +423,15 @@ export function editorDispatch(
 
   const result: DispatchResult = actionGroupsToProcess.reduce(
     (working: DispatchResult, actions) => {
-      return editorDispatchInner(boundDispatch, actions, working, allTransient, spyCollector)
+      const newStore = editorDispatchInner(
+        boundDispatch,
+        actions,
+        working,
+        allTransient,
+        spyCollector,
+      )
+      updateReduxDevtools(actions, newStore)
+      return newStore
     },
     { ...storedState, entireUpdateFinished: Promise.resolve(true), nothingChanged: true },
   )

--- a/editor/src/core/shared/redux-devtools.ts
+++ b/editor/src/core/shared/redux-devtools.ts
@@ -1,0 +1,41 @@
+import type { EditorAction } from '../../components/editor/action-types'
+import type { EditorStore } from '../../components/editor/store/editor-state'
+
+interface Connection {
+  subscribe: (listener: (message: { type: string; state: string }) => void) => () => void // adds a change listener. It will be called any time an action is dispatched from the monitor. Returns a function to unsubscribe the current listener.
+  unsubscribe: () => void // unsubscribes all listeners.
+  send: (action: string, state: any) => void // sends a new action and state manually to be shown on the monitor. If action is null then we suppose we send liftedState.
+  init: (state: any) => void // sends the initial state to the monitor.
+  error: (message: string) => void // sends the error message to be shown in the extension's monitor.
+}
+
+function connectDevToolsExtension(): Connection | null {
+  if (
+    window != null &&
+    (window as any).__REDUX_DEVTOOLS_EXTENSION__ != null &&
+    (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect != null
+  ) {
+    return (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect()
+  } else {
+    return null
+  }
+}
+
+const maybeDevTools = connectDevToolsExtension()
+
+const ActionsToOmit: Array<EditorAction['action']> = ['UPDATE_PREVIEW_CONNECTED']
+
+export function updateReduxDevtools(actions: Array<EditorAction>, newStore: EditorStore): void {
+  if (maybeDevTools != null) {
+    // filter out the actions we are not interested in
+    if (!actions.some((a) => ActionsToOmit.includes(a.action))) {
+      maybeDevTools.send(actions.map((action) => action.action).join(' '), newStore)
+    }
+  }
+}
+
+export function reduxDevtoolsSendInitialState(newStore: EditorStore): void {
+  if (maybeDevTools != null) {
+    maybeDevTools.init(newStore)
+  }
+}

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -92,6 +92,7 @@ import {
   isUpdatePropertyControlsInfo,
 } from '../components/editor/actions/actions'
 import { updateCssVars, UtopiaStyles } from '../uuiui'
+import { reduxDevtoolsSendInitialState } from '../core/shared/redux-devtools'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
@@ -148,6 +149,8 @@ export class Editor {
     this.utopiaStoreHook = storeHook
     this.updateStore = storeHook.setState
     this.utopiaStoreApi = storeHook
+
+    reduxDevtoolsSendInitialState(this.storedState)
 
     const handleWorkerMessage = (msg: OutgoingWorkerMessage) => {
       switch (msg.type) {


### PR DESCRIPTION
Well this was easier than expected!

to make it work install https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd

<img width="2200" alt="image" src="https://user-images.githubusercontent.com/2226774/117187509-495a5800-addc-11eb-924a-997d078ea9e0.png">

If a redux devtools extension is detected, the editor will now forward the name of the dispatched actions and the updated state for every dispatch.

This makes it very easy to record (save and SHARE!) a small session of user interactions, alongside the full states for every action.

The best thing is that when you inspect an action, the devtool will intelligently diff the editor state and only show what changed, this is very handy because our full editor state is huge, so being able to quickly focus on the relevant parts is a huge boost.
