### PR TITLE
ux/slider behaviour

### DIFF
--- a/editor/src/components/inspector/controls/slider-control.tsx
+++ b/editor/src/components/inspector/controls/slider-control.tsx
@@ -20,7 +20,101 @@ export type SliderControlProps = DEPRECATEDControlProps<number> & {
   DEPRECATED_controlOptions: DEPRECATEDSliderControlOptions
 }
 
-export class SliderControl extends React.Component<SliderControlProps> {
+export const SliderControl: React.FunctionComponent<SliderControlProps> = (props) => {
+  const [isSliding, setIsSliding] = React.useState(false)
+
+  const handleBeforeChange = React.useCallback(() => {
+    setIsSliding(true)
+  }, [])
+
+  const onChangeFn = props.onForcedSubmitValue ?? props.onSubmitValue
+
+  const handleOnAfterChange = React.useCallback(
+    (n: number) => {
+      onChangeFn(n)
+      setIsSliding(false)
+    },
+    [onChangeFn],
+  )
+
+  const controlOptions = {
+    ...defaultSliderControlOptions,
+    ...props.DEPRECATED_controlOptions,
+  }
+
+  let marks: Marks = {}
+  if (typeof controlOptions.origin === 'number') {
+    marks[controlOptions.origin] = {
+      style: {
+        display: 'none',
+      },
+      label: String(controlOptions.origin),
+    }
+  }
+  return (
+    <FlexRow
+      style={{
+        width: '100%',
+        height: UtopiaTheme.layout.inputHeight.default,
+        paddingLeft: 4,
+        paddingRight: 4,
+        alignItems: 'center',
+        ...props.style,
+      }}
+      className={props.controlClassName}
+      onContextMenu={props.onContextMenu}
+    >
+      <Slider
+        disabled={!props.controlStyles.interactive}
+        value={props.value}
+        onBeforeChange={handleBeforeChange}
+        onChange={props.onTransientSubmitValue}
+        // onAfterChange={props.onForcedSubmitValue ?? props.onSubmitValue}
+        onAfterChange={handleOnAfterChange}
+        min={controlOptions.minimum}
+        max={controlOptions.maximum}
+        step={controlOptions.stepSize}
+        marks={marks}
+        handleStyle={{
+          backgroundColor: controlOptions.filled ? props.controlStyles.trackColor : undefined,
+        }}
+        trackStyle={{
+          backgroundColor: controlOptions.filled ? props.controlStyles.trackColor : undefined,
+        }}
+        activeDotStyle={{
+          backgroundColor: controlOptions.filled
+            ? props.controlStyles.trackColor
+            : props.controlStyles.railColor,
+        }}
+        railStyle={{
+          backgroundColor: props.controlStyles.railColor,
+        }}
+        dotStyle={{
+          backgroundColor: props.controlStyles.railColor,
+        }}
+      />
+      {/* This div blocks other controls from receiving hover events 
+          while you're sliding the slider. NB this needs to come here, 
+          i.e. *after* the Slider component - so it doesn't obscure it. 
+      */}
+      {isSliding ? (
+        <div
+          style={{
+            position: 'fixed',
+            background: 'transparent',
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+            zIndex: 1,
+          }}
+        />
+      ) : null}
+    </FlexRow>
+  )
+}
+
+export class SliderControl2 extends React.Component<SliderControlProps> {
   render() {
     const controlOptions = {
       ...defaultSliderControlOptions,

--- a/editor/src/components/inspector/controls/slider-control.tsx
+++ b/editor/src/components/inspector/controls/slider-control.tsx
@@ -37,10 +37,26 @@ export const SliderControl: React.FunctionComponent<SliderControlProps> = (props
     [onChangeFn],
   )
 
-  const controlOptions = {
-    ...defaultSliderControlOptions,
-    ...props.DEPRECATED_controlOptions,
-  }
+  const controlOptions = React.useMemo(() => {
+    return {
+      ...defaultSliderControlOptions,
+      ...props.DEPRECATED_controlOptions,
+    }
+  }, [props.DEPRECATED_controlOptions])
+
+  const handleAndTrackStyle = React.useMemo(() => {
+    return {
+      backgroundColor: controlOptions.filled ? props.controlStyles.trackColor : undefined,
+    }
+  }, [controlOptions.filled, props.controlStyles])
+
+  const activeDotStyle = React.useMemo(() => {
+    return {
+      backgroundColor: controlOptions.filled
+        ? props.controlStyles.trackColor
+        : props.controlStyles.railColor,
+    }
+  }, [controlOptions.filled, props.controlStyles])
 
   let marks: Marks = {}
   if (typeof controlOptions.origin === 'number') {
@@ -69,23 +85,14 @@ export const SliderControl: React.FunctionComponent<SliderControlProps> = (props
         value={props.value}
         onBeforeChange={handleBeforeChange}
         onChange={props.onTransientSubmitValue}
-        // onAfterChange={props.onForcedSubmitValue ?? props.onSubmitValue}
         onAfterChange={handleOnAfterChange}
         min={controlOptions.minimum}
         max={controlOptions.maximum}
         step={controlOptions.stepSize}
         marks={marks}
-        handleStyle={{
-          backgroundColor: controlOptions.filled ? props.controlStyles.trackColor : undefined,
-        }}
-        trackStyle={{
-          backgroundColor: controlOptions.filled ? props.controlStyles.trackColor : undefined,
-        }}
-        activeDotStyle={{
-          backgroundColor: controlOptions.filled
-            ? props.controlStyles.trackColor
-            : props.controlStyles.railColor,
-        }}
+        handleStyle={handleAndTrackStyle}
+        trackStyle={handleAndTrackStyle}
+        activeDotStyle={activeDotStyle}
         railStyle={{
           backgroundColor: props.controlStyles.railColor,
         }}
@@ -112,70 +119,4 @@ export const SliderControl: React.FunctionComponent<SliderControlProps> = (props
       ) : null}
     </FlexRow>
   )
-}
-
-export class SliderControl2 extends React.Component<SliderControlProps> {
-  render() {
-    const controlOptions = {
-      ...defaultSliderControlOptions,
-      ...this.props.DEPRECATED_controlOptions,
-    }
-
-    let marks: Marks = {}
-    if (typeof controlOptions.origin === 'number') {
-      marks[controlOptions.origin] = {
-        style: {
-          display: 'none',
-        },
-        label: String(controlOptions.origin),
-      }
-    }
-
-    return (
-      <FlexRow
-        style={{
-          width: '100%',
-          height: UtopiaTheme.layout.inputHeight.default,
-          paddingLeft: 4,
-          paddingRight: 4,
-          alignItems: 'center',
-          ...this.props.style,
-        }}
-        className={this.props.controlClassName}
-        onContextMenu={this.props.onContextMenu}
-      >
-        <Slider
-          disabled={!this.props.controlStyles.interactive}
-          value={this.props.value}
-          onChange={this.props.onTransientSubmitValue}
-          onAfterChange={this.props.onForcedSubmitValue ?? this.props.onSubmitValue}
-          min={controlOptions.minimum}
-          max={controlOptions.maximum}
-          step={controlOptions.stepSize}
-          marks={marks}
-          handleStyle={{
-            backgroundColor: controlOptions.filled
-              ? this.props.controlStyles.trackColor
-              : undefined,
-          }}
-          trackStyle={{
-            backgroundColor: controlOptions.filled
-              ? this.props.controlStyles.trackColor
-              : undefined,
-          }}
-          activeDotStyle={{
-            backgroundColor: controlOptions.filled
-              ? this.props.controlStyles.trackColor
-              : this.props.controlStyles.railColor,
-          }}
-          railStyle={{
-            backgroundColor: this.props.controlStyles.railColor,
-          }}
-          dotStyle={{
-            backgroundColor: this.props.controlStyles.railColor,
-          }}
-        />
-      </FlexRow>
-    )
-  }
 }

--- a/editor/src/components/inspector/controls/slider-control.tsx
+++ b/editor/src/components/inspector/controls/slider-control.tsx
@@ -58,6 +58,12 @@ export const SliderControl: React.FunctionComponent<SliderControlProps> = (props
     }
   }, [controlOptions.filled, props.controlStyles])
 
+  const railAndDotStyle = React.useMemo(() => {
+    return {
+      backgroundColor: props.controlStyles.railColor,
+    }
+  }, [props.controlStyles])
+
   let marks: Marks = {}
   if (typeof controlOptions.origin === 'number') {
     marks[controlOptions.origin] = {
@@ -93,12 +99,8 @@ export const SliderControl: React.FunctionComponent<SliderControlProps> = (props
         handleStyle={handleAndTrackStyle}
         trackStyle={handleAndTrackStyle}
         activeDotStyle={activeDotStyle}
-        railStyle={{
-          backgroundColor: props.controlStyles.railColor,
-        }}
-        dotStyle={{
-          backgroundColor: props.controlStyles.railColor,
-        }}
+        railStyle={railAndDotStyle}
+        dotStyle={railAndDotStyle}
       />
       {/* This div blocks other controls from receiving hover events 
           while you're sliding the slider. NB this needs to come here, 

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -760,19 +760,35 @@ export const NumberInput = betterReactMemo<NumberInputProps>(
           ) : null}
         </div>
         {DEPRECATED_labelBelow == null && controlStatus != 'off' ? null : (
-          <div
-            onMouseDown={onLabelMouseDown}
-            style={{
-              cursor: CSSCursor.ResizeEW,
-              fontSize: 9,
-              textAlign: 'center',
-              display: 'block',
-              color: controlStyles.secondaryColor,
-              paddingTop: 2,
-            }}
-          >
-            {DEPRECATED_labelBelow != null ? DEPRECATED_labelBelow : null}
-          </div>
+          <React.Fragment>
+            {isFauxcused ? (
+              <div
+                css={{
+                  label: 'hover-avoider-while-sliding',
+                  position: 'fixed',
+                  left: 0,
+                  top: 0,
+                  bottom: 0,
+                  right: 0,
+                  background: 'transparent',
+                  zIndex: 1,
+                }}
+              ></div>
+            ) : null}
+            <div
+              onMouseDown={onLabelMouseDown}
+              style={{
+                cursor: CSSCursor.ResizeEW,
+                fontSize: 9,
+                textAlign: 'center',
+                display: 'block',
+                color: controlStyles.secondaryColor,
+                paddingTop: 2,
+              }}
+            >
+              {DEPRECATED_labelBelow != null ? DEPRECATED_labelBelow : null}
+            </div>
+          </React.Fragment>
         )}
       </form>
     )

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -763,8 +763,7 @@ export const NumberInput = betterReactMemo<NumberInputProps>(
           <React.Fragment>
             {isFauxcused ? (
               <div
-                css={{
-                  label: 'hover-avoider-while-sliding',
+                style={{
                   position: 'fixed',
                   left: 0,
                   top: 0,


### PR DESCRIPTION
**Problem:**
For years now, we've had scrubbing/sliding behaviours that could trigger other hover effects in the UI. It's a detail, but it _really_ felt wrong / brittle. 

**Fix:**
This trivially fixes the problem by temporarily rendering a hover-effect-blocking div for the scrubbable label, and the slider. It doesn't include the sliding behaviours of the colour picker. 

NB we discussed in the past to do this via on-click-outside; can confirm this won't work (you can put a wrapper div, but that then will swallow the first click even while _not_  using the slider. I guess we could do this via editor state etc, but not only does that feel like a sledge hammer, but that would make it v difficult to put the insulating div in the right place, z-index-wise.

