### PR TITLE
Fix/inspector blinking

### DIFF
--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -2,6 +2,7 @@ import {
   generateCodeResultCache,
   incorporateBuildResult,
   normalisePathEndsAtDependency,
+  normalisePathImportNotFound,
   normalisePathSuccess,
   normalisePathToUnderlyingTarget,
   normalisePathUnableToProceed,
@@ -514,7 +515,7 @@ describe('normalisePathToUnderlyingTarget', () => {
     const expectedResult = normalisePathUnableToProceed('/src/nonexistant.js')
     expect(actualResult).toEqual(expectedResult)
   })
-  it('skips attempting to traverse when confronted with an unparsed code file', () => {
+  it('returns existing parse result for unparsed code file', () => {
     const actualResult = normalisePathToUnderlyingTarget(
       projectContents,
       SampleNodeModules,
@@ -523,7 +524,7 @@ describe('normalisePathToUnderlyingTarget', () => {
         'storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-div',
       ),
     )
-    const expectedResult = normalisePathUnableToProceed('/utopia/unparsedstoryboard.js')
+    const expectedResult = normalisePathImportNotFound('app-entity')
     expect(actualResult).toEqual(expectedResult)
   })
   it('handles hitting an external dependency', () => {

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -379,12 +379,7 @@ export function normalisePathToUnderlyingTarget(
 ): NormalisePathResult {
   const currentFile = getContentsTreeFileFromString(projectContents, currentFilePath)
   if (isTextFile(currentFile)) {
-    if (
-      currentFile.fileContents.revisionsState === RevisionsState.CodeAhead ||
-      !isParseSuccess(currentFile.fileContents.parsed)
-    ) {
-      // As the code is ahead this would potentially be looking at a path
-      // which now doesn't exist.
+    if (!isParseSuccess(currentFile.fileContents.parsed)) {
       return normalisePathUnableToProceed(currentFilePath)
     } else {
       const staticPath = elementPath == null ? null : EP.dynamicPathToStaticPath(elementPath)


### PR DESCRIPTION
Fixes #1262

**Problem:**
When typing into the code editor the inspector flickers.

**Fix:**
Normalise path returns no result when the code is not parsed yet, this causes the inspector to render with empty fallback values. Using the normalise path on the UI code not reliable because of these extra rerenders. The fix is to use the old parse result. 
