### PR TITLE
Fix/filebrowser droptarget

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -809,6 +809,11 @@ export interface SetLoginState {
   loginState: LoginState
 }
 
+export interface SetFilebrowserDropTarget {
+  action: 'SET_FILEBROWSER_DROPTARGET'
+  target: string | null
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -942,6 +947,7 @@ export type EditorAction =
   | SetFollowSelectionEnabled
   | UpdateConfigFromVSCode
   | SetLoginState
+  | SetFilebrowserDropTarget
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -183,6 +183,7 @@ import type {
   UpdateConfigFromVSCode,
   SetFollowSelectionEnabled,
   SetLoginState,
+  SetFilebrowserDropTarget,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -1283,5 +1284,12 @@ export function setLoginState(loginState: LoginState): SetLoginState {
   return {
     action: 'SET_LOGIN_STATE',
     loginState: loginState,
+  }
+}
+
+export function setFilebrowserDropTarget(target: string | null): SetFilebrowserDropTarget {
+  return {
+    action: 'SET_FILEBROWSER_DROPTARGET',
+    target: target,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -88,6 +88,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_FOLLOW_SELECTION_ENABLED':
     case 'UPDATE_CONFIG_FROM_VSCODE':
     case 'SET_LOGIN_STATE':
+    case 'SET_FILEBROWSER_DROPTARGET':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -355,6 +355,7 @@ import {
   SetFollowSelectionEnabled,
   UpdateConfigFromVSCode,
   SetLoginState,
+  SetFilebrowserDropTarget,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -918,6 +919,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     },
     fileBrowser: {
       minimised: currentEditor.fileBrowser.minimised,
+      dropTarget: null,
       renamingTarget: currentEditor.fileBrowser.renamingTarget,
     },
     dependencyList: {
@@ -4095,6 +4097,18 @@ export const UPDATE_FNS = {
     return {
       ...userState,
       loginState: action.loginState,
+    }
+  },
+  SET_FILEBROWSER_DROPTARGET: (
+    action: SetFilebrowserDropTarget,
+    editor: EditorModel,
+  ): EditorModel => {
+    return {
+      ...editor,
+      fileBrowser: {
+        ...editor.fileBrowser,
+        dropTarget: action.target,
+      },
     }
   },
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -295,6 +295,7 @@ export interface EditorState {
   fileBrowser: {
     minimised: boolean
     renamingTarget: string | null
+    dropTarget: string | null
   }
   dependencyList: {
     minimised: boolean
@@ -1136,6 +1137,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     },
     fileBrowser: {
       minimised: false,
+      dropTarget: null,
       renamingTarget: null,
     },
     navigator: {
@@ -1397,6 +1399,7 @@ export function editorModelFromPersistentModel(
     },
     fileBrowser: {
       renamingTarget: null,
+      dropTarget: null,
       minimised: persistentModel.fileBrowser.minimised,
     },
     codeEditorErrors: persistentModel.codeEditorErrors,

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -289,6 +289,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_CONFIG_FROM_VSCODE(action, state)
     case 'SET_FOLLOW_SELECTION_ENABLED':
       return UPDATE_FNS.SET_FOLLOW_SELECTION_ENABLED(action, state)
+    case 'SET_FILEBROWSER_DROPTARGET':
+      return UPDATE_FNS.SET_FILEBROWSER_DROPTARGET(action, state)
     default:
       return state
   }

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -178,6 +178,7 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
     codeResultCache,
     propertyControlsInfo,
     renamingTarget,
+    dropTarget,
     openUiFileName,
   } = useEditorState((store) => {
     const uiFile = getOpenUIJSFile(store.editor)
@@ -190,6 +191,7 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
       codeResultCache: store.editor.codeResultCache,
       propertyControlsInfo: store.editor.propertyControlsInfo,
       renamingTarget: store.editor.fileBrowser.renamingTarget,
+      dropTarget: store.editor.fileBrowser.dropTarget,
       openUiFileName: getOpenUIJSFileKey(store.editor),
     }
   }, 'FileBrowserItems')
@@ -307,6 +309,7 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
             setSelected={setSelected}
             collapsed={element.type === 'file' && collapsedPaths.indexOf(element.path) > -1}
             hasErrorMessages={fileHasErrorMessages(element.path, errorMessages)}
+            dropTarget={dropTarget}
           />
         </div>
       ))}

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -38,7 +38,7 @@ import {
   Button,
 } from '../../uuiui'
 import { notice } from '../common/notice'
-import { getNearestAncestorDirectory } from '../../utils/path-utils'
+import { getParentDirectory } from '../../utils/path-utils'
 
 export interface FileBrowserItemProps extends FileBrowserItemInfo {
   isSelected: boolean
@@ -770,10 +770,8 @@ export function FileBrowserItem(props: FileBrowserItemProps) {
     canDrop: () => true,
     drop: () => props,
     hover: (item: FilebrowserDragItem) => {
-      const targetDirectory = getNearestAncestorDirectory(
-        props.path,
-        props.fileType === 'DIRECTORY',
-      )
+      const targetDirectory =
+        props.fileType === 'DIRECTORY' ? props.path : getParentDirectory(props.path)
       // do not trigger highlight when it tries to move to it's descendant directories
       if (targetDirectory.includes(item.props.path)) {
         if (props.dropTarget != null) {

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -38,7 +38,7 @@ import {
   Button,
 } from '../../uuiui'
 import { notice } from '../common/notice'
-import { getParentDirectory } from '../../utils/path-utils'
+import { appendToPath, getParentDirectory } from '../../utils/path-utils'
 
 export interface FileBrowserItemProps extends FileBrowserItemInfo {
   isSelected: boolean
@@ -82,7 +82,7 @@ function onDrop(
       isRootArea
     ) {
       const newDirectory = draggedOntoProps.dropTarget != null ? draggedOntoProps.dropTarget : '/'
-      const newFilePath = `${newDirectory}/${R.last(draggedProps.path.split('/')) as string}`
+      const newFilePath = appendToPath(newDirectory, R.last(draggedProps.path.split('/')) as string)
       if (draggedProps.path !== newFilePath && draggedProps.path !== draggedOntoProps.path) {
         draggedOntoProps.dispatch(
           [

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -4,7 +4,13 @@ import * as Path from 'path'
 import * as pathParse from 'path-parse'
 import * as R from 'ramda'
 import * as React from 'react'
-import { ConnectableElement, ConnectDragPreview, useDrag, useDrop } from 'react-dnd'
+import {
+  ConnectableElement,
+  ConnectDragPreview,
+  DragObjectWithType,
+  useDrag,
+  useDrop,
+} from 'react-dnd'
 import { codeFile, ProjectFileType } from '../../core/shared/project-file-types'
 import { parseClipboardData } from '../../utils/clipboard'
 import Utils from '../../utils/utils'
@@ -32,6 +38,7 @@ import {
   Button,
 } from '../../uuiui'
 import { notice } from '../common/notice'
+import { getNearestAncestorDirectory } from '../../utils/path-utils'
 
 export interface FileBrowserItemProps extends FileBrowserItemInfo {
   isSelected: boolean
@@ -39,6 +46,7 @@ export interface FileBrowserItemProps extends FileBrowserItemInfo {
   key: string
   dispatch: EditorDispatch
   collapsed: boolean
+  dropTarget: string | null
   toggleCollapse: (filePath: string) => void
   Expand: (filePath: string) => void
   setSelected: (selectedItem: FileBrowserItemInfo | null) => void
@@ -69,21 +77,18 @@ function onDrop(
     const isRootArea = draggedOntoProps.fileType != null
     if (
       draggedOntoProps.fileType == null ||
-      draggedOntoProps.fileType === 'DIRECTORY' ||
+      (draggedOntoProps.dropTarget != null &&
+        draggedOntoProps.path.includes(draggedOntoProps.dropTarget)) ||
       isRootArea
     ) {
-      let newFilePath = draggedProps.path
-      if (
-        isRootArea &&
-        (draggedOntoProps.fileType == null || draggedOntoProps.fileType !== 'DIRECTORY')
-      ) {
-        newFilePath = R.last(draggedProps.path.split('/')) as string
-      } else {
-        newFilePath = `${draggedOntoProps.path}/${R.last(draggedProps.path.split('/')) as string}`
-      }
+      const newDirectory = draggedOntoProps.dropTarget != null ? draggedOntoProps.dropTarget : '/'
+      const newFilePath = `${newDirectory}/${R.last(draggedProps.path.split('/')) as string}`
       if (draggedProps.path !== newFilePath && draggedProps.path !== draggedOntoProps.path) {
         draggedOntoProps.dispatch(
-          [EditorActions.updateFilePath(draggedProps.path, newFilePath)],
+          [
+            EditorActions.updateFilePath(draggedProps.path, newFilePath),
+            EditorActions.setFilebrowserDropTarget(null),
+          ],
           'everyone',
         )
       }
@@ -551,9 +556,15 @@ class FileBrowserItemInner extends React.PureComponent<
     }
   }
 
+  isCurrentDropTargetForInternalFiles = () => {
+    return (
+      (this.props.isOver && this.props.fileType === 'DIRECTORY') ||
+      this.props.dropTarget === this.props.path
+    )
+  }
+
   render() {
-    const isCurrentDropTargetForInternalFiles =
-      this.props.isOver && this.props.fileType === 'DIRECTORY'
+    const isCurrentDropTargetForInternalFiles = this.isCurrentDropTargetForInternalFiles()
     const isCurrentDropTargetForExternalFiles =
       this.state.externalFilesDraggedIn && this.props.fileType === 'DIRECTORY'
 
@@ -711,9 +722,14 @@ class FileBrowserItemInner extends React.PureComponent<
   }
 }
 
+interface FilebrowserDragItem extends DragObjectWithType {
+  type: 'filebrowser'
+  props: FileBrowserItemProps
+}
+
 export function FileBrowserItem(props: FileBrowserItemProps) {
   const [{ isDragging }, drag, dragPreview] = useDrag({
-    item: { type: 'filebrowser', id: props },
+    item: { type: 'filebrowser', props: props } as FilebrowserDragItem,
     canDrag: () => canDragnDrop(props),
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),
@@ -730,7 +746,13 @@ export function FileBrowserItem(props: FileBrowserItemProps) {
       if (didDrop) {
         onDrop(monitor.getDropResult(), props)
       } else {
-        props.dispatch([EditorActions.switchEditorMode(EditorModes.selectMode())], 'everyone')
+        props.dispatch(
+          [
+            EditorActions.switchEditorMode(EditorModes.selectMode()),
+            EditorActions.setFilebrowserDropTarget(null),
+          ],
+          'everyone',
+        )
       }
     },
   })
@@ -738,6 +760,15 @@ export function FileBrowserItem(props: FileBrowserItemProps) {
     accept: 'filebrowser',
     canDrop: () => true,
     drop: () => props,
+    hover: () => {
+      const ancestorDirectory = getNearestAncestorDirectory(
+        props.path,
+        props.fileType === 'DIRECTORY',
+      )
+      if (props.dropTarget !== ancestorDirectory) {
+        props.dispatch([EditorActions.setFilebrowserDropTarget(ancestorDirectory)], 'leftpane')
+      }
+    },
     collect: (monitor) => ({
       isOver: monitor.isOver(),
     }),

--- a/editor/src/utils/path-utils.ts
+++ b/editor/src/utils/path-utils.ts
@@ -27,6 +27,14 @@ export function appendToPath(firstPart: string, secondPart: string): string {
   return `${left}/${right}`
 }
 
+export function getNearestAncestorDirectory(filepath: string, isDirectory: boolean): string {
+  if (isDirectory) {
+    return filepath
+  } else {
+    return makePathFromParts(getPartsFromPath(filepath).slice(0, -1))
+  }
+}
+
 export function makePathFromParts(parts: Array<string>): string {
   return `/${parts.join('/')}`
 }

--- a/editor/src/utils/path-utils.ts
+++ b/editor/src/utils/path-utils.ts
@@ -27,12 +27,8 @@ export function appendToPath(firstPart: string, secondPart: string): string {
   return `${left}/${right}`
 }
 
-export function getNearestAncestorDirectory(filepath: string, isDirectory: boolean): string {
-  if (isDirectory) {
-    return filepath
-  } else {
-    return makePathFromParts(getPartsFromPath(filepath).slice(0, -1))
-  }
+export function getParentDirectory(filepath: string): string {
+  return makePathFromParts(getPartsFromPath(filepath).slice(0, -1))
 }
 
 export function makePathFromParts(parts: Array<string>): string {


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/1147

**Problem:**
There are different issues with the filebrowser now, this fixes 2 of them.
- it is possible to drag folder into child folder, creating lots of weird folders
- drop target highlights only on directory dragover, on files parent folder could be highlighted to have a more realistic behavior

**Commit Details:**
- added filebrowser droptarget to editorstate to highlight folder on child file dragover
- the droptarget is the target folder, to reduce editorstate updates
- remove highlight when trying to drag a folder into itself
- fix the `onDragEnter` to not change react state without real files, and to only show highlights for files, file drag and drop is the same as before, it only highlights on folder names for now