### PR TITLE
Do not reload vscode when forking a project

### DIFF
--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -73,7 +73,6 @@ function forceSetValueAtPath(
 interface InsertModeControlContainerProps extends ControlProps {
   mode: InsertMode
   keysPressed: KeysPressed
-  projectId: string | null
   dragState: InsertDragState | null
   canvasOffset: CanvasVector
   scale: number

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -364,7 +364,6 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
             mode={props.editor.mode}
             keysPressed={props.editor.keysPressed}
             windowToCanvasPosition={props.windowToCanvasPosition}
-            projectId={props.editor.id}
             dragState={
               dragState != null && dragState.type === 'INSERT_DRAG_STATE' ? dragState : null
             }

--- a/editor/src/components/code-editor/code-editor-container.tsx
+++ b/editor/src/components/code-editor/code-editor-container.tsx
@@ -4,6 +4,7 @@ import { useEditorState } from '../editor/store/store-hook'
 import { MONACO_EDITOR_IFRAME_BASE_URL } from '../../common/env-vars'
 import { createIframeUrl } from '../../core/shared/utils'
 import { forceNotNull } from '../../core/shared/optional-utils'
+import { reduxDevtoolsLogMessage } from '../../core/shared/redux-devtools'
 
 const VSCodeIframeContainer = betterReactMemo(
   'VSCodeIframeContainer',
@@ -35,7 +36,7 @@ const VSCodeIframeContainer = betterReactMemo(
 export const CodeEditorWrapper = betterReactMemo('CodeEditorWrapper', () => {
   const selectedProps = useEditorState((store) => {
     return {
-      projectID: store.editor.id,
+      vscodeBridgeId: store.editor.vscodeBridgeId,
       vscodeBridgeReady: store.editor.vscodeBridgeReady,
     }
   }, 'CodeEditorWrapper')
@@ -44,8 +45,8 @@ export const CodeEditorWrapper = betterReactMemo('CodeEditorWrapper', () => {
     return (
       <VSCodeIframeContainer
         projectID={forceNotNull(
-          'Project ID must be set when launching the code editor',
-          selectedProps.projectID,
+          'VSCode Bridge ID must be set when launching the code editor',
+          selectedProps.vscodeBridgeId,
         )}
       />
     )

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -293,6 +293,11 @@ export interface SetProjectID {
   id: string
 }
 
+export interface SetForkedFromProjectID {
+  action: 'SET_FORKED_FROM_PROJECT_ID'
+  id: string | null
+}
+
 export interface OpenTextEditor {
   action: 'OPEN_TEXT_EDITOR'
   target: ElementPath
@@ -851,6 +856,7 @@ export type EditorAction =
   | PasteJSXElements
   | CopySelectionToClipboard
   | SetProjectID
+  | SetForkedFromProjectID
   | OpenTextEditor
   | CloseTextEditor
   | SetLeftMenuTab

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -182,6 +182,7 @@ import type {
   SetFollowSelectionEnabled,
   SetLoginState,
   SetFilebrowserDropTarget,
+  SetForkedFromProjectID,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -698,6 +699,13 @@ export function setStoredFontSettings(fontSettings: FontSettings): SetStoredFont
 export function setProjectID(id: string): SetProjectID {
   return {
     action: 'SET_PROJECT_ID',
+    id: id,
+  }
+}
+
+export function setForkedFromProjectID(id: string | null): SetForkedFromProjectID {
+  return {
+    action: 'SET_FORKED_FROM_PROJECT_ID',
     id: id,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -89,6 +89,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_CONFIG_FROM_VSCODE':
     case 'SET_LOGIN_STATE':
     case 'SET_FILEBROWSER_DROPTARGET':
+    case 'SET_FORKED_FROM_PROJECT_ID':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -352,6 +352,7 @@ import {
   UpdateConfigFromVSCode,
   SetLoginState,
   SetFilebrowserDropTarget,
+  SetForkedFromProjectID,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -906,6 +907,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
   const poppedEditor = history.current.editor
   return {
     id: currentEditor.id,
+    vscodeBridgeId: currentEditor.vscodeBridgeId,
     forkedFromProjectId: currentEditor.forkedFromProjectId,
     appID: currentEditor.appID,
     projectName: currentEditor.projectName,
@@ -1494,6 +1496,7 @@ export const UPDATE_FNS = {
       ...editorModelFromPersistentModel(parsedModel, dispatch),
       projectName: action.title,
       id: action.projectId,
+      vscodeBridgeId: action.projectId, // we assign a first value when loading a project. SET_PROJECT_ID will not change this, saving us from having to reload VSCode
       nodeModules: {
         skipDeepFreeze: true,
         files: action.nodeModules,
@@ -3124,16 +3127,11 @@ export const UPDATE_FNS = {
       return editor
     }
   },
-  SET_PROJECT_ID: (
-    action: SetProjectID,
-    editor: EditorModel,
-    dispatch: EditorDispatch,
-  ): EditorModel => {
-    initVSCodeBridge(action.id, editor.projectContents, dispatch)
-    return UPDATE_FNS.MARK_VSCODE_BRIDGE_READY(markVSCodeBridgeReady(false), {
+  SET_PROJECT_ID: (action: SetProjectID, editor: EditorModel): EditorModel => {
+    return {
       ...editor,
       id: action.id,
-    })
+    }
   },
   UPDATE_CODE_RESULT_CACHE: (action: UpdateCodeResultCache, editor: EditorModel): EditorModel => {
     return {
@@ -4266,6 +4264,15 @@ export const UPDATE_FNS = {
         ...editor.fileBrowser,
         dropTarget: action.target,
       },
+    }
+  },
+  SET_FORKED_FROM_PROJECT_ID: (
+    action: SetForkedFromProjectID,
+    editor: EditorModel,
+  ): EditorModel => {
+    return {
+      ...editor,
+      forkedFromProjectId: action.id,
     }
   },
 }

--- a/editor/src/components/editor/persistence-hooks.ts
+++ b/editor/src/components/editor/persistence-hooks.ts
@@ -6,6 +6,6 @@ export function useTriggerForkProject(): () => void {
   const storeRef = useRefEditorState((store) => store)
   return React.useCallback(async () => {
     const store = storeRef.current
-    triggerForkProject(store.dispatch, store.editor, store.workers, store.userState.loginState)
+    triggerForkProject(store.dispatch, store.editor, store.userState.loginState)
   }, [storeRef])
 }

--- a/editor/src/components/editor/persistence.ts
+++ b/editor/src/components/editor/persistence.ts
@@ -8,7 +8,12 @@ import { checkProjectOwnership } from '../../common/server'
 import Utils from '../../utils/utils'
 import { EditorDispatch } from './action-types'
 import { load, loadSampleProject, newProject } from './actions/actions'
-import { setProjectID, showToast, setSaveError } from './actions/action-creators'
+import {
+  setProjectID,
+  showToast,
+  setSaveError,
+  setForkedFromProjectID,
+} from './actions/action-creators'
 import {
   createNewProjectID,
   loadProject,
@@ -279,18 +284,17 @@ export async function saveToServer(
 export async function triggerForkProject(
   dispatch: EditorDispatch,
   editor: EditorState,
-  workers: UtopiaTsWorkers,
   loginState: LoginState,
 ): Promise<void> {
+  const oldProjectId = editor.id
   const newProjectId = await createNewProjectID()
   const updatedEditor = {
     ...editor,
-    forkedFromProjectId: editor.id,
+    forkedFromProjectId: oldProjectId,
     id: newProjectId,
   }
-  const newModel = persistentModelFromEditorModel(updatedEditor)
   await save(updatedEditor, dispatch, loginState, 'both', true)
-  load(dispatch, newModel, updatedEditor.projectName, newProjectId, workers, NO_OP)
+  dispatch([setProjectID(newProjectId), setForkedFromProjectID(oldProjectId)])
 }
 
 async function checkCanSaveProject(projectId: string | null): Promise<boolean> {

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -349,9 +349,9 @@ async function applyVSCodeChanges(
   updateCameFromVSCode: boolean,
 ): Promise<void> {
   // Update the file system that is shared between Utopia and VS Code.
-  if (oldStoredState.editor.id != null && !updateCameFromVSCode) {
+  if (oldStoredState.editor.vscodeBridgeId != null && !updateCameFromVSCode) {
     const changes = collateProjectChanges(
-      oldStoredState.editor.id,
+      oldStoredState.editor.vscodeBridgeId,
       oldStoredState.editor.projectContents,
       newEditorState.projectContents,
     )
@@ -374,7 +374,9 @@ export function editorDispatch(
   spyCollector: UiJsxCanvasContextData,
 ): DispatchResult {
   const isLoadAction = dispatchedActions.some((a) => a.action === 'LOAD')
-  const nameUpdated = dispatchedActions.some((action) => action.action === 'SET_PROJECT_NAME')
+  const nameUpdated = dispatchedActions.some(
+    (action) => action.action === 'SET_PROJECT_NAME' || action.action === 'SET_PROJECT_ID',
+  )
   const forceSave =
     nameUpdated || dispatchedActions.some((action) => action.action === 'SAVE_CURRENT_FILE')
   const onlyNameUpdated = nameUpdated && dispatchedActions.length === 1

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -273,6 +273,7 @@ export interface DesignerFile {
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
   id: string | null
+  vscodeBridgeId: string | null
   forkedFromProjectId: string | null
   appID: string | null
   projectName: string
@@ -1029,6 +1030,7 @@ export const BaseCanvasOffsetLeftPane = {
 export function createEditorState(dispatch: EditorDispatch): EditorState {
   return {
     id: null,
+    vscodeBridgeId: null,
     forkedFromProjectId: null,
     appID: null,
     projectName: createNewProjectName(),
@@ -1258,6 +1260,7 @@ export function editorModelFromPersistentModel(
   )
   const editor: EditorState = {
     id: null,
+    vscodeBridgeId: null,
     forkedFromProjectId: persistentModel.forkedFromProjectId,
     appID: persistentModel.appID ?? null,
     projectName: createNewProjectName(),

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -156,7 +156,7 @@ export function runSimpleLocalEditorAction(
     case 'SET_STORED_FONT_SETTINGS':
       return UPDATE_FNS.SET_STORED_FONT_SETTINGS(action, state)
     case 'SET_PROJECT_ID':
-      return UPDATE_FNS.SET_PROJECT_ID(action, state, dispatch)
+      return UPDATE_FNS.SET_PROJECT_ID(action, state)
     case 'UPDATE_CODE_RESULT_CACHE':
       return UPDATE_FNS.UPDATE_CODE_RESULT_CACHE(action, state)
     case 'SET_CODE_EDITOR_VISIBILITY':
@@ -291,6 +291,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SET_FOLLOW_SELECTION_ENABLED(action, state)
     case 'SET_FILEBROWSER_DROPTARGET':
       return UPDATE_FNS.SET_FILEBROWSER_DROPTARGET(action, state)
+    case 'SET_FORKED_FROM_PROJECT_ID':
+      return UPDATE_FNS.SET_FORKED_FROM_PROJECT_ID(action, state)
     default:
       return state
   }


### PR DESCRIPTION
Fixes #1289

**Problem:**
When forking the project, VSCode would reload. This would mean the user had to wait long seconds AND manually open the edited file again so they can continue editing. Urgh!

**Fix:**
The project ID and vscode's bridge ID were coming from the same editorState.id . The fix is to split `id` and `vscodeBridgeId` into two separate fields. For the sake of not changing too many things, `vscodeBridgeId` is initialized to `editor.id`, but subsequent changes to editor.id (such as when forking a project) do not update `vscodeBridgeId`, because there is no need. This means that the vscode instance can survive an ID change, and keep on working.

**Commit Details:**
- Added `vscodeBridgeId` to editor-state, LOAD initializes it to editor.id
- SET_PROJECT_ID does NOT change `vscodeBridgeId`, does NOT call `initVSCodeBridge`
- `triggerForkProject` does not call `LOAD` anymore, I realized it can get by with only dispatching `SET_PROJECT_ID` and `SET_FORKED_FROM_PROJECT_ID`