### PR TITLE
fix(inspector) layoutsection and inspector props

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -67,6 +67,7 @@ import {
 import { Icn, colorTheme, InspectorSectionHeader, UtopiaTheme, FlexRow } from '../../uuiui'
 import { emptyComments } from '../../core/workers/parser-printer/parser-printer-comments'
 import { getElementsToTarget } from './common/inspector-utils'
+import { ElementPath, PropertyPath } from '../../core/shared/project-file-types'
 
 export interface ElementPathElement {
   name?: string

--- a/editor/src/components/inspector/sections/layout-section/layout-section.spec.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-section.spec.tsx
@@ -39,27 +39,9 @@ describe('Layout Section', () => {
         editorStoreData={storeHookForTest}
       >
         <LayoutSection
-          isChildOfFlexComponent={false}
           hasNonDefaultPositionAttributes={true}
           aspectRatioLocked={false}
-          parentFlexAxis={null}
           toggleAspectRatioLock={NO_OP}
-          specialSizeMeasurements={emptySpecialSizeMeasurements}
-          position='static'
-          input={{
-            frame: {
-              x: 10,
-              y: 10,
-              width: 200,
-              height: 100,
-            } as LocalRectangle,
-            parentFrame: {
-              x: 0,
-              y: 0,
-              width: 350,
-              height: 850,
-            } as CanvasRectangle,
-          }}
         />
       </TestInspectorContextProvider>,
     )

--- a/editor/src/components/inspector/sections/layout-section/layout-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-section.tsx
@@ -1,42 +1,47 @@
 import * as React from 'react'
-import { CanvasRectangle, LocalRectangle } from '../../../../core/shared/math-utils'
 import { LayoutSystemSubsection } from './layout-system-subsection/layout-system-subsection'
 import { SelfLayoutSubsection } from './self-layout-subsection/self-layout-subsection'
-import { CSSPosition } from '../../common/css-utils'
-import {
-  DetectedLayoutSystem,
-  SpecialSizeMeasurements,
-} from '../../../../core/shared/element-template'
+import { emptySpecialSizeMeasurements } from '../../../../core/shared/element-template'
 import { betterReactMemo } from '../../../../uuiui-deps'
-
-export interface ResolvedLayoutProps {
-  frame: LocalRectangle | null
-  parentFrame: CanvasRectangle | null
-}
+import { useEditorState } from '../../../editor/store/store-hook'
+import { fastForEach } from '../../../../core/shared/utils'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { SpecialSizeMeasurementsKeepDeepEquality } from '../../../editor/store/store-deep-equality-instances'
 
 interface LayoutSectionProps {
-  input: ResolvedLayoutProps
-  specialSizeMeasurements: SpecialSizeMeasurements
-  isChildOfFlexComponent: boolean
-  position: CSSPosition | null
   hasNonDefaultPositionAttributes: boolean
-  parentFlexAxis: 'horizontal' | 'vertical' | null
   aspectRatioLocked: boolean
   toggleAspectRatioLock: () => void
 }
 
 export const LayoutSection = betterReactMemo('LayoutSection', (props: LayoutSectionProps) => {
+  const specialSizeMeasurements = useEditorState(
+    (state) => {
+      let foundSpecialSizeMeasurements = emptySpecialSizeMeasurements
+      fastForEach(state.editor.selectedViews, (path) => {
+        // TODO multiselect
+        const jsxMetadata = state.editor.jsxMetadata
+        const elementMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
+        if (elementMetadata != null) {
+          foundSpecialSizeMeasurements = elementMetadata.specialSizeMeasurements
+        }
+      })
+      return foundSpecialSizeMeasurements
+    },
+    'RenderedLayoutSection specialSizeMeasurements',
+    (old, next) => SpecialSizeMeasurementsKeepDeepEquality()(old, next).areEqual,
+  )
+
   return (
     <>
       <SelfLayoutSubsection
-        input={props.input}
-        position={props.position}
-        isChildOfFlexComponent={props.isChildOfFlexComponent}
-        parentFlexAxis={props.parentFlexAxis}
+        position={specialSizeMeasurements.position}
+        isChildOfFlexComponent={specialSizeMeasurements.parentLayoutSystem === 'flex'}
+        parentFlexDirection={specialSizeMeasurements.parentFlexDirection}
         aspectRatioLocked={props.aspectRatioLocked}
         toggleAspectRatioLock={props.toggleAspectRatioLock}
       />
-      <LayoutSystemSubsection specialSizeMeasurements={props.specialSizeMeasurements} />
+      <LayoutSystemSubsection specialSizeMeasurements={specialSizeMeasurements} />
     </>
   )
 })

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -28,7 +28,6 @@ import {
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import { PinControl, PinHeightControl, PinWidthControl } from '../../../controls/pin-control'
 import { PropertyLabel } from '../../../widgets/property-label'
-import { ResolvedLayoutProps } from '../layout-section'
 import { SelfLayoutTab } from './self-layout-subsection'
 import {
   useWrappedEmptyOrUnknownOnSubmitValue,
@@ -291,7 +290,6 @@ export const FlexLayoutNumberControl = betterReactMemo(
 )
 
 interface PinControlsProps {
-  frame: LocalRectangle | null
   resetPins: () => void
   framePins: FramePinsInfo
   togglePin: (prop: LayoutPinnedProp) => void
@@ -331,12 +329,11 @@ function flexStyleNumberControl(label: string, styleProp: StyleLayoutNumberProp)
 const spacingButton = <SquareButton />
 
 interface WidthHeightRowProps {
-  frame: LocalRectangle | null
   layoutType: SelfLayoutTab
   toggleMinMax: () => void
   togglePin: (prop: LayoutPinnedProp) => void
   framePins: FramePinsInfo
-  parentFlexAxis: 'horizontal' | 'vertical' | null
+  parentFlexDirection: string | null
   aspectRatioLocked: boolean
   toggleAspectRatioLock: () => void
 }
@@ -347,8 +344,7 @@ const WidthHeightRow = betterReactMemo('WidthHeightRow', (props: WidthHeightRowP
     toggleMinMax,
     togglePin,
     framePins,
-    frame,
-    parentFlexAxis,
+    parentFlexDirection,
     aspectRatioLocked,
     toggleAspectRatioLock,
   } = props
@@ -356,12 +352,14 @@ const WidthHeightRow = betterReactMemo('WidthHeightRow', (props: WidthHeightRowP
   let widthControl: React.ReactElement | null = null
   let heightControl: React.ReactElement | null = null
   if (layoutType === 'flex') {
-    switch (parentFlexAxis) {
-      case 'horizontal':
+    switch (parentFlexDirection) {
+      case 'row':
+      case 'row-reverse':
       case null:
         widthControl = <FlexBasisShorthandCSSNumberControl label='W' />
         break
-      case 'vertical':
+      case 'column':
+      case 'column-reverse':
         heightControl = <FlexBasisShorthandCSSNumberControl label='H' />
         break
       default:
@@ -493,7 +491,7 @@ const FlexGrowShrinkRow = betterReactMemo('FlexGrowShrinkRow', () => {
 })
 
 const OtherPinsRow = betterReactMemo('OtherPinsRow', (props: PinControlsProps) => {
-  const { frame, resetPins: resetPinsFn, framePins, togglePin } = props
+  const { resetPins: resetPinsFn, framePins, togglePin } = props
   let firstXAxisControl: React.ReactElement = <div />
   let secondXAxisControl: React.ReactElement = <div />
   let firstYAxisControl: React.ReactElement = <div />
@@ -539,12 +537,7 @@ const OtherPinsRow = betterReactMemo('OtherPinsRow', (props: PinControlsProps) =
       variant='<---1fr--->|------172px-------|'
       style={{ height: undefined }}
     >
-      <PinControls
-        frame={frame}
-        resetPins={resetPinsFn}
-        framePins={framePins}
-        togglePin={togglePin}
-      />
+      <PinControls resetPins={resetPinsFn} framePins={framePins} togglePin={togglePin} />
       <FlexColumn>
         <UIGridRow padded={false} variant='|--67px--||16px||--67px--||16px|'>
           {firstXAxisControl}
@@ -564,9 +557,8 @@ const OtherPinsRow = betterReactMemo('OtherPinsRow', (props: PinControlsProps) =
 })
 
 interface GiganticSizePinsSubsectionProps {
-  input: ResolvedLayoutProps
   layoutType: SelfLayoutTab
-  parentFlexAxis: 'horizontal' | 'vertical' | null
+  parentFlexDirection: string | null
   aspectRatioLocked: boolean
   toggleAspectRatioLock: () => void
 }
@@ -574,8 +566,7 @@ interface GiganticSizePinsSubsectionProps {
 export const GiganticSizePinsSubsection = betterReactMemo(
   'GiganticSizePinsSubsection',
   (props: GiganticSizePinsSubsectionProps) => {
-    const { input, layoutType, parentFlexAxis, aspectRatioLocked, toggleAspectRatioLock } = props
-    const { frame } = input
+    const { layoutType, parentFlexDirection, aspectRatioLocked, toggleAspectRatioLock } = props
 
     const minWidth = useInspectorLayoutInfo('minWidth')
     const maxWidth = useInspectorLayoutInfo('maxWidth')
@@ -597,12 +588,11 @@ export const GiganticSizePinsSubsection = betterReactMemo(
     return (
       <>
         <WidthHeightRow
-          frame={frame}
           layoutType={layoutType}
           togglePin={togglePin}
           framePins={framePins}
           toggleMinMax={toggleMinMax}
-          parentFlexAxis={parentFlexAxis}
+          parentFlexDirection={parentFlexDirection}
           aspectRatioLocked={aspectRatioLocked}
           toggleAspectRatioLock={toggleAspectRatioLock}
         />
@@ -619,12 +609,7 @@ export const GiganticSizePinsSubsection = betterReactMemo(
           </>
         ) : null}
         {layoutType === 'absolute' ? (
-          <OtherPinsRow
-            frame={frame}
-            resetPins={resetAllPins}
-            framePins={framePins}
-            togglePin={togglePin}
-          />
+          <OtherPinsRow resetPins={resetAllPins} framePins={framePins} togglePin={togglePin} />
         ) : null}
       </>
     )

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -4,7 +4,6 @@ import { usePropControlledState, betterReactMemo } from '../../../../../uuiui-de
 import { CSSPosition } from '../../../common/css-utils'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import { FlexElementSubsection } from '../flex-element-subsection/flex-element-subsection'
-import { ResolvedLayoutProps } from '../layout-section'
 import { GiganticSizePinsSubsection } from './gigantic-size-pins-subsection'
 import { LayoutTypePicker } from './self-layout-controls'
 
@@ -21,10 +20,9 @@ function useActiveLayoutTab(position: CSSPosition | null, isChildOfFlexComponent
 }
 
 interface SelfLayoutSubsectionProps {
-  input: ResolvedLayoutProps
   position: CSSPosition | null
   isChildOfFlexComponent: boolean
-  parentFlexAxis: 'horizontal' | 'vertical' | null
+  parentFlexDirection: string | null
   aspectRatioLocked: boolean
   toggleAspectRatioLock: () => void
 }
@@ -44,9 +42,8 @@ export const SelfLayoutSubsection = betterReactMemo(
           <LayoutTypePicker value={activeTab} setActiveTab={setActiveTab} />
         </UIGridRow>
         <GiganticSizePinsSubsection
-          input={props.input}
           layoutType={activeTab}
-          parentFlexAxis={props.parentFlexAxis}
+          parentFlexDirection={props.parentFlexDirection}
           aspectRatioLocked={props.aspectRatioLocked}
           toggleAspectRatioLock={props.toggleAspectRatioLock}
         />

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -563,5 +563,3 @@ export function isUnknownOrGeneratedElement(elementOriginType: ElementOriginType
     elementOriginType === 'generated-static-definition-present'
   )
 }
-
-export type LayoutWrapper = 'Layoutable' | 'Positionable' | 'Resizeable'

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -33,8 +33,6 @@ export const UtopiaApiComponents: DependencyBoundDescriptors = {
     name: 'utopia-api',
     components: [
       createBasicUtopiaComponent('Ellipse', 'Ellipse', StyleObjectProps),
-      createBasicUtopiaComponent('Layoutable', 'Layoutable', StyleObjectProps),
-      createBasicUtopiaComponent('Positionable', 'Positionable', StyleObjectProps),
       createBasicUtopiaComponent('Rectangle', 'Rectangle', StyleObjectProps),
       createBasicUtopiaComponent('Text', 'Text', StyleObjectProps),
       createBasicUtopiaComponent('View', 'View', StyleObjectProps),


### PR DESCRIPTION
**Fix:**
Cleaning up some ancient code called InspectorModel.

**Commit Details:**
- still found some layoutwrapper related variables here
- removed inspectorModel, moved the only thing used from it: specialSizeMeasurements to layout-section
- removed underlying path resolving from inspector.tsx, because for the CSSTarget this could be extracted from the metadata
- changed props about the flex direction in the layout-section components because now it uses the specialsizemeasurements metadata
