### PR TITLE
Check the props of scene children.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
@@ -5,7 +5,6 @@ import { Scene, SceneProps } from 'utopia-api'
 import { colorTheme, UtopiaStyles } from '../../../uuiui'
 import { betterReactMemo } from '../../../uuiui-deps'
 import { RerenderUtopiaContext } from './ui-jsx-canvas-contexts'
-import { shallowEqual } from '../../../core/shared/equality-utils'
 
 export const SceneComponent = betterReactMemo(
   'Scene',
@@ -58,7 +57,7 @@ function childUnchanged(prevChild: ReactChild, nextChild: ReactChild): boolean {
     return (
       React.isValidElement(nextChild) &&
       prevChild.type === nextChild.type &&
-      shallowEqual(prevChild.props, nextChild.props)
+      fastDeepEquals(prevChild.props, nextChild.props)
     )
   } else {
     // FIXME Fragments are all that is left

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
@@ -5,6 +5,7 @@ import { Scene, SceneProps } from 'utopia-api'
 import { colorTheme, UtopiaStyles } from '../../../uuiui'
 import { betterReactMemo } from '../../../uuiui-deps'
 import { RerenderUtopiaContext } from './ui-jsx-canvas-contexts'
+import { shallowEqual } from '../../../core/shared/equality-utils'
 
 export const SceneComponent = betterReactMemo(
   'Scene',
@@ -54,7 +55,11 @@ function childUnchanged(prevChild: ReactChild, nextChild: ReactChild): boolean {
   if (typeof prevChild === 'string' || typeof prevChild === 'number') {
     return nextChild === prevChild
   } else if (React.isValidElement(prevChild)) {
-    return React.isValidElement(nextChild) && prevChild.type === nextChild.type
+    return (
+      React.isValidElement(nextChild) &&
+      prevChild.type === nextChild.type &&
+      shallowEqual(prevChild.props, nextChild.props)
+    )
   } else {
     // FIXME Fragments are all that is left
     return false

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -58,8 +58,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(265) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(275)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(280) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(285)
   })
 
   it('Changing the selected view', async () => {


### PR DESCRIPTION
Fixes #1293

**Problem:**
Changes to the children of scene elements would not cause changes to the canvas to apply.

**Fix:**
The props of the scene element children need to be included so that changes to their children and changes to things like their `style` property to cause them to re-render.

**Commit Details:**
- Fixes #1293.
- `childUnchanged` now also includes a shallow equality check against
  the props of the scene component children.
