### PR TITLE
Unreversing the navigator items

### DIFF
--- a/editor/src/components/canvas/canvas-utils.spec.browser.tsx
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.tsx
@@ -1268,13 +1268,13 @@ describe('moveTemplate', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...props.style }} data-uid='aaa'>
           <View data-uid='eee'>
-            <View data-uid='ddd' style={{ left: 52, top: -141 }} />
             <View
               style={{ backgroundColor: '#0091FFAA', position: 'relative', left: 52, top: -141, width: 256, height: 202 }}
               data-uid='bbb'
             >
               <View data-uid='ccc' />
             </View>
+            <View data-uid='ddd' style={{ left: 52, top: -141 }} />
           </View>
         </View>
       `,

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -1383,7 +1383,7 @@ function getZIndexOrderedViewsWithoutDirectChildren(
     const index = derived.navigatorTargets.findIndex((tp) => EP.pathsEqual(tp, target))
     targetsAndZIndex.push({ target: target, index: index })
   })
-  targetsAndZIndex.sort((a, b) => a.index - b.index)
+  targetsAndZIndex.sort((a, b) => b.index - a.index)
   const orderedTargets = Utils.pluck(targetsAndZIndex, 'target')
 
   // keep direct children from reparenting

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -15,7 +15,7 @@ interface NavigatorHintProps {
 }
 
 export const NavigatorHintTop: React.FunctionComponent<NavigatorHintProps> = (props) => {
-  if (props.isOver && props.dropTargetType != null && props.dropTargetType === 'after') {
+  if (props.isOver && props.dropTargetType != null && props.dropTargetType === 'before') {
     return (
       <div
         style={{
@@ -37,7 +37,7 @@ export const NavigatorHintTop: React.FunctionComponent<NavigatorHintProps> = (pr
 NavigatorHintTop.displayName = 'NavigatorHintTop'
 
 export const NavigatorHintBottom: React.FunctionComponent<NavigatorHintProps> = (props) => {
-  if (props.isOver && props.dropTargetType != null && props.dropTargetType === 'before') {
+  if (props.isOver && props.dropTargetType != null && props.dropTargetType === 'after') {
     return (
       <div
         style={{

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -148,9 +148,9 @@ function onHover(
     }
 
     if (isCursorInTopArea(dropTargetRectangle, cursor.y, numberOfAreasToCut)) {
-      if (props.dropTargetHint.type !== 'after') {
+      if (props.dropTargetHint.type !== 'before') {
         props.editorDispatch(
-          [...targetAction, showNavigatorDropTargetHint('after', component.props.elementPath)],
+          [...targetAction, showNavigatorDropTargetHint('before', component.props.elementPath)],
           'leftpane',
         )
       }
@@ -167,20 +167,20 @@ function onHover(
         const targetDistance = Math.min(cursorTargetDepth, maximumTargetDepth)
         const targetTP = EP.getNthParent(props.elementPath, targetDistance)
         if (
-          props.dropTargetHint.type !== 'before' ||
+          props.dropTargetHint.type !== 'after' ||
           !EP.pathsEqual(props.dropTargetHint.target, targetTP)
         ) {
           props.editorDispatch(
-            [...targetAction, showNavigatorDropTargetHint('before', targetTP)],
+            [...targetAction, showNavigatorDropTargetHint('after', targetTP)],
             'leftpane',
           )
         }
       } else if (
-        props.dropTargetHint.type !== 'before' ||
+        props.dropTargetHint.type !== 'after' ||
         !EP.pathsEqual(props.dropTargetHint.target, component.props.elementPath)
       ) {
         props.editorDispatch(
-          [...targetAction, showNavigatorDropTargetHint('before', component.props.elementPath)],
+          [...targetAction, showNavigatorDropTargetHint('after', component.props.elementPath)],
           'leftpane',
         )
       }

--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -596,17 +596,17 @@ describe('getting the root paths', () => {
 
 describe('createOrderedElementPathsFromElements returns all of the ordered navigator targets, visible and not', () => {
   const expectedNavigatorTargets: Array<ElementPath> = [
-    testStoryboardChildElement.elementPath,
-    testStoryboardGrandChildElement.elementPath,
     testComponentSceneElement.elementPath,
-    testComponentRoot1.elementPath,
-    testComponentMetadataChild3.elementPath,
-    testComponentMetadataGrandchild.elementPath,
-    testComponentMetadataChild2.elementPath,
-    testComponentMetadataChild1.elementPath,
     testComponentSceneChildElement.elementPath,
     testComponentSceneChildElementRoot.elementPath,
     testComponentSceneChildElementRootChild.elementPath,
+    testComponentRoot1.elementPath,
+    testComponentMetadataChild1.elementPath,
+    testComponentMetadataChild2.elementPath,
+    testComponentMetadataChild3.elementPath,
+    testComponentMetadataGrandchild.elementPath,
+    testStoryboardChildElement.elementPath,
+    testStoryboardGrandChildElement.elementPath,
   ]
 
   it('with no collapsed paths', () => {
@@ -623,9 +623,9 @@ describe('createOrderedElementPathsFromElements returns all of the ordered navig
 
     expect(actualResult.navigatorTargets).toEqual(expectedNavigatorTargets)
     expect(actualResult.visibleNavigatorTargets).toEqual([
+      testComponentSceneElement.elementPath,
       testStoryboardChildElement.elementPath,
       testStoryboardGrandChildElement.elementPath,
-      testComponentSceneElement.elementPath,
     ])
   })
 
@@ -637,11 +637,11 @@ describe('createOrderedElementPathsFromElements returns all of the ordered navig
 
     expect(actualResult.navigatorTargets).toEqual(expectedNavigatorTargets)
     expect(actualResult.visibleNavigatorTargets).toEqual([
+      testComponentSceneElement.elementPath,
+      testComponentSceneChildElement.elementPath,
+      testComponentRoot1.elementPath,
       testStoryboardChildElement.elementPath,
       testStoryboardGrandChildElement.elementPath,
-      testComponentSceneElement.elementPath,
-      testComponentRoot1.elementPath,
-      testComponentSceneChildElement.elementPath,
     ])
   })
 })

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -754,8 +754,7 @@ export const MetadataUtils = {
     navigatorTargets: Array<ElementPath>
     visibleNavigatorTargets: Array<ElementPath>
   } {
-    // This function exists separately from getAllPaths because the Navigator has a specific
-    // ordering for the paths, which arguably should go in the bin
+    // This function exists separately from getAllPaths because the Navigator handles collapsed views
     let navigatorTargets: Array<ElementPath> = []
     let visibleNavigatorTargets: Array<ElementPath> = []
 
@@ -770,16 +769,15 @@ export const MetadataUtils = {
         unfurledComponents,
       } = MetadataUtils.getAllChildrenIncludingUnfurledFocusedComponents(path, metadata)
       const childrenIncludingFocusedElements = [...children, ...unfurledComponents]
-      const reversedChildren = reverse(childrenIncludingFocusedElements)
 
       const isCollapsed = EP.containsPath(path, collapsedViews)
-      fastForEach(reversedChildren, (childElement) => {
+      fastForEach(childrenIncludingFocusedElements, (childElement) => {
         walkAndAddKeys(childElement, collapsedAncestor || isCollapsed)
       })
     }
 
-    const reverseCanvasRoots = MetadataUtils.getAllStoryboardChildrenPaths(metadata).reverse()
-    fastForEach(reverseCanvasRoots, (childElement) => {
+    const canvasRoots = MetadataUtils.getAllStoryboardChildrenPaths(metadata)
+    fastForEach(canvasRoots, (childElement) => {
       walkAndAddKeys(childElement, false)
     })
 


### PR DESCRIPTION
**Problem:**
Our navigator used ordering similar to Sketch and Figma: elements that are above another are higher in the list. For applications which deal with mostly absolutely positioned layouts, this is not a problem: if you have a layout where things are visually above each other, you have no problem reordering them in the navigator to reflect this relationship. 
However, if you use a layout system (any layout system, really) this becomes a problem: if something is defined "after" something else in the code, it will go after it on screen, but above it in the navigator!

Example:
<img width="900" alt="image" src="https://user-images.githubusercontent.com/2226774/121914037-33707900-cd32-11eb-9e48-663184b69ecc.png">

Here "Beaches" is clearly the topmost element on the page, why is it at the bottom of my navigator?

Figma has the same problem when using Autolayout, and lot of confused users are asking for a solution in their support forums.

We struggled with this question for a long time, and our conclusion is that there is probably no good answer, and this should be a user preference. 

However, in the meantime, I am going to unreverse our navigator just for this week, and create a follow-up ticket to create a user preference entry for this.

**Fix:**
This PR unreverses the navigator, so it will display elements in the same order they are declared in code.

<img width="746" alt="image" src="https://user-images.githubusercontent.com/2226774/121914136-4aaf6680-cd32-11eb-89f8-85072ddbb07d.png">

