### PR TITLE
fixing npm dependencies that require react/jsx-runtime

### DIFF
--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -1,6 +1,7 @@
 import * as UtopiaAPI from 'utopia-api'
 import * as UUIUI from '../../../uuiui'
 import * as UUIUIDeps from '../../../uuiui-deps'
+import * as ReactJsxRuntime from 'react/jsx-runtime'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import * as EmotionReact from '@emotion/react'
@@ -57,6 +58,7 @@ export const BuiltInDependencies = (mode: 'preview' | 'canvas'): Array<BuiltInDe
   builtInDependency('utopia-api', UtopiaAPI, utopiaAPIPackageJSON.version),
   builtInDependency('uuiui', UUIUI, editorPackageJSON.version),
   builtInDependency('uuiui-deps', UUIUIDeps, editorPackageJSON.version),
+  builtInDependency('react/jsx-runtime', ReactJsxRuntime, editorPackageJSON.dependencies.react),
   builtInDependency('react', React, editorPackageJSON.dependencies.react),
   builtInDependency('react-dom', SafeReactDOM(mode), editorPackageJSON.dependencies['react-dom']),
   builtInDependency(

--- a/editor/src/missing-types/index.d.ts
+++ b/editor/src/missing-types/index.d.ts
@@ -95,3 +95,5 @@ declare module 'npm-package-arg'
 declare module '@svgr/plugin-jsx'
 
 declare module '@root/encoding/base64'
+
+declare module 'react/jsx-runtime'

--- a/editor/webpack.config.js
+++ b/editor/webpack.config.js
@@ -190,7 +190,6 @@ const config = {
       'uuiui-deps': srcPath('uuiui-deps'),
       fs: require.resolve('./node_modules/browserfs/dist/shims/fs'),
       process: require.resolve('./node_modules/browserfs/dist/shims/process'),
-      react: require.resolve('./node_modules/react'),
 
       // Support running the profiler against production build of react
       ...(performance ? { 'scheduler/tracing': 'scheduler/tracing-profiling' } : {}),

--- a/editor/webpack.config.js
+++ b/editor/webpack.config.js
@@ -190,6 +190,8 @@ const config = {
       'uuiui-deps': srcPath('uuiui-deps'),
       fs: require.resolve('./node_modules/browserfs/dist/shims/fs'),
       process: require.resolve('./node_modules/browserfs/dist/shims/process'),
+      'react/jsx-runtime': require.resolve('./node_modules/react/jsx-runtime'),
+      react: require.resolve('./node_modules/react'),
 
       // Support running the profiler against production build of react
       ...(performance ? { 'scheduler/tracing': 'scheduler/tracing-profiling' } : {}),


### PR DESCRIPTION
Fixes #1437

**Problem:**
If you try to import a package from npm which uses `react/jsx-runtime` it would fail with an error message.

**Fix:**
The issue was that we have `react` as a hardcoded dependency, but the built-in dependency resolver is dead simple, so I had to manually add `react/jsx-runtime` as a new dependency. All is well now!

**Commit Details:**
- Add `react/jsx-runtime` to the list of built-in dependencies.
- Add `react/jsx-runtime` to the list of fixed aliases in the webpack config so we can import from 'react/jsx-runtime'
