### PR TITLE
Fix: bring back linting

### DIFF
--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -45,7 +45,7 @@ export const CanvasWrapperComponent = betterReactMemo(
     )
 
     const fatalErrors = React.useMemo(() => {
-      return getAllCodeEditorErrors(editorState, true, true)
+      return getAllCodeEditorErrors(editorState, 'fatal', true)
     }, [editorState])
 
     const safeMode = useEditorState((store) => {
@@ -91,7 +91,7 @@ const ErrorOverlayComponent = betterReactMemo(
       )
     }, 'ErrorOverlayComponent utopiaParserErrors')
     const fatalCodeEditorErrors = useEditorState((store) => {
-      return getAllCodeEditorErrors(store.editor, true, true)
+      return getAllCodeEditorErrors(store.editor, 'error', true)
     }, 'ErrorOverlayComponent fatalCodeEditorErrors')
 
     const runtimeErrors = useReadOnlyRuntimeErrors()

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -191,6 +191,7 @@ export function isFromVSCode(action: EditorAction): boolean {
     case 'ATOMIC':
       return action.actions.some(isFromVSCode)
     case 'UPDATE_FROM_CODE_EDITOR':
+    case 'SEND_LINTER_REQUEST_MESSAGE':
       return true
     default:
       return false

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -72,6 +72,7 @@ import {
   isProjectContentFile,
   ProjectContentsTree,
   ProjectContentTreeRoot,
+  treeToContents,
   walkContentsTree,
   zipContentsTree,
 } from '../../assets'
@@ -630,7 +631,9 @@ function editorDispatchInner(
 }
 
 function filterEditorForFiles(editor: EditorState) {
-  const allFiles = Object.keys(editor.projectContents)
+  // FIXME: Reimplement this in a way that doesn't require converting from `ProjectContents`.
+  const projectContents = treeToContents(editor.projectContents)
+  const allFiles = Object.keys(projectContents)
   return {
     ...editor,
     codeResultCache: {

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -388,14 +388,6 @@ export function editorDispatch(
         allTransient,
         spyCollector,
       )
-      if (!newStore.nothingChanged) {
-        /**
-         * Heads up: we do not log dispatches that resulted in a NO_OP. This is to avoid clogging up the
-         * history with a million CLEAR_HIGHLIGHTED_VIEWS and other such actions.
-         *  */
-
-        reduxDevtoolsSendActions(actions, newStore)
-      }
       return newStore
     },
     { ...storedState, entireUpdateFinished: Promise.resolve(true), nothingChanged: true },
@@ -457,6 +449,15 @@ export function editorDispatch(
       editorWithModelChecked.modelUpdateFinished,
     ]),
     alreadySaved: alreadySaved || shouldSave,
+  }
+
+  if (!finalStore.nothingChanged) {
+    /**
+     * Heads up: we do not log dispatches that resulted in a NO_OP. This is to avoid clogging up the
+     * history with a million CLEAR_HIGHLIGHTED_VIEWS and other such actions.
+     *  */
+
+    reduxDevtoolsSendActions(actionGroupsToProcess, finalStore)
   }
 
   if (shouldSave) {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -29,7 +29,7 @@ import {
   getHighlightBoundsForProject,
   applyUtopiaJSXComponentsChanges,
 } from '../../../core/model/project-file-utils'
-import { ErrorMessage } from '../../../core/shared/error-messages'
+import type { ErrorMessage, ErrorMessageSeverity } from '../../../core/shared/error-messages'
 import type { PackageStatus, PackageStatusMap } from '../../../core/shared/npm-dependency-types'
 import {
   Imports,
@@ -1610,14 +1610,18 @@ export function areGeneratedElementsTargeted(
 
 export function getAllCodeEditorErrors(
   editor: EditorState,
-  onlyFatal: boolean,
+  minimumSeverity: ErrorMessageSeverity,
   skipTsErrors: boolean,
 ): Array<ErrorMessage> {
   const allLintErrors = getAllLintErrors(editor)
   const allBuildErrors = getAllBuildErrors(editor)
   const errorsAndWarnings = skipTsErrors ? allLintErrors : [...allBuildErrors, ...allLintErrors]
-  if (onlyFatal) {
+  if (minimumSeverity === 'fatal') {
     return errorsAndWarnings.filter((error) => error.severity === 'fatal')
+  } else if (minimumSeverity === 'error') {
+    return errorsAndWarnings.filter(
+      (error) => error.severity === 'fatal' || error.severity === 'error',
+    )
   } else {
     return errorsAndWarnings
   }

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -187,7 +187,7 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
       dispatch: store.dispatch,
       projectContents: store.editor.projectContents,
       editorSelectedFile: getOpenFilename(store.editor),
-      errorMessages: getAllCodeEditorErrors(store.editor, false, true),
+      errorMessages: getAllCodeEditorErrors(store.editor, 'warning', true),
       codeResultCache: store.editor.codeResultCache,
       propertyControlsInfo: store.editor.propertyControlsInfo,
       renamingTarget: store.editor.fileBrowser.renamingTarget,

--- a/editor/src/core/shared/redux-devtools.ts
+++ b/editor/src/core/shared/redux-devtools.ts
@@ -89,12 +89,14 @@ function sanitizeLoggedState(store: EditorStore) {
 }
 
 export function reduxDevtoolsSendActions(
-  actions: Array<EditorAction>,
+  actions: Array<Array<EditorAction>>,
   newStore: EditorStore,
 ): void {
   if (maybeDevTools != null && sendActionUpdates) {
     // filter out the actions we are not interested in
-    const filteredActions = actions.filter((action) => !ActionsToOmit.includes(action.action))
+    const filteredActions = actions
+      .flat()
+      .filter((action) => !ActionsToOmit.includes(action.action))
     if (filteredActions.length > 0) {
       const sanitizedStore = sanitizeLoggedState(newStore)
       const actionNames = pluck(filteredActions, 'action').join(' ')

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -15,6 +15,7 @@ import {
   updateFromCodeEditor,
   sendCodeEditorInitialisation,
   updateConfigFromVSCode,
+  sendLinterRequestMessage,
 } from '../../components/editor/actions/action-creators'
 import {
   getSavedCodeFromTextFile,
@@ -127,12 +128,17 @@ function watchForChanges(dispatch: EditorDispatch): void {
     stat(fsPath).then((fsStat) => {
       if (fsStat.type === 'FILE' && fsStat.sourceOfLastChange !== UtopiaFSUser) {
         readFileAsUTF8(fsPath).then((fileContent) => {
-          const action = updateFromCodeEditor(
-            fromFSPath(fsPath),
+          const path = fromFSPath(fsPath)
+          const updateAction = updateFromCodeEditor(
+            path,
             fileContent.content,
             fileContent.unsavedContent,
           )
-          dispatch([action], 'everyone')
+          const requestLintAction = sendLinterRequestMessage(
+            path,
+            fileContent.unsavedContent ?? fileContent.content,
+          )
+          dispatch([updateAction, requestLintAction], 'everyone')
         })
       }
     })

--- a/editor/src/core/workers/linter/eslint-config.ts
+++ b/editor/src/core/workers/linter/eslint-config.ts
@@ -198,11 +198,11 @@ export const ESLINT_CONFIG: Linter.Config = {
     //   },
     // ],
     'no-use-before-define': [
-      'warn',
+      'error',
       {
         functions: false,
-        classes: false,
-        variables: false,
+        classes: true,
+        variables: true,
       },
     ],
     'no-useless-computed-key': 'warn',

--- a/editor/src/core/workers/linter/linter.ts
+++ b/editor/src/core/workers/linter/linter.ts
@@ -42,6 +42,7 @@ export function lintCode(
   const passTime = Date.now()
   try {
     const lintResult = linter.verify(code, config, { filename: filename })
+    const codeLines = code.split('\n')
 
     return lintResult.map(
       (r: any): ErrorMessage => {
@@ -59,7 +60,10 @@ export function lintCode(
 
         const message = strippedAndSplitMessage[0]
         const messageWithRule = r.ruleId == null ? message : `${message} (${r.ruleId})`
-        const codeSnippet = strippedAndSplitMessage[1]
+        const codeSnippetFromESLint = strippedAndSplitMessage[1]
+        const codeSnippet =
+          codeSnippetFromESLint ??
+          codeLines.slice(Math.max(r.line - 3, 0), r.endLine + 3).join('\n')
 
         return {
           message: messageWithRule,


### PR DESCRIPTION
Fixes #1171

**Problem:**
This PR tackles two problems:
1. in general we lost Linting when we switched to VSCode. I don't think it was intentional, but none of us was bothered by it enough to bring it back sooner. SAD!
2. In specific, the problem in #1171 is that we are sometimes more permissive on the canvas than javascript Eval would be. To work around this issue, the fastest fix was to enable a lint error that prevents the users from writing illegal JS code. for this I had to resurrect linting!


**Fix:**
Linting is now triggered in UPDATE_FROM_CODE_EDITOR. Lint errors, not just fatal errors now trigger the canvas overlay.

<img width="1925" alt="image" src="https://user-images.githubusercontent.com/2226774/120643884-f923f380-c476-11eb-88e3-4ca4fb136832.png">


**Commit Details:**
- when processing `UPDATE_FROM_CODE_EDITOR`, also trigger a `SEND_LINTER_REQUEST_MESSAGE`
- Include Lint Errors, not just Lint Fatal Errors to turn the canvas overlay on – this might be too agressive behavior
- move the `reduxDevtoolsSendActions` to after the point where the editorState is finalized – this avoids the head scratchy situations where an action seemingly properly updates the editor state, but then the value goes away by the time the next action gets dispatched
- fix `filterEditorForFiles` which broke lint errors and the code cache when we turned `projectContents` into a tree – so about 6 months ago 😅

**Note:**
We have a lot of lint rules which are set to Error severity – some of these should break the canvas, some of these should not.
We have two options here:
1. create a very special Fatal Error category for those lint errors where we want to break the canvas, and otherwise keep Errors and Warnings (red squiggly underline and yellow squiggly underline) in VSCode and the Errors tab
2. review what lint rules are Errors and turn some of them into Warnings, and every Error should break the canvas
This question primarily goes to @maltenuhn 

**PS**
It seems like I accidentally fixed the exportsInfo and now the File navigator shows the exported components again 😅– I thought we deliberately killed that feature, I was not aware it's a regression. We do seem to reliably regress everything that doesn't have explicit tests for it.
