### PR TITLE
quick fix: reduce user state polling

### DIFF
--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -398,6 +398,8 @@ export async function downloadGithubRepo(
 
 const loginLostNoticeID: string = 'login-lost-notice'
 
+const LoginStatePollingInterval = 30 * 1000
+
 export function startPollingLoginState(
   dispatch: EditorDispatch,
   initialLoginState: LoginState,
@@ -436,5 +438,5 @@ export function startPollingLoginState(
       }
     }
     previousLoginState = loginState
-  }, 5000)
+  }, LoginStatePollingInterval)
 }


### PR DESCRIPTION
**Problem:**
Every open editor session pings the server every 5 seconds to query login state. This puts load on the infra.

**Fix:**
Reduce the polling rate to 30 seconds. This is at best a temporary solution, because if the user enters a "Login lost" state, and then logs back in again, the "You have been logged out of Utopia." sidebar will stick around for up to 30 seconds.

I am open to merging this or not merging this too – let's discuss!
