### PR TITLE
Spike/component state in inspector

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -73,6 +73,7 @@ export function createComponentRendererComponent(params: {
   topLevelElementName: string
   filePath: string
   mutableContextRef: React.MutableRefObject<MutableUtopiaContextProps>
+  metadataContext: UiJsxCanvasContextData
 }): ComponentRendererComponent {
   const Component = (realPassedPropsIncludingUtopiaSpecialStuff: any) => {
     const {
@@ -136,7 +137,11 @@ export function createComponentRendererComponent(params: {
       instancePath,
       getUtopiaID(utopiaJsxComponent.rootElement),
     )
-
+    // console.log(
+    //   'utopiaJsxComponent.arbitraryJSBlock',
+    //   EP.toString(rootElementPath),
+    //   utopiaJsxComponent.arbitraryJSBlock,
+    // )
     if (utopiaJsxComponent.arbitraryJSBlock != null) {
       const lookupRenderer = createLookupRender(
         rootElementPath,
@@ -167,6 +172,8 @@ export function createComponentRendererComponent(params: {
         mutableContext.requireResult,
         utopiaJsxComponent.arbitraryJSBlock,
         scope,
+        metadataContext,
+        rootElementPath,
       )
     }
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.tsx
@@ -100,6 +100,7 @@ export function createExecutionScope(
           topLevelElementName: topLevelElement.name,
           mutableContextRef: mutableContextRef,
           filePath: filePath,
+          metadataContext: metadataContext,
         })
       }
     }
@@ -137,8 +138,13 @@ export function createExecutionScope(
       executionScope,
       lookupRenderer,
     )
-
-    runBlockUpdatingScope(requireResult, combinedTopLevelArbitraryBlock, executionScope)
+    runBlockUpdatingScope(
+      requireResult,
+      combinedTopLevelArbitraryBlock,
+      executionScope,
+      metadataContext,
+      null,
+    )
   }
 
   // WARNING: mutating the mutableContextRef

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-scope-utils.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-scope-utils.ts
@@ -1,14 +1,24 @@
 import { MapLike } from 'typescript'
 import { ArbitraryJSBlock } from '../../../core/shared/element-template'
 import { resolveParamsAndRunJsCode } from '../../../core/shared/javascript-cache'
+import { ElementPath } from '../../../core/shared/project-file-types'
 import { fastForEach } from '../../../core/shared/utils'
+import { UiJsxCanvasContextData } from '../ui-jsx-canvas'
 
 export function runBlockUpdatingScope(
   requireResult: MapLike<any>,
   block: ArbitraryJSBlock,
   currentScope: MapLike<any>,
+  metadataContext: UiJsxCanvasContextData,
+  componentPath: ElementPath | null,
 ): void {
-  const result = resolveParamsAndRunJsCode(block, requireResult, currentScope)
+  const result = resolveParamsAndRunJsCode(
+    block,
+    requireResult,
+    currentScope,
+    metadataContext,
+    componentPath ?? undefined,
+  )
   fastForEach(block.definedWithin, (within) => {
     currentScope[within] = result[within]
   })

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -262,7 +262,7 @@ function useClearSpyMetadataOnRemount(
   canvasMountCountRef.current = canvasMountCount
   domWalkerInvalidateCountRef.current = domWalkerInvalidateCount
 }
-
+let count = 0
 export const UiJsxCanvas = betterReactMemo(
   'UiJsxCanvas',
   React.forwardRef<HTMLDivElement, UiJsxCanvasPropsWithErrorCallback>((props, ref) => {
@@ -305,6 +305,13 @@ export const UiJsxCanvas = betterReactMemo(
     const dispatch = useRefEditorState((state) => state.dispatch)
     window.setInterval(() => {
       if (Object.keys(metadataContext.current.componentStateValues).length > 0) {
+        Object.keys(metadataContext.current.componentStateValues).map((k) => {
+          try {
+            // metadataContext.current.componentStateValues[k]['useState1'][1](count++)
+          } catch (e) {
+            console.error('metadataContext.current.componentStateValues updater not found', e)
+          }
+        })
         dispatch.current(
           [updateComponentStateData(metadataContext.current.componentStateValues)],
           'everyone',

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -51,6 +51,7 @@ import { BuildType } from '../../core/workers/ts/ts-worker'
 import { ParseResult } from '../../utils/value-parser-utils'
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import type { LoginState } from '../../common/user'
+import { MapLike } from 'typescript'
 export { isLoggedIn, loggedInUser, LoginState, notLoggedIn, UserDetails } from '../../common/user'
 
 export interface PropertyTarget {
@@ -830,6 +831,11 @@ export interface SetCurrentTheme {
   theme: Theme
 }
 
+export interface UpdateComponentStateData {
+  action: 'UPDATE_COMPONENT_STATE_DATA'
+  value: MapLike<MapLike<any>>
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -967,6 +973,7 @@ export type EditorAction =
   | ResetCanvas
   | SetFilebrowserDropTarget
   | SetCurrentTheme
+  | UpdateComponentStateData
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1,3 +1,4 @@
+import { MapLike } from 'typescript'
 import { LayoutSystem } from 'utopia-api' // TODO fixme this imports utopia-api
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import type { LoginState } from '../../../common/user'
@@ -185,6 +186,7 @@ import type {
   SetFilebrowserDropTarget,
   SetForkedFromProjectID,
   SetCurrentTheme,
+  UpdateComponentStateData,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -1315,5 +1317,11 @@ export function setCurrentTheme(theme: Theme): SetCurrentTheme {
   return {
     action: 'SET_CURRENT_THEME',
     theme: theme,
+  }
+}
+export function updateComponentStateData(value: MapLike<MapLike<any>>): UpdateComponentStateData {
+  return {
+    action: 'UPDATE_COMPONENT_STATE_DATA',
+    value: value,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -90,6 +90,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'RESET_CANVAS':
     case 'SET_FILEBROWSER_DROPTARGET':
     case 'SET_FORKED_FROM_PROJECT_ID':
+    case 'UPDATE_COMPONENT_STATE_DATA':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -495,6 +495,7 @@ import { emptySet } from '../../../core/shared/set-utils'
 import { absolutePathFromRelativePath, stripLeadingSlash } from '../../../utils/path-utils'
 import { resolveModule } from '../../../core/es-modules/package-manager/module-resolution'
 import { reverse, uniqBy } from '../../../core/shared/array-utils'
+import { MapLike } from 'typescript'
 
 export function updateSelectedLeftMenuTab(editorState: EditorState, tab: LeftMenuTab): EditorState {
   return {
@@ -4330,9 +4331,13 @@ export const UPDATE_FNS = {
     action: UpdateComponentStateData,
     editor: EditorModel,
   ): EditorModel => {
+    const copiedValue: MapLike<MapLike<any>> = {}
+    fastForEach(Object.keys(action.value), (k) => {
+      copiedValue[k] = { ...action.value[k] }
+    })
     return {
       ...editor,
-      componentStateData: action.value,
+      componentStateData: copiedValue,
     }
   },
 }

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -353,6 +353,7 @@ import {
   SetFilebrowserDropTarget,
   SetForkedFromProjectID,
   SetCurrentTheme,
+  UpdateComponentStateData,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -1023,6 +1024,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     focusedElementPath: currentEditor.focusedElementPath,
     config: defaultConfig(),
     theme: currentEditor.theme,
+    componentStateData: currentEditor.componentStateData,
   }
 }
 
@@ -4322,6 +4324,15 @@ export const UPDATE_FNS = {
     return {
       ...editor,
       theme: action.theme,
+    }
+  },
+  UPDATE_COMPONENT_STATE_DATA: (
+    action: UpdateComponentStateData,
+    editor: EditorModel,
+  ): EditorModel => {
+    return {
+      ...editor,
+      componentStateData: action.value,
     }
   },
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -143,6 +143,7 @@ import { importedFromWhere } from '../import-utils'
 import { defaultConfig, UtopiaVSCodeConfig } from 'utopia-vscode-common'
 
 import * as OPI from 'object-path-immutable'
+import { MapLike } from 'typescript'
 const ObjectPathImmutable: any = OPI
 
 export const enum LeftMenuTab {
@@ -397,6 +398,7 @@ export interface EditorState {
   focusedElementPath: ElementPath | null
   config: UtopiaVSCodeConfig
   theme: Theme
+  componentStateData: MapLike<MapLike<any>>
 }
 
 export interface StoredEditorState {
@@ -1162,6 +1164,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     focusedElementPath: null,
     config: defaultConfig(),
     theme: 'light',
+    componentStateData: {},
   }
 }
 
@@ -1398,6 +1401,7 @@ export function editorModelFromPersistentModel(
     focusedElementPath: null,
     config: defaultConfig(),
     theme: 'light',
+    componentStateData: {},
   }
   return editor
 }

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -297,6 +297,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SET_FORKED_FROM_PROJECT_ID(action, state)
     case 'SET_CURRENT_THEME':
       return UPDATE_FNS.SET_CURRENT_THEME(action, state)
+    case 'UPDATE_COMPONENT_STATE_DATA':
+      return UPDATE_FNS.UPDATE_COMPONENT_STATE_DATA(action, state)
     default:
       return state
   }

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -46,6 +46,7 @@ import {
   paddingTop,
   Subdued,
   VerySubdued,
+  InspectorSubsectionHeader,
 } from '../../../../uuiui'
 import { getControlStyles } from '../../../../uuiui-deps'
 import { InfoBox } from '../../../common/notices'
@@ -769,14 +770,23 @@ export const ComponentSectionInner = betterReactMemo(
             </div>
           </UIGridRow>
         ) : null}
-        {stateData != null &&
-          Object.keys(stateData).map((key) => {
-            return (
-              <UIGridRow key={key} padded tall={false} variant={'<-------------1fr------------->'}>
-                {key}: {JSON.stringify(stateData[key])}
-              </UIGridRow>
-            )
-          })}
+        {stateData != null && (
+          <>
+            <InspectorSubsectionHeader>Initial State</InspectorSubsectionHeader>
+            {Object.keys(stateData).map((key) => {
+              return (
+                <UIGridRow
+                  key={key}
+                  padded
+                  tall={false}
+                  variant={'<-------------1fr------------->'}
+                >
+                  {key}: {JSON.stringify(stateData[key])}
+                </UIGridRow>
+              )
+            })}
+          </>
+        )}
       </>
     )
   },

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -47,6 +47,7 @@ import {
   Subdued,
   VerySubdued,
   InspectorSubsectionHeader,
+  StringInput,
 } from '../../../../uuiui'
 import { getControlStyles } from '../../../../uuiui-deps'
 import { InfoBox } from '../../../common/notices'
@@ -775,13 +776,14 @@ export const ComponentSectionInner = betterReactMemo(
             <InspectorSubsectionHeader>Component UseState</InspectorSubsectionHeader>
             {Object.keys(stateData).map((key) => {
               return (
-                <UIGridRow
-                  key={key}
-                  padded
-                  tall={false}
-                  variant={'<-------------1fr------------->'}
-                >
-                  {key}: {JSON.stringify(stateData[key][0])}
+                <UIGridRow key={key} padded tall={false} variant={'<--1fr--><--1fr-->'}>
+                  {key}:
+                  <StringInput
+                    testId=''
+                    value={stateData[key][0]}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onChange={(event) => stateData[key][1](event.target.value)}
+                  />
                 </UIGridRow>
               )
             })}

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -568,6 +568,10 @@ export const ComponentSectionInner = betterReactMemo(
 
     const target = selectedViews[0]
 
+    const stateData = useEditorState((state) => {
+      return state.editor.componentStateData[EP.toString(target)]
+    }, 'componentSectionInner componentStateData')
+
     const isFocused = EP.isFocused(focusedElementPath, target)
 
     const toggleFocusMode = React.useCallback(() => {
@@ -765,6 +769,14 @@ export const ComponentSectionInner = betterReactMemo(
             </div>
           </UIGridRow>
         ) : null}
+        {stateData != null &&
+          Object.keys(stateData).map((key) => {
+            return (
+              <UIGridRow key={key} padded tall={false} variant={'<-------------1fr------------->'}>
+                {key}: {JSON.stringify(stateData[key])}
+              </UIGridRow>
+            )
+          })}
       </>
     )
   },

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -772,7 +772,7 @@ export const ComponentSectionInner = betterReactMemo(
         ) : null}
         {stateData != null && (
           <>
-            <InspectorSubsectionHeader>Initial State</InspectorSubsectionHeader>
+            <InspectorSubsectionHeader>Component UseState</InspectorSubsectionHeader>
             {Object.keys(stateData).map((key) => {
               return (
                 <UIGridRow
@@ -781,7 +781,7 @@ export const ComponentSectionInner = betterReactMemo(
                   tall={false}
                   variant={'<-------------1fr------------->'}
                 >
-                  {key}: {JSON.stringify(stateData[key])}
+                  {key}: {JSON.stringify(stateData[key][0])}
                 </UIGridRow>
               )
             })}

--- a/editor/src/core/shared/javascript-cache.ts
+++ b/editor/src/core/shared/javascript-cache.ts
@@ -3,8 +3,13 @@ import {
   ArbitraryJSBlock,
   JSXArbitraryBlock,
 } from './element-template'
+import * as React from 'react'
 import { MapLike } from 'typescript'
 import { SafeFunctionCurriedErrorHandler } from './code-exec-utils'
+import { ElementPath } from './project-file-types'
+import * as EP from '../../core/shared/element-path'
+import { UiJsxCanvasContextData } from '../../components/canvas/ui-jsx-canvas'
+import { dropLast } from './array-utils'
 
 type JavaScriptContainer = JSXAttributeOtherJavaScript | ArbitraryJSBlock | JSXArbitraryBlock
 
@@ -22,16 +27,53 @@ export function resolveParamsAndRunJsCode(
   javascriptBlock: JavaScriptContainer,
   requireResult: MapLike<any>,
   currentScope: MapLike<any>,
+  metadataContext?: UiJsxCanvasContextData,
+  elementPath?: ElementPath,
 ): any {
+  let hookCounter = 0
+  const MonkeyReact = {
+    ...React,
+    useState: (initialState: any) => {
+      hookCounter += 1
+      const hookId = `useState${hookCounter}`
+      let stateToUse = initialState
+      if (elementPath != null && metadataContext != null) {
+        const componentPath = { ...elementPath, parts: dropLast(elementPath.parts) }
+        if (metadataContext.current.componentStateValues[EP.toString(componentPath)] == null) {
+          metadataContext.current.componentStateValues[EP.toString(componentPath)] = {}
+        }
+        if (
+          metadataContext.current.componentStateValues[EP.toString(componentPath)][hookId] == null
+        ) {
+          metadataContext.current.componentStateValues[EP.toString(componentPath)][
+            hookId
+          ] = initialState
+        } else {
+          stateToUse =
+            metadataContext.current.componentStateValues[EP.toString(componentPath)][hookId]
+        }
+      }
+      return React.useState(stateToUse)
+    },
+  }
   const definedElsewhereInfo = resolveDefinedElsewhere(
     javascriptBlock.definedElsewhere,
     requireResult,
     currentScope,
   )
+  // console.log('definedElsewhereInfo', definedElsewhereInfo, componentPath, javascriptBlock)
+  definedElsewhereInfo['React'] = MonkeyReact
   const updatedBlock = {
     ...javascriptBlock,
     definedElsewhere: Object.keys(definedElsewhereInfo),
   }
+
+  // const original = React.useState
+  // if (componentPath != null) {
+  //   ;(React as any)['useState'] = MonkeyReact.useState
+  //   ;(React as any)['acica'] = true
+  // }
+
   // NOTE: If the external dependencies of this block of code aren't present when this is first called,
   // we'll cache the block without those keys. This _shouldn't_ be an issue since we replace the unique ID
   // on a new parse, but it means we have to be careful of this when reusing js blocks in tests
@@ -41,6 +83,9 @@ export function resolveParamsAndRunJsCode(
   const result = getOrUpdateFunctionCache(updatedBlock, requireResult, (e) => {
     throw e
   })(currentScope['callerThis'], ...Object.values(definedElsewhereInfo))
+  // if (componentPath != null) {
+  //   ;(React as any)['useState'] = original
+  // }
   return result
 }
 

--- a/editor/src/core/shared/javascript-cache.ts
+++ b/editor/src/core/shared/javascript-cache.ts
@@ -35,37 +35,18 @@ export function resolveParamsAndRunJsCode(
     hookCounter += 1
     const hookId = `useState${hookCounter}`
     const useStateResult = React.useState(initialState)
-    const monkeySetState = (newValue: any) => {
-      useStateResult[1](newValue)
 
-      if (elementPath != null && metadataContext != null) {
-        const componentPath = { ...elementPath, parts: dropLast(elementPath.parts) }
-        if (metadataContext.current.componentStateValues[EP.toString(componentPath)] == null) {
-          metadataContext.current.componentStateValues[EP.toString(componentPath)] = {}
-        }
-        metadataContext.current.componentStateValues[EP.toString(componentPath)][hookId] = [
-          newValue,
-          monkeySetState,
-        ]
-      }
-    }
-
-    const resultToReturn = [useStateResult[0], monkeySetState]
     if (elementPath != null && metadataContext != null) {
       const componentPath = { ...elementPath, parts: dropLast(elementPath.parts) }
       if (metadataContext.current.componentStateValues[EP.toString(componentPath)] == null) {
         metadataContext.current.componentStateValues[EP.toString(componentPath)] = {}
       }
-      if (
-        metadataContext.current.componentStateValues[EP.toString(componentPath)][hookId] == null
-      ) {
-        metadataContext.current.componentStateValues[EP.toString(componentPath)][
-          hookId
-        ] = resultToReturn
-      }
+      metadataContext.current.componentStateValues[EP.toString(componentPath)][
+        hookId
+      ] = useStateResult
     }
 
-    return resultToReturn
+    return useStateResult
   }
   const MonkeyReact = {
     ...React,


### PR DESCRIPTION
This spike is exploring what options there are to show and give control over React useState to users. 
In this video it's visible that the App component uses the number of cards shown from the state. It is showing the current number of cards on the right side in the inspector Component Section. 

With this it's also possible to manipulate the state, allowing setting different states to check the application with different number of list items, optionally rendered content, toggling buttons etc. without manually triggering the state by clicking in the App. 

https://user-images.githubusercontent.com/4403069/123987139-3cff0f80-d9c7-11eb-9643-3676cd91752b.mov




