### PR TITLE
Fix an undefined error in the dom walker

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -476,7 +476,9 @@ function useGetStoryboardRoot(
           transientFilesState,
           resolve,
         )
-  const storyboardRootElementPath = useKeepReferenceEqualityIfPossible(validPaths[0]) // >:D
+  const storyboardRootElementPath = useKeepReferenceEqualityIfPossible(
+    validPaths[0] ?? EP.emptyElementPath,
+  )
 
   return {
     StoryboardRootComponent: StoryboardRootComponent,


### PR DESCRIPTION
**Problem:**
When we first render the canvas after removing an error overlay, we return `undefined` for `storyboardRootElementPath` as a result of indexing into an empty array. This causes an error much later during DOM walking when trying to use that `ElementPath`. 

**Fix:**
If the array is empty, return `EP.emptyElementPath`.