### PR TITLE
Update performance test messages to use mean, min and max

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -137,5 +137,5 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Staging deploy success. Link to test editor: https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }}
+            Staging deploy success. [Link to test editor](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})
             Performance: ${{ steps.run-performance-test.outputs.perf-result }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -137,5 +137,5 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Staging deploy success. [Link to test editor](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})
-            Performance: ${{ steps.run-performance-test.outputs.perf-result }}
+            [Link to test editor](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})
+            ${{ steps.run-performance-test.outputs.perf-result }}

--- a/editor/src/core/model/performance-scripts.ts
+++ b/editor/src/core/model/performance-scripts.ts
@@ -75,7 +75,7 @@ export function useTriggerResizePerformanceTest(): () => void {
       performance.mark(`resize_step_${framesPassed}`)
       const dragState = resizeDragState(
         targetStartPoint,
-        { x: framesPassed, y: framesPassed } as CanvasVector,
+        { x: framesPassed % 100, y: framesPassed % 100 } as CanvasVector,
         true,
         false,
         false,

--- a/editor/src/core/model/performance-scripts.ts
+++ b/editor/src/core/model/performance-scripts.ts
@@ -75,7 +75,7 @@ export function useTriggerResizePerformanceTest(): () => void {
       performance.mark(`resize_step_${framesPassed}`)
       const dragState = resizeDragState(
         targetStartPoint,
-        { x: framesPassed / 10, y: framesPassed / 10 } as CanvasVector,
+        { x: framesPassed, y: framesPassed } as CanvasVector,
         true,
         false,
         false,

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -81,7 +81,7 @@ export const setupBrowser = async (): Promise<{
   const browser = await puppeteer.launch({
     args: ['--no-sandbox', '--enable-thread-instruction-count'],
     headless: yn(process.env.HEADLESS),
-    executablePath: process.env.BROWSER
+    executablePath: process.env.BROWSER,
   })
   const page = await browser.newPage()
   await page.setViewport({ width: 1500, height: 768 })
@@ -115,7 +115,7 @@ export const testPerformance = async function () {
   const summaryImage = await uploadSummaryImage([selectionResult, scrollResult, resizeResult])
 
   console.info(
-    `::set-output name=perf-result:: ${scrollResult.title}:  ${scrollResult.analytics.frameMin}ms | ${resizeResult.title}: ${resizeResult.analytics.frameMin}ms | ${selectionResult.title}: ${selectionResult.analytics.frameMin}ms ![SummaryChart](${summaryImage})`,
+    `::set-output name=perf-result:: ${scrollResult.title}:  ${scrollResult.analytics.percentile50}ms | ${resizeResult.title}: ${resizeResult.analytics.percentile50}ms | ${selectionResult.title}: ${selectionResult.analytics.percentile50}ms ![SummaryChart](${summaryImage})`,
   )
 }
 

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -103,8 +103,7 @@ const ResizeButtonExpression = "//a[contains(., 'P R')]"
 
 async function initialiseProject(page: puppeteer.Page): Promise<void> {
   console.log('Initialising the project')
-  await page.waitForXPath('[class^="monaco-editor"]')
-  await page.waitForXPath('[class^="item-label-container"]')
+  await page.waitForXPath('//div[contains(@class, "item-label-container")]')
 
   // Select something a resize it to trigger a fork
   const navigatorElement = await page.$('[class^="item-label-container"]')
@@ -120,8 +119,6 @@ async function initialiseProject(page: puppeteer.Page): Promise<void> {
   // This change should have triggered a fork, so pause again
   await page.waitForTimeout(15000)
 
-  // Ensure VS Code is ready
-  await page.waitForXPath('[class^="monaco-editor"]')
   console.log('Finished initialising')
 }
 

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -99,7 +99,7 @@ export const setupBrowser = async (): Promise<{
 }
 
 function consoleMessageForResult(result: FrameResult): string {
-  return `*${result.title}*: ${result.analytics.percentile50}ms (${result.analytics.frameMin}-${result.analytics.frameMax}ms)`
+  return `${result.title}: **${result.analytics.percentile50}**ms (${result.analytics.frameMin}-${result.analytics.frameMax}ms)`
 }
 
 export const testPerformance = async function () {
@@ -125,7 +125,7 @@ export const testPerformance = async function () {
       scrollResult,
     )} | ${consoleMessageForResult(resizeResult)} | ${consoleMessageForResult(
       selectionResult,
-    )} ![](${summaryImage})`,
+    )} ![chart](${summaryImage})`,
   )
 }
 

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -99,7 +99,7 @@ export const setupBrowser = async (): Promise<{
 }
 
 function consoleMessageForResult(result: FrameResult): string {
-  return `${result.title}: **${result.analytics.percentile50}**ms (${result.analytics.frameMin}-${result.analytics.frameMax}ms)`
+  return `${result.title}: ${result.analytics.percentile50}ms (${result.analytics.frameMin}-${result.analytics.frameMax}ms)`
 }
 
 export const testPerformance = async function () {
@@ -125,7 +125,7 @@ export const testPerformance = async function () {
       scrollResult,
     )} | ${consoleMessageForResult(resizeResult)} | ${consoleMessageForResult(
       selectionResult,
-    )} ![chart](${summaryImage})`,
+    )} ![(Chart)](${summaryImage})`,
   )
 }
 

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -103,7 +103,8 @@ const ResizeButtonExpression = "//a[contains(., 'P R')]"
 
 async function initialiseProject(page: puppeteer.Page): Promise<void> {
   console.log('Initialising the project')
-  await page.$('[class^="monaco-editor"]')
+  await page.waitForXPath('[class^="monaco-editor"]')
+  await page.waitForXPath('[class^="item-label-container"]')
 
   // Select something a resize it to trigger a fork
   const navigatorElement = await page.$('[class^="item-label-container"]')
@@ -120,7 +121,7 @@ async function initialiseProject(page: puppeteer.Page): Promise<void> {
   await page.waitForTimeout(15000)
 
   // Ensure VS Code is ready
-  await page.$('[class^="monaco-editor"]')
+  await page.waitForXPath('[class^="monaco-editor"]')
   console.log('Finished initialising')
 }
 

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -219,8 +219,8 @@ const getFrameData = (traceJson: any, markNamePrefix: string, title: string): Fr
   const sortedFrameTimes = frameTimesFixed.sort((a, b) => a - b)
 
   const analytics = {
-    frameMin: sortedFrameTimes[0],
-    frameMax: sortedFrameTimes[sortedFrameTimes.length - 1],
+    frameMin: sortedFrameTimes[0]!,
+    frameMax: sortedFrameTimes[sortedFrameTimes.length - 1]!,
     frameAvg: Number((totalFrameTimes / sortedFrameTimes.length).toFixed()),
     percentile25: sortedFrameTimes[Math.floor(sortedFrameTimes.length * 0.25)],
     percentile50: sortedFrameTimes[Math.floor(sortedFrameTimes.length * 0.5)],

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -155,16 +155,20 @@ export const testScrollingPerformance = async function (
 export const testResizePerformance = async function (page: puppeteer.Page): Promise<FrameResult> {
   console.log('Test Resize Performance')
   await page.waitForXPath("//a[contains(., 'P R')]")
-  // we run it twice without measurements to warm up the environment
-  const [button] = await page.$x("//a[contains(., 'P R')]")
-  await button!.click()
 
   // select element using the navigator
   const navigatorElement = await page.$('[class^="item-label-container"]')
   await navigatorElement!.click()
+
+  // we run it twice without measurements to warm up the environment
+  const [button] = await page.$x("//a[contains(., 'P R')]")
+  await button!.click()
+  await consoleDoneMessage(page, 'RESIZE_TEST_FINISHED', 'RESIZE_TEST_MISSING_SELECTEDVIEW')
+
   const [button2] = await page.$x("//a[contains(., 'P R')]")
   await button2!.click()
   await consoleDoneMessage(page, 'RESIZE_TEST_FINISHED', 'RESIZE_TEST_MISSING_SELECTEDVIEW')
+
   // and then we run the test for a third time, this time running tracing
   await page.tracing.start({ path: 'trace.json' })
   const [button3] = await page.$x("//a[contains(., 'P R')]")


### PR DESCRIPTION
**Problem:**
Currently our performance tests were using the min value for the summarised message.

**Fix:**
Update the message to default to the median value, but also include the min and max values (min for historical reasons, max for identifying extreme outliers). I've also slightly tidied the message format.

To tackle the previously extreme outliers we were seeing, I've also done the following:

1. Added an initialise project step, which will make a change in order to trigger an initial (local) fork of the project. This would have previously been happening during the resize test, so by doing this upfront we prevent it from affecting those results
2. Updated each of the tests so that they _actually_ run twice before recording (previously they each had a comment stating that they were doing this, but weren't)
3. Removed the `page.reload()` call made between tests, as that would undo any benefit from the initialise project step added. I'm not sure if there was a specific requirement for this that I've missed though, so if we do need to reload after each test we should again be performing the initialisation step each time too
4. Removed a `/ 10` in the resize check and replaced with `% 100`, since that was previously masking a recent performance regression