### PR TITLE
Fix/canvas shortcuts unwrap

### DIFF
--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -11,7 +11,12 @@ import { fireEvent } from '@testing-library/react'
 import { act } from 'react-dom/test-utils'
 import { generateUidWithExistingComponents } from '../../core/model/element-template-utils'
 import { canvasRectangle, CanvasVector } from '../../core/shared/math-utils'
-import { selectComponents, setCanvasFrames, wrapInView } from '../editor/actions/action-creators'
+import {
+  selectComponents,
+  setCanvasFrames,
+  unwrapGroupOrView,
+  wrapInView,
+} from '../editor/actions/action-creators'
 import { reparentComponents } from '../navigator/actions'
 import * as EP from '../../core/shared/element-path'
 import {
@@ -1056,6 +1061,85 @@ describe('moveTemplate', () => {
         PrettierConfig,
       ),
     )
+  })
+  it('unwraps in 1 non-storyboard element', async () => {
+    const appFilePath = '/src/app.js'
+    let projectContents: ProjectContents = {
+      '/package.json': textFile(
+        textFileContents(
+          JSON.stringify(DefaultPackageJson, null, 2),
+          unparsed,
+          RevisionsState.BothMatch,
+        ),
+        null,
+        0,
+      ),
+      '/src': directory(),
+      '/utopia': directory(),
+      [StoryboardFilePath]: createCodeFile(
+        StoryboardFilePath,
+        `
+  import * as React from 'react'
+  import { Scene, Storyboard } from 'utopia-api'
+  import { App } from '/src/app.js'
+
+  export var storyboard = (
+    <Storyboard data-uid='${BakedInStoryboardUID}'>
+      <Scene
+        data-uid='${TestSceneUID}'
+        style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+      >
+        <App data-uid='${TestAppUID}' />
+      </Scene>
+    </Storyboard>
+  )`,
+      ),
+      [appFilePath]: createCodeFile(
+        appFilePath,
+        `
+  import * as React from 'react'
+  import { View } from 'utopia-api'
+  export var App = (props) => {
+    return <div data-uid='app-outer-div' style={{position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF'}}>
+      <View data-uid='app-wrapper-view'>
+        <div data-uid='app-inner-div' style={{ width: 50, height: 100 }}><span data-uid='app-inner-span'>hello</span></div>
+      </View>
+    </div>
+  }`,
+      ),
+    }
+    const renderResult = await renderTestEditorWithProjectContent(contentsToTree(projectContents))
+    const targetPath = EP.appendNewElementPath(TestScenePath, ['app-outer-div', 'app-wrapper-view'])
+    const selectionAfterUnwrap = EP.appendNewElementPath(TestScenePath, [
+      'app-outer-div',
+      'app-inner-div',
+    ])
+
+    await renderResult.dispatch([unwrapGroupOrView(targetPath)], true)
+    expect(getPrintedUiJsCode(renderResult.getEditorState(), appFilePath)).toEqual(
+      Prettier.format(
+        `
+    import * as React from 'react'
+    import { View } from 'utopia-api'
+    export var App = (props) => {
+      return (
+        <div
+          data-uid='app-outer-div'
+          style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
+        >
+          <div
+            data-uid='app-inner-div'
+            style={{ width: 50, height: 100 }}
+          >
+            <span data-uid='app-inner-span'>hello</span>
+          </div>
+        </div>
+      )
+    }`,
+        PrettierConfig,
+      ),
+    )
+    expect(renderResult.getEditorState().editor.selectedViews).toEqual([selectionAfterUnwrap])
   })
   it('reparents multiselected elements', async () => {
     const renderResult = await renderTestEditorWithCode(

--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1062,7 +1062,7 @@ describe('moveTemplate', () => {
       ),
     )
   })
-  it('unwraps in 1 non-storyboard element', async () => {
+  it('unwraps 1 non-storyboard element', async () => {
     const appFilePath = '/src/app.js'
     let projectContents: ProjectContents = {
       '/package.json': textFile(

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -2033,12 +2033,13 @@ export const UPDATE_FNS = {
           editor,
           'forward',
         )
+        let newSelection: ElementPath[] = []
         const withChildrenMoved = children.reduce((working, child) => {
           const childFrame = MetadataUtils.getFrameInCanvasCoords(
             child.elementPath,
             editor.jsxMetadata,
           )
-          return editorMoveTemplate(
+          const result = editorMoveTemplate(
             child.elementPath,
             child.elementPath,
             childFrame,
@@ -2047,11 +2048,22 @@ export const UPDATE_FNS = {
             parentFrame,
             working,
             null,
-          ).editor
+          )
+          if (result.newPath != null) {
+            newSelection.push(result.newPath)
+          }
+          return result.editor
         }, editor)
         const withViewDeleted = deleteElements([action.target], withChildrenMoved)
 
-        return withViewDeleted
+        return {
+          ...withViewDeleted,
+          selectedViews: newSelection,
+          canvas: {
+            ...withViewDeleted.canvas,
+            mountCount: editor.canvas.mountCount + 1,
+          },
+        }
       },
       dispatch,
     )


### PR DESCRIPTION
Fixes #1205

**Problem:**
After unwrapping a view the jsxMetadata was not correct and it looked like the spy wrapping is missing from the deleted element children. It was actually a dom-walker cache clearing it during `cullSpyCollector`. The dom-walker result contained cached metadata after deletion so the spy data and dom metadata was very different. It's not a problem for reparentElement action, because that changes selected views. Changing selected views invalidates the dom-walker cache, increasing mountcount has the same effect. Actually unwrapping had a bug where the selection was lost, so it now does both to really make sure that it will get new dom-walking data.

**Commit Details:**
- increase mountcount at the end of unwrap action to force dom-walking
- fix missing selected views from unwrapping
- test for unwrap view
