### PR TITLE
resurrect the console and errors pane

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../uuiui'
 import { betterReactMemo } from '../../uuiui-deps'
 import { TopMenu } from '../editor/top-menu'
+import { ConsoleAndErrorsPane } from '../code-editor/console-and-errors-pane'
 
 interface DesignPanelRootProps {
   isUiJsFileOpen: boolean
@@ -281,6 +282,7 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
             }}
           >
             <CodeEditorWrapper />
+            <ConsoleAndErrorsPane />
           </Resizable>
         </SimpleFlexColumn>
 

--- a/editor/src/components/code-editor/code-editor-container.tsx
+++ b/editor/src/components/code-editor/code-editor-container.tsx
@@ -51,6 +51,6 @@ export const CodeEditorWrapper = betterReactMemo('CodeEditorWrapper', () => {
       />
     )
   } else {
-    return <div>Loading...</div>
+    return <div style={{ flex: 1 }}>Loading...</div>
   }
 })

--- a/editor/src/components/code-editor/code-problems.tsx
+++ b/editor/src/components/code-editor/code-problems.tsx
@@ -192,6 +192,50 @@ export const CodeEditorTabPane = betterReactMemo<CodeEditorTabPaneProps>(
       setSelectedTab('console')
     }, [setSelectedTab, isOpen, toggleIsOpen])
 
+    const problemsTabBackgroundColor = getTabStyleForErrors(errorMessages).backgroundColor
+    const ProblemsTabLabel = React.useMemo(() => {
+      return (
+        <span>
+          Problems
+          <span
+            style={{
+              marginLeft: 8,
+              fontSize: 10,
+              padding: '1px 5px',
+              borderRadius: 2,
+              fontWeight: 500,
+              color: colorTheme.neutralInvertedForeground.value,
+              backgroundColor: problemsTabBackgroundColor,
+            }}
+          >
+            {errorMessages.length}
+          </span>
+        </span>
+      )
+    }, [problemsTabBackgroundColor, errorMessages.length])
+
+    const consoleTabBackgroundColor = getTabStyleForLogs(canvasConsoleLogs).backgroundColor
+    const ConsoleTabLabel = React.useMemo(() => {
+      return (
+        <span>
+          Console
+          <span
+            style={{
+              marginLeft: 8,
+              fontSize: 10,
+              padding: '1px 5px',
+              borderRadius: 2,
+              fontWeight: 500,
+              color: colorTheme.neutralInvertedForeground.value,
+              backgroundColor: consoleTabBackgroundColor,
+            }}
+          >
+            {canvasConsoleLogs.length}
+          </span>
+        </span>
+      )
+    }, [consoleTabBackgroundColor, canvasConsoleLogs.length])
+
     function getTabContents() {
       switch (selectedTab) {
         case 'problems':
@@ -279,24 +323,7 @@ export const CodeEditorTabPane = betterReactMemo<CodeEditorTabPaneProps>(
             selected={selectedTab === 'problems'}
             showCloseIndicator={false}
             showModifiedIndicator={false}
-            label={
-              <span>
-                Problems
-                <span
-                  style={{
-                    marginLeft: 8,
-                    fontSize: 10,
-                    padding: '1px 5px',
-                    borderRadius: 2,
-                    fontWeight: 500,
-                    color: colorTheme.neutralInvertedForeground.value,
-                    ...getTabStyleForErrors(errorMessages),
-                  }}
-                >
-                  {errorMessages.length}
-                </span>
-              </span>
-            }
+            label={ProblemsTabLabel}
           />
           <TabComponent
             onClick={selectConsoleTab}
@@ -304,24 +331,7 @@ export const CodeEditorTabPane = betterReactMemo<CodeEditorTabPaneProps>(
             selected={selectedTab == 'console'}
             showCloseIndicator={false}
             showModifiedIndicator={false}
-            label={
-              <span>
-                Console
-                <span
-                  style={{
-                    marginLeft: 8,
-                    fontSize: 10,
-                    padding: '1px 5px',
-                    borderRadius: 2,
-                    fontWeight: 500,
-                    color: colorTheme.neutralInvertedForeground.value,
-                    ...getTabStyleForLogs(canvasConsoleLogs),
-                  }}
-                >
-                  {canvasConsoleLogs.length}
-                </span>
-              </span>
-            }
+            label={ConsoleTabLabel}
           />
         </UIRow>
         {isOpen ? getTabContents() : null}

--- a/editor/src/components/code-editor/console-and-errors-pane.tsx
+++ b/editor/src/components/code-editor/console-and-errors-pane.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react'
 import { useReadOnlyConsoleLogs } from '../../core/shared/runtime-report-logs'
+import { betterReactMemo } from '../../uuiui-deps'
 import { setFocus } from '../common/actions'
 import { openCodeEditorFile } from '../editor/actions/action-creators'
 import { getAllCodeEditorErrors } from '../editor/store/editor-state'
 import { useEditorState } from '../editor/store/store-hook'
 import { CodeEditorTabPane } from './code-problems'
 
-export const ConsoleAndErrorsPane = React.memo(() => {
+export const ConsoleAndErrorsPane = betterReactMemo('ConsoleAndErrorsPane', () => {
   const dispatch = useEditorState((store) => store.dispatch, 'ConsoleAndErrorsPane dispatch')
 
   const canvasConsoleLogs = useReadOnlyConsoleLogs()

--- a/editor/src/components/code-editor/console-and-errors-pane.tsx
+++ b/editor/src/components/code-editor/console-and-errors-pane.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+import { useReadOnlyConsoleLogs } from '../../core/shared/runtime-report-logs'
+import { setFocus } from '../common/actions'
+import { openCodeEditorFile } from '../editor/actions/action-creators'
+import { getAllCodeEditorErrors } from '../editor/store/editor-state'
+import { useEditorState } from '../editor/store/store-hook'
+import { CodeEditorTabPane } from './code-problems'
+
+export const ConsoleAndErrorsPane = React.memo(() => {
+  const dispatch = useEditorState((store) => store.dispatch, 'ConsoleAndErrorsPane dispatch')
+
+  const canvasConsoleLogs = useReadOnlyConsoleLogs()
+
+  const errorMessages = useEditorState((store) => {
+    return getAllCodeEditorErrors(store.editor, 'warning', false)
+  }, 'ConsoleAndErrorsPane errorMessages')
+
+  const onOpenFile = React.useCallback(
+    (path: string) => {
+      dispatch([openCodeEditorFile(path, true), setFocus('codeEditor')])
+    },
+    [dispatch],
+  )
+
+  return (
+    <CodeEditorTabPane
+      canvasConsoleLogs={canvasConsoleLogs}
+      errorMessages={errorMessages}
+      onOpenFile={onOpenFile}
+    />
+  )
+})

--- a/editor/src/uuiui/tab.tsx
+++ b/editor/src/uuiui/tab.tsx
@@ -11,6 +11,7 @@ import { colorTheme, UtopiaTheme } from './styles/theme'
 import { CSSObject } from '@emotion/serialize'
 import { defaultIfNull } from '../core/shared/optional-utils'
 import { NO_OP } from '../core/shared/utils'
+import { betterReactMemo } from '../uuiui-deps'
 
 interface TabComponentProps {
   modified?: boolean
@@ -27,95 +28,98 @@ interface TabComponentProps {
   className?: string
 }
 
-export const TabComponent: React.FunctionComponent<TabComponentProps> = (props) => {
-  const [tabIsHovered, setTabIsHovered] = React.useState(false)
-  const [indicatorIsHovered, setIndicatorIsHovered] = React.useState(false)
+export const TabComponent: React.FunctionComponent<TabComponentProps> = betterReactMemo(
+  'TabComponent',
+  (props) => {
+    const [tabIsHovered, setTabIsHovered] = React.useState(false)
+    const [indicatorIsHovered, setIndicatorIsHovered] = React.useState(false)
 
-  const modified = defaultIfNull<boolean>(false, props.showModifiedIndicator)
-  const showModifiedIndicator = defaultIfNull<boolean>(true, props.showModifiedIndicator)
-  const showCloseIndicator = defaultIfNull<boolean>(true, props.showCloseIndicator)
-  const selected = defaultIfNull<boolean>(false, props.selected)
-  const hasErrorMessages = defaultIfNull<boolean>(false, props.hasErrorMessages)
-  const label = defaultIfNull<React.ReactElement | string>('', props.label)
-  const icon = defaultIfNull<React.ReactElement | string>('', props.icon)
-  const onClose = defaultIfNull(NO_OP, props.onClose)
+    const modified = defaultIfNull<boolean>(false, props.showModifiedIndicator)
+    const showModifiedIndicator = defaultIfNull<boolean>(true, props.showModifiedIndicator)
+    const showCloseIndicator = defaultIfNull<boolean>(true, props.showCloseIndicator)
+    const selected = defaultIfNull<boolean>(false, props.selected)
+    const hasErrorMessages = defaultIfNull<boolean>(false, props.hasErrorMessages)
+    const label = defaultIfNull<React.ReactElement | string>('', props.label)
+    const icon = defaultIfNull<React.ReactElement | string>('', props.icon)
+    const onClose = defaultIfNull(NO_OP, props.onClose)
 
-  const baseStyle = {
-    paddingLeft: 4,
-    paddingRight: 4,
-    transition: 'all .05s ease-in-out',
-    '&:hover': {
-      backgroundColor: UtopiaTheme.color.tabHoveredBackground.value,
-    },
-    cursor: 'pointer',
-  }
+    const baseStyle = {
+      paddingLeft: 4,
+      paddingRight: 4,
+      transition: 'all .05s ease-in-out',
+      '&:hover': {
+        backgroundColor: UtopiaTheme.color.tabHoveredBackground.value,
+      },
+      cursor: 'pointer',
+    }
 
-  const selectionHandlingStyle = {
-    boxShadow: selected ? `inset 0px 2px 0px 0px ${colorTheme.primary.value}` : undefined,
-    color: hasErrorMessages
-      ? UtopiaTheme.color.errorForeground.value
-      : UtopiaTheme.color.tabSelectedForeground.value,
+    const selectionHandlingStyle = {
+      boxShadow: selected ? `inset 0px 2px 0px 0px ${colorTheme.primary.value}` : undefined,
+      color: hasErrorMessages
+        ? UtopiaTheme.color.errorForeground.value
+        : UtopiaTheme.color.tabSelectedForeground.value,
 
-    fontWeight: selected ? 500 : undefined,
-  }
+      fontWeight: selected ? 500 : undefined,
+    }
 
-  const modifiedIndicator = showModifiedIndicator ? <Icons.CircleSmall /> : null
-  const closeIndicator = showCloseIndicator ? <Icons.CrossSmall /> : null
-  const closeIndicatorHovered = showCloseIndicator ? <Icons.CrossInTranslucentCircle /> : null
+    const modifiedIndicator = showModifiedIndicator ? <Icons.CircleSmall /> : null
+    const closeIndicator = showCloseIndicator ? <Icons.CrossSmall /> : null
+    const closeIndicatorHovered = showCloseIndicator ? <Icons.CrossInTranslucentCircle /> : null
 
-  const tabUnhoveredIndicator = modified ? modifiedIndicator : selected ? closeIndicator : null
-  const tabHoveredIndicator = indicatorIsHovered ? closeIndicatorHovered : closeIndicator
+    const tabUnhoveredIndicator = modified ? modifiedIndicator : selected ? closeIndicator : null
+    const tabHoveredIndicator = indicatorIsHovered ? closeIndicatorHovered : closeIndicator
 
-  const setTabHoveredTrue = React.useCallback(() => setTabIsHovered(true), [setTabIsHovered])
-  const setTabHoveredFalse = React.useCallback(() => setTabIsHovered(false), [setTabIsHovered])
+    const setTabHoveredTrue = React.useCallback(() => setTabIsHovered(true), [setTabIsHovered])
+    const setTabHoveredFalse = React.useCallback(() => setTabIsHovered(false), [setTabIsHovered])
 
-  const setIndicatorHoveredTrue = React.useCallback(() => setIndicatorIsHovered(true), [
-    setIndicatorIsHovered,
-  ])
-  const setIndicatorHoveredFalse = React.useCallback(() => setIndicatorIsHovered(false), [
-    setIndicatorIsHovered,
-  ])
+    const setIndicatorHoveredTrue = React.useCallback(() => setIndicatorIsHovered(true), [
+      setIndicatorIsHovered,
+    ])
+    const setIndicatorHoveredFalse = React.useCallback(() => setIndicatorIsHovered(false), [
+      setIndicatorIsHovered,
+    ])
 
-  const close = React.useCallback(
-    (e) => {
-      onClose()
-      e.stopPropagation()
-    },
-    [onClose],
-  )
+    const close = React.useCallback(
+      (e) => {
+        onClose()
+        e.stopPropagation()
+      },
+      [onClose],
+    )
 
-  return (
-    <SimpleFlexRow
-      onMouseEnter={setTabHoveredTrue}
-      onMouseLeave={setTabHoveredFalse}
-      onClick={props.onClick}
-      onDoubleClick={props.onDoubleClick}
-      onMouseDown={props.onMouseDown}
-      style={{
-        ...baseStyle,
-        ...selectionHandlingStyle,
-      }}
-      className={props.className}
-    >
-      <SimpleFlexRow style={{ flexGrow: 1, marginRight: 32 }}>
-        <SimpleFlexRow style={{ marginLeft: 4 }}>{icon}</SimpleFlexRow>
-        <SimpleFlexRow style={{ marginLeft: 8 }}>{label}</SimpleFlexRow>
-      </SimpleFlexRow>
-      <Button
-        css={{
-          label: 'indicatorContainer',
-          width: 18,
-          height: 18,
-          '&:active': {
-            transform: 'scale(.92)',
-          },
+    return (
+      <SimpleFlexRow
+        onMouseEnter={setTabHoveredTrue}
+        onMouseLeave={setTabHoveredFalse}
+        onClick={props.onClick}
+        onDoubleClick={props.onDoubleClick}
+        onMouseDown={props.onMouseDown}
+        style={{
+          ...baseStyle,
+          ...selectionHandlingStyle,
         }}
-        onMouseEnter={setIndicatorHoveredTrue}
-        onMouseLeave={setIndicatorHoveredFalse}
-        onClick={close}
+        className={props.className}
       >
-        {showCloseIndicator ? (tabIsHovered ? tabHoveredIndicator : tabUnhoveredIndicator) : null}
-      </Button>
-    </SimpleFlexRow>
-  )
-}
+        <SimpleFlexRow style={{ flexGrow: 1, marginRight: 32 }}>
+          <SimpleFlexRow style={{ marginLeft: 4 }}>{icon}</SimpleFlexRow>
+          <SimpleFlexRow style={{ marginLeft: 8 }}>{label}</SimpleFlexRow>
+        </SimpleFlexRow>
+        <Button
+          css={{
+            label: 'indicatorContainer',
+            width: 18,
+            height: 18,
+            '&:active': {
+              transform: 'scale(.92)',
+            },
+          }}
+          onMouseEnter={setIndicatorHoveredTrue}
+          onMouseLeave={setIndicatorHoveredFalse}
+          onClick={close}
+        >
+          {showCloseIndicator ? (tabIsHovered ? tabHoveredIndicator : tabUnhoveredIndicator) : null}
+        </Button>
+      </SimpleFlexRow>
+    )
+  },
+)


### PR DESCRIPTION
**Problem:**
We accidentally deleted the Errors tab and the console tab alongside Monaco

**Fix:**
Bring them back.

<img width="523" alt="image" src="https://user-images.githubusercontent.com/2226774/120659608-d0a3f580-c486-11eb-89e2-03704d8497e3.png">
<img width="536" alt="image" src="https://user-images.githubusercontent.com/2226774/120659617-d26db900-c486-11eb-92bf-454d6e9d6f61.png">


**Commit Details:**
- Created new `ConsoleAndErrorsPane` which is a thin wrapper and data provider for `CodeEditorTabPane`
- Use it in the `DesignPanelRoot`

**Note:**
The errors and console pane are in the main editor iframe. IF we can feel this affects performance, we can think about moving it to either the VSCode iframe or a new iframe.
