### PR TITLE
FollowSelectionConfigKey should be Workspace level instead of Global

### DIFF
--- a/editor/src/components/editor/top-menu.tsx
+++ b/editor/src/components/editor/top-menu.tsx
@@ -61,12 +61,14 @@ export const TopMenu = betterReactMemo('TopMenu', () => {
           <MenuIcons.Navigator />
         </SquareButton>
       </Tooltip>
-      <IconToggleButton
-        onToggle={onToggleFollow}
-        value={followSelection.enabled}
-        srcOn={UNSAFE_getIconURL('bracketed-pointer', 'blue', 'semantic', 18, 18)}
-        srcOff={UNSAFE_getIconURL('bracketed-pointer', 'darkgray', 'semantic', 18, 18)}
-      />
+      <Tooltip title='Mirror selection between canvas and code editor' placement='bottom'>
+        <IconToggleButton
+          onToggle={onToggleFollow}
+          value={followSelection.enabled}
+          srcOn={UNSAFE_getIconURL('bracketed-pointer', 'blue', 'semantic', 18, 18)}
+          srcOff={UNSAFE_getIconURL('bracketed-pointer', 'darkgray', 'semantic', 18, 18)}
+        />
+      </Tooltip>
       <ComponentOrInstanceIndicator />
       <FormulaBar key={formulaBarKey} />
     </SimpleFlexRow>

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -111,7 +111,7 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(465) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(475)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(470) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(480)
   })
 })

--- a/editor/src/uuiui/icon-toggle-button.tsx
+++ b/editor/src/uuiui/icon-toggle-button.tsx
@@ -11,37 +11,40 @@ interface IconToggleButtonProps {
   className?: string
 }
 
-export const IconToggleButton: React.FunctionComponent<IconToggleButtonProps> = (props) => {
-  const { value, onToggle, srcOn, srcOff, className } = props
-  return (
-    <div
-      role='button'
-      tabIndex={0}
-      className={className}
-      css={{
-        width: 22,
-        height: 22,
-        backgroundColor: value ? colorTheme.toggleButtonBackground.value : 'transparent',
-        backgroundSize: 18,
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat',
-        outline: 'none',
-        border: 'none',
-        backgroundImage: value ? `url(${srcOn})` : `url(${srcOff})`,
-        '&:focus-within': {
-          border: `1px solid ${colorTheme.toggleButtonHoverBorder.value}`,
+export const IconToggleButton = React.forwardRef<HTMLDivElement, IconToggleButtonProps>(
+  (props, ref) => {
+    const { value, onToggle, srcOn, srcOff, className } = props
+    return (
+      <div
+        ref={ref}
+        role='button'
+        tabIndex={0}
+        className={className}
+        css={{
+          width: 22,
+          height: 22,
+          backgroundColor: value ? colorTheme.toggleButtonBackground.value : 'transparent',
+          backgroundSize: 18,
+          backgroundPosition: 'center',
+          backgroundRepeat: 'no-repeat',
           outline: 'none',
-        },
-        '&:hover': {
-          backgroundColor: colorTheme.toggleButtonHoverBackground.value,
-          border: `1px solid ${colorTheme.toggleButtonHoverBorder.value}`,
-        },
-        '&:active': {
-          transform: 'translateY(1px)',
-          backgroundImage: value ? `url(${srcOff})` : `url(${srcOn})`,
-        },
-      }}
-      onClick={onToggle}
-    />
-  )
-}
+          border: 'none',
+          backgroundImage: value ? `url(${srcOn})` : `url(${srcOff})`,
+          '&:focus-within': {
+            border: `1px solid ${colorTheme.toggleButtonHoverBorder.value}`,
+            outline: 'none',
+          },
+          '&:hover': {
+            backgroundColor: colorTheme.toggleButtonHoverBackground.value,
+            border: `1px solid ${colorTheme.toggleButtonHoverBorder.value}`,
+          },
+          '&:active': {
+            transform: 'translateY(1px)',
+            backgroundImage: value ? `url(${srcOff})` : `url(${srcOn})`,
+          },
+        }}
+        onClick={onToggle}
+      />
+    )
+  },
+)

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -339,7 +339,7 @@ function initMessaging(context: vscode.ExtensionContext, workspaceRootUri: vscod
       case 'SET_FOLLOW_SELECTION_CONFIG':
         vscode.workspace
           .getConfiguration()
-          .update(FollowSelectionConfigKey, message.enabled, vscode.ConfigurationTarget.Global)
+          .update(FollowSelectionConfigKey, message.enabled, vscode.ConfigurationTarget.Workspace)
         break
       case 'ACCUMULATED_TO_VSCODE_MESSAGE':
         for (const innerMessage of message.messages) {


### PR DESCRIPTION
Fixes #1320

**Problem:**
Code editor selection would not follow Canvas. Turns out that it was a user / UX error: we didn't realize that Malte's "Follow selection" icon was toggled off. And we didn't realize that it was a Global setting in VSCode, meaning creating a new project would not fix it.

**Fix:**
I personally wanted to make this a Session-level setting, but as it stands, `utopia.editor.followSelection.enabled` is the only configuration which lives in the VSCode configuration management, so it is kind of an example code. Rheese developed synchronization / retreaval logic for it etc, the system is waiting for more config keys to be added. I don't want to erase this functionality, so I decided to keep it inside VSCode config, but change it from Global to Workspace-level. That means that if you create a new project it will start from enabled, but if you change it, we will save the setting for a project.

**Commit Details:**
- Turned `utopia.editor.followSelection.enabled` from Global to Workspace
- Added tooltip to the follow selection button, copy: `Mirror selection between canvas and code editor`
- Added a forwardRef to `IconToggleButton` to fix Tippy
