### PR TITLE
Correct the parsing of hsl colours.

### DIFF
--- a/editor/src/components/inspector/common/css-utils.spec.ts
+++ b/editor/src/components/inspector/common/css-utils.spec.ts
@@ -15,6 +15,7 @@ import {
   CSSBorderRadius,
   cssColor,
   CSSColor,
+  cssColorHSL,
   cssColorToChromaColor,
   cssDefault,
   cssKeyword,
@@ -1621,6 +1622,21 @@ describe('cssColorToChromaColor', () => {
     invalidStrings.forEach((invalid) => {
       expect(isLeft(cssColorToChromaColor({ type: 'Keyword', keyword: invalid }))).toEqual(true)
     })
+  })
+  it('parses hsl values correctly', () => {
+    expect(cssColorToChromaColor(cssColorHSL(0, 0, 95, 1, false))).toMatchInlineSnapshot(`
+      Object {
+        "type": "RIGHT",
+        "value": Color {
+          "_rgb": Array [
+            242.25,
+            242.25,
+            242.25,
+            1,
+          ],
+        },
+      }
+    `)
   })
 })
 

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -2055,7 +2055,7 @@ export function cssColorToChromaColor(c: CSSColor): Either<string, Chroma.Color>
   } else if (isHex(c)) {
     return right(Chroma.hex(c.hex))
   } else if (isHSL(c)) {
-    return right((Chroma.hsl as any)(c.h, c.s, c.l, c.a))
+    return right((Chroma.hsl as any)(c.h, c.s / 100.0, c.l / 100.0, c.a))
   } else {
     return right(Chroma(c.r, c.g, c.b, c.a))
   }


### PR DESCRIPTION
Fixes #1216

**Problem:**
Previously when parsing `hsl(...)` colours, the wrong range was used when invoking the conversion function in Chroma.

**Fix:**
Reduced the range of saturation and lightness values when passing them to Chroma.

**Commit Details:**
- Fixes #1216.
- When invoking the `Chroma.hsl` function, reduce the saturation
  and lightness values down to the range `[0..1]`.
