### PR TITLE
Restore the ability to zoom with 'z'.

### DIFF
--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -327,15 +327,15 @@ export function handleKeyDown(
   const editorTargeted = editorIsTarget(event, editor)
   let updatedKeysPressed: KeysPressed
   if (editorTargeted) {
-    updatedKeysPressed = updateModifiers(
-      editor.keysPressed,
-      Modifier.modifiersForKeyboardEvent(event),
-    )
-  } else {
     updatedKeysPressed = updateKeysPressed(
       editor.keysPressed,
       key,
       true,
+      Modifier.modifiersForKeyboardEvent(event),
+    )
+  } else {
+    updatedKeysPressed = updateModifiers(
+      editor.keysPressed,
       Modifier.modifiersForKeyboardEvent(event),
     )
   }


### PR DESCRIPTION
Fixes #1027

**Problem:**
Users are unable to use the `z` key to trigger zooming when clicking on the canvas.

**Fix:**
Inverted a conditional for the logic that determines if either the modifiers or any keys pressed are updated, as the value had been flipped previously, but the then/else clauses hadn't been flipped with it.

**Commit Details:**
- Fixes #1027.
- Flips the conditional that checks to see if only
  the modifiers should be updated on a key down.