### PR TITLE
Redux Devtool: sanitizing logged state, adding log function 

### DIFF
--- a/editor/src/core/shared/redux-devtools.ts
+++ b/editor/src/core/shared/redux-devtools.ts
@@ -60,9 +60,10 @@ function sanitizeLoggedState(store: EditorStore) {
 export function updateReduxDevtools(actions: Array<EditorAction>, newStore: EditorStore): void {
   if (maybeDevTools != null) {
     // filter out the actions we are not interested in
-    if (!actions.some((a) => ActionsToOmit.includes(a.action))) {
+    const filteredActions = actions.filter((action) => !ActionsToOmit.includes(action.action))
+    if (filteredActions.length > 0) {
       const sanitizedStore = sanitizeLoggedState(newStore)
-      const actionNames = pluck(actions, 'action').join(' ')
+      const actionNames = pluck(filteredActions, 'action').join(' ')
       maybeDevTools.send(`⚫️ ${actionNames}`, sanitizedStore)
       lastDispatchedStore = sanitizedStore
     }


### PR DESCRIPTION
**Problem:**
The logged state was ginormous and it made the devtools extension to crash after a few minutes of editor use.

**Fix:**
I made a filter function and it is filtering out the history, node_modules, and some other parts of the store that were sticking out. We can refine this any time if it is still too large

**Commit Details:**
- `sanitizeLoggedState` function
- new `reduxDevtoolsLogMessage` function to be able to write custom loglines so they show up among the dispatched actions, like so:
<img width="545" alt="image" src="https://user-images.githubusercontent.com/2226774/117286321-55d8c200-ae69-11eb-93bb-1e7b4adbe7d6.png">

