### PR TITLE
Handle fragments as root elements in the dom walker

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
@@ -28,7 +28,12 @@ import { View } from "utopia-api";
 import { App } from "/src/app";
 
 const HiElement = (props) => {
-  return <div data-uid="other-hi-element-root">hi!</div>
+  return (
+    <>
+      <div data-uid="hi-element-fragment-child-1">hi!</div>
+      <div data-uid="hi-element-fragment-child-2">hi!</div>
+    </>
+  )
 }
 
 const Button = (props) => {
@@ -525,17 +530,17 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1": Object {
           "children": Array [],
-          "name": "div",
+          "name": "fragment",
           "rootElements": Array [],
         },
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
-          "name": "div",
+          "name": "fragment",
           "rootElements": Array [],
         },
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
           "children": Array [],
-          "name": "div",
+          "name": "fragment",
           "rootElements": Array [],
         },
         "storyboard/scene-2": Object {
@@ -840,17 +845,17 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1": Object {
           "children": Array [],
-          "name": "div",
+          "name": "fragment",
           "rootElements": Array [],
         },
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
-          "name": "div",
+          "name": "fragment",
           "rootElements": Array [],
         },
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
           "children": Array [],
-          "name": "div",
+          "name": "fragment",
           "rootElements": Array [],
         },
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance:other-button-root": Object {
@@ -1075,7 +1080,12 @@ describe('Spy Wrapper Template Path Tests', () => {
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:other-hi-element-root": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:hi-element-fragment-child-1": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:hi-element-fragment-child-2": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
@@ -1165,24 +1175,30 @@ describe('Spy Wrapper Template Path Tests', () => {
         },
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1": Object {
           "children": Array [],
-          "name": "div",
+          "name": "fragment",
           "rootElements": Array [],
         },
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
-          "name": "div",
+          "name": "fragment",
           "rootElements": Array [
-            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:other-hi-element-root",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:hi-element-fragment-child-1",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:hi-element-fragment-child-2",
           ],
         },
-        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:other-hi-element-root": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:hi-element-fragment-child-1": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:hi-element-fragment-child-2": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],
         },
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
           "children": Array [],
-          "name": "div",
+          "name": "fragment",
           "rootElements": Array [],
         },
         "storyboard/scene-2": Object {
@@ -1277,10 +1293,16 @@ describe('Spy Wrapper Template Path Tests', () => {
           "children": Array [],
           "name": "HiElement",
           "rootElements": Array [
-            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:other-hi-element-root",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:hi-element-fragment-child-1",
+            "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:hi-element-fragment-child-2",
           ],
         },
-        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:other-hi-element-root": Object {
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:hi-element-fragment-child-1": Object {
+          "children": Array [],
+          "name": "div",
+          "rootElements": Array [],
+        },
+        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2:hi-element-fragment-child-2": Object {
           "children": Array [],
           "name": "div",
           "rootElements": Array [],

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -106,16 +106,6 @@ import { withUnderlyingTarget } from '../../components/editor/store/editor-state
 import { ProjectContentTreeRoot } from '../../components/assets'
 const ObjectPathImmutable: any = OPI
 
-type MergeCandidate = These<ElementInstanceMetadata, ElementInstanceMetadata>
-
-function fromSpyMergeCandidate(fromSpy: ElementInstanceMetadata): MergeCandidate {
-  return makeThis(fromSpy)
-}
-
-function fromDOMMergeCandidate(fromDOM: ElementInstanceMetadata): MergeCandidate {
-  return makeThat(fromDOM)
-}
-
 export const getChildrenOfCollapsedViews = (
   elementPaths: ElementPath[],
   collapsedViews: Array<ElementPath>,


### PR DESCRIPTION
Fixes #1340
Co-authored by @enidemi 

**Problem:**
As fragments don't result in an actual element being rendered, we were losing metadata for components that return a fragment at the root, replacing it with the metadata of the last child of the fragment.

**Fix:**
During the DOM walking we capture the metadata for a fragment at the root in multiple parts via the `data-paths` attribute (as we are capturing it for each of the children). We can therefore combine those when collecting the final dom metadata (binning any irrelevant data such as the style since fragments can't have a style). We still keep the local and global frames for selection.

**Commit Details:**
- Combine metadata for fragments in `dom-walker.ts`
- Also filter duplicate child paths in `dom-walker.ts`
- Updated `ui-jsx-canvas-spy-wrapper.spec.browser.tsx` to include tests for fragments at the root
