### PR TITLE
feature(topmenu) split search

### DIFF
--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -196,15 +196,17 @@ function findMatchingOptions<T>(
 ): Array<Array<T>> {
   let orderedMatchedResults: Array<Array<T>> = []
   let perfectMatchCount = 0
+  let splitInput = input.split(' ')
   for (var i = 0; i < options.length && perfectMatchCount < maxPerfectMatches; i++) {
     const nextOption = options[i]
     const asString = toString(nextOption)
-    const indexOf = asString.indexOf(input)
-    if (indexOf > -1) {
-      let existingMatched = orderedMatchedResults[indexOf] ?? []
+    const splitInputIndexResult = splitInput.map((s) => asString.indexOf(s))
+    const minimumIndexOf = Math.min(...splitInputIndexResult)
+    if (minimumIndexOf > -1) {
+      let existingMatched = orderedMatchedResults[minimumIndexOf] ?? []
       existingMatched.push(nextOption)
-      orderedMatchedResults[indexOf] = existingMatched
-      if (indexOf === 0) {
+      orderedMatchedResults[minimumIndexOf] = existingMatched
+      if (minimumIndexOf === 0) {
         perfectMatchCount++
       }
     }


### PR DESCRIPTION
**Problem:**
Using the search field requires you to know exactly what you are searching. 

**Fix:**
Allow searching with typing different parts of the result. 

**Commit Details:**
- split the input 
- check if each of the split input is found in the option

<img width="629" alt="Screenshot 2021-07-13 at 14 24 20" src="https://user-images.githubusercontent.com/4403069/125457367-791b5d5e-1820-4b1a-9c29-80d44cf4183f.png">


