### PR TITLE
fix(vscode) update editor when a file is already included the local dirtyfiles set

### DIFF
--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -185,6 +185,8 @@ async function doSubscriptionWork(work: SubscriptionWork): Promise<void> {
       if (event.document.isDirty) {
         // New unsaved change
         dirtyFiles.add(path)
+      }
+      if (dirtyFiles.has(path)) {
         if (incomingFileChanges.has(path)) {
           // This change actually came from Utopia, so we don't want to re-write it to the FS
           incomingFileChanges.delete(path)


### PR DESCRIPTION
**Problem:**
When undoing changes in the code editor sometimes the canvas doesn't update. One of the reliably method to trigger the bug is:
1. type to the code editor, save it
2. type more, realize you don't want that change
3. press undo a few times until it reaches the original saved file
4. at this point there is a problem, the canvas doesn't update  

**Fix:**
After reaching the end of the undo stack `event.document.isDirty` becomes false, so the editor update is not triggered.

**Commit Details:**
- call write file content function when a file is included in the `dirtyFiles` 
