### PR TITLE
Add CDN headers when serving website content

### DIFF
--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -435,7 +435,7 @@ clearBranchCacheEndpoint branchName = do
 websiteAssetsEndpoint :: FilePath -> ServerMonad Application
 websiteAssetsEndpoint notProxiedPath = do
   possibleProxyManager <- getProxyManager
-  maybe (servePath notProxiedPath Nothing) (\proxyManager -> return $ proxyApplication proxyManager 3000 []) possibleProxyManager
+  fmap addCDNHeaders $ maybe (servePath notProxiedPath Nothing) (\proxyManager -> return $ proxyApplication proxyManager 3000 []) possibleProxyManager
 
 vsCodeAssetsEndpoint :: ServerMonad Application
 vsCodeAssetsEndpoint = do


### PR DESCRIPTION
**Problem:**
We weren't including the required access control headers when serving content for the website, meaning CDN requests were failing CORS checks.

**Fix:**
Add the headers when serving the website content.
