### PR TITLE
Fix/component section rows

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -755,7 +755,9 @@ export const ComponentSectionInner = betterReactMemo(
               <Subdued>{`Props: ${propsGivenToElement.join(', ')}${
                 propsUsedWithoutControls.length > 0 ? ', ' : '.'
               }`}</Subdued>
-              <VerySubdued>{`${propsUsedWithoutControls.join(', ')}`}</VerySubdued>
+              <VerySubdued>{`${propsUsedWithoutControls.join(', ')}${
+                propsUsedWithoutControls.length > 0 ? '.' : ''
+              }`}</VerySubdued>
             </div>
           </UIGridRow>
         ) : null}

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -692,7 +692,9 @@ export const ComponentSectionInner = betterReactMemo(
             return <ParseErrorControl parseError={rootParseError} />
           },
           (rootParseSuccess) => {
-            const propNames = Object.keys(rootParseSuccess)
+            const propNames = Object.keys(rootParseSuccess).filter(
+              (name) => name !== 'style' && name !== 'css',
+            )
             if (propNames.length > 0) {
               return (
                 <>

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -549,12 +549,7 @@ export const ComponentSectionInner = betterReactMemo(
       useUsedPropsWithoutControls(),
     )
     const dispatch = useEditorState((state) => state.dispatch, 'ComponentSectionInner')
-
-    const propsUsedWithoutDefaults = useKeepReferenceEqualityIfPossible(
-      useUsedPropsWithoutDefaults(),
-    )
     const missingControlsWarning = getMissingPropertyControlsWarning(propsUsedWithoutControls)
-    const missingDefaultsWarning = getMissingDefaultsWarning(propsUsedWithoutDefaults)
 
     const selectedViews = useEditorState(
       (store) => store.editor.selectedViews,
@@ -698,19 +693,12 @@ export const ComponentSectionInner = betterReactMemo(
           },
           (rootParseSuccess) => {
             const propNames = Object.keys(rootParseSuccess)
-
-            // TODO FIX ME
-            if (Math.random() > 0) {
+            if (propNames.length > 0) {
               return (
                 <>
                   {missingControlsWarning == null ? null : (
                     <InfoBox message={'Missing Property Controls'}>
                       {missingControlsWarning}
-                    </InfoBox>
-                  )}
-                  {missingDefaultsWarning == null ? null : (
-                    <InfoBox message={'Missing Default Properties'}>
-                      {missingDefaultsWarning}
                     </InfoBox>
                   )}
                   {propNames.map((propName) => {
@@ -749,25 +737,20 @@ export const ComponentSectionInner = betterReactMemo(
                       )
                     }
                   })}
-                  {propsUsedWithoutControls.length > 0 ? (
-                    <Subdued>{`Additional props used in code: ${propsUsedWithoutControls.join(
-                      ', ',
-                    )}`}</Subdued>
-                  ) : null}
                 </>
               )
             } else {
-              return (
-                <>
-                  <UIGridRow padded tall={false} variant={'<-------------1fr------------->'}>
-                    <Subdued>No properties available to configure</Subdued>
-                  </UIGridRow>
-                </>
-              )
+              return null
             }
           },
           propertyControls,
         )}
+        {/** props used in the component code without controltypes set */}
+        {propsUsedWithoutControls.length > 0 ? (
+          <Subdued>{`${
+            Object.keys(propertyControls.value ?? {}).length > 0 ? 'Additional props' : 'Props'
+          } used in code: ${propsUsedWithoutControls.join(', ')}`}</Subdued>
+        ) : null}
       </>
     )
   },

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -237,23 +237,39 @@ export function importInfoFromImportDetails(name: JSXElementName, imports: Impor
   return foundImportDetail
 }
 
-export function isImportedComponent(
-  elementInstanceMetadata: ElementInstanceMetadata | null,
-): boolean {
-  const importInfo = elementInstanceMetadata?.importInfo
-  return importInfo != null && isRight(importInfo)
+export function getFilePathForImportedComponent(
+  element: ElementInstanceMetadata | null,
+): string | null {
+  const importInfo = element?.importInfo
+  if (importInfo != null && isRight(importInfo)) {
+    return importInfo.value.path
+  } else {
+    return null
+  }
 }
 
-export function isImportedComponentNPM(
+export function isImportedComponentFromProjectFiles(
+  element: ElementInstanceMetadata | null,
+): boolean {
+  return !isImportedComponentNPM(element)
+}
+
+export function isImportedComponent(
   elementInstanceMetadata: ElementInstanceMetadata | null,
 ): boolean {
   const importInfo = elementInstanceMetadata?.importInfo
   if (importInfo != null && isRight(importInfo)) {
     const importKey = importInfo.value.path
-    return importKey !== 'utopia-api' && !importKey.startsWith('.') && !importKey.startsWith('/')
+    return !importKey.startsWith('.') && !importKey.startsWith('/')
   } else {
     return false
   }
+}
+
+export function isImportedComponentNPM(
+  elementInstanceMetadata: ElementInstanceMetadata | null,
+): boolean {
+  return isImportedComponent(elementInstanceMetadata) // es nem utopia-api
 }
 
 const defaultEmptyUtopiaComponent = EmptyUtopiaCanvasComponent

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -269,7 +269,11 @@ export function isImportedComponent(
 export function isImportedComponentNPM(
   elementInstanceMetadata: ElementInstanceMetadata | null,
 ): boolean {
-  return isImportedComponent(elementInstanceMetadata) // es nem utopia-api
+  return (
+    isImportedComponent(elementInstanceMetadata) &&
+    elementInstanceMetadata != null &&
+    !isUtopiaAPIComponentFromMetadata(elementInstanceMetadata)
+  )
 }
 
 const defaultEmptyUtopiaComponent = EmptyUtopiaCanvasComponent

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -111,7 +111,7 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(495) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(505)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(460) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(470)
   })
 })

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -750,7 +750,7 @@ export function pathUpToElementPath(
   return foundIndex === -1 ? null : elementPath(fullElementPath.slice(0, foundIndex + 1))
 }
 
-interface DropFirstPathElementResultType {
+export interface DropFirstPathElementResultType {
   newPath: StaticElementPath | null
   droppedPathElements: StaticElementPathPart | null
 }

--- a/editor/src/uuiui/widgets/headings/headings.tsx
+++ b/editor/src/uuiui/widgets/headings/headings.tsx
@@ -46,6 +46,9 @@ export const Subdued = styled.span([
     lineHeight: '17px',
   },
 ])
+export const VerySubdued = styled(Subdued)({
+  color: colorTheme.verySubduedForeground.value,
+})
 
 export const InspectorSectionHeader = styled(H1)({
   label: 'section-header',


### PR DESCRIPTION
**Fix:**
Fixing some of the missing functionalities of the component-section.

**Commit Details:**
- incorrectly displayed import filepath information fixed using the metadata importinfo, for non-imported files it uses the same underlyingtarget path as before
- removed missing defaults and controls warnings
- show list of given properties from element metadata, filtering for utopia specific props
- same list shows props used by the component implementation in a different color, excluding given props
- for this I changed the normalisePath a little to access the original jsx component imported by the underlying path
- fixing the navigator icons showing npm-components for everything

<img width="260" alt="Screenshot 2021-06-10 at 16 33 18" src="https://user-images.githubusercontent.com/4403069/121544682-330e7000-ca0a-11eb-8ab2-446bfd3c2a52.png">
