### PR TITLE
Fix/inspector section rerender on scroll

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -546,15 +546,7 @@ export const ComponentSectionInner = betterReactMemo(
       useUsedPropsWithoutControls(),
     )
     const dispatch = useEditorState((state) => state.dispatch, 'ComponentSectionInner')
-    const onResetClicked = React.useCallback(
-      (event: React.MouseEvent<HTMLElement>) => {
-        dispatch(
-          [showContextMenu('context-menu-instance-inspector', event.nativeEvent)],
-          'everyone',
-        )
-      },
-      [dispatch],
-    )
+
     const propsUsedWithoutDefaults = useKeepReferenceEqualityIfPossible(
       useUsedPropsWithoutDefaults(),
     )
@@ -566,54 +558,51 @@ export const ComponentSectionInner = betterReactMemo(
       'ComponentSectionInner selectedViews',
     )
 
-    const { editor, derived } = useEditorState((store) => {
-      return {
-        editor: store.editor,
-        derived: store.derived,
-      }
-    }, 'Focusable values')
+    const focusedElementPath = useEditorState(
+      (store) => store.editor.focusedElementPath,
+      'ComponentSectionInner focusedElementPath',
+    )
 
     const target = selectedViews[0]
 
-    const isFocused = EP.isFocused(editor.focusedElementPath, target)
-    const isNotFocused = EP.isFocused(editor.focusedElementPath, target)
+    const isFocused = EP.isFocused(focusedElementPath, target)
+    const isNotFocused = EP.isFocused(focusedElementPath, target)
 
     const toggleFocusMode = React.useCallback(() => {
       dispatch([setFocusedElement(isFocused ? null : target)])
     }, [dispatch, isFocused, target])
 
-    const metadata = useEditorState(
-      (state) => state.editor.jsxMetadata,
-      'Component-Section jsxMetaData',
-    )
+    const locationOfComponentInstance = useEditorState((state) => {
+      const underlyingTarget = normalisePathToUnderlyingTarget(
+        state.editor.projectContents,
+        state.editor.nodeModules.files,
+        state.editor.canvas.openFile?.filename ?? '',
+        selectedViews[0],
+      )
 
-    let elementName: string
-    const targetName = target
+      return underlyingTarget.type === 'NORMALISE_PATH_SUCCESS' ? underlyingTarget.filePath : ''
+    }, 'ComponentSectionInner locationOfComponentInstance')
 
-    const element = MetadataUtils.findElementByElementPath(metadata, targetName)
-    if (element != null) {
-      const jsxElement = eitherToMaybe(element.element)
-      if (jsxElement != null && isJSXElement(jsxElement)) {
-        elementName = getJSXElementNameAsString(jsxElement.name)
-      }
-    }
-
-    const componentMetadata = MetadataUtils.findElementByElementPath(metadata, target)
-
-    const underlyingTarget = normalisePathToUnderlyingTarget(
-      editor.projectContents,
-      editor.nodeModules.files,
-      editor.canvas.openFile?.filename ?? '',
-      selectedViews[0],
-    )
-    const locationOfComponentInstance =
-      underlyingTarget.type === 'NORMALISE_PATH_SUCCESS' ? underlyingTarget.filePath : ''
-
-    const componentPackageName = maybeEitherToMaybe(componentMetadata?.importInfo)?.path
+    const componentPackageName = useEditorState((state) => {
+      const componentMetadata = MetadataUtils.findElementByElementPath(
+        state.editor.jsxMetadata,
+        target,
+      )
+      return maybeEitherToMaybe(componentMetadata?.importInfo)?.path
+    }, 'ComponentSectionInner componentPackageName')
 
     const componentPackageMgrLink = `https://www.npmjs.com/package/${componentPackageName}`
 
-    const isFocusable = MetadataUtils.isFocusableComponent(target, metadata)
+    const isFocusable = useEditorState((state) => {
+      return MetadataUtils.isFocusableComponent(target, state.editor.jsxMetadata)
+    }, 'ComponentSectionInner isFocusable')
+    const isImportedComponent = useEditorState((state) => {
+      const componentMetadata = MetadataUtils.findElementByElementPath(
+        state.editor.jsxMetadata,
+        target,
+      )
+      return isImportedComponentNPM(componentMetadata)
+    }, 'ComponentSectionInner isImportedComponent')
 
     const componentType = useComponentType(target)
 
@@ -674,7 +663,7 @@ export const ComponentSectionInner = betterReactMemo(
                     (controlDescription) => {
                       return (
                         <UIGridRow padded tall={false} variant='<-------------1fr------------->'>
-                          {isImportedComponentNPM(componentMetadata) ? (
+                          {isImportedComponent ? (
                             <UIGridRow
                               padded
                               tall={false}
@@ -782,7 +771,7 @@ export const ComponentSectionInner = betterReactMemo(
                 </UIGridRow>
               </InspectorSectionHeader>
 
-              {isImportedComponentNPM(componentMetadata) ? (
+              {isImportedComponent ? (
                 <UIGridRow padded tall={false} variant={'|--32px--|<--------auto-------->'}>
                   <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                     <LargerIcons.NpmLogo />

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -566,7 +566,6 @@ export const ComponentSectionInner = betterReactMemo(
     const target = selectedViews[0]
 
     const isFocused = EP.isFocused(focusedElementPath, target)
-    const isNotFocused = EP.isFocused(focusedElementPath, target)
 
     const toggleFocusMode = React.useCallback(() => {
       dispatch([setFocusedElement(isFocused ? null : target)])
@@ -686,7 +685,7 @@ export const ComponentSectionInner = betterReactMemo(
                                 via NPM.
                               </p>
                             </UIGridRow>
-                          ) : isFocusable && !isNotFocused ? (
+                          ) : isFocusable && !isFocused ? (
                             <UIGridRow
                               padded
                               tall={false}
@@ -784,7 +783,7 @@ export const ComponentSectionInner = betterReactMemo(
                     via NPM.
                   </p>
                 </UIGridRow>
-              ) : isFocusable && !isNotFocused ? (
+              ) : isFocusable && !isFocused ? (
                 <UIGridRow padded tall={false} variant={'|--32px--|<--------auto-------->'}>
                   <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                     <IconToggleButton

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -58,8 +58,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(290) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(300)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(265) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(275)
   })
 
   it('Changing the selected view', async () => {


### PR DESCRIPTION
Fixes #1264

**Fix:**
When scrolling the inspector component section rerenders without real changes.

**Commit Details:**
- moving editorstate and jsxmetadata related things into smaller useeditorstate hooks that use memoization
- removed unused function and variable called elementName
- update render count test
