### PR TITLE
Introduce use-optimized-selector

### DIFF
--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -27508,6 +27508,11 @@
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.1.tgz",
       "integrity": "sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ=="
     },
+    "use-optimized-selector": {
+      "version": "1.0.0-beta3",
+      "resolved": "https://registry.npmjs.org/use-optimized-selector/-/use-optimized-selector-1.0.0-beta3.tgz",
+      "integrity": "sha512-cPkq04eHjRdVrSSKUrqz2JuZ6j9YED2JMe3VrrlF5fBfvCITnr2j6P1zDXNbA3ANHfPXECbLzjvrwOCjt0L06g=="
+    },
     "util": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",

--- a/editor/package.json
+++ b/editor/package.json
@@ -184,6 +184,7 @@
     "typescript": "4.0.5",
     "url-join": "4.0.1",
     "use-context-selector": "git://github.com/dai-shi/use-context-selector.git#3f1df8f",
+    "use-optimized-selector": "1.0.0-beta3",
     "utopia-api": "file:../utopia-api",
     "utopia-vscode-common": "file:../utopia-vscode-common",
     "uuid": "3.0.1",

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
@@ -1,15 +1,17 @@
 import * as React from 'react'
 import * as fastDeepEquals from 'fast-deep-equal'
-import { useContextSelector } from 'use-context-selector'
+import { useContextSelector } from '../../../utils/react-performance'
 import { Scene, SceneProps } from 'utopia-api'
 import { colorTheme, UtopiaStyles } from '../../../uuiui'
 import { betterReactMemo } from '../../../uuiui-deps'
-import { RerenderUtopiaContext } from './ui-jsx-canvas-contexts'
+import { RerenderUtopiaContext, RerenderUtopiaContextProps } from './ui-jsx-canvas-contexts'
+
+const selectCanvasIsLive = (c: RerenderUtopiaContextProps) => c.canvasIsLive
 
 export const SceneComponent = betterReactMemo(
   'Scene',
   (props: React.PropsWithChildren<SceneProps>) => {
-    const canvasIsLive = useContextSelector(RerenderUtopiaContext, (c) => c.canvasIsLive)
+    const canvasIsLive = useContextSelector(RerenderUtopiaContext, selectCanvasIsLive)
 
     const { style, ...remainingProps } = props
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -13,6 +13,7 @@ import { UiJsxCanvasContext, UiJsxCanvasContextData } from '../ui-jsx-canvas'
 import {
   MutableUtopiaContextProps,
   RerenderUtopiaContext,
+  RerenderUtopiaContextProps,
   SceneLevelUtopiaContext,
 } from './ui-jsx-canvas-contexts'
 import { applyPropsParamToPassedProps } from './ui-jsx-canvas-props-utils'
@@ -23,7 +24,7 @@ import {
   renderCoreElement,
   utopiaCanvasJSXLookup,
 } from './ui-jsx-canvas-element-renderer-utils'
-import { useContextSelector } from 'use-context-selector'
+import { useContextSelector } from '../../../utils/react-performance'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { UTOPIA_INSTANCE_PATH, UTOPIA_PATHS_KEY } from '../../../core/model/utopia-constants'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/workers/parser-printer/parser-printer-utils'
@@ -63,6 +64,11 @@ function tryToGetInstancePath(
   }
 }
 
+const selectShouldIncludeCanvasRootInTheSpy = (c: RerenderUtopiaContextProps) =>
+  c.shouldIncludeCanvasRootInTheSpy
+
+const selectHiddenInstances = (c: RerenderUtopiaContextProps) => c.hiddenInstances
+
 export function createComponentRendererComponent(params: {
   topLevelElementName: string
   filePath: string
@@ -92,9 +98,9 @@ export function createComponentRendererComponent(params: {
 
     const shouldIncludeCanvasRootInTheSpy = useContextSelector(
       RerenderUtopiaContext,
-      (c) => c.shouldIncludeCanvasRootInTheSpy,
+      selectShouldIncludeCanvasRootInTheSpy,
     )
-    const hiddenInstances = useContextSelector(RerenderUtopiaContext, (c) => c.hiddenInstances)
+    const hiddenInstances = useContextSelector(RerenderUtopiaContext, selectHiddenInstances)
     const sceneContext = React.useContext(SceneLevelUtopiaContext)
 
     let metadataContext: UiJsxCanvasContextData = React.useContext(UiJsxCanvasContext)

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
@@ -29,7 +29,7 @@ export function updateMutableUtopiaContextWithNewProps(
   ref.current = newProps
 }
 
-interface RerenderUtopiaContextProps {
+export interface RerenderUtopiaContextProps {
   hiddenInstances: Array<ElementPath>
   canvasIsLive: boolean
   shouldIncludeCanvasRootInTheSpy: boolean
@@ -42,7 +42,7 @@ export const RerenderUtopiaContext = createContext<RerenderUtopiaContextProps>({
 })
 RerenderUtopiaContext.displayName = 'RerenderUtopiaContext'
 
-interface UtopiaProjectContextProps {
+export interface UtopiaProjectContextProps {
   projectContents: ProjectContentTreeRoot
   openStoryboardFilePathKILLME: string | null
   transientFilesState: TransientFilesState | null

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-top-level-elements.ts
@@ -1,9 +1,11 @@
-import { useContextSelector } from 'use-context-selector'
 import { ArbitraryJSBlock, TopLevelElement } from '../../../core/shared/element-template'
 import { Imports, isParseSuccess, isTextFile } from '../../../core/shared/project-file-types'
+import { useContextSelector } from '../../../utils/react-performance'
 import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../../assets'
 import { TransientFilesState, TransientFileState } from '../../editor/store/editor-state'
 import { UtopiaProjectContext } from './ui-jsx-canvas-contexts'
+import { useMemo } from 'react'
+import * as deepEqual from 'fast-deep-equal'
 
 interface GetParseSuccessOrTransientResult {
   topLevelElements: TopLevelElement[]
@@ -50,15 +52,22 @@ export function getParseSuccessOrTransientForFilePath(
 }
 
 export function useGetTopLevelElements(filePath: string | null): TopLevelElement[] {
-  return useContextSelector(UtopiaProjectContext, (c) => {
-    if (filePath == null) {
-      return EmptyResult.topLevelElements
-    } else {
-      return getParseSuccessOrTransientForFilePath(
-        filePath,
-        c.projectContents,
-        c.transientFilesState,
-      ).topLevelElements
-    }
-  })
+  return useContextSelector(
+    UtopiaProjectContext,
+    useMemo(
+      () => (c) => {
+        if (filePath == null) {
+          return EmptyResult.topLevelElements
+        } else {
+          return getParseSuccessOrTransientForFilePath(
+            filePath,
+            c.projectContents,
+            c.transientFilesState,
+          ).topLevelElements
+        }
+      },
+      [filePath],
+    ),
+    deepEqual,
+  )
 }

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -1,12 +1,14 @@
 import * as deepEqual from 'fast-deep-equal'
-import { useContextSelector } from 'use-context-selector'
 import { flatMapArray, last, mapArrayToDictionary } from '../../../core/shared/array-utils'
 import { jsxAttributeValue } from '../../../core/shared/element-template'
 import { objectMap } from '../../../core/shared/object-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { arrayEquals, NO_OP } from '../../../core/shared/utils'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
-import { useKeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
+import {
+  useContextSelector,
+  useKeepReferenceEqualityIfPossible,
+} from '../../../utils/react-performance'
 import {
   getControlStatusFromPropertyStatus,
   getControlStyles,
@@ -25,6 +27,7 @@ import {
   InspectorPropsContext,
   ParsedValues,
   PathMappingFn,
+  selectTargetPath,
   useGetOrderedPropertyKeys,
   useInspectorContext,
   useInspectorInfo,
@@ -114,7 +117,7 @@ export function useInspectorInfoLonghandShorthand<
     'useInspectorInfoLonghandShorthand dispatch',
   )
   const inspectorTargetPath = useKeepReferenceEqualityIfPossible(
-    useContextSelector(InspectorPropsContext, (contextData) => contextData.targetPath, deepEqual),
+    useContextSelector(InspectorPropsContext, selectTargetPath, deepEqual),
   )
   const { selectedViewsRef } = useInspectorContext()
 

--- a/editor/src/components/inspector/common/property-controls-hooks.ts
+++ b/editor/src/components/inspector/common/property-controls-hooks.ts
@@ -1,7 +1,6 @@
 import * as deepEqual from 'fast-deep-equal'
 import * as ObjectPath from 'object-path'
 import * as React from 'react'
-import { useContextSelector } from 'use-context-selector'
 import { PropertyPath } from '../../../core/shared/project-file-types'
 import {
   printerForPropertyControl,
@@ -17,6 +16,7 @@ import {
 import {
   InspectorInfo,
   InspectorPropsContext,
+  InspectorPropsContextData,
   useCallbackFactory,
   useInspectorContext,
 } from './property-path-hooks'
@@ -32,7 +32,10 @@ import {
   getControlStatusFromPropertyStatus,
   getControlStyles,
 } from './control-status'
-import { useKeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
+import {
+  useContextSelector,
+  useKeepReferenceEqualityIfPossible,
+} from '../../../utils/react-performance'
 
 type RawValues = Either<string, ModifiableAttribute>[]
 type RealValues = unknown[]
@@ -44,11 +47,14 @@ export function useInspectorInfoForPropertyControl(
   const rawValues: RawValues = useKeepReferenceEqualityIfPossible(
     useContextSelector(
       InspectorPropsContext,
-      (contextData) => {
-        return contextData.editedMultiSelectedProps.map((props) => {
-          return getModifiableJSXAttributeAtPath(props, propertyPath)
-        })
-      },
+      React.useMemo(
+        () => (contextData) => {
+          return contextData.editedMultiSelectedProps.map((props) => {
+            return getModifiableJSXAttributeAtPath(props, propertyPath)
+          })
+        },
+        [propertyPath],
+      ),
       deepEqual,
     ),
   )
@@ -56,11 +62,14 @@ export function useInspectorInfoForPropertyControl(
   const realValues: RealValues = useKeepReferenceEqualityIfPossible(
     useContextSelector(
       InspectorPropsContext,
-      (contextData) => {
-        return contextData.spiedProps.map((props) => {
-          return ObjectPath.get(props, PP.getElements(propertyPath))
-        })
-      },
+      React.useMemo(
+        () => (contextData) => {
+          return contextData.spiedProps.map((props) => {
+            return ObjectPath.get(props, PP.getElements(propertyPath))
+          })
+        },
+        [propertyPath],
+      ),
       deepEqual,
     ),
   )
@@ -120,10 +129,13 @@ function useFirstRawValue(propertyPath: PropertyPath): Either<string, Modifiable
   return useKeepReferenceEqualityIfPossible(
     useContextSelector(
       InspectorPropsContext,
-      (contextData) => {
-        const firstElemProps = contextData.editedMultiSelectedProps[0] ?? {}
-        return getModifiableJSXAttributeAtPath(firstElemProps, propertyPath)
-      },
+      React.useMemo(
+        () => (contextData) => {
+          const firstElemProps = contextData.editedMultiSelectedProps[0] ?? {}
+          return getModifiableJSXAttributeAtPath(firstElemProps, propertyPath)
+        },
+        [propertyPath],
+      ),
       deepEqual,
     ),
   )
@@ -133,10 +145,13 @@ function useFirstRealValue(propertyPath: PropertyPath): unknown {
   return useKeepReferenceEqualityIfPossible(
     useContextSelector(
       InspectorPropsContext,
-      (contextData) => {
-        const firstElemProps = contextData.spiedProps[0] ?? {}
-        return ObjectPath.get(firstElemProps, PP.getElements(propertyPath))
-      },
+      React.useMemo(
+        () => (contextData) => {
+          const firstElemProps = contextData.spiedProps[0] ?? {}
+          return ObjectPath.get(firstElemProps, PP.getElements(propertyPath))
+        },
+        [propertyPath],
+      ),
       deepEqual,
     ),
   )

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -58,8 +58,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(270) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(280)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(705) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(715)
   })
 
   it('Changing the selected view', async () => {

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -58,8 +58,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(705) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(715)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(270) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(280)
   })
 
   it('Changing the selected view', async () => {

--- a/editor/src/missing-types/index.d.ts
+++ b/editor/src/missing-types/index.d.ts
@@ -51,26 +51,6 @@ declare module 'eslint4b'
 declare module 'babel-eslint'
 declare module 'strip-ansi'
 
-declare module 'use-context-selector' {
-  import * as React from 'react'
-
-  const CONTEXT_LISTENERS = Symbol('C_L')
-
-  type ContextWithListeners<T> = React.Context<T> & {
-    [CONTEXT_LISTENERS]: Set<(nextValue: T) => void>
-  }
-
-  export const createContext: <T>(defaultValue: T) => ContextWithListeners<T>
-
-  export const useContextSelector: <T, S>(
-    context: ContextWithListeners<T>,
-    selector: (value: T) => S,
-    equalityCheck: (a: S, b: S) => boolean = Object.is,
-  ) => S
-
-  export const useContext: <T>(context: ContextWithListeners<T>) => T
-}
-
 declare module 'console-feed'
 declare module 'console-feed/lib/Hook/parse'
 

--- a/editor/src/utils/react-performance.ts
+++ b/editor/src/utils/react-performance.ts
@@ -3,6 +3,8 @@ import * as fastDeepEqual from 'fast-deep-equal'
 import { PRODUCTION_ENV } from '../common/env-vars'
 import { KeepDeepEqualityCall, keepDeepEqualityResult } from './deep-equality'
 import { shallowEqual } from '../core/shared/equality-utils'
+import { useContextSelector as useContextSelectorDaiShi } from 'use-context-selector'
+import { useOptimizedSelector } from 'use-optimized-selector'
 
 export function useHookUpdateAnalysisStrictEquals<P>(name: string, newValue: P) {
   const previousValue = React.useRef(newValue)
@@ -474,4 +476,13 @@ export function useKeepDeepEqualityCall<T>(newValue: T, keepDeepCall: KeepDeepEq
   const oldValue = React.useRef<T>(newValue)
   oldValue.current = keepDeepCall(oldValue.current, newValue).value
   return oldValue.current
+}
+
+export function useContextSelector<T, S>(
+  context: React.Context<T>,
+  selector: (value: T) => S,
+  isEqual: (l: S, r: S) => boolean = Object.is,
+): S {
+  const optimizedSelector = useOptimizedSelector(selector, isEqual)
+  return useContextSelectorDaiShi(context, optimizedSelector)
 }


### PR DESCRIPTION
Part way to a solution to #1186 

**Problem:**
We're still stuck on an old build of [`use-context-selector`](https://github.com/dai-shi/use-context-selector) as we're relying on a patch of that for adding an equality check param.

**Fix:**
Introduce [`use-optimized-selector`](https://github.com/johnrom/use-optimized-selector) for applying a layer of caching around selectors used by the above, as discussed in [this comment thread](https://github.com/dai-shi/use-context-selector/issues/19#issuecomment-798984730). I'm opening this PR primarily to see how the performance tests run with this, since it completely removes the passing of that equality function to the patched build of `use-context-selector`.

I have also tested this out with the latest version of `use-context-selector` (1.3.7), which pushes the render count tests up again, so there is still further work to be done to allow us to move onto the latest version of that.

**Commit Details:**
- Added a new function `useContextSelector` to `react-performance.ts`, which combines the above two libraries
- Point all uses of `use-context-selector` to the above function
- Ensure each selector function is either a constant or is memoised (as [is required](https://github.com/johnrom/use-optimized-selector#getting-started))

Annoyingly, the `react-hooks/exhaustive-deps` eslint rule was tripped in a few cases by generic type symbols (e.g. in `useGetMultiselectedProps` the rule complains that `P` is not included in the list of dependencies, which is nonsense!), so I've had to disable those on a few lines. I'll check to see if there is an update for that rule to fix the issue.