### PR TITLE
Correctly handle checking for the default background colour.

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -2159,7 +2159,9 @@ export function parseBackgroundColor(color?: unknown): Either<string, CSSDefault
       parsed = parseColor(matches[2])
       const enabled = matches[1] === undefined && matches[3] === undefined
       if (isRight(parsed)) {
-        return right(cssDefault(cssSolidColor(parsed.value, enabled), false))
+        const underlyingColor = cssSolidColor(parsed.value, enabled)
+        const isDefault = fastDeepEqual(underlyingColor, emptyBackgroundColor)
+        return right(cssDefault(underlyingColor, isDefault))
       } else {
         return parsed
       }
@@ -3667,8 +3669,10 @@ const updateBackgroundImageLayersWithNewValues = (
         if (workingNewValueForAll == null) {
           workingNewValueForAll = !v.enabled
         }
-        v.enabled = workingNewValueForAll
-        return v
+        return {
+          ...v,
+          enabled: workingNewValueForAll,
+        }
       })
       // set all backgroundImage layers to the new value
       return setJSXValueInAttributeAtPath(

--- a/editor/src/components/inspector/sections/style-section/background-subsection/background-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/background-subsection.tsx
@@ -91,7 +91,9 @@ export function cssBackgroundLayerArrayToBackgroundImagesAndColor(
     }
     case 1: {
       const zerothBackgroundLayer = cssBackgroundLayers[0]
-      if (zerothBackgroundLayer != null) {
+      if (zerothBackgroundLayer == null) {
+        return {}
+      } else {
         if (isCSSSolidBackgroundLayer(zerothBackgroundLayer)) {
           return {
             backgroundColor: cssDefault(
@@ -105,13 +107,13 @@ export function cssBackgroundLayerArrayToBackgroundImagesAndColor(
             ...getBackgroundSizeOrUndefinedIfDefault(cssBackgroundLayers),
           }
         }
-      } else {
-        return {}
       }
     }
     default: {
       const zerothBackgroundLayer = cssBackgroundLayers[0]
-      if (zerothBackgroundLayer != null) {
+      if (zerothBackgroundLayer == null) {
+        return {}
+      } else {
         if (isCSSSolidBackgroundLayer(zerothBackgroundLayer)) {
           const newCSSBackgroundLayers = cssBackgroundLayers.slice(1)
           return {
@@ -130,8 +132,6 @@ export function cssBackgroundLayerArrayToBackgroundImagesAndColor(
             ...getBackgroundSizeOrUndefinedIfDefault(cssBackgroundLayers),
           }
         }
-      } else {
-        return {}
       }
     }
   }
@@ -148,10 +148,10 @@ export function backgroundImagesAndColorToCSSBackgroundLayerArray(values: {
       return cssBackgroundToCSSBackgroundLayer(bgImage, bgSize)
     })
     .reverse()
-  if (!values.backgroundColor.default) {
-    return [cssSolidBackgroundLayer(values.backgroundColor.value), ...backgroundLayers]
-  } else {
+  if (values.backgroundColor.default) {
     return backgroundLayers
+  } else {
+    return [cssSolidBackgroundLayer(values.backgroundColor.value), ...backgroundLayers]
   }
 }
 


### PR DESCRIPTION
Fixes #347

**Problem:**
When trying to change an element with a `backgroundImage` property and no `backgroundColor` property, any change resulting in it gaining a default valued `backgroundColor` property.

**Fix:**
This just needed a check to see if the colour being parsed from in this case the computed value was indeed the default.

**Commit Details:**
- Fixes #347.
- `parseBackgroundColor` now checks to see if the colour is the same
  as `emptyBackgroundColor` and sets the `default` property appropriately
  based on the result of the comparison.
- Fixed a mutation in `updateBackgroundImageLayersWithNewValues`.
- Added some return types.
- Made `parseFinalValue` only parse as much as it needs to, rather
  than parsing everything upfront.
- Flipped some conditionals for clarity.
