### PR TITLE
fix(fragments) apply uid fix on children

### DIFF
--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -859,6 +859,12 @@ export function isJSXFragment(element: JSXElementChild): element is JSXFragment 
   return element.type === 'JSX_FRAGMENT'
 }
 
+export function isJSXElementLikeWithChildren(
+  element: JSXElementChild,
+): element is JSXElement | JSXFragment {
+  return isJSXElement(element) || isJSXFragment(element)
+}
+
 export type JSXElementChildren = Array<JSXElementChild>
 
 export function clearJSXElementUniqueIDs<T extends JSXElementChild>(element: T): T {

--- a/editor/src/core/workers/parser-printer/uid-fix.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.ts
@@ -65,7 +65,7 @@ export function fixParseSuccessUIDs(
 
   const newToOldUidMappingArray = Object.values(newToOldUidMapping)
 
-  if (newToOldUidMappingArray.length > 0) {
+  if (newToOldUidMappingArray.length === 1) {
     // we found a single UID mismatch, which means there's a very good chance that it was an update element, let's fix that up
     let workingComponents = getComponentsFromTopLevelElements(newParsed.topLevelElements)
 

--- a/editor/src/core/workers/parser-printer/uid-fix.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.ts
@@ -1,6 +1,5 @@
 import {
   isJSXElement,
-  isJSXElementLikeWithChildren,
   isJSXFragment,
   isUtopiaJSXComponent,
   JSXElementChild,
@@ -177,21 +176,15 @@ function walkElementChildren(
   newElements.forEach((newElement, index) => {
     const oldElement: JSXElementChild | null = oldElements[index]
 
-    if (
-      oldElement != null &&
-      isJSXElementLikeWithChildren(oldElement) &&
-      isJSXElementLikeWithChildren(newElement)
-    ) {
+    if (oldElement != null && isJSXElement(oldElement) && isJSXElement(newElement)) {
       const oldUID = getUtopiaID(oldElement)
       const newUid = getUtopiaID(newElement)
       const path = EP.appendToElementPath(pathSoFar, newUid)
       const oldPathToRestore = EP.appendToElementPath(pathSoFar, oldUID)
-      if (isJSXFragment(newElement)) {
-        walkElementChildren(pathSoFar, oldElement.children, newElement.children, onElement)
-      } else {
-        onElement(oldUID, newUid, oldPathToRestore, path)
-        walkElementChildren(path, oldElement.children, newElement.children, onElement)
-      }
+      onElement(oldUID, newUid, oldPathToRestore, path)
+      walkElementChildren(path, oldElement.children, newElement.children, onElement)
+    } else if (oldElement != null && isJSXFragment(oldElement) && isJSXFragment(newElement)) {
+      walkElementChildren(pathSoFar, oldElement.children, newElement.children, onElement)
     }
   })
 }


### PR DESCRIPTION
**Problem:**
Editing jsx fragments in the code editor throws error. Part of #1340

**Fix:**
The error is coming from uid-fix, it only works on jsx elements and fails on fragments at a point in `transformAtPathOptionally`. The fix is that when the uid fix finds a jsx fragments it skips itself and only applies on child elements, using the original path without appending the special uuid.

**Commit Details:**
- added helper `isJSXElementLikeWithChildren`
- removed duplicated call of `onElement` as the `walkElementChildren` in the next line calls it on the same rootElement too
- extended `walkElementChildren` to handle fragments too
- test for uid fix on fragments
