### PR TITLE
Component button fixed, typecheck added

### DIFF
--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -81,8 +81,10 @@ export const RenderAsRow = betterReactMemo('RenderAsRow', () => {
       const nameToSearchFor: JSXElementName = hookResult[0].name
       for (const selectOption of insertableComponents) {
         const insertableComponent: InsertableComponent = selectOption.value
-        if (jsxElementNameEquals(insertableComponent.element.name, nameToSearchFor)) {
-          return selectOption
+        if (insertableComponent != null) {
+          if (jsxElementNameEquals(insertableComponent.element.name, nameToSearchFor)) {
+            return selectOption
+          }
         }
       }
     }


### PR DESCRIPTION
Whenever a component is selected and the component is clicked it would crash the editor. Added a type check in the currentInsertableComponent function to prevent this from happening.

<img width="548" alt="Screenshot 2021-05-05 at 19 12 36" src="https://user-images.githubusercontent.com/72036965/117189238-dc43c400-add5-11eb-9138-2a47ed6dc3dc.png">

