### PR TITLE
Fix the parse for asset files in the server.

### DIFF
--- a/server/src/Utopia/Web/ClientModel.hs
+++ b/server/src/Utopia/Web/ClientModel.hs
@@ -63,7 +63,7 @@ data AssetFile = AssetFile
                  deriving (Eq, Show, Generic)
 
 instance FromJSON AssetFile where
-  parseJSON = genericParseJSON defaultOptions
+  parseJSON = const $ pure AssetFile
 
 data ProjectFile = ProjectTextFile TextFile
                  | ProjectImageFile ImageFile


### PR DESCRIPTION
**Problem:**
The server logic for parsing an `ASSET_FILE` was invalid and caused valid project contents parses to fail.

**Fix:**
Always succeed an `AssetFile` parse as it contains zero useful values.

**Commit Details:**
- The `FromJSON` instance for `AssetFile` now just always returns
  an empty `AssetFile` without invoking `genericParseJSON` which was
  failing as it expected to find an array.
