### PR TITLE
devtools can now import state

### DIFF
--- a/editor/src/core/shared/redux-devtools.ts
+++ b/editor/src/core/shared/redux-devtools.ts
@@ -3,9 +3,9 @@ import type { EditorStore } from '../../components/editor/store/editor-state'
 import { pluck } from './array-utils'
 
 interface Connection {
-  subscribe: (listener: (message: { type: string; state: string }) => void) => () => void // adds a change listener. It will be called any time an action is dispatched from the monitor. Returns a function to unsubscribe the current listener.
+  subscribe: (listener: (message: { type: string; payload: any }) => void) => () => void // adds a change listener. It will be called any time an action is dispatched from the monitor. Returns a function to unsubscribe the current listener.
   unsubscribe: () => void // unsubscribes all listeners.
-  send: (action: any, state: any) => void // sends a new action and state manually to be shown on the monitor. If action is null then we suppose we send liftedState.
+  send: (action: any, state: SanitizedState) => void // sends a new action and state manually to be shown on the monitor. If action is null then we suppose we send liftedState.
   init: (state: any) => void // sends the initial state to the monitor.
   error: (message: string) => void // sends the error message to be shown in the extension's monitor.
 }
@@ -16,20 +16,51 @@ function connectDevToolsExtension(): Connection | null {
     (window as any).__REDUX_DEVTOOLS_EXTENSION__ != null &&
     (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect != null
   ) {
-    return (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect()
+    return (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect({
+      maxAge: 50, // maximum allowed actions to be stored in the history tree. It's critical for performance
+      features: {
+        pause: true, // start/pause recording of dispatched actions
+        lock: false, // lock/unlock dispatching actions and side effects
+        persist: false, // persist states on page reloading
+        export: true, // export history of actions in a file
+        import: 'custom', // import history of actions from a file
+        jump: false, // jump back and forth (time travelling)
+        skip: false, // skip (cancel) actions
+        reorder: false, // drag and drop actions in the history list
+        dispatch: false, // dispatch custom actions or action creators
+        test: false, // generate tests for the selected actions
+      },
+    })
   } else {
     return null
   }
 }
 
 const maybeDevTools = connectDevToolsExtension()
+let sendActionUpdates = true
+
+// eslint-disable-next-line no-unused-expressions
+maybeDevTools?.subscribe((message) => {
+  // console.log('message from devtools', message, message.type)
+  if (message.type === 'DISPATCH') {
+    if (message.payload.type === 'IMPORT_STATE') {
+      // this is a very primitive way to enable Redux Devtool to import someone elses exported state.
+      // It tells the devtool that this is our new state, essentially lying about it.
+      maybeDevTools.send(null, message.payload.nextLiftedState)
+      sendActionUpdates = false
+    } else if (message.payload.type === 'PAUSE_RECORDING') {
+      sendActionUpdates = !message.payload.status
+    }
+  }
+})
 
 const ActionsToOmit: Array<EditorAction['action']> = ['UPDATE_PREVIEW_CONNECTED']
 
-let lastDispatchedStore: ReturnType<typeof sanitizeLoggedState>
+let lastDispatchedStore: SanitizedState
 
-const PlaceholderMessage = 'SANITIZED_FROM_DEVTOOLS'
+const PlaceholderMessage = '<<SANITIZED_FROM_DEVTOOLS>>'
 
+type SanitizedState = ReturnType<typeof sanitizeLoggedState>
 function sanitizeLoggedState(store: EditorStore) {
   return {
     ...store,
@@ -61,7 +92,7 @@ export function reduxDevtoolsSendActions(
   actions: Array<EditorAction>,
   newStore: EditorStore,
 ): void {
-  if (maybeDevTools != null) {
+  if (maybeDevTools != null && sendActionUpdates) {
     // filter out the actions we are not interested in
     const filteredActions = actions.filter((action) => !ActionsToOmit.includes(action.action))
     if (filteredActions.length > 0) {
@@ -74,19 +105,19 @@ export function reduxDevtoolsSendActions(
 }
 
 export function reduxDevtoolsSendInitialState(newStore: EditorStore): void {
-  if (maybeDevTools != null) {
+  if (maybeDevTools != null && sendActionUpdates) {
     maybeDevTools.init(newStore)
   }
 }
 
 export function reduxDevtoolsLogMessage(message: string, optionalPayload?: any): void {
-  if (maybeDevTools != null) {
+  if (maybeDevTools != null && sendActionUpdates) {
     maybeDevTools.send({ type: `🟢 ${message}`, payload: optionalPayload }, lastDispatchedStore)
   }
 }
 
 export function reduxDevtoolsUpdateState(message: string, newStore: EditorStore): void {
-  if (maybeDevTools != null) {
+  if (maybeDevTools != null && sendActionUpdates) {
     const sanitizedStore = sanitizeLoggedState(newStore)
     maybeDevTools.send(`🟣 ${message}`, sanitizedStore)
     lastDispatchedStore = sanitizedStore


### PR DESCRIPTION
**Problem:**
Being able to export / import the log of actions and state from Redux Devtools would help us tracking down hard to reproduce bugs.

**Fix:**
This is a very primitive PR that allows the Devtool to load an exported state, without changing anything in the real editor. so once you import a state, the devtool "detaches" from the editor's own state history, beware of this! But still, this allows us to easily read in someone else's state recording and look at the dispatched actions and the resulting states of the editor.

**Commit Details:**
* the devtool connector now `subscribe`s to the messages coming from redux devtool
* handling `IMPORT_STATE` in the simplest way possible
* handling `PAUSE_RECORDING` so we can toggle action recording on or off
* disabling a bunch of unused `features` in the devtools configuration object
