### PR TITLE
Fix local projects in the preview pane.

### DIFF
--- a/editor/src/templates/preview.tsx
+++ b/editor/src/templates/preview.tsx
@@ -60,7 +60,7 @@ export async function startPolledLoad({
   const loadLocalProject = async () => {
     const project = await fetchLocalProject(projectId)
     const model = Utils.forceNotNull(`Local project ${projectId} could not be found.`, project)
-      .model
+      .model.projectContents
     onModelChanged(model)
   }
 


### PR DESCRIPTION
**Problem:**
Local projects didn't work at all in the preview.

**Fix:**
Pass the value of `projectContents` into the preview for building the initial TS worker message instead of the entire `PersistentModel`.

**Commit Details:**
- Related to #1421.
- Passes the `projectContents` from the model into the preview.
