### PR TITLE
Fixed parsing of postcss and tailwind config when using module.exports

### DIFF
--- a/editor/src/core/tailwind/tailwind.ts
+++ b/editor/src/core/tailwind/tailwind.ts
@@ -35,9 +35,8 @@ function postCSSIncludesTailwindPlugin(postCSSFile: ProjectFile, requireFn: Requ
   if (isTextFile(postCSSFile)) {
     try {
       const requireResult = requireFn('/', PostCSSPath)
-      if (requireResult?.default != null) {
-        return requireResult?.default?.plugins?.tailwindcss != null
-      }
+      const plugins = requireResult?.plugins ?? requireResult?.default?.plugins
+      return plugins?.tailwindcss != null
     } catch (e) {
       /* Do nothing */
     }
@@ -96,8 +95,9 @@ function getTailwindConfig(
   if (tailwindFile != null && isTextFile(tailwindFile)) {
     try {
       const requireResult = requireFn('/', TailwindConfigPath)
-      if (requireResult?.default != null) {
-        const twindConfig = convertTailwindToTwindConfig(requireResult.default)
+      const rawConfig = requireResult?.default ?? requireResult
+      if (rawConfig != null) {
+        const twindConfig = convertTailwindToTwindConfig(rawConfig)
         return right(twindConfig)
       } else {
         return left('Tailwind config contains no default export')

--- a/editor/src/core/tailwind/tailwind.ts
+++ b/editor/src/core/tailwind/tailwind.ts
@@ -9,6 +9,7 @@ import { packageJsonFileFromProjectContents } from '../../components/editor/stor
 import { includesDependency } from '../../components/editor/npm-dependency/npm-dependency'
 import { propOrNull } from '../shared/object-utils'
 import { memoize } from '../shared/memoize'
+import { importDefault } from '../es-modules/commonjs-interop'
 
 const PostCSSPath = '/postcss.config.js'
 const TailwindConfigPath = '/tailwind.config.js'
@@ -35,7 +36,8 @@ function postCSSIncludesTailwindPlugin(postCSSFile: ProjectFile, requireFn: Requ
   if (isTextFile(postCSSFile)) {
     try {
       const requireResult = requireFn('/', PostCSSPath)
-      const plugins = requireResult?.plugins ?? requireResult?.default?.plugins
+      const defaultImport = importDefault(requireResult)
+      const plugins = (defaultImport as any)?.plugins
       return plugins?.tailwindcss != null
     } catch (e) {
       /* Do nothing */
@@ -95,7 +97,7 @@ function getTailwindConfig(
   if (tailwindFile != null && isTextFile(tailwindFile)) {
     try {
       const requireResult = requireFn('/', TailwindConfigPath)
-      const rawConfig = requireResult?.default ?? requireResult
+      const rawConfig = importDefault(requireResult)
       if (rawConfig != null) {
         const twindConfig = convertTailwindToTwindConfig(rawConfig)
         return right(twindConfig)


### PR DESCRIPTION
**Problem:**
When using `module.exports =` vs `export default`, the imported object will differ between having everything at the top level of the object (in the former case), or having a `default` key containing everything (in the latter case).

**Fix:**
Try both to see which contains the part we're interested in