### PR TITLE
Highlight that a canvas error might be Utopia's fault

### DIFF
--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -28,6 +28,7 @@ import { betterReactMemo } from '../../uuiui-deps'
 import { ElementPath } from '../../core/shared/project-file-types'
 import { usePropControlledStateV2 } from '../inspector/common/inspector-utils'
 import { useReadOnlyRuntimeErrors } from '../../core/shared/runtime-report-logs'
+import StackFrame from '../../third-party/react-error-overlay/utils/stack-frame'
 
 interface CanvasWrapperComponentProps {}
 
@@ -98,7 +99,13 @@ const ErrorOverlayComponent = betterReactMemo(
     const overlayErrors = React.useMemo(() => {
       return runtimeErrors.map((runtimeError) => {
         const stackFrames =
-          runtimeError.error.stackFrames != null ? runtimeError.error.stackFrames : []
+          runtimeError.error.stackFrames != null
+            ? runtimeError.error.stackFrames
+            : [
+                new StackFrame(
+                  'WARNING: This error has no Stack Frames, it might be coming from Utopia itself!',
+                ),
+              ]
         return {
           error: runtimeError.error,
           unhandledRejection: false,


### PR DESCRIPTION
**Problem:**
The CanvasErrorBoundary would sometimes catch errors thrown that are
1. coming from our own code and is our fault
2. user code that is bad, but somehow slipped through the cracks and we didn't capture a stack trace for it, and it's totally not helpful to the users – which is our fault

**Fix:**
On the canvas error overlay if there's no stack frames, explain that it is our fault:
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/2226774/119529379-5981a980-bd82-11eb-9247-38a8945ecc1a.png">

