### PR TITLE
Fix the "add storyboard" button

### DIFF
--- a/editor/src/core/model/__snapshots__/storyboard-utils.spec.ts.snap
+++ b/editor/src/core/model/__snapshots__/storyboard-utils.spec.ts.snap
@@ -3,6 +3,12 @@
 exports[`addStoryboardFileToProject adds storyboard file to project that does not have one 1`] = `
 Array [
   Object {
+    "rawCode": "
+
+",
+    "type": "UNPARSED_CODE",
+  },
+  Object {
     "arbitraryJSBlock": null,
     "blockOrExpression": "block",
     "declarationSyntax": "var",
@@ -17,7 +23,36 @@ Array [
     "rootElement": Object {
       "children": Array [
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": Object {
+                "baseVariable": "App",
+                "propertyPath": Object {
+                  "propertyElements": Array [],
+                },
+              },
+              "props": Array [
+                Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "key": "data-uid",
+                  "value": Object {
+                    "comments": Object {
+                      "leadingComments": Array [],
+                      "trailingComments": Array [],
+                    },
+                    "type": "ATTRIBUTE_VALUE",
+                    "value": "be6",
+                  },
+                },
+              ],
+              "type": "JSX_ELEMENT",
+              "uid": "be6",
+            },
+          ],
           "name": Object {
             "baseVariable": "Scene",
             "propertyPath": Object {
@@ -25,23 +60,6 @@ Array [
             },
           },
           "props": Array [
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "component",
-              "value": Object {
-                "definedElsewhere": Array [
-                  "App",
-                ],
-                "javascript": "App",
-                "sourceMap": null,
-                "transpiledJavascript": "return App",
-                "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
-                "uniqueID": "",
-              },
-            },
             Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -55,21 +73,6 @@ Array [
                 },
                 "type": "ATTRIBUTE_VALUE",
                 "value": "scene-1",
-              },
-            },
-            Object {
-              "comments": Object {
-                "leadingComments": Array [],
-                "trailingComments": Array [],
-              },
-              "key": "props",
-              "value": Object {
-                "comments": Object {
-                  "leadingComments": Array [],
-                  "trailingComments": Array [],
-                },
-                "type": "ATTRIBUTE_VALUE",
-                "value": Object {},
               },
             },
             Object {

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -45,6 +45,7 @@ import { getUtopiaID } from './element-template-utils'
 import { emptyComments } from '../workers/parser-printer/parser-printer-comments'
 import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../../components/assets'
 import { getUtopiaJSXComponentsFromSuccess } from './project-file-utils'
+import { generateUID } from '../shared/uid-utils'
 
 export const PathForSceneComponent = PP.create(['component'])
 export const PathForSceneDataUid = PP.create(['data-uid'])
@@ -142,14 +143,7 @@ export function convertScenesToUtopiaCanvasComponent(
 
 export function createSceneFromComponent(componentImportedAs: string, uid: string): JSXElement {
   const sceneProps = jsxAttributesFromMap({
-    component: jsxAttributeOtherJavaScript(
-      componentImportedAs,
-      `return ${componentImportedAs}`,
-      [componentImportedAs],
-      null,
-    ),
     [UTOPIA_UIDS_KEY]: jsxAttributeValue(uid, emptyComments),
-    props: jsxAttributeValue({}, emptyComments),
     style: jsxAttributeValue(
       {
         position: 'absolute',
@@ -161,7 +155,17 @@ export function createSceneFromComponent(componentImportedAs: string, uid: strin
       emptyComments,
     ),
   })
-  return jsxElement('Scene', uid, sceneProps, [])
+  const componentUID = generateUID([])
+  return jsxElement('Scene', uid, sceneProps, [
+    jsxElement(
+      componentImportedAs,
+      componentUID,
+      jsxAttributesFromMap({
+        [UTOPIA_UIDS_KEY]: jsxAttributeValue(componentUID, emptyComments),
+      }),
+      [],
+    ),
+  ])
 }
 
 export function createStoryboardElement(scenes: Array<JSXElement>, uid: string): JSXElement {

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -47,7 +47,6 @@ import { emptyComments } from '../workers/parser-printer/parser-printer-comments
 import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../../components/assets'
 import { getUtopiaJSXComponentsFromSuccess } from './project-file-utils'
 import { generateConsistentUID, generateUID } from '../shared/uid-utils'
-import { StoryboardFilePath } from '../../components/editor/store/editor-state'
 import { emptySet } from '../shared/set-utils'
 
 export const PathForSceneComponent = PP.create(['component'])
@@ -144,7 +143,11 @@ export function convertScenesToUtopiaCanvasComponent(
   )
 }
 
-export function createSceneFromComponent(componentImportedAs: string, uid: string): JSXElement {
+export function createSceneFromComponent(
+  filePath: string,
+  componentImportedAs: string,
+  uid: string,
+): JSXElement {
   const sceneProps = jsxAttributesFromMap({
     [UTOPIA_UIDS_KEY]: jsxAttributeValue(uid, emptyComments),
     style: jsxAttributeValue(
@@ -159,7 +162,7 @@ export function createSceneFromComponent(componentImportedAs: string, uid: strin
     ),
   })
   const hash = Hash({
-    fileName: StoryboardFilePath,
+    fileName: filePath,
     name: componentImportedAs,
     props: jsxAttributesFromMap({}),
   })

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -1,3 +1,4 @@
+import * as Hash from 'object-hash'
 import {
   SceneMetadata,
   StaticElementPath,
@@ -45,7 +46,9 @@ import { getUtopiaID } from './element-template-utils'
 import { emptyComments } from '../workers/parser-printer/parser-printer-comments'
 import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../../components/assets'
 import { getUtopiaJSXComponentsFromSuccess } from './project-file-utils'
-import { generateUID } from '../shared/uid-utils'
+import { generateConsistentUID, generateUID } from '../shared/uid-utils'
+import { StoryboardFilePath } from '../../components/editor/store/editor-state'
+import { emptySet } from '../shared/set-utils'
 
 export const PathForSceneComponent = PP.create(['component'])
 export const PathForSceneDataUid = PP.create(['data-uid'])
@@ -155,7 +158,12 @@ export function createSceneFromComponent(componentImportedAs: string, uid: strin
       emptyComments,
     ),
   })
-  const componentUID = generateUID([])
+  const hash = Hash({
+    fileName: StoryboardFilePath,
+    name: componentImportedAs,
+    props: jsxAttributesFromMap({}),
+  })
+  const componentUID = generateConsistentUID(emptySet(), hash)
   return jsxElement('Scene', uid, sceneProps, [
     jsxElement(
       componentImportedAs,

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -18,6 +18,7 @@ import {
 import {
   isUtopiaJSXComponent,
   JSXElement,
+  unparsedCode,
   UtopiaJSXComponent,
   utopiaJSXComponent,
 } from '../shared/element-template'
@@ -223,12 +224,13 @@ function addStoryboardFileForComponent(
   editorModel: EditorState,
 ): EditorState {
   // Add import of storyboard and scene components.
-  let imports = addImport(
+  let imports = addImport('react', null, [], 'React', {})
+  imports = addImport(
     'utopia-api',
     null,
-    [importAlias('Storyboard'), importAlias('Scene'), importAlias('jsx')],
+    [importAlias('Storyboard'), importAlias('Scene')],
     null,
-    {},
+    imports,
   )
   // Create the storyboard variable.
   let sceneElement: JSXElement
@@ -320,11 +322,11 @@ function addStoryboardFileForComponent(
   // Create the file.
   const success = parseSuccess(
     imports,
-    [storyboardComponent],
+    [unparsedCode('\n\n'), storyboardComponent],
     {},
-    'jsx',
     null,
-    addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+    null,
+    addModifierExportToDetail(EmptyExportsDetail, BakedInStoryboardVariableName),
   )
   const storyboardFileContents = textFile(
     textFileContents('', success, RevisionsState.ParsedAhead),

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -237,7 +237,11 @@ function addStoryboardFileForComponent(
   let updatedProjectContents: ProjectContentTreeRoot = editorModel.projectContents
   switch (createFileWithComponent.type) {
     case 'NAMED_COMPONENT_TO_IMPORT':
-      sceneElement = createSceneFromComponent(createFileWithComponent.toImport, 'scene-1')
+      sceneElement = createSceneFromComponent(
+        StoryboardFilePath,
+        createFileWithComponent.toImport,
+        'scene-1',
+      )
       imports = addImport(
         createFileWithComponent.path,
         null,
@@ -247,11 +251,15 @@ function addStoryboardFileForComponent(
       )
       break
     case 'DEFAULT_COMPONENT_TO_IMPORT':
-      sceneElement = createSceneFromComponent('StoryboardComponent', 'scene-1')
+      sceneElement = createSceneFromComponent(StoryboardFilePath, 'StoryboardComponent', 'scene-1')
       imports = addImport(createFileWithComponent.path, 'StoryboardComponent', [], null, imports)
       break
     case 'UNEXPORTED_RENDERED_COMPONENT':
-      sceneElement = createSceneFromComponent(createFileWithComponent.elementName, 'scene-1')
+      sceneElement = createSceneFromComponent(
+        StoryboardFilePath,
+        createFileWithComponent.elementName,
+        'scene-1',
+      )
       imports = addImport(
         createFileWithComponent.path,
         null,

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   PropertyPath,
   PropertyPathPart,
   StaticElementPathPart,
@@ -23,7 +23,7 @@ import {
   isParsedCommentsEmpty,
   ParsedComments,
 } from '../workers/parser-printer/parser-printer-comments'
-import { MapLike } from 'typescript'
+import type { MapLike } from 'typescript'
 import { forceNotNull } from './optional-utils'
 import { string } from 'fast-check/*'
 


### PR DESCRIPTION
Fixes #1287

**Problem:**
The "add missing storyboard" functionality still generated Olde Style Code.

**Fix:**
Fixed the add missing storyboard functionality

**Commit Details:**
- Importing * as React at the top of the file
- No longer importing jsx from utopia-api
- Component is now the child of Scene
- Component has a Hash uid similar to the parser-printer one, (mainly so that it is easier to snapshot test)

**Bonus:**
- I added a nice white-space between the imports and the storyboard declaration
- var storyboard is now exported properly