### PR TITLE
Fix the Render As dropdown

### DIFF
--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -29,9 +29,6 @@ export const RenderAsRow = betterReactMemo('RenderAsRow', () => {
     )
   }, 'RenderAsRow selectedElementName')
 
-  const constrolStatus = 'simple'
-  const controlStyles = getControlStyles(constrolStatus)
-
   const refElementsToTargetForUpdates = usePropControlledRef_DANGEROUS(
     getElementsToTarget(selectedViews),
   )
@@ -112,7 +109,7 @@ export const RenderAsRow = betterReactMemo('RenderAsRow', () => {
       </span>
       {insertableComponents.length > 0 ? (
         <PopupList
-          disabled={!controlStyles.interactive}
+          disabled={false}
           value={currentInsertableComponent}
           onSubmitValue={onSelect}
           options={insertableComponents}

--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useEditorState } from '../../editor/store/store-hook'
+import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 import { usePropControlledRef_DANGEROUS } from '../../inspector/common/inspector-utils'
 import { betterReactMemo, getControlStyles, SelectOption, Utils } from '../../../uuiui-deps'
 import * as EP from '../../../core/shared/element-path'
@@ -18,9 +18,9 @@ import { usePossiblyResolvedPackageDependencies } from '../../../components/edit
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 
 export const RenderAsRow = betterReactMemo('RenderAsRow', () => {
-  const { dispatch, selectedViews } = useEditorState((store) => {
-    return { dispatch: store.dispatch, selectedViews: store.editor.selectedViews }
-  }, 'TopMenuContextProvider')
+  const dispatch = useEditorState((store) => {
+    return store.dispatch
+  }, 'RenderAsRow dispatch')
 
   const selectedElementName = useEditorState((store) => {
     return MetadataUtils.getJSXElementNameFromMetadata(
@@ -29,9 +29,9 @@ export const RenderAsRow = betterReactMemo('RenderAsRow', () => {
     )
   }, 'RenderAsRow selectedElementName')
 
-  const refElementsToTargetForUpdates = usePropControlledRef_DANGEROUS(
-    getElementsToTarget(selectedViews),
-  )
+  const refElementsToTargetForUpdates = useRefEditorState((store) => {
+    return getElementsToTarget(store.editor.selectedViews)
+  })
 
   const onElementTypeChange = React.useCallback(
     (newElementName: JSXElementName, importsToAdd: Imports) => {
@@ -62,7 +62,7 @@ export const RenderAsRow = betterReactMemo('RenderAsRow', () => {
         fullPath: store.editor.canvas.openFile?.filename ?? null,
       }
     },
-    'Name Row Values',
+    'RenderAsRow',
   )
 
   const insertableComponents = React.useMemo(() => {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -970,6 +970,21 @@ export const MetadataUtils = {
       return null
     }
   },
+  getJSXElementNameFromMetadata(
+    path: ElementPath,
+    metadata: ElementInstanceMetadataMap,
+  ): JSXElementName | null {
+    const element = MetadataUtils.findElementByElementPath(metadata, path)
+    if (element != null) {
+      if (isRight(element.element) && isJSXElement(element.element.value)) {
+        return element.element.value.name
+      } else {
+        return null
+      }
+    } else {
+      return null
+    }
+  },
   getJSXElementBaseName(path: ElementPath, components: Array<UtopiaJSXComponent>): string | null {
     const jsxElement = findElementAtPath(path, components)
     if (jsxElement != null) {


### PR DESCRIPTION
**Problem:**
<img width="398" alt="image" src="https://user-images.githubusercontent.com/2226774/117988959-31cf2200-b33c-11eb-9c4a-ca1d7f3ba065.png">

The Render As menu would never show a selected value. opening the dropdown and selecting something would work, but then the closed dropdown would show "empty".

I discovered this because I was looking at `useNamesAndIconsAllPaths` and why is it used because that function is terribly slow AND triggers a rerender for any user interaction.

**Fix:**
I removed the usage of `useNamesAndIconsAllPaths` and fixed `currentInsertableComponent`

**Commit Details:**
- Added function `MetadataUtils.getJSXElementNameFromMetadata` that only uses path and metadata to be able to skip having to drill into the project hierarchy
- Use `MetadataUtils.getJSXElementNameFromMetadata` instead of `useNamesAndIconsAllPaths`
- Fix a bug with `currentInsertableComponent` which meant that it could never correctly find the current insertable component
