### PR TITLE
feature(filebrowser) show a label on asset files that are uploaded ☁️

### DIFF
--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -52,6 +52,7 @@ import {
   SquareButton,
   Icons,
 } from '../../uuiui'
+import { isLocal } from '../editor/persistence'
 
 export type FileBrowserItemType = 'file' | 'export'
 
@@ -64,6 +65,7 @@ export interface FileBrowserItemInfo {
   modified: boolean
   hasErrorMessages: boolean
   exportedFunction: boolean
+  isUploadedAssetFile: boolean
 }
 
 export function fileHasErrorMessages(path: string, errorMessages: ErrorMessage[] | null): boolean {
@@ -95,6 +97,8 @@ function collectFileBrowserItems(
         hasErrorMessages: hasErrorMessages,
         modified: isModifiedFile(element),
         exportedFunction: false,
+        isUploadedAssetFile:
+          !isLocal() && (element.type === 'IMAGE_FILE' || element.type === 'ASSET_FILE'),
       })
       if (
         element.type === 'TEXT_FILE' &&
@@ -115,6 +119,7 @@ function collectFileBrowserItems(
                 hasErrorMessages: false,
                 modified: false,
                 exportedFunction: typeInformation.includes('=>'),
+                isUploadedAssetFile: false,
               })
             }
           })

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -637,6 +637,18 @@ class FileBrowserItemInner extends React.PureComponent<
               {this.renderIcon()}
               {this.renderLabel()}
               {this.renderModifiedIcon()}
+              {this.props.isUploadedAssetFile ? (
+                <span
+                  style={{
+                    border: '1px solid primary',
+                    padding: '2px 4px',
+                    fontSize: 9,
+                    color: colorTheme.primary.value,
+                  }}
+                >
+                  S3
+                </span>
+              ) : null}
             </div>,
           )}
           {this.props.type === 'file' ? (


### PR DESCRIPTION
Part of #1147 

**Fix:**
To help track how the files are handled by the editor and the asset files are uploaded to s3 an extra label is added on all asset/image files. When the user is signed in files are automatically uploaded. On local projects this label is not shown.

**Commit Details:**
- new label in filebrowseritem
- extended item props
