### PR TITLE
Fix updating of asset filenames.

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -501,7 +501,7 @@ import Meta from 'antd/lib/card/Meta'
 import utils from '../../../utils/utils'
 import { defaultConfig } from 'utopia-vscode-common'
 import { getTargetParentForPaste } from '../../../utils/clipboard'
-import { absolutePathFromRelativePath } from '../../../utils/path-utils'
+import { absolutePathFromRelativePath, stripLeadingSlash } from '../../../utils/path-utils'
 import { resolveModule } from '../../../core/es-modules/package-manager/module-resolution'
 
 function applyUpdateToJSXElement(
@@ -3228,7 +3228,7 @@ export const UPDATE_FNS = {
         if (oldContent != null && (isImageFile(oldContent) || isAssetFile(oldContent))) {
           // Update assets.
           if (isLoggedIn(userState.loginState) && editor.id != null) {
-            updateAssetFileName(editor.id, action.oldPath, action.newPath)
+            updateAssetFileName(editor.id, stripLeadingSlash(oldPath), newPath)
           }
         }
       })


### PR DESCRIPTION
Fixes #1220

**Problem:**
When updating the asset path, the incorrect values were being passed to the server.

**Fix:**
Use the file paths not the path from the update action.

**Commit Details:**
- Fixes #1220.
- Use the per-file old and new paths, not the paths from the action.
- Strip the leading slash from the old file path.
