### PR TITLE
Add Auth0 Client ID to PR deploy job

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -61,6 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       UTOPIA_SHA: ${{ github.sha }}
+      AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
+      AUTH0_ENDPOINT: enter.utopia.app
+      AUTH0_REDIRECT_URI: https://utopia.pizza/authenticate
     steps:
       # Gets the branch that this PR is targeting and replaces forward slashes in the name with hyphens.
       # So that later steps can produce a bundle incorporating that into the name and upload it.


### PR DESCRIPTION
**Problem:**
The sign in button for branch deploys is broken

**Fix:**
pass in the staging auth0 client ID for branch deploys
