### PR TITLE
Insert with defaults action.

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -51,7 +51,7 @@ import { BuildType } from '../../core/workers/ts/ts-worker'
 import { ParseResult } from '../../utils/value-parser-utils'
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import type { LoginState } from '../../common/user'
-import { InsertableComponent } from '../shared/project-components'
+import { InsertableComponent, StylePropOption } from '../shared/project-components'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -845,6 +845,7 @@ export interface InsertWithDefaults {
   action: 'INSERT_WITH_DEFAULTS'
   targetParent: ElementPath
   toInsert: InsertableComponent
+  styleProps: StylePropOption
 }
 
 export type EditorAction =

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -51,6 +51,7 @@ import { BuildType } from '../../core/workers/ts/ts-worker'
 import { ParseResult } from '../../utils/value-parser-utils'
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import type { LoginState } from '../../common/user'
+import { InsertableComponent } from '../shared/project-components'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -840,6 +841,12 @@ export interface UpdateFormulaBarMode {
   value: 'css' | 'content'
 }
 
+export interface InsertWithDefaults {
+  action: 'INSERT_WITH_DEFAULTS'
+  targetParent: ElementPath
+  toInsert: InsertableComponent
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -979,6 +986,7 @@ export type EditorAction =
   | SetCurrentTheme
   | FocusFormulaBar
   | UpdateFormulaBarMode
+  | InsertWithDefaults
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -49,6 +49,7 @@ import type { CodeResultCache, PropertyControlsInfo } from '../../custom-code/co
 import type { ElementContextMenuInstance } from '../../element-context-menu'
 import type { FontSettings } from '../../inspector/common/css-utils'
 import type { CSSTarget } from '../../inspector/sections/header-section/target-selector'
+import { InsertableComponent } from '../../shared/project-components'
 import type {
   AddFolder,
   AddMissingDimensions,
@@ -187,6 +188,7 @@ import type {
   SetCurrentTheme,
   FocusFormulaBar,
   UpdateFormulaBarMode,
+  InsertWithDefaults,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -1330,5 +1332,16 @@ export function updateFormulaBarMode(value: 'css' | 'content'): UpdateFormulaBar
   return {
     action: 'UPDATE_FORMULA_BAR_MODE',
     value: value,
+  }
+}
+
+export function insertWithDefaults(
+  targetParent: ElementPath,
+  toInsert: InsertableComponent,
+): InsertWithDefaults {
+  return {
+    action: 'INSERT_WITH_DEFAULTS',
+    targetParent: targetParent,
+    toInsert: toInsert,
   }
 }

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -49,7 +49,7 @@ import type { CodeResultCache, PropertyControlsInfo } from '../../custom-code/co
 import type { ElementContextMenuInstance } from '../../element-context-menu'
 import type { FontSettings } from '../../inspector/common/css-utils'
 import type { CSSTarget } from '../../inspector/sections/header-section/target-selector'
-import { InsertableComponent } from '../../shared/project-components'
+import { InsertableComponent, StylePropOption } from '../../shared/project-components'
 import type {
   AddFolder,
   AddMissingDimensions,
@@ -1338,10 +1338,12 @@ export function updateFormulaBarMode(value: 'css' | 'content'): UpdateFormulaBar
 export function insertWithDefaults(
   targetParent: ElementPath,
   toInsert: InsertableComponent,
+  styleProps: StylePropOption,
 ): InsertWithDefaults {
   return {
     action: 'INSERT_WITH_DEFAULTS',
     targetParent: targetParent,
     toInsert: toInsert,
+    styleProps: styleProps,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -148,6 +148,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'ADD_MISSING_DIMENSIONS':
     case 'ADD_STORYBOARD_FILE':
     case 'UPDATE_CHILD_TEXT':
+    case 'INSERT_WITH_DEFAULTS':
       return false
     case 'SAVE_ASSET':
       return (

--- a/editor/src/components/editor/import-utils.ts
+++ b/editor/src/components/editor/import-utils.ts
@@ -43,36 +43,3 @@ export function importedFromWhere(
   }
   return null
 }
-
-/*
-interface OriginatingNameResult {
-  filePath: string
-  variableName: string
-}
-
-export function findOriginatingName(
-  projectContents: ProjectContentTreeRoot,
-  originFilePath: string,
-  originVariableName: string,
-): OriginatingNameResult | null {
-  const file = getContentsTreeFileFromString(projectContents, originFilePath)
-  if (file == null) {
-    return null
-  } else if (isTextFile(file)) {
-    const fileParseResult = file.fileContents.parsed
-    if (isParseSuccess(fileParseResult)) {
-      const importedFromResult = importedFromWhere(
-        originFilePath,
-        originVariableName,
-        fileParseResult.topLevelElements,
-        fileParseResult.imports,
-      )
-
-    } else {
-      return null
-    }
-  } else {
-    return null
-  }
-}
-*/

--- a/editor/src/components/editor/import-utils.ts
+++ b/editor/src/components/editor/import-utils.ts
@@ -1,5 +1,6 @@
 import { TopLevelElement } from '../../core/shared/element-template'
-import { Imports } from '../../core/shared/project-file-types'
+import { Imports, isParseSuccess, isTextFile } from '../../core/shared/project-file-types'
+import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../assets'
 
 export function importedFromWhere(
   originFilePath: string,
@@ -42,3 +43,36 @@ export function importedFromWhere(
   }
   return null
 }
+
+/*
+interface OriginatingNameResult {
+  filePath: string
+  variableName: string
+}
+
+export function findOriginatingName(
+  projectContents: ProjectContentTreeRoot,
+  originFilePath: string,
+  originVariableName: string,
+): OriginatingNameResult | null {
+  const file = getContentsTreeFileFromString(projectContents, originFilePath)
+  if (file == null) {
+    return null
+  } else if (isTextFile(file)) {
+    const fileParseResult = file.fileContents.parsed
+    if (isParseSuccess(fileParseResult)) {
+      const importedFromResult = importedFromWhere(
+        originFilePath,
+        originVariableName,
+        fileParseResult.topLevelElements,
+        fileParseResult.imports,
+      )
+
+    } else {
+      return null
+    }
+  } else {
+    return null
+  }
+}
+*/

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -301,6 +301,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.FOCUS_FORMULA_BAR(action, state)
     case 'UPDATE_FORMULA_BAR_MODE':
       return UPDATE_FNS.UPDATE_FORMULA_BAR_MODE(action, state)
+    case 'INSERT_WITH_DEFAULTS':
+      return UPDATE_FNS.INSERT_WITH_DEFAULTS(action, state)
     default:
       return state
   }

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -17,6 +17,9 @@ Array [
         },
         "importsToAdd": Object {},
         "name": "App",
+        "stylePropOptions": Array [
+          "do-not-add",
+        ],
       },
     ],
     "source": Object {
@@ -52,6 +55,10 @@ Array [
           },
         },
         "name": "div",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -72,6 +79,10 @@ Array [
           },
         },
         "name": "span",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -92,6 +103,10 @@ Array [
           },
         },
         "name": "button",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -112,6 +127,10 @@ Array [
           },
         },
         "name": "input",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
     ],
     "source": Object {
@@ -149,6 +168,10 @@ Array [
           },
         },
         "name": "Date Picker",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -159,7 +182,136 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [],
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "disabled",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "type",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "default",
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "shape",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "default",
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "ghost",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "block",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "danger",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "loading",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "target",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "button",
+              },
+            },
+          ],
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -179,6 +331,10 @@ Array [
           },
         },
         "name": "Button",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -209,6 +365,10 @@ Array [
           },
         },
         "name": "Number Input",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -219,7 +379,56 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [],
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "align",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "top",
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "gutter",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "justify",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "center",
+              },
+            },
+          ],
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -239,6 +448,10 @@ Array [
           },
         },
         "name": "Row",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -249,7 +462,184 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [],
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "flex",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 1,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "offset",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "order",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "pull",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "push",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "xs",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "sm",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "md",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "lg",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "xl",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "xxl",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0,
+              },
+            },
+          ],
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -269,6 +659,10 @@ Array [
           },
         },
         "name": "Col",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -279,7 +673,56 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [],
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "align",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "center",
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "direction",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "vertical",
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "size",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "middle",
+              },
+            },
+          ],
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -299,6 +742,10 @@ Array [
           },
         },
         "name": "Space",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -309,7 +756,152 @@ Array [
               "propertyElements": Array [],
             },
           },
-          "props": Array [],
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "forceSubMenuRender",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "inlineCollapsed",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "inlineIndent",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 24,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "mode",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "inline",
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "multiple",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "selectable",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": true,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "subMenuCloseDelay",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0.1,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "subMenuOpenDelay",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": 0,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "theme",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "light",
+              },
+            },
+          ],
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -329,6 +921,10 @@ Array [
           },
         },
         "name": "Menu",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -341,7 +937,40 @@ Array [
               ],
             },
           },
-          "props": Array [],
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "disabled",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "danger",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+          ],
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -361,6 +990,10 @@ Array [
           },
         },
         "name": "Menu Item",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -373,7 +1006,24 @@ Array [
               ],
             },
           },
-          "props": Array [],
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "disabled",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+          ],
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -393,6 +1043,10 @@ Array [
           },
         },
         "name": "Menu SubMenu",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -425,6 +1079,10 @@ Array [
           },
         },
         "name": "Menu ItemGroup",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
       Object {
         "element": Object {
@@ -437,7 +1095,168 @@ Array [
               ],
             },
           },
-          "props": Array [],
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "code",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "copyable",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "delete",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "disabled",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "editable",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "ellipsis",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "mark",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "keyboard",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "underline",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "strong",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": false,
+              },
+            },
+          ],
         },
         "importsToAdd": Object {
           "antd": Object {
@@ -457,6 +1276,10 @@ Array [
           },
         },
         "name": "Typography Text",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
       },
     ],
     "source": Object {

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -1,4 +1,15 @@
-import { jsxElementWithoutUID, JSXElementWithoutUID } from '../../core/shared/element-template'
+import {
+  defaultPropertiesForComponent,
+  defaultPropertiesForComponentInFile,
+} from '../../core/property-controls/property-controls-utils'
+import {
+  JSXAttributes,
+  jsxAttributesEntry,
+  jsxAttributeValue,
+  jsxElementWithoutUID,
+  JSXElementWithoutUID,
+} from '../../core/shared/element-template'
+import { dropFileExtension } from '../../core/shared/file-utils'
 import {
   isResolvedNpmDependency,
   PackageStatus,
@@ -14,6 +25,7 @@ import {
 } from '../../core/shared/project-file-types'
 import { getThirdPartyComponents } from '../../core/third-party/third-party-components'
 import { addImport, emptyImports } from '../../core/workers/common/project-file-utils'
+import { emptyComments } from '../../core/workers/parser-printer/parser-printer-comments'
 import { SelectOption } from '../../uuiui-deps'
 import { ProjectContentTreeRoot, walkContentsTree } from '../assets'
 import { PropertyControlsInfo } from '../custom-code/code-file'
@@ -170,9 +182,24 @@ export function getComponentGroups(
       )
       if (possibleExportedComponents != null) {
         const insertableComponents = possibleExportedComponents.map((exportedComponent) => {
+          const defaultProps = defaultPropertiesForComponentInFile(
+            exportedComponent.listingName,
+            dropFileExtension(fullPath),
+            propertyControlsInfo,
+          )
+          let attributes: JSXAttributes = []
+          for (const key of Object.keys(defaultProps)) {
+            attributes.push(
+              jsxAttributesEntry(
+                key,
+                jsxAttributeValue(defaultProps[key], emptyComments),
+                emptyComments,
+              ),
+            )
+          }
           return insertableComponent(
             exportedComponent.importsToAdd,
-            jsxElementWithoutUID(exportedComponent.listingName, [], []),
+            jsxElementWithoutUID(exportedComponent.listingName, attributes, []),
             exportedComponent.listingName,
           )
         })

--- a/editor/src/core/third-party/antd-components.ts
+++ b/editor/src/core/third-party/antd-components.ts
@@ -4,9 +4,18 @@ import {
   DependencyBoundDescriptors,
   ComponentDescriptor,
 } from './third-party-types'
-import { jsxElementName, jsxElementWithoutUID } from '../shared/element-template'
+import {
+  JSXAttributes,
+  jsxAttributesEntry,
+  jsxAttributeValue,
+  jsxElementName,
+  jsxElementWithoutUID,
+} from '../shared/element-template'
 import { AntdControls } from '../property-controls/third-party-property-controls/antd-controls'
-import { PropertyControls } from 'utopia-api'
+import { getDefaultProps, PropertyControls } from 'utopia-api'
+import { emptyComments } from '../workers/parser-printer/parser-printer-comments'
+import { objectMap } from '../shared/object-utils'
+import { getDefaultPropsAsAttributes } from './shared'
 
 const StyleObjectProps: PropertyControls = {
   style: {
@@ -20,12 +29,13 @@ function createBasicComponent(
   name: string,
   propertyControls: PropertyControls | null,
 ): ComponentDescriptor {
+  const defaultAttributes = getDefaultPropsAsAttributes(propertyControls)
   return componentDescriptor(
     {
       antd: importDetails(null, [importAlias(baseVariable)], null),
       'antd/dist/antd.css': importDetails(null, [], null),
     },
-    jsxElementWithoutUID(jsxElementName(baseVariable, propertyPathParts), [], []),
+    jsxElementWithoutUID(jsxElementName(baseVariable, propertyPathParts), defaultAttributes, []),
     name,
     { ...StyleObjectProps, ...propertyControls },
   )

--- a/editor/src/core/third-party/shared.ts
+++ b/editor/src/core/third-party/shared.ts
@@ -1,0 +1,16 @@
+import { getDefaultProps, PropertyControls } from 'utopia-api'
+import { JSXAttributes, jsxAttributesEntry, jsxAttributeValue } from '../shared/element-template'
+import { emptyComments } from '../workers/parser-printer/parser-printer-comments'
+
+export function getDefaultPropsAsAttributes(
+  propertyControls: PropertyControls | null | undefined,
+): JSXAttributes {
+  const defaultProps = getDefaultProps(propertyControls ?? {})
+  let result: JSXAttributes = []
+  for (const key of Object.keys(defaultProps)) {
+    result.push(
+      jsxAttributesEntry(key, jsxAttributeValue(defaultProps[key], emptyComments), emptyComments),
+    )
+  }
+  return result
+}

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -6,17 +6,19 @@ import {
 } from './third-party-types'
 import { jsxElementName, jsxElementWithoutUID } from '../shared/element-template'
 import { PropertyControls } from 'utopia-api'
+import { getDefaultPropsAsAttributes } from './shared'
 
 function createBasicUtopiaComponent(
   baseVariable: string,
   name: string,
   propertyControls: PropertyControls | null,
 ): ComponentDescriptor {
+  const defaultAttributes = getDefaultPropsAsAttributes(propertyControls)
   return componentDescriptor(
     {
       'utopia-api': importDetails(null, [importAlias(baseVariable)], null),
     },
-    jsxElementWithoutUID(jsxElementName(baseVariable, []), [], []),
+    jsxElementWithoutUID(jsxElementName(baseVariable, []), defaultAttributes, []),
     name,
     propertyControls,
   )


### PR DESCRIPTION
Partly address #1455.

**Problem:**
To support a new menu for directly inserting without select-dragging the dimensions, a new action is needed to be triggered which handles the instant insertion.

**Fix:**
An action `INSERT_WITH_DEFAULTS` implements the desired insertion behaviour, taking a definition of what should be inserted from the editor-wide insertion descriptors. To support the ability to optionally add style sizing, the property controls info has also been extended to provide an indicator as to whether or not that can be added.

**Commit Details:**
- Added `INSERT_WITH_DEFAULTS` action along with action creator, which inserts directly into the hierarchy without any partly inserted state.
- `stylePropOptions` field added to `InsertableComponent`, which flags if the size can be added.
- `getComponentGroups` now ensures the default properties of an element are also included.
- `getComponentGroups` determines that value that should be supplied for `stylePropOptions`.
- Broke apart `defaultPropertiesForComponentInFile` and slightly refactored it to include the parsed property controls in the result so that it can be used in the caller. Also fixed a slight performance issue where an entire object was mapped but a single value was plucked from it, by flipping that around. This appears to have also fixed a bug where the properties weren't coming through for at least the antd components, which has been highlighted by the change in a snapshot test.
- Added a `getDefaultPropsAsAttributes` shared function for the third party components as it's used in both we currently have.
- For the antd and utopia-api components, the properties with default values are added to the props.