### PR TITLE
Use ETags for project assets and thumbnails.

### DIFF
--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -325,8 +325,8 @@ sendProjectFileContentsResponse filePath contents = \sendResponse ->
 assetCallFold :: Maybe Application -> ServerMonad (Maybe Application) -> ServerMonad (Maybe Application)
 assetCallFold priorResult assetCall = maybe assetCall (\a -> pure $ Just a) priorResult
 
-loadProjectFileEndpoint :: ProjectIdWithSuffix -> [Text] -> ServerMonad Application
-loadProjectFileEndpoint (ProjectIdWithSuffix projectID _) filePath = do
+loadProjectFileEndpoint :: ProjectIdWithSuffix -> Maybe Text -> [Text] -> ServerMonad Application
+loadProjectFileEndpoint (ProjectIdWithSuffix projectID _) possibleETag filePath = do
   let normalizedPath = normalizePath filePath
   -- Check /public/a/b/ before checking /a/b/.
   let pathsToCheck = ["public" : filePath, filePath]
@@ -344,7 +344,7 @@ loadProjectFileEndpoint (ProjectIdWithSuffix projectID _) filePath = do
     (Right Nothing) -> do
       -- Unable to find the file in the project contents.
       -- Speculatively try loading the various paths in order instead.
-      let assetCalls = fmap loadProjectAsset $ fmap (\p -> projectID : p) pathsToCheck
+      let assetCalls = fmap (\proj -> loadProjectAsset proj possibleETag) $ fmap (\p -> projectID : p) pathsToCheck
       let possibleResult = foldlM assetCallFold Nothing assetCalls
       handleNoAsset possibleResult
     (Right (Just ((ProjectTextFile (TextFile{..})), _))) -> do
@@ -354,7 +354,7 @@ loadProjectFileEndpoint (ProjectIdWithSuffix projectID _) filePath = do
     (Right (Just (_, pathFound))) -> do
       -- Found the file in the project contents, so
       -- load the asset from that path.
-      handleNoAsset $ loadProjectAsset (projectID : pathFound)
+      handleNoAsset $ loadProjectAsset (projectID : pathFound) possibleETag
 
 saveProjectAssetEndpoint :: Maybe Text -> ProjectIdWithSuffix -> [Text] -> ServerMonad Application
 saveProjectAssetEndpoint cookie (ProjectIdWithSuffix projectID _) path = requireUser cookie $ \sessionUser -> do
@@ -370,9 +370,9 @@ deleteProjectAssetEndpoint cookie (ProjectIdWithSuffix projectID _) path = requi
   deleteProjectAsset (view id sessionUser) projectID path
   return NoContent
 
-loadProjectThumbnailEndpoint :: ProjectIdWithSuffix -> ServerMonad BL.ByteString
-loadProjectThumbnailEndpoint (ProjectIdWithSuffix projectID _) = do
-  possibleProjectThumbnail <- loadProjectThumbnail projectID
+loadProjectThumbnailEndpoint :: ProjectIdWithSuffix -> Maybe Text -> ServerMonad Application
+loadProjectThumbnailEndpoint (ProjectIdWithSuffix projectID _) possibleETag = do
+  possibleProjectThumbnail <- loadProjectThumbnail projectID possibleETag
   maybe notFound return possibleProjectThumbnail
 
 saveProjectThumbnailEndpoint :: Maybe Text -> ProjectIdWithSuffix -> BL.ByteString -> ServerMonad NoContent

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -21,7 +21,7 @@ import           Data.Pool
 import           Data.String               (String)
 import           Data.Time
 import           Database.Persist.Sql
-import           Network.HTTP.Client
+import           Network.HTTP.Client       hiding (Response)
 import           Network.HTTP.Types.Header
 import           Network.HTTP.Types.Status
 import           Network.Mime
@@ -29,7 +29,7 @@ import           Network.Wai
 import qualified Network.Wreq              as WR
 import           Protolude                 hiding ((<.>))
 import           Servant
-import           Servant.Client
+import           Servant.Client            hiding (Response)
 import           System.Directory
 import           System.Environment
 import           System.FilePath
@@ -184,12 +184,24 @@ saveProjectAssetWithCall metrics pool user projectID assetPath saveCall = do
 getPathMimeType :: [Text] -> MimeType
 getPathMimeType pathElements = maybe defaultMimeType defaultMimeLookup $ lastOf traverse pathElements
 
-loadProjectAssetWithCall :: (MonadIO m, MonadThrow m) => LoadAsset -> [Text] -> m (Maybe Application)
-loadProjectAssetWithCall loadCall assetPath = do
-  possibleAsset <- liftIO $ loadCall assetPath
-  let mimeType = getPathMimeType assetPath
-  let buildResponse asset = responseLBS ok200 [(hContentType, mimeType)] asset
-  pure $ fmap (\asset -> \_ -> \sendResponse -> sendResponse $ buildResponse asset) possibleAsset
+getAssetHeaders :: Maybe [Text] -> Maybe Text -> ResponseHeaders
+getAssetHeaders possibleAssetPath possibleETag =
+  let mimeTypeHeaders = foldMap (\assetPath -> [(hContentType, getPathMimeType assetPath)]) possibleAssetPath
+      etagHeaders = foldMap (\etag -> [(hCacheControl, "public, must-revalidate, proxy-revalidate, max-age=0"), ("ETag", toS etag)]) possibleETag
+  in  mimeTypeHeaders <> etagHeaders
+
+responseFromLoadAssetResult :: [Text] -> LoadAssetResult -> Maybe Response
+responseFromLoadAssetResult _ AssetUnmodified = Just $ responseLBS notModified304 [] mempty
+responseFromLoadAssetResult _ AssetNotFound   = Nothing
+responseFromLoadAssetResult assetPath (AssetLoaded bytes possibleETag) =
+  let headers = getAssetHeaders (Just assetPath) possibleETag
+  in  Just $ responseLBS ok200 headers bytes
+
+loadProjectAssetWithCall :: (MonadIO m, MonadThrow m) => LoadAsset -> [Text] -> Maybe Text -> m (Maybe Application)
+loadProjectAssetWithCall loadCall assetPath possibleETag = do
+  possibleAsset <- liftIO $ loadCall assetPath possibleETag
+  let possibleResponse = responseFromLoadAssetResult assetPath possibleAsset
+  pure $ fmap (\response -> \_ -> \sendResponse -> sendResponse response) possibleResponse
 
 renameProjectAssetWithCall :: (MonadIO m, MonadThrow m) => DB.DatabaseMetrics -> Pool SqlBackend -> Text -> Text -> OldPathText -> NewPathText -> (OldPathText -> NewPathText -> IO ()) -> m ()
 renameProjectAssetWithCall metrics pool user projectID (OldPath oldPath) (NewPath newPath) renameCall = do
@@ -198,6 +210,19 @@ renameProjectAssetWithCall metrics pool user projectID (OldPath oldPath) (NewPat
 deleteProjectAssetWithCall :: (MonadIO m, MonadThrow m) => DB.DatabaseMetrics -> Pool SqlBackend -> Text -> Text -> [Text] -> ([Text] -> IO ()) -> m()
 deleteProjectAssetWithCall metrics pool user projectID assetPath deleteCall = do
   whenProjectOwner metrics pool user projectID $ liftIO $ deleteCall (projectID : assetPath)
+
+responseFromLoadThumbnailResult :: LoadAssetResult -> Maybe Response
+responseFromLoadThumbnailResult AssetUnmodified = Just $ responseLBS notModified304 [] mempty
+responseFromLoadThumbnailResult AssetNotFound   = Nothing
+responseFromLoadThumbnailResult (AssetLoaded bytes possibleETag) =
+  let headers = getAssetHeaders Nothing possibleETag
+  in  Just $ responseLBS ok200 headers bytes
+
+loadProjectThumbnailWithCall :: (MonadIO m, MonadThrow m) => LoadThumbnail -> Text -> Maybe Text -> m (Maybe Application)
+loadProjectThumbnailWithCall loadCall projectID possibleETag = do
+  possibleThumbnail <- liftIO $ loadCall projectID possibleETag
+  let possibleResponse = responseFromLoadThumbnailResult possibleThumbnail
+  pure $ fmap (\response -> \_ -> \sendResponse -> sendResponse response) possibleResponse
 
 saveProjectThumbnailWithCall :: (MonadIO m, MonadThrow m) => DB.DatabaseMetrics -> Pool SqlBackend -> Text -> Text -> BL.ByteString -> (Text -> BL.ByteString -> IO ()) -> m ()
 saveProjectThumbnailWithCall metrics pool user projectID thumbnail saveCall = do

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -188,10 +188,10 @@ innerServerExecutor (SetShowcaseProjects showcaseProjects next) = do
   pool <- fmap _projectPool ask
   metrics <- fmap _databaseMetrics ask
   setShowcaseProjectsWithPool metrics pool showcaseProjects next
-innerServerExecutor (LoadProjectAsset path action) = do
+innerServerExecutor (LoadProjectAsset path possibleETag action) = do
   awsResource <- fmap _awsResources ask
   let loadCall = maybe loadProjectAssetFromDisk loadProjectAssetFromS3 awsResource
-  application <- loadProjectAssetWithCall loadCall path
+  application <- loadProjectAssetWithCall loadCall path possibleETag
   return $ action application
 innerServerExecutor (SaveProjectAsset user projectID path action) = do
   awsResource <- fmap _awsResources ask
@@ -214,11 +214,11 @@ innerServerExecutor (DeleteProjectAsset user projectID path next) = do
   let deleteCall = maybe deleteProjectAssetOnDisk deleteProjectAssetOnS3 awsResource
   liftIO $ deleteProjectAssetWithCall metrics pool user projectID path deleteCall
   return next
-innerServerExecutor (LoadProjectThumbnail projectID action) = do
+innerServerExecutor (LoadProjectThumbnail projectID possibleETag action) = do
   awsResource <- fmap _awsResources ask
   let loadCall = maybe loadProjectThumbnailFromDisk loadProjectThumbnailFromS3 awsResource
-  loadedThumbnail <- liftIO $ loadCall projectID
-  return $ action loadedThumbnail
+  application <- loadProjectThumbnailWithCall loadCall projectID possibleETag
+  return $ action application
 innerServerExecutor (SaveProjectThumbnail user projectID thumbnail next) = do
   pool <- fmap _projectPool ask
   awsResource <- fmap _awsResources ask

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -131,9 +131,9 @@ innerServerExecutor (SetShowcaseProjects showcaseProjects next) = do
   pool <- fmap _projectPool ask
   metrics <- fmap _databaseMetrics ask
   setShowcaseProjectsWithPool metrics pool showcaseProjects next
-innerServerExecutor (LoadProjectAsset path action) = do
+innerServerExecutor (LoadProjectAsset path possibleETag action) = do
   awsResource <- fmap _awsResources ask
-  application <- loadProjectAssetWithCall (loadProjectAssetFromS3 awsResource) path
+  application <- loadProjectAssetWithCall (loadProjectAssetFromS3 awsResource) path possibleETag
   return $ action application
 innerServerExecutor (SaveProjectAsset user projectID path action) = do
   pool <- fmap _projectPool ask
@@ -153,10 +153,10 @@ innerServerExecutor (DeleteProjectAsset user projectID path next) = do
   metrics <- fmap _databaseMetrics ask
   liftIO $ deleteProjectAssetWithCall metrics pool user projectID path (deleteProjectAssetOnS3 awsResource)
   return next
-innerServerExecutor (LoadProjectThumbnail projectID action) = do
+innerServerExecutor (LoadProjectThumbnail projectID possibleETag action) = do
   awsResource <- fmap _awsResources ask
-  loadedThumbnail <- liftIO $ loadProjectThumbnailFromS3 awsResource projectID
-  return $ action loadedThumbnail
+  application <- loadProjectThumbnailWithCall (loadProjectThumbnailFromS3 awsResource) projectID possibleETag
+  return $ action application
 innerServerExecutor (SaveProjectThumbnail user projectID thumbnail next) = do
   pool <- fmap _projectPool ask
   awsResource <- fmap _awsResources ask

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -100,11 +100,11 @@ data ServiceCallsF a = NotFound
                      | CreateProject (Text -> a)
                      | SaveProject SessionUser Text (Maybe Text) (Maybe Value) a
                      | DeleteProject SessionUser Text a
-                     | LoadProjectAsset [Text] (Maybe Application -> a)
+                     | LoadProjectAsset [Text] (Maybe Text) (Maybe Application -> a)
                      | SaveProjectAsset Text Text [Text] (Application -> a)
                      | RenameProjectAsset Text Text OldPathText NewPathText a
                      | DeleteProjectAsset Text Text [Text] a
-                     | LoadProjectThumbnail Text (Maybe BL.ByteString -> a)
+                     | LoadProjectThumbnail Text (Maybe Text) (Maybe Application -> a)
                      | SaveProjectThumbnail Text Text BL.ByteString a
                      | GetProxyManager (Maybe Manager -> a)
                      | GetProjectsForUser Text ([ProjectListing] -> a)

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -71,7 +71,7 @@ type EmptyProjectPageAPI = "p" :> BranchNameParam :> Get '[HTML] H.Html
 
 type ProjectPageAPI = "p" :> Capture "project_id" ProjectIdWithSuffix :> BranchNameParam :> Get '[HTML] H.Html
 
-type LoadProjectFileAPI = "p" :> Capture "project_id" ProjectIdWithSuffix :> CaptureAll "file_path" Text :> RawM
+type LoadProjectFileAPI = "p" :> Capture "project_id" ProjectIdWithSuffix :> Header "If-None-Match" Text :> CaptureAll "file_path" Text :> RawM
 
 type EmptyPreviewPageAPI = "share" :> BranchNameParam :> Get '[HTML] H.Html
 
@@ -103,7 +103,7 @@ type ShowcaseAPI = "v1" :> "showcase" :> Get '[JSON] ProjectListResponse
 
 type SetShowcaseAPI = "v1" :> "showcase" :> "overwrite" :> QueryParam' '[Required] "projects" Text :> Post '[JSON] NoContent
 
-type PreviewProjectFileAPI = "share" :> Capture "project_id" ProjectIdWithSuffix :> CaptureAll "file_path" Text :> RawM
+type PreviewProjectFileAPI = "share" :> Capture "project_id" ProjectIdWithSuffix :> Header "If-None-Match" Text :> CaptureAll "file_path" Text :> RawM
 
 type RenameProjectAssetAPI = "v1" :> "asset" :> Capture "project_id" ProjectIdWithSuffix :> CaptureAll "path" Text :> QueryParam' '[Required] "old_file_name" Text :> Put '[JSON] NoContent
 
@@ -111,7 +111,7 @@ type DeleteProjectAssetAPI = "v1" :> "asset" :> Capture "project_id" ProjectIdWi
 
 type SaveProjectAssetAPI = "v1" :> "asset" :> Capture "project_id" ProjectIdWithSuffix :> CaptureAll "path" Text :> RawM
 
-type LoadProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" ProjectIdWithSuffix :> Get '[BMP, GIF, JPG, PNG, SVG] BL.ByteString
+type LoadProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" ProjectIdWithSuffix :> Header "If-None-Match" Text :> RawM
 
 type SaveProjectThumbnailAPI = "v1" :> "thumbnail" :> Capture "project_id" ProjectIdWithSuffix :> ReqBody '[BMP, GIF, JPG, PNG, SVG] BL.ByteString :> Post '[JSON] NoContent
 


### PR DESCRIPTION
Fixes #1350

**Problem:**
Project assets (and thumbnails) currently lack any kind of caching, causing them to be fully loaded each time they are referenced.

**Fix:**
Now the `ETag` and `Cache-Control` headers are appropriately supplied if they can be in the response and `If-None-Match` is handled in the requests for assets and thumbnails.

**Commit Details:**
- Fixes #1350.
- `LoadAsset` type changed to include the concept of the asset
  being unmodified into the return type.
- `loadFileFromS3` now incorporates the ability to send the ETag
  header to S3 and to handle the 304 response that it may return.
- `loadProjectAssetWithCall` refactored and broken apart to handle
  the `LoadAssetResponse` value and for some of the functionality
  to be reused in the new `loadProjectThumbnailWithCall`.
- `LoadProjectAsset` and `LoadProjectThumbnail` service types updated.
- Endpoints and their types now include handling for the
  `If-None-Match` header.
