### PR TITLE
Improvement: agressively sourcemapped errors

### DIFF
--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -4418,6 +4418,11 @@
         "@react-spring/shared": "9.0.0-rc.3"
       }
     },
+    "@root/encoding": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@root/encoding/-/encoding-1.0.1.tgz",
+      "integrity": "sha512-OaEub02ufoU038gy6bsNHQOjIn8nUjGiLcaRmJ40IUykneJkIW5fxDqKxQx48cszuNflYldsJLPPXCrGfHs8yQ=="
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",

--- a/editor/package.json
+++ b/editor/package.json
@@ -94,6 +94,7 @@
     "@emotion/styled": "11.0.0",
     "@emotion/styled-base": "11.0.0",
     "@popperjs/core": "2.4.4",
+    "@root/encoding": "1.0.1",
     "@seznam/compose-react-refs": "^1.0.4",
     "@svgr/plugin-jsx": "5.5.0",
     "@tippyjs/react": "4.1.0",

--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -16,6 +16,7 @@ import {
   useWriteOnlyConsoleLogs,
   useWriteOnlyRuntimeErrors,
 } from '../../core/shared/runtime-report-logs'
+import { processErrorWithSourceMap } from '../../core/shared/code-exec-utils'
 interface CanvasComponentEntryProps {}
 
 export const CanvasComponentEntry = betterReactMemo(
@@ -130,8 +131,9 @@ export class CanvasErrorBoundary extends React.Component<
     }
   }
 
-  componentDidCatch(error: unknown, errorInfo: React.ErrorInfo): void {
-    this.props.reportError(this.props.filePath, asErrorObject(error), errorInfo)
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    const fancyError = processErrorWithSourceMap(error, true)
+    this.props.reportError(this.props.filePath, asErrorObject(fancyError), errorInfo)
   }
 
   render(): React.ReactNode {

--- a/editor/src/core/shared/code-exec-utils.ts
+++ b/editor/src/core/shared/code-exec-utils.ts
@@ -1,3 +1,4 @@
+import { strToBase64, base64ToStr } from '@root/encoding/base64'
 import StackFrame from '../../third-party/react-error-overlay/utils/stack-frame'
 import { parseUtopiaError } from '../../third-party/react-error-overlay/utils/parseUtopiaError'
 import { getSourceMapConsumer } from '../../third-party/react-error-overlay/utils/getSourceMap'
@@ -54,7 +55,7 @@ export function processErrorWithSourceMap(
 
       // TODO turn ;sourceMap= into const
       const rawSourceMap: RawSourceMap | null = JSON.parse(
-        atob(parsedStackFrames[0].fileName?.split(SOURCE_MAP_PREFIX)[1] ?? ''),
+        base64ToStr(parsedStackFrames[0].fileName?.split(SOURCE_MAP_PREFIX)[1] ?? ''),
       )
       const sourceCode = rawSourceMap?.transpiledContentUtopia
 
@@ -108,7 +109,7 @@ export const SafeFunctionCurriedErrorHandler = {
         ? { ...sourceMapWithoutTranspiledCode, transpiledContentUtopia: code }
         : null
 
-    let sourceMapBase64 = btoa(JSON.stringify(sourceMap))
+    let sourceMapBase64 = strToBase64(JSON.stringify(sourceMap))
 
     const fileName = `${UTOPIA_FUNCTION_ROOT_NAME}(${sourceMap?.sources?.[0]})`
 

--- a/editor/src/core/shared/code-exec-utils.ts
+++ b/editor/src/core/shared/code-exec-utils.ts
@@ -27,6 +27,8 @@ export type ErrorHandler = (e: Error) => void
 
 const UTOPIA_FUNCTION_ROOT_NAME = 'SafeFunctionCurriedErrorHandler'
 
+export const SOURCE_MAP_PREFIX = `;sourceMap=`
+
 export function processErrorWithSourceMap(
   error: Error | FancyError,
   inSafeFunction: boolean,
@@ -52,7 +54,7 @@ export function processErrorWithSourceMap(
 
       // TODO turn ;sourceMap= into const
       const rawSourceMap: RawSourceMap | null = JSON.parse(
-        atob(parsedStackFrames[0].fileName?.split(';sourceMap=')[1] ?? ''),
+        atob(parsedStackFrames[0].fileName?.split(SOURCE_MAP_PREFIX)[1] ?? ''),
       )
       const sourceCode = rawSourceMap?.transpiledContentUtopia
 
@@ -106,14 +108,13 @@ export const SafeFunctionCurriedErrorHandler = {
         ? { ...sourceMapWithoutTranspiledCode, transpiledContentUtopia: code }
         : null
 
-    let objJsonStr = JSON.stringify(sourceMap)
-    let objJsonB64 = Buffer.from(objJsonStr).toString('base64')
+    let sourceMapBase64 = btoa(JSON.stringify(sourceMap))
 
     const fileName = `${UTOPIA_FUNCTION_ROOT_NAME}(${sourceMap?.sources?.[0]})`
 
     const codeWithSourceMapAttached = `${code}
 
-    //# sourceURL=${fileName};sourceMap=${objJsonB64}
+    //# sourceURL=${fileName}${SOURCE_MAP_PREFIX}${sourceMapBase64}
     `
 
     const FunctionOrAsyncFunction = async ? AsyncFunction : Function

--- a/editor/src/core/workers/ts/ts-typings/RawSourceMap.ts
+++ b/editor/src/core/workers/ts/ts-typings/RawSourceMap.ts
@@ -4,6 +4,7 @@ export interface RawSourceMap {
   names: string[]
   sourceRoot?: string
   sourcesContent?: string[]
+  transpiledContentUtopia?: string
   mappings: string
   file: string
 }

--- a/editor/src/missing-types/index.d.ts
+++ b/editor/src/missing-types/index.d.ts
@@ -93,3 +93,5 @@ declare module 'react-windowed-select' {
 declare module 'npm-package-arg'
 
 declare module '@svgr/plugin-jsx'
+
+declare module '@root/encoding/base64'

--- a/editor/src/third-party/react-error-overlay/utils/parseUtopiaError.ts
+++ b/editor/src/third-party/react-error-overlay/utils/parseUtopiaError.ts
@@ -5,24 +5,23 @@ import parseError from './parser'
  * Turns an <code>Error</code>, or similar object, into a set of <code>StackFrame</code>s.
  */
 export function parseUtopiaError(
-  error: Error | string | string[] | { stack: string },
+  parsedStackFrames: Array<StackFrame>,
   scriptFile: string[],
 ): StackFrame[] {
-  const parsedStackFrames = parseError(error)
-
   // TODO make it work for multi-file stack traces
   const scriptLines = scriptFile.map(
     (sourceLine, index) => new ScriptLine(index + 1, sourceLine, false),
   )
   return parsedStackFrames.map((frame) => {
+    const fixedFilename = frame.fileName?.split(`;sourceMap=`)[0]
     return new StackFrame(
       frame.functionName,
-      frame.fileName,
+      fixedFilename,
       frame.lineNumber,
       frame.columnNumber,
       scriptLines,
       frame.functionName,
-      frame.fileName,
+      fixedFilename,
       frame.lineNumber,
       frame.columnNumber,
       scriptLines,

--- a/editor/src/third-party/react-error-overlay/utils/parseUtopiaError.ts
+++ b/editor/src/third-party/react-error-overlay/utils/parseUtopiaError.ts
@@ -1,5 +1,6 @@
 import StackFrame, { ScriptLine } from './stack-frame'
 import parseError from './parser'
+import { SOURCE_MAP_PREFIX } from '../../../core/shared/code-exec-utils'
 
 /**
  * Turns an <code>Error</code>, or similar object, into a set of <code>StackFrame</code>s.
@@ -13,7 +14,7 @@ export function parseUtopiaError(
     (sourceLine, index) => new ScriptLine(index + 1, sourceLine, false),
   )
   return parsedStackFrames.map((frame) => {
-    const fixedFilename = frame.fileName?.split(`;sourceMap=`)[0]
+    const fixedFilename = frame.fileName?.split(SOURCE_MAP_PREFIX)[0]
     return new StackFrame(
       frame.functionName,
       fixedFilename,


### PR DESCRIPTION
**Problem:**
If a runtime error is thrown when the code is evaluated (like an expression using a variable that is not defined), we show a nice error with a nice source code snippet.
However, if the runtime error happens later when React tries to call the component (if the source code is a function component and the function component is only called by react, not us), the error is almost not actionable: we don't get to know anything other than the error's name:
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/2226774/119658642-ae2e2e80-be2d-11eb-8c29-35779409b85e.png">

This is hostile to novice users and not how codesandbox / create-react-app works!

It turns out that the problem is that the SafeFunctionCurriedErrorHandler's errorHandler is only called if the code throws an error immediately on evaluation. If the code evaluates correctly, and that code later throws an error in usage, the error would go to the CanvasErrorBoundary and that means we couldn't apply our `processErrorWithSourceMap` function which eats the error, and decorates it with the nice StackFrames based on the source map.

**Fix:**
I realized that the only place where I can sneak information into Chrome's runtime error was the `//# sourceURL=` magic comment, which becomes the "filename" in the error stack:
<img width="454" alt="image" src="https://user-images.githubusercontent.com/2226774/119659026-1250f280-be2e-11eb-925b-7a4d90c734de.png">
in the screenshot, `canvas-react-utils.ts` and `react-dom.development.js` comes from Chrome parsing the `sourceURL` and trusting its value.
I learned that I can literally put any valid string in here, including a base64 encoded version of the entire encoded source map!
I can use this later when I unpack the error message, to extract the sourcemap from here and use it in `processErrorWithSourceMap`! 
This means that `SafeFunctionCurriedErrorHandler` now converts the soruceMap into base64 and squirrels it away into the evaluated source code's `sourceURL` field. Later, in `CanvasErrorBoundary`'s `componentDidCatch` I can now call `processErrorWithSourceMap` because the Error object itself is enough for processErrorWithSourceMap to extract the source map. This means that when an evaluated component throws a runtime error mid-render, we now have the ability to show an intelligible error message:
<img width="425" alt="image" src="https://user-images.githubusercontent.com/2226774/119659578-92775800-be2e-11eb-84c9-7586e020c38a.png">


**Commit Details:**
- Abusing `//# sourceURL=` to include an entire base64 encoded sourcemap to the file
- removing the dependencies on `code` and `rawSourceMap` in `processErrorWithSourceMap`, so we can call it from  `CanvasErrorBoundary`
- calling `processErrorWithSourceMap` from `CanvasErrorBoundary`

**Note:**
The only downside of our abuse of `sourceURL` is that in the real Chrome console, the error message printed by react becomes pretty scary:
<img width="1348" alt="image" src="https://user-images.githubusercontent.com/2226774/119659896-ec781d80-be2e-11eb-8329-f14e79c2f209.png">
I consider this to be a cosmetic issue, we can certainly improve on this by only including a key to a source map cache here, and maintain a source map cache instead of serializing the entire map into the fileName field. But I think this PR is good enough as it is, we can improve it later if we want to.
