### PR TITLE
Handle missing React imports more like a regular app.

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -55,6 +55,7 @@ import {
   clearParseResultPassTimes,
   clearParseResultUniqueIDsAndEmptyBlocks,
   clearTopLevelElementUniqueIDsAndEmptyBlocks,
+  elementsStructure,
   ensureElementsHaveUID,
   JustImportViewAndReact,
   PrintableProjectContent,
@@ -4357,6 +4358,26 @@ export var whatever2 = (props) => <View data-uid='aaa'>
     const printableArbitrary = printableProjectContentArbitrary()
     const dataUIDProperty = FastCheck.property(printableArbitrary, checkDataUIDsPopulated)
     FastCheck.assert(dataUIDProperty, { verbose: true })
+  })
+  it('when react is not imported treat components as arbitrary blocks', () => {
+    const code = `
+export var whatever = (props) => <View data-uid='aaa'>
+  <View data-uid='aaa' />
+</View>
+`
+    const actualResult = testParseCode(code)
+    foldParsedTextFile(
+      (_) => fail('Unable to parse code.'),
+      (success) => {
+        expect(elementsStructure(success.topLevelElements)).toMatchInlineSnapshot(`
+          "UNPARSED_CODE
+          ARBITRARY_JS_BLOCK
+          UNPARSED_CODE"
+        `)
+      },
+      (_) => fail('Unable to parse code.'),
+      actualResult,
+    )
   })
 })
 

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -1048,6 +1048,28 @@ export function getComponentsRenderedWithReactDOM(
   return []
 }
 
+export function isReactImported(sourceFile: TS.SourceFile): boolean {
+  const topLevelNodes = flatMapArray(
+    (e) => flattenOutAnnoyingContainers(sourceFile, e),
+    sourceFile.getChildren(sourceFile),
+  )
+  return topLevelNodes.some((topLevelNode) => {
+    if (TS.isImportDeclaration(topLevelNode)) {
+      if (TS.isStringLiteral(topLevelNode.moduleSpecifier)) {
+        const importClause: TS.ImportClause | undefined = topLevelNode.importClause
+        const importFrom: string = topLevelNode.moduleSpecifier.text
+        if (
+          (importClause?.namedBindings != null || importClause?.name != null) &&
+          importFrom === 'react'
+        ) {
+          return true
+        }
+      }
+    }
+    return false
+  })
+}
+
 export function parseCode(
   filename: string,
   sourceText: string,
@@ -1060,6 +1082,7 @@ export function parseCode(
   if (sourceFile == null) {
     return parseFailure([], null, `File ${filename} not found.`, [])
   } else {
+    const reactJSXPermitted = jsxFactoryFunction != null || isReactImported(sourceFile)
     let topLevelElements: Array<Either<string, TopLevelElement>> = []
     let imports: Imports = emptyImports()
     // Find the already existing UIDs so that when we generate one it doesn't duplicate one
@@ -1220,68 +1243,74 @@ export function parseCode(
           let isFunction: boolean = false
           let parsedFunctionParam: Either<string, WithParserMetadata<Param> | null> = right(null)
           let propsUsed: Array<string> = []
-          if (isPossibleCanvasContentsFunction(canvasContents)) {
-            const { parameters, body } = canvasContents
-            isFunction = true
-            const parsedFunctionParams = parseParams(
-              parameters,
-              sourceFile,
-              sourceText,
-              filename,
-              imports,
-              topLevelNames,
-              highlightBounds,
-              alreadyExistingUIDs,
-            )
-            parsedFunctionParam = flatMapEither((parsedParams) => {
-              const paramsValue = parsedParams.value
-              if (paramsValue.length === 0) {
-                return right(null)
-              } else if (paramsValue.length === 1) {
-                // Note: We're explicitly ignoring the `propsUsed` value as
-                // that should be handled by the call to `propNamesForParam` below.
-                return right(
-                  withParserMetadata(paramsValue[0], parsedParams.highlightBounds, [], []),
-                )
-              } else {
-                return left('Invalid number of params')
-              }
-            }, parsedFunctionParams)
-            forEachRight(parsedFunctionParam, (param) => {
-              const boundParam = param?.value.boundParam
-              const propsObjectName =
-                boundParam != null && isRegularParam(boundParam) ? boundParam.paramName : null
-
-              propsUsed = param == null ? [] : propNamesForParam(param.value)
-
-              parsedContents = parseOutFunctionContents(
+          // If react isn't imported don't parse this and
+          // let the arbitrary node handling handle it instead.
+          // This should result in a runtime error which matches
+          // regular code not running in the editor.
+          if (reactJSXPermitted) {
+            if (isPossibleCanvasContentsFunction(canvasContents)) {
+              const { parameters, body } = canvasContents
+              isFunction = true
+              const parsedFunctionParams = parseParams(
+                parameters,
                 sourceFile,
                 sourceText,
                 filename,
                 imports,
                 topLevelNames,
-                propsObjectName,
-                body,
-                param?.highlightBounds ?? {},
-                alreadyExistingUIDs,
-              )
-            })
-          } else {
-            // In this case it's likely/hopefully a straight JSX expression attached to the var.
-            parsedContents = liftParsedElementsIntoFunctionContents(
-              expressionTypeForExpression(canvasContents.initializer),
-              parseOutJSXElements(
-                sourceFile,
-                sourceText,
-                filename,
-                [canvasContents.initializer],
-                imports,
-                topLevelNames,
-                null,
                 highlightBounds,
                 alreadyExistingUIDs,
-              ),
-            )
+              )
+              parsedFunctionParam = flatMapEither((parsedParams) => {
+                const paramsValue = parsedParams.value
+                if (paramsValue.length === 0) {
+                  return right(null)
+                } else if (paramsValue.length === 1) {
+                  // Note: We're explicitly ignoring the `propsUsed` value as
+                  // that should be handled by the call to `propNamesForParam` below.
+                  return right(
+                    withParserMetadata(paramsValue[0], parsedParams.highlightBounds, [], []),
+                  )
+                } else {
+                  return left('Invalid number of params')
+                }
+              }, parsedFunctionParams)
+              forEachRight(parsedFunctionParam, (param) => {
+                const boundParam = param?.value.boundParam
+                const propsObjectName =
+                  boundParam != null && isRegularParam(boundParam) ? boundParam.paramName : null
+
+                propsUsed = param == null ? [] : propNamesForParam(param.value)
+
+                parsedContents = parseOutFunctionContents(
+                  sourceFile,
+                  sourceText,
+                  filename,
+                  imports,
+                  topLevelNames,
+                  propsObjectName,
+                  body,
+                  param?.highlightBounds ?? {},
+                  alreadyExistingUIDs,
+                )
+              })
+            } else {
+              // In this case it's likely/hopefully a straight JSX expression attached to the var.
+              parsedContents = liftParsedElementsIntoFunctionContents(
+                expressionTypeForExpression(canvasContents.initializer),
+                parseOutJSXElements(
+                  sourceFile,
+                  sourceText,
+                  filename,
+                  [canvasContents.initializer],
+                  imports,
+                  topLevelNames,
+                  null,
+                  highlightBounds,
+                  alreadyExistingUIDs,
+                ),
+              )
+            }
           }
           if (isLeft(parsedContents) || (isFunction && isLeft(parsedFunctionParam))) {
             pushArbitraryNode(topLevelElement)


### PR DESCRIPTION
Fixes #1282

**Problem:**
Because of the way we parse components we were being more permissive than regular JS because an import to React or a JSX pragma is required to use JSX syntax. Which meant that the user wouldn't get the feedback about it.

**Fix:**
When neither of the above conditions are satisfied, the parsing is disabled for a file and it defers them down to the arbitrary JS handling which results in an error about React in the canvas.

**Commit Details:**
- Fixes #1282.
- Implemented `isReactImported` to scan the top level imports of a
  given file to see if React is amongst the imports.
- `parseCode` now defers top level elements to arbitrary blocks if
  neither React is imported or a JSX pragma has been supplied.
