### PR TITLE
Fix object-utils/pick

### DIFF
--- a/editor/src/core/shared/object-utils.ts
+++ b/editor/src/core/shared/object-utils.ts
@@ -234,7 +234,9 @@ export function pick<T, K extends keyof T>(keys: Array<K>, obj: T): Pick<T, K> {
   var result = {} as Pick<T, K>
 
   fastForEach(keys, (key) => {
-    result[key] = obj[key]
+    if (key in obj) {
+      result[key] = obj[key]
+    }
   })
   return result
 }


### PR DESCRIPTION
Fixes #1317

**Problem:**
Adding new NPM dependencies totally failed. 

**Fix:**
It turns out the reason why it failed is because `filterEditorForFiles` would use our in-house `pick` instead of `R.pick`, but the implementation had a bug which would create `undefined` entries for nonexistent keys. This would then make `UPDATE_NODE_MODULES_CONTENTS` call `codeCacheToBuildResult` with a `codeResultCache.cache` that would contain entries like this: `{src: undefined}` which would then kak out saying that `undefined.transpiledCode` is runtime error

**Commit Details:**
- Fix pick

**Note:**
Turns out `filterEditorForFiles` has been dead for a million years now: it is using `const allFiles = Object.keys(editor.projectContents)` but since we moved to the tree structure representation, that would only give us the tree roots. Which means that `filterEditorForFiles` would effectively clear `codeResultCache.cache` and `codeEditorErrors` on the very next action dispatched after any action that would set these fields.

It makes me think that we are not really using `codeResultCache.cache` for anything at all, and makes me seriously question how the heck `codeEditorErrors` is working 
