### PR TITLE
Close deleted files in VS Code.

### DIFF
--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -43,6 +43,26 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   watchForChangesFromVSCode(context, projectID)
 
   sendMessage(sendInitialData())
+
+  watchForFileDeletions()
+}
+
+function watchForFileDeletions() {
+  let fileWatcherChain: Promise<void> = Promise.resolve()
+  const fileWatcher = vscode.workspace.createFileSystemWatcher('**/*')
+  fileWatcher.onDidDelete(async (deletedFile) => {
+    for (const textDocument of vscode.workspace.textDocuments) {
+      if (textDocument.uri.fsPath === deletedFile.fsPath) {
+        fileWatcherChain = fileWatcherChain.then(async () => {
+          await vscode.window.showTextDocument(textDocument)
+          return Promise.resolve()
+        })
+        fileWatcherChain = fileWatcherChain.then(async () => {
+          return vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+        })
+      }
+    }
+  })
 }
 
 async function initFS(projectID: string): Promise<void> {

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -57,6 +57,9 @@ function watchForFileDeletions() {
           await vscode.window.showTextDocument(textDocument)
           return Promise.resolve()
         })
+        if (textDocument.isDirty) {
+          await clearDirtyFlags(textDocument.uri)
+        }
         fileWatcherChain = fileWatcherChain.then(async () => {
           return vscode.commands.executeCommand('workbench.action.closeActiveEditor')
         })


### PR DESCRIPTION
Fixes #1221

**Problem:**
When files are moved around in the editor, VS Code gets confused and for something which has disappeared will show the file as deleted.

**Fix:**
Since there's no way to sensibly track that a file has moved in the main editor _and_ then synchronise that up with the state in VS Code once all the file changes have been applied, it seemed better to close the tabs so that a user wont be typing into the abyss.

**Notes:**
- The only way to close tabs is...dubious...as it involves making a file the active editor and then closing the active editor. By opening the deleted/moved file we even get an error in the console which feels slightly disappointing.

**Commit Details:**
- Fixes #1221.
- Adds `watchForFileDeletions` which performs a slightly unusual
  way of closing the editors for deleted files.
