### PR TITLE
Fix/assorted property control related fixes

### DIFF
--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -1,6 +1,6 @@
 import { MetadataUtils } from '../core/model/element-metadata-utils'
 import { Either } from '../core/shared/either'
-import { ElementInstanceMetadataMap, isIntrinsicHTMLElement } from '../core/shared/element-template'
+import { ElementInstanceMetadataMap, isIntrinsicElement } from '../core/shared/element-template'
 import { CanvasPoint } from '../core/shared/math-utils'
 import { NodeModules, ElementPath } from '../core/shared/project-file-types'
 import * as PP from '../core/shared/property-path'
@@ -145,7 +145,7 @@ export const setAsFocusedElement: ContextMenuItem<CanvasData> = {
   isHidden: (data) => {
     return data.selectedViews.every((view) => {
       const elementName = MetadataUtils.getJSXElementFromMetadata(data.jsxMetadata, view)
-      return elementName != null ? isIntrinsicHTMLElement(elementName) : true
+      return elementName != null ? isIntrinsicElement(elementName) : true
     })
   },
   action: (data, dispatch?: EditorDispatch) => {

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -286,7 +286,7 @@ const RowForArrayControl = betterReactMemo(
     )
 
     const rowHeight = UtopiaTheme.layout.rowHeight.max
-    const transformedValue = Array.isArray(value) ? value : []
+    const transformedValue = Array.isArray(value) ? value : [value]
     const { springs, bind } = useArraySuperControl(
       transformedValue,
       onSubmitValue,

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -286,7 +286,13 @@ const RowForArrayControl = betterReactMemo(
     )
 
     const rowHeight = UtopiaTheme.layout.rowHeight.max
-    const { springs, bind } = useArraySuperControl(value, onSubmitValue, rowHeight, false)
+    const transformedValue = Array.isArray(value) ? value : []
+    const { springs, bind } = useArraySuperControl(
+      transformedValue,
+      onSubmitValue,
+      rowHeight,
+      false,
+    )
     const [insertingRow, setInsertingRow] = React.useState(false)
 
     let warningTooltip: string | undefined = undefined

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -1,7 +1,6 @@
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { isAnimatedElement, isImg, isImportedComponent } from '../../core/model/project-file-utils'
 import {
-  isIntrinsicHTMLElement,
   isJSXElement,
   ElementInstanceMetadataMap,
   UtopiaJSXComponent,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1353,7 +1353,7 @@ export const MetadataUtils = {
     if (isImported) {
       return false
     }
-    const isComponent = elementName != null && !isIntrinsicHTMLElement(elementName)
+    const isComponent = elementName != null && !isIntrinsicElement(elementName)
     if (isComponent) {
       return true
     } else {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1278,7 +1278,7 @@ export const MetadataUtils = {
   },
   isComponentInstance(path: ElementPath, rootElements: Array<UtopiaJSXComponent>): boolean {
     const elementName = MetadataUtils.getStaticElementName(path, rootElements)
-    return elementName != null && !isIntrinsicElement(elementName)
+    return elementName != null && !isIntrinsicHTMLElement(elementName)
   },
   isPinnedAndNotAbsolutePositioned(
     metadata: ElementInstanceMetadataMap,

--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -260,6 +260,18 @@ describe('setJSXValueAtPath', () => {
     expect(compiledProps.objectWithNestedArray.array).toEqual([0, 1, 'wee'])
   })
 
+  it('updating a NESTED_ARRAY with a string key converts it to object', () => {
+    const updatedAttributes = forceRight(
+      setJSXValueAtPath(
+        sampleJsxAttributes(),
+        PP.create(['objectWithNestedArray', 'array', 'wee']),
+        jsxAttributeValue('wee', emptyComments),
+      ),
+    )
+    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    expect(compiledProps.objectWithNestedArray.array).toEqual({ 0: 0, 1: 1, 2: 2, wee: 'wee' })
+  })
+
   it('updating part of an ATTRIBUTE_VALUE which is a string throws error', () => {
     expect(() => {
       const updatedAttributes = forceRight(

--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -100,6 +100,16 @@ function sampleJsxAttributes(): JSXAttributes {
         }),
         emptyComments,
       ),
+      objectWithNestedArray: jsxAttributeNestedObjectSimple(
+        jsxAttributesFromMap({
+          array: jsxAttributeNestedArraySimple([
+            jsxAttributeValue(0, emptyComments),
+            jsxAttributeValue(1, emptyComments),
+            jsxAttributeValue(2, emptyComments),
+          ]),
+        }),
+        emptyComments,
+      ),
       doggo: jsxAttributeOtherJavaScript('props.hello', 'return props.hello;', ['props'], null),
       objectValue: jsxAttributeValue(
         {
@@ -137,6 +147,9 @@ const expectedCompiledProps = {
     },
   },
   objectWithArray: {
+    array: [0, 1, 2],
+  },
+  objectWithNestedArray: {
     array: [0, 1, 2],
   },
   doggo: 'kitty',
@@ -221,6 +234,30 @@ describe('setJSXValueAtPath', () => {
     )
     const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
     expect(compiledProps.objectWithArray.array).toEqual([0, 1, 'wee'])
+  })
+
+  it('updating a NESTED_ARRAY at a deep path works', () => {
+    const updatedAttributes = forceRight(
+      setJSXValueAtPath(
+        sampleJsxAttributes(),
+        PP.create(['objectWithNestedArray', 'array', 2]),
+        jsxAttributeValue('wee', emptyComments),
+      ),
+    )
+    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    expect(compiledProps.objectWithNestedArray.array).toEqual([0, 1, 'wee'])
+  })
+
+  it('updating a NESTED_ARRAY at a deep path works and it is resilient to string attribute keys', () => {
+    const updatedAttributes = forceRight(
+      setJSXValueAtPath(
+        sampleJsxAttributes(),
+        PP.create(['objectWithNestedArray', 'array', '2']),
+        jsxAttributeValue('wee', emptyComments),
+      ),
+    )
+    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    expect(compiledProps.objectWithNestedArray.array).toEqual([0, 1, 'wee'])
   })
 
   it('updating part of an ATTRIBUTE_VALUE which is a string throws error', () => {

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -479,7 +479,7 @@ export function setJSXValueInAttributeAtPath(
             )
             return setJSXValueInAttributeAtPath(
               jsxAttributeNestedObject(newProps, emptyComments),
-              tailPath,
+              path,
               newAttrib,
             )
           }

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -414,8 +414,16 @@ export function deeplyCreatedValue(path: PropertyPath, value: JSXAttribute): JSX
   }, value)
 }
 
+const PositiveIntegerRegex = /^(0|[1-9]\d*)$/
+
 function isArrayIndex(maybeIndex: string | number): maybeIndex is number {
-  return !isNaN(maybeIndex as any)
+  if (typeof maybeIndex === 'number') {
+    return Number.isInteger(maybeIndex)
+  } else if (typeof maybeIndex === 'string') {
+    return PositiveIntegerRegex.test(maybeIndex)
+  } else {
+    return false
+  }
 }
 export function setJSXValueInAttributeAtPath(
   attribute: JSXAttribute,

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -414,6 +414,9 @@ export function deeplyCreatedValue(path: PropertyPath, value: JSXAttribute): JSX
   }, value)
 }
 
+function isArrayIndex(maybeIndex: string | number): maybeIndex is number {
+  return !isNaN(maybeIndex as any)
+}
 export function setJSXValueInAttributeAtPath(
   attribute: JSXAttribute,
   path: PropertyPath,
@@ -439,7 +442,7 @@ export function setJSXValueInAttributeAtPath(
             return left(`Unable to set an indexed value in an array containing spread elements`)
           }
 
-          if (typeof attributeKey === 'number') {
+          if (isArrayIndex(attributeKey)) {
             let newArray: Array<JSXArrayElement> = [...attribute.content]
             if (lastPartOfPath) {
               newArray[attributeKey] = jsxArrayValue(newAttrib, emptyComments)


### PR DESCRIPTION
**Problem:**
While trying to use property controls for a first time in _a long while_ I encountered some issues.

**Commit Details:**
- jsxAttributeNestedArrays can now be updated with paths such as `['props', 'someArray', '3']`, we now properly treat the string '3' as an array index. This is necessary because `Object.keys([1, 2, 3])` returns `["0", "1", "2"]`...
- While I was fixing that, I realized that there's a bug in the behavior that converts the jsxAttributeNestedArray into a jsxAttributeNestedObject. I fixed that and wrote a test for it
- `isComponentInstance` only returns false if the selected element is a HTML DOM Host
- A fix to the array supercontrol in the inspector (via @enidemi )
