### PR TITLE
Fix/fork url and title

### DIFF
--- a/editor/src/components/editor/persistence.ts
+++ b/editor/src/components/editor/persistence.ts
@@ -12,6 +12,7 @@ import {
   showToast,
   setSaveError,
   setForkedFromProjectID,
+  setProjectName,
 } from './actions/action-creators'
 import {
   createNewProjectID,
@@ -292,9 +293,14 @@ export async function triggerForkProject(
     ...editor,
     forkedFromProjectId: oldProjectId,
     id: newProjectId,
+    name: editor.projectName + ' (forked)',
   }
   await save(updatedEditor, dispatch, loginState, 'both', true)
-  dispatch([setProjectID(newProjectId), setForkedFromProjectID(oldProjectId)])
+  dispatch([
+    setProjectID(newProjectId),
+    setProjectName(editor.projectName + ' (forked)'),
+    setForkedFromProjectID(oldProjectId),
+  ])
 }
 
 async function checkCanSaveProject(projectId: string | null): Promise<boolean> {

--- a/editor/src/components/editor/persistence.ts
+++ b/editor/src/components/editor/persistence.ts
@@ -293,7 +293,7 @@ export async function triggerForkProject(
     ...editor,
     forkedFromProjectId: oldProjectId,
     id: newProjectId,
-    name: editor.projectName + ' (forked)',
+    name: `${editor.projectName} (forked)`,
   }
   await save(updatedEditor, dispatch, loginState, 'both', true)
   dispatch([

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -2,7 +2,12 @@
 import { jsx } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as React from 'react'
-import { fetchProjectMetadata, projectURL, thumbnailURL } from '../../common/server'
+import {
+  fetchProjectMetadata,
+  projectEditorURL,
+  projectURL,
+  thumbnailURL,
+} from '../../common/server'
 import { useGetProjectMetadata, useIsMyProject } from '../common/server-hooks'
 import { getAllUniqueUids } from '../../core/model/element-template-utils'
 import { getUtopiaJSXComponentsFromSuccess } from '../../core/model/project-file-utils'
@@ -141,7 +146,7 @@ const ForksGiven = betterReactMemo('ForkPanel', () => {
   const forkedFromText =
     forkedFrom == null ? null : (
       <React.Fragment>
-        Forked from <Link href={projectURL(forkedFrom)}>{forkedFromMetadata?.title}</Link>
+        Forked from <Link href={projectEditorURL(forkedFrom)}>{forkedFromMetadata?.title}</Link>
       </React.Fragment>
     )
 
@@ -762,7 +767,7 @@ const ProjectPane = betterReactMemo('ProjectSettingsPanel', () => {
   const forkedFromText =
     forkedFrom == null ? null : (
       <React.Fragment>
-        Forked from <Link href={projectURL(forkedFrom)}>{forkedFromMetadata?.title}</Link>
+        Forked from <Link href={projectEditorURL(forkedFrom)}>{forkedFromMetadata?.title}</Link>
       </React.Fragment>
     )
 

--- a/website/src/common/server.ts
+++ b/website/src/common/server.ts
@@ -14,6 +14,7 @@ import {
 const urljoin = require('url-join')
 
 export const PROJECT_ENDPOINT = UTOPIA_BACKEND + 'project/'
+export const PROJECT_EDITOR = BASE_URL + 'project'
 
 // if we want to enable CORS, we need the server to be able to answer to preflight OPTION requests with the proper Allow-Access headers
 // until then, this is keeping us safe from attempting a CORS request that results in cryptic error messages
@@ -50,6 +51,10 @@ export function assetURL(projectId: string, fileName: string): string {
 
 export function projectURL(projectId: string): string {
   return urljoin(PROJECT_ENDPOINT, projectId)
+}
+
+export function projectEditorURL(projectId: string): string {
+  return urljoin(PROJECT_EDITOR, projectId)
 }
 
 export function thumbnailURL(projectId: string): string {


### PR DESCRIPTION
**Problem:**
1. The "forked from" link would send users to a URL including `v1`
2. Forking a project gave too little visual confirmation which project you were now editing

**Fix:**
1. Changed the destination URL to just be the editor
2. Include `(forked)` in the project name / URL after forking
