### PR TITLE
Wrap in div not view.

### DIFF
--- a/editor/src/components/canvas/canvas-utils.spec.browser.tsx
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.tsx
@@ -849,12 +849,12 @@ describe('moveTemplate', () => {
     const targets = [EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])]
     ;(generateUidWithExistingComponents as any) = jest.fn().mockReturnValue(NewUID)
 
-    await renderResult.dispatch([wrapInView(targets, 'default-empty-View')], true)
+    await renderResult.dispatch([wrapInView(targets, 'default-empty-div')], true)
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...props.style }} data-uid='aaa'>
-        <View
+        <div
           style={{ position: 'absolute', left: 52, top: 61, width: 256, height: 202 }}
           data-uid='${NewUID}'
         >
@@ -862,7 +862,7 @@ describe('moveTemplate', () => {
             style={{ position: 'absolute', backgroundColor: '#0091FFAA', left: 0, top: 0, width: 256, height: 202 }}
             data-uid='bbb'
           />
-        </View>
+        </div>
       </View>
       `),
     )
@@ -903,7 +903,7 @@ describe('moveTemplate', () => {
     ]
     ;(generateUidWithExistingComponents as any) = jest.fn().mockReturnValue(NewUID)
 
-    await renderResult.dispatch([wrapInView(targets, 'default-empty-View')], true)
+    await renderResult.dispatch([wrapInView(targets, 'default-empty-div')], true)
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
@@ -918,7 +918,7 @@ describe('moveTemplate', () => {
           data-uid='fff'
         />
         <View data-uid='hhh' />
-        <View
+        <div
           style={{ position: 'absolute', left: 15, top: 10, width: 246, height: 161 }}
           data-uid='${NewUID}'
         >
@@ -932,7 +932,7 @@ describe('moveTemplate', () => {
             style={{ left: 0, top: 0, width: 246, height: 150, position: 'absolute' }}
             data-uid='ggg'
           />
-        </View>
+        </div>
       </View>
       `),
     )
@@ -960,13 +960,13 @@ describe('moveTemplate', () => {
     ]
     ;(generateUidWithExistingComponents as any) = jest.fn().mockReturnValue(NewUID)
 
-    await renderResult.dispatch([wrapInView(targets, 'default-empty-View')], true)
+    await renderResult.dispatch([wrapInView(targets, 'default-empty-div')], true)
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...props.style }} data-uid='aaa'>
         <View data-uid='eee' />
-        <View
+        <div
           style={{ position: 'absolute', left: 52, top: 61, width: 256, height: 202 }}
           data-uid='${NewUID}'
         >
@@ -978,7 +978,7 @@ describe('moveTemplate', () => {
               <View data-uid='ddd' />
             </View>
           </View>
-        </View>
+        </div>
       </View>
       `),
     )
@@ -1031,19 +1031,18 @@ describe('moveTemplate', () => {
 
     ;(generateUidWithExistingComponents as any) = jest.fn().mockReturnValue(NewUID)
 
-    await renderResult.dispatch([wrapInView([targetPath], 'default-empty-View')], true)
+    await renderResult.dispatch([wrapInView([targetPath], 'default-empty-div')], true)
     expect(getPrintedUiJsCode(renderResult.getEditorState(), appFilePath)).toEqual(
       Prettier.format(
         `
     import * as React from 'react'
-    import { View } from 'utopia-api'
     export var App = (props) => {
       return (
         <div
           data-uid='app-outer-div'
           style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
         >
-          <View
+          <div
             style={{ position: 'absolute', left: 0, top: 0, width: 50, height: 100 }}
             data-uid='${NewUID}'
           >
@@ -1053,7 +1052,7 @@ describe('moveTemplate', () => {
             >
               <span data-uid='app-inner-span'>hello</span>
             </div>
-          </View>
+          </div>
         </div>
       )
     }`,

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -232,7 +232,7 @@ export const wrapInView: ContextMenuItem<CanvasData> = {
   enabled: true,
   action: (data, dispatch?: EditorDispatch) => {
     requireDispatch(dispatch)(
-      [EditorActions.wrapInView(data.selectedViews, 'default-empty-View')],
+      [EditorActions.wrapInView(data.selectedViews, 'default-empty-div')],
       'everyone',
     )
   },

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -416,7 +416,7 @@ export interface WrapInView {
   action: 'WRAP_IN_VIEW'
   targets: ElementPath[]
   layoutSystem: LayoutSystem
-  whatToWrapWith: { element: JSXElement; importsToAdd: Imports } | 'default-empty-View'
+  whatToWrapWith: { element: JSXElement; importsToAdd: Imports } | 'default-empty-div'
 }
 
 export interface WrapInPicker {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -597,7 +597,7 @@ export function resetPins(target: ElementPath): ResetPins {
 }
 
 export function wrapInGroup(targets: Array<ElementPath>): WrapInView {
-  return wrapInView(targets, 'default-empty-View')
+  return wrapInView(targets, 'default-empty-div')
   // FIXME: Make Groups Great Again.
   //return {
   //  action: 'WRAP_IN_VIEW',
@@ -625,7 +625,7 @@ export function wrapInPicker(targets: Array<ElementPath>): WrapInPicker {
 
 export function wrapInView(
   targets: Array<ElementPath>,
-  whatToWrapWith: { element: JSXElement; importsToAdd: Imports } | 'default-empty-View',
+  whatToWrapWith: { element: JSXElement; importsToAdd: Imports } | 'default-empty-div',
 ): WrapInView {
   return {
     action: 'WRAP_IN_VIEW',

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -156,6 +156,7 @@ import {
   addImport,
   codeNeedsParsing,
   codeNeedsPrinting,
+  emptyImports,
   mergeImports,
 } from '../../../core/workers/common/project-file-utils'
 import { OutgoingWorkerMessage, isJsFile, BuildType } from '../../../core/workers/ts/ts-worker'
@@ -2066,7 +2067,7 @@ export const UPDATE_FNS = {
         }
 
         const newUID =
-          action.whatToWrapWith === 'default-empty-View'
+          action.whatToWrapWith === 'default-empty-div'
             ? generateUidWithExistingComponents(editor.projectContents)
             : action.whatToWrapWith.element.uid
 
@@ -2126,7 +2127,7 @@ export const UPDATE_FNS = {
             editor,
             (parseSuccess) => {
               const elementToInsert: JSXElement =
-                action.whatToWrapWith === 'default-empty-View'
+                action.whatToWrapWith === 'default-empty-div'
                   ? defaultTransparentViewElement(newUID)
                   : action.whatToWrapWith.element
 
@@ -2147,11 +2148,8 @@ export const UPDATE_FNS = {
               viewPath = EP.appendToPath(parentPath, newUID)
 
               const importsToAdd: Imports =
-                action.whatToWrapWith === 'default-empty-View'
-                  ? {
-                      // the default View import
-                      ['utopia-api']: importDetails(null, [importAlias('View')], null),
-                    }
+                action.whatToWrapWith === 'default-empty-div'
+                  ? emptyImports()
                   : action.whatToWrapWith.importsToAdd
 
               return modifyParseSuccessWithSimple((success: SimpleParseSuccess) => {

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -67,7 +67,7 @@ export function defaultAnimatedDivElement(uid: string): JSXElement {
 
 export function defaultTransparentViewElement(uid: string): JSXElement {
   return jsxElement(
-    jsxElementName('View', []),
+    jsxElementName('div', []),
     uid,
     jsxAttributesFromMap({
       style: jsxAttributeValue(

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -554,7 +554,7 @@ export function handleKeyDown(
       },
       [WRAP_ELEMENT_DEFAULT_SHORTCUT]: () => {
         return isSelectMode(editor.mode)
-          ? [EditorActions.wrapInView(editor.selectedViews, 'default-empty-View')]
+          ? [EditorActions.wrapInView(editor.selectedViews, 'default-empty-div')]
           : []
       },
       [WRAP_ELEMENT_PICKER_SHORTCUT]: () => {


### PR DESCRIPTION
Fixes #1489.

**Problem:**
We want less of our special `utopia-api` components like `View` being used and specifically in this case when wrapping an element.

**Fix:**
Changed the element to be a `div` instead of a `View`.

**Commit Details:**
- Fixes #1489.
- `WRAP_IN_VIEW` action now creates a div instead.
- Changed the type `default-empty-View` to `default-empty-div`.
