### PR TITLE
Cleanup obsolete entries in nodeModules for project files.

### DIFF
--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -28,7 +28,14 @@ import {
   getTextFileByPath,
   SampleNodeModules,
 } from './code-file.test-utils'
-import { NodeModules } from '../../core/shared/project-file-types'
+import {
+  NodeModules,
+  RevisionsState,
+  textFile,
+  textFileContents,
+  unparsed,
+} from '../../core/shared/project-file-types'
+import { addFileToProjectContents } from '../assets'
 
 function transpileCode(
   rootFilenames: Array<string>,
@@ -50,9 +57,11 @@ function transpileCode(
   return objectMap((_, filename) => emitFile(services, `${filename}`), files)
 }
 
+const appJSCode =
+  "\nimport * as React from 'react'\nimport {\n  Ellipse,\n  HelperFunctions,\n  Image,\n  NodeImplementations,\n  Rectangle,\n  Text,\n  View,\n} from 'utopia-api'\nimport {\n  colorTheme,\n  Button,\n  Dialog,\n  Icn,\n  Icons,\n  LargerIcons,\n  FunctionIcons,\n  MenuIcons,\n  Isolator,\n  TabComponent,\n  Tooltip,\n  ActionSheet,\n  Avatar,\n  ControlledTextArea,\n  Title,\n  H1,\n  H2,\n  H3,\n  Subdued,\n  InspectorSectionHeader,\n  InspectorSubsectionHeader,\n  FlexColumn,\n  FlexRow,\n  ResizableFlexColumn,\n  PopupList,\n  Section,\n  SectionTitleRow,\n  SectionBodyArea,\n  UtopiaListSelect,\n  UtopiaListItem,\n  CheckboxInput,\n  NumberInput,\n  StringInput,\n  OnClickOutsideHOC,\n} from 'uuiui'\n\nexport var canvasMetadata = {\n  specialNodes: [],\n  nodeMetadata: {},\n  scenes: [\n    {\n      component: 'App',\n      frame: { height: 812, left: 0, width: 375, top: 0 },\n      props: { layout: { top: 0, left: 0, bottom: 0, right: 0 } },\n      container: { layoutSystem: 'pinSystem' },\n    },\n  ],\n  elementMetadata: {},\n}\n\nexport var App = (props) => {\n  return (\n    <View\n      style={{ ...props.style, backgroundColor: colorTheme.white.value }}\n      layout={{ layoutSystem: 'pinSystem' }}\n      data-uid={'aaa'}\n    ></View>\n  )\n}\n\n"
+
 const SampleSingleFileBuildResult = transpileCode(['/app.js'], {
-  '/app.js':
-    "\nimport * as React from 'react'\nimport {\n  Ellipse,\n  HelperFunctions,\n  Image,\n  NodeImplementations,\n  Rectangle,\n  Text,\n  View,\n} from 'utopia-api'\nimport {\n  colorTheme,\n  Button,\n  Dialog,\n  Icn,\n  Icons,\n  LargerIcons,\n  FunctionIcons,\n  MenuIcons,\n  Isolator,\n  TabComponent,\n  Tooltip,\n  ActionSheet,\n  Avatar,\n  ControlledTextArea,\n  Title,\n  H1,\n  H2,\n  H3,\n  Subdued,\n  InspectorSectionHeader,\n  InspectorSubsectionHeader,\n  FlexColumn,\n  FlexRow,\n  ResizableFlexColumn,\n  PopupList,\n  Section,\n  SectionTitleRow,\n  SectionBodyArea,\n  UtopiaListSelect,\n  UtopiaListItem,\n  CheckboxInput,\n  NumberInput,\n  StringInput,\n  OnClickOutsideHOC,\n} from 'uuiui'\n\nexport var canvasMetadata = {\n  specialNodes: [],\n  nodeMetadata: {},\n  scenes: [\n    {\n      component: 'App',\n      frame: { height: 812, left: 0, width: 375, top: 0 },\n      props: { layout: { top: 0, left: 0, bottom: 0, right: 0 } },\n      container: { layoutSystem: 'pinSystem' },\n    },\n  ],\n  elementMetadata: {},\n}\n\nexport var App = (props) => {\n  return (\n    <View\n      style={{ ...props.style, backgroundColor: colorTheme.white.value }}\n      layout={{ layoutSystem: 'pinSystem' }}\n      data-uid={'aaa'}\n    ></View>\n  )\n}\n\n",
+  '/app.js': appJSCode,
 })
 
 const SampleSingleFileExportsInfo = [
@@ -450,12 +459,28 @@ describe('Creating require function', () => {
 
 describe('incorporateBuildResult', () => {
   it('should remove a value if there is no transpiled code', () => {
+    const projectContents = addFileToProjectContents(
+      {},
+      '/app.js',
+      textFile(textFileContents(appJSCode, unparsed, RevisionsState.CodeAhead), null, 0),
+    )
     let nodeModules: NodeModules = {}
-    incorporateBuildResult(nodeModules, SampleSingleFileBuildResult)
-    incorporateBuildResult(nodeModules, {
+    incorporateBuildResult(nodeModules, projectContents, SampleSingleFileBuildResult)
+    incorporateBuildResult(nodeModules, projectContents, {
       ['/app.js']: { errors: [], transpiledCode: null, sourceMap: null },
     })
-    expect(nodeModules).toMatchInlineSnapshot(`Object {}`)
+    expect(Object.keys(nodeModules)).toMatchInlineSnapshot(`Array []`)
+  })
+  it('should remove a value if there is no transpiled code', () => {
+    const projectContents = addFileToProjectContents(
+      {},
+      '/app.js',
+      textFile(textFileContents(appJSCode, unparsed, RevisionsState.CodeAhead), null, 0),
+    )
+    let nodeModules: NodeModules = {}
+    incorporateBuildResult(nodeModules, projectContents, SampleSingleFileBuildResult)
+    incorporateBuildResult(nodeModules, {}, {})
+    expect(Object.keys(nodeModules)).toMatchInlineSnapshot(`Array []`)
   })
 })
 

--- a/editor/src/core/property-controls/property-controls-processor.ts
+++ b/editor/src/core/property-controls/property-controls-processor.ts
@@ -34,7 +34,7 @@ export const initPropertyControlsProcessor = (
     currentNodeModules = applyNodeModulesUpdate(currentNodeModules, nodeModulesUpdate)
     const resolvedNpmDependencies = resolvedDependencyVersions(npmDependencies, currentNodeModules)
 
-    incorporateBuildResult(currentNodeModules, bundledProjectFiles)
+    incorporateBuildResult(currentNodeModules, projectContents, bundledProjectFiles)
 
     let propertyControlsInfo: PropertyControlsInfo = getControlsForExternalDependencies(
       resolvedNpmDependencies,

--- a/editor/src/templates/preview.tsx
+++ b/editor/src/templates/preview.tsx
@@ -246,7 +246,7 @@ const initPreview = () => {
       await createBundle(bundlerWorker, emptyTypeDefinitions, projectContents)
     ).buildResult
 
-    incorporateBuildResult(nodeModules, bundledProjectFiles)
+    incorporateBuildResult(nodeModules, projectContents, bundledProjectFiles)
 
     const requireFn = getRequireFn(
       onRemoteModuleDownload,


### PR DESCRIPTION
Fixes #1334

**Problem:**
In the process of trying to reproduce #1330, it was noticed that there's almost a completely inverse issue. If a file is renamed, currently it is possible to import from the old name.

**Fix:**
As a result of falling back from project contents to node modules, as the former are also stored in the latter they were not kept up to date when the project contents had rename or delete type changes which left zombie entries in the node modules which could still be retrieved. The fix was to make `incorporateBuildResult` cull those obsolete entries by comparing them against the project contents.

This also fixes the origin of files being added in there as they were all being incorrectly attributed to `NODE_MODULES` as their origin.

**Commit Details:**
- Fixes #1334.
- `incorporateBuildResult` now includes a fix to ensure that entries
  get tagged with the correct origin.
- `incorporateBuildResult` ensures that entries for project files
  which do not have a matching entry in the project contents are culled.
