### PR TITLE
fix(canvas) add transientfilestate to creating validpaths

### DIFF
--- a/editor/src/components/canvas/canvas-utils.spec.browser.ts
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.ts
@@ -1860,6 +1860,9 @@ describe('moveTemplate', () => {
         </div>
       `),
     )
+    expect(renderResult.getEditorState().editor.selectedViews).toEqual([
+      EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb', NewUID]),
+    ])
   })
 
   it('inserting a new element as an orphan', async () => {
@@ -1997,6 +2000,9 @@ describe('moveTemplate', () => {
         PrettierConfig,
       ),
     )
+    expect(renderResult.getEditorState().editor.selectedViews).toEqual([
+      EP.elementPath([['storyboard', NewUID]]),
+    ])
   })
 
   it('reparents an element while dragging', async () => {

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -382,6 +382,7 @@ export const UiJsxCanvas = betterReactMemo(
         executionScope,
         projectContents,
         uiFilePath,
+        transientFilesState,
         resolve,
       )
 
@@ -450,6 +451,7 @@ function useGetStoryboardRoot(
   executionScope: MapLike<any>,
   projectContents: ProjectContentTreeRoot,
   uiFilePath: string,
+  transientFilesState: TransientFilesState | null,
   resolve: (importOrigin: string, toImport: string) => Either<string, string>,
 ): {
   StoryboardRootComponent: ComponentRendererComponent | undefined
@@ -471,6 +473,7 @@ function useGetStoryboardRoot(
           EP.emptyElementPath,
           projectContents,
           uiFilePath,
+          transientFilesState,
           resolve,
         )
   const storyboardRootElementPath = useKeepReferenceEqualityIfPossible(validPaths[0]) // >:D


### PR DESCRIPTION
Fixes #1190 

**Problem:**
After insertion the selection is lost. The newly inserted element should be selected.

**Fix:**
Collecting the validpaths for the canvas worked with the projectContents directly, not being aware of the transient files. During insertion the new element is only part of the transient file state. Without the validpaths it is not spywrapped, missing from the metadata, so on drag end the selection filtering clears it.

**Commit Details:**
- added transient files state to `getValidElementPaths`
- using `getParseSuccessOrTransientForFilePath` instead of finding the element from `projectContents`
- extended tests with selectedview