### PR TITLE
Fix for empty navigator after fixing code errors

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -260,6 +260,11 @@ export const UiJsxCanvas = betterReactMemo(
     clearConsoleLogs()
     proxyConsole(console, addToConsoleLogs)
 
+    if (clearErrors != null) {
+      // a new canvas render, a new chance at having no errors
+      clearErrors()
+    }
+
     let metadataContext: UiJsxCanvasContextData = React.useContext(UiJsxCanvasContext)
 
     // Handle the imports changing, this needs to run _before_ any require function
@@ -275,12 +280,6 @@ export const UiJsxCanvas = betterReactMemo(
     let topLevelComponentRendererComponents = React.useRef<
       MapLike<MapLike<ComponentRendererComponent>>
     >({})
-
-    if (clearErrors != null) {
-      // a new canvas render, a new chance at having no errors
-      // FIXME This is illegal! The line below is triggering a re-render
-      clearErrors()
-    }
 
     // TODO after merge requireFn can never be null
     if (requireFn != null) {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3667,6 +3667,8 @@ export const UPDATE_FNS = {
         ...editor,
         codeEditorErrors: updatedCodeEditorErrors,
         jsxMetadata: emptyJsxMetadata,
+        domMetadata: [],
+        spyMetadata: emptyJsxMetadata,
       }
     }
   },

--- a/editor/src/core/shared/redux-devtools.ts
+++ b/editor/src/core/shared/redux-devtools.ts
@@ -116,6 +116,12 @@ export function reduxDevtoolsLogMessage(message: string, optionalPayload?: any):
   }
 }
 
+export function reduxDevtoolsLogError(message: string, optionalPayload?: any): void {
+  if (maybeDevTools != null && sendActionUpdates) {
+    maybeDevTools.send({ type: `🔴 ${message}`, payload: optionalPayload }, lastDispatchedStore)
+  }
+}
+
 export function reduxDevtoolsUpdateState(message: string, newStore: EditorStore): void {
   if (maybeDevTools != null && sendActionUpdates) {
     const sanitizedStore = sanitizeLoggedState(newStore)

--- a/editor/src/core/shared/runtime-report-logs.ts
+++ b/editor/src/core/shared/runtime-report-logs.ts
@@ -8,6 +8,7 @@ import {
 } from './atom-with-pub-sub'
 import type { FancyError, RuntimeErrorInfo } from './code-exec-utils'
 import { defaultIfNull } from './optional-utils'
+import { reduxDevtoolsLogError } from './redux-devtools'
 
 const EmptyArray: Array<RuntimeErrorInfo> = []
 
@@ -37,6 +38,12 @@ export function useWriteOnlyRuntimeErrors(): {
 
   const onRuntimeError = React.useCallback(
     (editedFile: string, error: FancyError, errorInfo?: React.ErrorInfo) => {
+      reduxDevtoolsLogError('Canvas Runtime Errors Reported', {
+        editedFile,
+        error,
+        errorInfo,
+        errorToString: error.toString(),
+      })
       updateRuntimeErrors([
         {
           editedFile: editedFile,
@@ -49,7 +56,14 @@ export function useWriteOnlyRuntimeErrors(): {
   )
 
   const clearRuntimeErrors = React.useCallback(() => {
-    updateRuntimeErrors(EmptyArray)
+    updateRuntimeErrors((current) => {
+      if (current.length !== 0) {
+        reduxDevtoolsLogError('Canvas Runtime Errors Cleared by re-render', {
+          deletedErrors: current,
+        })
+      }
+      return EmptyArray
+    })
   }, [updateRuntimeErrors])
 
   return {

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -15,6 +15,7 @@ import { CodeResultCache, generateCodeResultCache } from '../components/custom-c
 import { getAllErrorsFromBuildResult } from '../components/custom-code/custom-code-utils'
 import {
   DebugDispatch,
+  DispatchPriority,
   EditorAction,
   EditorDispatch,
   isLoggedIn,
@@ -112,7 +113,6 @@ export class Editor {
   utopiaStoreHook: UtopiaStoreHook
   utopiaStoreApi: UtopiaStoreAPI
   updateStore: (partialState: EditorStore) => void
-  boundDispatch: DebugDispatch = this.dispatch.bind(this)
   spyCollector: UiJsxCanvasContextData = emptyUiJsxCanvasContextData()
 
   constructor() {
@@ -357,11 +357,12 @@ export class Editor {
     )
   }
 
-  dispatch(
+  boundDispatch = (
     dispatchedActions: readonly EditorAction[],
+    priority?: DispatchPriority,
   ): {
     entireUpdateFinished: Promise<any>
-  } {
+  } => {
     const runDispatch = () => {
       const result = editorDispatch(
         this.boundDispatch,


### PR DESCRIPTION
Fixes parts of #1281

**Problem:**
Create a code error. Observe the error overlay and the navigator going empty. Fix the code error. Observe the canvas rendering and the navigator remaining empty.

It turns out the problem is that `SET_CODE_EDITOR_BUILD_ERRORS` would clear `jsxMetadata` but it would leave `domMetadata` and `spyMetadata` intact! That is bad because once the canvas renders again, `domMetadata` and `spyMetadata` will be equal to their old selves and so the `dispatch` function will be tricked into not regenerating `jsxMetadata` and thus leaving it empty.

**Fix:**
`SET_CODE_EDITOR_BUILD_ERRORS ` will now also delete `spyMetadata` and `domMetadata`

**Commit Details:**
- `SET_CODE_EDITOR_BUILD_ERRORS ` to delete `spyMetadata` and `domMetadata`
- Canvas errors are logged into the Redux Devtool using `reduxDevtoolsLogError`
- `editor.tsx`'s boundDispatch is now an arrow function to avoid weird edge cases we never learned about because we don't use this.bind anywhere else in the codebase
