### PR TITLE
move css class section to the bottom

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -296,7 +296,6 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
             aspectRatioLocked={aspectRatioLocked}
             toggleAspectRatioLock={toggleAspectRatioLock}
           />
-          <ClassNameSubsection />
           <StyleSection />
           <WarningSubsection />
           <ImgSection />
@@ -308,6 +307,7 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
             onStyleSelectorDelete={props.onStyleSelectorDelete}
             onStyleSelectorInsert={props.onStyleSelectorInsert}
           />
+          <ClassNameSubsection />
           <EventHandlersSection />
         </React.Fragment>
       )


### PR DESCRIPTION
**Problem/Fix:**
Moving the css classnames section to the bottom of the inspector as it's not that frequently used to have an important spot.

