### PR TITLE
Don't remove or rewrite selected views when the code breaks.

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -1447,6 +1447,32 @@ function toastOnGeneratedElementsTargeted(
 let checkpointTimeoutId: number | undefined = undefined
 let canvasScrollAnimationTimer: number | undefined = undefined
 
+function updateSelectedComponentsFromEditorPosition(
+  derived: DerivedState,
+  editor: EditorState,
+  dispatch: EditorDispatch,
+  filePath: string,
+  line: number,
+): EditorState {
+  if (Object.keys(editor.jsxMetadata).length === 0) {
+    // Looks like the canvas has errored out, so leave it alone for now.
+    return editor
+  } else {
+    const allElementPaths = derived.navigatorTargets
+    const highlightBoundsForUids = getHighlightBoundsForFile(editor, filePath)
+    const newlySelectedElements = getElementPathsInBounds(
+      line,
+      highlightBoundsForUids,
+      allElementPaths,
+    )
+    return UPDATE_FNS.SELECT_COMPONENTS(
+      selectComponents(newlySelectedElements, false),
+      editor,
+      dispatch,
+    )
+  }
+}
+
 // JS Editor Actions:
 export const UPDATE_FNS = {
   NEW: (
@@ -4120,17 +4146,12 @@ export const UPDATE_FNS = {
     derived: DerivedState,
     dispatch: EditorDispatch,
   ): EditorModel => {
-    const allElementPaths = derived.navigatorTargets
-    const highlightBoundsForUids = getHighlightBoundsForFile(editor, action.filePath)
-    const newlySelectedElements = getElementPathsInBounds(
-      action.line,
-      highlightBoundsForUids,
-      allElementPaths,
-    )
-    return UPDATE_FNS.SELECT_COMPONENTS(
-      selectComponents(newlySelectedElements, false),
+    return updateSelectedComponentsFromEditorPosition(
+      derived,
       editor,
       dispatch,
+      action.filePath,
+      action.line,
     )
   },
   SEND_CODE_EDITOR_INITIALISATION: (

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -76,16 +76,6 @@ import {
   zipContentsTree,
 } from '../../assets'
 import { isSendPreviewModel, restoreDerivedState, UPDATE_FNS } from '../actions/actions'
-import { applyProjectChanges } from '../../../core/vscode/vscode-bridge'
-import {
-  accumulatedToVSCodeMessage,
-  AccumulatedToVSCodeMessage,
-  boundsInFile,
-  SelectedElementChanged,
-  sendMessage,
-  ToVSCodeMessageNoAccumulated,
-  UpdateDecorationsMessage,
-} from 'utopia-vscode-common'
 import { ElementPathArrayKeepDeepEquality } from '../../../utils/deep-equality-instances'
 import { mapDropNulls } from '../../../core/shared/array-utils'
 import {
@@ -580,11 +570,7 @@ function editorDispatchInner(
       }
     }
 
-    const cleanedEditor = metadataChanged
-      ? removeNonExistingViewReferencesFromState(result.editor)
-      : result.editor
-
-    let frozenEditorState: EditorState = optionalDeepFreeze(cleanedEditor)
+    let frozenEditorState: EditorState = optionalDeepFreeze(result.editor)
 
     let frozenDerivedState: DerivedState
     if (anyUndoOrRedo) {

--- a/editor/src/core/shared/code-exec-utils.ts
+++ b/editor/src/core/shared/code-exec-utils.ts
@@ -54,9 +54,15 @@ export function processErrorWithSourceMap(
       const parsedStackFrames = parseError(error)
 
       // TODO turn ;sourceMap= into const
-      const rawSourceMap: RawSourceMap | null = JSON.parse(
-        base64ToStr(parsedStackFrames[0].fileName?.split(SOURCE_MAP_PREFIX)[1] ?? ''),
-      )
+      let rawSourceMap: RawSourceMap | null = null
+      let possibleSourceMapSegment: string | null = null
+      if (0 in parsedStackFrames) {
+        possibleSourceMapSegment =
+          parsedStackFrames[0].fileName?.split(SOURCE_MAP_PREFIX)[1] ?? null
+      }
+      if (possibleSourceMapSegment != null) {
+        rawSourceMap = JSON.parse(base64ToStr(possibleSourceMapSegment))
+      }
       const sourceCode = rawSourceMap?.transpiledContentUtopia
 
       const fixedSourceCode = sourceCode?.split('\n') ?? []

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -357,7 +357,7 @@ function initMessaging(context: vscode.ExtensionContext, workspaceRootUri: vscod
       updateDecorations(currentDecorations)
     }),
     vscode.window.onDidChangeTextEditorSelection((event) => {
-      if (event.kind != null && event.kind !== vscode.TextEditorSelectionChangeKind.Command) {
+      if (event.kind !== vscode.TextEditorSelectionChangeKind.Command) {
         cursorPositionChanged(event)
       }
     }),


### PR DESCRIPTION
Fixes #1310.

**Problem:**
At certain points with a particular timing if the code would produce an error the `navigatorTargets` end up empty, if the mouse position trigger came in at that point the selected views would be set to an empty array.

**Fix:**
The solution was to attempt to keep the selected items as much as possible, by both avoiding updating the selection if the canvas appears to be broken and removing the call to the function that eliminates the "invalid" selections and highlighted views if they don't exist anymore.

**Commit Details:**
- Fixes some unrelated issues in `processErrorWithSourceMap` that logged
  out a lot of console errors.
- Ensures that backspace in VS Code still triggers a cursor position
  changed event as apparently they come without a `kind` property.
- Removed the call to `removeNonExistingViewReferencesFromState` as
  we want those fields to survive a broken canvas.
- Refactored out the logic for updating the selection based on the
  cursor position and added in check to see if the canvas appears to be
  broken current, which doesn't update the selected elements.
