### PR TITLE
Support auto closing login in new tab.

### DIFF
--- a/editor/src/components/common/notice.ts
+++ b/editor/src/components/common/notice.ts
@@ -23,6 +23,7 @@ export function notice(
   message: React.ReactChild,
   level: NoticeLevel = 'INFO',
   persistent: boolean = false,
+  id: string = UUID(),
 ): Notice {
-  return { message: message, persistent: persistent, level: level, id: UUID() }
+  return { message: message, persistent: persistent, level: level, id: id }
 }

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -330,6 +330,7 @@ export interface ToggleCollapse {
 
 export interface AddToast {
   action: 'ADD_TOAST'
+  // FIXME: This contains React.ReactChild and is likely not serializable.
   toast: Notice
 }
 

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -1736,9 +1736,10 @@ export const UPDATE_FNS = {
       setTimeout(() => dispatch([removeToast(action.toast.id)], 'everyone'), 5500)
     }
 
+    const withOldToastRemoved = UPDATE_FNS.REMOVE_TOAST(removeToast(action.toast.id), editor)
     return {
-      ...editor,
-      toasts: [...editor.toasts, action.toast],
+      ...withOldToastRemoved,
+      toasts: [...withOldToastRemoved.toasts, action.toast],
     }
   },
   REMOVE_TOAST: (action: RemoveToast, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/notification-bar.tsx
+++ b/editor/src/components/editor/notification-bar.tsx
@@ -26,12 +26,8 @@ export const EditorOfflineBar = betterReactMemo('EditorOfflineBar', () => {
 export const LoginStatusBar = betterReactMemo('LoginStatusBar', () => {
   const loginState = useEditorState((store) => store.userState.loginState, 'LoginStatusBar')
 
-  const onClickLoginSameTab = React.useCallback(() => {
-    setRedirectUrl(window.top.location.pathname).then(() => window.top.location.replace(auth0Url))
-  }, [])
-
   const onClickLoginNewTab = React.useCallback(() => {
-    window.open(auth0Url, '_blank')
+    window.open(auth0Url('auto-close'), '_blank')
   }, [])
 
   switch (loginState.type) {
@@ -42,7 +38,7 @@ export const LoginStatusBar = betterReactMemo('LoginStatusBar', () => {
         <NotificationBar
           level='PRIMARY'
           message={'Welcome to Utopia. Click here to sign in and save your projects.'}
-          onClick={onClickLoginSameTab}
+          onClick={onClickLoginNewTab}
           style={{ cursor: 'pointer' }}
         />
       )

--- a/editor/src/components/editor/persistence.ts
+++ b/editor/src/components/editor/persistence.ts
@@ -592,7 +592,7 @@ async function generateThumbnail(force: boolean): Promise<Buffer | null> {
   }
 }
 
-function isSafeToClose(): boolean {
+export function isSafeToClose(): boolean {
   return (
     _saveState.type === 'never-saved' ||
     (_saveState.type === 'saved' && _saveState.setTimeoutId == null)

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -15,10 +15,11 @@ import { LoginState } from '../../uuiui-deps'
 import urljoin = require('url-join')
 import * as JSZip from 'jszip'
 import { addFileToProjectContents, walkContentsTree } from '../assets'
-import type { EditorDispatch } from './action-types'
-import { setLoginState, showToast } from './actions/action-creators'
-import { isLoginLost } from '../../common/user'
+import { isLoginLost, isNotLoggedIn } from '../../common/user'
 import { notice } from '../common/notice'
+import { EditorDispatch, isLoggedIn } from './action-types'
+import { setLoginState, showToast, removeToast } from './actions/action-creators'
+import { isLocal } from './persistence'
 
 export { fetchProjectList, fetchShowcaseProjects, getLoginState } from '../../common/server'
 
@@ -393,6 +394,8 @@ export async function downloadGithubRepo(
   }
 }
 
+const loginLostNoticeID: string = 'login-lost-notice'
+
 export function startPollingLoginState(
   dispatch: EditorDispatch,
   initialLoginState: LoginState,
@@ -409,9 +412,25 @@ export function startPollingLoginState(
               `You have been logged out. You can continue working, but your work won't be saved until you log in again.`,
               'ERROR',
               true,
+              loginLostNoticeID,
             ),
           ),
         ])
+      }
+
+      if (isLoggedIn(loginState)) {
+        if (isLoginLost(previousLoginState)) {
+          // Login was lost and subsequently regained so remove the persistent toast.
+          dispatch([removeToast(loginLostNoticeID)])
+        }
+        if (isNotLoggedIn(previousLoginState)) {
+          if (isLocal()) {
+            // The handling of local file uploading is done on load currently.
+            // Since there's implications around the project ID from that, it's
+            // likely vastly easier to just reload the page here.
+            window.location.reload()
+          }
+        }
       }
     }
     previousLoginState = loginState

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -19,7 +19,7 @@ import { isLoginLost, isNotLoggedIn } from '../../common/user'
 import { notice } from '../common/notice'
 import { EditorDispatch, isLoggedIn } from './action-types'
 import { setLoginState, showToast, removeToast } from './actions/action-creators'
-import { isLocal } from './persistence'
+import { isLocal, isSafeToClose } from './persistence'
 
 export { fetchProjectList, fetchShowcaseProjects, getLoginState } from '../../common/server'
 
@@ -424,7 +424,7 @@ export function startPollingLoginState(
           dispatch([removeToast(loginLostNoticeID)])
         }
         if (isNotLoggedIn(previousLoginState)) {
-          if (isLocal()) {
+          if (isLocal() && isSafeToClose()) {
             // The handling of local file uploading is done on load currently.
             // Since there's implications around the project ID from that, it's
             // likely vastly easier to just reload the page here.

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -61,7 +61,7 @@ type AuthCookie = Header "Cookie" Text
 
 type BranchNameParam = QueryParam' '[Optional] "branch_name" Text
 
-type AuthenticateAPI = "authenticate" :> QueryParam "code" Text :> Get '[HTML] (SetSessionCookies H.Html)
+type AuthenticateAPI a = "authenticate" :> QueryParam "code" Text :> QueryParam "onto" Text :> Get '[HTML] (SetSessionCookies a)
 
 type LogoutAPI = "logout" :> Get '[HTML] (SetSessionCookies H.Html)
 
@@ -169,7 +169,7 @@ type Protected = LogoutAPI
             :<|> SaveProjectThumbnailAPI
             :<|> DownloadGithubProjectAPI
 
-type Unprotected = AuthenticateAPI
+type Unprotected = AuthenticateAPI H.Html
               :<|> EmptyProjectPageAPI
               :<|> ProjectPageAPI
               :<|> EmptyPreviewPageAPI

--- a/server/src/Utopia/Web/Utils/Files.hs
+++ b/server/src/Utopia/Web/Utils/Files.hs
@@ -166,7 +166,7 @@ normalizePath :: [Text] -> [Text]
 normalizePath path = normalizePath' path []
 
 projectContentsPathForFilePath :: [Text] -> [Text]
-projectContentsPathForFilePath filePath = 
+projectContentsPathForFilePath filePath =
   let withChildrenInserted = intersperse "children" filePath
       withContentsKeyPrepended = "projectContents" : withChildrenInserted
   in withContentsKeyPrepended ++ ["content", "fileContents", "code"]

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -34,7 +34,7 @@ var PlaceholderScreen = () => {
 
 class App extends Component {
   loginRender = () => {
-    window.location.replace(auth0Url)
+    window.location.replace(auth0Url('redirect'))
     return null
   }
 

--- a/website/src/common/env-vars.ts
+++ b/website/src/common/env-vars.ts
@@ -65,9 +65,27 @@ export const GOOGLE_WEB_FONTS_KEY =
     ? process.env.GOOGLE_WEB_FONTS_KEY
     : 'AIzaSyBffJtCo2vL68hdQKH3IYjo0ELFAAGYNW4'
 
-export const auth0Url = USE_AUTH0
-  ? `https://${AUTH0_HOST}/authorize?scope=openid%20profile%20email&response_type=code&client_id=${AUTH0_CLIENT_ID}&redirect_uri=${AUTH0_REDIRECT_URI}`
-  : `${BASE_URL}authenticate?code=logmein`
+export type AuthRedirectBehaviour = 'redirect' | 'auto-close'
+
+export function auth0Url(behaviour: AuthRedirectBehaviour): string {
+  let url: URL
+  if (USE_AUTH0) {
+    url = new URL(`https://${AUTH0_HOST}/authorize`)
+    url.searchParams.set('scope', 'openid profile email')
+    url.searchParams.set('response_type', 'code')
+    url.searchParams.set('client_id', AUTH0_CLIENT_ID)
+
+    const redirectURL = new URL(AUTH0_REDIRECT_URI)
+    redirectURL.searchParams.set('onto', behaviour)
+
+    url.searchParams.set('redirect_uri', redirectURL.href)
+  } else {
+    url = new URL(`${BASE_URL}authenticate`)
+    url.searchParams.set('code', 'logmein')
+    url.searchParams.set('onto', behaviour)
+  }
+  return url.href
+}
 
 const COMMIT_HASH = process.env.REACT_APP_COMMIT_HASH || ''
 export const URL_HASH = COMMIT_HASH === '' ? 'nocommit' : COMMIT_HASH


### PR DESCRIPTION
Fixes #1209

**Problem:**
Currently the login triggers change the current page of the editor which is an undesirable way for it to be handled.

**Fix:**
Change the authentication endpoint to either redirect or close the window when completing the authentication based on the `onto` query parameter. This also necessitates some handling in the editor when it becomes logged in while polling so that it can handle that appropriately like removing the persistent toast when login has been lost.

**Commit Details:**
- Fixes #1209.
- `notice` function now supports specifying the id of the notice directly.
- `ADD_TOAST` action removes existing toasts with the same id.
- `auth0Url` env-var function now supports an option to specify a
  query parameter on the redirect URL.
- `startPollingLoginState` now checks to see if the user has become logged
  in and removes the persistent toast about having lost their login and
  potentially reloads the app for local projects.
- `authenticate` endpoint provides different content depending on the new
  `onto` query parameter.
- Refactored the `AuthenticateAPI` so that it can be used in the tests.
- Removed old `ClientAuthenticateAPI` from the server tests as it was hiding
  an issue with the type diverging from `AuthenticateAPI`.
- Cleaned up the server test logic around authenticating with a function
  `validAuthenticate`.
