### PR TITLE
Prevent selection mania.

### DIFF
--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -359,7 +359,7 @@ function initMessaging(context: vscode.ExtensionContext, workspaceRootUri: vscod
       updateDecorations(currentDecorations)
     }),
     vscode.window.onDidChangeTextEditorSelection((event) => {
-      if (event.kind !== vscode.TextEditorSelectionChangeKind.Command) {
+      if (event.kind !== undefined && event.kind !== vscode.TextEditorSelectionChangeKind.Command) {
         cursorPositionChanged(event)
       }
     }),


### PR DESCRIPTION
Fixes #1321

**Problem:**
Open file triggers going to VS Code were causing a cursor position changed event to be triggered, coming back to the editor updating selection to the same element. However as these are buffered with mailboxes it was possible to get 2 or more of these updates orbiting around on opposite sides of the flow to each other, causing them to trigger their changes repeatedly.

**Fix:**
This re-adds a check that was originally in there but was removed to fix an issue with the selection, as the updates come through with the `undefined` value when backspacing. It _appears_ that subsequent fixes have rendered that unnecessary as far as I can tell from my testing.

**Commit Details:**
- Fixes #1321.
- Re-add the `!== undefined` case for checking the kind of a text change
  selection event in the extension. It appears the open file command
  triggers the change to come through with an `undefined` value for that.
