### PR TITLE
Fix/editor single file functions

### DIFF
--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -38,7 +38,6 @@ export interface CanvasData {
   canvasOffset: CanvasPoint
   selectedViews: Array<ElementPath>
   jsxMetadata: ElementInstanceMetadataMap
-  currentFilePath: string | null
   projectContents: ProjectContentTreeRoot
   nodeModules: NodeModules
   transientFilesState: TransientFilesState | null
@@ -139,13 +138,9 @@ export const toggleShadowItem: ContextMenuItem<CanvasData> = {
 export const setAsFocusedElement: ContextMenuItem<CanvasData> = {
   name: 'Edit Component',
   enabled: (data) => {
-    if (data.currentFilePath == null) {
-      return false
-    } else {
-      return data.selectedViews.every((view) => {
-        return MetadataUtils.isFocusableComponent(view, data.jsxMetadata)
-      })
-    }
+    return data.selectedViews.every((view) => {
+      return MetadataUtils.isFocusableComponent(view, data.jsxMetadata)
+    })
   },
   isHidden: (data) => {
     return data.selectedViews.every((view) => {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -1593,21 +1593,7 @@ export const UPDATE_FNS = {
     const dragSources = action.dragSources
     const dropTarget = action.dropTarget
     const targetPath = dropTarget.target
-    let index: number
-    const uiFile = getOpenUIJSFile(editor)
-    if (uiFile == null) {
-      console.warn('Attempted to find the index of a view with no ui file open.')
-      return editor
-    } else {
-      if (isParseSuccess(uiFile.fileContents.parsed)) {
-        index = MetadataUtils.getViewZIndexFromMetadata(editor.jsxMetadata, targetPath)
-      } else {
-        console.warn(
-          'Attempted to find the index of a view when the code currently does not parse.',
-        )
-        return editor
-      }
-    }
+    const index = MetadataUtils.getViewZIndexFromMetadata(editor.jsxMetadata, targetPath)
     let indexPosition: IndexPosition
     let newParentPath: ElementPath | null
     switch (dropTarget.type) {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -392,7 +392,6 @@ import {
   getMainUIFromModel,
   getOpenFilename,
   getOpenTextFileKey,
-  getOpenUIJSFile,
   getOpenUIJSFileKey,
   insertElementAtPath,
   mergeStoredEditorStateIntoEditorState,

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -32,7 +32,6 @@ import * as EP from '../core/shared/element-path'
 import { ElementPath } from '../core/shared/project-file-types'
 import { useNamesAndIconsAllPaths } from './inspector/common/name-and-icon-hook'
 import { FlexRow, Icn, IcnProps } from '../uuiui'
-import { getOpenUIJSFileKey } from './editor/store/editor-state'
 import { getAllTargetsAtPoint } from './canvas/dom-lookup'
 import { WindowMousePositionRaw } from '../utils/global-positions'
 
@@ -177,7 +176,6 @@ export const ElementContextMenu = betterReactMemo(
         selectedViews: store.editor.selectedViews,
         jsxMetadata: store.editor.jsxMetadata,
         editorDispatch: store.dispatch,
-        currentFilePath: getOpenUIJSFileKey(store.editor),
         projectContents: store.editor.projectContents,
         nodeModules: store.editor.nodeModules.files,
         transientFilesState: store.derived.canvas.transientState.filesState,
@@ -193,7 +191,6 @@ export const ElementContextMenu = betterReactMemo(
         canvasOffset: currentEditor.canvasOffset,
         selectedViews: currentEditor.selectedViews,
         jsxMetadata: currentEditor.jsxMetadata,
-        currentFilePath: currentEditor.currentFilePath,
         projectContents: currentEditor.projectContents,
         nodeModules: currentEditor.nodeModules,
         transientFilesState: currentEditor.transientFilesState,


### PR DESCRIPTION
Fixes #1252

**Problem:**
It is possible that there are features in the editor only working on the storyboard file.

**Fix:**
I found unset property from inspector context-menu where this was missing and fixed that. Also found some unused code where I removed the uifile related parts.

**Commit Details:**
- update UNSET_PROPERTY action to work on multiple files
- removed current file from canvas contextmenu data, because only the metadata is used
- removed unused variable componentUIDs from filebrowser
- removed ui file from filebrowser since this was part of the exported component insertion and that functionality is part of the insert menu
- updated NAVIGATOR_REORDER action because it was using uifile for zindex, but only uses the metadata 
