### PR TITLE
fix(editor) hide debug and test buttons from production

### DIFF
--- a/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
+++ b/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
@@ -19,7 +19,6 @@ import {
   Button,
 } from '../../../../uuiui'
 import { betterReactMemo } from '../../../../uuiui-deps'
-import { PRODUCTION_CONFIG } from '../../../../common/env-vars'
 
 const StyledFlexRow = styled(FlexRow)({
   height: UtopiaTheme.layout.rowHeight.normal,
@@ -132,19 +131,6 @@ export const SettingsPanel = betterReactMemo('SettingsPanel', () => {
         <label htmlFor='toggleInterfaceDesignerAdditionalCanvasControls'>Additional controls</label>
       </StyledFlexRow>
       <br />
-      {(PRODUCTION_CONFIG as boolean) ? null : (
-        <>
-          <Button outline spotlight onClick={printEditorState}>
-            Print Current Editor State to Console
-          </Button>
-          <Button outline spotlight onClick={printOpenUiJsFileModel}>
-            Print Current Model to Console
-          </Button>
-          <Button outline spotlight onClick={printCanvasMetadata}>
-            Print Latest Metadata / Measurements
-          </Button>
-        </>
-      )}
       <FeatureSwitchesSection />
     </FlexColumn>
   )

--- a/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
+++ b/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
@@ -19,6 +19,7 @@ import {
   Button,
 } from '../../../../uuiui'
 import { betterReactMemo } from '../../../../uuiui-deps'
+import { PRODUCTION_CONFIG } from '../../../../common/env-vars'
 
 const StyledFlexRow = styled(FlexRow)({
   height: UtopiaTheme.layout.rowHeight.normal,
@@ -131,15 +132,19 @@ export const SettingsPanel = betterReactMemo('SettingsPanel', () => {
         <label htmlFor='toggleInterfaceDesignerAdditionalCanvasControls'>Additional controls</label>
       </StyledFlexRow>
       <br />
-      <Button outline spotlight onClick={printEditorState}>
-        Print Current Editor State to Console
-      </Button>
-      <Button outline spotlight onClick={printOpenUiJsFileModel}>
-        Print Current Model to Console
-      </Button>
-      <Button outline spotlight onClick={printCanvasMetadata}>
-        Print Latest Metadata / Measurements
-      </Button>
+      {(PRODUCTION_CONFIG as boolean) ? null : (
+        <>
+          <Button outline spotlight onClick={printEditorState}>
+            Print Current Editor State to Console
+          </Button>
+          <Button outline spotlight onClick={printOpenUiJsFileModel}>
+            Print Current Model to Console
+          </Button>
+          <Button outline spotlight onClick={printCanvasMetadata}>
+            Print Latest Metadata / Measurements
+          </Button>
+        </>
+      )}
       <FeatureSwitchesSection />
     </FlexColumn>
   )

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -1,4 +1,5 @@
 import * as localforage from 'localforage'
+import { PRODUCTION_CONFIG } from '../common/env-vars'
 import { fastForEach, isBrowserEnvironment } from '../core/shared/utils'
 
 export type FeatureName =
@@ -22,8 +23,8 @@ let FeatureSwitches: { [feature: string]: boolean } = {
   'Dragging Shows Overlay': false,
   'Invisible Element Controls': false,
   'Advanced Resize Box': false,
-  'Re-parse Project Button': false,
-  'Performance Test Triggers': true,
+  'Re-parse Project Button': !(PRODUCTION_CONFIG as boolean),
+  'Performance Test Triggers': !(PRODUCTION_CONFIG as boolean),
 }
 
 function settingKeyForName(featureName: FeatureName): string {

--- a/website-next/components/common/env-vars.ts
+++ b/website-next/components/common/env-vars.ts
@@ -6,7 +6,7 @@ export const BARE_HOST = HOST.startsWith('www.') ? HOST.slice(4) : HOST
 export const BASE_URL: string = `${SCHEME}//${HOST}/`
 
 export const PRODUCTION_ENV: boolean = process.env.NODE_ENV === 'production'
-const PRODUCTION_CONFIG: boolean = process.env.REACT_APP_ENVIRONMENT_CONFIG === 'production'
+export const PRODUCTION_CONFIG: boolean = process.env.REACT_APP_ENVIRONMENT_CONFIG === 'production'
 const STAGING_CONFIG: boolean = process.env.REACT_APP_ENVIRONMENT_CONFIG === 'staging'
 const PRODUCTION_OR_STAGING_CONFIG = PRODUCTION_CONFIG || STAGING_CONFIG
 


### PR DESCRIPTION
**Problem:**
Debug and test buttons are useful for development, but should not be visible in production.

**Commit Details:**
- remove buttons for console logging from inspector
- toggle test feature flags based on production environment
