### PR TITLE
Handle cookies or indexeddb being disabled.

### DIFF
--- a/editor/src/components/editor/notification-bar.tsx
+++ b/editor/src/components/editor/notification-bar.tsx
@@ -61,6 +61,15 @@ export const LoginStatusBar = betterReactMemo('LoginStatusBar', () => {
           style={{ cursor: 'pointer' }}
         />
       )
+    case 'COOKIES_OR_LOCALFORAGE_UNAVAILABLE':
+      return (
+        <NotificationBar
+          level='ERROR'
+          message={
+            'Cookies or IndexedDB are currently disabled in this browser. Please enable those and then refresh this window.'
+          }
+        />
+      )
     default:
       const _exhaustiveCheck: never = loginState
       throw new Error(`Unhandled login state ${loginState}`)

--- a/editor/src/components/editor/persistence.ts
+++ b/editor/src/components/editor/persistence.ts
@@ -602,7 +602,7 @@ export async function loadFromServer(
 }
 
 export async function projectIsStoredLocally(projectId: string): Promise<boolean> {
-  const keys = await localforage.keys()
+  const keys = await localforage.keys().catch(() => [])
   const targetKey = localProjectKey(projectId)
   return arrayContains(keys, targetKey)
 }

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -349,6 +349,7 @@ export async function getUserConfiguration(loginState: LoginState): Promise<User
     case 'NOT_LOGGED_IN':
     case 'LOGIN_LOST':
     case 'OFFLINE_STATE':
+    case 'COOKIES_OR_LOCALFORAGE_UNAVAILABLE':
       return emptyUserConfiguration()
     default:
       const _exhaustiveCheck: never = loginState

--- a/website/src/common/server.ts
+++ b/website/src/common/server.ts
@@ -99,7 +99,7 @@ export async function isLocalForageAvailable(): Promise<boolean> {
 
 async function areCookiesAndLocalForageAvailable(): Promise<boolean> {
   const localForageAvailable = await isLocalForageAvailable()
-  // tslint:disable-next-line:no-restricted-globals
+  // eslint-disable-next-line no-restricted-globals
   return localForageAvailable && navigator.cookieEnabled
 }
 

--- a/website/src/common/server.ts
+++ b/website/src/common/server.ts
@@ -99,6 +99,7 @@ export async function isLocalForageAvailable(): Promise<boolean> {
 
 async function areCookiesAndLocalForageAvailable(): Promise<boolean> {
   const localForageAvailable = await isLocalForageAvailable()
+  // tslint:disable-next-line:no-restricted-globals
   return localForageAvailable && navigator.cookieEnabled
 }
 

--- a/website/src/common/server.ts
+++ b/website/src/common/server.ts
@@ -1,6 +1,8 @@
+import * as localforage from 'localforage'
 import { UTOPIA_BACKEND, THUMBNAIL_ENDPOINT, ASSET_ENDPOINT, BASE_URL } from './env-vars'
 import { ProjectListing } from './persistence'
 import {
+  cookiesOrLocalForageUnavailable,
   isLoggedIn,
   isLoginLost,
   isNotLoggedIn,
@@ -80,24 +82,49 @@ export async function getLoginState(useCache: 'cache' | 'no-cache'): Promise<Log
   }
 }
 
+let localForageAvailableResult: boolean | null = null
+
+export async function isLocalForageAvailable(): Promise<boolean> {
+  if (localForageAvailableResult == null) {
+    const result = await localforage
+      .keys()
+      .then(() => true)
+      .catch(() => false)
+    localForageAvailableResult = result
+    return result
+  } else {
+    return localForageAvailableResult
+  }
+}
+
+async function areCookiesAndLocalForageAvailable(): Promise<boolean> {
+  const localForageAvailable = await isLocalForageAvailable()
+  return localForageAvailable && navigator.cookieEnabled
+}
+
 async function createGetLoginStatePromise(
   previousLogin: Promise<LoginState> | null,
 ): Promise<LoginState> {
   try {
-    const url = UTOPIA_BACKEND + 'user'
-    const response = await fetch(url, {
-      method: 'GET',
-      credentials: 'include',
-      headers: HEADERS,
-      mode: MODE,
-    })
-    if (response.ok) {
-      const result = await response.json()
-      const previousLoginState = previousLogin == null ? null : await previousLogin
-      return getLoginStateFromResponse(result, previousLoginState)
+    const cookiesAndLocalForageAvailable = await areCookiesAndLocalForageAvailable()
+    if (cookiesAndLocalForageAvailable) {
+      const url = UTOPIA_BACKEND + 'user'
+      const response = await fetch(url, {
+        method: 'GET',
+        credentials: 'include',
+        headers: HEADERS,
+        mode: MODE,
+      })
+      if (response.ok) {
+        const result = await response.json()
+        const previousLoginState = previousLogin == null ? null : await previousLogin
+        return getLoginStateFromResponse(result, previousLoginState)
+      } else {
+        console.error(`Fetch user details failed (${response.status}): ${response.statusText}`)
+        return loginLost
+      }
     } else {
-      console.error(`Fetch user details failed (${response.status}): ${response.statusText}`)
-      return loginLost
+      return cookiesOrLocalForageUnavailable
     }
   } catch (e) {
     console.error(`Fetch user details failed: ${e}`)

--- a/website/src/common/user.ts
+++ b/website/src/common/user.ts
@@ -26,7 +26,12 @@ interface CookiesOrLocalForageUnavailable {
   type: 'COOKIES_OR_LOCALFORAGE_UNAVAILABLE'
 }
 
-export type LoginState = LoggedInUser | NotLoggedIn | LoginLost | OfflineState | CookiesOrLocalForageUnavailable
+export type LoginState =
+  | LoggedInUser
+  | NotLoggedIn
+  | LoginLost
+  | OfflineState
+  | CookiesOrLocalForageUnavailable
 
 export function loggedInUser(user: UserDetails): LoggedInUser {
   return {
@@ -61,9 +66,13 @@ export function isOfflineState(loginState: unknown): loginState is OfflineState 
   return (loginState as Partial<LoginState>)?.type === 'OFFLINE_STATE'
 }
 
-export const cookiesOrLocalForageUnavailable: CookiesOrLocalForageUnavailable = { type: 'COOKIES_OR_LOCALFORAGE_UNAVAILABLE' }
+export const cookiesOrLocalForageUnavailable: CookiesOrLocalForageUnavailable = {
+  type: 'COOKIES_OR_LOCALFORAGE_UNAVAILABLE',
+}
 
-export function isCookiesOrLocalForageUnavailable(loginState: unknown): loginState is CookiesOrLocalForageUnavailable {
+export function isCookiesOrLocalForageUnavailable(
+  loginState: unknown,
+): loginState is CookiesOrLocalForageUnavailable {
   return (loginState as Partial<LoginState>)?.type === 'COOKIES_OR_LOCALFORAGE_UNAVAILABLE'
 }
 

--- a/website/src/common/user.ts
+++ b/website/src/common/user.ts
@@ -22,7 +22,11 @@ interface OfflineState {
   type: 'OFFLINE_STATE'
 }
 
-export type LoginState = LoggedInUser | NotLoggedIn | LoginLost | OfflineState
+interface CookiesOrLocalForageUnavailable {
+  type: 'COOKIES_OR_LOCALFORAGE_UNAVAILABLE'
+}
+
+export type LoginState = LoggedInUser | NotLoggedIn | LoginLost | OfflineState | CookiesOrLocalForageUnavailable
 
 export function loggedInUser(user: UserDetails): LoggedInUser {
   return {
@@ -55,6 +59,12 @@ export const offlineState: OfflineState = { type: 'OFFLINE_STATE' }
 
 export function isOfflineState(loginState: unknown): loginState is OfflineState {
   return (loginState as Partial<LoginState>)?.type === 'OFFLINE_STATE'
+}
+
+export const cookiesOrLocalForageUnavailable: CookiesOrLocalForageUnavailable = { type: 'COOKIES_OR_LOCALFORAGE_UNAVAILABLE' }
+
+export function isCookiesOrLocalForageUnavailable(loginState: unknown): loginState is CookiesOrLocalForageUnavailable {
+  return (loginState as Partial<LoginState>)?.type === 'COOKIES_OR_LOCALFORAGE_UNAVAILABLE'
 }
 
 export function getUserPicture(loginState: LoginState): string | null {


### PR DESCRIPTION
Fixes #1197

**Problem:**
If cookies or indexeddb are not working the editor ends up in a broken state.

**Fix:**
Cater for cookies and/or indexeddb being disabled by treating that as an additional login state which puts a banner across the top of the editor with a stern warning.

**Commit Details:**
- Fixes #1197.
- Added a `CookiesOrLocalForageUnavailable` case to `LoginState`.
- Implemented `isLocalForageAvailable` to capture that particular
  check, but only doing it once per session for performance reasons.
- Updated `createGetLoginStatePromise` to cater for this new check.
- Added an additional case to the main loading logic of `editor.tsx`
  so that a default project is loaded to make the editor startup even
  when cookies are disabled.
- `projectIsStoredLocally` now defends against the case that
  localforage is broken.
