### PR TITLE
Automatically tag and release every day at 05:00 UTC

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -6,9 +6,8 @@ on:
         description: 'Tag to give this release (will increment patch version by default)'
         required: false
       commit-ref:
-        description: 'Branch or SHA to tag'
-        required: true
-        default: 'master'
+        description: 'Branch or SHA to tag (defaults to master)'
+        required: false
   schedule:
     - cron: '0 5 * * *' # Run every day 5:00 UTC
 jobs:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -9,6 +9,8 @@ on:
         description: 'Branch or SHA to tag'
         required: true
         default: 'master'
+  schedule:
+    - cron: '0 5 * * *' # Run every day 5:00 UTC
 jobs:
   release:
     name: Create Release
@@ -44,7 +46,7 @@ jobs:
         with:
           tag_name: ${{ env.NEW_TAG }}
           release_name: Release ${{ env.NEW_TAG }}
-          commitish: ${{ github.event.inputs.commit-ref }}
+          commitish: ${{ github.event.inputs.commit-ref || master }}
           body: Release ${{ env.NEW_TAG }}
           draft: false
           prerelease: false


### PR DESCRIPTION
**Problem:**
Manually releasing "periodically" is just not working

**Fix:**
Update the workflow to automatically release the latest master to production every day. I have gone with 05:00 UTC because it is early enough to not interrupt our working days, and also late enough that it won't affect US users during their working days.