### PR TITLE
Fix the basic github import from the left pane

### DIFF
--- a/editor/src/components/editor/persistence.ts
+++ b/editor/src/components/editor/persistence.ts
@@ -13,6 +13,7 @@ import {
   setSaveError,
   setForkedFromProjectID,
   setProjectName,
+  addStoryboardFile,
 } from './actions/action-creators'
 import {
   createNewProjectID,
@@ -28,6 +29,7 @@ import {
   PersistentModel,
   persistentModelForProjectContents,
   persistentModelFromEditorModel,
+  StoryboardFilePath,
 } from './store/editor-state'
 import { UtopiaTsWorkers } from '../../core/workers/common/worker-types'
 import { arrayContains, NO_OP, projectURLForProject } from '../../core/shared/utils'
@@ -37,6 +39,7 @@ import { CURRENT_PROJECT_VERSION } from './actions/migrations/migrations'
 import { notice } from '../common/notice'
 import { replaceAll } from '../../core/shared/string-utils'
 import { isLoggedIn, isNotLoggedIn, LoginState } from '../../common/user'
+import { getContentsTreeFileFromString } from '../assets'
 
 interface NeverSaved {
   type: 'never-saved'
@@ -223,7 +226,20 @@ export async function createNewProjectFromImportedProject(
     true,
   )
   await saveAssets(projectId, importedProject.assetsToUpload)
-  load(dispatch, persistentModel, importedProject.projectName, projectId, workers, renderEditorRoot)
+  await load(
+    dispatch,
+    persistentModel,
+    importedProject.projectName,
+    projectId,
+    workers,
+    renderEditorRoot,
+  )
+
+  const storyboardFileMissing =
+    getContentsTreeFileFromString(persistentModel.projectContents, StoryboardFilePath) == null
+  if (storyboardFileMissing) {
+    dispatch([addStoryboardFile()])
+  }
 }
 
 export async function createNewProjectFromSampleProject(

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -13,7 +13,7 @@ import { getAllUniqueUids } from '../../core/model/element-template-utils'
 import { getUtopiaJSXComponentsFromSuccess } from '../../core/model/project-file-utils'
 import { isParseSuccess, isTextFile, ProjectFile } from '../../core/shared/project-file-types'
 import { NO_OP } from '../../core/shared/utils'
-import { auth0Url, FLOATING_PREVIEW_BASE_URL } from '../../common/env-vars'
+import { auth0Url, BASE_URL, FLOATING_PREVIEW_BASE_URL } from '../../common/env-vars'
 import { shareURLForProject } from '../../core/shared/utils'
 import Utils from '../../utils/utils'
 import {
@@ -57,6 +57,9 @@ import { StoryboardFilePath } from '../editor/store/editor-state'
 import { getContentsTreeFileFromString } from '../assets'
 import { Link } from '../../uuiui/link'
 import { useTriggerForkProject } from '../editor/persistence-hooks'
+import urljoin = require('url-join')
+import { parseGithubProjectString } from '../../core/shared/github'
+
 export interface LeftPaneProps {
   editorState: EditorState
   derivedState: DerivedState
@@ -657,6 +660,28 @@ const SharingPane = betterReactMemo('SharingPane', () => {
 })
 
 const GithubPane = betterReactMemo('GithubPane', () => {
+  const [githubRepoStr, setGithubRepoStr] = React.useState('')
+  const parsedRepo = parseGithubProjectString(githubRepoStr)
+
+  const onStartImport = React.useCallback(() => {
+    if (parsedRepo != null) {
+      const { owner, repo } = parsedRepo
+
+      const url = new URL(urljoin(BASE_URL, 'p'))
+      url.searchParams.set('github_owner', owner)
+      url.searchParams.set('github_repo', repo)
+
+      window.open(url.toString())
+    }
+  }, [parsedRepo])
+
+  const onChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setGithubRepoStr(e.currentTarget.value)
+    },
+    [setGithubRepoStr],
+  )
+
   return (
     <FlexColumn
       id='leftPaneGithub'
@@ -685,12 +710,12 @@ const GithubPane = betterReactMemo('GithubPane', () => {
           fontSize: '11px',
         }}
       >
-        You can import a new project from Github. It might take a few minutes, and will show up in{' '}
-        <a href='/projects'>your projects</a> (not here).
+        You can import a new project from Github. It might take a few minutes, and will show up in a
+        new tab.
       </div>
       <UIGridRow padded variant='<--------auto-------->|--45px--|'>
-        <StringInput testId='importProject' value='' />
-        <Button spotlight highlight>
+        <StringInput testId='importProject' value={githubRepoStr} onChange={onChange} />
+        <Button spotlight highlight disabled={parsedRepo == null} onMouseUp={onStartImport}>
           Start
         </Button>
       </UIGridRow>

--- a/editor/src/core/shared/github.ts
+++ b/editor/src/core/shared/github.ts
@@ -1,0 +1,23 @@
+import { trimUpToAndIncluding } from './string-utils'
+
+export interface GithubRepo {
+  owner: string
+  repo: string
+}
+
+export function parseGithubProjectString(maybeProject: string): GithubRepo | null {
+  const withoutGithubPrefix = trimUpToAndIncluding('github.com/', maybeProject)
+
+  const repoParts = withoutGithubPrefix.split('/')
+  const owner = repoParts[0] ?? ''
+  const repo = repoParts[1] ?? ''
+
+  if (owner === '' || repo === '') {
+    return null
+  } else {
+    return {
+      owner: owner,
+      repo: repo,
+    }
+  }
+}

--- a/editor/src/core/shared/string-utils.ts
+++ b/editor/src/core/shared/string-utils.ts
@@ -39,3 +39,11 @@ export function splitIntoLines(s: string): Array<string> {
 export function splitAt(index: number, value: string): [string, string] {
   return [value.slice(0, index), value.slice(index, value.length)]
 }
+
+export function trimUpToAndIncluding(prefix: string, target: string): string {
+  if (target.includes(prefix)) {
+    return target.slice(target.indexOf(prefix) + prefix.length)
+  } else {
+    return target
+  }
+}


### PR DESCRIPTION
**Problem:**
The Github Import functionality in the left pane wasn't hooked up

**Fix:**
Provide it with the most basic functionality, meaning that clicking "Start" will actually trigger the import in a new tab, and upon completion will add a storyboard file to the imported project.