### PR TITLE
make IconToggleButton tippy compatible

### DIFF
--- a/editor/src/uuiui/icon-toggle-button.tsx
+++ b/editor/src/uuiui/icon-toggle-button.tsx
@@ -11,36 +11,39 @@ interface IconToggleButtonProps {
   className?: string
 }
 
-export const IconToggleButton: React.FunctionComponent<IconToggleButtonProps> = (props) => {
-  const { value, onToggle, srcOn, srcOff, className } = props
-  return (
-    <div
-      role='button'
-      tabIndex={0}
-      className={className}
-      css={{
-        width: 22,
-        height: 22,
-        cursor: 'pointer',
-        backgroundColor: 'transparent',
-        backgroundSize: 18,
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat',
-        outline: 'none',
-        border: 'none',
-        backgroundImage: value ? `url(${srcOn})` : `url(${srcOff})`,
-        '&:focus-within': {
+export const IconToggleButton = React.forwardRef<HTMLDivElement, IconToggleButtonProps>(
+  (props, ref) => {
+    const { value, onToggle, srcOn, srcOff, className } = props
+    return (
+      <div
+        ref={ref}
+        role='button'
+        tabIndex={0}
+        className={className}
+        css={{
+          width: 22,
+          height: 22,
+          cursor: 'pointer',
+          backgroundColor: 'transparent',
+          backgroundSize: 18,
+          backgroundPosition: 'center',
+          backgroundRepeat: 'no-repeat',
           outline: 'none',
-        },
-        '&:hover': {
-          backgroundColor: colorTheme.buttonHoverBackground.value,
-        },
-        '&:active': {
-          backgroundImage: value ? `url(${srcOff})` : `url(${srcOn})`,
-          filter: 'brightness(99%)',
-        },
-      }}
-      onClick={onToggle}
-    />
-  )
-}
+          border: 'none',
+          backgroundImage: value ? `url(${srcOn})` : `url(${srcOff})`,
+          '&:focus-within': {
+            outline: 'none',
+          },
+          '&:hover': {
+            backgroundColor: colorTheme.buttonHoverBackground.value,
+          },
+          '&:active': {
+            backgroundImage: value ? `url(${srcOff})` : `url(${srcOn})`,
+            filter: 'brightness(99%)',
+          },
+        }}
+        onClick={onToggle}
+      />
+    )
+  },
+)


### PR DESCRIPTION
**Problem:**
The "mirror selection" button had no working tooltip

**Fix:**
i wrapped IconToggleButton in a forwardRef

<img width="420" alt="image" src="https://user-images.githubusercontent.com/2226774/122039028-856ada80-cdd6-11eb-89db-4bfa63f5b2e6.png">

