### PR TITLE
Insertion checkboxes

### DIFF
--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -25,6 +25,7 @@ import { generateUidWithExistingComponents } from '../../../core/model/element-t
 import {
   jsxAttributeValue,
   jsxElement,
+  jsxTextBlock,
   setJSXAttributesAttribute,
 } from '../../../core/shared/element-template'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
@@ -357,11 +358,22 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
             }),
           ]
         } else if (insertMenuMode === 'insert') {
+          let elementToInsert = pickedInsertableComponent
+          if (addContentForInsertion && pickedInsertableComponent.element.children.length === 0) {
+            elementToInsert = {
+              ...pickedInsertableComponent,
+              element: {
+                ...pickedInsertableComponent.element,
+                children: [jsxTextBlock('Utopia')],
+              },
+            }
+          }
+
           // TODO multiselect?
           actionsToDispatch = [
             insertWithDefaults(
               selectedViews[0],
-              pickedInsertableComponent,
+              elementToInsert,
               fixedSizeForInsertion ? 'add-size' : 'do-not-add',
             ),
           ]
@@ -379,7 +391,14 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
         dispatch([...actionsToDispatch, closeFloatingInsertMenu()])
       }
     },
-    [dispatch, insertMenuMode, projectContentsRef, selectedViewsref, fixedSizeForInsertion],
+    [
+      dispatch,
+      insertMenuMode,
+      projectContentsRef,
+      selectedViewsref,
+      fixedSizeForInsertion,
+      addContentForInsertion,
+    ],
   )
 
   return (

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -6,7 +6,7 @@ import Select, { StylesConfig, ValueType } from 'react-select'
 import { betterReactMemo } from '../../../uuiui-deps'
 import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 
-import { FlexColumn, OnClickOutsideHOC, useColorTheme } from '../../../uuiui'
+import { FlexColumn, FlexRow, OnClickOutsideHOC, useColorTheme } from '../../../uuiui'
 import { usePossiblyResolvedPackageDependencies } from '../../editor/npm-dependency/npm-dependency'
 import {
   getComponentGroups,
@@ -247,6 +247,47 @@ function useComponentSelectorStyles(): StylesConfig {
   )
 }
 
+interface CheckboxRowProps {
+  id: string
+  checked: boolean
+  onChange: (value: boolean) => void
+}
+
+const CheckboxRow = betterReactMemo<React.PropsWithChildren<CheckboxRowProps>>(
+  'CheckboxRow',
+  ({ id, checked, onChange, children }) => {
+    const colorTheme = useColorTheme()
+
+    const handleChange = React.useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        onChange(event.target.checked)
+      },
+      [onChange],
+    )
+
+    return (
+      <FlexRow css={{ height: 25, gap: 8 }}>
+        <input
+          type='checkbox'
+          checked={checked}
+          onChange={handleChange}
+          css={{
+            '&:focus': {
+              outline: 'auto',
+              outlineColor: colorTheme.primary.value,
+              outlineOffset: 0,
+            },
+          }}
+          id={id}
+        />
+        <label htmlFor={id} tabIndex={1}>
+          {children}
+        </label>
+      </FlexRow>
+    )
+  },
+)
+
 function getMenuTitle(insertMenuMode: 'closed' | 'insert' | 'convert' | 'wrap'): string {
   switch (insertMenuMode) {
     case 'closed':
@@ -268,6 +309,8 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
     'FloatingMenu insertMenuMode',
   )
 
+  const showInsertionControls = insertMenuMode === 'insert'
+
   const menuTitle: string = getMenuTitle(insertMenuMode)
 
   const componentSelectorStyles = useComponentSelectorStyles()
@@ -283,6 +326,9 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
   const projectContentsRef = useRefEditorState((store) => store.editor.projectContents)
   const selectedViewsref = useRefEditorState((store) => store.editor.selectedViews)
   const insertableComponents = useGetInsertableComponents()
+
+  const [addContentForInsertion, setAddContentForInsertion] = React.useState(false)
+  const [fixedSizeForInsertion, setFixedSizeForInsertion] = React.useState(false)
 
   const onChange = React.useCallback(
     (value: ValueType<InsertMenuItem>) => {
@@ -376,6 +422,24 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
           styles={componentSelectorStyles}
           tabSelectsValue={false}
         />
+        {showInsertionControls ? (
+          <FlexColumn css={{ paddingTop: 8, paddingLeft: 8, paddingRight: 8 }}>
+            <CheckboxRow
+              id='add-content-label'
+              checked={addContentForInsertion}
+              onChange={setAddContentForInsertion}
+            >
+              Add content
+            </CheckboxRow>
+            <CheckboxRow
+              id='fixed-dimensions-label'
+              checked={fixedSizeForInsertion}
+              onChange={setFixedSizeForInsertion}
+            >
+              Fixed dimensions
+            </CheckboxRow>
+          </FlexColumn>
+        ) : null}
       </FlexColumn>
     </div>
   )

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -359,7 +359,11 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
         } else if (insertMenuMode === 'insert') {
           // TODO multiselect?
           actionsToDispatch = [
-            insertWithDefaults(selectedViews[0], pickedInsertableComponent, 'add-size'),
+            insertWithDefaults(
+              selectedViews[0],
+              pickedInsertableComponent,
+              fixedSizeForInsertion ? 'add-size' : 'do-not-add',
+            ),
           ]
         } else if (insertMenuMode === 'convert') {
           // this is taken from render-as.tsx
@@ -375,7 +379,7 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
         dispatch([...actionsToDispatch, closeFloatingInsertMenu()])
       }
     },
-    [dispatch, insertMenuMode, projectContentsRef, selectedViewsref],
+    [dispatch, insertMenuMode, projectContentsRef, selectedViewsref, fixedSizeForInsertion],
   )
 
   return (

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -191,7 +191,11 @@ function getTextEditorTarget(editor: EditorState, derived: DerivedState): Elemen
 }
 
 function shouldTabBeHandledByBrowser(editor: EditorState): boolean {
-  return editor.focusedPanel === 'inspector' || editor.focusedPanel === 'dependencylist'
+  return (
+    editor.focusedPanel === 'inspector' ||
+    editor.focusedPanel === 'dependencylist' ||
+    editor.floatingInsertMenu.insertMenuMode !== 'closed'
+  )
 }
 
 export function preventBrowserShortcuts(editor: EditorState, event: KeyboardEvent): void {


### PR DESCRIPTION
**Problem:**
I forgot to add the 'Add content' and 'Fixed dimensions' checkboxes to the insert menu
<img width="334" alt="image" src="https://user-images.githubusercontent.com/2226774/125601268-836ac74d-66b5-4a0a-852c-2324e9725177.png">


**Fix:**
I do it

**Known issue**
If you type filter text to react-select, then tab out to manipulate the checkboxes, react-select loses focus and deletes the filter text. Very annoying, probably needs hacking of react-select so it doesn't do this silliness.
