### PR TITLE
Attempt to make the root element UIDs stable.

### DIFF
--- a/editor/src/core/workers/parser-printer/uid-fix.spec.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.spec.ts
@@ -95,6 +95,16 @@ describe('fixParseSuccessUIDs', () => {
           component"
     `)
   })
+
+  it('uids should match including root element when root element changes', () => {
+    const firstResult = lintAndParse('test.js', baseFileContents, null)
+    const secondResult = lintAndParse(
+      'test.js',
+      baseFileContentsWithDifferentBackground,
+      firstResult,
+    )
+    expect(getUidTree(firstResult)).toEqual(getUidTree(secondResult))
+  })
 })
 
 const baseFileContents = createFileText(`
@@ -102,6 +112,22 @@ export var SameFileApp = (props) => {
   return (
     <div
       style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
+    >
+      <View
+        style={{
+          width: 191,
+        }}
+      />
+    </div>
+  )
+}
+`)
+
+const baseFileContentsWithDifferentBackground = createFileText(`
+export var SameFileApp = (props) => {
+  return (
+    <div
+      style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: 'red' }}
     >
       <View
         style={{


### PR DESCRIPTION
Fixes #1304

**Problem:**
Changes to the props of root elements cause the UID to be regenerated which makes the current selection go away. 

**Fix:**
UID restoration is now applied to the UIDs of root elements as well as to their children.

**Notes:**
As part of #1304 there was also reference to the item becoming uneditable, which I was never able to reproduce.

**Commit Details:**
- Fixes #1304.
- Modified `fixParseSuccessUIDs` to apply the same kind of stability
  UID restoring for root elements that is done for any children of
  those root elements.
