### PR TITLE
Use a Set to prevent duplicate options during filtering

### DIFF
--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -321,14 +321,15 @@ function findMatchingOptions<T>(
   return orderedMatchedResults
 }
 
-function takeBestOptions<T>(orderedSparseArray: Array<Array<T>>, maxMatches: number): Array<T> {
-  let matchedResults: Array<T> = []
+function takeBestOptions<T>(orderedSparseArray: Array<Array<T>>, maxMatches: number): Set<T> {
+  let matchedResults: Set<T> = new Set()
   let matchCount = 0
   for (var i = 0; i < orderedSparseArray.length && matchCount < maxMatches; i++) {
     const nextMatches = orderedSparseArray[i]
     if (nextMatches != null) {
-      matchedResults.push(...nextMatches.slice(0, maxMatches - matchCount))
-      matchCount += nextMatches.length
+      const maxNextMatches = nextMatches.slice(0, maxMatches - matchCount)
+      maxNextMatches.forEach((m) => matchedResults.add(m))
+      matchCount = matchedResults.size
     }
   }
 
@@ -368,7 +369,7 @@ export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNa
       let matchedResults = takeBestOptions(orderedMatchedResults, MaxResults)
 
       // Next if we haven't hit our max result count, we find matches based on attributes
-      const remainingAllowedMatches = MaxResults - matchedResults.length
+      const remainingAllowedMatches = MaxResults - matchedResults.size
       if (remainingAllowedMatches > 0) {
         const orderedAttributeMatchedResults = findMatchingOptions(
           searchTerms,
@@ -380,13 +381,14 @@ export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNa
           orderedAttributeMatchedResults,
           remainingAllowedMatches,
         )
-        const optionsForBestMatchedAttributes = bestMatchedAttributes.flatMap(
-          (attribute) => AttributeOptionLookup[attribute] ?? [],
-        )
-        matchedResults.push(...optionsForBestMatchedAttributes)
+
+        bestMatchedAttributes.forEach((attribute) => {
+          const matchingOptions = AttributeOptionLookup[attribute] ?? []
+          matchingOptions.forEach((option) => matchedResults.add(option))
+        })
       }
 
-      results = matchedResults
+      results = Array.from(matchedResults)
     }
 
     if (results.length === 0) {


### PR DESCRIPTION
**Problem:**
Since we were using an array to store the filtered results, we were duplicating the options in the select list when matching an option on the class name and attributes.

**Fix:**
Use a Set when building the results and convert to an array at the end.

**Before:** (matched on the class name and two of the attributes, hence the option appears 3 times)
![Screenshot_20210714_154403](https://user-images.githubusercontent.com/1044774/125643674-38c0f514-4ffc-4cb7-88f4-3f1acdfcd307.png)

**After:** (pure bliss)
![Screenshot_20210714_155200](https://user-images.githubusercontent.com/1044774/125643694-0fb0b48c-d977-4058-bcaf-83f1bb54bce2.png)
