### PR TITLE
Support searching class names via the attributes they affect

### DIFF
--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -262,7 +262,7 @@ export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNa
 
       // Next if we haven't hit our max result count, we find matches based on attributes
       const remainingAllowedMatches = MaxResults - matchedResults.length
-      if (remainingAllowedMatches) {
+      if (remainingAllowedMatches > 0) {
         const orderedAttributeMatchedResults = findMatchingOptions(
           trimmedLowerCaseInput,
           AllAttributes,

--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -4,16 +4,18 @@ import React from 'react'
 import { jsx } from '@emotion/react'
 import styled from '@emotion/styled'
 
-import { AllTailwindClasses } from '../../../core/third-party/tailwind-defaults'
+import {
+  AllTailwindClasses,
+  AllAttributes,
+  AttributeToClassNames,
+} from '../../../core/third-party/tailwind-defaults'
 import WindowedSelect, {
   components,
-  createFilter,
   IndicatorProps,
   MultiValueProps,
   ValueContainerProps,
 } from 'react-windowed-select'
 import type { StylesConfig } from 'react-select'
-import type { Option } from 'react-select/src/filters'
 import chroma from 'chroma-js'
 
 import * as EditorActions from '../../editor/actions/action-creators'
@@ -21,7 +23,6 @@ import { betterReactMemo } from '../../../uuiui-deps'
 import { useColorTheme } from '../../../uuiui'
 import { useEditorState } from '../../editor/store/store-hook'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import * as EP from '../../../core/shared/element-path'
 import * as PP from '../../../core/shared/property-path'
 import {
   ElementInstanceMetadata,
@@ -36,6 +37,7 @@ import {
   getModifiableJSXAttributeAtPath,
   ModifiableAttribute,
 } from '../../../core/shared/jsx-attributes'
+import { stripNulls } from '../../../core/shared/array-utils'
 
 interface TailWindOption {
   label: string
@@ -186,6 +188,58 @@ const ValueContainer = betterReactMemo(
 const filterOption = () => true
 const MaxResults = 500
 
+function findMatchingOptions<T>(
+  input: string,
+  options: Array<T>,
+  toString: (t: T) => string,
+  maxPerfectMatches: number,
+): Array<Array<T>> {
+  let orderedMatchedResults: Array<Array<T>> = []
+  let perfectMatchCount = 0
+  for (var i = 0; i < options.length && perfectMatchCount < maxPerfectMatches; i++) {
+    const nextOption = options[i]
+    const asString = toString(nextOption)
+    const indexOf = asString.indexOf(input)
+    if (indexOf > -1) {
+      let existingMatched = orderedMatchedResults[indexOf] ?? []
+      existingMatched.push(nextOption)
+      orderedMatchedResults[indexOf] = existingMatched
+      if (indexOf === 0) {
+        perfectMatchCount++
+      }
+    }
+  }
+
+  return orderedMatchedResults
+}
+
+function takeBestOptions<T>(orderedSparseArray: Array<Array<T>>, maxMatches: number): Array<T> {
+  let matchedResults: Array<T> = []
+  let matchCount = 0
+  for (var i = 0; i < orderedSparseArray.length && matchCount < maxMatches; i++) {
+    const nextMatches = orderedSparseArray[i]
+    if (nextMatches != null) {
+      matchedResults.push(...nextMatches.slice(0, maxMatches - matchCount))
+      matchCount += nextMatches.length
+    }
+  }
+
+  return matchedResults
+}
+
+function mapToClassNames(attributes: Array<string>, maxMatches: number): Array<string> {
+  let results: Set<string> = new Set()
+  for (var i = 0; i < attributes.length && results.size < maxMatches; i++) {
+    const nextAttribute = attributes[i]
+    const classNames = AttributeToClassNames[nextAttribute]
+    if (classNames != null) {
+      classNames.forEach((className) => results.add(className))
+    }
+  }
+
+  return Array.from(results)
+}
+
 export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNameSelect', () => {
   const theme = useColorTheme()
   const dispatch = useEditorState((store) => store.dispatch, 'ClassNameSelect dispatch')
@@ -196,31 +250,37 @@ export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNa
       return TailWindOptions.slice(0, MaxResults)
     } else {
       // First find all matches, and use a sparse array to keep the best matches at the front
-      let orderedMatchedResults: Array<Array<TailWindOption>> = []
-      let perfectMatchCount = 0
-      for (var i = 0; i < TailWindOptions.length && perfectMatchCount < MaxResults; i++) {
-        const nextOption = TailWindOptions[i]
-        const indexOf = nextOption.label.indexOf(trimmedLowerCaseInput)
-        if (indexOf > -1) {
-          let existingMatched = orderedMatchedResults[indexOf] ?? []
-          existingMatched.push(nextOption)
-          orderedMatchedResults[indexOf] = existingMatched
-          if (indexOf === 0) {
-            perfectMatchCount++
-          }
-        }
-      }
+      const orderedMatchedResults = findMatchingOptions(
+        trimmedLowerCaseInput,
+        TailWindOptions,
+        (option) => option.label,
+        MaxResults,
+      )
 
       // Now go through and take the first n best matches
-      let matchedResults: Array<TailWindOption> = []
-      let matchCount = 0
+      let matchedResults = takeBestOptions(orderedMatchedResults, MaxResults)
 
-      for (var j = 0; j < orderedMatchedResults.length && matchCount < MaxResults; j++) {
-        const nextMatches = orderedMatchedResults[j]
-        if (nextMatches != null) {
-          matchedResults.push(...nextMatches.slice(0, MaxResults - matchCount))
-          matchCount += nextMatches.length
-        }
+      // Next if we haven't hit our max result count, we find matches based on attributes
+      const remainingAllowedMatches = MaxResults - matchedResults.length
+      if (remainingAllowedMatches) {
+        const orderedAttributeMatchedResults = findMatchingOptions(
+          trimmedLowerCaseInput,
+          AllAttributes,
+          (a) => a,
+          remainingAllowedMatches,
+        )
+        const bestMatchedAttributes = takeBestOptions(
+          orderedAttributeMatchedResults,
+          remainingAllowedMatches,
+        )
+        const classNamesFromBestMatchedAttributes = mapToClassNames(
+          bestMatchedAttributes,
+          remainingAllowedMatches,
+        )
+        const optionsForClassNames = classNamesFromBestMatchedAttributes.map((className) =>
+          TailWindOptions.find((option) => option.label === className),
+        )
+        matchedResults.push(...stripNulls(optionsForClassNames))
       }
 
       return matchedResults


### PR DESCRIPTION
Continued work towards #1474 

**Problem:**
Users won't necessarily know the tailwind classes they are after, so we want to support searching their affected attributes too.

**Fix:**
After searching class names, if we still haven't reached our max results we also search the list of attributes. Then, if any matches are found, we perform the reverse lookup to find the classes that are matched.

Note that the UX for this is very raw. Continued work is in progress on that front. This PR is just for the core work to provide that search and include the results.
