### PR TITLE
Some module import fixes

### DIFF
--- a/editor/src/core/es-modules/package-manager/module-resolution.ts
+++ b/editor/src/core/es-modules/package-manager/module-resolution.ts
@@ -221,7 +221,7 @@ function processPackageJson(
   return foldEither(
     (_) => resolveNotPresent,
     (packageJson) => {
-      const moduleName: string | null = packageJson.name ?? last(containerFolder) ?? null
+      const moduleName: string | null = packageJson.name ?? null
       const mainEntry: string | null = packageJson.main ?? null
       const moduleEntry: string | null = packageJson.module ?? null
       if (mainEntry != null && !mainEntry.endsWith('.cjs')) {
@@ -232,6 +232,8 @@ function processPackageJson(
       }
       if (moduleName != null) {
         return resolveSuccess(normalizePath([...containerFolder, ...getPartsFromPath(moduleName)]))
+      } else if (containerFolder.length > 0) {
+        return resolveSuccess(normalizePath(containerFolder))
       }
       return resolveNotPresent
     },

--- a/editor/src/core/es-modules/package-manager/module-resolution.ts
+++ b/editor/src/core/es-modules/package-manager/module-resolution.ts
@@ -221,14 +221,17 @@ function processPackageJson(
   return foldEither(
     (_) => resolveNotPresent,
     (packageJson) => {
-      const moduleName: string = packageJson.name ?? makePathFromParts(containerFolder)
+      const moduleName: string | null = packageJson.name ?? last(containerFolder) ?? null
       const mainEntry: string | null = packageJson.main ?? null
       const moduleEntry: string | null = packageJson.module ?? null
-      if (moduleEntry != null && mainEntry == null) {
-        return resolveSuccess(normalizePath([...containerFolder, ...getPartsFromPath(moduleName)]))
-      }
-      if (mainEntry != null) {
+      if (mainEntry != null && !mainEntry.endsWith('.cjs')) {
         return resolveSuccess(normalizePath([...containerFolder, ...getPartsFromPath(mainEntry)]))
+      }
+      if (moduleEntry != null && !moduleEntry.endsWith('.cjs')) {
+        return resolveSuccess(normalizePath([...containerFolder, ...getPartsFromPath(moduleEntry)]))
+      }
+      if (moduleName != null) {
+        return resolveSuccess(normalizePath([...containerFolder, ...getPartsFromPath(moduleName)]))
       }
       return resolveNotPresent
     },

--- a/editor/src/core/webpack-loaders/default-loader.ts
+++ b/editor/src/core/webpack-loaders/default-loader.ts
@@ -1,7 +1,7 @@
 import { LoadModule, loadModuleResult, MatchFile, ModuleLoader } from './loader-types'
 
 const matchFile: MatchFile = (filename: string) => {
-  return ['.js', '.jsx', '.ts', '.tsx', '.d.ts', '.json'].some((extension) =>
+  return ['.js', '.jsx', '.mjs', '.ts', '.tsx', '.d.ts', '.json'].some((extension) =>
     filename.endsWith(extension),
   )
 }

--- a/editor/src/third-party/react-error-overlay/utils/parser.ts
+++ b/editor/src/third-party/react-error-overlay/utils/parser.ts
@@ -25,10 +25,15 @@ function extractLocation(token: string): [string, number, number] {
 
 const regexValidFrame_Chrome = /^\s*(at|in)\s.+(:\d+)/
 const regexValidFrame_FireFox = /(^|@)\S+:\d+|.+line\s+\d+\s+>\s+(eval|Function).+/
+const maxParseableErrorLength = 10000
 
 export function parseStack(stack: string[]): StackFrame[] {
   const frames = stack
-    .filter((e) => regexValidFrame_Chrome.test(e) || regexValidFrame_FireFox.test(e))
+    .filter(
+      (e) =>
+        e.length < maxParseableErrorLength &&
+        (regexValidFrame_Chrome.test(e) || regexValidFrame_FireFox.test(e)),
+    )
     .map((e) => {
       if (regexValidFrame_FireFox.test(e)) {
         // Strip eval, we don't care about it


### PR DESCRIPTION
**Problem:**
We had a few issues in the module importing that were exposed when trying to import [`twind`](https://github.com/tw-in-js/twind), namely:

1. Execution can fail on a `.cjs` file as it may include reference to variables provided by the node.js runtime (e.g. `__filename`) - I will create a follow up ticket to tackle injecting all of the node.js variables
2. The module resolution logic when using the `module` field was incorrect as it was doubling up the folder path
3. Importing whilst resolving these issues was causing the error parsing to blow out as the attached source map was *huge*

**Fix:**

1. Prevent resolving of `.cjs` files (but support resolving of `.mjs` files)
2. Fixed module resolution when a `module` or `name` value is present in the `package.json`
3. Constrain error stack parsing if the size of the stack entry is too huge
