### PR TITLE
Ensure consistent JSX attribute simplifying for the sake of memoisation

### DIFF
--- a/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
+++ b/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
@@ -51,109 +51,14 @@ Array [
                   "leadingComments": Array [],
                   "trailingComments": Array [],
                 },
-                "content": Array [
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "position",
-                    "keyComments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "type": "PROPERTY_ASSIGNMENT",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "type": "ATTRIBUTE_VALUE",
-                      "value": "absolute",
-                    },
-                  },
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "height",
-                    "keyComments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "type": "PROPERTY_ASSIGNMENT",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "type": "ATTRIBUTE_VALUE",
-                      "value": 300,
-                    },
-                  },
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "left",
-                    "keyComments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "type": "PROPERTY_ASSIGNMENT",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "type": "ATTRIBUTE_VALUE",
-                      "value": 0,
-                    },
-                  },
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "top",
-                    "keyComments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "type": "PROPERTY_ASSIGNMENT",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "type": "ATTRIBUTE_VALUE",
-                      "value": 0,
-                    },
-                  },
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "width",
-                    "keyComments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "type": "PROPERTY_ASSIGNMENT",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "type": "ATTRIBUTE_VALUE",
-                      "value": 200,
-                    },
-                  },
-                ],
-                "type": "ATTRIBUTE_NESTED_OBJECT",
+                "type": "ATTRIBUTE_VALUE",
+                "value": Object {
+                  "height": 300,
+                  "left": 0,
+                  "position": "absolute",
+                  "top": 0,
+                  "width": 200,
+                },
               },
             },
           ],
@@ -193,49 +98,11 @@ Array [
               "leadingComments": Array [],
               "trailingComments": Array [],
             },
-            "content": Array [
-              Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "key": "backgroundColor",
-                "keyComments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "PROPERTY_ASSIGNMENT",
-                "value": Object {
-                  "comments": Object {
-                    "leadingComments": Array [],
-                    "trailingComments": Array [],
-                  },
-                  "type": "ATTRIBUTE_VALUE",
-                  "value": "#FFFFFF",
-                },
-              },
-              Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "key": "position",
-                "keyComments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "PROPERTY_ASSIGNMENT",
-                "value": Object {
-                  "comments": Object {
-                    "leadingComments": Array [],
-                    "trailingComments": Array [],
-                  },
-                  "type": "ATTRIBUTE_VALUE",
-                  "value": "absolute",
-                },
-              },
-            ],
-            "type": "ATTRIBUTE_NESTED_OBJECT",
+            "type": "ATTRIBUTE_VALUE",
+            "value": Object {
+              "backgroundColor": "#FFFFFF",
+              "position": "absolute",
+            },
           },
         },
         Object {
@@ -400,69 +267,12 @@ Array [
                   "leadingComments": Array [],
                   "trailingComments": Array [],
                 },
-                "content": Array [
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "position",
-                    "keyComments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "type": "PROPERTY_ASSIGNMENT",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "type": "ATTRIBUTE_VALUE",
-                      "value": "relative",
-                    },
-                  },
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "flexBasis",
-                    "keyComments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "type": "PROPERTY_ASSIGNMENT",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "type": "ATTRIBUTE_VALUE",
-                      "value": 200,
-                    },
-                  },
-                  Object {
-                    "comments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "key": "height",
-                    "keyComments": Object {
-                      "leadingComments": Array [],
-                      "trailingComments": Array [],
-                    },
-                    "type": "PROPERTY_ASSIGNMENT",
-                    "value": Object {
-                      "comments": Object {
-                        "leadingComments": Array [],
-                        "trailingComments": Array [],
-                      },
-                      "type": "ATTRIBUTE_VALUE",
-                      "value": 300,
-                    },
-                  },
-                ],
-                "type": "ATTRIBUTE_NESTED_OBJECT",
+                "type": "ATTRIBUTE_VALUE",
+                "value": Object {
+                  "flexBasis": 200,
+                  "height": 300,
+                  "position": "relative",
+                },
               },
             },
           ],
@@ -502,49 +312,11 @@ Array [
               "leadingComments": Array [],
               "trailingComments": Array [],
             },
-            "content": Array [
-              Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "key": "backgroundColor",
-                "keyComments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "PROPERTY_ASSIGNMENT",
-                "value": Object {
-                  "comments": Object {
-                    "leadingComments": Array [],
-                    "trailingComments": Array [],
-                  },
-                  "type": "ATTRIBUTE_VALUE",
-                  "value": "#FFFFFF",
-                },
-              },
-              Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "key": "display",
-                "keyComments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "PROPERTY_ASSIGNMENT",
-                "value": Object {
-                  "comments": Object {
-                    "leadingComments": Array [],
-                    "trailingComments": Array [],
-                  },
-                  "type": "ATTRIBUTE_VALUE",
-                  "value": "flex",
-                },
-              },
-            ],
-            "type": "ATTRIBUTE_NESTED_OBJECT",
+            "type": "ATTRIBUTE_VALUE",
+            "value": Object {
+              "backgroundColor": "#FFFFFF",
+              "display": "flex",
+            },
           },
         },
         Object {

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -21,6 +21,7 @@ import {
   emptyAttributeMetadatada,
   jsxAttributeOtherJavaScript,
   JSXElementChild,
+  partOfJsxAttributeValue,
 } from '../../../core/shared/element-template'
 import { getModifiableJSXAttributeAtPath } from '../../../core/shared/jsx-attributes'
 import {
@@ -226,7 +227,7 @@ describe('SET_PROP', () => {
       updatedViewProps,
       PP.create(['test', 'prop']),
     )
-    chaiExpect(updatedTestProp).to.deep.equal(right(jsxAttributeValue(100, emptyComments)))
+    chaiExpect(updatedTestProp).to.deep.equal(right(partOfJsxAttributeValue(100)))
   })
 })
 

--- a/editor/src/components/inspector/common/css-utils.spec.ts
+++ b/editor/src/components/inspector/common/css-utils.spec.ts
@@ -123,10 +123,10 @@ describe('toggleStyleProp', () => {
     const expectedElement = jsxTestElement(
       'View',
       jsxAttributesFromMap({
-        style: jsxAttributeNestedObjectSimple(
-          jsxAttributesFromMap({
-            backgroundColor: jsxAttributeValue('red', emptyComments),
-          }),
+        style: jsxAttributeValue(
+          {
+            backgroundColor: 'red',
+          },
           emptyComments,
         ),
       }),

--- a/editor/src/core/layout/layout-utils.spec.ts
+++ b/editor/src/core/layout/layout-utils.spec.ts
@@ -23,33 +23,13 @@ describe('roundAttributeLayoutValues', () => {
     })
     const actualResult = roundAttributeLayoutValues(attributes)
     const expectedResult: JSXAttributes = jsxAttributesFromMap({
-      style: jsxAttributeNestedObject(
-        [
-          jsxPropertyAssignment(
-            'left',
-            jsxAttributeValue(0, emptyComments),
-            emptyComments,
-            emptyComments,
-          ),
-          jsxPropertyAssignment(
-            'top',
-            jsxAttributeValue('0%', emptyComments),
-            emptyComments,
-            emptyComments,
-          ),
-          jsxPropertyAssignment(
-            'width',
-            jsxAttributeValue(141, emptyComments),
-            emptyComments,
-            emptyComments,
-          ),
-          jsxPropertyAssignment(
-            'height',
-            jsxAttributeValue('65.5%', emptyComments),
-            emptyComments,
-            emptyComments,
-          ),
-        ],
+      style: jsxAttributeValue(
+        {
+          left: 0,
+          top: '0%',
+          width: 141,
+          height: '65.5%',
+        },
         emptyComments,
       ),
     })
@@ -89,33 +69,13 @@ describe('roundAttributeLayoutValues', () => {
     })
     const actualResult = roundAttributeLayoutValues(attributes)
     const expectedResult: JSXAttributes = jsxAttributesFromMap({
-      style: jsxAttributeNestedObject(
-        [
-          jsxPropertyAssignment(
-            'left',
-            jsxAttributeValue(0, emptyComments),
-            emptyComments,
-            emptyComments,
-          ),
-          jsxPropertyAssignment(
-            'top',
-            jsxAttributeValue('0%', emptyComments),
-            emptyComments,
-            emptyComments,
-          ),
-          jsxPropertyAssignment(
-            'width',
-            jsxAttributeValue(141, emptyComments),
-            emptyComments,
-            emptyComments,
-          ),
-          jsxPropertyAssignment(
-            'height',
-            jsxAttributeValue('65.5%', emptyComments),
-            emptyComments,
-            emptyComments,
-          ),
-        ],
+      style: jsxAttributeValue(
+        {
+          left: 0,
+          top: '0%',
+          width: 141,
+          height: '65.5%',
+        },
         emptyComments,
       ),
     })

--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -335,21 +335,11 @@ describe('setJSXValueAtPath', () => {
 
     expect(result.value).toEqual(
       jsxAttributesFromMap({
-        style: jsxAttributeNestedObject(
-          [
-            jsxPropertyAssignment(
-              'paddingLeft',
-              jsxAttributeValue(100, emptyComments),
-              emptyComments,
-              emptyComments,
-            ),
-            jsxPropertyAssignment(
-              'padding',
-              jsxAttributeValue(5, emptyComments),
-              emptyComments,
-              emptyComments,
-            ),
-          ],
+        style: jsxAttributeValue(
+          {
+            paddingLeft: 100,
+            padding: 5,
+          },
           emptyComments,
         ),
       }),
@@ -400,21 +390,11 @@ describe('setJSXValueAtPath', () => {
 
     expect(result.value).toEqual(
       jsxAttributesFromMap({
-        style: jsxAttributeNestedObject(
-          [
-            jsxPropertyAssignment(
-              'paddingLeft',
-              jsxAttributeValue(100, emptyComments),
-              emptyComments,
-              emptyComments,
-            ),
-            jsxPropertyAssignment(
-              'padding',
-              jsxAttributeValue(5, emptyComments),
-              emptyComments,
-              emptyComments,
-            ),
-          ],
+        style: jsxAttributeValue(
+          {
+            paddingLeft: 100,
+            padding: 5,
+          },
           emptyComments,
         ),
       }),
@@ -694,10 +674,7 @@ describe('unsetJSXValueAtPath', () => {
     const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 'left']))
     const expectedValue = right(
       jsxAttributesFromMap({
-        style: jsxAttributeNestedObjectSimple(
-          jsxAttributesFromMap({ top: jsxAttributeValue({ x: 1, y: 1 }, emptyComments) }),
-          emptyComments,
-        ),
+        style: jsxAttributeValue({ top: { x: 1, y: 1 } }, emptyComments),
         'data-uid': jsxAttributeValue('aaa', emptyComments),
       }),
     )
@@ -714,10 +691,7 @@ describe('unsetJSXValueAtPath', () => {
     const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 'left', 'x']))
     const expectedValue = right(
       jsxAttributesFromMap({
-        style: jsxAttributeNestedObjectSimple(
-          jsxAttributesFromMap({ top: jsxAttributeValue({ x: 1, y: 1 }, emptyComments) }),
-          emptyComments,
-        ),
+        style: jsxAttributeValue({ top: { x: 1, y: 1 } }, emptyComments),
         'data-uid': jsxAttributeValue('aaa', emptyComments),
       }),
     )
@@ -734,7 +708,7 @@ describe('unsetJSXValueAtPath', () => {
     const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 1]))
     const expectedValue = right(
       jsxAttributesFromMap({
-        style: jsxAttributeNestedArraySimple([jsxAttributeValue(0, emptyComments)]),
+        style: jsxAttributeValue([0], emptyComments),
         'data-uid': jsxAttributeValue('aaa', emptyComments),
       }),
     )
@@ -748,7 +722,7 @@ describe('unsetJSXValueAtPath', () => {
     const actualValue = unsetJSXValueAtPath(startingValue, PP.create(['style', 1]))
     const expectedValue = right(
       jsxAttributesFromMap({
-        style: jsxAttributeNestedArraySimple([jsxAttributeValue(0, emptyComments)]),
+        style: jsxAttributeValue([0], emptyComments),
         'data-uid': jsxAttributeValue('aaa', emptyComments),
       }),
     )
@@ -794,32 +768,26 @@ describe('unsetJSXValueAtPath', () => {
     )
     const expectedValue = right(
       jsxAttributesFromMap({
-        style: jsxAttributeNestedObjectSimple(
-          jsxAttributesFromMap({
-            left: jsxAttributeNestedArraySimple([
-              jsxAttributeValue('29', emptyComments),
-              jsxAttributeNestedObjectSimple(
-                jsxAttributesFromMap({
-                  stateEnabled: jsxAttributeNestedArraySimple([
-                    jsxAttributeValue(
-                      {
-                        lightSide: {
-                          ten: 10,
-                        },
-                        darkSide: {
-                          twelve: 12,
-                          nine: 9,
-                        },
-                      },
-                      emptyComments,
-                    ),
-                  ]),
-                }),
-                emptyComments,
-              ),
-            ]),
-            top: jsxAttributeValue({ x: 1, y: 1 }, emptyComments),
-          }),
+        style: jsxAttributeValue(
+          {
+            left: [
+              '29',
+              {
+                stateEnabled: [
+                  {
+                    lightSide: {
+                      ten: 10,
+                    },
+                    darkSide: {
+                      twelve: 12,
+                      nine: 9,
+                    },
+                  },
+                ],
+              },
+            ],
+            top: { x: 1, y: 1 },
+          },
           emptyComments,
         ),
         backgroundColor: jsxAttributeValue('red', emptyComments),

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -58,8 +58,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(705) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(715)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(270) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(280)
   })
 
   it('Changing the selected view', async () => {

--- a/editor/src/core/shared/element-template.tsx
+++ b/editor/src/core/shared/element-template.tsx
@@ -328,6 +328,12 @@ export function clearJSXAttributeOtherJavaScriptUniqueIDs(
   }
 }
 
+export function simplifyAttributesIfPossible(attributes: JSXAttributes): JSXAttributes {
+  return attributes.map(({ key, value, comments }) =>
+    jsxAttributesEntry(key, simplifyAttributeIfPossible(value), comments),
+  )
+}
+
 export function simplifyAttributeIfPossible(attribute: JSXAttribute): JSXAttribute {
   switch (attribute.type) {
     case 'ATTRIBUTE_VALUE':
@@ -628,16 +634,17 @@ export function setJSXAttributesAttribute(
   value: JSXAttribute,
 ): JSXAttributes {
   let updatedExistingField: boolean = false
+  const simplifiedValue = simplifyAttributeIfPossible(value)
   let result: JSXAttributes = attributes.map((attr) => {
     if (attr.key === key) {
       updatedExistingField = true
-      return jsxAttributesEntry(key, value, attr.comments)
+      return jsxAttributesEntry(key, simplifiedValue, attr.comments)
     } else {
       return attr
     }
   })
   if (!updatedExistingField) {
-    result.push(jsxAttributesEntry(key, value, emptyComments))
+    result.push(jsxAttributesEntry(key, simplifiedValue, emptyComments))
   }
   return result
 }

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -26,6 +26,7 @@ import {
   deleteJSXAttribute,
   setJSXAttributesAttribute,
   isJSXAttributeValue,
+  simplifyAttributesIfPossible,
 } from './element-template'
 import { resolveParamsAndRunJsCode } from './javascript-cache'
 import { PropertyPath } from './project-file-types'
@@ -612,7 +613,7 @@ export function setJSXValuesAtPaths(
   )
 }
 
-export function unsetValueAtPath(value: any, path: PropertyPath): Either<string, any> {
+function unsetValueAtPath(value: any, path: PropertyPath): Either<string, any> {
   switch (PP.depth(path)) {
     case 0:
       // As this is invalid throw an exception.
@@ -658,16 +659,19 @@ export function unsetJSXValuesAtPaths(
   attributes: JSXAttributes,
   paths: Array<PropertyPath>,
 ): Either<string, JSXAttributes> {
-  return reduceWithEither(
-    (working, path) => {
-      return unsetJSXValueAtPath(working, path)
-    },
-    attributes,
-    paths,
+  return mapEither(
+    simplifyAttributesIfPossible,
+    reduceWithEither(
+      (working, path) => {
+        return unsetJSXValueAtPath(working, path)
+      },
+      attributes,
+      paths,
+    ),
   )
 }
 
-export function unsetJSXValueInAttributeAtPath(
+function unsetJSXValueInAttributeAtPath(
   attribute: JSXAttribute,
   path: PropertyPath,
 ): Either<string, JSXAttribute> {
@@ -784,7 +788,7 @@ export function unsetJSXValueAtPath(
   }
 }
 
-export function walkAttribute(
+function walkAttribute(
   attribute: JSXAttribute,
   path: PropertyPath | null,
   walk: (a: JSXAttribute, path: PropertyPath | null) => void,
@@ -833,7 +837,7 @@ export function walkAttribute(
   }
 }
 
-export function walkAttributes(
+function walkAttributes(
   attributes: JSXAttributes,
   walk: (attribute: JSXAttribute, path: PropertyPath | null) => void,
 ): void {


### PR DESCRIPTION
**Problem:**
We're blowing memoisation in a lot of places because non-changes to the model will result in a simple `JsxAttributeValue` being replaced with a more complex `JSXAttributeNestedObject`. This was because the simplification was only applied during parsing the initial code, and never applied after making changes to the model.

**Fix:**
Ensure we always simplify the model after making changes. This happens in 2 places:

1. In `element-template.tsx` as part of `setJSXAttributesAttribute` (which updates the list of attributes with a new value)
2. In `jsx-attributes.ts` when unsetting values