### PR TITLE
do not show two black bars when the editor is offline

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -19,7 +19,7 @@ import { EditorDispatch, LoginState } from './action-types'
 import * as EditorActions from './actions/action-creators'
 import { handleKeyDown, handleKeyUp } from './global-shortcuts'
 import { StateHistory } from './history'
-import { LoginStatusBar, EditorOfflineBar, BrowserInfoBar } from './notification-bar'
+import { LoginStatusBar, BrowserInfoBar } from './notification-bar'
 import {
   ConsoleLog,
   getOpenFile,
@@ -180,11 +180,6 @@ export const EditorComponentInner = betterReactMemo(
 
     const delayedLeftMenuExpanded = useDelayedValueHook(leftMenuExpanded, 200)
 
-    const saveError = useEditorState(
-      (store) => store.editor.saveError,
-      'EditorComponentInner saveError',
-    )
-
     React.useEffect(() => {
       document.title = projectName + ' - Utopia'
     }, [projectName])
@@ -245,7 +240,6 @@ export const EditorComponentInner = betterReactMemo(
         >
           {isChrome ? null : <BrowserInfoBar />}
           <LoginStatusBar />
-          {saveError ? <EditorOfflineBar /> : null}
 
           <SimpleFlexRow
             className='editor-main-horizontal'

--- a/editor/src/components/editor/notification-bar.tsx
+++ b/editor/src/components/editor/notification-bar.tsx
@@ -14,7 +14,7 @@ export const BrowserInfoBar = betterReactMemo('EditorOfflineBar', () => {
   )
 })
 
-export const EditorOfflineBar = betterReactMemo('EditorOfflineBar', () => {
+const EditorOfflineBar = betterReactMemo('EditorOfflineBar', () => {
   return (
     <NotificationBar
       level='ERROR'
@@ -25,14 +25,24 @@ export const EditorOfflineBar = betterReactMemo('EditorOfflineBar', () => {
 
 export const LoginStatusBar = betterReactMemo('LoginStatusBar', () => {
   const loginState = useEditorState((store) => store.userState.loginState, 'LoginStatusBar')
+  const saveError = useEditorState(
+    (store) => store.editor.saveError,
+    'EditorComponentInner saveError',
+  )
 
   const onClickLoginNewTab = React.useCallback(() => {
     window.open(auth0Url('auto-close'), '_blank')
   }, [])
 
+  if (saveError) {
+    return <EditorOfflineBar />
+  }
+
   switch (loginState.type) {
     case 'LOGGED_IN':
       return null
+    case 'OFFLINE_STATE':
+      return <EditorOfflineBar />
     case 'NOT_LOGGED_IN':
       return (
         <NotificationBar

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -348,6 +348,7 @@ export async function getUserConfiguration(loginState: LoginState): Promise<User
       }
     case 'NOT_LOGGED_IN':
     case 'LOGIN_LOST':
+    case 'OFFLINE_STATE':
       return emptyUserConfiguration()
     default:
       const _exhaustiveCheck: never = loginState

--- a/website/src/common/server.ts
+++ b/website/src/common/server.ts
@@ -1,6 +1,14 @@
 import { UTOPIA_BACKEND, THUMBNAIL_ENDPOINT, ASSET_ENDPOINT, BASE_URL } from './env-vars'
 import { ProjectListing } from './persistence'
-import { isLoggedIn, isLoginLost, isNotLoggedIn, loginLost, LoginState, notLoggedIn } from './user'
+import {
+  isLoggedIn,
+  isLoginLost,
+  isNotLoggedIn,
+  loginLost,
+  LoginState,
+  notLoggedIn,
+  offlineState,
+} from './user'
 // Stupid style of import because the website and editor are different
 // and so there's no style of import which works with both projects.
 const urljoin = require('url-join')
@@ -93,7 +101,7 @@ async function createGetLoginStatePromise(
     }
   } catch (e) {
     console.error(`Fetch user details failed: ${e}`)
-    return loginLost
+    return offlineState
   }
 }
 

--- a/website/src/common/user.ts
+++ b/website/src/common/user.ts
@@ -18,7 +18,11 @@ interface LoginLost {
   type: 'LOGIN_LOST'
 }
 
-export type LoginState = LoggedInUser | NotLoggedIn | LoginLost
+interface OfflineState {
+  type: 'OFFLINE_STATE'
+}
+
+export type LoginState = LoggedInUser | NotLoggedIn | LoginLost | OfflineState
 
 export function loggedInUser(user: UserDetails): LoggedInUser {
   return {
@@ -45,4 +49,10 @@ export const loginLost: LoginLost = {
 
 export function isLoginLost(loginState: unknown): loginState is LoginLost {
   return (loginState as Partial<LoginState>)?.type === 'LOGIN_LOST'
+}
+
+export const offlineState: OfflineState = { type: 'OFFLINE_STATE' }
+
+export function isOfflineState(loginState: unknown): loginState is OfflineState {
+  return (loginState as Partial<LoginState>)?.type === 'OFFLINE_STATE'
 }


### PR DESCRIPTION
Fixes #1196

**Problem:**
After my previous PR #1198 we still had an issue: if the editor was offline, it would both say that it was offline and also that it was logged out. 

**Fix:**
I unified the handling of the two error messages, and if the login polling cannot reach the server, it switches to offline state instead of logged out state.

**Commit Details:**
- Moved `EditorOfflineBar` to `LoginStatusBar` so we don't show two of them at the same time
- if the `getLoginState` fetch fails, we assume the editor is offline instead of the user being logged out