### PR TITLE
webiste: serve images from CDN

### DIFF
--- a/website-next/components/hosted-image.tsx
+++ b/website-next/components/hosted-image.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react'
+
+const cdnUrl = process.env.UTOPIA_CDN_URL ?? ''
+
+function srcToCdn(src: string): string {
+  return `${cdnUrl}${src}`
+}
+
+type HostedImageProps = React.DetailedHTMLProps<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  HTMLImageElement
+> & { src: string }
+
+export function HostedImage(props: HostedImageProps) {
+  return <img {...props} src={srcToCdn(props.src)} />
+}

--- a/website-next/components/menu.js
+++ b/website-next/components/menu.js
@@ -1,6 +1,7 @@
 import { Fragment } from 'react'
 import { Popover, Transition } from '@headlessui/react'
 import { MenuIcon, XIcon } from '@heroicons/react/outline'
+import { HostedImage } from './hosted-image'
 
 const navigation = [
   { name: ' ', href: '#' },
@@ -17,7 +18,7 @@ export function Menu() {
         <>
           <div className='relative px-4 sm:px-6 lg:px-8 flex-grow'>
             <nav className='relative flex items-center justify-between sm:h-10 max-w-6xl m-auto font-menu'>
-              <img className='h-8 w-auto sm:h-10' src='/pyramid_fullsize.png' />
+              <HostedImage className='h-8 w-auto sm:h-10' src='/pyramid_fullsize.png' />
               {navigation.map((item) => (
                 <a
                   key={item.name}
@@ -54,7 +55,7 @@ export function Menu() {
               <div className='rounded-lg shadow-md bg-white ring-1 ring-black ring-opacity-5 overflow-hidden'>
                 <div className='px-5 pt-4 flex items-center justify-between'>
                   <div>
-                    <img className='h-8 w-auto' src='/pyramid_fullsize.png' alt='' />
+                    <HostedImage className='h-8 w-auto' src='/pyramid_fullsize.png' alt='' />
                   </div>
                   <div className='-mr-2'>
                     <Popover.Button className='bg-white rounded-md p-2 inline-flex items-center justify-center text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500'>

--- a/website-next/pages/index.js
+++ b/website-next/pages/index.js
@@ -7,6 +7,7 @@ import SwitchHorizontalIcon from '@heroicons/react/outline/SwitchHorizontalIcon'
 import { Menu } from '../components/menu'
 import { GhostBrowser } from '../components/ghostbrowser'
 import { Header } from '../components/header'
+import { HostedImage } from '../components/hosted-image'
 
 function MainTitle({ children }) {
   return (
@@ -92,7 +93,7 @@ function HeroSection() {
       </div>
       <div className='px-2 pt-6 sm:pt-16 lg:pt-32 max-w-screen-2xl mx-auto'>
         <GhostBrowser className='w-full object-cover'>
-          <img src='/screenshots/screenshot2.png' />
+          <HostedImage src='/screenshots/screenshot2.png' />
         </GhostBrowser>
       </div>
     </>
@@ -112,7 +113,7 @@ function DesignToolForCodeSection() {
       </div>
       <div className='px-2 pt-6 sm:pt-16 lg:pt-32 max-w-screen-2xl mx-auto'>
         <GhostBrowser className='w-full object-cover'>
-          <img src='/screenshots/screenshot2.png' />
+          <HostedImage src='/screenshots/screenshot2.png' />
         </GhostBrowser>
       </div>
     </>
@@ -131,7 +132,7 @@ function CodeEditorForDesignSection() {
       </div>
       <div className='px-2 pt-6 sm:pt-16 lg:pt-32 max-w-screen-2xl mx-auto'>
         <GhostBrowser className='w-full object-cover'>
-          <img src='/screenshots/screenshot2.png' />
+          <HostedImage src='/screenshots/screenshot2.png' />
         </GhostBrowser>
       </div>
     </>
@@ -150,7 +151,7 @@ function AlwaysLiveSection() {
       </div>
       <div className='px-2 pt-6 sm:pt-16 lg:pt-32 max-w-screen-2xl mx-auto'>
         <GhostBrowser className='w-full object-cover'>
-          <img src='/screenshots/screenshot2.png' />
+          <HostedImage src='/screenshots/screenshot2.png' />
         </GhostBrowser>
       </div>
     </>


### PR DESCRIPTION
**Problem:**
The next.js exported website's images were not getting the CDN url.

**Fix:**
Turns out we need to manually CDN prefix every asset from `/public/`, so I created a `HostedImage` component that does that.
