### PR TITLE
Fix/assets toast messages

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -2813,6 +2813,7 @@ export const UPDATE_FNS = {
     actionsToRunAfterSave.push(updateFile(assetFilename, projectFile, true))
 
     // Side effects.
+    let editorWithToast = editor
     if (isLoggedIn(userState.loginState) && editor.id != null) {
       saveAssetToServer(notNullProjectID, action.fileType, action.base64, assetFilename)
         .then(() => {
@@ -2828,7 +2829,11 @@ export const UPDATE_FNS = {
           dispatch([showToast(notice(`Failed to upload ${assetFilename}`, 'ERROR'))])
         })
     } else {
-      dispatch([showToast(notice(`Please log in to upload assets`, 'ERROR', true))])
+      editorWithToast = UPDATE_FNS.ADD_TOAST(
+        showToast(notice(`Please log in to upload assets`, 'ERROR', true)),
+        editor,
+        dispatch,
+      )
     }
 
     const updatedProjectContents = addFileToProjectContents(
@@ -2876,7 +2881,11 @@ export const UPDATE_FNS = {
           )
           const size = width != null && height != null ? { width: width, height: height } : null
           const switchMode = enableInsertModeForJSXElement(imageElement, newUID, {}, size)
-          const editorInsertEnabled = UPDATE_FNS.SWITCH_EDITOR_MODE(switchMode, editor, derived)
+          const editorInsertEnabled = UPDATE_FNS.SWITCH_EDITOR_MODE(
+            switchMode,
+            editorWithToast,
+            derived,
+          )
           return {
             ...editorInsertEnabled,
             projectContents: updatedProjectContents,
@@ -2917,7 +2926,7 @@ export const UPDATE_FNS = {
           const insertJSXElementAction = insertJSXElement(imageElement, parent, {})
 
           const withComponentCreated = UPDATE_FNS.INSERT_JSX_ELEMENT(insertJSXElementAction, {
-            ...editor,
+            ...editorWithToast,
             projectContents: updatedProjectContents,
           })
           return {
@@ -2937,7 +2946,7 @@ export const UPDATE_FNS = {
               true,
             ),
           )
-          return UPDATE_FNS.ADD_TOAST(toastAction, editor, dispatch)
+          return UPDATE_FNS.ADD_TOAST(toastAction, editorWithToast, dispatch)
         }
         case 'SAVE_IMAGE_DO_NOTHING':
           return editor

--- a/editor/src/components/editor/image-insert.ts
+++ b/editor/src/components/editor/image-insert.ts
@@ -5,15 +5,19 @@ import { notice } from '../common/notice'
 import { EditorAction, EditorDispatch } from './action-types'
 import * as EditorActions from './actions/action-creators'
 
-async function fileUploadAction(file: File, targetPath: string): Promise<EditorAction> {
+async function fileUploadAction(
+  file: File,
+  targetPath: string,
+  replace: boolean,
+): Promise<EditorAction> {
   const fileResult = await extractFile(file)
-  return fileResultUploadAction(fileResult, targetPath)
+  return fileResultUploadAction(fileResult, targetPath, false)
 }
 
 export function fileResultUploadAction(
   fileResult: FileResult,
   targetPath: string,
-  replace: boolean = false,
+  replace: boolean,
 ): EditorAction {
   switch (fileResult.type) {
     case 'IMAGE_RESULT': {
@@ -83,7 +87,7 @@ function handleImageSelected(
         })
     } else {
       // FIXME Support inserting SVGs by adding an import statement
-      fileUploadAction(file, imageFilePath).then((saveFileAction) => {
+      fileUploadAction(file, imageFilePath, false).then((saveFileAction) => {
         const warningMessage = EditorActions.showToast(notice(`File saved to ${imageFilePath}`))
         dispatch([saveFileAction, warningMessage], 'everyone')
       })

--- a/editor/src/components/editor/image-insert.ts
+++ b/editor/src/components/editor/image-insert.ts
@@ -10,10 +10,16 @@ async function fileUploadAction(file: File, targetPath: string): Promise<EditorA
   return fileResultUploadAction(fileResult, targetPath)
 }
 
-export function fileResultUploadAction(fileResult: FileResult, targetPath: string): EditorAction {
+export function fileResultUploadAction(
+  fileResult: FileResult,
+  targetPath: string,
+  replace: boolean = false,
+): EditorAction {
   switch (fileResult.type) {
     case 'IMAGE_RESULT': {
-      const afterSave = EditorActions.saveImageReplace()
+      const afterSave = replace
+        ? EditorActions.saveImageReplace()
+        : EditorActions.saveImageDoNothing()
       return EditorActions.saveAsset(
         targetPath,
         fileResult.fileType,

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -448,6 +448,7 @@ class FileBrowserItemInner extends React.PureComponent<
       let actions: Array<EditorAction> = []
       Utils.fastForEach(result.files, (resultFile: FileResult) => {
         let targetPath: string | null = null
+        let replace = false
         switch (this.props.fileType) {
           case 'DIRECTORY':
             // Put the image "into" the directory.
@@ -457,13 +458,14 @@ class FileBrowserItemInner extends React.PureComponent<
           case 'IMAGE_FILE':
             // Overwrite the image.
             targetPath = this.props.path
+            replace = true
             break
           default:
           // Do nothing, overwriting an image onto a UI file seems wrong.
         }
 
         if (targetPath != null) {
-          actions.push(fileResultUploadAction(resultFile, targetPath))
+          actions.push(fileResultUploadAction(resultFile, targetPath, replace))
         }
       })
       this.props.dispatch(actions, 'everyone')


### PR DESCRIPTION
Fixes #1218

**Problem:**
There were problems with the image drag and drop toast messages. One of the issues was a missing toast message for logged out user about trying to insert an asset.
The other image insertion issue is the red toast message when drag and drop an image to the filebrowser was always visible, even when inserting a completely new image it was showing `Assets replaced. You may need to reload the editor to see changes.`.

To reliably remove the need for the replace toast message hashing would be required, as discussed [here](https://github.com/concrete-utopia/dystopia/pull/3454/files#r421373984).

**Commit Details:**
- fixed  `actions.ts` to add the missing toast to the editor state for logged out users
- fixed `fileResultUploadAction` to make replace toast message show only on image overwrite
