### PR TITLE
Rename/move folder corrects imports as it goes.

### DIFF
--- a/editor/src/components/canvas/dom-walker.spec.browser.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser.tsx
@@ -71,6 +71,7 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
       new FakeWatchdogWorker(),
     ),
     dispatch: dispatch,
+    alreadySaved: false,
   }
 
   const storeHook = create<EditorStore>((set) => initialEditorStore)

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -160,6 +160,7 @@ export async function renderTestEditorWithModel(
       new FakeWatchdogWorker(),
     ),
     dispatch: asyncTestDispatch,
+    alreadySaved: false,
   }
 
   const storeHook = create<EditorStore>((set) => initialEditorStore)

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -65,6 +65,7 @@ import {
   deleteJSXAttribute,
   setJSXAttributesAttribute,
   emptyJsxMetadata,
+  isImportStatement,
 } from '../../../core/shared/element-template'
 import {
   generateUidWithExistingComponents,
@@ -105,6 +106,7 @@ import {
   applyToAllUIJSFiles,
   updateFileContents,
   applyUtopiaJSXComponentsChanges,
+  saveTextFileContents,
 } from '../../../core/model/project-file-utils'
 import {
   Either,
@@ -144,6 +146,8 @@ import {
   unparsed,
   ParseSuccess,
   importAlias,
+  Imports,
+  importStatementFromImportDetails,
 } from '../../../core/shared/project-file-types'
 import {
   addImport,
@@ -496,6 +500,7 @@ import Meta from 'antd/lib/card/Meta'
 import utils from '../../../utils/utils'
 import { defaultConfig } from 'utopia-vscode-common'
 import { getTargetParentForPaste } from '../../../utils/clipboard'
+import { absolutePathFromRelativePath } from '../../../utils/path-utils'
 
 function applyUpdateToJSXElement(
   element: JSXElement,
@@ -1188,29 +1193,110 @@ function replaceFilePath(
     ...projectContents,
   }
   let updatedFiles: Array<{ oldPath: string; newPath: string }> = []
-  Utils.fastForEach(Object.keys(projectContents), (key) => {
-    if (oldFolderRegex.test(key)) {
-      const projectFile = projectContents[key]
-      const newFilePath = key.replace(oldPath, newPath)
+  Utils.fastForEach(Object.keys(projectContents), (filename) => {
+    if (oldFolderRegex.test(filename)) {
+      const projectFile = projectContents[filename]
+      const newFilePath = filename.replace(oldPath, newPath)
       const fileType = isDirectory(projectFile) ? 'DIRECTORY' : fileTypeFromFileName(newFilePath)
       if (fileType == null) {
         // Can't identify the file type.
-        error = `Can't rename ${key} to ${newFilePath}.`
+        error = `Can't rename ${filename} to ${newFilePath}.`
       } else {
         const updatedProjectFile = switchToFileType(projectFile, fileType)
         if (updatedProjectFile == null) {
           // Appears this file can't validly be changed.
-          error = `Can't rename ${key} to ${newFilePath}.`
+          error = `Can't rename ${filename} to ${newFilePath}.`
         } else {
           // Remove the old file.
-          delete updatedProjectContents[key]
+          delete updatedProjectContents[filename]
           updatedProjectContents[newFilePath] = updatedProjectFile
-          updatedFiles.push({ oldPath: key, newPath: newFilePath })
+          updatedFiles.push({ oldPath: filename, newPath: newFilePath })
         }
       }
     }
   })
 
+  // Correct any imports in files that have changed because of the above file movements.
+  Utils.fastForEach(Object.keys(updatedProjectContents), (filename) => {
+    const projectFile = updatedProjectContents[filename]
+    // Only for successfully parsed text files, with some protection for files that are yet to be parsed.
+    if (
+      isTextFile(projectFile) &&
+      isParseSuccess(projectFile.fileContents.parsed) &&
+      projectFile.fileContents.revisionsState !== RevisionsState.CodeAhead
+    ) {
+      let updatedParseResult: ParseSuccess = projectFile.fileContents.parsed
+      fastForEach(updatedFiles, (updatedFile) => {
+        fastForEach(Object.keys(updatedParseResult.imports), (importSource) => {
+          // Only do this for import sources that look like file paths.
+          if (importSource.startsWith('.') || importSource.startsWith('/')) {
+            const importSourceAbsolutePath = absolutePathFromRelativePath(
+              filename,
+              false,
+              importSource,
+            )
+            if (importSourceAbsolutePath === updatedFile.oldPath) {
+              // Create new absolute import path and shift the import in this file to represent that.
+              const importFromParse = updatedParseResult.imports[importSource]
+              let updatedImports: Imports = {
+                ...updatedParseResult.imports,
+              }
+              delete updatedImports[importSource]
+              // If an absolute path was used before, use the updated absolute path.
+              const newImportPath = importSource.startsWith('/')
+                ? updatedFile.newPath
+                : getFilePathToImport(updatedFile.newPath, filename)
+              updatedImports[newImportPath] = importFromParse
+
+              // Update the parse result to be incorporated later.
+              updatedParseResult = {
+                ...updatedParseResult,
+                imports: updatedImports,
+              }
+            }
+          }
+        })
+
+        // Update the top level element import statements.
+        const updatedTopLevelElements = updatedParseResult.topLevelElements.map(
+          (topLevelElement) => {
+            if (isImportStatement(topLevelElement)) {
+              if (topLevelElement.module === updatedFile.oldPath) {
+                // If an absolute path was used before, use the updated absolute path.
+                const newImportPath = topLevelElement.module.startsWith('/')
+                  ? updatedFile.newPath
+                  : getFilePathToImport(updatedFile.newPath, filename)
+                const importDefinition = forceNotNull(
+                  'Import should exist.',
+                  updatedParseResult.imports[newImportPath],
+                )
+                return importStatementFromImportDetails(newImportPath, importDefinition)
+              } else {
+                return topLevelElement
+              }
+            } else {
+              return topLevelElement
+            }
+          },
+        )
+
+        updatedParseResult = {
+          ...updatedParseResult,
+          topLevelElements: updatedTopLevelElements,
+        }
+      })
+
+      updatedProjectContents[filename] = saveTextFileContents(
+        projectFile,
+        textFileContents(
+          projectFile.fileContents.code,
+          updatedParseResult,
+          RevisionsState.ParsedAhead,
+        ),
+        projectFile.lastSavedContents == null,
+      )
+    }
+  })
   // Check if we discovered an error.
   if (error == null) {
     return {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -179,6 +179,7 @@ export type EditorStore = {
   userState: UserState
   workers: UtopiaTsWorkers
   dispatch: EditorDispatch
+  alreadySaved: boolean
 }
 
 export interface FileDeleteModal {

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -18,6 +18,7 @@ function createEmptyEditorStoreHook() {
     userState: null as any,
     workers: null as any,
     dispatch: null as any,
+    alreadySaved: false,
   }
 
   const storeHook = create<EditorStore>((set) => initialEditorStore)

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -387,8 +387,7 @@ class FileBrowserItemInner extends React.PureComponent<
             : 'File'
           : 'this'
       }`,
-      enabled:
-        this.props.fileType != null && canRename(this.props) && this.props.fileType !== 'DIRECTORY',
+      enabled: this.props.fileType != null && canRename(this.props),
       action: () => {
         this.props.dispatch(
           [EditorActions.setFilebrowserRenamingTarget(this.props.path)],

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -54,6 +54,7 @@ export function getStoreHook(
     userState: defaultUserState,
     workers: null as any,
     dispatch: mockDispatch,
+    alreadySaved: false,
   }
 
   const storeHook = create<EditorStore & UpdateFunctionHelpers>((set) => ({

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -54,6 +54,7 @@ function getPaddingHookResult<P extends ParsedPropertiesKeys, S extends ParsedPr
       userState: null as any,
       workers: null as any,
       dispatch: mockDispatch,
+      alreadySaved: false,
     }
 
     const storeHook = create<EditorStore>(() => initialEditorStore)

--- a/editor/src/core/shared/project-contents-dependencies.spec.ts
+++ b/editor/src/core/shared/project-contents-dependencies.spec.ts
@@ -14,6 +14,7 @@ describe('getDirectReverseDependencies', () => {
     expect(actualResult).toMatchInlineSnapshot(`
       Object {
         "/src/app.js": Array [
+          "/src/index.js",
           "/utopia/storyboard.js",
         ],
         "/src/card.js": Array [

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -1,6 +1,6 @@
 import * as TS from 'typescript'
 import { NormalisedFrame } from 'utopia-api'
-import { ArbitraryJSBlock, TopLevelElement } from './element-template'
+import { ArbitraryJSBlock, ImportStatement, TopLevelElement } from './element-template'
 import { ErrorMessage } from './error-messages'
 import { arrayEquals, objectEquals } from './utils'
 
@@ -91,6 +91,39 @@ export function importDetails(
     importedWithName: importedWithName,
     importedFromWithin: importedFromWithin,
     importedAs: importedAs,
+  }
+}
+
+export function importStatementFromImportDetails(
+  moduleName: string,
+  details: ImportDetails,
+): ImportStatement {
+  let importParts: Array<string> = []
+  if (details.importedWithName != null) {
+    importParts.push(details.importedWithName)
+  }
+  if (details.importedAs != null) {
+    importParts.push(`* as ${details.importedAs}`)
+  }
+  if (details.importedFromWithin.length > 0) {
+    let importedFromWithinParts: Array<string> = []
+    for (const fromWithin of details.importedFromWithin) {
+      if (fromWithin.name === fromWithin.alias) {
+        importedFromWithinParts.push(fromWithin.name)
+      } else {
+        importedFromWithinParts.push(`${fromWithin.name} as ${fromWithin.alias}`)
+      }
+      importParts.push(`{ ${importedFromWithinParts.join(', ')} }`)
+    }
+  }
+  const rawCode = `import ${importParts.join(', ')} from '${moduleName}'`
+  return {
+    type: 'IMPORT_STATEMENT',
+    rawCode: rawCode,
+    importStarAs: details.importedAs != null,
+    importWithName: details.importedWithName != null,
+    imports: details.importedFromWithin.map((i) => i.name),
+    module: moduleName,
   }
 }
 

--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -68,7 +68,7 @@ export function createComplexDefaultProjectContents(): ProjectContents {
     '/src': directory(),
     '/assets': directory(),
     '/public': directory(),
-    '/src/index.js': getSamplePreviewFile(),
+    '/src/index.js': createCodeFile('/src/index.js', getSamplePreviewFile().fileContents.code),
     '/public/index.html': getSamplePreviewHTMLFile(),
     [StoryboardFilePath]: createCodeFile(
       StoryboardFilePath,

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -142,6 +142,7 @@ export class Editor {
         watchdogWorker,
       ),
       dispatch: this.boundDispatch,
+      alreadySaved: false,
     }
 
     const storeHook = create<EditorStore>((set) => this.storedState)

--- a/utopia-vscode-common/src/fs/fs-utils.ts
+++ b/utopia-vscode-common/src/fs/fs-utils.ts
@@ -40,7 +40,11 @@ const existingFileError = (path: string) => handleError(eexist(path))
 const isDirectoryError = (path: string) => handleError(eisdir(path))
 const isNotDirectoryError = (path: string) => handleError(enotdir(path))
 
-export async function initializeFS(storeName: string, user: FSUser, driver: string = INDEXEDDB): Promise<void> {
+export async function initializeFS(
+  storeName: string,
+  user: FSUser,
+  driver: string = INDEXEDDB,
+): Promise<void> {
   fsUser = user
   await initializeStore(storeName, driver)
   await simpleCreateDirectoryIfMissing('/')
@@ -98,11 +102,13 @@ export async function readFileUnsavedContent(path: string): Promise<Uint8Array |
   return fileNode.unsavedContent
 }
 
-export async function readFileAsUTF8(path: string): Promise<{content: string, unsavedContent: string | null}> {
+export async function readFileAsUTF8(
+  path: string,
+): Promise<{ content: string; unsavedContent: string | null }> {
   const { content, unsavedContent } = await getFile(path)
   return {
     content: decoder.decode(content),
-    unsavedContent: unsavedContent == null ? null : decoder.decode(unsavedContent)
+    unsavedContent: unsavedContent == null ? null : decoder.decode(unsavedContent),
   }
 }
 
@@ -140,7 +146,10 @@ export async function getDescendentPaths(path: string): Promise<string[]> {
 async function targetsForOperation(path: string, recursive: boolean): Promise<string[]> {
   if (recursive) {
     const allDescendents = await getDescendentPaths(path)
-    return [path, ...allDescendents]
+    let result = [path, ...allDescendents]
+    result.sort()
+    result.reverse()
+    return result
   } else {
     return [path]
   }
@@ -149,7 +158,7 @@ async function targetsForOperation(path: string, recursive: boolean): Promise<st
 function directoryOfPath(path: string): string | null {
   const target = path.endsWith('/') ? path.slice(0, -1) : path
   const lastSlashIndex = target.lastIndexOf('/')
-  return lastSlashIndex >= 0 ? path.slice(0, lastSlashIndex + 1) : null
+  return lastSlashIndex >= 0 ? path.slice(0, lastSlashIndex) : null
 }
 
 function filenameOfPath(path: string): string {
@@ -242,10 +251,16 @@ async function simpleCreateDirectoryIfMissing(path: string): Promise<void> {
 
 export async function ensureDirectoryExists(path: string): Promise<void> {
   const allPaths = allPathsUpToPath(path)
-  await Promise.all(allPaths.map(simpleCreateDirectoryIfMissing))
+  for (const pathToCreate of allPaths) {
+    await simpleCreateDirectoryIfMissing(pathToCreate)
+  }
 }
 
-export async function writeFile(path: string, content: Uint8Array, unsavedContent: Uint8Array | null): Promise<void> {
+export async function writeFile(
+  path: string,
+  content: Uint8Array,
+  unsavedContent: Uint8Array | null,
+): Promise<void> {
   const parent = await getParent(path)
   const maybeExistingFile = await getItem(path)
   if (maybeExistingFile != null && isDirectory(maybeExistingFile)) {
@@ -254,7 +269,8 @@ export async function writeFile(path: string, content: Uint8Array, unsavedConten
 
   const now = Date.now()
   const fileCTime = maybeExistingFile == null ? now : maybeExistingFile.ctime
-  const lastSavedTime = unsavedContent == null || maybeExistingFile == null ? now : maybeExistingFile.lastSavedTime
+  const lastSavedTime =
+    unsavedContent == null || maybeExistingFile == null ? now : maybeExistingFile.lastSavedTime
   const fileToWrite = fsFile(content, unsavedContent, fileCTime, now, lastSavedTime, fsUser)
   await setItem(path, fileToWrite)
   if (parent != null) {
@@ -266,20 +282,37 @@ export async function writeFileSavedContent(path: string, content: Uint8Array): 
   return writeFile(path, content, null)
 }
 
-export async function writeFileUnsavedContent(path: string, unsavedContent: Uint8Array): Promise<void> {
+export async function writeFileUnsavedContent(
+  path: string,
+  unsavedContent: Uint8Array,
+): Promise<void> {
   const savedContent = await readFileSavedContent(path)
   return writeFile(path, savedContent, unsavedContent)
 }
 
-export async function writeFileAsUTF8(path: string, content: string, unsavedContent: string | null): Promise<void> {
-  return writeFile(path, encoder.encode(content), unsavedContent == null ? null : encoder.encode(unsavedContent))
+export async function writeFileAsUTF8(
+  path: string,
+  content: string,
+  unsavedContent: string | null,
+): Promise<void> {
+  return writeFile(
+    path,
+    encoder.encode(content),
+    unsavedContent == null ? null : encoder.encode(unsavedContent),
+  )
 }
 
-export async function writeFileSavedContentAsUTF8(path: string, savedContent: string): Promise<void> {
+export async function writeFileSavedContentAsUTF8(
+  path: string,
+  savedContent: string,
+): Promise<void> {
   return writeFileAsUTF8(path, savedContent, null)
 }
 
-export async function writeFileUnsavedContentAsUTF8(path: string, unsavedContent: string): Promise<void> {
+export async function writeFileUnsavedContentAsUTF8(
+  path: string,
+  unsavedContent: string,
+): Promise<void> {
   return writeFileUnsavedContent(path, encoder.encode(unsavedContent))
 }
 
@@ -331,7 +364,9 @@ export async function deletePath(path: string, recursive: boolean): Promise<stri
 
   // Really this should fail if recursive isn't set to true when trying to delete a
   // non-empty directory, but for some reason VSCode doesn't provide an error suitable for that
-  await Promise.all(targets.map((p) => removeItem(p)))
+  for (const target of targets) {
+    await removeItem(target)
+  }
 
   if (parent != null) {
     await markModified(parent)

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -122,6 +122,14 @@ function watchForChangesFromVSCode(context: vscode.ExtensionContext, projectID: 
         }
       }
     }),
+    vscode.workspace.onDidOpenTextDocument((document) => {
+      if (isUtopiaDocument(document)) {
+        const path = fromUtopiaURI(document.uri)
+        if (!incomingFileChanges.has(path)) {
+          updateDirtyContent(document.uri)
+        }
+      }
+    }),
   )
 }
 


### PR DESCRIPTION
Fixes #1222

**Problem:**
Currently if a file/folder is renamed/moved the file contents of those files remains as it was and any imports to or from those files are likely to be broken.

**Fix:**
Primarily the work for this was in `replaceFilePath` which does the work of correcting the imports in the files of the project. Using the resolved path of an import and compares that to the old paths of the files that have moved.

There was a lot of fallout from this change mostly centred on our synchronising layer that updates the files for VS Code.

**Commit Details:**
- Fix an issue in `zipContentsTree(Async)` to ensure that it will continue deeper into a hierarchy if the left hand side does not exist.
- Improved early exiting in `zipContentsTreeAsync`.
- Added a test case for `UPDATE_FILE_PATH` to double check what happens to the files and their imports.
- `replaceFilePath` now works through the imports of the project contents updating them if they resolve to ones that have been updated.
- `applyProjectContentChanges` now split into `collateProjectChanges` that determines what all the changes are that need to be made and `applyProjectChanges` which applies each of those in turn. The `ProjectChange` type represents those changes.
- `applyVSCodeChanges` is now chained off of the previous invocation to ensure that multiple calls aren't running simultaneously.
- `editorDispatch` checks if an `UPDATE_FROM_WORKER` action has been triggered and if there has already been a save, to ensure that updates from that action are saved instead of losing them should the user reload.
- `alreadySaved` added to `EditorStore` to indicate if the project has been saved.
- Allow directories to be renamed in the file browser.
- Implemented `importStatementFromImportDetails` as a way to produce an `ImportStatement` from a module name and `ImportDetails`, which constructs the `rawCode` value, allowing these statements to be updated.
- Removed `projectID` from `writeProjectFile` and `writeProjectContents`.
- Make `/src/index.js` be the parsed version when used in tests.
- Make sure that `targetsForOperation` returns elements in the order they need to be to be deleted.
- `directoryOfPath` doesn't include the trailing slash.
- `ensureDirectoryExists` runs down the ancestors specifically in order rather than creating each one "simultaneously".
- `deletePath` deletes the targets one at a time.
- Added a call to `onDidOpenTextDocument` so that dirty changes for unloaded files show up when those files are loaded.