### PR TITLE
make react component stack trace more readable

### DIFF
--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -169,30 +169,34 @@ const MeasureRenderTimes = !PRODUCTION_ENV && typeof window.performance.mark ===
 const mangleFunctionType = Utils.memoize(
   (type: unknown): React.FunctionComponent => {
     const uuid = MeasureRenderTimes ? v4() : ''
-    const mangledFunction = (p: any, context?: any) => {
-      if (MeasureRenderTimes) {
-        performance.mark(`render_start_${uuid}`)
-      }
-      let originalTypeResponse = (type as React.FunctionComponent)(p, context)
-      const res = attachDataUidToRoot(
-        originalTypeResponse,
-        (p as any)?.[UTOPIA_UIDS_KEY],
-        (p as any)?.[UTOPIA_PATHS_KEY],
-      )
-      if (MeasureRenderTimes) {
-        performance.mark(`render_end_${uuid}`)
-        performance.measure(
-          `Render Component ${getDisplayName(type)}`,
-          `render_start_${uuid}`,
-          `render_end_${uuid}`,
+    const mangledFunctionName = `UtopiaSpiedFunctionComponent(${getDisplayName(type)})`
+
+    const mangledFunction = {
+      [mangledFunctionName]: (p: any, context?: any) => {
+        if (MeasureRenderTimes) {
+          performance.mark(`render_start_${uuid}`)
+        }
+        let originalTypeResponse = (type as React.FunctionComponent)(p, context)
+        const res = attachDataUidToRoot(
+          originalTypeResponse,
+          (p as any)?.[UTOPIA_UIDS_KEY],
+          (p as any)?.[UTOPIA_PATHS_KEY],
         )
-      }
-      return res
-    }
+        if (MeasureRenderTimes) {
+          performance.mark(`render_end_${uuid}`)
+          performance.measure(
+            `Render Component ${getDisplayName(type)}`,
+            `render_start_${uuid}`,
+            `render_end_${uuid}`,
+          )
+        }
+        return res
+      },
+    }[mangledFunctionName]
     ;(mangledFunction as any).theOriginalType = type
     ;(mangledFunction as any).contextTypes = (type as any).contextTypes
     ;(mangledFunction as any).childContextTypes = (type as any).childContextTypes
-    ;(mangledFunction as any).displayName = `UtopiaSpiedExoticType(${getDisplayName(type)})`
+    ;(mangledFunction as any).displayName = `UtopiaSpiedFunctionComponent(${getDisplayName(type)})`
     return mangledFunction
   },
   {


### PR DESCRIPTION
**Problem:**
The React error output is unreadable because of the Monkey Function:
<img width="765" alt="image" src="https://user-images.githubusercontent.com/2226774/119379180-71442980-bcbf-11eb-91ef-b138b50022ba.png">

**Fix:**
Use a horrible javascript trick to give a dynamic name to the monkey function that contains the name of the wrapped original function
<img width="516" alt="image" src="https://user-images.githubusercontent.com/2226774/119379238-8456f980-bcbf-11eb-959b-095634aabede.png">

**TODO:**
We should also use horrible javascript hacks to change the source file and source line to match the original function instead of pointing to canvas-react-utils