### PR TITLE
Prevent VSCode from grabbing focus when selecting elements.

### DIFF
--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -278,7 +278,7 @@ async function openFile(fileUri: vscode.Uri, retries: number = 5): Promise<boole
   const filePath = fromUtopiaURI(fileUri)
   const fileExists = await exists(filePath)
   if (fileExists) {
-    await vscode.commands.executeCommand('vscode.open', fileUri)
+    await vscode.commands.executeCommand('vscode.open', fileUri, { preserveFocus: true })
     return true
   } else {
     // Just in case the message is processed before the file has been written to the FS


### PR DESCRIPTION
Fixes #1246

**Problem:**
When selecting an element on the canvas, VS Code was focusing the text editor part of itself when the file was opened grabbing focus from the canvas.

There was a regression from a prior piece of work noticed while doing this which was breaking the mailbox loading, involving trailing slashes on paths for directories. 

**Fix:**
VS Code includes a `preserveFocus` option in the handling of file opening which is now passed when triggering the files to open.

The parent path lookup was made more consistent by not having a trailing slash and using a different approach to producing the parent path from a given path which is more reliable involving splitting based on the path separator.

**Commit Details:**
- Fixes #1246.
- Fixed regression caused by #1240, where all the child paths would be
  filtered out and messages would not exit the mailbox. `directoryOfPath`
  was rewritten (and renaming it to `getParentPath`) and then ensuring
  the various call sites were aligned.
- Passed the `preserveFocus` option when invoking the `vscode.open` command.
