### PR TITLE
Support spread operators at the root of an element.

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -21,8 +21,8 @@ exports[`UiJsxCanvas #747 - DOM object constructor cannot be called as a functio
     data-uid=\\"scene sb\\"
   >
     <div
-      data-uid=\\"comment-root 1d1~~~1 app\\"
-      data-paths=\\"1d1~~~1:comment-root 1d1~~~1 sb/scene/app\\"
+      data-uid=\\"comment-root 9dc~~~1 app\\"
+      data-paths=\\"9dc~~~1:comment-root 9dc~~~1 sb/scene/app\\"
     >
       hat
     </div>
@@ -68,6 +68,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -95,6 +96,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -110,6 +112,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -222,6 +225,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -83,6 +83,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -98,6 +99,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -131,6 +133,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -152,6 +155,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -258,6 +262,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -273,6 +278,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -399,6 +405,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -414,6 +421,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-label",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -493,6 +501,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -565,6 +574,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -670,6 +680,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -685,6 +696,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -785,6 +797,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -800,6 +813,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -900,6 +914,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -915,6 +930,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1064,6 +1080,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -1079,6 +1096,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -1112,6 +1130,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1133,6 +1152,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1239,6 +1259,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1254,6 +1275,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1372,6 +1394,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1440,6 +1463,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1455,6 +1479,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1563,9 +1588,9 @@ exports[`UiJsxCanvas render Renders input tag without errors 1`] = `
     data-uid=\\"scene-aaa utopia-storyboard-uid\\"
   >
     <input
-      data-uid=\\"5f4 567 app-entity\\"
+      data-uid=\\"78b 567 app-entity\\"
       style=\\"top: 10px;\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:567:5f4 utopia-storyboard-uid/scene-aaa/app-entity:567 utopia-storyboard-uid/scene-aaa/app-entity\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:567:78b utopia-storyboard-uid/scene-aaa/app-entity:567 utopia-storyboard-uid/scene-aaa/app-entity\\"
     />
   </div>
 </div>
@@ -1609,6 +1634,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -1624,6 +1650,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -1657,6 +1684,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1678,6 +1706,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1784,6 +1813,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1799,6 +1829,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1917,6 +1948,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -2094,6 +2126,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -2109,6 +2142,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -2142,6 +2176,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -2163,6 +2198,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -2269,6 +2305,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -2284,6 +2321,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -2461,6 +2499,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -2541,6 +2580,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -2690,6 +2730,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -2840,6 +2881,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -2990,6 +3032,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -3206,6 +3249,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -3221,6 +3265,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -3254,6 +3299,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -3275,6 +3321,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -3381,6 +3428,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -3396,6 +3444,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -3588,6 +3637,7 @@ Object {
                               "trailingComments": Array [],
                             },
                             "key": "data-uid",
+                            "type": "JSX_ATTRIBUTES_ENTRY",
                             "value": Object {
                               "comments": Object {
                                 "leadingComments": Array [],
@@ -3674,6 +3724,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -3769,6 +3820,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -3933,6 +3985,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -4019,6 +4072,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -4175,6 +4229,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -4332,6 +4387,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -4489,6 +4545,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -4655,6 +4712,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -4741,6 +4799,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -4897,6 +4956,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -5054,6 +5114,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -5211,6 +5272,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -5377,6 +5439,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -5463,6 +5526,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -5619,6 +5683,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -5776,6 +5841,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -5933,6 +5999,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -6093,6 +6160,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -6108,6 +6176,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -6141,6 +6210,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -6162,6 +6232,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -6268,6 +6339,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -6283,6 +6355,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -6432,6 +6505,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -6460,6 +6534,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -6487,6 +6562,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -6585,6 +6661,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -6684,6 +6761,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -6831,6 +6909,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -6846,6 +6925,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -6879,6 +6959,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -6900,6 +6981,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -7006,6 +7088,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -7021,6 +7104,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -7139,6 +7223,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -7209,6 +7294,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -7380,6 +7466,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -7395,6 +7482,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -7428,6 +7516,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -7449,6 +7538,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -7555,6 +7645,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -7570,6 +7661,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -7697,6 +7789,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -7712,6 +7805,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "title",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "definedElsewhere": Array [
                         "n",
@@ -7836,6 +7930,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -7938,6 +8033,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -7953,6 +8049,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "n",
@@ -8110,6 +8207,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -8125,6 +8223,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "n",
@@ -8282,6 +8381,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -8297,6 +8397,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "n",
@@ -8520,6 +8621,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -8535,6 +8637,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -8568,6 +8671,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -8589,6 +8693,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -8695,6 +8800,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -8710,6 +8816,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -8837,6 +8944,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -8852,6 +8960,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "title",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "definedElsewhere": Array [
                         "n",
@@ -8976,6 +9085,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -9078,6 +9188,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -9093,6 +9204,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "n",
@@ -9250,6 +9362,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -9265,6 +9378,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "n",
@@ -9422,6 +9536,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -9437,6 +9552,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "n",
@@ -9654,6 +9770,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -9669,6 +9786,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -9702,6 +9820,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -9723,6 +9842,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -9829,6 +9949,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -9844,6 +9965,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -9993,6 +10115,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -10021,6 +10144,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -10048,6 +10172,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -10146,6 +10271,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -10259,6 +10385,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -10432,6 +10559,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -10447,6 +10575,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -10480,6 +10609,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -10501,6 +10631,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -10607,6 +10738,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -10622,6 +10754,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -10749,6 +10882,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -10829,6 +10963,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -10927,6 +11062,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -11040,6 +11176,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -11214,6 +11351,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -11229,6 +11367,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -11248,6 +11387,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "title",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -11275,6 +11415,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -11296,6 +11437,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -11402,6 +11544,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -11417,6 +11560,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -11436,6 +11580,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -11564,6 +11709,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -11579,6 +11725,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -11597,6 +11744,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "title",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "definedElsewhere": Array [
                     "props",
@@ -11671,6 +11819,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -11769,6 +11918,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -11877,6 +12027,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -11892,6 +12043,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -11910,6 +12062,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "props",
@@ -12135,6 +12288,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -12150,6 +12304,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -12169,6 +12324,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "title",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -12196,6 +12352,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -12217,6 +12374,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -12323,6 +12481,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -12338,6 +12497,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -12357,6 +12517,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -12485,6 +12646,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -12500,6 +12662,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -12518,6 +12681,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "title",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "definedElsewhere": Array [
                     "props",
@@ -12592,6 +12756,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -12690,6 +12855,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -12798,6 +12964,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -12813,6 +12980,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -12831,6 +12999,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "props",
@@ -13057,6 +13226,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -13072,6 +13242,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -13091,6 +13262,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "title",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -13118,6 +13290,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -13139,6 +13312,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -13245,6 +13419,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -13260,6 +13435,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -13279,6 +13455,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -13407,6 +13584,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -13422,6 +13600,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -13440,6 +13619,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "titles",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -13562,6 +13742,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -13660,6 +13841,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -13768,6 +13950,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -13783,6 +13966,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -13801,6 +13985,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "titles",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -14081,6 +14266,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -14096,6 +14282,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -14115,6 +14302,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "title",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -14142,6 +14330,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -14163,6 +14352,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -14269,6 +14459,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -14284,6 +14475,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -14303,6 +14495,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -14431,6 +14624,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -14446,6 +14640,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -14464,6 +14659,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "titles",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -14586,6 +14782,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -14684,6 +14881,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -14792,6 +14990,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -14807,6 +15006,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -14825,6 +15025,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "titles",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -15091,6 +15292,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -15106,6 +15308,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -15139,6 +15342,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -15160,6 +15364,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -15266,6 +15471,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -15281,6 +15487,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -15399,6 +15606,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -15680,6 +15888,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -15695,6 +15904,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -15728,6 +15938,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -15749,6 +15960,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -15855,6 +16067,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -15870,6 +16083,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -16136,6 +16350,7 @@ export var storyboard = (props) => {
                           "trailingComments": Array [],
                         },
                         "key": "data-uid",
+                        "type": "JSX_ATTRIBUTES_ENTRY",
                         "value": Object {
                           "comments": Object {
                             "leadingComments": Array [],
@@ -16151,6 +16366,7 @@ export var storyboard = (props) => {
                           "trailingComments": Array [],
                         },
                         "key": "data-label",
+                        "type": "JSX_ATTRIBUTES_ENTRY",
                         "value": Object {
                           "definedElsewhere": Array [
                             "pair",
@@ -16291,6 +16507,7 @@ export var storyboard = (props) => {
                               "trailingComments": Array [],
                             },
                             "key": "data-uid",
+                            "type": "JSX_ATTRIBUTES_ENTRY",
                             "value": Object {
                               "comments": Object {
                                 "leadingComments": Array [],
@@ -16306,6 +16523,7 @@ export var storyboard = (props) => {
                               "trailingComments": Array [],
                             },
                             "key": "shortcut",
+                            "type": "JSX_ATTRIBUTES_ENTRY",
                             "value": Object {
                               "definedElsewhere": Array [
                                 "pair",
@@ -16443,6 +16661,7 @@ export var storyboard = (props) => {
                           "trailingComments": Array [],
                         },
                         "key": "data-uid",
+                        "type": "JSX_ATTRIBUTES_ENTRY",
                         "value": Object {
                           "comments": Object {
                             "leadingComments": Array [],
@@ -16458,6 +16677,7 @@ export var storyboard = (props) => {
                           "trailingComments": Array [],
                         },
                         "key": "data-label",
+                        "type": "JSX_ATTRIBUTES_ENTRY",
                         "value": Object {
                           "definedElsewhere": Array [
                             "pair",
@@ -16737,6 +16957,7 @@ export var storyboard = (props) => {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -16764,6 +16985,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -17065,6 +17287,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -17311,6 +17534,7 @@ export var storyboard = (props) => {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -17326,6 +17550,7 @@ export var storyboard = (props) => {
                       "trailingComments": Array [],
                     },
                     "key": "data-label",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "definedElsewhere": Array [
                         "pair",
@@ -17466,6 +17691,7 @@ export var storyboard = (props) => {
                           "trailingComments": Array [],
                         },
                         "key": "data-uid",
+                        "type": "JSX_ATTRIBUTES_ENTRY",
                         "value": Object {
                           "comments": Object {
                             "leadingComments": Array [],
@@ -17481,6 +17707,7 @@ export var storyboard = (props) => {
                           "trailingComments": Array [],
                         },
                         "key": "shortcut",
+                        "type": "JSX_ATTRIBUTES_ENTRY",
                         "value": Object {
                           "definedElsewhere": Array [
                             "pair",
@@ -17618,6 +17845,7 @@ export var storyboard = (props) => {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -17633,6 +17861,7 @@ export var storyboard = (props) => {
                       "trailingComments": Array [],
                     },
                     "key": "data-label",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "definedElsewhere": Array [
                         "pair",
@@ -17912,6 +18141,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -18146,6 +18376,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -18161,6 +18392,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "pair",
@@ -18493,6 +18725,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -18508,6 +18741,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "pair",
@@ -18840,6 +19074,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -18855,6 +19090,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "pair",
@@ -19068,6 +19304,7 @@ export var storyboard = (props) => {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -19083,6 +19320,7 @@ export var storyboard = (props) => {
                   "trailingComments": Array [],
                 },
                 "key": "shortcut",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "definedElsewhere": Array [
                     "pair",
@@ -19220,6 +19458,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -19235,6 +19474,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "pair",
@@ -19450,6 +19690,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -19465,6 +19706,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "shortcut",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "pair",
@@ -19699,6 +19941,7 @@ export var storyboard = (props) => {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -19714,6 +19957,7 @@ export var storyboard = (props) => {
                   "trailingComments": Array [],
                 },
                 "key": "shortcut",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "definedElsewhere": Array [
                     "pair",
@@ -19851,6 +20095,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -19866,6 +20111,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "pair",
@@ -20077,6 +20323,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -20092,6 +20339,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "shortcut",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "pair",
@@ -20322,6 +20570,7 @@ export var storyboard = (props) => {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -20337,6 +20586,7 @@ export var storyboard = (props) => {
                   "trailingComments": Array [],
                 },
                 "key": "shortcut",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "definedElsewhere": Array [
                     "pair",
@@ -20474,6 +20724,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -20489,6 +20740,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "pair",
@@ -20700,6 +20952,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -20715,6 +20968,7 @@ export var storyboard = (props) => {
               "trailingComments": Array [],
             },
             "key": "shortcut",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "pair",
@@ -21003,6 +21257,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -21018,6 +21273,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -21051,6 +21307,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -21072,6 +21329,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -21178,6 +21436,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -21193,6 +21452,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -21342,6 +21602,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -21357,6 +21618,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "name",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -21385,6 +21647,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -21400,6 +21663,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "name",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -21427,6 +21691,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -21525,6 +21790,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -21540,6 +21806,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "name",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -21654,6 +21921,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -21669,6 +21937,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "name",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -21832,6 +22101,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -21847,6 +22117,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -21880,6 +22151,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -21901,6 +22173,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -22007,6 +22280,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -22022,6 +22296,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -22140,6 +22415,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "ref",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "console",
@@ -22202,6 +22478,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -22348,6 +22625,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -22363,6 +22641,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -22396,6 +22675,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -22417,6 +22697,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -22523,6 +22804,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -22538,6 +22820,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -22656,6 +22939,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "ref",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "console",
@@ -22713,6 +22997,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -22781,6 +23066,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -22943,6 +23229,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -22970,6 +23257,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -22985,6 +23273,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -23097,6 +23386,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -23226,6 +23516,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -23241,6 +23532,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "thing",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "definedElsewhere": Array [
                     "React",
@@ -23317,6 +23609,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -23332,6 +23625,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -23439,6 +23733,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -23454,6 +23749,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "thing",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "React",
@@ -23711,6 +24007,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -23726,6 +24023,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -23759,6 +24057,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -23780,6 +24079,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -23886,6 +24186,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -23901,6 +24202,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -24038,6 +24340,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "style",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -24059,6 +24362,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -24086,6 +24390,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -24101,6 +24406,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -24133,6 +24439,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -24151,6 +24458,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -24275,6 +24583,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -24296,6 +24605,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -24323,6 +24633,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -24338,6 +24649,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -24462,6 +24774,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -24483,6 +24796,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -24655,6 +24969,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -24670,6 +24985,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -24689,6 +25005,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "title",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -24716,6 +25033,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -24737,6 +25055,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -24843,6 +25162,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -24858,6 +25178,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -24877,6 +25198,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -25011,6 +25333,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -25028,6 +25351,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -25055,6 +25379,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -25152,6 +25477,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -25266,6 +25592,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -25283,6 +25610,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -25455,6 +25783,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -25470,6 +25799,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -25503,6 +25833,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -25524,6 +25855,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -25630,6 +25962,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -25645,6 +25978,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -25772,6 +26106,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -25787,6 +26122,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "title",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "definedElsewhere": Array [
                         "n",
@@ -25911,6 +26247,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -26013,6 +26350,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -26028,6 +26366,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "n",
@@ -26185,6 +26524,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -26200,6 +26540,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "n",
@@ -26357,6 +26698,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -26372,6 +26714,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "n",
@@ -26595,6 +26938,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -26610,6 +26954,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -26643,6 +26988,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -26664,6 +27010,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -26770,6 +27117,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -26785,6 +27133,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -26912,6 +27261,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -26927,6 +27277,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "title",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "definedElsewhere": Array [
                         "div",
@@ -27052,6 +27403,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -27154,6 +27506,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -27169,6 +27522,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "div",
@@ -27327,6 +27681,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -27342,6 +27697,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "div",
@@ -27500,6 +27856,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -27515,6 +27872,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "div",
@@ -27739,6 +28097,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -27754,6 +28113,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -27787,6 +28147,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -27808,6 +28169,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -27914,6 +28276,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -27929,6 +28292,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -28057,6 +28421,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -28072,6 +28437,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "title",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "definedElsewhere": Array [
                         "n",
@@ -28202,6 +28568,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -28304,6 +28671,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -28319,6 +28687,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "n",
@@ -28476,6 +28845,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -28491,6 +28861,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "n",
@@ -28648,6 +29019,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -28663,6 +29035,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "n",
@@ -28801,6 +29174,773 @@ Object {
 }
 `;
 
+exports[`UiJsxCanvas render renders a component using the spread operator 1`] = `
+"<div
+  id=\\"canvas-container\\"
+  style=\\"all: initial; position: absolute;\\"
+  data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
+>
+  <div
+    data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
+    data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+    style=\\"
+      position: absolute;
+      background-color: rgba(255, 255, 255, 1);
+      box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+      height: 200px;
+      left: 59px;
+      width: 200px;
+      top: 79px;
+    \\"
+    data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+  >
+    <div
+      style=\\"position: absolute; height: 99.9; width: 77.7;\\"
+      title=\\"Hi there!\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+      data-uid=\\"aaa app-entity\\"
+    >
+      <div
+        style=\\"position: absolute;\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
+        data-uid=\\"bbb\\"
+      >
+        hi
+      </div>
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`UiJsxCanvas render renders a component using the spread operator 2`] = `
+Object {
+  "utopia-storyboard-uid/scene-aaa": Object {
+    "attributeMetadatada": Object {},
+    "children": Array [
+      Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+        ],
+        "type": "elementpath",
+      },
+    ],
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "App",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "app-entity",
+                },
+              },
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": Object {
+                    "height": "99.9",
+                    "position": "absolute",
+                    "width": "77.7",
+                  },
+                },
+              },
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "title",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "Hi there!",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "app-entity",
+          },
+        ],
+        "name": Object {
+          "baseVariable": "Scene",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": Object {
+                "height": 200,
+                "left": 59,
+                "position": "absolute",
+                "top": 79,
+                "width": 200,
+              },
+            },
+          },
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "scene-aaa",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "scene-aaa",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "Scene",
+        "path": "utopia-api",
+        "variableName": "Scene",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
+      "skipDeepFreeze": true,
+      "style": Object {
+        "height": 200,
+        "left": 59,
+        "position": "absolute",
+        "top": 79,
+        "width": 200,
+      },
+    },
+    "rootElements": Array [],
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity": Object {
+    "attributeMetadatada": Object {},
+    "children": Array [],
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "App",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "app-entity",
+            },
+          },
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": Object {
+                "height": "99.9",
+                "position": "absolute",
+                "width": "77.7",
+              },
+            },
+          },
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "title",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "Hi there!",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "app-entity",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "LEFT",
+      "value": "NOT_IMPORTED",
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-uid": "app-entity",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+      "style": Object {
+        "height": "99.9",
+        "position": "absolute",
+        "width": "77.7",
+      },
+      "title": "Hi there!",
+    },
+    "rootElements": Array [],
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:aaa": Object {
+    "attributeMetadatada": Object {},
+    "children": Array [
+      Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "aaa",
+            "bbb",
+          ],
+        ],
+        "type": "elementpath",
+      },
+    ],
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "text": "hi",
+                "type": "JSX_TEXT_BLOCK",
+                "uniqueID": "",
+              },
+            ],
+            "name": Object {
+              "baseVariable": "View",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": Object {
+                    "position": "absolute",
+                  },
+                },
+              },
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "bbb",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "bbb",
+          },
+        ],
+        "name": Object {
+          "baseVariable": "View",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "spreadValue": Object {
+              "definedElsewhere": Array [
+                "props",
+              ],
+              "javascript": "props",
+              "sourceMap": Object {
+                "file": "code.tsx",
+                "mappings": "OAOiBA",
+                "names": Array [
+                  "props",
+                ],
+                "sources": Array [
+                  "code.tsx",
+                ],
+                "sourcesContent": Array [
+                  "
+      import * as React from 'react'
+      import { View, Storyboard, Scene } from 'utopia-api'
+      
+      export var App = (props) => {
+        return (
+          <View
+            {...props}
+            data-uid={'aaa'}
+          >
+            <View style={{position: 'absolute'}} data-uid={'bbb'}>hi</View>
+          </View>
+        )
+      }
+      export var storyboard = (props) => {
+        return (
+          <Storyboard data-uid={'utopia-storyboard-uid'}>
+            <Scene
+              style={{ position: 'absolute', height: 200, left: 59, width: 200, top: 79 }}
+              data-uid={'scene-aaa'}
+            >
+              <App
+                data-uid='app-entity'
+                style={{ position: 'absolute', height: '99.9', width: '77.7' }}
+                title={'Hi there!'}
+              />
+            </Scene>
+          </Storyboard>
+        )
+      }
+      ",
+                ],
+                "version": 3,
+              },
+              "transpiledJavascript": "return props;",
+              "type": "ATTRIBUTE_OTHER_JAVASCRIPT",
+              "uniqueID": "",
+            },
+            "type": "JSX_ATTRIBUTES_SPREAD",
+          },
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "aaa",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "aaa",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "aaa",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "View",
+        "path": "utopia-api",
+        "variableName": "View",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-uid": "aaa app-entity",
+      "skipDeepFreeze": true,
+      "style": Object {
+        "height": "99.9",
+        "position": "absolute",
+        "width": "77.7",
+      },
+      "title": "Hi there!",
+    },
+    "rootElements": Array [],
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb": Object {
+    "attributeMetadatada": Object {},
+    "children": Array [],
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [
+          Object {
+            "text": "hi",
+            "type": "JSX_TEXT_BLOCK",
+            "uniqueID": "",
+          },
+        ],
+        "name": Object {
+          "baseVariable": "View",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": Object {
+                "position": "absolute",
+              },
+            },
+          },
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "bbb",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "bbb",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "aaa",
+          "bbb",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "View",
+        "path": "utopia-api",
+        "variableName": "View",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
+      "data-uid": "bbb",
+      "skipDeepFreeze": true,
+      "style": Object {
+        "position": "absolute",
+      },
+    },
+    "rootElements": Array [],
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "usesParentBounds": false,
+    },
+  },
+}
+`;
+
 exports[`UiJsxCanvas render renders a component with a fragment at the root 1`] = `
 "<div
   id=\\"canvas-container\\"
@@ -28876,6 +30016,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -28903,6 +30044,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -28918,6 +30060,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -28939,6 +30082,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -29046,6 +30190,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -29157,6 +30302,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -29261,6 +30407,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -29407,6 +30554,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -29434,6 +30582,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -29449,6 +30598,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -29561,6 +30711,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -29683,6 +30834,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -29698,6 +30850,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -29731,6 +30884,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "value",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "definedElsewhere": Array [
                 "storeRef",
@@ -29789,6 +30943,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -29890,6 +31045,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -29905,6 +31061,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -30061,6 +31218,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -30088,6 +31246,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -30103,6 +31262,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -30215,6 +31375,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -30320,6 +31481,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -30481,6 +31643,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -30508,6 +31671,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -30523,6 +31687,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -30635,6 +31800,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -30872,6 +32038,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -30887,6 +32054,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -31043,6 +32211,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -31070,6 +32239,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -31091,6 +32261,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -31197,6 +32368,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -31302,6 +32474,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -31317,6 +32490,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "x",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -31487,6 +32661,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -31502,6 +32677,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -31535,6 +32711,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -31556,6 +32733,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -31662,6 +32840,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -31677,6 +32856,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -31829,6 +33009,7 @@ Object {
                               "trailingComments": Array [],
                             },
                             "key": "data-label",
+                            "type": "JSX_ATTRIBUTES_ENTRY",
                             "value": Object {
                               "comments": Object {
                                 "leadingComments": Array [],
@@ -31844,6 +33025,7 @@ Object {
                               "trailingComments": Array [],
                             },
                             "key": "style",
+                            "type": "JSX_ATTRIBUTES_ENTRY",
                             "value": Object {
                               "comments": Object {
                                 "leadingComments": Array [],
@@ -31862,6 +33044,7 @@ Object {
                               "trailingComments": Array [],
                             },
                             "key": "data-uid",
+                            "type": "JSX_ATTRIBUTES_ENTRY",
                             "value": Object {
                               "comments": Object {
                                 "leadingComments": Array [],
@@ -31894,6 +33077,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-label",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -31909,6 +33093,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "style",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -31927,6 +33112,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -31972,6 +33158,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -31999,6 +33186,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -32114,6 +33302,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -32233,6 +33422,7 @@ export var storyboard = (
                       "trailingComments": Array [],
                     },
                     "key": "data-label",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -32248,6 +33438,7 @@ export var storyboard = (
                       "trailingComments": Array [],
                     },
                     "key": "style",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -32266,6 +33457,7 @@ export var storyboard = (
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -32298,6 +33490,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -32313,6 +33506,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -32331,6 +33525,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -32435,6 +33630,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "data-label",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -32450,6 +33646,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -32468,6 +33665,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -32579,6 +33777,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -32731,6 +33930,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -32746,6 +33946,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -32779,6 +33980,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -32800,6 +34002,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -32906,6 +34109,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -32921,6 +34125,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -33056,6 +34261,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -33071,6 +34277,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "src",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -33098,6 +34305,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -33200,6 +34408,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -33215,6 +34424,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "src",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -33366,6 +34576,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -33381,6 +34592,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -33414,6 +34626,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -33435,6 +34648,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -33542,6 +34756,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -33557,6 +34772,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -33676,6 +34892,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -33869,6 +35086,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -33884,6 +35102,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -33917,6 +35136,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -33938,6 +35158,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -34044,6 +35265,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -34059,6 +35281,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -34241,6 +35464,7 @@ Object {
                           "trailingComments": Array [],
                         },
                         "key": "data-uid",
+                        "type": "JSX_ATTRIBUTES_ENTRY",
                         "value": Object {
                           "comments": Object {
                             "leadingComments": Array [],
@@ -34268,6 +35492,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -34355,6 +35580,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -34513,6 +35739,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -34540,6 +35767,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -34693,6 +35921,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -34849,6 +36078,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -34876,6 +36106,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -35029,6 +36260,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -35185,6 +36417,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -35212,6 +36445,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -35365,6 +36599,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -35467,8 +36702,8 @@ exports[`UiJsxCanvas render the canvas supports emotion CSS prop 1`] = `
     data-uid=\\"scene-aaa utopia-storyboard-uid\\"
   >
     <div
-      data-uid=\\"d39 aaa app-entity\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:d39 utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+      data-uid=\\"ba3 aaa app-entity\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:ba3 utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
       class=\\"css-16au7uv\\"
     >
       Utopia
@@ -35515,6 +36750,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -35530,6 +36766,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -35563,6 +36800,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -35584,6 +36822,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -35690,6 +36929,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -35705,6 +36945,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -35823,6 +37064,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -35994,6 +37236,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -36009,6 +37252,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -36042,6 +37286,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -36063,6 +37308,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -36169,6 +37415,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -36184,6 +37431,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -36327,6 +37575,7 @@ Object {
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -36354,6 +37603,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -36381,6 +37631,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -36503,6 +37754,7 @@ Object {
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -36530,6 +37782,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -36649,6 +37902,7 @@ Object {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1228,8 +1228,8 @@ export var ${BakedInStoryboardVariableName} = (props) => {
         >
           <div
             id=\\"nasty-div\\"
-            data-uid=\\"8cd~~~1 833~~~2 65e~~~1 aaa app-entity\\"
-            data-paths=\\"833~~~2/8cd~~~1 833~~~2 65e~~~1 utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+            data-uid=\\"77f~~~1 833~~~2 65e~~~1 aaa app-entity\\"
+            data-paths=\\"833~~~2/77f~~~1 833~~~2 65e~~~1 utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
           >
             huhahuha
           </div>
@@ -1669,6 +1669,43 @@ export var storyboard = (
     </Scene>
   </Storyboard>
 )`,
+    )
+  })
+
+  it('renders a component using the spread operator', () => {
+    testCanvasRender(
+      null,
+      `
+      import * as React from 'react'
+      import { View, Storyboard, Scene } from 'utopia-api'
+      
+      export var App = (props) => {
+        return (
+          <View
+            {...props}
+            data-uid={'aaa'}
+          >
+            <View style={{position: 'absolute'}} data-uid={'bbb'}>hi</View>
+          </View>
+        )
+      }
+      export var ${BakedInStoryboardVariableName} = (props) => {
+        return (
+          <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+            <Scene
+              style={{ position: 'absolute', height: 200, left: 59, width: 200, top: 79 }}
+              data-uid={'${TestSceneUID}'}
+            >
+              <App
+                data-uid='${TestAppUID}'
+                style={{ position: 'absolute', height: '99.9', width: '77.7' }}
+                title={'Hi there!'}
+              />
+            </Scene>
+          </Storyboard>
+        )
+      }
+      `,
     )
   })
 })

--- a/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
+++ b/editor/src/components/editor/actions/__snapshots__/actions.spec.ts.snap
@@ -31,6 +31,7 @@ Array [
                 "trailingComments": Array [],
               },
               "key": "data-uid",
+              "type": "JSX_ATTRIBUTES_ENTRY",
               "value": Object {
                 "comments": Object {
                   "leadingComments": Array [],
@@ -46,6 +47,7 @@ Array [
                 "trailingComments": Array [],
               },
               "key": "style",
+              "type": "JSX_ATTRIBUTES_ENTRY",
               "value": Object {
                 "comments": Object {
                   "leadingComments": Array [],
@@ -79,6 +81,7 @@ Array [
             "trailingComments": Array [],
           },
           "key": "data-uid",
+          "type": "JSX_ATTRIBUTES_ENTRY",
           "value": Object {
             "comments": Object {
               "leadingComments": Array [],
@@ -94,6 +97,7 @@ Array [
             "trailingComments": Array [],
           },
           "key": "style",
+          "type": "JSX_ATTRIBUTES_ENTRY",
           "value": Object {
             "comments": Object {
               "leadingComments": Array [],
@@ -112,6 +116,7 @@ Array [
             "trailingComments": Array [],
           },
           "key": "layout",
+          "type": "JSX_ATTRIBUTES_ENTRY",
           "value": Object {
             "comments": Object {
               "leadingComments": Array [],
@@ -157,6 +162,7 @@ Array [
                 "trailingComments": Array [],
               },
               "key": "component",
+              "type": "JSX_ATTRIBUTES_ENTRY",
               "value": Object {
                 "definedElsewhere": Array [
                   "App",
@@ -174,6 +180,7 @@ Array [
                 "trailingComments": Array [],
               },
               "key": "data-uid",
+              "type": "JSX_ATTRIBUTES_ENTRY",
               "value": Object {
                 "comments": Object {
                   "leadingComments": Array [],
@@ -201,6 +208,7 @@ Array [
             "trailingComments": Array [],
           },
           "key": "data-uid",
+          "type": "JSX_ATTRIBUTES_ENTRY",
           "value": Object {
             "comments": Object {
               "leadingComments": Array [],
@@ -251,6 +259,7 @@ Array [
                 "trailingComments": Array [],
               },
               "key": "data-uid",
+              "type": "JSX_ATTRIBUTES_ENTRY",
               "value": Object {
                 "comments": Object {
                   "leadingComments": Array [],
@@ -266,6 +275,7 @@ Array [
                 "trailingComments": Array [],
               },
               "key": "style",
+              "type": "JSX_ATTRIBUTES_ENTRY",
               "value": Object {
                 "comments": Object {
                   "leadingComments": Array [],
@@ -297,6 +307,7 @@ Array [
             "trailingComments": Array [],
           },
           "key": "data-uid",
+          "type": "JSX_ATTRIBUTES_ENTRY",
           "value": Object {
             "comments": Object {
               "leadingComments": Array [],
@@ -312,6 +323,7 @@ Array [
             "trailingComments": Array [],
           },
           "key": "style",
+          "type": "JSX_ATTRIBUTES_ENTRY",
           "value": Object {
             "comments": Object {
               "leadingComments": Array [],
@@ -330,6 +342,7 @@ Array [
             "trailingComments": Array [],
           },
           "key": "layout",
+          "type": "JSX_ATTRIBUTES_ENTRY",
           "value": Object {
             "comments": Object {
               "leadingComments": Array [],
@@ -375,6 +388,7 @@ Array [
                 "trailingComments": Array [],
               },
               "key": "component",
+              "type": "JSX_ATTRIBUTES_ENTRY",
               "value": Object {
                 "definedElsewhere": Array [
                   "App",
@@ -392,6 +406,7 @@ Array [
                 "trailingComments": Array [],
               },
               "key": "data-uid",
+              "type": "JSX_ATTRIBUTES_ENTRY",
               "value": Object {
                 "comments": Object {
                   "leadingComments": Array [],
@@ -419,6 +434,7 @@ Array [
             "trailingComments": Array [],
           },
           "key": "data-uid",
+          "type": "JSX_ATTRIBUTES_ENTRY",
           "value": Object {
             "comments": Object {
               "leadingComments": Array [],

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3965,7 +3965,7 @@ export const UPDATE_FNS = {
 
       if (pathToUpdate == null) {
         return setPropertyOnTarget(editor, target, (props) => {
-          let updatedProps = jsxAttributesFromMap(
+          let updatedProps: JSXAttributes = jsxAttributesFromMap(
             objectMap((value) => jsxAttributeValue(value, emptyComments), defaultProps),
           )
           const dataUID = getJSXAttribute(props, 'data-uid')

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -58,6 +58,11 @@ import {
   ImportInfo,
   createImportedFrom,
   FoundImportInfo,
+  JSXAttributesSpread,
+  jsxAttributesSpread,
+  JSXAttributesPart,
+  isJSXAttributesEntry,
+  isJSXAttributesSpread,
 } from '../../../core/shared/element-template'
 import { CanvasRectangle, LocalPoint, LocalRectangle } from '../../../core/shared/math-utils'
 import {
@@ -384,8 +389,30 @@ export function JSXAttributesEntryDeepEqualityCall(): KeepDeepEqualityCall<JSXAt
   )
 }
 
+export function JSXAttributesSpreadDeepEqualityCall(): KeepDeepEqualityCall<JSXAttributesSpread> {
+  return combine2EqualityCalls(
+    (entry) => entry.spreadValue,
+    JSXAttributeKeepDeepEqualityCall(),
+    (entry) => entry.comments,
+    ParsedCommentsKeepDeepEqualityCall(),
+    jsxAttributesSpread,
+  )
+}
+
+export function JSXAttributesPartDeepEqualityCall(): KeepDeepEqualityCall<JSXAttributesPart> {
+  return (oldPart, newPart) => {
+    if (isJSXAttributesEntry(oldPart) && isJSXAttributesEntry(newPart)) {
+      return JSXAttributesEntryDeepEqualityCall()(oldPart, newPart)
+    } else if (isJSXAttributesSpread(oldPart) && isJSXAttributesSpread(newPart)) {
+      return JSXAttributesSpreadDeepEqualityCall()(oldPart, newPart)
+    } else {
+      return keepDeepEqualityResult(newPart, false)
+    }
+  }
+}
+
 export function JSXAttributesKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXAttributes> {
-  return arrayDeepEquality(JSXAttributesEntryDeepEqualityCall())
+  return arrayDeepEquality(JSXAttributesPartDeepEqualityCall())
 }
 
 export function JSXElementKeepDeepEquality(): KeepDeepEqualityCall<JSXElement> {

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -3784,7 +3784,7 @@ export function toggleShadow(attribute: ModifiableAttribute): JSXAttributeValue<
 export function toggleStylePropPath(
   path: PropertyPath,
   toggleFn: (attribute: ModifiableAttribute) => ModifiableAttribute,
-) {
+): (element: JSXElement) => JSXElement {
   return (element: JSXElement): JSXElement => {
     const attributeResult = getModifiableJSXAttributeAtPath(element.props, path)
     if (isRight(attributeResult)) {
@@ -3807,7 +3807,9 @@ export function toggleStylePropPath(
   }
 }
 
-export function toggleStylePropPaths(toggleFn: (attribute: JSXAttribute) => JSXAttribute) {
+export function toggleStylePropPaths(
+  toggleFn: (attribute: JSXAttribute) => JSXAttribute,
+): (element: JSXElement) => JSXElement {
   return (element: JSXElement): JSXElement => {
     const styleProp = getJSXAttributeAtPath(element.props, PP.create(['style']))
     const attribute = styleProp.attribute

--- a/editor/src/core/model/__snapshots__/storyboard-utils.spec.ts.snap
+++ b/editor/src/core/model/__snapshots__/storyboard-utils.spec.ts.snap
@@ -39,6 +39,7 @@ Array [
                     "trailingComments": Array [],
                   },
                   "key": "data-uid",
+                  "type": "JSX_ATTRIBUTES_ENTRY",
                   "value": Object {
                     "comments": Object {
                       "leadingComments": Array [],
@@ -66,6 +67,7 @@ Array [
                 "trailingComments": Array [],
               },
               "key": "data-uid",
+              "type": "JSX_ATTRIBUTES_ENTRY",
               "value": Object {
                 "comments": Object {
                   "leadingComments": Array [],
@@ -81,6 +83,7 @@ Array [
                 "trailingComments": Array [],
               },
               "key": "style",
+              "type": "JSX_ATTRIBUTES_ENTRY",
               "value": Object {
                 "comments": Object {
                   "leadingComments": Array [],
@@ -114,6 +117,7 @@ Array [
             "trailingComments": Array [],
           },
           "key": "data-uid",
+          "type": "JSX_ATTRIBUTES_ENTRY",
           "value": Object {
             "comments": Object {
               "leadingComments": Array [],

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -60,6 +60,7 @@ import {
   jsxElementName,
   ElementInstanceMetadataMap,
   isIntrinsicHTMLElement,
+  getJSXAttribute,
 } from '../shared/element-template'
 import {
   getModifiableJSXAttributeAtPath,
@@ -293,17 +294,24 @@ export const MetadataUtils = {
     ) {
       return true
     }
-    if (instance != null && isRight(instance.element) && isJSXElement(instance.element.value)) {
-      const buttonRoleFound = instance.element.value.props.some(
-        (attribute) =>
-          attribute.key === 'role' &&
-          eitherToMaybe(jsxSimpleAttributeToValue(attribute.value)) === 'button',
-      )
-      if (buttonRoleFound) {
-        return true
-      }
+    let buttonRoleFound: boolean = false
+    if (instance != null) {
+      forEachRight(instance.element, (elem) => {
+        if (isJSXElement(elem)) {
+          const attrResult = getSimpleAttributeAtPath(right(elem.props), PP.create(['role']))
+          forEachRight(attrResult, (value) => {
+            if (value === 'button') {
+              buttonRoleFound = true
+            }
+          })
+        }
+      })
     }
-    return instance?.specialSizeMeasurements.htmlElementName.toLowerCase() === 'button'
+    if (buttonRoleFound) {
+      return true
+    } else {
+      return instance?.specialSizeMeasurements.htmlElementName.toLowerCase() === 'button'
+    }
   },
   getYogaSizeProps(target: ElementPath, metadata: ElementInstanceMetadataMap): Partial<Size> {
     const parentInstance = this.getParent(metadata, target)

--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -401,50 +401,6 @@ describe('setJSXValueAtPath', () => {
       }),
     )
   })
-
-  it('can set an attribute into a spread attribute', () => {
-    const originalAttributes: JSXAttributes = [
-      jsxAttributesSpread(
-        jsxAttributeNestedObject(
-          [
-            jsxPropertyAssignment(
-              'style',
-              jsxAttributeValue({ backgroundColor: 'red' }, emptyComments),
-              emptyComments,
-              emptyComments,
-            ),
-          ],
-          emptyComments,
-        ),
-        emptyComments,
-      ),
-    ]
-
-    const actualResult = setJSXValueAtPath(
-      originalAttributes,
-      PP.create(['style', 'backgroundColor']),
-      jsxAttributeValue('green', emptyComments),
-    )
-
-    const expectedResult: Either<string, JSXAttributes> = right([
-      jsxAttributesSpread(
-        jsxAttributeNestedObject(
-          [
-            jsxPropertyAssignment(
-              'style',
-              jsxAttributeValue({ backgroundColor: 'green' }, emptyComments),
-              emptyComments,
-              emptyComments,
-            ),
-          ],
-          emptyComments,
-        ),
-        emptyComments,
-      ),
-    ])
-
-    expect(actualResult).toEqual(expectedResult)
-  })
 })
 
 describe('jsxAttributesToProps', () => {

--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -1,6 +1,6 @@
 import * as PP from '../shared/property-path'
 import { deepFreeze } from '../../utils/deep-freeze'
-import { forceRight, isLeft, isRight, right } from '../shared/either'
+import { Either, forceRight, isLeft, isRight, right } from '../shared/either'
 import {
   getJSXAttributeForced,
   isJSXAttributeFunctionCall,
@@ -17,6 +17,7 @@ import {
   jsxAttributeOtherJavaScript,
   JSXAttributes,
   jsxAttributesFromMap,
+  jsxAttributesSpread,
   jsxAttributeValue,
   jsxPropertyAssignment,
   jsxSpreadAssignment,
@@ -399,6 +400,50 @@ describe('setJSXValueAtPath', () => {
         ),
       }),
     )
+  })
+
+  it('can set an attribute into a spread attribute', () => {
+    const originalAttributes: JSXAttributes = [
+      jsxAttributesSpread(
+        jsxAttributeNestedObject(
+          [
+            jsxPropertyAssignment(
+              'style',
+              jsxAttributeValue({ backgroundColor: 'red' }, emptyComments),
+              emptyComments,
+              emptyComments,
+            ),
+          ],
+          emptyComments,
+        ),
+        emptyComments,
+      ),
+    ]
+
+    const actualResult = setJSXValueAtPath(
+      originalAttributes,
+      PP.create(['style', 'backgroundColor']),
+      jsxAttributeValue('green', emptyComments),
+    )
+
+    const expectedResult: Either<string, JSXAttributes> = right([
+      jsxAttributesSpread(
+        jsxAttributeNestedObject(
+          [
+            jsxPropertyAssignment(
+              'style',
+              jsxAttributeValue({ backgroundColor: 'green' }, emptyComments),
+              emptyComments,
+              emptyComments,
+            ),
+          ],
+          emptyComments,
+        ),
+        emptyComments,
+      ),
+    ])
+
+    expect(actualResult).toEqual(expectedResult)
   })
 })
 

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -691,13 +691,7 @@ export function deleteJSXAttribute(attributes: JSXAttributes, key: string): JSXA
         }
         break
       case 'JSX_ATTRIBUTES_SPREAD':
-        const spreadValue = attrPart.spreadValue
-        if (isJSXAttributeNestedObject(spreadValue)) {
-          const updatedNestedObject = dropKeyFromNestedObject(spreadValue, key)
-          newAttributes.push(jsxAttributesSpread(updatedNestedObject, spreadValue.comments))
-        } else {
-          newAttributes.push(attrPart)
-        }
+        // Skip these for now.
         break
       default:
         const _exhaustiveCheck: never = attrPart
@@ -727,27 +721,7 @@ export function setJSXAttributesAttribute(
         }
         break
       case 'JSX_ATTRIBUTES_SPREAD':
-        const spreadValue = attrPart.spreadValue
-        if (isJSXAttributeNestedObject(spreadValue)) {
-          if (spreadValue.content.some((v) => isPropertyAssignment(v) && v.key === key)) {
-            const setResult = setJSXValueInAttributeAtPath(
-              attrPart.spreadValue,
-              PP.create([key]),
-              simplifiedValue,
-            )
-            const updatedAttr = foldEither(
-              (_) => attrPart,
-              (updated) => jsxAttributesSpread(updated, attrPart.comments),
-              setResult,
-            )
-            result.push(updatedAttr)
-            updatedExistingField = true
-          } else {
-            result.push(attrPart)
-          }
-        } else {
-          result.push(attrPart)
-        }
+        // Ignore these for now.
         break
       default:
         const _exhaustiveCheck: never = attrPart

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -5,16 +5,21 @@ import type {
   ElementPath,
 } from './project-file-types'
 import { CanvasRectangle, LocalRectangle, LocalPoint, zeroCanvasRect } from './math-utils'
-import { Either, isLeft, left, right } from './either'
+import { Either, foldEither, isLeft, left, right } from './either'
 import { v4 as UUID } from 'uuid'
 import { RawSourceMap } from '../workers/ts/ts-typings/RawSourceMap'
 import * as PP from './property-path'
 import { Sides, sides, NormalisedFrame, LayoutSystem } from 'utopia-api'
 import { fastForEach, unknownObjectProperty } from './utils'
-import { addAllUniquely, mapDropNulls } from './array-utils'
+import { addAllUniquely, mapDropNulls, reverse } from './array-utils'
 import { objectMap } from './object-utils'
 import { CSSPosition } from '../../components/inspector/common/css-utils'
-import { ModifiableAttribute } from './jsx-attributes'
+import {
+  dropKeyFromNestedObject,
+  getJSXAttributeAtPathInner,
+  ModifiableAttribute,
+  setJSXValueInAttributeAtPath,
+} from './jsx-attributes'
 import * as EP from './element-path'
 import { firstLetterIsLowerCase } from './string-utils'
 import { intrinsicHTMLElementNamesAsStrings } from './dom-utils'
@@ -25,7 +30,6 @@ import {
 } from '../workers/parser-printer/parser-printer-comments'
 import type { MapLike } from 'typescript'
 import { forceNotNull } from './optional-utils'
-import { string } from 'fast-check/*'
 
 interface BaseComment {
   comment: string
@@ -222,7 +226,7 @@ export function jsxAttributeNestedObject(
 }
 
 export function jsxAttributeNestedObjectSimple(
-  content: JSXAttributes,
+  content: Array<JSXAttributesEntry>,
   comments: ParsedComments,
 ): JSXAttributeNestedObject {
   return {
@@ -329,9 +333,24 @@ export function clearJSXAttributeOtherJavaScriptUniqueIDs(
 }
 
 export function simplifyAttributesIfPossible(attributes: JSXAttributes): JSXAttributes {
-  return attributes.map(({ key, value, comments }) =>
-    jsxAttributesEntry(key, simplifyAttributeIfPossible(value), comments),
-  )
+  return attributes.map((attribute) => {
+    switch (attribute.type) {
+      case 'JSX_ATTRIBUTES_ENTRY':
+        return jsxAttributesEntry(
+          attribute.key,
+          simplifyAttributeIfPossible(attribute.value),
+          attribute.comments,
+        )
+      case 'JSX_ATTRIBUTES_SPREAD':
+        return jsxAttributesSpread(
+          simplifyAttributeIfPossible(attribute.spreadValue),
+          attribute.comments,
+        )
+      default:
+        const _exhaustiveCheck: never = attribute
+        throw new Error(`Unhandled attribute type ${JSON.stringify(attribute)}`)
+    }
+  })
 }
 
 export function simplifyAttributeIfPossible(attribute: JSXAttribute): JSXAttribute {
@@ -587,6 +606,7 @@ export function isRegularJSXAttribute(
 }
 
 export interface JSXAttributesEntry extends WithComments {
+  type: 'JSX_ATTRIBUTES_ENTRY'
   key: string
   value: JSXAttribute
 }
@@ -597,35 +617,94 @@ export function jsxAttributesEntry(
   comments: ParsedComments,
 ): JSXAttributesEntry {
   return {
+    type: 'JSX_ATTRIBUTES_ENTRY',
     key: key,
     value: value,
     comments: comments,
   }
 }
 
-export type JSXAttributes = Array<JSXAttributesEntry>
+export interface JSXAttributesSpread extends WithComments {
+  type: 'JSX_ATTRIBUTES_SPREAD'
+  spreadValue: JSXAttribute
+}
 
-export function jsxAttributesFromMap(map: MapLike<JSXAttribute>): JSXAttributes {
+export function jsxAttributesSpread(
+  spreadValue: JSXAttribute,
+  comments: ParsedComments,
+): JSXAttributesSpread {
+  return {
+    type: 'JSX_ATTRIBUTES_SPREAD',
+    spreadValue: spreadValue,
+    comments: comments,
+  }
+}
+
+export type JSXAttributesPart = JSXAttributesEntry | JSXAttributesSpread
+
+export function isJSXAttributesEntry(part: JSXAttributesPart): part is JSXAttributesEntry {
+  return part.type === 'JSX_ATTRIBUTES_ENTRY'
+}
+
+export function isJSXAttributesSpread(part: JSXAttributesPart): part is JSXAttributesSpread {
+  return part.type === 'JSX_ATTRIBUTES_SPREAD'
+}
+
+export type JSXAttributes = Array<JSXAttributesPart>
+
+export function jsxAttributesFromMap(map: MapLike<JSXAttribute>): Array<JSXAttributesEntry> {
   return Object.keys(map).map((objectKey) => {
     return jsxAttributesEntry(objectKey, map[objectKey], emptyComments)
   })
 }
 
 export function getJSXAttribute(attributes: JSXAttributes, key: string): JSXAttribute | null {
-  const entry = attributes.find((attr) => attr.key === key)
-  if (entry == null) {
-    return null
-  } else {
-    return entry.value
+  for (const attrPart of reverse(attributes)) {
+    switch (attrPart.type) {
+      case 'JSX_ATTRIBUTES_ENTRY':
+        if (attrPart.key === key) {
+          return attrPart.value
+        }
+        break
+      case 'JSX_ATTRIBUTES_SPREAD':
+        // Ignore these for now.
+        break
+      default:
+        const _exhaustiveCheck: never = attrPart
+        throw new Error(`Unhandled attribute type ${JSON.stringify(attrPart)}`)
+    }
   }
+  return null
 }
 
-export function getJSXAttributeForced(attributes: JSXAttributes, key: string): JSXAttribute {
+export function getJSXAttributeForced(attributes: JSXAttributes, key: string): ModifiableAttribute {
   return forceNotNull('Should not be null.', getJSXAttribute(attributes, key))
 }
 
 export function deleteJSXAttribute(attributes: JSXAttributes, key: string): JSXAttributes {
-  return attributes.filter((a) => a.key !== key)
+  let newAttributes: JSXAttributes = []
+  for (const attrPart of attributes) {
+    switch (attrPart.type) {
+      case 'JSX_ATTRIBUTES_ENTRY':
+        if (attrPart.key !== key) {
+          newAttributes.push(attrPart)
+        }
+        break
+      case 'JSX_ATTRIBUTES_SPREAD':
+        const spreadValue = attrPart.spreadValue
+        if (isJSXAttributeNestedObject(spreadValue)) {
+          const updatedNestedObject = dropKeyFromNestedObject(spreadValue, key)
+          newAttributes.push(jsxAttributesSpread(updatedNestedObject, spreadValue.comments))
+        } else {
+          newAttributes.push(attrPart)
+        }
+        break
+      default:
+        const _exhaustiveCheck: never = attrPart
+        throw new Error(`Unhandled attribute type ${JSON.stringify(attrPart)}`)
+    }
+  }
+  return newAttributes
 }
 
 export function setJSXAttributesAttribute(
@@ -635,14 +714,47 @@ export function setJSXAttributesAttribute(
 ): JSXAttributes {
   let updatedExistingField: boolean = false
   const simplifiedValue = simplifyAttributeIfPossible(value)
-  let result: JSXAttributes = attributes.map((attr) => {
-    if (attr.key === key) {
-      updatedExistingField = true
-      return jsxAttributesEntry(key, simplifiedValue, attr.comments)
-    } else {
-      return attr
+  let result: JSXAttributes = []
+
+  for (const attrPart of attributes) {
+    switch (attrPart.type) {
+      case 'JSX_ATTRIBUTES_ENTRY':
+        if (attrPart.key === key) {
+          result.push(jsxAttributesEntry(key, simplifiedValue, attrPart.comments))
+          updatedExistingField = true
+        } else {
+          result.push(attrPart)
+        }
+        break
+      case 'JSX_ATTRIBUTES_SPREAD':
+        const spreadValue = attrPart.spreadValue
+        if (isJSXAttributeNestedObject(spreadValue)) {
+          if (spreadValue.content.some((v) => isPropertyAssignment(v) && v.key === key)) {
+            const setResult = setJSXValueInAttributeAtPath(
+              attrPart.spreadValue,
+              PP.create([key]),
+              simplifiedValue,
+            )
+            const updatedAttr = foldEither(
+              (_) => attrPart,
+              (updated) => jsxAttributesSpread(updated, attrPart.comments),
+              setResult,
+            )
+            result.push(updatedAttr)
+            updatedExistingField = true
+          } else {
+            result.push(attrPart)
+          }
+        } else {
+          result.push(attrPart)
+        }
+        break
+      default:
+        const _exhaustiveCheck: never = attrPart
+        throw new Error(`Unhandled attribute type ${JSON.stringify(attrPart)}`)
     }
-  })
+  }
+
   if (!updatedExistingField) {
     result.push(jsxAttributesEntry(key, simplifiedValue, emptyComments))
   }
@@ -667,7 +779,15 @@ export function getDefinedElsewhereFromAttribute(attribute: JSXAttribute): Array
 
 export function getDefinedElsewhereFromAttributes(attributes: JSXAttributes): Array<string> {
   return attributes.reduce<Array<string>>((working, entry) => {
-    return addAllUniquely(working, getDefinedElsewhereFromAttribute(entry.value))
+    switch (entry.type) {
+      case 'JSX_ATTRIBUTES_ENTRY':
+        return addAllUniquely(working, getDefinedElsewhereFromAttribute(entry.value))
+      case 'JSX_ATTRIBUTES_SPREAD':
+        return addAllUniquely(working, getDefinedElsewhereFromAttribute(entry.spreadValue))
+      default:
+        const _exhaustiveCheck: never = entry
+        throw new Error(`Unhandled attribute type ${JSON.stringify(entry)}`)
+    }
   }, [])
 }
 
@@ -686,21 +806,43 @@ export function getDefinedElsewhereFromElement(element: JSXElement): Array<strin
 
 export function clearAttributesUniqueIDs(attributes: JSXAttributes): JSXAttributes {
   return attributes.map((attribute) => {
-    return jsxAttributesEntry(
-      attribute.key,
-      clearAttributeUniqueIDs(attribute.value),
-      attribute.comments,
-    )
+    switch (attribute.type) {
+      case 'JSX_ATTRIBUTES_ENTRY':
+        return jsxAttributesEntry(
+          attribute.key,
+          clearAttributeUniqueIDs(attribute.value),
+          attribute.comments,
+        )
+      case 'JSX_ATTRIBUTES_SPREAD':
+        return jsxAttributesSpread(
+          clearAttributeUniqueIDs(attribute.spreadValue),
+          attribute.comments,
+        )
+      default:
+        const _exhaustiveCheck: never = attribute
+        throw new Error(`Unhandled attribute type ${JSON.stringify(attribute)}`)
+    }
   })
 }
 
 export function clearAttributesSourceMaps(attributes: JSXAttributes): JSXAttributes {
   return attributes.map((attribute) => {
-    return jsxAttributesEntry(
-      attribute.key,
-      clearAttributeSourceMaps(attribute.value),
-      attribute.comments,
-    )
+    switch (attribute.type) {
+      case 'JSX_ATTRIBUTES_ENTRY':
+        return jsxAttributesEntry(
+          attribute.key,
+          clearAttributeSourceMaps(attribute.value),
+          attribute.comments,
+        )
+      case 'JSX_ATTRIBUTES_SPREAD':
+        return jsxAttributesSpread(
+          clearAttributeSourceMaps(attribute.spreadValue),
+          attribute.comments,
+        )
+      default:
+        const _exhaustiveCheck: never = attribute
+        throw new Error(`Unhandled attribute type ${JSON.stringify(attribute)}`)
+    }
   })
 }
 

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -223,7 +223,20 @@ export function jsxAttributesToProps(
 ): any {
   let result: any = {}
   for (const entry of attributes) {
-    result[entry.key] = jsxAttributeToValue(inScope, requireResult, entry.value)
+    switch (entry.type) {
+      case 'JSX_ATTRIBUTES_ENTRY':
+        result[entry.key] = jsxAttributeToValue(inScope, requireResult, entry.value)
+        break
+      case 'JSX_ATTRIBUTES_SPREAD':
+        result = {
+          ...result,
+          ...jsxAttributeToValue(inScope, requireResult, entry.spreadValue),
+        }
+        break
+      default:
+        const _exhaustiveCheck: never = entry
+        throw new Error(`Unhandled entry ${JSON.stringify(entry)}`)
+    }
   }
   return result
 }
@@ -401,8 +414,6 @@ export function deeplyCreatedValue(path: PropertyPath, value: JSXAttribute): JSX
   }, value)
 }
 
-// TODO This function should absolutely be returning an Either since there is no guarantee that it
-// won't be called with "illegal" params
 export function setJSXValueInAttributeAtPath(
   attribute: JSXAttribute,
   path: PropertyPath,
@@ -842,7 +853,17 @@ function walkAttributes(
   walk: (attribute: JSXAttribute, path: PropertyPath | null) => void,
 ): void {
   fastForEach(attributes, (attr) => {
-    walkAttribute(attr.value, PP.create([attr.key]), walk)
+    switch (attr.type) {
+      case 'JSX_ATTRIBUTES_ENTRY':
+        walkAttribute(attr.value, PP.create([attr.key]), walk)
+        break
+      case 'JSX_ATTRIBUTES_SPREAD':
+        walkAttribute(attr.spreadValue, PP.create([]), walk)
+        break
+      default:
+        const _exhaustiveCheck: never = attr
+        throw new Error(`Unhandled attribute ${JSON.stringify(attr)}`)
+    }
   })
 }
 

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.tsx.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.tsx.snap
@@ -478,6 +478,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -493,6 +494,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -512,6 +514,7 @@ export var storyboard = (
               "trailingComments": Array [],
             },
             "key": "layout",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -666,6 +669,7 @@ return { b: b };",
                       "trailingComments": Array [],
                     },
                     "key": "data-uid",
+                    "type": "JSX_ATTRIBUTES_ENTRY",
                     "value": Object {
                       "comments": Object {
                         "leadingComments": Array [],
@@ -693,6 +697,7 @@ return { b: b };",
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -708,6 +713,7 @@ return { b: b };",
                   "trailingComments": Array [],
                 },
                 "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -741,6 +747,7 @@ return { b: b };",
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -756,6 +763,7 @@ return { b: b };",
               "trailingComments": Array [],
             },
             "key": "layout",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.tsx.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-dot-notation.spec.tsx.snap
@@ -87,6 +87,7 @@ Array [
                     "trailingComments": Array [],
                   },
                   "key": "data-uid",
+                  "type": "JSX_ATTRIBUTES_ENTRY",
                   "value": Object {
                     "comments": Object {
                       "leadingComments": Array [],
@@ -163,6 +164,7 @@ export var storyboard = (props) => {
             "trailingComments": Array [],
           },
           "key": "data-uid",
+          "type": "JSX_ATTRIBUTES_ENTRY",
           "value": Object {
             "comments": Object {
               "leadingComments": Array [],

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -460,6 +460,7 @@ return { otherFn: otherFn };",
                   "trailingComments": Array [],
                 },
                 "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "comments": Object {
                     "leadingComments": Array [],
@@ -475,6 +476,7 @@ return { otherFn: otherFn };",
                   "trailingComments": Array [],
                 },
                 "key": "left",
+                "type": "JSX_ATTRIBUTES_ENTRY",
                 "value": Object {
                   "definedElsewhere": Array [
                     "cakeFn",
@@ -550,6 +552,7 @@ export var whatever = (props) => {
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -779,6 +782,7 @@ return { a: a };",
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],
@@ -1136,6 +1140,7 @@ export var App = (props) => <View data-uid='bbb'>
               "trailingComments": Array [],
             },
             "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
             "value": Object {
               "comments": Object {
                 "leadingComments": Array [],

--- a/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
@@ -232,7 +232,7 @@ export var ${BakedInStoryboardVariableName} = (
 `
     testParseThenPrint(code, code)
   })
-  it('does something odd for spread mapping - #1365', () => {
+  it('parses elements that use props spreading - #1365', () => {
     const spreadCode = `import * as React from 'react'
 const Test = (props) => {
   return (

--- a/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
@@ -86,7 +86,7 @@ export var App = props => {
       fail(parsedPlainCode)
     }
   })
-  it('does something odd for spread mapping - #1365', () => {
+  it('parses elements that use props spreading - #1365', () => {
     const nonSpreadCode = `
     import * as React from "react"
     import { Card } from './card'

--- a/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
@@ -9,6 +9,7 @@ import {
 import { forEachLeft, isRight } from '../../shared/either'
 import {
   clearParseResultUniqueIDsAndEmptyBlocks,
+  elementsStructure,
   testParseCode,
   testParseThenPrint,
 } from './parser-printer.test-utils'
@@ -84,6 +85,63 @@ export var App = props => {
     } else {
       fail(parsedPlainCode)
     }
+  })
+  it('does something odd for spread mapping - #1365', () => {
+    const nonSpreadCode = `
+    import * as React from "react"
+    import { Card } from './card'
+    const Test = (props) => {
+      return <div data-uid='mapper-parent'>
+        {props.data.map((entry) => (
+          <Card
+            data-uid='card'
+            style={{ flexBasis: 50 }}
+            name={entry.name}
+            country={entry.country}
+            image={entry.image}
+          />
+        ))}
+      </div>
+    }`
+    const spreadCode = `
+    import * as React from "react"
+    import { Card } from './card'
+    const Test = (props) => {
+      return <div data-uid='mapper-parent'>
+        {props.data.map((entry) => (
+          <Card
+            {...entry}
+            data-uid='card'
+            style={{ flexBasis: 50 }}
+          />
+        ))}
+      </div>
+    }`
+
+    expect(elementsStructure((testParseCode(nonSpreadCode) as any).topLevelElements))
+      .toMatchInlineSnapshot(`
+      "UNPARSED_CODE
+      IMPORT_STATEMENT
+      UNPARSED_CODE
+      IMPORT_STATEMENT
+      UNPARSED_CODE
+      UTOPIA_JSX_COMPONENT - Test
+        JSX_ELEMENT - div - mapper-parent
+          JSX_ARBITRARY_BLOCK
+            JSX_ELEMENT - Card - card"
+    `)
+    expect(elementsStructure((testParseCode(spreadCode) as any).topLevelElements))
+      .toMatchInlineSnapshot(`
+      "UNPARSED_CODE
+      IMPORT_STATEMENT
+      UNPARSED_CODE
+      IMPORT_STATEMENT
+      UNPARSED_CODE
+      UTOPIA_JSX_COMPONENT - Test
+        JSX_ELEMENT - div - mapper-parent
+          JSX_ARBITRARY_BLOCK
+            JSX_ELEMENT - Card - card"
+    `)
   })
 })
 
@@ -173,6 +231,29 @@ export var ${BakedInStoryboardVariableName} = (
 )
 `
     testParseThenPrint(code, code)
+  })
+  it('does something odd for spread mapping - #1365', () => {
+    const spreadCode = `import * as React from 'react'
+const Test = (props) => {
+  return (
+    <div data-uid='mapper-parent'>
+      {props.data.map((entry) => (
+        <div
+          {...entry}
+          data-uid='card'
+          style={{ flexBasis: 50 }}
+        />
+      ))}
+    </div>
+  )
+}
+
+export var ${BakedInStoryboardVariableName} = (
+  <Storyboard data-uid='${BakedInStoryboardUID}' />
+)
+`
+
+    testParseThenPrint(spreadCode, spreadCode)
   })
 })
 

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -27,6 +27,7 @@ import {
   clearArbitraryJSBlockUniqueIDs,
   jsxAttributesFromMap,
   getJSXAttributeForced,
+  isJSXAttributesEntry,
 } from '../../shared/element-template'
 import { sampleCode } from '../../model/new-project-files'
 import { addImport, emptyImports, parseSuccess } from '../common/project-file-utils'
@@ -2369,7 +2370,7 @@ export var whatever = (props) => <View data-uid='aaa'>
         if (result.rootElement.children.length === 1) {
           const child = result.rootElement.children[0]
           if (isJSXElement(child)) {
-            const childPropKeys = child.props.map((prop) => prop.key)
+            const childPropKeys = child.props.filter(isJSXAttributesEntry).map((prop) => prop.key)
             expect(childPropKeys).toEqual(['data-uid', 'left'])
             const leftProp = getJSXAttributeForced(child.props, 'left')
             expect(leftProp.type).toEqual('ATTRIBUTE_OTHER_JAVASCRIPT')
@@ -4481,7 +4482,9 @@ export var App = props => {
 
     const arbitraryProp = optionalMap(
       (p) => p.value,
-      appComponent.rootElement.props.find((p) => p.key === 'arbitrary'),
+      appComponent.rootElement.props
+        .filter(isJSXAttributesEntry)
+        .find((p) => p.key === 'arbitrary'),
     )
 
     if (arbitraryProp == null || !isJSXAttributeOtherJavaScript(arbitraryProp)) {

--- a/editor/src/core/workers/parser-printer/uid-fix.spec.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.spec.ts
@@ -17,8 +17,8 @@ describe('fixParseSuccessUIDs', () => {
     expect(getUidTree(newFile)).toMatchInlineSnapshot(`
       "4ed
         random-uuid
-      a04
-        ce5
+      001
+        f6d
       storyboard
         scene
           component"
@@ -37,10 +37,10 @@ describe('fixParseSuccessUIDs', () => {
     expect(getUidTree(newFileFixed)).toMatchInlineSnapshot(`
       "4ed
         random-uuid
-      6f6
-        edd
-      a04
-        ce5
+      0bf
+        a2e
+      001
+        f6d
       storyboard
         scene
           component"
@@ -65,8 +65,8 @@ describe('fixParseSuccessUIDs', () => {
       "4ed
         random-uuid
       random-uuid
-        a04
-        ce5
+        001
+        f6d
       storyboard
         scene
           component"
@@ -79,8 +79,8 @@ describe('fixParseSuccessUIDs', () => {
     expect(getUidTree(newFile)).toMatchInlineSnapshot(`
       "4ed
         random-uuid
-      a04
-        ce5
+      001
+        f6d
       storyboard
         scene
           component"
@@ -92,9 +92,9 @@ describe('fixParseSuccessUIDs', () => {
     expect(getUidTree(newFile)).toMatchInlineSnapshot(`
       "4ed
         random-uuid
-      a04
-        edd
-        ce5
+      001
+        a2e
+        f6d
       storyboard
         scene
           component"
@@ -106,10 +106,10 @@ describe('fixParseSuccessUIDs', () => {
     expect(getUidTree(newFile)).toMatchInlineSnapshot(`
       "4ed
         random-uuid
-      a04
-        ce5
-        0b4
-        e78
+      001
+        f6d
+        1d1
+        8d0
       storyboard
         scene
           component"
@@ -127,11 +127,11 @@ describe('fixParseSuccessUIDs', () => {
     expect(getUidTree(fourViews)).toMatchInlineSnapshot(`
       "4ed
         random-uuid
-      a04
-        395
-        ce5
-        0b4
-        e78
+      001
+        f07
+        f6d
+        1d1
+        8d0
       storyboard
         scene
           component"

--- a/editor/src/utils/clipboard.spec.tsx
+++ b/editor/src/utils/clipboard.spec.tsx
@@ -75,7 +75,7 @@ export var App = (props) => {
     expect(clipboardData?.data.length).toEqual(1)
     expect(clipboardData?.data[0].type).toEqual('ELEMENT_COPY')
     expect(clipboardData?.data[0].elements).toMatchInlineSnapshot(
-      `"[{type:\\"JSX_ELEMENT\\",name:{baseVariable:\\"div\\",propertyPath:{propertyElements:[]}},uid:\\"app-inner-div-to-copy\\",props:[{key:\\"data-uid\\",value:{type:\\"ATTRIBUTE_VALUE\\",value:\\"app-inner-div-to-copy\\",comments:{leadingComments:[],trailingComments:[]}},comments:{leadingComments:[],trailingComments:[]}}],children:[]}]"`,
+      `"[{type:\\"JSX_ELEMENT\\",name:{baseVariable:\\"div\\",propertyPath:{propertyElements:[]}},uid:\\"app-inner-div-to-copy\\",props:[{type:\\"JSX_ATTRIBUTES_ENTRY\\",key:\\"data-uid\\",value:{type:\\"ATTRIBUTE_VALUE\\",value:\\"app-inner-div-to-copy\\",comments:{leadingComments:[],trailingComments:[]}},comments:{leadingComments:[],trailingComments:[]}}],children:[]}]"`,
     )
   })
 })


### PR DESCRIPTION
Fixes #1365

**Problem:**
Currently if a user includes a root level spread operator in an element the element becomes an arbitrary block to the parser, which means it becomes effectively opaque.

**Fix:**
Added support for parsing and printing root level spread operators, so that elements can continue to be parsed validly when those are present. Currently these are handled correctly as far as rendering and reproduction, but are not manipulable when it comes to modifying their values as it seems like this would be a rare case compared to their use for spreading an object passed in as part of the props.

**Commit Details:**
- Fixes #1365.
- Created the `JSXAttributesSpread` type to represent the segment
  that contains a spread.
- `JSXAttributes` is now an array of `JSXAttributesEntry` and/or
  `JSXAttributesSpread`.
- Updated various functions like `getJSXAttribute` to cater for the
  changed type of `JSXAttributes`.
- Updated the parser logic to pull out the root level spread.
- Code printer also prints out the root level spreads.
- Added the new hierarchy of types in the deep equality calls.
