### PR TITLE
Fix user defined property controls

### DIFF
--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -254,7 +254,12 @@ export function generateCodeResultCache(
   incorporateBuildResult(nodeModules, projectContents, projectModules)
 
   // Trigger async call to build the property controls info.
-  sendPropertyControlsInfoRequest(exportsInfo, nodeModules, projectContents, onlyProjectFiles)
+  sendPropertyControlsInfoRequest(
+    nodeModules,
+    projectContents,
+    onlyProjectFiles,
+    updatedAndReverseDepFilenames,
+  )
 
   const requireFn = getEditorRequireFn(projectContents, nodeModules, dispatch, evaluationCache)
   const resolveFn = getEditorResolveFunction(projectContents, nodeModules)

--- a/editor/src/core/property-controls/property-controls-processor.spec.ts
+++ b/editor/src/core/property-controls/property-controls-processor.spec.ts
@@ -56,7 +56,6 @@ describe('Property Controls Processor', () => {
       {},
       {},
       {},
-      [],
     )
   })
 
@@ -108,7 +107,6 @@ describe('Property Controls Processor', () => {
           errors: [],
         },
       },
-      [],
     )
   })
 })

--- a/editor/src/core/property-controls/property-controls-processor.spec.ts
+++ b/editor/src/core/property-controls/property-controls-processor.spec.ts
@@ -85,9 +85,10 @@ describe('Property Controls Processor', () => {
     const onControlsProcess = (propertyControlsInfo: PropertyControlsInfo) => {
       callbackCount++
 
-      expect(propertyControlsInfo).toEqual(
-        getThirdPartyPropertyControls(packageName, packageVersion),
-      )
+      expect(propertyControlsInfo).toEqual({
+        '/src/index': {},
+        ...getThirdPartyPropertyControls(packageName, packageVersion),
+      })
 
       if (callbackCount === 2) {
         done()

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -128,20 +128,20 @@ export function combineUpdates(
 }
 
 export interface GetPropertyControlsInfoMessage {
-  exportsInfo: ReadonlyArray<ExportsInfo>
   nodeModulesUpdate: NodeModulesUpdate
   projectContents: ProjectContentTreeRoot
+  updatedAndReverseDepFilenames: Array<string>
 }
 
 export function createGetPropertyControlsInfoMessage(
-  exportsInfo: ReadonlyArray<ExportsInfo>,
   nodeModulesUpdate: NodeModulesUpdate,
   projectContents: ProjectContentTreeRoot,
+  updatedAndReverseDepFilenames: Array<string>,
 ): GetPropertyControlsInfoMessage {
   return {
-    exportsInfo: exportsInfo,
     nodeModulesUpdate: nodeModulesUpdate,
     projectContents: projectContents,
+    updatedAndReverseDepFilenames: updatedAndReverseDepFilenames,
   }
 }
 
@@ -488,10 +488,10 @@ export function setPropertyControlsIFrameAvailable(value: boolean): void {
 }
 
 export function sendPropertyControlsInfoRequest(
-  exportsInfo: ReadonlyArray<ExportsInfo>,
   nodeModules: NodeModules,
   projectContents: ProjectContentTreeRoot,
   onlyProjectFiles: boolean,
+  updatedAndReverseDepFilenames: Array<string>,
 ): void {
   let nodeModulesUpdate: NodeModulesUpdate
   if (onlyProjectFiles) {
@@ -538,9 +538,9 @@ export function sendPropertyControlsInfoRequest(
             if (queuedNodeModulesUpdate != null) {
               contentWindow.postMessage(
                 createGetPropertyControlsInfoMessage(
-                  exportsInfo,
                   queuedNodeModulesUpdate,
                   projectContents,
+                  updatedAndReverseDepFilenames,
                 ),
                 '*',
               )

--- a/editor/src/templates/property-controls-info.tsx
+++ b/editor/src/templates/property-controls-info.tsx
@@ -20,9 +20,9 @@ import deepEquals from 'fast-deep-equal'
 function fastPropertyControlsParse(value: unknown): ParseResult<GetPropertyControlsInfoMessage> {
   return applicative3Either(
     createGetPropertyControlsInfoMessage,
-    objectKeyParser(parseAny, 'exportsInfo')(value),
     objectKeyParser(parseAny, 'nodeModulesUpdate')(value),
     objectKeyParser(parseAny, 'projectContents')(value),
+    objectKeyParser(parseAny, 'updatedAndReverseDepFilenames')(value),
   )
 }
 
@@ -53,6 +53,11 @@ const initPropertyControlsWorker = () => {
         await createBundle(bundlerWorker, emptyTypeDefinitions, projectContents)
       ).buildResult
 
+      // Mutating the evaluation cache.
+      for (const fileToDelete of model.updatedAndReverseDepFilenames) {
+        delete evaluationCache[fileToDelete]
+      }
+
       const npmDependencies = dependenciesWithEditorRequirements(projectContents)
       propertyControlsProcessor(
         npmDependencies,
@@ -60,7 +65,6 @@ const initPropertyControlsWorker = () => {
         projectContents,
         evaluationCache,
         bundledProjectFiles,
-        model.exportsInfo,
       )
     }
   }


### PR DESCRIPTION
**Problem:**
Currently property controls info is lost which results in the inspector being unable to include the component section for a component.

**Fix:**
Changed what was iterated over to populate the `propertyControlsInfo` value from `exportsInfo` to the result of invoking `getExportValuesFromAllModules`, each and every time.

**Commit Details:**
-  removing the reliance on exportsInfo in propertyControlsInfo processing.
