### PR TITLE
Bumped the re-resizable dependency.

### DIFF
--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -27756,9 +27756,9 @@
       }
     },
     "re-resizable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.2.0.tgz",
-      "integrity": "sha512-3bi0yTzub/obnqoTPs9C8A1ecrgt5OSWlKdHDJ6gBPiEiEIG5LO0PqbwWTpABfzAzdE4kldOG2MQDQEaJJNYkQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.0.tgz",
+      "integrity": "sha512-3cUDG81ylyqI0Pdgle/RHwwRYq0ORZzsUaySOCO8IbEtNyaRtrIHYm/jMQ5pjcNiKCxR3vsSymIQZHwJq4gg2Q==",
       "requires": {
         "fast-memoize": "^2.5.1"
       }

--- a/editor/package.json
+++ b/editor/package.json
@@ -156,7 +156,7 @@
     "prop-types": "15.6.2",
     "pubsub-js": "^1.9.2",
     "rc-slider": "git://github.com/momentumworks/slider.git#93a6ef5",
-    "re-resizable": "6.2.0",
+    "re-resizable": "6.9.0",
     "react": "npm:utopia-react@17.0.0-rc.1",
     "react-contexify": "5.0.0",
     "react-dnd": "10.0.2",

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -155,7 +155,7 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
     (
       event: MouseEvent | TouchEvent,
       direction: ResizeDirection,
-      elementRef: HTMLDivElement,
+      elementRef: HTMLElement,
       delta: NumberSize,
     ) => {
       if (props.isUiJsFileOpen) {
@@ -170,7 +170,7 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
     (
       event: MouseEvent | TouchEvent,
       direction: ResizeDirection,
-      elementRef: HTMLDivElement,
+      elementRef: HTMLElement,
       delta: NumberSize,
     ) => {
       if (props.isUiJsFileOpen && navigatorPosition !== 'hidden') {


### PR DESCRIPTION
**Problem:**
When resizing the code editor, sometimes a few of the major parts of the editor shift upwards..

**Fix:**
I have been unable to reproduce the bug potentially since fully restarting my dev tools. Even if this does not fix the issue, it still bumps the version of re-resizable to the latest.

**Commit Details:**
- Potentially fixes #1483.
- Updated re-resizable to 6.9.0.
- Changed the type of `elementRef` in `DesignPanelRoot` to bring it
  in line with the (apparent) changes to re-resizable.