### PR TITLE
Components: allow resize/move on all elements

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -97,7 +97,6 @@ export interface ControlProps {
   windowToCanvasPosition: (event: MouseEvent) => CanvasPositions
   cmdKeyPressed: boolean
   showAdditionalControls: boolean
-  elementsThatRespectLayout: Array<ElementPath>
   maybeClearHighlightsOnHoverEnd: () => void
   transientState: TransientCanvasState
   resolve: ResolveFn
@@ -221,37 +220,6 @@ interface NewCanvasControlsInnerProps {
   setLocalSelectedViews: (newSelectedViews: ElementPath[]) => void
 }
 
-export const selectElementsThatRespectLayout = createSelector(
-  (store: EditorStore) => store.derived.navigatorTargets,
-  (store: EditorStore) => store.editor.propertyControlsInfo,
-  (store: EditorStore) => getOpenUIJSFileKey(store.editor),
-  (store: EditorStore) => store.editor.projectContents,
-  (store: EditorStore) => store.editor.nodeModules.files,
-  (store: EditorStore) => store.editor.jsxMetadata,
-  (
-    navigatorTargets: ElementPath[],
-    propertyControlsInfo: PropertyControlsInfo,
-    openFilePath: string | null,
-    projectContents: ProjectContentTreeRoot,
-    nodeModules: NodeModules,
-    metadata: ElementInstanceMetadataMap,
-  ) => {
-    const targetsWithRootViewPaths = flatMapArray((view) => {
-      const rootElements = MetadataUtils.getRootViewPaths(metadata, view)
-      return [view, ...rootElements]
-    }, navigatorTargets)
-    return targetsWithRootViewPaths.filter((view) => {
-      return targetRespectsLayout(
-        view,
-        propertyControlsInfo,
-        openFilePath,
-        projectContents,
-        nodeModules,
-      )
-    })
-  },
-)
-
 const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
   const startDragStateAfterDragExceedsThreshold = useStartDragStateAfterDragExceedsThreshold()
 
@@ -291,11 +259,6 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
     return 'enabled'
   }
 
-  const elementsThatRespectLayout = useEditorState(
-    selectElementsThatRespectLayout,
-    'NewCanvasControls elementsThatRespectLayout',
-  )
-
   const renderModeControlContainer = () => {
     const elementAspectRatioLocked = localSelectedViews.every((target) => {
       const possibleElement = MetadataUtils.findElementByElementPath(componentMetadata, target)
@@ -325,7 +288,6 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       windowToCanvasPosition: props.windowToCanvasPosition,
       cmdKeyPressed: cmdKeyPressed,
       showAdditionalControls: props.editor.interfaceDesigner.additionalControls,
-      elementsThatRespectLayout: elementsThatRespectLayout,
       maybeClearHighlightsOnHoverEnd: maybeClearHighlightsOnHoverEnd,
       projectContents: props.editor.projectContents,
       nodeModules: props.editor.nodeModules.files,

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -453,12 +453,7 @@ export class SelectModeControlContainer extends React.Component<
   }
 
   canResizeElements(): boolean {
-    return (
-      this.props.draggingEnabled &&
-      this.props.selectedViews.every((target) => {
-        return this.props.elementsThatRespectLayout.some((path) => EP.pathsEqual(path, target))
-      })
-    )
+    return this.props.draggingEnabled
   }
 
   render(): JSX.Element {

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -34,7 +34,6 @@ import {
   getValidTargetAtPoint,
 } from '../../dom-lookup'
 import { useWindowToCanvasCoordinates } from '../../dom-lookup-hooks'
-import { selectElementsThatRespectLayout } from '../new-canvas-controls'
 import { useInsertModeSelectAndHover } from './insert-mode-hooks'
 import { WindowMousePositionRaw } from '../../../../utils/global-positions'
 
@@ -245,10 +244,6 @@ function useStartDragState(): (
       const componentMetadata = entireEditorStoreRef.current.editor.jsxMetadata
       const selectedViews = entireEditorStoreRef.current.editor.selectedViews
 
-      const elementsThatRespectLayout = selectElementsThatRespectLayout(
-        entireEditorStoreRef.current,
-      )
-
       const duplicate = event.altKey
       const duplicateNewUIDs = duplicate
         ? createDuplicationNewUIDs(
@@ -260,14 +255,10 @@ function useStartDragState(): (
 
       const isTargetSelected = selectedViews.some((sv) => EP.pathsEqual(sv, target))
 
-      const selection =
+      const moveTargets =
         isTargetSelected && EP.areAllElementsInSameInstance(selectedViews)
           ? selectedViews
           : [target]
-
-      const moveTargets = selection.filter((view) =>
-        elementsThatRespectLayout.some((path) => EP.pathsEqual(path, view)),
-      )
 
       let originalFrames = getOriginalCanvasFrames(moveTargets, componentMetadata)
       originalFrames = originalFrames.filter((f) => f.frame != null)


### PR DESCRIPTION
**Problem:**
It's not clear why a component cannot be resized/moved on the canvas while the inspector can change style props, especially for all kind of third party components relying on propertyControls might not be the best way. 

**Fix:**
Support canvas controls without the component annotation, assume components are aware of the style prop.

**Commit Details:**
- removing elementsThatRespectLayout list from the select mode controls
