### PR TITLE
Use reserved IDs when determining if a project exists.

### DIFF
--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -277,3 +277,12 @@ getUserConfigurationWithPool metrics pool userID action = do
 saveUserConfigurationWithPool :: (MonadIO m) => DB.DatabaseMetrics -> Pool SqlBackend -> Text -> Maybe Value -> m ()
 saveUserConfigurationWithPool metrics pool userID possibleShortcutConfig = do
   liftIO $ DB.saveUserConfiguration metrics pool userID possibleShortcutConfig
+
+getProjectDetailsWithPool :: (MonadIO m) => DB.DatabaseMetrics -> Pool SqlBackend -> Text -> m ProjectDetails
+getProjectDetailsWithPool metrics pool projectID = do
+  projectIDReserved <- liftIO $ DB.checkIfProjectIDReserved metrics pool projectID
+  projectMetadata <- liftIO $ DB.getProjectMetadataWithPool metrics pool projectID
+  pure $ case (projectIDReserved, projectMetadata) of
+            (_, Just metadata) -> ProjectDetailsMetadata metadata
+            (True, _)          -> ReservedProjectID projectID
+            (False, _)         -> UnknownProject

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -156,7 +156,7 @@ innerServerExecutor (DebugLog logContent next) = do
 innerServerExecutor (GetProjectMetadata projectID action) = do
   pool <- fmap _projectPool ask
   metrics <- fmap _databaseMetrics ask
-  metadata <- liftIO $ DB.getProjectMetadataWithPool metrics pool projectID
+  metadata <- liftIO $ getProjectDetailsWithPool metrics pool projectID
   return $ action metadata
 innerServerExecutor (LoadProject projectID action) = do
   pool <- fmap _projectPool ask

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -99,7 +99,7 @@ innerServerExecutor (DebugLog logContent next) = do
 innerServerExecutor (GetProjectMetadata projectID action) = do
   pool <- fmap _projectPool ask
   metrics <- fmap _databaseMetrics ask
-  metadata <- liftIO $ DB.getProjectMetadataWithPool metrics pool projectID
+  metadata <- liftIO $ getProjectDetailsWithPool metrics pool projectID
   return $ action metadata
 innerServerExecutor (LoadProject projectID action) = do
   pool <- fmap _projectPool ask

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -76,6 +76,11 @@ listingFromProjectMetadata project = ProjectListing
                                    , _modifiedAt = view modifiedAt project
                                    }
 
+data ProjectDetails = UnknownProject
+                    | ReservedProjectID Text
+                    | ProjectDetailsMetadata ProjectMetadata
+                    deriving (Eq, Show)
+
 {-|
   'ServiceCallsF' defines what can be called from the endpoints, thereby preventing arbitrary
   side effects from being invoked. The type parameter 'a' is needed to support chaining multiple
@@ -90,7 +95,7 @@ data ServiceCallsF a = NotFound
                      | ValidateAuth Text (Maybe SessionUser -> a)
                      | UserForId Text (Maybe User -> a)
                      | DebugLog Text a
-                     | GetProjectMetadata Text (Maybe ProjectMetadata -> a)
+                     | GetProjectMetadata Text (ProjectDetails -> a)
                      | LoadProject Text (Maybe DecodedProject -> a)
                      | CreateProject (Text -> a)
                      | SaveProject SessionUser Text (Maybe Text) (Maybe Value) a


### PR DESCRIPTION
Fixes #1314

**Problem:**
The previous change for the project page to immediately 404 on non-existent projects was also being tripped by local projects as they could not be found by the server.

**Fix:**
Project IDs for local projects have been reserved within the server, so that collection of IDs are consulted along with the project metadata when determining if a project exists.

**Commit Details:**
- Fixes #1314.
- Added `checkIfProjectIDReserved` for looking up if a project ID
  has been allocated previously.
- Added `ProjectDetails` data type to cater for the three cases of
  an unknown project, a project with a reserved ID and one with some
  metadata.
- `GetProjectMetadata` now has a final parameter of `ProjectDetails -> a`
  instead of `Maybe ProjectMetadata -> a`.
- Implemented `getProjectDetailsWithPool` to do the double lookup
  around reserved project IDs and their metadata.
- Rejigged the project and preview endpoints to work with `ProjectDetails`
  where previously they had `Maybe ProjectMetadata`.
- `renderPageWithMetadata` introduced to cover the commonality between
  project and preview pages.
