### PR TITLE
Hide Landing page placeholders

### DIFF
--- a/website-next/components/menu.js
+++ b/website-next/components/menu.js
@@ -3,11 +3,11 @@ import { Popover, Transition } from '@headlessui/react'
 import { MenuIcon, XIcon } from '@heroicons/react/outline'
 
 const navigation = [
-  { name: 'Sunscreen', href: '#' },
-  { name: 'Samples', href: '#' },
-  { name: 'Stickers', href: '#' },
-  { name: 'Source', href: 'https://github.com/concrete-utopia/utopia' },
-  { name: 'Log In', href: '#' },
+  { name: ' ', href: '#' },
+  { name: ' ', href: '#' },
+  { name: ' ', href: '#' },
+  { name: ' ', href: 'https://github.com/concrete-utopia/utopia' },
+  { name: 'Create a Project', href: '/project' },
 ]
 
 export function Menu() {

--- a/website-next/pages/index.js
+++ b/website-next/pages/index.js
@@ -39,11 +39,11 @@ function Subtitle({ children, center }) {
   )
 }
 
-function HeroButton({ children, primary }) {
+function HeroButton({ href, children, primary }) {
   return (
     <div className='rounded-2xl shadow mt-3'>
       <a
-        href='#'
+        href={href}
         className={
           'rounded-2xl w-full flex items-center justify-center text-base font-medium font-button ' +
           'md:text-lg px-4 py-2 md:px-6 md:py-2 ' +
@@ -81,8 +81,10 @@ function HeroSection() {
                 sm:flex sm:justify-center gap-x-3
                 '
               >
-                <HeroButton primary>Create a Project</HeroButton>
-                <HeroButton>Read More</HeroButton>
+                <HeroButton primary href='/project'>
+                  Create a Project
+                </HeroButton>
+                {/* <HeroButton>Read More</HeroButton> */}
               </div>
             </div>
           </main>
@@ -178,9 +180,9 @@ export default function LandingPage() {
         </div>
 
         <HeroSection />
-        <DesignToolForCodeSection />
+        {/* <DesignToolForCodeSection />
         <CodeEditorForDesignSection />
-        <AlwaysLiveSection />
+        <AlwaysLiveSection /> */}
         <div className='pt-80' />
       </div>
     </div>


### PR DESCRIPTION
**Problem:**
The landing page on `master` as of now is full of placeholders. In case we need to push something to production, we would unintentionally deploy this half-baked page. 

**Fix:**
Remove the placeholders, leave a barebones landing page in place.
