### PR TITLE
Fix some bugs in the classname select

### DIFF
--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -51,10 +51,17 @@ export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNa
   )
 
   const classNames = selectedElement?.props?.className
+  const splitClassNames =
+    typeof classNames === 'string'
+      ? classNames
+          .split(' ')
+          .map((s) => s.trim())
+          .filter((s) => s !== '')
+      : []
   const selectedValues =
-    classNames == null || classNames.length === 0
+    splitClassNames.length === 0
       ? null
-      : classNames.split(' ').map((name: string) => ({
+      : splitClassNames.map((name: string) => ({
           label: name,
           value: name,
         }))
@@ -63,7 +70,7 @@ export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNa
     <WindowedSelect
       isMulti={true}
       options={TailWindOptions}
-      onSubmitValue={onSubmitValue}
+      onChange={onSubmitValue}
       value={selectedValues}
     />
   )


### PR DESCRIPTION
**Problem:**
The classname select will crash the editor if the value of a `className` isn't a string, and fails to submit changes to the class names of the selected element.

**Fix:**
- Explicitly check that the value is a string before attempting to split it
- Trim each of the results of the split, and filter empty strings
- Replace `onSubmitValue` with `onChange` to actually update the element
