### PR TITLE
Include the devDependencies from the package.json when building projects

### DIFF
--- a/editor/src/components/editor/npm-dependency/npm-dependency.spec.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.spec.ts
@@ -239,21 +239,21 @@ describe('Parsing the package.json', () => {
   })
 
   it('dependenciesFromPackageJson returns the combined dependencies if includeDevDependencies is true', () => {
-    const combinedDependencies = dependenciesFromPackageJson(packageJsonFile, true)
+    const combinedDependencies = dependenciesFromPackageJson(packageJsonFile, 'combined')
     expect(combinedDependencies).toEqual(expectedCombined)
   })
 
   it('dependenciesFromPackageJson returns the regular dependencies only if includeDevDependencies is false', () => {
-    const regularDependencies = dependenciesFromPackageJson(packageJsonFile, false)
+    const regularDependencies = dependenciesFromPackageJson(packageJsonFile, 'regular-only')
     expect(regularDependencies).toEqual(expectedDependencies)
   })
 
   it('dependenciesFromPackageJson returns a cached result if called again with the same unchanged file contents', () => {
-    const firstCombined = dependenciesFromPackageJson(packageJsonFile, true)
-    const secondCombined = dependenciesFromPackageJson(packageJsonFile, true)
+    const firstCombined = dependenciesFromPackageJson(packageJsonFile, 'combined')
+    const secondCombined = dependenciesFromPackageJson(packageJsonFile, 'combined')
 
-    const firstRegular = dependenciesFromPackageJson(packageJsonFile, false)
-    const secondRegular = dependenciesFromPackageJson(packageJsonFile, false)
+    const firstRegular = dependenciesFromPackageJson(packageJsonFile, 'regular-only')
+    const secondRegular = dependenciesFromPackageJson(packageJsonFile, 'regular-only')
 
     expect(firstCombined === secondCombined).toBeTruthy()
     expect(firstRegular === secondRegular).toBeTruthy()

--- a/editor/src/components/editor/npm-dependency/npm-dependency.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.ts
@@ -372,11 +372,11 @@ function maybeCachedDependenciesFromPackageJson(
 
 export function dependenciesFromPackageJson(
   packageJsonFile: ProjectFile | null,
-  includeDevDependencies: boolean,
+  combinedOrRegularOnly: 'combined' | 'regular-only',
 ): Array<RequestedNpmDependency> {
   const npmDependencies = maybeCachedDependenciesFromPackageJson(packageJsonFile)
 
-  if (includeDevDependencies) {
+  if (combinedOrRegularOnly === 'combined') {
     return npmDependencies.combined
   } else {
     return npmDependencies.dependencies
@@ -414,7 +414,7 @@ export function dependenciesWithEditorRequirements(
   projectContents: ProjectContentTreeRoot,
 ): Array<RequestedNpmDependency> {
   const packageJsonFile = packageJsonFileFromProjectContents(projectContents)
-  const userDefinedDeps = dependenciesFromPackageJson(packageJsonFile, true)
+  const userDefinedDeps = dependenciesFromPackageJson(packageJsonFile, 'combined')
   return [...userDefinedDeps, ...EditorTypePackageDependencies]
 }
 

--- a/editor/src/components/editor/npm-dependency/npm-dependency.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.ts
@@ -39,7 +39,11 @@ import * as GitHost from 'hosted-git-info'
 import { importDefault, importStar } from '../../../core/es-modules/commonjs-interop'
 
 import * as OPI from 'object-path-immutable'
+import { forEachValue, propOrNull } from '../../../core/shared/object-utils'
 const ObjectPathImmutable: any = OPI
+
+const DependenciesKey = 'dependencies'
+const DevDependenciesKey = 'devDependencies'
 
 interface PackageNotFound {
   type: 'PACKAGE_NOT_FOUND'
@@ -257,46 +261,88 @@ export async function checkPackageVersionExists(
   }
 }
 
+function allDependenciesFromUnparsedPackageJson(
+  packageJson: string,
+): { dependencies: any; devDependencies: any } {
+  try {
+    const parsedJSON = json5.parse(packageJson)
+    if (typeof parsedJSON === 'object') {
+      return {
+        dependencies: propOrNull(DependenciesKey, parsedJSON),
+        devDependencies: propOrNull(DevDependenciesKey, parsedJSON),
+      }
+    } else {
+      return {
+        dependencies: {},
+        devDependencies: {},
+      }
+    }
+  } catch (error) {
+    return {
+      dependencies: {},
+      devDependencies: {},
+    }
+  }
+}
+
+interface DependenciesAndDevDependencies {
+  dependencies: Array<RequestedNpmDependency>
+  devDependencies: Array<RequestedNpmDependency>
+  combined: Array<RequestedNpmDependency>
+}
+
+const EmptyDependencies: DependenciesAndDevDependencies = deepFreeze({
+  dependencies: [],
+  devDependencies: [],
+  combined: [],
+})
+
+export function allDependenciesFromPackageJsonContents(
+  packageJson: string,
+): DependenciesAndDevDependencies {
+  function parseDependencies(dependenciesJSON: unknown): Array<RequestedNpmDependency> {
+    let result: Array<RequestedNpmDependency> = []
+    if (typeof dependenciesJSON === 'object' && dependenciesJSON != null) {
+      forEachValue((dependencyValue, dependencyKey) => {
+        if (typeof dependencyKey === 'string' && typeof dependencyValue === 'string') {
+          result.push(requestedNpmDependency(dependencyKey, dependencyValue))
+        }
+      }, dependenciesJSON)
+    }
+    return result
+  }
+
+  const { dependencies, devDependencies } = allDependenciesFromUnparsedPackageJson(packageJson)
+  const parsedDependencies = parseDependencies(dependencies)
+  const parsedDevDependencies = parseDependencies(devDependencies)
+
+  return {
+    dependencies: parsedDependencies,
+    devDependencies: parsedDevDependencies,
+    combined: [...parsedDependencies, ...parsedDevDependencies],
+  }
+}
+
 export function dependenciesFromPackageJsonContents(
   packageJson: string,
 ): Array<RequestedNpmDependency> {
-  try {
-    const parsedJSON = json5.parse(packageJson)
-
-    const dependenciesJSON = Utils.path<any>(['dependencies'], parsedJSON)
-    if (typeof dependenciesJSON === 'object') {
-      let result: Array<RequestedNpmDependency> = []
-      for (const dependencyKey of Object.keys(dependenciesJSON)) {
-        const dependencyValue = dependenciesJSON[dependencyKey]
-        if (typeof dependencyValue === 'string') {
-          result.push(requestedNpmDependency(dependencyKey, dependencyValue))
-        } else {
-          return []
-        }
-      }
-      return result
-    } else {
-      return []
-    }
-  } catch (error) {
-    return []
-  }
+  return allDependenciesFromPackageJsonContents(packageJson).combined
 }
 
 // Cache the dependencies when getting them from `EditorState` because lots of things need this information.
 // IMPORTANT: This caching is relied upon indirectly by monaco-wrapper.tsx
 interface PackageJsonAndDeps {
   packageJsonFile: ProjectFile
-  npmDependencies: Array<RequestedNpmDependency>
+  npmDependencies: DependenciesAndDevDependencies
 }
 
 let cachedDependencies: PackageJsonAndDeps | null = null
 
-export function dependenciesFromPackageJson(
+function maybeCachedDependenciesFromPackageJson(
   packageJsonFile: ProjectFile | null,
-): Array<RequestedNpmDependency> {
+): DependenciesAndDevDependencies {
   if (packageJsonFile == null) {
-    return []
+    return EmptyDependencies
   } else {
     if (
       cachedDependencies != null &&
@@ -305,7 +351,7 @@ export function dependenciesFromPackageJson(
       return cachedDependencies.npmDependencies
     } else {
       if (isTextFile(packageJsonFile)) {
-        const npmDependencies = dependenciesFromPackageJsonContents(
+        const npmDependencies = allDependenciesFromPackageJsonContents(
           packageJsonFile.fileContents.code,
         )
         if (npmDependencies == null) {
@@ -324,18 +370,31 @@ export function dependenciesFromPackageJson(
   }
 }
 
+export function dependenciesFromPackageJson(
+  packageJsonFile: ProjectFile | null,
+  includeDevDependencies: boolean,
+): Array<RequestedNpmDependency> {
+  const npmDependencies = maybeCachedDependenciesFromPackageJson(packageJsonFile)
+
+  if (includeDevDependencies) {
+    return npmDependencies.combined
+  } else {
+    return npmDependencies.dependencies
+  }
+}
+
 export function includesDependency(
   packageJsonFile: ProjectFile | null,
   dependencyToCheck: string,
 ): boolean {
   if (packageJsonFile != null) {
     if (isTextFile(packageJsonFile)) {
-      const parsedJSON = json5.parse(packageJsonFile.fileContents.code)
-      const fromDependencies = Utils.path<unknown>(['dependencies', dependencyToCheck], parsedJSON)
-      const fromDevDependencies = Utils.path<unknown>(
-        ['devDependencies', dependencyToCheck],
-        parsedJSON,
+      const { dependencies, devDependencies } = allDependenciesFromUnparsedPackageJson(
+        packageJsonFile.fileContents.code,
       )
+
+      const fromDependencies = propOrNull(dependencyToCheck, dependencies)
+      const fromDevDependencies = propOrNull(dependencyToCheck, devDependencies)
 
       return fromDependencies != null || fromDevDependencies != null
     }
@@ -355,7 +414,7 @@ export function dependenciesWithEditorRequirements(
   projectContents: ProjectContentTreeRoot,
 ): Array<RequestedNpmDependency> {
   const packageJsonFile = packageJsonFileFromProjectContents(projectContents)
-  const userDefinedDeps = dependenciesFromPackageJson(packageJsonFile)
+  const userDefinedDeps = dependenciesFromPackageJson(packageJsonFile, true)
   return [...userDefinedDeps, ...EditorTypePackageDependencies]
 }
 
@@ -404,7 +463,7 @@ export function updateDependenciesInPackageJson(
 ): string {
   function updateDeps(parsedPackageJson: any): string {
     return JSON.stringify(
-      ObjectPathImmutable.set(parsedPackageJson, ['dependencies'], npmDependencies),
+      ObjectPathImmutable.set(parsedPackageJson, [DependenciesKey], npmDependencies),
       null,
       2,
     )

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -127,10 +127,7 @@ import * as friendlyWords from 'friendly-words'
 import { fastForEach } from '../../../core/shared/utils'
 import { ShortcutConfiguration } from '../shortcut-definitions'
 import { notLoggedIn } from '../../../common/user'
-import {
-  dependenciesWithEditorRequirements,
-  immediatelyResolvableDependenciesWithEditorRequirements,
-} from '../npm-dependency/npm-dependency'
+import { immediatelyResolvableDependenciesWithEditorRequirements } from '../npm-dependency/npm-dependency'
 import { getControlsForExternalDependencies } from '../../../core/property-controls/property-controls-utils'
 import { parseSuccess } from '../../../core/workers/common/project-file-utils'
 import {

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -161,7 +161,7 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
   }
 
   removeDependency = (key: string) => {
-    let npmDependencies = dependenciesFromPackageJson(this.props.packageJsonFile)
+    let npmDependencies = dependenciesFromPackageJson(this.props.packageJsonFile, false)
     // If we can't get the dependencies that implies something is broken, so avoid changing it.
     if (npmDependencies != null) {
       npmDependencies = npmDependencies.filter((dep) => dep.name != key)
@@ -313,7 +313,7 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
             this.packagesUpdateNotFound(editedPackageName)
           } else {
             this.setState((prevState) => {
-              const currentNpmDeps = dependenciesFromPackageJson(this.props.packageJsonFile)
+              const currentNpmDeps = dependenciesFromPackageJson(this.props.packageJsonFile, false)
               const npmDepsWithoutCurrentDep = currentNpmDeps.filter(
                 (p) => p.name !== editedPackageName && p.name !== dependencyBeingEdited,
               )
@@ -385,7 +385,7 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
 
   render() {
     const packagesWithStatus: Array<DependencyPackageDetails> = packageDetailsFromDependencies(
-      dependenciesFromPackageJson(this.props.packageJsonFile),
+      dependenciesFromPackageJson(this.props.packageJsonFile, false),
       this.props.packageStatus,
     )
 

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -161,7 +161,7 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
   }
 
   removeDependency = (key: string) => {
-    let npmDependencies = dependenciesFromPackageJson(this.props.packageJsonFile, false)
+    let npmDependencies = dependenciesFromPackageJson(this.props.packageJsonFile, 'regular-only')
     // If we can't get the dependencies that implies something is broken, so avoid changing it.
     if (npmDependencies != null) {
       npmDependencies = npmDependencies.filter((dep) => dep.name != key)
@@ -313,7 +313,10 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
             this.packagesUpdateNotFound(editedPackageName)
           } else {
             this.setState((prevState) => {
-              const currentNpmDeps = dependenciesFromPackageJson(this.props.packageJsonFile, false)
+              const currentNpmDeps = dependenciesFromPackageJson(
+                this.props.packageJsonFile,
+                'regular-only',
+              )
               const npmDepsWithoutCurrentDep = currentNpmDeps.filter(
                 (p) => p.name !== editedPackageName && p.name !== dependencyBeingEdited,
               )
@@ -385,7 +388,7 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
 
   render() {
     const packagesWithStatus: Array<DependencyPackageDetails> = packageDetailsFromDependencies(
-      dependenciesFromPackageJson(this.props.packageJsonFile, false),
+      dependenciesFromPackageJson(this.props.packageJsonFile, 'regular-only'),
       this.props.packageStatus,
     )
 

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -413,7 +413,7 @@ export function getPropertyControlsForTarget(
           } else {
             // you can add more intrinsic (ie not imported) element types here
             const packageJsonFile = packageJsonFileFromProjectContents(projectContents)
-            const dependencies = dependenciesFromPackageJson(packageJsonFile)
+            const dependencies = dependenciesFromPackageJson(packageJsonFile, true)
             if (dependencies.some((dependency) => dependency.name === '@react-three/fiber')) {
               if (ReactThreeFiberControls[element.name.baseVariable] != null) {
                 return ReactThreeFiberControls[element.name.baseVariable]

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -413,7 +413,7 @@ export function getPropertyControlsForTarget(
           } else {
             // you can add more intrinsic (ie not imported) element types here
             const packageJsonFile = packageJsonFileFromProjectContents(projectContents)
-            const dependencies = dependenciesFromPackageJson(packageJsonFile, true)
+            const dependencies = dependenciesFromPackageJson(packageJsonFile, 'combined')
             if (dependencies.some((dependency) => dependency.name === '@react-three/fiber')) {
               if (ReactThreeFiberControls[element.name.baseVariable] != null) {
                 return ReactThreeFiberControls[element.name.baseVariable]

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -78,7 +78,6 @@ import '../utils/react-shim'
 import Utils from '../utils/utils'
 import { HeartbeatRequestMessage } from '../core/workers/watchdog-worker'
 import { triggerHashedAssetsUpdate } from '../utils/hashed-assets'
-import { dependenciesWithEditorRequirements } from '../components/editor/npm-dependency/npm-dependency'
 import {
   UiJsxCanvasContextData,
   emptyUiJsxCanvasContextData,


### PR DESCRIPTION
Fixes #1468 

**Problem:**
Currently Utopia will only include regular `dependencies` when running a project. Since this is a development environment, it should also include the `devDependencies`.

**Fix:**
Update the internal package parsing to include both fields, keeping them separate for the sake of the caching logic. The functions that expose the results to the rest of the editor then mostly return the combined list of packages, with the exception being around `dependency-list.tsx` since that only focuses on the regular (i.e. non-dev) dependencies.
