### PR TITLE
Focus canvas on mouse down.

### DIFF
--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -565,10 +565,6 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
       this.props.dispatch([CanvasActions.setSelectionControlsVisibility(true)], 'canvas')
     }
 
-    if (this.props.model.focusedPanel !== 'canvas' && event.event !== 'WHEEL') {
-      return
-    }
-
     if (
       (event.nativeEvent != null &&
         event.nativeEvent.srcElement != null &&
@@ -592,10 +588,15 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
       } as WindowRectangle
     }
 
-    const actions = [
-      ...handleCanvasEvent(this.props.model, event),
-      ...on(this.props.model, event, canvasBounds),
-    ]
+    let actions: Array<EditorAction> = []
+    // Focus the panel as something is happening in/on it.
+    if (this.props.model.focusedPanel !== 'canvas' && event.event === 'MOUSE_DOWN') {
+      actions.push(setFocus('canvas'))
+    }
+
+    actions.push(...handleCanvasEvent(this.props.model, event))
+    actions.push(...on(this.props.model, event, canvasBounds))
+
     const realActions = actions.filter((action) => action.action !== 'TRANSIENT_ACTIONS')
     const transientActions = actions.filter((action) => action.action === 'TRANSIENT_ACTIONS')
     if (realActions.length > 0) {


### PR DESCRIPTION
Fixes #1258.

**Problem:**
Should selection be triggered from somewhere other than the canvas that would cause certain events to be either ignored or potentially mishandled because the canvas is not the "focused panel",

**Fix:**
An early exit condition was removed so that the second fix which focuses the canvas panel on a mouse down.

**Commit Details:**
- Fixes #1258.
- Removes an early exit conditional in `handleEvent` which was
  preventing some calls from reaching the canvas when for example
  selection had been triggered from the navigator. As that would
  cause the resize controls to be available.
- A mouse down on the canvas when it is not the focused panel causes
  it to be the focused panel.
