### PR TITLE
Support transient unset property from the Inspector

### DIFF
--- a/editor/src/components/inspector/common/property-controls-hooks.ts
+++ b/editor/src/components/inspector/common/property-controls-hooks.ts
@@ -85,7 +85,7 @@ export function useInspectorInfoForPropertyControl(
   const onSubmitValue = React.useCallback(
     (newValue: any, transient = false) => {
       if (newValue == null) {
-        onSingleUnsetValue(propertyPath)
+        onSingleUnsetValue(propertyPath, transient)
       } else {
         const printedValue = printerFn(newValue)
         onSingleSubmitValue(printedValue, propertyPath, transient)
@@ -101,7 +101,7 @@ export function useInspectorInfoForPropertyControl(
   const useSubmitValueFactory = useCallbackFactory(parsedValue, onSubmitValue)
 
   const onUnsetValues = React.useCallback(() => {
-    onSingleUnsetValue(propertyPath)
+    onSingleUnsetValue(propertyPath, false)
   }, [onSingleUnsetValue, propertyPath])
 
   return {

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -118,7 +118,7 @@ export interface InspectorPropsContextData {
 export interface InspectorCallbackContextData {
   selectedViewsRef: ReadonlyRef<Array<ElementPath>>
   onSubmitValue: (newValue: any, propertyPath: PropertyPath, transient: boolean) => void
-  onUnsetValue: (propertyPath: PropertyPath | Array<PropertyPath>) => void
+  onUnsetValue: (propertyPath: PropertyPath | Array<PropertyPath>, transient: boolean) => void
 }
 
 export const InspectorPropsContext = createContext<InspectorPropsContextData>({
@@ -370,7 +370,10 @@ export function useInspectorStyleInfo<P extends ParsedCSSPropertiesKeys>(
 export function useInspectorContext(): {
   selectedViewsRef: ReadonlyRef<Array<ElementPath>>
   onContextSubmitValue: (newValue: any, propertyPath: PropertyPath, transient: boolean) => void
-  onContextUnsetValue: (propertyPath: PropertyPath | Array<PropertyPath>) => void
+  onContextUnsetValue: (
+    propertyPath: PropertyPath | Array<PropertyPath>,
+    transient: boolean,
+  ) => void
 } {
   const { onSubmitValue, onUnsetValue, selectedViewsRef } = React.useContext(
     InspectorCallbackContext,
@@ -520,7 +523,10 @@ export function useInspectorInfo<P extends ParsedPropertiesKeys, T = ParsedPrope
     useContextSelector(InspectorPropsContext, (contextData) => contextData.targetPath, deepEqual),
   )
   const onUnsetValues = React.useCallback(() => {
-    onUnsetValue(propKeys.map((propKey) => pathMappingFn(propKey, target)))
+    onUnsetValue(
+      propKeys.map((propKey) => pathMappingFn(propKey, target)),
+      false,
+    )
   }, [onUnsetValue, propKeys, pathMappingFn, target])
 
   const transformedValue = transformValue(values)
@@ -561,7 +567,7 @@ function useCreateOnSubmitValue<P extends ParsedPropertiesKeys, T = ParsedProper
   pathMappingFn: PathMappingFn<P>,
   target: readonly string[],
   onSingleSubmitValue: (newValue: any, propertyPath: PropertyPath, transient: boolean) => void,
-  onUnsetValue: (propertyPath: PropertyPath | Array<PropertyPath>) => void,
+  onUnsetValue: (propertyPath: PropertyPath | Array<PropertyPath>, transient: boolean) => void,
 ): (newValue: T, transient?: boolean | undefined) => void {
   return React.useCallback(
     (newValue, transient = false) => {
@@ -573,7 +579,7 @@ function useCreateOnSubmitValue<P extends ParsedPropertiesKeys, T = ParsedProper
           const printedProperty = printCSSValue(propKey, valueToPrint as ParsedProperties[P])
           onSingleSubmitValue(printedProperty, propertyPath, transient)
         } else {
-          onUnsetValue(propertyPath)
+          onUnsetValue(propertyPath, transient)
         }
       })
     },
@@ -877,7 +883,7 @@ export function useInspectorInfoSimpleUntyped(
 
   const onUnsetValues = React.useCallback(() => {
     for (const propertyPath of propertyPaths) {
-      onSingleUnsetValue(propertyPath)
+      onSingleUnsetValue(propertyPath, false)
     }
   }, [onSingleUnsetValue, propertyPaths])
 
@@ -894,7 +900,7 @@ export function useInspectorInfoSimpleUntyped(
           const printedProperty = maybePrintCSSValue(property, propertyToPrint)
           onSingleSubmitValue(printedProperty, path, transient)
         } else {
-          onSingleUnsetValue(path)
+          onSingleUnsetValue(path, transient)
         }
       }) as (path: PropertyPath) => void
       propertyPaths.forEach(submitValue)

--- a/editor/src/components/inspector/controls/color-picker.tsx
+++ b/editor/src/components/inspector/controls/color-picker.tsx
@@ -291,7 +291,7 @@ export class ColorPickerInner extends React.Component<
       const origin = this.SVControlRef.current.getBoundingClientRect()
       this.SVOrigin = { x: origin.left, y: origin.top } as WindowPoint
 
-      this.setSVFromClientPosition(e.clientX, e.clientY, false)
+      this.setSVFromClientPosition(e.clientX, e.clientY, true)
 
       document.addEventListener('mousemove', this.onSVMouseMove)
       document.addEventListener('mouseup', this.onSVMouseUp)

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -598,17 +598,19 @@ export const InspectorContextProvider = betterReactMemo<{
   )
 
   const onUnsetValue = React.useCallback(
-    (property: PropertyPath | Array<PropertyPath>) => {
-      let actions: Array<EditorAction> = []
+    (property: PropertyPath | Array<PropertyPath>, transient: boolean) => {
+      let actionsArray: Array<EditorAction> = []
       Utils.fastForEach(refElementsToTargetForUpdates.current, (elem) => {
         if (Array.isArray(property)) {
           Utils.fastForEach(property, (p) => {
-            actions.push(unsetProperty(elem, p))
+            actionsArray.push(unsetProperty(elem, p))
           })
         } else {
-          actions.push(unsetProperty(elem, property))
+          actionsArray.push(unsetProperty(elem, property))
         }
       })
+
+      const actions: EditorAction[] = transient ? [transientActions(actionsArray)] : actionsArray
       dispatch(actions, 'everyone')
     },
     [dispatch, refElementsToTargetForUpdates],

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -281,7 +281,7 @@ const layoutSystemConfigPropertyPaths = [
 function useDeleteAllLayoutConfig() {
   const { onUnsetValue } = React.useContext(InspectorCallbackContext)
   return React.useCallback(() => {
-    onUnsetValue(layoutSystemConfigPropertyPaths)
+    onUnsetValue(layoutSystemConfigPropertyPaths, false)
   }, [onUnsetValue])
 }
 


### PR DESCRIPTION
Second part of the fix to #1408

**Problem:**
Whilst the inspector supports transient updates to set properties (meaning those won't trigger the full code printing and vscode updating process) for the sake of performance (e.g. when scrubbing values), it didn't support transient unsetting of properties. Scrubbing the colour picker happens to unset some values because of some deeper logic in the Inspector (it can set backgroundImage as well as backgroundColor, so if there is no backgroundImage it _unsets_ that).

**Fix:**
Support the `unsetValue` wrapping the dispatched actions in a `transientActions` like we do with `setValue`
