### PR TITLE
Feature/insert convert popup

### DIFF
--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -336,7 +336,7 @@ export const FloatingInsertMenu = betterReactMemo(
   (props: FloatingInsertMenuProps) => {
     const dispatch = useEditorState((store) => store.dispatch, 'FloatingInsertMenu dispatch')
     const isVisible = useEditorState(
-      (store) => store.editor.floatingInsertMenu.insertMenuOpen,
+      (store) => store.editor.floatingInsertMenu.insertMenuMode !== 'closed',
       'FloatingInsertMenu insertMenuOpen',
     )
     const onClickOutside = React.useCallback(() => {

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -252,11 +252,11 @@ function getMenuTitle(insertMenuMode: 'closed' | 'insert' | 'convert' | 'wrap'):
     case 'closed':
       return ''
     case 'convert':
-      return 'Convert'
+      return 'Convert to'
     case 'insert':
       return 'Insert'
     case 'wrap':
-      return 'Wrap'
+      return 'Wrap in'
   }
 }
 

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -252,11 +252,11 @@ function getMenuTitle(insertMenuMode: 'closed' | 'insert' | 'convert' | 'wrap'):
     case 'closed':
       return ''
     case 'convert':
-      return 'Convert selected element to...'
+      return 'Convert'
     case 'insert':
-      return 'Insert element'
+      return 'Insert'
     case 'wrap':
-      return 'Wrap selection in element'
+      return 'Wrap'
   }
 }
 

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -237,8 +237,30 @@ function useComponentSelectorStyles(): StylesConfig {
     [colorTheme],
   )
 }
+
+function getMenuTitle(insertMenuMode: 'closed' | 'insert' | 'convert' | 'wrap'): string {
+  switch (insertMenuMode) {
+    case 'closed':
+      return ''
+    case 'convert':
+      return 'Convert selected element to...'
+    case 'insert':
+      return 'Insert element'
+    case 'wrap':
+      return 'Wrap selection in element'
+  }
+}
+
 export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
   const colorTheme = useColorTheme()
+
+  const insertMenuMode = useEditorState(
+    (store) => store.editor.floatingInsertMenu.insertMenuMode,
+    'FloatingMenu insertMenuMode',
+  )
+
+  const menuTitle: string = getMenuTitle(insertMenuMode)
+
   const componentSelectorStyles = useComponentSelectorStyles()
   const dispatch = useEditorState((store) => store.dispatch, 'FloatingMenu dispatch')
   useHandleCloseOnESCOrEnter(
@@ -309,7 +331,7 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
             alignItems: 'center',
           }}
         >
-          <b>Wrap In...</b>
+          <b>{menuTitle}</b>
         </div>
 
         <Select

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -222,7 +222,7 @@ export const wrapInPicker: ContextMenuItem<CanvasData> = {
   shortcut: 'G',
   enabled: true,
   action: (data, dispatch?: EditorDispatch) => {
-    requireDispatch(dispatch)([EditorActions.wrapInPicker(data.selectedViews)], 'everyone')
+    requireDispatch(dispatch)([EditorActions.openFloatingInsertMenu('wrap')], 'everyone')
   },
 }
 

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -194,6 +194,24 @@ export const resetPins: ContextMenuItem<unknown> = {
   },
 }
 
+export const insert: ContextMenuItem<CanvasData> = {
+  name: 'Insert Element…',
+  shortcut: 'R',
+  enabled: true,
+  action: (data, dispatch) => {
+    requireDispatch(dispatch)([EditorActions.openFloatingInsertMenu('insert')])
+  },
+}
+
+export const convert: ContextMenuItem<CanvasData> = {
+  name: 'Convert Element To…',
+  shortcut: 'J',
+  enabled: true,
+  action: (data, dispatch) => {
+    requireDispatch(dispatch)([EditorActions.openFloatingInsertMenu('convert')])
+  },
+}
+
 export const group: ContextMenuItem<CanvasData> = {
   name: 'Group Selection',
   shortcut: '⌘G',

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -419,10 +419,9 @@ export interface WrapInView {
   whatToWrapWith: { element: JSXElement; importsToAdd: Imports } | 'default-empty-View'
 }
 
-export interface WrapInPicker {
-  action: 'WRAP_IN_PICKER'
-  targets: ElementPath[]
-  layoutSystem: LayoutSystem
+export interface OpenFloatingInsertMenu {
+  action: 'OPEN_FLOATING_INSERT_MENU'
+  mode: 'insert' | 'convert' | 'wrap'
 }
 
 export interface CloseFloatingInsertMenu {
@@ -917,7 +916,7 @@ export type EditorAction =
   | SaveAsset
   | ResetPins
   | WrapInView
-  | WrapInPicker
+  | OpenFloatingInsertMenu
   | CloseFloatingInsertMenu
   | UnwrapGroupOrView
   | SetCanvasAnimationsEnabled

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -188,7 +188,7 @@ import type {
   SetCurrentTheme,
   FocusFormulaBar,
   UpdateFormulaBarMode,
-  WrapInPicker,
+  OpenFloatingInsertMenu,
   CloseFloatingInsertMenu,
   InsertWithDefaults,
 } from '../action-types'
@@ -615,11 +615,12 @@ export function unwrapGroupOrView(target: ElementPath): UnwrapGroupOrView {
   }
 }
 
-export function wrapInPicker(targets: Array<ElementPath>): WrapInPicker {
+export function openFloatingInsertMenu(
+  mode: 'insert' | 'convert' | 'wrap',
+): OpenFloatingInsertMenu {
   return {
-    action: 'WRAP_IN_PICKER',
-    targets: targets,
-    layoutSystem: LayoutSystem.PinSystem,
+    action: 'OPEN_FLOATING_INSERT_MENU',
+    mode: mode,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -93,7 +93,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_CURRENT_THEME':
     case 'FOCUS_FORMULA_BAR':
     case 'UPDATE_FORMULA_BAR_MODE':
-    case 'WRAP_IN_PICKER':
+    case 'OPEN_FLOATING_INSERT_MENU':
     case 'CLOSE_FLOATING_INSERT_MENU':
       return true
 

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -1150,7 +1150,7 @@ describe('INSERT_WITH_DEFAULTS', () => {
       const parsed = cardFile.fileContents.parsed
       if (isParseSuccess(parsed)) {
         const printedCode = printCode(
-          printCodeOptions(false, true, true, false),
+          printCodeOptions(false, true, true, true),
           parsed.imports,
           parsed.topLevelElements,
           parsed.jsxFactoryFunction,
@@ -1162,12 +1162,8 @@ describe('INSERT_WITH_DEFAULTS', () => {
           import { Menu } from 'antd'
           export var Card = (props) => {
             return (
-              <div
-                data-uid='card-outer-div'
-                style={{ ...props.style }}
-              >
+              <div style={{ ...props.style }}>
                 <div
-                  data-uid='card-inner-div'
                   style={{
                     position: 'absolute',
                     left: 0,
@@ -1178,7 +1174,6 @@ describe('INSERT_WITH_DEFAULTS', () => {
                   }}
                 />
                 <Rectangle
-                  data-uid='card-inner-rectangle'
                   style={{
                     position: 'absolute',
                     left: 100,
@@ -1250,7 +1245,7 @@ describe('INSERT_WITH_DEFAULTS', () => {
       const parsed = cardFile.fileContents.parsed
       if (isParseSuccess(parsed)) {
         const printedCode = printCode(
-          printCodeOptions(false, true, true, false),
+          printCodeOptions(false, true, true, true),
           parsed.imports,
           parsed.topLevelElements,
           parsed.jsxFactoryFunction,
@@ -1262,12 +1257,8 @@ describe('INSERT_WITH_DEFAULTS', () => {
           import { Menu } from 'antd'
           export var Card = (props) => {
             return (
-              <div
-                data-uid='card-outer-div'
-                style={{ ...props.style }}
-              >
+              <div style={{ ...props.style }}>
                 <div
-                  data-uid='card-inner-div'
                   style={{
                     position: 'absolute',
                     left: 0,
@@ -1278,7 +1269,6 @@ describe('INSERT_WITH_DEFAULTS', () => {
                   }}
                 />
                 <Rectangle
-                  data-uid='card-inner-rectangle'
                   style={{
                     position: 'absolute',
                     left: 100,
@@ -1349,7 +1339,7 @@ describe('INSERT_WITH_DEFAULTS', () => {
       const parsed = cardFile.fileContents.parsed
       if (isParseSuccess(parsed)) {
         const printedCode = printCode(
-          printCodeOptions(false, true, true, false),
+          printCodeOptions(false, true, true, true),
           parsed.imports,
           parsed.topLevelElements,
           parsed.jsxFactoryFunction,
@@ -1360,12 +1350,8 @@ describe('INSERT_WITH_DEFAULTS', () => {
           import { Rectangle } from 'utopia-api'
           export var Card = (props) => {
             return (
-              <div
-                data-uid='card-outer-div'
-                style={{ ...props.style }}
-              >
+              <div style={{ ...props.style }}>
                 <div
-                  data-uid='card-inner-div'
                   style={{
                     position: 'absolute',
                     left: 0,
@@ -1376,7 +1362,6 @@ describe('INSERT_WITH_DEFAULTS', () => {
                   }}
                 />
                 <Rectangle
-                  data-uid='card-inner-rectangle'
                   style={{
                     position: 'absolute',
                     left: 100,

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -503,6 +503,7 @@ import { emptySet } from '../../../core/shared/set-utils'
 import { absolutePathFromRelativePath, stripLeadingSlash } from '../../../utils/path-utils'
 import { resolveModule } from '../../../core/es-modules/package-manager/module-resolution'
 import { reverse, uniqBy } from '../../../core/shared/array-utils'
+import { UTOPIA_UIDS_KEY } from '../../../core/model/utopia-constants'
 
 export function updateSelectedLeftMenuTab(editorState: EditorState, tab: LeftMenuTab): EditorState {
   return {
@@ -4425,8 +4426,16 @@ export const UPDATE_FNS = {
           const utopiaComponents = getUtopiaJSXComponentsFromSuccess(success)
           const newUID = generateUidWithExistingComponents(editor.projectContents)
 
+          const propsWithUid = forceRight(
+            setJSXValueAtPath(
+              action.toInsert.element.props,
+              PP.create([UTOPIA_UIDS_KEY]),
+              jsxAttributeValue(newUID, emptyComments),
+            ),
+            `Could not set data-uid on props of insertable element ${action.toInsert.element.name}`,
+          )
           // Potentially add in some default position and sizing.
-          let props = action.toInsert.element.props
+          let props = propsWithUid
           if (action.styleProps === 'add-size') {
             const sizesToSet: Array<ValueAtPath> = [
               { path: PP.create(['style', 'width']), value: jsxAttributeValue(100, emptyComments) },

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -359,7 +359,7 @@ import {
   SetCurrentTheme,
   FocusFormulaBar,
   UpdateFormulaBarMode,
-  WrapInPicker,
+  OpenFloatingInsertMenu,
   CloseFloatingInsertMenu,
   InsertWithDefaults,
 } from '../action-types'
@@ -980,7 +980,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
       scrollAnimation: currentEditor.canvas.scrollAnimation,
     },
     floatingInsertMenu: {
-      insertMenuOpen: currentEditor.floatingInsertMenu.insertMenuOpen,
+      insertMenuMode: currentEditor.floatingInsertMenu.insertMenuMode,
     },
     inspector: {
       visible: currentEditor.inspector.visible,
@@ -2205,17 +2205,12 @@ export const UPDATE_FNS = {
       dispatch,
     )
   },
-  WRAP_IN_PICKER: (
-    action: WrapInPicker,
-    editor: EditorModel,
-    derived: DerivedState,
-    dispatch: EditorDispatch,
-  ): EditorModel => {
+  OPEN_FLOATING_INSERT_MENU: (action: OpenFloatingInsertMenu, editor: EditorModel): EditorModel => {
     return {
       ...editor,
       floatingInsertMenu: {
         ...editor.floatingInsertMenu,
-        insertMenuOpen: true,
+        insertMenuMode: action.mode,
       },
     }
   },
@@ -2227,7 +2222,7 @@ export const UPDATE_FNS = {
       ...editor,
       floatingInsertMenu: {
         ...editor.floatingInsertMenu,
-        insertMenuOpen: false,
+        insertMenuMode: 'closed',
       },
     }
   },

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -593,7 +593,9 @@ export function handleKeyDown(
         }
       },
       [INSERT_RECTANGLE_SHORTCUT]: () => {
-        if (isSelectMode(editor.mode) || isInsertMode(editor.mode)) {
+        if (isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)) {
+          return [EditorActions.openFloatingInsertMenu('insert')]
+        } else if (isInsertMode(editor.mode)) {
           const newUID = generateUidWithExistingComponents(editor.projectContents)
           return [
             EditorActions.enableInsertModeForJSXElement(
@@ -651,7 +653,9 @@ export function handleKeyDown(
         }
       },
       [INSERT_VIEW_SHORTCUT]: () => {
-        if (isSelectMode(editor.mode) || isInsertMode(editor.mode)) {
+        if (isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)) {
+          return [EditorActions.openFloatingInsertMenu('insert')]
+        } else if (isInsertMode(editor.mode)) {
           const newUID = generateUidWithExistingComponents(editor.projectContents)
           return [
             EditorActions.enableInsertModeForJSXElement(

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -558,7 +558,7 @@ export function handleKeyDown(
           : []
       },
       [WRAP_ELEMENT_PICKER_SHORTCUT]: () => {
-        return isSelectMode(editor.mode) ? [EditorActions.wrapInPicker(editor.selectedViews)] : []
+        return isSelectMode(editor.mode) ? [EditorActions.openFloatingInsertMenu('wrap')] : []
       },
       [TOGGLE_HIDDEN_SHORTCUT]: () => {
         return [EditorActions.toggleHidden()]

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -112,6 +112,7 @@ import {
   ZOOM_UI_IN_SHORTCUT,
   ZOOM_UI_OUT_SHORTCUT,
   ShortcutNamesByKey,
+  CONVERT_ELEMENT_SHORTCUT,
 } from './shortcut-definitions'
 import { DerivedState, EditorState, getOpenFile } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
@@ -712,6 +713,13 @@ export function handleKeyDown(
       },
       [TOGGLE_INSPECTOR_AND_LEFT_MENU_SHORTCUT]: () => {
         return [EditorActions.togglePanel('inspector'), EditorActions.togglePanel('leftmenu')]
+      },
+      [CONVERT_ELEMENT_SHORTCUT]: () => {
+        if (isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)) {
+          return [EditorActions.openFloatingInsertMenu('convert')]
+        } else {
+          return []
+        }
       },
     })
   }

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -654,9 +654,7 @@ export function handleKeyDown(
         }
       },
       [INSERT_VIEW_SHORTCUT]: () => {
-        if (isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)) {
-          return [EditorActions.openFloatingInsertMenu('insert')]
-        } else if (isInsertMode(editor.mode)) {
+        if (isSelectMode(editor.mode) || isInsertMode(editor.mode)) {
           const newUID = generateUidWithExistingComponents(editor.projectContents)
           return [
             EditorActions.enableInsertModeForJSXElement(

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -88,6 +88,7 @@ export const TOGGLE_RIGHT_MENU_SHORTCUT = 'toggle-right-menu'
 export const TOGGLE_DESIGNER_ADDITIONAL_CONTROLS_SHORTCUT = 'toggle-designer-additional-controls'
 export const TOGGLE_CODE_EDITOR_SHORTCUT = 'toggle-code-editor'
 export const TOGGLE_INSPECTOR_AND_LEFT_MENU_SHORTCUT = 'toggle-inspector-and-left-menu'
+export const CONVERT_ELEMENT_SHORTCUT = 'convert-element'
 
 export type ShortcutDetails = { [key: string]: Shortcut }
 
@@ -275,6 +276,7 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
     'Toggle the inspector and the left menu.',
     key('backslash', 'cmd'),
   ),
+  [CONVERT_ELEMENT_SHORTCUT]: shortcut('Convert selected element to...', key('j', [])),
 }
 
 export type ShortcutConfiguration = { [key: string]: Array<Key> }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -342,7 +342,7 @@ export interface EditorState {
     scrollAnimation: boolean
   }
   floatingInsertMenu: {
-    insertMenuOpen: boolean
+    insertMenuMode: 'closed' | 'insert' | 'convert' | 'wrap'
   }
   inspector: {
     visible: boolean
@@ -1114,7 +1114,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
       scrollAnimation: false,
     },
     floatingInsertMenu: {
-      insertMenuOpen: false,
+      insertMenuMode: 'closed',
     },
     inspector: {
       visible: true,
@@ -1364,7 +1364,7 @@ export function editorModelFromPersistentModel(
       scrollAnimation: false,
     },
     floatingInsertMenu: {
-      insertMenuOpen: false,
+      insertMenuMode: 'closed',
     },
     inspector: {
       visible: true,

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -229,8 +229,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.DELETE_SELECTED(action, state, derivedState, dispatch)
     case 'WRAP_IN_VIEW':
       return UPDATE_FNS.WRAP_IN_VIEW(action, state, derivedState, dispatch)
-    case 'WRAP_IN_PICKER':
-      return UPDATE_FNS.WRAP_IN_PICKER(action, state, derivedState, dispatch)
+    case 'OPEN_FLOATING_INSERT_MENU':
+      return UPDATE_FNS.OPEN_FLOATING_INSERT_MENU(action, state)
     case 'UNWRAP_GROUP_OR_VIEW':
       return UPDATE_FNS.UNWRAP_GROUP_OR_VIEW(action, state, derivedState, dispatch)
     case 'INSERT_IMAGE_INTO_UI':

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -22,6 +22,8 @@ import {
   CanvasData,
   setAsFocusedElement,
   scrollToElement,
+  insert,
+  convert,
 } from './context-menu-items'
 import { MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState } from './editor/store/store-hook'
@@ -52,6 +54,10 @@ const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
   cutElements,
   copyElements,
   duplicateElement,
+  lineSeparator,
+  insert,
+  lineSeparator,
+  convert,
   lineSeparator,
   wrapInPicker,
   wrapInView,

--- a/editor/src/components/inspector/common/inspector-utils.tsx
+++ b/editor/src/components/inspector/common/inspector-utils.tsx
@@ -185,6 +185,7 @@ export function clampString(value: string, maxLength: number) {
   return value.length > maxLength ? `${value.substring(0, maxLength)}…` : value
 }
 
+// TODO this function needs a better name :)
 export function getElementsToTarget(paths: Array<ElementPath>): Array<ElementPath> {
   let result: Array<ElementPath> = []
   fastForEach(paths, (path) => {

--- a/editor/src/core/shared/either.ts
+++ b/editor/src/core/shared/either.ts
@@ -463,9 +463,9 @@ export function joinEither<L, R>(either: Either<L, Either<L, R>>): Either<L, R> 
 // Danger Will Robinson! This defeats the purpose of an Either. I've added this for the
 // sake of testing AND ONLY FOR THE SAKE OF TESTING!
 // If you use this for *ANYTHING* other than a test, I will personally hunt you down!
-export function forceRight<L, R>(e: Either<L, R>): R {
+export function forceRight<L, R>(e: Either<L, R>, reason?: string): R {
   if (isLeft(e)) {
-    throw new Error(`Unable to force either to a right: ${JSON.stringify(e.value)}`)
+    throw new Error(reason ?? 'Unable to force either to a right' + ' - ' + JSON.stringify(e.value))
   } else {
     return e.value
   }


### PR DESCRIPTION
Fixes #1455,  Fixes #1454, Fixes #1456

<img width="321" alt="image" src="https://user-images.githubusercontent.com/2226774/125453346-020f070f-8fb8-4a11-9c1d-563cd2d4c1ad.png">
<img width="325" alt="image" src="https://user-images.githubusercontent.com/2226774/125453353-1213013f-7fbb-4416-bd02-347bb4bf7689.png">
<img width="336" alt="image" src="https://user-images.githubusercontent.com/2226774/125453335-6b66a14f-061b-4281-ae97-0f83a9891c5c.png">

**Description**
This PR wires in the "floating insertion popup" for insertion and converting. It keeps it working for wrap.

**Commit Details:**
- Renamed action OPEN_FLOATING_INSERT_MENU
- R and V open the insertion floating popup
- J opens the conversion floating popup
- Fixing missing data-uid prop in INSERT_WITH_DEFAULTS
- Floating popup inserts in insert mode
- Floating popup converts in convert mode
