### PR TITLE
Fix Add, Convert, Wrap shortcuts

### DIFF
--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -254,7 +254,7 @@ function getMenuTitle(insertMenuMode: 'closed' | 'insert' | 'convert' | 'wrap'):
     case 'convert':
       return 'Convert to'
     case 'insert':
-      return 'Insert'
+      return 'Add Element'
     case 'wrap':
       return 'Wrap in'
   }

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -195,8 +195,8 @@ export const resetPins: ContextMenuItem<unknown> = {
 }
 
 export const insert: ContextMenuItem<CanvasData> = {
-  name: 'Insert Element…',
-  shortcut: 'R',
+  name: 'Add Element…',
+  shortcut: 'A',
   enabled: true,
   action: (data, dispatch) => {
     requireDispatch(dispatch)([EditorActions.openFloatingInsertMenu('insert')])
@@ -205,7 +205,7 @@ export const insert: ContextMenuItem<CanvasData> = {
 
 export const convert: ContextMenuItem<CanvasData> = {
   name: 'Convert Element To…',
-  shortcut: 'J',
+  shortcut: 'C',
   enabled: true,
   action: (data, dispatch) => {
     requireDispatch(dispatch)([EditorActions.openFloatingInsertMenu('convert')])
@@ -245,7 +245,7 @@ export const wrapInPicker: ContextMenuItem<CanvasData> = {
 }
 
 export const wrapInView: ContextMenuItem<CanvasData> = {
-  name: 'Wrap in View',
+  name: 'Wrap in div',
   shortcut: '⌘G',
   enabled: true,
   action: (data, dispatch?: EditorDispatch) => {

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -113,6 +113,9 @@ import {
   ZOOM_UI_OUT_SHORTCUT,
   ShortcutNamesByKey,
   CONVERT_ELEMENT_SHORTCUT,
+  ADD_ELEMENT_SHORTCUT,
+  GROUP_ELEMENT_PICKER_SHORTCUT,
+  GROUP_ELEMENT_DEFAULT_SHORTCUT,
 } from './shortcut-definitions'
 import { DerivedState, EditorState, getOpenFile } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
@@ -561,6 +564,15 @@ export function handleKeyDown(
       [WRAP_ELEMENT_PICKER_SHORTCUT]: () => {
         return isSelectMode(editor.mode) ? [EditorActions.openFloatingInsertMenu('wrap')] : []
       },
+      // For now, the "Group / G" shortcuts do the same as the Wrap Element shortcuts – until we have Grouping working again
+      [GROUP_ELEMENT_DEFAULT_SHORTCUT]: () => {
+        return isSelectMode(editor.mode)
+          ? [EditorActions.wrapInView(editor.selectedViews, 'default-empty-div')]
+          : []
+      },
+      [GROUP_ELEMENT_PICKER_SHORTCUT]: () => {
+        return isSelectMode(editor.mode) ? [EditorActions.openFloatingInsertMenu('wrap')] : []
+      },
       [TOGGLE_HIDDEN_SHORTCUT]: () => {
         return [EditorActions.toggleHidden()]
       },
@@ -594,9 +606,7 @@ export function handleKeyDown(
         }
       },
       [INSERT_RECTANGLE_SHORTCUT]: () => {
-        if (isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)) {
-          return [EditorActions.openFloatingInsertMenu('insert')]
-        } else if (isInsertMode(editor.mode)) {
+        if (isSelectMode(editor.mode) || isInsertMode(editor.mode)) {
           const newUID = generateUidWithExistingComponents(editor.projectContents)
           return [
             EditorActions.enableInsertModeForJSXElement(
@@ -715,6 +725,13 @@ export function handleKeyDown(
       [CONVERT_ELEMENT_SHORTCUT]: () => {
         if (isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)) {
           return [EditorActions.openFloatingInsertMenu('convert')]
+        } else {
+          return []
+        }
+      },
+      [ADD_ELEMENT_SHORTCUT]: () => {
+        if (isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)) {
+          return [EditorActions.openFloatingInsertMenu('insert')]
         } else {
           return []
         }

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -61,6 +61,8 @@ export const TOGGLE_BACKGROUND_SHORTCUT = 'toggle-background'
 export const UNWRAP_ELEMENT_SHORTCUT = 'unwrap-element'
 export const WRAP_ELEMENT_PICKER_SHORTCUT = 'wrap-element-picker'
 export const WRAP_ELEMENT_DEFAULT_SHORTCUT = 'wrap-element-default'
+export const GROUP_ELEMENT_PICKER_SHORTCUT = 'group-element-picker'
+export const GROUP_ELEMENT_DEFAULT_SHORTCUT = 'group-element-default'
 export const TOGGLE_HIDDEN_SHORTCUT = 'toggle-hidden'
 export const TOGGLE_TEXT_ITALIC_SHORTCUT = 'toggle-text-italic'
 export const INSERT_IMAGE_SHORTCUT = 'insert-image'
@@ -69,6 +71,7 @@ export const TOGGLE_LIVE_CANVAS_SHORTCUT = 'toggle-live-canvas'
 export const START_RENAMING_SHORTCUT = 'start-renaming'
 export const INSERT_RECTANGLE_SHORTCUT = 'insert-rectangle'
 export const INSERT_ELLIPSE_SHORTCUT = 'insert-ellipse'
+export const ADD_ELEMENT_SHORTCUT = 'add-element'
 export const SAVE_CURRENT_FILE_SHORTCUT = 'save-current-file'
 export const TOGGLE_SHADOW_SHORTCUT = 'toggle-shadow'
 export const INSERT_TEXT_SHORTCUT = 'insert-text'
@@ -200,8 +203,13 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
     'Unwrap children of an element into their grandparent element.',
     key('g', ['cmd', 'shift']),
   ),
-  [WRAP_ELEMENT_PICKER_SHORTCUT]: shortcut('Wrap elements with a group.', key('g', [])),
-  [WRAP_ELEMENT_DEFAULT_SHORTCUT]: shortcut('Wrap elements with a group.', key('g', 'cmd')),
+  [WRAP_ELEMENT_PICKER_SHORTCUT]: shortcut('Wrap elements with a selected element.', key('w', [])),
+  [WRAP_ELEMENT_DEFAULT_SHORTCUT]: shortcut('Wrap elements with a div.', key('w', 'cmd')),
+  [GROUP_ELEMENT_PICKER_SHORTCUT]: shortcut(
+    'Group elements with a selected element.',
+    key('g', []),
+  ),
+  [GROUP_ELEMENT_DEFAULT_SHORTCUT]: shortcut('Group elements with a div.', key('g', 'cmd')),
   [TOGGLE_HIDDEN_SHORTCUT]: shortcut('Toggle element as hidden.', key('h', ['cmd', 'shift'])),
   [TOGGLE_TEXT_ITALIC_SHORTCUT]: shortcut(
     'Toggle the italic attribute of the current text element.',
@@ -276,7 +284,8 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
     'Toggle the inspector and the left menu.',
     key('backslash', 'cmd'),
   ),
-  [CONVERT_ELEMENT_SHORTCUT]: shortcut('Convert selected element to...', key('j', [])),
+  [CONVERT_ELEMENT_SHORTCUT]: shortcut('Convert selected element to...', key('c', [])),
+  [ADD_ELEMENT_SHORTCUT]: shortcut('Add element...', key('a', [])),
 }
 
 export type ShortcutConfiguration = { [key: string]: Array<Key> }


### PR DESCRIPTION
**Problem:**
As per our discord conversation, I am changing the shortcuts (and context menu items):

<img width="239" alt="image" src="https://user-images.githubusercontent.com/2226774/125477602-beb1f2fb-a8b5-4061-b77e-7b07270e86dc.png">

'A' for Add Content...
'C' for Convert Element...
'G' or 'W' for Wrap (but I am keeping it displayed as 'G', because it goes along with `CMD + G` and `Shift + CMD + G` – guess what, `CMD + W` has a different behavior that is already taken 😂)

