### PR TITLE
Fix/monkey providers

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -29361,9 +29361,9 @@ exports[`UiJsxCanvas render renders correctly with a context 1`] = `
     data-uid=\\"ddd ccc\\"
   >
     <div
-      data-uid=\\"bbb app-entity\\"
+      data-uid=\\"bbb aaa app-entity\\"
       style=\\"width: 100%; height: 100%; background-color: #eb1010;\\"
-      data-paths=\\"ccc/ddd/app-entity:aaa/bbb ccc/ddd/app-entity\\"
+      data-paths=\\"ccc/ddd/app-entity:aaa/bbb ccc/ddd/app-entity:aaa ccc/ddd/app-entity\\"
     ></div>
   </div>
 </div>
@@ -29946,8 +29946,8 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd/app-entity:aaa/bbb ccc/ddd/app-entity",
-      "data-uid": "bbb app-entity",
+      "data-paths": "ccc/ddd/app-entity:aaa/bbb ccc/ddd/app-entity:aaa ccc/ddd/app-entity",
+      "data-uid": "bbb aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "#EB1010",
@@ -30015,9 +30015,9 @@ exports[`UiJsxCanvas render renders correctly with a nested context in another c
     data-uid=\\"ddd ccc\\"
   >
     <div
-      data-uid=\\"bbb card app-entity\\"
+      data-uid=\\"bbb inner aaa card app-entity\\"
       style=\\"width: 100%; height: 100%; background-color: #eb1010;\\"
-      data-paths=\\"ccc/ddd/app-entity:card:aaa/inner/bbb ccc/ddd/app-entity:card ccc/ddd/app-entity\\"
+      data-paths=\\"ccc/ddd/app-entity:card:aaa/inner/bbb ccc/ddd/app-entity:card:aaa/inner ccc/ddd/app-entity:card:aaa ccc/ddd/app-entity:card ccc/ddd/app-entity\\"
     ></div>
   </div>
 </div>

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -218,21 +218,6 @@ export function uidsToString(uidList: Array<string>): string {
   return uidList.join(' ')
 }
 
-export function popFrontUID(
-  uidList: string | null | undefined,
-): { head: string | null; tail: string | null } {
-  if (uidList == null) {
-    return { head: null, tail: null }
-  }
-  const uids = uidsFromString(uidList)
-  const head = uids[0]
-  const tail = uids.slice(1)
-  return {
-    head: uids[0],
-    tail: tail.length > 0 ? uidsToString(tail) : null,
-  }
-}
-
 export function appendToUidString(
   uidsString: string | null | undefined,
   uidsToAppendString: string | null | undefined,

--- a/editor/src/utils/canvas-react-utils.spec.tsx
+++ b/editor/src/utils/canvas-react-utils.spec.tsx
@@ -35,18 +35,23 @@ describe('Monkey Function', () => {
     class TestClass extends React.Component {
       render() {
         return (
-          <div data-uid='cica'>
-            <div data-uid='kutya'>Hello!</div>
-            <div data-uid='majom'>Hello!</div>
+          <div data-uid='cica' data-paths='cica'>
+            <div data-uid='kutya' data-paths='kutya'>
+              Hello!
+            </div>
+            <div data-uid='majom' data-paths='majom'>
+              Hello!
+            </div>
           </div>
         )
       }
     }
 
-    expect(renderToFormattedString(<TestClass data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"cica test1\\">
-        <div data-uid=\\"kutya\\">Hello!</div>
-        <div data-uid=\\"majom\\">Hello!</div>
+    expect(renderToFormattedString(<TestClass data-uid={'test1'} data-paths='test1' />))
+      .toMatchInlineSnapshot(`
+      "<div data-uid=\\"cica test1\\" data-paths=\\"cica test1\\">
+        <div data-uid=\\"kutya\\" data-paths=\\"kutya\\">Hello!</div>
+        <div data-uid=\\"majom\\" data-paths=\\"majom\\">Hello!</div>
       </div>
       "
     `)
@@ -56,40 +61,28 @@ describe('Monkey Function', () => {
     const MyContext = React.createContext({ value: 'wrong!' })
     class TestClass extends React.Component {
       render() {
-        return <div>{this.context.value}</div>
+        return (
+          <div data-uid='inner-div' data-paths='inner-div'>
+            {this.context.value}
+          </div>
+        )
       }
     }
     TestClass.contextType = MyContext
 
     expect(
       renderToFormattedString(
-        <MyContext.Provider value={{ value: 'hello!' }}>
-          <TestClass data-uid={'test1'} />
+        <MyContext.Provider value={{ value: 'hello!' }} data-uid='provider' data-paths='provider'>
+          <TestClass data-uid={'test-class'} data-paths='test-class' />
         </MyContext.Provider>,
       ),
     ).toMatchInlineSnapshot(`
-      "<div data-uid=\\"test1\\">hello!</div>
-      "
-    `)
-  })
-
-  it('class components have a working context, second variant', () => {
-    const MyContext = React.createContext({ value: 'wrong!' })
-    class TestClass extends React.Component {
-      render() {
-        return <div>{this.context.value}</div>
-      }
-    }
-    TestClass.contextType = MyContext
-
-    expect(
-      renderToFormattedString(
-        <MyContext.Provider value={{ value: 'hello!' }} data-uid={'test1'}>
-          <TestClass />
-        </MyContext.Provider>,
-      ),
-    ).toMatchInlineSnapshot(`
-      "<div data-uid=\\"test1\\">hello!</div>
+      "<div
+        data-uid=\\"inner-div test-class provider\\"
+        data-paths=\\"inner-div test-class provider\\"
+      >
+        hello!
+      </div>
       "
     `)
   })

--- a/editor/src/utils/canvas-react-utils.spec.tsx
+++ b/editor/src/utils/canvas-react-utils.spec.tsx
@@ -91,21 +91,31 @@ describe('Monkey Function', () => {
     const MyContext = React.createContext({ value: 'wrong!' })
     class TestClass extends React.Component {
       render() {
-        return <div>{this.context.value}</div>
+        return (
+          <div data-uid='inner-div' data-paths='inner-div'>
+            {this.context.value}
+          </div>
+        )
       }
     }
     TestClass.contextType = MyContext
 
     const Renderer = () => {
       return (
-        <MyContext.Provider value={{ value: 'hello!' }}>
-          <TestClass />
+        <MyContext.Provider value={{ value: 'hello!' }} data-uid='provider' data-paths='provider'>
+          <TestClass data-uid='test-class' data-paths='test-class' />
         </MyContext.Provider>
       )
     }
 
-    expect(renderToFormattedString(<Renderer data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"test1\\">hello!</div>
+    expect(renderToFormattedString(<Renderer data-uid={'renderer'} data-paths={'renderer'} />))
+      .toMatchInlineSnapshot(`
+      "<div
+        data-uid=\\"inner-div test-class provider renderer\\"
+        data-paths=\\"inner-div test-class provider renderer\\"
+      >
+        hello!
+      </div>
       "
     `)
   })
@@ -147,7 +157,7 @@ describe('Monkey Function', () => {
 
   it('works for function components', () => {
     const OtherTestComponent: React.FunctionComponent = (props) => {
-      return <div>Hello!</div>
+      return <div data-uid='root-div'>Hello!</div>
     }
 
     const TestComponent: React.FunctionComponent = (props) => {
@@ -155,7 +165,7 @@ describe('Monkey Function', () => {
     }
 
     expect(renderToFormattedString(<TestComponent data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"cica test1\\">Hello!</div>
+      "<div data-uid=\\"root-div cica test1\\">Hello!</div>
       "
     `)
   })
@@ -218,18 +228,18 @@ describe('Monkey Function', () => {
   it('works for class components returning class components', () => {
     class OtherTestClass extends React.Component {
       render() {
-        return <div>Hello!</div>
+        return <div data-uid='root-div'>Hello!</div>
       }
     }
 
     class TestClass extends React.Component {
       render() {
-        return <OtherTestClass />
+        return <OtherTestClass data-uid='test-class' />
       }
     }
 
     expect(renderToFormattedString(<TestClass data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"test1\\">Hello!</div>
+      "<div data-uid=\\"root-div test-class test1\\">Hello!</div>
       "
     `)
   })
@@ -241,16 +251,16 @@ describe('Monkey Function', () => {
 
     const Cica = (props: any) => {
       return (
-        <CallRenderPropChild>
+        <CallRenderPropChild data-uid='wrapper-component'>
           {(data: string) => {
-            return <div>{data}</div>
+            return <div data-uid='root-div'>{data}</div>
           }}
         </CallRenderPropChild>
       )
     }
 
     expect(renderToFormattedString(<Cica data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"test1\\">Hello!</div>
+      "<div data-uid=\\"root-div wrapper-component test1\\">Hello!</div>
       "
     `)
   })
@@ -262,7 +272,7 @@ describe('Monkey Function', () => {
 
     class TestClass extends React.Component {
       renderComponent(data: string) {
-        return <div>{data}</div>
+        return <div data-uid='root-div'>{data}</div>
       }
 
       render() {
@@ -271,7 +281,7 @@ describe('Monkey Function', () => {
     }
 
     expect(renderToFormattedString(<TestClass data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"cica test1\\">Hello!</div>
+      "<div data-uid=\\"root-div cica test1\\">Hello!</div>
       "
     `)
   })
@@ -312,6 +322,21 @@ describe('Monkey Function', () => {
     `)
   })
 
+  it('Fragments work if theres a uid 2', () => {
+    const Component = () => {
+      return (
+        <React.Fragment data-uid='fragment'>
+          <div data-uid='root-div'>Hello!</div>
+        </React.Fragment>
+      )
+    }
+
+    expect(renderToFormattedString(<Component data-uid={'test1'} />)).toMatchInlineSnapshot(`
+      "<div data-uid=\\"root-div fragment test1\\">Hello!</div>
+      "
+    `)
+  })
+
   it('Fragments work if in absence of uid too', () => {
     const Component = () => {
       return (
@@ -347,8 +372,8 @@ describe('Monkey Function', () => {
       return (
         <div data-uid='cica'>
           <React.Fragment data-uid='kutya'>
-            <div>Hello</div>
-            <div>world!</div>
+            <div data-uid='hello-div'>Hello</div>
+            <div data-uid='world-div'>world!</div>
           </React.Fragment>
         </div>
       )
@@ -356,8 +381,8 @@ describe('Monkey Function', () => {
 
     expect(renderToFormattedString(<Component />)).toMatchInlineSnapshot(`
       "<div data-uid=\\"cica\\">
-        <div data-uid=\\"kutya\\">Hello</div>
-        <div data-uid=\\"kutya\\">world!</div>
+        <div data-uid=\\"hello-div kutya\\">Hello</div>
+        <div data-uid=\\"world-div kutya\\">world!</div>
       </div>
       "
     `)

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -13,7 +13,7 @@ import {
 } from '../core/model/utopia-constants'
 import { v4 } from 'uuid'
 import { PRODUCTION_ENV } from '../common/env-vars'
-import { appendToUidString, popFrontUID, uidsFromString } from '../core/shared/uid-utils'
+import { appendToUidString } from '../core/shared/uid-utils'
 
 const realCreateElement = React.createElement
 
@@ -238,11 +238,6 @@ const mangleClassType = Utils.memoize(
   },
 )
 
-function uidsWithoutExoticUID(uids: string | null): string | null {
-  const { head: uidsHead, tail: uidsTail } = popFrontUID(uids)
-  return uidsTail ?? uidsHead
-}
-
 const mangleExoticType = Utils.memoize(
   (type: React.ComponentType): React.FunctionComponent => {
     function updateChild(
@@ -304,8 +299,8 @@ const mangleExoticType = Utils.memoize(
             return attachDataUidToRoot(originalResponse, uids, paths)
           }
         } else {
-          const uidsToPass = uidsWithoutExoticUID(uids)
-          const pathsToPass = uidsWithoutExoticUID(paths)
+          const uidsToPass = uids
+          const pathsToPass = paths
 
           if (Array.isArray(p?.children)) {
             children = React.Children.map(p?.children, (child) =>


### PR DESCRIPTION
Fixes #1319

**Problem:**
If you are using a ThemeProvider, the spying would stop working and the navigator / selection / etc would give up:
<img width="317" alt="image" src="https://user-images.githubusercontent.com/2226774/120466852-d4a91800-c39f-11eb-9d23-5cd27b27d057.png">
Sad!

**Fix:**
Turns out the problem was in the Monkey Function. 
ThemeProvider is an exotic component, but that shouldn't prevent us from printing its UID to the DOM. And as it turns out, nothing technically prevents us from doing so, except some weird (old) special cased handling that was deliberately doing this!
I don't quite know _why_ we were omitting Fragment uids in the first place, but I believe the explanation only makes sense for a single-uid world, and ever since the Monkey started accumulating UIDs, it was doing fragments and exotic components a misservice by deliberately skipping their UIDs from the accumulation.

The fix is to simply delete the 1 line that was snipping out the exotic uid.
<img width="319" alt="image" src="https://user-images.githubusercontent.com/2226774/120467291-539e5080-c3a0-11eb-8c69-547941ff8567.png">


**Commit Details:**
- Extended the tests to also cover data-paths not just data-uid
- Identified a test case called `class components have a working context, third variant` that demonstrates my problem
- Realized that the culprit was `uidsWithoutExoticUID`
- Delete `uidsWithoutExoticUID` 
- Profit
