### PR TITLE
Provide a page for the case where no project can be found.

### DIFF
--- a/editor/src/templates/project-not-found.html
+++ b/editor/src/templates/project-not-found.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link
+      rel="icon"
+      type="image/png"
+      href="/editor/icons/favicons/favicon128.png?hash=%UTOPIA_SHA%"
+    />
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="use-credentials" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="%UTOPIA_DOMAIN%/editor/css/utopions.css?hash=%UTOPIA_SHA%"
+      crossorigin="anonymous"
+    />
+  </head>
+  <body>
+    <span>Project not found.</span>
+  </body>
+</html>

--- a/editor/src/templates/project-not-found.html
+++ b/editor/src/templates/project-not-found.html
@@ -15,6 +15,6 @@
     />
   </head>
   <body>
-    <span>Project not found.</span>
+    <span>Project not found. This project may not exist, was only saved locally, or you're not allowed to view it. Ask the owner to check the URL or update the permissions, and refresh this page.</span>
   </body>
 </html>

--- a/editor/webpack.config.js
+++ b/editor/webpack.config.js
@@ -102,6 +102,14 @@ const config = {
       minify: false,
     }),
     new HtmlWebpackPlugin({
+      chunks: [],
+      inject: 'head', // Add the script tags to the end of the <head>
+      scriptLoading: 'defer',
+      template: './src/templates/project-not-found.html',
+      filename: 'project-not-found.html',
+      minify: false,
+    }),
+    new HtmlWebpackPlugin({
       // Run it again to generate the preview.html
       chunks: ['preview'],
       inject: 'head', // Add the script tags to the end of the <head>

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -161,6 +161,9 @@ projectIDScript (ProjectIdWithSuffix projectID _) = do
     ("window.utopiaProjectID = \"" <> projectID <> "\";")
 
 innerProjectPage :: Maybe ProjectIdWithSuffix -> Maybe ProjectMetadata -> Maybe Text -> ServerMonad H.Html
+innerProjectPage (Just _) Nothing branchName = do
+  projectNotFoundHtml <- getEditorTextContent branchName "project-not-found.html"
+  return $ H.preEscapedToHtml projectNotFoundHtml
 innerProjectPage possibleProjectID possibleMetadata branchName = do
   indexHtml <- getEditorTextContent branchName "index.html"
   siteRoot <- getSiteRoot
@@ -179,6 +182,9 @@ emptyProjectPage :: Maybe Text -> ServerMonad H.Html
 emptyProjectPage branchName = innerProjectPage Nothing Nothing branchName
 
 innerPreviewPage :: Maybe ProjectIdWithSuffix -> Maybe ProjectMetadata -> Maybe Text -> ServerMonad H.Html
+innerPreviewPage (Just _) Nothing branchName = do
+  projectNotFoundHtml <- getEditorTextContent branchName "project-not-found.html"
+  return $ H.preEscapedToHtml projectNotFoundHtml
 innerPreviewPage possibleProjectID possibleMetadata branchName = do
   indexHtml <- getEditorTextContent branchName "preview.html"
   siteRoot <- getSiteRoot

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -107,13 +107,13 @@ localAuthCodeCheck "logmein" action = do
 localAuthCodeCheck _ action = do
   return $ action Nothing
 
-readIndexHtmlFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text
-readIndexHtmlFromDisk (Just downloads) (Just branchName) fileName = do
+readHtmlFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text
+readHtmlFromDisk (Just downloads) (Just branchName) fileName = do
   readBranchHTMLContent downloads branchName fileName
-readIndexHtmlFromDisk _ _ fileName = readFile $ toS $ "../editor/lib/" <> fileName
+readHtmlFromDisk _ _ fileName = readFile $ toS $ "../editor/lib/" <> fileName
 
-readIndexHtmlFromWebpack :: Text -> IO Text
-readIndexHtmlFromWebpack fileName = simpleWebpackRequest ("editor/" <> fileName)
+readHtmlFromWebpack :: Text -> IO Text
+readHtmlFromWebpack fileName = simpleWebpackRequest ("editor/" <> fileName)
 
 simpleWebpackRequest :: Text -> IO Text
 simpleWebpackRequest endpoint = do
@@ -250,8 +250,8 @@ innerServerExecutor (GetCommitHash action) = do
 innerServerExecutor (GetEditorTextContent branchName fileName action) = do
   downloads <- fmap _branchDownloads ask
   manager <- fmap _proxyManager ask
-  let readIndexHtml = if isJust manager && (isNothing branchName || isNothing downloads) then readIndexHtmlFromWebpack else readIndexHtmlFromDisk downloads branchName
-  indexHtml <- liftIO $ readIndexHtml fileName
+  let readHtml = if isJust manager && (isNothing branchName || isNothing downloads) then readHtmlFromWebpack else readHtmlFromDisk downloads branchName
+  indexHtml <- liftIO $ readHtml fileName
   return $ action indexHtml
 innerServerExecutor (GetHashedAssetPaths action) = do
   AssetsCaches{..} <- fmap _assetsCaches ask


### PR DESCRIPTION
Fixes #1270

**Problem:**
Currently the full editor is loaded and then replaces the UI with a message saying the project could not be found if it doesn't exist.

**Fix:**
If the project details can't be found the server immediately renders a "project could not be found" page instead of loading the editor and allowing that to handle it.

**Commit Details:**
- Fixes #1270.
- Slightly refactored `innerProjectPage` and `innerPreviewPage` to
  render the `project-not-found.html` page.
- Added `project-not-found.html` to the templates and included it in
  the webpack config.
- Some slight renaming taking functions from `readIndexHtmlFromWebpack`
  to `readHtmlFromWebpack`.
