### PR TITLE
Public folder used ahead of root for assets.

### DIFF
--- a/editor/src/components/assets.spec.ts
+++ b/editor/src/components/assets.spec.ts
@@ -22,12 +22,12 @@ function codeFileArbitrary(): FastCheck.Arbitrary<TextFile> {
 }
 
 function remoteImageFileArbitrary(): FastCheck.Arbitrary<ImageFile> {
-  return FastCheck.constant(imageFile(undefined, undefined, 100, 100, 'hat'))
+  return FastCheck.constant(imageFile(undefined, undefined, 100, 100, 123456))
 }
 
 function localImageFileArbitrary(): FastCheck.Arbitrary<ImageFile> {
   return FastCheck.tuple(FastCheck.string(), FastCheck.string()).map(([imageType, base64]) =>
-    imageFile(imageType, base64, 100, 100, 'hat'),
+    imageFile(imageType, base64, 100, 100, 123456),
   )
 }
 

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -400,7 +400,7 @@ export type SaveAsset = {
   fileName: string
   fileType: string
   base64: string
-  hash: string
+  hash: number
   imageDetails: SaveImageDetails | null
 }
 

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -568,7 +568,7 @@ export function saveAsset(
   fileName: string,
   fileType: string,
   base64: string,
-  hash: string,
+  hash: number,
   imageDetails: SaveImageDetails | null,
 ): SaveAsset {
   return {

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -434,7 +434,7 @@ export function imageFile(
   base64: string | undefined,
   width: number | undefined,
   height: number | undefined,
-  hash: string,
+  hash: number,
 ): ImageFile {
   return {
     type: 'IMAGE_FILE',

--- a/editor/src/core/model/project-import.ts
+++ b/editor/src/core/model/project-import.ts
@@ -20,7 +20,7 @@ export interface UnsavedAsset {
   fileName: string
   fileType: string
   base64: string
-  hash: string
+  hash: number
   size: Size | null
 }
 

--- a/editor/src/core/shared/file-utils.ts
+++ b/editor/src/core/shared/file-utils.ts
@@ -7,14 +7,14 @@ export interface ImageResult {
   base64Bytes: string
   size: Size
   fileType: string
-  hash: string
+  hash: number
 }
 
 export interface AssetResult {
   type: 'ASSET_RESULT'
   filename: string
   base64Bytes: string
-  hash: string
+  hash: number
 }
 
 export interface TextResult {

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -521,7 +521,7 @@ export interface ImageFile {
   base64?: string
   width?: number
   height?: number
-  hash: string
+  hash: number
 }
 
 export interface AssetFile {

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -5,7 +5,7 @@ description: Utopia Web
 github: concrete-utopia/utopia
 category: Development
 license: MIT
-ghc-options: -Wall -Werror -threaded -rtsopts
+ghc-options: -threaded -rtsopts
 dependencies:
   - aeson
   - aeson-pretty
@@ -33,6 +33,7 @@ dependencies:
   - http-client-tls
   - http-media
   - http-types
+  - generic-lens
   - lens
   - lens-aeson
   - lifted-base

--- a/server/src/Utopia/Web/ClientModel.hs
+++ b/server/src/Utopia/Web/ClientModel.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MonoLocalBinds        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeOperators         #-}
+
+{-|
+  Functionality for manipulating the data held in `PersistentModel` in the client.
+-}
+module Utopia.Web.ClientModel where
+
+import           Control.Lens
+import           Control.Monad.Fail
+import           Data.Aeson
+import           Data.Aeson.Lens
+import           Data.Aeson.Types
+import           Data.Generics.Product
+import           Data.Generics.Sum
+import qualified Data.HashMap.Strict       as M
+import           Data.Text                 hiding (foldl', reverse)
+import           Protolude
+import           Utopia.Web.Database.Types
+
+-- This is very specifically designed to be limited to what
+-- we need on the server side.
+data TextFileContents = TextFileContents
+                      { code       :: Text
+                      }
+                      deriving (Eq, Show, Generic)
+
+instance FromJSON TextFileContents where
+  parseJSON = genericParseJSON defaultOptions
+
+data TextFile = TextFile
+              { fileContents      :: TextFileContents
+              , lastSavedContents :: Maybe TextFileContents
+              , lastRevisedTime   :: Double
+              }
+              deriving (Eq, Show, Generic)
+
+instance FromJSON TextFile where
+  parseJSON = genericParseJSON defaultOptions
+
+data ImageFile = ImageFile
+               { imageType :: Maybe Text
+               , base64    :: Maybe Text
+               , width     :: Maybe Double
+               , height    :: Maybe Double
+               , hash      :: Integer
+               }
+               deriving (Eq, Show, Generic)
+
+instance FromJSON ImageFile where
+  parseJSON = genericParseJSON defaultOptions
+
+data AssetFile = AssetFile
+                 deriving (Eq, Show, Generic)
+
+instance FromJSON AssetFile where
+  parseJSON = genericParseJSON defaultOptions
+
+data ProjectFile = ProjectTextFile TextFile
+                 | ProjectImageFile ImageFile
+                 | ProjectAssetFile AssetFile
+                 deriving (Eq, Show, Generic)
+
+instance FromJSON ProjectFile where
+  parseJSON value =
+    let fileType = firstOf (key "type" . _String) value
+     in case fileType of
+          (Just "TEXT_FILE")  -> fmap ProjectTextFile $ parseJSON value
+          (Just "IMAGE_FILE") -> fmap ProjectImageFile $ parseJSON value
+          (Just "ASSET_FILE") -> fmap ProjectAssetFile $ parseJSON value
+          (Just unknownType)  -> fail ("Unknown type: " <> unpack unknownType)
+          _                   -> fail "No type for ProjectFile specified."
+
+type ProjectContentsTreeRoot = M.HashMap Text ProjectContentsTree
+
+data ProjectContentDirectory = ProjectContentDirectory
+                             { fullPath :: Text
+                             , children :: ProjectContentsTreeRoot
+                             }
+                             deriving (Eq, Show, Generic)
+
+instance FromJSON ProjectContentDirectory where
+  parseJSON = genericParseJSON defaultOptions
+
+data ProjectContentFile = ProjectContentFile
+                        { fullPath :: Text
+                        , content  :: ProjectFile
+                        }
+                        deriving (Eq, Show, Generic)
+
+instance FromJSON ProjectContentFile where
+  parseJSON = genericParseJSON defaultOptions
+
+data ProjectContentsTree = ProjectContentsTreeDirectory ProjectContentDirectory
+                         | ProjectContentsTreeFile ProjectContentFile
+                         deriving (Eq, Show, Generic)
+
+instance FromJSON ProjectContentsTree where
+  parseJSON value =
+    let fileType = firstOf (key "type" . _String) value
+     in case fileType of
+              (Just "PROJECT_CONTENT_DIRECTORY") -> fmap ProjectContentsTreeDirectory $ parseJSON value
+              (Just "PROJECT_CONTENT_FILE") -> fmap ProjectContentsTreeFile $ parseJSON value
+              (Just unknownType) -> fail ("Unknown type: " <> unpack unknownType)
+              _ -> fail "No type for ProjectContentsTree specified."
+
+getProjectContentsTreeFile :: ProjectContentsTreeRoot -> [Text] -> Maybe ProjectFile
+getProjectContentsTreeFile _ [] = Nothing
+getProjectContentsTreeFile projectContentsTree pathElements =
+  let directoryContentLens filename = ix filename . _Ctor @"ProjectContentsTreeDirectory" . field @"children"
+      fileLens filename = ix filename . _Ctor @"ProjectContentsTreeFile" . field @"content"
+      finalPathElement : remainingPathElements = reverse pathElements
+      -- Construct the lens from the leaf up to the root.
+      lookupLens = foldl' (\soFar -> \filename -> directoryContentLens filename . soFar) (fileLens finalPathElement) remainingPathElements
+   in firstOf lookupLens projectContentsTree
+
+projectContentsTreeFromDecodedProject :: DecodedProject -> Either Text ProjectContentsTreeRoot
+projectContentsTreeFromDecodedProject DecodedProject{..} = do
+  projectContentsValue <- maybe (Left "No projectContents field in decoded project model.") pure $ firstOf (key "projectContents") _content
+  first pack $ parseEither parseJSON projectContentsValue
+
+
+
+
+
+
+

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -35,6 +35,7 @@ import           Text.Blaze.Html5                ((!))
 import qualified Text.Blaze.Html5                as H
 import qualified Text.Blaze.Html5.Attributes     as HA
 import           Utopia.Web.Assets
+import           Utopia.Web.ClientModel
 import           Utopia.Web.Database.Types
 import qualified Utopia.Web.Database.Types       as DB
 import           Utopia.Web.Executors.Common
@@ -229,8 +230,8 @@ setShowcaseEndpoint projectIdsString = do
 projectOwnerEndpoint :: Maybe Text -> ProjectIdWithSuffix -> ServerMonad ProjectOwnerResponse
 projectOwnerEndpoint cookie (ProjectIdWithSuffix projectID _) = checkForUser cookie $ \maybeUser -> do
   possibleProject <- loadProject projectID
-  case (maybeUser, possibleProject) of 
-    (_, Nothing) -> notFound 
+  case (maybeUser, possibleProject) of
+    (_, Nothing) -> notFound
     (Nothing, _) -> notAuthenticated
     (Just sessionUser, Just project) -> return $ ProjectOwnerResponse $ (view id sessionUser) == (view ownerId project)
 
@@ -243,7 +244,7 @@ projectChangedSince projectID lastChangedDate = do
 downloadProjectEndpoint :: ProjectIdWithSuffix -> [Text] -> ServerMonad Value
 downloadProjectEndpoint (ProjectIdWithSuffix projectID _) pathIntoContent = do
   possibleProject <- loadProject projectID
-  let contentLookup = foldl' (\lensSoFar -> \pathPart -> lensSoFar . key pathPart) content pathIntoContent
+  let contentLookup = foldl' (\lensSoFar -> \pathPart -> lensSoFar . key pathPart) DB.content pathIntoContent
   fromMaybe notFound $ do
     project <- possibleProject
     contentFromLookup <- firstOf contentLookup project
@@ -271,7 +272,7 @@ createLoadProjectResponse project = ProjectLoaded { _id=(view id project)
                                                   , _ownerId=(view ownerId project)
                                                   , _title=(view title project)
                                                   , _modifiedAt=(view modifiedAt project)
-                                                  , _content=(view content project)}
+                                                  , _content=(view DB.content project)}
 
 createProjectEndpoint :: ServerMonad CreateProjectResponse
 createProjectEndpoint = do
@@ -295,7 +296,7 @@ forkProject sessionUser sourceProject projectTitle = do
 
 saveProjectEndpoint :: Maybe Text -> ProjectIdWithSuffix -> SaveProjectRequest -> ServerMonad SaveProjectResponse
 saveProjectEndpoint cookie (ProjectIdWithSuffix projectID _) saveRequest = requireUser cookie $ \sessionUser -> do
-  saveProject sessionUser projectID (view name saveRequest) (view content saveRequest)
+  saveProject sessionUser projectID (view name saveRequest) (view DB.content saveRequest)
   return $ SaveProjectResponse projectID (view id sessionUser)
 
 deleteProjectEndpoint :: Maybe Text -> ProjectIdWithSuffix -> ServerMonad NoContent
@@ -303,13 +304,11 @@ deleteProjectEndpoint cookie (ProjectIdWithSuffix projectID _) = requireUser coo
   deleteProject sessionUser projectID
   return NoContent
 
-loadProjectFileContents :: Maybe DecodedProject -> [Text] -> Maybe Text
-loadProjectFileContents possibleProject filePath = do
-  let projectFilePath = projectContentsPathForFilePath filePath
-  let projectFileLookup = foldl' (\lensSoFar -> \pathPart -> lensSoFar . key pathPart) content projectFilePath
-  project <- possibleProject
-  contentFromLookup <- firstOf (projectFileLookup . _String) project
-  return contentFromLookup
+loadProjectFileContents :: DecodedProject -> [[Text]] -> Either Text (Maybe (ProjectFile, [Text]))
+loadProjectFileContents decodedProject pathsToCheck = do
+  projectContentsTree <- projectContentsTreeFromDecodedProject decodedProject
+  let projectFile = getFirst $ foldMap (\path -> First $ fmap (\c -> (c, path)) $ getProjectContentsTreeFile projectContentsTree path) pathsToCheck
+  pure projectFile
 
 sendProjectFileContentsResponse :: [Text] -> Text -> (Response -> a) -> a
 sendProjectFileContentsResponse filePath contents = \sendResponse ->
@@ -317,14 +316,39 @@ sendProjectFileContentsResponse filePath contents = \sendResponse ->
       builtResponse = responseLBS ok200 [(hContentType, mimeType)] (BL.fromStrict $ encodeUtf8 contents)
   in sendResponse builtResponse
 
+assetCallFold :: Maybe Application -> ServerMonad (Maybe Application) -> ServerMonad (Maybe Application)
+assetCallFold priorResult assetCall = maybe assetCall (\a -> pure $ Just a) priorResult
+
 loadProjectFileEndpoint :: ProjectIdWithSuffix -> [Text] -> ServerMonad Application
 loadProjectFileEndpoint (ProjectIdWithSuffix projectID _) filePath = do
   let normalizedPath = normalizePath filePath
+  -- Check /public/a/b/ before checking /a/b/.
+  let pathsToCheck = ["public" : filePath, filePath]
   possibleProject <- loadProject projectID
-  let projectFileContents = loadProjectFileContents possibleProject normalizedPath
+  decodedProject <- maybe notFound pure possibleProject
+  let handleNoAsset assetCall = do
+        possibleResult <- assetCall
+        maybe notFound pure possibleResult
+  let projectFileContents = loadProjectFileContents decodedProject pathsToCheck
   case projectFileContents of
-    Just fileContents -> return $ \_ -> sendProjectFileContentsResponse normalizedPath fileContents
-    Nothing -> loadProjectAsset ([projectID] ++ normalizedPath)
+    (Left errorMessage) -> do
+      -- There was an error parsing the project contents JSON.
+      debugLog errorMessage
+      badRequest
+    (Right Nothing) -> do
+      -- Unable to find the file in the project contents.
+      -- Speculatively try loading the various paths in order instead.
+      let assetCalls = fmap loadProjectAsset $ fmap (\p -> projectID : p) pathsToCheck
+      let possibleResult = foldlM assetCallFold Nothing assetCalls
+      handleNoAsset possibleResult
+    (Right (Just ((ProjectTextFile (TextFile{..})), _))) -> do
+      -- Found the file in the project contents and it's a text file,
+      -- so return the text file contents from within there.
+      pure $ const $ sendProjectFileContentsResponse normalizedPath $ code fileContents
+    (Right (Just (_, pathFound))) -> do
+      -- Found the file in the project contents, so
+      -- load the asset from that path.
+      handleNoAsset $ loadProjectAsset (projectID : pathFound)
 
 saveProjectAssetEndpoint :: Maybe Text -> ProjectIdWithSuffix -> [Text] -> ServerMonad Application
 saveProjectAssetEndpoint cookie (ProjectIdWithSuffix projectID _) path = requireUser cookie $ \sessionUser -> do

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -95,7 +95,7 @@ data ServiceCallsF a = NotFound
                      | CreateProject (Text -> a)
                      | SaveProject SessionUser Text (Maybe Text) (Maybe Value) a
                      | DeleteProject SessionUser Text a
-                     | LoadProjectAsset [Text] (Application -> a)
+                     | LoadProjectAsset [Text] (Maybe Application -> a)
                      | SaveProjectAsset Text Text [Text] (Application -> a)
                      | RenameProjectAsset Text Text OldPathText NewPathText a
                      | DeleteProjectAsset Text Text [Text] a

--- a/server/test/Test/Utopia/Web/Endpoints.hs
+++ b/server/test/Test/Utopia/Web/Endpoints.hs
@@ -7,6 +7,7 @@ module Test.Utopia.Web.Endpoints where
 
 import           Control.Lens                   hiding ((.=))
 import           Data.Aeson
+import           Data.Aeson.Lens
 import           Data.Time
 import           GHC.Conc
 import           Network.HTTP.Client            (CookieJar, cookie_value,
@@ -145,7 +146,7 @@ updateAssetPathSpec :: Spec
 updateAssetPathSpec =
   describe "PUT v1/asset/{project_id}/{asset_path}?old_file_name={old_asset_path}" $ do
     it "should update the asset path" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
-      let projectContents = object ["firstThing" .= (1 :: Int), "secondThing" .= True]
+      projectContents <- getSampleProject
       -- Create a project, save an asset, rename it and try to load it from the new path.
       assetFromNewPathResult <- withClientEnv clientEnv $ do
         _ <- validAuthenticate
@@ -173,7 +174,7 @@ deleteAssetSpec :: Spec
 deleteAssetSpec =
   describe "DELETE v1/asset/{project_id}/{asset_path}?old_file_name={old_asset_path}" $ do
     it "should delete the asset" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
-      let projectContents = object ["firstThing" .= (1 :: Int), "secondThing" .= True]
+      let projectContents = object ["projectContents" .= object []]
       -- Create a project, save an asset, rename it and try to load it from the new path.
       loadedFromPath <- withClientEnv clientEnv $ do
         _ <- validAuthenticate
@@ -220,7 +221,7 @@ routingSpec = around_ withServer $ do
       length cookies `shouldBe` 1
   describe "GET /project/{project_id}/owner" $ do
     it "return the owner of the project" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
-      let projectContents = object ["firstThing" .= (1 :: Int), "secondThing" .= True]
+      projectContents <- getSampleProject
       projectOwnerResponse <- withClientEnv clientEnv $ do
         _ <- validAuthenticate
         cookieHeader <- getCookieHeader cookieJarTVar
@@ -237,7 +238,7 @@ routingSpec = around_ withServer $ do
         projectsClient cookieHeader
       projectListingResponse `shouldBe` (Right $ ProjectListResponse [])
     it "return a list of the user's projects when a project has been created" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
-      let projectContents = object ["firstThing" .= (1 :: Int), "secondThing" .= True]
+      projectContents <- getSampleProject
       projectIdAndListingResult <- withClientEnv clientEnv $ do
         _ <- validAuthenticate
         cookieHeader <- getCookieHeader cookieJarTVar
@@ -254,7 +255,7 @@ routingSpec = around_ withServer $ do
         getShowcaseClient
       projectListingResponse `shouldBe` (Right $ ProjectListResponse [])
     it "return a list containing whatever project that has been added" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
-      let projectContents = object ["firstThing" .= (1 :: Int), "secondThing" .= True]
+      projectContents <- getSampleProject
       projectIdAndListingResult <- withClientEnv clientEnv $ do
         _ <- validAuthenticate
         cookieHeader <- getCookieHeader cookieJarTVar
@@ -268,8 +269,8 @@ routingSpec = around_ withServer $ do
       (listing ^.. projects . traverse . id) `shouldBe` [toUrlPiece projectId]
   describe "GET /project/{project_id}" $ do
     it "returns the not changed result if the last updated data is the same" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
+      projectContents <- getSampleProject
       earlyTime <- getCurrentTime
-      let projectContents = object ["firstThing" .= (1 :: Int), "secondThing" .= True]
       loadedProjectResult <- withClientEnv clientEnv $ do
         _ <- validAuthenticate
         cookieHeader <- getCookieHeader cookieJarTVar
@@ -320,10 +321,22 @@ routingSpec = around_ withServer $ do
         loadProjectFileClient projectId ["assets", "picture.jpg"] identity
       fileFromPath <- either throwIO return fileFromPathResult
       (responseBody fileFromPath) `shouldBe` (toS jpgBytes)
+    it "should load from /public/ ahead of /" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
+      projectContents <- getSampleProject
+      fileFromPathResult <- withClientEnv clientEnv $ do
+        _ <- validAuthenticate
+        cookieHeader <- getCookieHeader cookieJarTVar
+        createProjectResult <- createProjectClient
+        let projectId = ProjectIdWithSuffix (view id createProjectResult) ""
+        _ <- saveProjectClient cookieHeader projectId $ SaveProjectRequest (Just "My Project") (Just projectContents)
+        _ <- saveProjectAssetClient cookieHeader projectId ["public", "picture.jpg"] setBodyAsJPG
+        loadProjectFileClient projectId ["picture.jpg"] identity
+      fileFromPath <- either throwIO return fileFromPathResult
+      (responseBody fileFromPath) `shouldBe` (toS jpgBytes)
   describe "POST /project" $ do
     it "should create a project if a request body is supplied" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
       earlyTime <- getCurrentTime
-      let projectContents = object ["firstThing" .= (1 :: Int), "secondThing" .= True]
+      projectContents <- getSampleProject
       loadedProjectResult <- withClientEnv clientEnv $ do
         _ <- validAuthenticate
         cookieHeader <- getCookieHeader cookieJarTVar
@@ -335,7 +348,7 @@ routingSpec = around_ withServer $ do
       (getLoadedTitleAndContents loadedProject) `shouldBe` (Just ("My Project", projectContents))
     it "should fork a project if an original project ID was passed in with no request body" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
       earlyTime <- getCurrentTime
-      let projectContents = object ["firstThing" .= (1 :: Int), "secondThing" .= True]
+      projectContents <- getSampleProject
       loadedProjectResult <- withClientEnv clientEnv $ do
         _ <- validAuthenticate
         cookieHeader <- getCookieHeader cookieJarTVar
@@ -350,8 +363,8 @@ routingSpec = around_ withServer $ do
   describe "PUT /project" $ do
     it "should update a project's contents if the project contents are supplied" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
       earlyTime <- getCurrentTime
-      let firstProjectContents = object ["firstThing" .= (1 :: Int), "secondThing" .= True]
-      let secondProjectContents = object ["firstThing" .= (5 :: Int), "secondThing" .= False]
+      firstProjectContents <- getSampleProject
+      let secondProjectContents = set (key "firstThing" . _Bool) False firstProjectContents
       loadedProjectResult <- withClientEnv clientEnv $ do
         _ <- validAuthenticate
         cookieHeader <- getCookieHeader cookieJarTVar
@@ -363,8 +376,8 @@ routingSpec = around_ withServer $ do
       loadedProject <- either throwIO return loadedProjectResult
       (getLoadedTitleAndContents loadedProject) `shouldBe` Just ("My Project", secondProjectContents)
     it "should update a project title if the project title is supplied" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
+      projectContents <- getSampleProject
       earlyTime <- getCurrentTime
-      let projectContents = object ["firstThing" .= (1 :: Int), "secondThing" .= True]
       loadedProjectResult <- withClientEnv clientEnv $ do
         _ <- validAuthenticate
         cookieHeader <- getCookieHeader cookieJarTVar
@@ -378,7 +391,7 @@ routingSpec = around_ withServer $ do
   describe "DELETE /project" $ do
     it "should delete a project" $ withClientAndCookieJar $ \(clientEnv, cookieJarTVar) -> do
       earlyTime <- getCurrentTime
-      let projectContents = object ["firstThing" .= (1 :: Int), "secondThing" .= True]
+      projectContents <- getSampleProject
       loadedProjectResult <- withClientEnv clientEnv $ do
         _ <- validAuthenticate
         cookieHeader <- getCookieHeader cookieJarTVar

--- a/server/test/Test/Utopia/Web/SampleProject.json
+++ b/server/test/Test/Utopia/Web/SampleProject.json
@@ -1,1 +1,235 @@
-{"appID":null,"projectVersion":6,"projectContents":{"package.json":{"type":"PROJECT_CONTENT_FILE","fullPath":"/package.json","content":{"type":"TEXT_FILE","fileContents":{"code":"{\n  \"name\": \"Utopia Project\",\n  \"version\": \"0.1.0\",\n  \"utopia\": {\n    \"main-ui\": \"src/app.js\",\n    \"html\": \"public/index.html\",\n    \"js\": \"src/index.js\"\n  },\n  \"dependencies\": {\n    \"react\": \"16.13.1\",\n    \"react-dom\": \"16.13.1\",\n    \"utopia-api\": \"0.4.1\",\n    \"react-spring\": \"8.0.27\"\n  }\n}","parsed":{"type":"UNPARSED"},"revisionsState":"BOTH_MATCH"},"lastSavedContents":null,"lastRevisedTime":0}},"src":{"type":"PROJECT_CONTENT_DIRECTORY","fullPath":"/src","directory":{"type":"DIRECTORY"},"children":{"app.js":{"type":"PROJECT_CONTENT_FILE","fullPath":"/src/app.js","content":{"type":"TEXT_FILE","fileContents":{"code":"/** @jsx jsx */\nimport * as React from 'react'\nimport { Scene, Storyboard, jsx } from 'utopia-api'\nexport var App = (props) => {\n  return (\n    <div\n      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}\n    />\n  )\n}\nexport var storyboard = (\n  <Storyboard>\n    <Scene\n      component={App}\n      props={{}}\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\n    />\n  </Storyboard>\n)\n\n","parsed":{"type":"PARSE_SUCCESS","imports":{"react":{"importedWithName":null,"importedFromWithin":[],"importedAs":"React"},"utopia-api":{"importedWithName":null,"importedFromWithin":[{"name":"Scene","alias":"Scene"},{"name":"Storyboard","alias":"Storyboard"},{"name":"jsx","alias":"jsx"}],"importedAs":null}},"topLevelElements":[{"type":"UTOPIA_JSX_COMPONENT","name":"App","isFunction":true,"param":{"type":"PARAM","dotDotDotToken":false,"boundParam":{"type":"REGULAR_PARAM","paramName":"props","defaultExpression":null}},"propsUsed":[],"rootElement":{"type":"JSX_ELEMENT","name":{"baseVariable":"div","propertyPath":{"propertyElements":[]}},"props":{"style":{"type":"ATTRIBUTE_VALUE","value":{"width":"100%","height":"100%","backgroundColor":"#FFFFFF","position":"relative"}},"data-uid":{"type":"ATTRIBUTE_VALUE","value":"d59"}},"children":[]},"arbitraryJSBlock":null,"usedInReactDOMRender":false},{"type":"UTOPIA_JSX_COMPONENT","name":"storyboard","isFunction":false,"param":null,"propsUsed":[],"rootElement":{"type":"JSX_ELEMENT","name":{"baseVariable":"Storyboard","propertyPath":{"propertyElements":[]}},"props":{"data-uid":{"type":"ATTRIBUTE_VALUE","value":"b32"}},"children":[{"type":"JSX_ELEMENT","name":{"baseVariable":"Scene","propertyPath":{"propertyElements":[]}},"props":{"component":{"type":"ATTRIBUTE_OTHER_JAVASCRIPT","javascript":"App","transpiledJavascript":"return App;","definedElsewhere":["App"],"sourceMap":{"version":3,"sources":["code.tsx"],"names":["App"],"mappings":"OAakBA","file":"code.tsx","sourcesContent":["/** @jsx jsx */\nimport * as React from 'react'\nimport { Scene, Storyboard, jsx } from 'utopia-api'\nexport var App = (props) => {\n  return (\n    <div\n      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}\n    />\n  )\n}\nexport var storyboard = (\n  <Storyboard>\n    <Scene\n      component={App}\n      props={{}}\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\n    />\n  </Storyboard>\n)\n\n"]},"uniqueID":"78a239df-7011-452c-ac06-954e0b49dd05"},"props":{"type":"ATTRIBUTE_VALUE","value":{}},"style":{"type":"ATTRIBUTE_VALUE","value":{"position":"absolute","left":0,"top":0,"width":375,"height":812}},"data-uid":{"type":"ATTRIBUTE_VALUE","value":"663"}},"children":[]}]},"arbitraryJSBlock":null,"usedInReactDOMRender":false}],"highlightBounds":{"663":{"startCol":4,"startLine":12,"endCol":6,"endLine":16,"uid":"663"},"d59":{"startCol":4,"startLine":5,"endCol":6,"endLine":7,"uid":"d59"},"b32":{"startCol":2,"startLine":11,"endCol":15,"endLine":17,"uid":"b32"}},"jsxFactoryFunction":"jsx","combinedTopLevelArbitraryBlock":null,"exportsDetail":{"defaultExport":null,"namedExports":{"App":{"type":"EXPORT_DETAIL_MODIFIER"},"storyboard":{"type":"EXPORT_DETAIL_MODIFIER"}}}},"revisionsState":"BOTH_MATCH"},"lastSavedContents":null,"lastRevisedTime":1608045469428}},"index.js":{"type":"PROJECT_CONTENT_FILE","fullPath":"/src/index.js","content":{"type":"TEXT_FILE","fileContents":{"code":"import * as React from \"react\";\nimport * as ReactDOM from \"react-dom\";\nimport { App } from \"../src/app\";\n\nconst root = document.getElementById(\"root\");\nif (root != null) {\n  ReactDOM.render(<App />, root);\n}","parsed":{"type":"UNPARSED"},"revisionsState":"CODE_AHEAD"},"lastSavedContents":null,"lastRevisedTime":0}}}},"assets":{"type":"PROJECT_CONTENT_DIRECTORY","fullPath":"/assets","directory":{"type":"DIRECTORY"},"children":{}},"public":{"type":"PROJECT_CONTENT_DIRECTORY","fullPath":"/public","directory":{"type":"DIRECTORY"},"children":{"index.html":{"type":"PROJECT_CONTENT_FILE","fullPath":"/public/index.html","content":{"type":"TEXT_FILE","fileContents":{"code":"<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <meta charset=\"utf-8\">\n    <title>Utopia React App</title>\n    <!-- Begin Generated Utopia External Links -->\n    <!-- End Generated Utopia External Links -->\n  </head>\n  <body>\n    <div id=\"root\"></div>\n  </body>\n</html>","parsed":{"type":"UNPARSED"},"revisionsState":"CODE_AHEAD"},"lastSavedContents":null,"lastRevisedTime":0}}}}},"exportsInfo":[],"openFiles":[{"type":"OPEN_FILE_TAB","filename":"/src/app.js"},{"type":"RELEASE_NOTES_TAB"}],"selectedFile":{"type":"RELEASE_NOTES_TAB"},"codeEditorErrors":{"buildErrors":{},"lintErrors":{}},"codeEditorTheme":"utopia-highvis","lastUsedFont":null,"hiddenInstances":[],"fileBrowser":{"minimised":false},"dependencyList":{"minimised":false},"projectSettings":{"minimised":false},"navigator":{"minimised":false}}
+{
+  "appID": null,
+  "projectVersion": 6,
+  "projectContents": {
+    "package.json": {
+      "type": "PROJECT_CONTENT_FILE",
+      "fullPath": "/package.json",
+      "content": {
+        "type": "TEXT_FILE",
+        "fileContents": {
+          "code": "{\n  \"name\": \"Utopia Project\",\n  \"version\": \"0.1.0\",\n  \"utopia\": {\n    \"main-ui\": \"src/app.js\",\n    \"html\": \"public/index.html\",\n    \"js\": \"src/index.js\"\n  },\n  \"dependencies\": {\n    \"react\": \"16.13.1\",\n    \"react-dom\": \"16.13.1\",\n    \"utopia-api\": \"0.4.1\",\n    \"react-spring\": \"8.0.27\"\n  }\n}",
+          "parsed": { "type": "UNPARSED" },
+          "revisionsState": "BOTH_MATCH"
+        },
+        "lastSavedContents": null,
+        "lastRevisedTime": 0
+      }
+    },
+    "src": {
+      "type": "PROJECT_CONTENT_DIRECTORY",
+      "fullPath": "/src",
+      "directory": { "type": "DIRECTORY" },
+      "children": {
+        "app.js": {
+          "type": "PROJECT_CONTENT_FILE",
+          "fullPath": "/src/app.js",
+          "content": {
+            "type": "TEXT_FILE",
+            "fileContents": {
+              "code": "/** @jsx jsx */\nimport * as React from 'react'\nimport { Scene, Storyboard, jsx } from 'utopia-api'\nexport var App = (props) => {\n  return (\n    <div\n      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}\n    />\n  )\n}\nexport var storyboard = (\n  <Storyboard>\n    <Scene\n      component={App}\n      props={{}}\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\n    />\n  </Storyboard>\n)\n\n",
+              "parsed": {
+                "type": "PARSE_SUCCESS",
+                "imports": {
+                  "react": {
+                    "importedWithName": null,
+                    "importedFromWithin": [],
+                    "importedAs": "React"
+                  },
+                  "utopia-api": {
+                    "importedWithName": null,
+                    "importedFromWithin": [
+                      { "name": "Scene", "alias": "Scene" },
+                      { "name": "Storyboard", "alias": "Storyboard" },
+                      { "name": "jsx", "alias": "jsx" }
+                    ],
+                    "importedAs": null
+                  }
+                },
+                "topLevelElements": [
+                  {
+                    "type": "UTOPIA_JSX_COMPONENT",
+                    "name": "App",
+                    "isFunction": true,
+                    "param": {
+                      "type": "PARAM",
+                      "dotDotDotToken": false,
+                      "boundParam": {
+                        "type": "REGULAR_PARAM",
+                        "paramName": "props",
+                        "defaultExpression": null
+                      }
+                    },
+                    "propsUsed": [],
+                    "rootElement": {
+                      "type": "JSX_ELEMENT",
+                      "name": { "baseVariable": "div", "propertyPath": { "propertyElements": [] } },
+                      "props": {
+                        "style": {
+                          "type": "ATTRIBUTE_VALUE",
+                          "value": {
+                            "width": "100%",
+                            "height": "100%",
+                            "backgroundColor": "#FFFFFF",
+                            "position": "relative"
+                          }
+                        },
+                        "data-uid": { "type": "ATTRIBUTE_VALUE", "value": "d59" }
+                      },
+                      "children": []
+                    },
+                    "arbitraryJSBlock": null,
+                    "usedInReactDOMRender": false
+                  },
+                  {
+                    "type": "UTOPIA_JSX_COMPONENT",
+                    "name": "storyboard",
+                    "isFunction": false,
+                    "param": null,
+                    "propsUsed": [],
+                    "rootElement": {
+                      "type": "JSX_ELEMENT",
+                      "name": {
+                        "baseVariable": "Storyboard",
+                        "propertyPath": { "propertyElements": [] }
+                      },
+                      "props": { "data-uid": { "type": "ATTRIBUTE_VALUE", "value": "b32" } },
+                      "children": [
+                        {
+                          "type": "JSX_ELEMENT",
+                          "name": {
+                            "baseVariable": "Scene",
+                            "propertyPath": { "propertyElements": [] }
+                          },
+                          "props": {
+                            "component": {
+                              "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
+                              "javascript": "App",
+                              "transpiledJavascript": "return App;",
+                              "definedElsewhere": ["App"],
+                              "sourceMap": {
+                                "version": 3,
+                                "sources": ["code.tsx"],
+                                "names": ["App"],
+                                "mappings": "OAakBA",
+                                "file": "code.tsx",
+                                "sourcesContent": [
+                                  "/** @jsx jsx */\nimport * as React from 'react'\nimport { Scene, Storyboard, jsx } from 'utopia-api'\nexport var App = (props) => {\n  return (\n    <div\n      style={{ width: '100%', height: '100%', backgroundColor: '#FFFFFF', position: 'relative' }}\n    />\n  )\n}\nexport var storyboard = (\n  <Storyboard>\n    <Scene\n      component={App}\n      props={{}}\n      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}\n    />\n  </Storyboard>\n)\n\n"
+                                ]
+                              },
+                              "uniqueID": "78a239df-7011-452c-ac06-954e0b49dd05"
+                            },
+                            "props": { "type": "ATTRIBUTE_VALUE", "value": {} },
+                            "style": {
+                              "type": "ATTRIBUTE_VALUE",
+                              "value": {
+                                "position": "absolute",
+                                "left": 0,
+                                "top": 0,
+                                "width": 375,
+                                "height": 812
+                              }
+                            },
+                            "data-uid": { "type": "ATTRIBUTE_VALUE", "value": "663" }
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    "arbitraryJSBlock": null,
+                    "usedInReactDOMRender": false
+                  }
+                ],
+                "highlightBounds": {
+                  "663": {
+                    "startCol": 4,
+                    "startLine": 12,
+                    "endCol": 6,
+                    "endLine": 16,
+                    "uid": "663"
+                  },
+                  "d59": { "startCol": 4, "startLine": 5, "endCol": 6, "endLine": 7, "uid": "d59" },
+                  "b32": {
+                    "startCol": 2,
+                    "startLine": 11,
+                    "endCol": 15,
+                    "endLine": 17,
+                    "uid": "b32"
+                  }
+                },
+                "jsxFactoryFunction": "jsx",
+                "combinedTopLevelArbitraryBlock": null,
+                "exportsDetail": {
+                  "defaultExport": null,
+                  "namedExports": {
+                    "App": { "type": "EXPORT_DETAIL_MODIFIER" },
+                    "storyboard": { "type": "EXPORT_DETAIL_MODIFIER" }
+                  }
+                }
+              },
+              "revisionsState": "BOTH_MATCH"
+            },
+            "lastSavedContents": null,
+            "lastRevisedTime": 1608045469428
+          }
+        },
+        "index.js": {
+          "type": "PROJECT_CONTENT_FILE",
+          "fullPath": "/src/index.js",
+          "content": {
+            "type": "TEXT_FILE",
+            "fileContents": {
+              "code": "import * as React from \"react\";\nimport * as ReactDOM from \"react-dom\";\nimport { App } from \"../src/app\";\n\nconst root = document.getElementById(\"root\");\nif (root != null) {\n  ReactDOM.render(<App />, root);\n}",
+              "parsed": { "type": "UNPARSED" },
+              "revisionsState": "CODE_AHEAD"
+            },
+            "lastSavedContents": null,
+            "lastRevisedTime": 0
+          }
+        }
+      }
+    },
+    "assets": {
+      "type": "PROJECT_CONTENT_DIRECTORY",
+      "fullPath": "/assets",
+      "directory": { "type": "DIRECTORY" },
+      "children": {}
+    },
+    "public": {
+      "type": "PROJECT_CONTENT_DIRECTORY",
+      "fullPath": "/public",
+      "directory": { "type": "DIRECTORY" },
+      "children": {
+        "index.html": {
+          "type": "PROJECT_CONTENT_FILE",
+          "fullPath": "/public/index.html",
+          "content": {
+            "type": "TEXT_FILE",
+            "fileContents": {
+              "code": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <meta charset=\"utf-8\">\n    <title>Utopia React App</title>\n    <!-- Begin Generated Utopia External Links -->\n    <!-- End Generated Utopia External Links -->\n  </head>\n  <body>\n    <div id=\"root\"></div>\n  </body>\n</html>",
+              "parsed": { "type": "UNPARSED" },
+              "revisionsState": "CODE_AHEAD"
+            },
+            "lastSavedContents": null,
+            "lastRevisedTime": 0
+          }
+        }
+      }
+    }
+  },
+  "exportsInfo": [],
+  "openFiles": [
+    { "type": "OPEN_FILE_TAB", "filename": "/src/app.js" },
+    { "type": "RELEASE_NOTES_TAB" }
+  ],
+  "selectedFile": { "type": "RELEASE_NOTES_TAB" },
+  "codeEditorErrors": { "buildErrors": {}, "lintErrors": {} },
+  "codeEditorTheme": "utopia-highvis",
+  "lastUsedFont": null,
+  "hiddenInstances": [],
+  "fileBrowser": { "minimised": false },
+  "dependencyList": { "minimised": false },
+  "projectSettings": { "minimised": false },
+  "navigator": { "minimised": false }
+}
+

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d6fac29493b80851a8b72b7c738676b1216539bce5813f217a084ac3e7c5c0cf
+-- hash: e942bc8fcfc90cc05d72651fab3b1fa0f69517c43187641199e82d135c82192c
 
 name:           utopia-web
 version:        0.1.0.4
@@ -27,6 +27,7 @@ executable utopia-web
       Utopia.Web.Auth
       Utopia.Web.Auth.Session
       Utopia.Web.Auth.Types
+      Utopia.Web.ClientModel
       Utopia.Web.Database
       Utopia.Web.Database.Types
       Utopia.Web.Editor.Branches
@@ -50,7 +51,7 @@ executable utopia-web
   hs-source-dirs:
       src
   default-extensions: NoImplicitPrelude
-  ghc-options: -Wall -Werror -threaded -rtsopts
+  ghc-options: -threaded -rtsopts
   extra-libraries:
       z
   build-depends:
@@ -74,6 +75,7 @@ executable utopia-web
     , exceptions
     , filepath
     , free
+    , generic-lens
     , http-api-data
     , http-client
     , http-client-tls
@@ -139,6 +141,7 @@ test-suite utopia-web-test
       Utopia.Web.Auth
       Utopia.Web.Auth.Session
       Utopia.Web.Auth.Types
+      Utopia.Web.ClientModel
       Utopia.Web.Database
       Utopia.Web.Database.Types
       Utopia.Web.Editor.Branches
@@ -163,7 +166,7 @@ test-suite utopia-web-test
       test
       src
   default-extensions: NoImplicitPrelude
-  ghc-options: -Wall -Werror -threaded -rtsopts
+  ghc-options: -threaded -rtsopts
   extra-libraries:
       z
   build-depends:
@@ -187,6 +190,7 @@ test-suite utopia-web-test
     , exceptions
     , filepath
     , free
+    , generic-lens
     , hedgehog
     , hspec
     , http-api-data

--- a/shell.nix
+++ b/shell.nix
@@ -140,7 +140,7 @@ let
       #!/usr/bin/env bash
       set -e
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/server
-      ${cabal}/bin/cabal new-update
+      ${cabal}/bin/cabal new-update 'hackage.haskell.org,2021-06-09T12:43:34Z'
     '')
     (pkgs.writeScriptBin "test-server-inner" ''
       #!/usr/bin/env bash


### PR DESCRIPTION
Fixes #1344

**Problem:**
We want users to be able to address files from the `/public` folder as if they were stored at the root, but then still fallback to loading anything not present from the root.

**Fix:**
The handling for the above behaviour was implemented into the endpoints. Also the prior handling for looking up files in the `projectContents` part of the persistent model has been fixed as it was broken by the change to the model in the frontend.

**Commit Details:**
- Fixes #1344.
- Added a snapshot date to the `cabal-update` script which results
  in it running near instantly repeatedly.
- Removed `-Werror` ghc-option as it can make things a bit laborious
  at times when making tweaks.
- Added `generic-lens` library.
- Fixed the type of `ImageFile.hash` and some associated types as
  we've been storing a `number` but everything was marked as being
  a `string`.
- Added the `Utopia.Web.ClientModel` module which provides some partial
  parsing of the `PersistentModel`, along with `getProjectContentsTreeFile`
  to walk the `projectContents` part of the model based on a file path.
- Changed `loadProjectAssetWithCall` to optionally return the `Application`
  if the asset cannot be found, instead of responding with a 404.
- Changed the `LoadProjectAsset` service type to handle optionally
  returned `Application` values.
- Make all the tests for the endpoints use the `getSampleProject`
  function so that the project includes a valid `projectContents`
  value.
- `loadProjectFileContents` takes multiple paths, possibly returns
  an error when parsing the `projectContents`. It now attempts to find
  the first file that matches one of the paths given.
- `loadProjectFileEndpoint` handles the lookup of paths under
  `/public/` ahead of `/`. Along with a speculative asset file lookup
  following the same priority ordering if the file is not found in
  the `projectContents` of the project.
