### PR TITLE
Provide default img attributes for insertion.

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -1312,4 +1312,94 @@ describe('INSERT_WITH_DEFAULTS', () => {
       fail('File is not a text file.')
     }
   })
+
+  it('inserts an img element into the project, also adding style props', () => {
+    const project = complexDefaultProject()
+    const editorState = editorModelFromPersistentModel(project, NO_OP)
+
+    const insertableGroups = getComponentGroups(
+      {},
+      {},
+      editorState.projectContents,
+      [],
+      StoryboardFilePath,
+    )
+    const htmlGroup = forceNotNull(
+      'Group should exist.',
+      insertableGroups.find((group) => {
+        return group.source.type === 'HTML_GROUP'
+      }),
+    )
+    const imgInsertable = forceNotNull(
+      'Component should exist.',
+      htmlGroup.insertableComponents.find((insertable) => {
+        return insertable.name === 'img'
+      }),
+    )
+
+    const targetPath = EP.elementPath([
+      ['storyboard-entity', 'scene-1-entity', 'app-entity'],
+      ['app-outer-div', 'card-instance'],
+      ['card-outer-div'],
+    ])
+    const action = insertWithDefaults(targetPath, imgInsertable, 'add-size')
+    const actualResult = UPDATE_FNS.INSERT_WITH_DEFAULTS(action, editorState)
+    const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
+    if (isTextFile(cardFile)) {
+      const parsed = cardFile.fileContents.parsed
+      if (isParseSuccess(parsed)) {
+        const printedCode = printCode(
+          printCodeOptions(false, true, true, false),
+          parsed.imports,
+          parsed.topLevelElements,
+          parsed.jsxFactoryFunction,
+          parsed.exportsDetail,
+        )
+        expect(printedCode).toMatchInlineSnapshot(`
+          "import * as React from 'react'
+          import { Rectangle } from 'utopia-api'
+          export var Card = (props) => {
+            return (
+              <div
+                data-uid='card-outer-div'
+                style={{ ...props.style }}
+              >
+                <div
+                  data-uid='card-inner-div'
+                  style={{
+                    position: 'absolute',
+                    left: 0,
+                    top: 0,
+                    width: 50,
+                    height: 50,
+                    backgroundColor: 'red',
+                  }}
+                />
+                <Rectangle
+                  data-uid='card-inner-rectangle'
+                  style={{
+                    position: 'absolute',
+                    left: 100,
+                    top: 200,
+                    width: 50,
+                    height: 50,
+                    backgroundColor: 'blue',
+                  }}
+                />
+                <img
+                  style={{ width: 100, height: 100 }}
+                  src='/editor/icons/favicons/favicon128.png?hash=nocommit\\"'
+                />
+              </div>
+            )
+          }
+          "
+        `)
+      } else {
+        fail('File does not contain parse success.')
+      }
+    } else {
+      fail('File is not a text file.')
+    }
+  })
 })

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -132,6 +132,66 @@ Array [
           "add-size",
         ],
       },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "img",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "style",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": Object {
+                  "height": "54px",
+                  "width": "54px",
+                },
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "src",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "/editor/icons/favicons/favicon128.png?hash=nocommit\\"",
+              },
+            },
+          ],
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "img",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
     ],
     "source": Object {
       "type": "HTML_GROUP",


### PR DESCRIPTION
**Problem:**
Images don't get enough default values to be clear and/or usable by default.

**Fix:**
Now we provide a default sizing and `src` attribute for `img` components.

**Commit Details:**
- Partly addresses #1455.
- Created `basicHTMLElementDescriptor` to hold the extra details
  for intrinsic HTML elements.
- Reworked `getComponentGroups` to populate the basic HTML elements
  from `basicHTMLElementDescriptor` instead of `basicHTMLEntities`.
