### PR TITLE
fix VSCode for new projects

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3130,10 +3130,21 @@ export const UPDATE_FNS = {
       return editor
     }
   },
-  SET_PROJECT_ID: (action: SetProjectID, editor: EditorModel): EditorModel => {
+  SET_PROJECT_ID: (
+    action: SetProjectID,
+    editor: EditorModel,
+    dispatch: EditorDispatch,
+  ): EditorModel => {
+    let newVscodeBridgeId = editor.vscodeBridgeId
+    if (editor.vscodeBridgeId == null) {
+      // ONLY update vscodeBridgeId if it was null
+      newVscodeBridgeId = action.id
+      initVSCodeBridge(action.id, editor.projectContents, dispatch)
+    }
     return {
       ...editor,
       id: action.id,
+      vscodeBridgeId: newVscodeBridgeId,
     }
   },
   UPDATE_CODE_RESULT_CACHE: (action: UpdateCodeResultCache, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -156,7 +156,7 @@ export function runSimpleLocalEditorAction(
     case 'SET_STORED_FONT_SETTINGS':
       return UPDATE_FNS.SET_STORED_FONT_SETTINGS(action, state)
     case 'SET_PROJECT_ID':
-      return UPDATE_FNS.SET_PROJECT_ID(action, state)
+      return UPDATE_FNS.SET_PROJECT_ID(action, state, dispatch)
     case 'UPDATE_CODE_RESULT_CACHE':
       return UPDATE_FNS.UPDATE_CODE_RESULT_CACHE(action, state)
     case 'SET_CODE_EDITOR_VISIBILITY':


### PR DESCRIPTION
**Problem:**
I was a bit too eager in #1291 and changed `SET_PROJECT_ID` to _never_ update `EditorState.vscodeBridgeId`. That's a problem because when the user opens  a fresh project (with the `/p/` url) the state will be initialized to `null`, which means we never initialize vscode.

**Fix:**
Take a half step baack and allow `SET_PROJECT_ID` to call `initVSCodeBridge` but only if `EditorState.vscodeBridgeId` is currently `null`
