### PR TITLE
Update puppeteer-test.ts

### DIFF
--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -355,7 +355,7 @@ async function createSummaryPng(
       },
     ],
     xaxis: {
-      title: 'lower is better, ms / frame (16.67 = 60fps), 100 runs, cutoff 200ms',
+      title: 'lower is better, ms / frame (16.67 = 60fps), many runs, cutoff 200ms',
       range: [0, 251],
       showgrid: true,
       zeroline: true,

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -355,8 +355,8 @@ async function createSummaryPng(
       },
     ],
     xaxis: {
-      title: 'lower is better, ms / frame (16.67 = 60fps), 100 runs',
-      autorange: true,
+      title: 'lower is better, ms / frame (16.67 = 60fps), 100 runs, cutoff 200ms',
+      range: [0, 200],
       showgrid: true,
       zeroline: true,
       dtick: 16.67,

--- a/performance-test/src/puppeteer-test.ts
+++ b/performance-test/src/puppeteer-test.ts
@@ -356,7 +356,7 @@ async function createSummaryPng(
     ],
     xaxis: {
       title: 'lower is better, ms / frame (16.67 = 60fps), 100 runs, cutoff 200ms',
-      range: [0, 200],
+      range: [0, 251],
       showgrid: true,
       zeroline: true,
       dtick: 16.67,


### PR DESCRIPTION
**Problem:**
Having a varied range makes it hard to compare performance charts at a glance

**Fix:**
Fixes the range from 0 to 200ms, adds a label. 