### PR TITLE
Shortcut for focusing omnibox and changing tabs

### DIFF
--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -456,17 +456,10 @@ export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNa
     }
   }, 'ClassNameSelect elementPath classNameFromAttributes isMenuEnabled')
 
-  const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
-
   const selectedValues = React.useMemo((): TailWindOption[] | null => {
     let classNameValue: string | null = null
     if (classNameFromAttributes != null) {
       classNameValue = classNameFromAttributes
-    } else {
-      if (elementPath != null) {
-        const element = MetadataUtils.findElementByElementPath(metadataRef.current, elementPath)
-        classNameValue = element?.props['className']
-      }
     }
 
     const splitClassNames =
@@ -482,7 +475,7 @@ export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNa
           label: name,
           value: name,
         }))
-  }, [classNameFromAttributes, elementPath, metadataRef])
+  }, [classNameFromAttributes])
 
   const ariaOnFocus = React.useCallback(
     ({ focused }: { focused: TailWindOption }) => {

--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -599,6 +599,7 @@ export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNa
     >
       <WindowedSelect
         ariaLiveMessages={ariaLiveMessages}
+        autoFocus={true}
         filterOption={filterOption}
         formatOptionLabel={formatOptionLabel}
         options={filteredOptions}
@@ -608,6 +609,7 @@ export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNa
         value={selectedValues}
         isMulti={true}
         isDisabled={!isMenuEnabled}
+        openMenuOnFocus={true}
         closeMenuOnSelect={false}
         styles={colourStyles}
         components={{

--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -452,10 +452,17 @@ export const ClassNameSelect = betterReactMemo(
       }
     }, 'ClassNameSelect elementPath classNameFromAttributes isMenuEnabled')
 
+    const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
+
     const selectedValues = React.useMemo((): TailWindOption[] | null => {
       let classNameValue: string | null = null
       if (classNameFromAttributes != null) {
         classNameValue = classNameFromAttributes
+      } else {
+        if (elementPath != null) {
+          const element = MetadataUtils.findElementByElementPath(metadataRef.current, elementPath)
+          classNameValue = element?.props['className']
+        }
       }
 
       const splitClassNames =
@@ -471,7 +478,7 @@ export const ClassNameSelect = betterReactMemo(
             label: name,
             value: name,
           }))
-    }, [classNameFromAttributes])
+    }, [classNameFromAttributes, elementPath, metadataRef])
 
     const ariaOnFocus = React.useCallback(
       ({ focused }: { focused: TailWindOption }) => {

--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -341,335 +341,341 @@ function takeBestOptions<T>(orderedSparseArray: Array<Array<T>>, maxMatches: num
   return matchedResults
 }
 
-export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNameSelect', () => {
-  const theme = useColorTheme()
-  const targets = useEditorState((store) => store.editor.selectedViews, 'ClassNameSelect targets')
-  const dispatch = useEditorState((store) => store.dispatch, 'ClassNameSelect dispatch')
-  const [input, setInput] = React.useState('')
-  const updateFocusedOption = usePubSubAtomWriteOnly(focusedOptionAtom)
-  const clearFocusedOption = React.useCallback(() => {
-    updateFocusedOption(null)
-    dispatch([EditorActions.clearTransientProps()], 'canvas')
-  }, [updateFocusedOption, dispatch])
+export const ClassNameSelect = betterReactMemo(
+  'ClassNameSelect',
+  React.forwardRef<HTMLInputElement>((_, ref) => {
+    const theme = useColorTheme()
+    const targets = useEditorState((store) => store.editor.selectedViews, 'ClassNameSelect targets')
+    const dispatch = useEditorState((store) => store.dispatch, 'ClassNameSelect dispatch')
+    const [input, setInput] = React.useState('')
+    const updateFocusedOption = usePubSubAtomWriteOnly(focusedOptionAtom)
+    const clearFocusedOption = React.useCallback(() => {
+      updateFocusedOption(null)
+      dispatch([EditorActions.clearTransientProps()], 'canvas')
+    }, [updateFocusedOption, dispatch])
 
-  const filteredOptions = React.useMemo(() => {
-    const searchTerms = searchStringToIndividualTerms(input)
-    let results: Array<TailWindOption>
+    const filteredOptions = React.useMemo(() => {
+      const searchTerms = searchStringToIndividualTerms(input)
+      let results: Array<TailWindOption>
 
-    if (searchTerms.length === 0) {
-      results = TailWindOptions.slice(0, MaxResults)
-    } else {
-      // First find all matches, and use a sparse array to keep the best matches at the front
-      const orderedMatchedResults = findMatchingOptions(
-        searchTerms,
-        TailWindOptions,
-        (option) => option.label,
-        MaxResults,
-      )
-
-      // Now go through and take the first n best matches
-      let matchedResults = takeBestOptions(orderedMatchedResults, MaxResults)
-
-      // Next if we haven't hit our max result count, we find matches based on attributes
-      const remainingAllowedMatches = MaxResults - matchedResults.length
-      if (remainingAllowedMatches > 0) {
-        const orderedAttributeMatchedResults = findMatchingOptions(
+      if (searchTerms.length === 0) {
+        results = TailWindOptions.slice(0, MaxResults)
+      } else {
+        // First find all matches, and use a sparse array to keep the best matches at the front
+        const orderedMatchedResults = findMatchingOptions(
           searchTerms,
-          AllAttributes,
-          (a) => a,
-          remainingAllowedMatches,
+          TailWindOptions,
+          (option) => option.label,
+          MaxResults,
         )
-        const bestMatchedAttributes = takeBestOptions(
-          orderedAttributeMatchedResults,
-          remainingAllowedMatches,
-        )
-        const optionsForBestMatchedAttributes = bestMatchedAttributes.flatMap(
-          (attribute) => AttributeOptionLookup[attribute] ?? [],
-        )
-        matchedResults.push(...optionsForBestMatchedAttributes)
+
+        // Now go through and take the first n best matches
+        let matchedResults = takeBestOptions(orderedMatchedResults, MaxResults)
+
+        // Next if we haven't hit our max result count, we find matches based on attributes
+        const remainingAllowedMatches = MaxResults - matchedResults.length
+        if (remainingAllowedMatches > 0) {
+          const orderedAttributeMatchedResults = findMatchingOptions(
+            searchTerms,
+            AllAttributes,
+            (a) => a,
+            remainingAllowedMatches,
+          )
+          const bestMatchedAttributes = takeBestOptions(
+            orderedAttributeMatchedResults,
+            remainingAllowedMatches,
+          )
+          const optionsForBestMatchedAttributes = bestMatchedAttributes.flatMap(
+            (attribute) => AttributeOptionLookup[attribute] ?? [],
+          )
+          matchedResults.push(...optionsForBestMatchedAttributes)
+        }
+
+        results = matchedResults
       }
 
-      results = matchedResults
-    }
+      if (results.length === 0) {
+        clearFocusedOption()
+      }
 
-    if (results.length === 0) {
-      clearFocusedOption()
-    }
+      return results
+    }, [input, clearFocusedOption])
 
-    return results
-  }, [input, clearFocusedOption])
+    const { classNameFromAttributes, elementPath, isMenuEnabled } = useEditorState((store) => {
+      const openUIJSFileKey = getOpenUIJSFileKey(store.editor)
+      if (openUIJSFileKey == null || store.editor.selectedViews.length !== 1) {
+        return {
+          elementPath: null,
+          classNameFromAttributes: null,
+          isMenuEnabled: false,
+        }
+      }
+      const underlyingTarget = normalisePathToUnderlyingTarget(
+        store.editor.projectContents,
+        store.editor.nodeModules.files,
+        openUIJSFileKey,
+        store.editor.selectedViews[0],
+      )
+      const underlyingPath =
+        underlyingTarget.type === 'NORMALISE_PATH_SUCCESS'
+          ? underlyingTarget.filePath
+          : openUIJSFileKey
+      const projectFile = getContentsTreeFileFromString(
+        store.editor.projectContents,
+        underlyingPath,
+      )
+      let element: JSXElementChild | null = null
+      if (isTextFile(projectFile) && isParseSuccess(projectFile.fileContents.parsed)) {
+        element = findElementAtPath(
+          store.editor.selectedViews[0],
+          getUtopiaJSXComponentsFromSuccess(projectFile.fileContents.parsed),
+        )
+      }
 
-  const { classNameFromAttributes, elementPath, isMenuEnabled } = useEditorState((store) => {
-    const openUIJSFileKey = getOpenUIJSFileKey(store.editor)
-    if (openUIJSFileKey == null || store.editor.selectedViews.length !== 1) {
+      let foundAttributeAsString: string | null = null
+      let menuEnabled = false
+      if (element != null && isJSXElement(element)) {
+        const jsxAttributes = element.props
+        let foundAttribute = eitherToMaybe(
+          getModifiableJSXAttributeAtPath(jsxAttributes, PP.create(['className'])),
+        )
+        if (foundAttribute != null && isJSXAttributeValue(foundAttribute)) {
+          foundAttributeAsString = foundAttribute.value
+        }
+        if (
+          foundAttribute == null ||
+          isJSXAttributeNotFound(foundAttribute) ||
+          isJSXAttributeValue(foundAttribute)
+        ) {
+          menuEnabled = true
+        }
+      }
+
       return {
-        elementPath: null,
-        classNameFromAttributes: null,
-        isMenuEnabled: false,
+        elementPath: MetadataUtils.findElementByElementPath(
+          store.editor.jsxMetadata,
+          store.editor.selectedViews[0],
+        )?.elementPath,
+        classNameFromAttributes: foundAttributeAsString,
+        isMenuEnabled: menuEnabled,
       }
-    }
-    const underlyingTarget = normalisePathToUnderlyingTarget(
-      store.editor.projectContents,
-      store.editor.nodeModules.files,
-      openUIJSFileKey,
-      store.editor.selectedViews[0],
+    }, 'ClassNameSelect elementPath classNameFromAttributes isMenuEnabled')
+
+    const selectedValues = React.useMemo((): TailWindOption[] | null => {
+      let classNameValue: string | null = null
+      if (classNameFromAttributes != null) {
+        classNameValue = classNameFromAttributes
+      }
+
+      const splitClassNames =
+        typeof classNameValue === 'string'
+          ? classNameValue
+              .split(' ')
+              .map((s) => s.trim())
+              .filter((s) => s !== '')
+          : []
+      return splitClassNames.length === 0
+        ? null
+        : splitClassNames.map((name: string) => ({
+            label: name,
+            value: name,
+          }))
+    }, [classNameFromAttributes])
+
+    const ariaOnFocus = React.useCallback(
+      ({ focused }: { focused: TailWindOption }) => {
+        if (targets.length === 1) {
+          const newClassNameString =
+            selectedValues?.map((v) => v.label).join(' ') + ' ' + focused.label
+          dispatch(
+            [
+              EditorActions.setPropTransient(
+                targets[0],
+                PP.create(['className']),
+                jsxAttributeValue(newClassNameString, emptyComments),
+              ),
+            ],
+            'canvas',
+          )
+        }
+        updateFocusedOption(focused)
+      },
+      [updateFocusedOption, dispatch, targets, selectedValues],
     )
-    const underlyingPath =
-      underlyingTarget.type === 'NORMALISE_PATH_SUCCESS'
-        ? underlyingTarget.filePath
-        : openUIJSFileKey
-    const projectFile = getContentsTreeFileFromString(store.editor.projectContents, underlyingPath)
-    let element: JSXElementChild | null = null
-    if (isTextFile(projectFile) && isParseSuccess(projectFile.fileContents.parsed)) {
-      element = findElementAtPath(
-        store.editor.selectedViews[0],
-        getUtopiaJSXComponentsFromSuccess(projectFile.fileContents.parsed),
-      )
-    }
+    const ariaLiveMessages = React.useMemo(() => ({ onFocus: ariaOnFocus }), [ariaOnFocus])
 
-    let foundAttributeAsString: string | null = null
-    let menuEnabled = false
-    if (element != null && isJSXElement(element)) {
-      const jsxAttributes = element.props
-      let foundAttribute = eitherToMaybe(
-        getModifiableJSXAttributeAtPath(jsxAttributes, PP.create(['className'])),
-      )
-      if (foundAttribute != null && isJSXAttributeValue(foundAttribute)) {
-        foundAttributeAsString = foundAttribute.value
-      }
-      if (
-        foundAttribute == null ||
-        isJSXAttributeNotFound(foundAttribute) ||
-        isJSXAttributeValue(foundAttribute)
-      ) {
-        menuEnabled = true
-      }
-    }
-
-    return {
-      elementPath: MetadataUtils.findElementByElementPath(
-        store.editor.jsxMetadata,
-        store.editor.selectedViews[0],
-      )?.elementPath,
-      classNameFromAttributes: foundAttributeAsString,
-      isMenuEnabled: menuEnabled,
-    }
-  }, 'ClassNameSelect elementPath classNameFromAttributes isMenuEnabled')
-
-  const selectedValues = React.useMemo((): TailWindOption[] | null => {
-    let classNameValue: string | null = null
-    if (classNameFromAttributes != null) {
-      classNameValue = classNameFromAttributes
-    }
-
-    const splitClassNames =
-      typeof classNameValue === 'string'
-        ? classNameValue
-            .split(' ')
-            .map((s) => s.trim())
-            .filter((s) => s !== '')
-        : []
-    return splitClassNames.length === 0
-      ? null
-      : splitClassNames.map((name: string) => ({
-          label: name,
-          value: name,
-        }))
-  }, [classNameFromAttributes])
-
-  const ariaOnFocus = React.useCallback(
-    ({ focused }: { focused: TailWindOption }) => {
-      if (targets.length === 1) {
-        const newClassNameString =
-          selectedValues?.map((v) => v.label).join(' ') + ' ' + focused.label
-        dispatch(
-          [
-            EditorActions.setPropTransient(
-              targets[0],
-              PP.create(['className']),
-              jsxAttributeValue(newClassNameString, emptyComments),
-            ),
-          ],
-          'canvas',
-        )
-      }
-      updateFocusedOption(focused)
-    },
-    [updateFocusedOption, dispatch, targets, selectedValues],
-  )
-  const ariaLiveMessages = React.useMemo(() => ({ onFocus: ariaOnFocus }), [ariaOnFocus])
-
-  const onChange = React.useCallback(
-    (newValue: Array<{ label: string; value: string }>) => {
-      if (elementPath != null) {
-        dispatch(
-          [
-            EditorActions.setProp_UNSAFE(
-              elementPath,
-              PP.create(['className']),
-              jsxAttributeValue(newValue.map((value) => value.value).join(' '), emptyComments),
-            ),
-          ],
-          'everyone',
-        )
-      }
-    },
-    [dispatch, elementPath],
-  )
-
-  const optionAndSelectedColor: OptionAndSelectedColor = React.useMemo(() => {
-    const themePrimary = chroma(theme.primary.value)
-    return {
-      primary: {
-        optionColor: themePrimary,
-        selectedColor: chroma.contrast(themePrimary, 'white') > 2 ? 'white' : 'black',
-      },
-      regular: {
-        optionColor: chroma('black'),
-        selectedColor: 'white',
-      },
-    }
-  }, [theme.primary.value])
-  const colourStyles: StylesConfig = React.useMemo(
-    () => ({
-      container: (styles: React.CSSProperties) => ({
-        // the outermost element. It contains the popup menu, so don't set a height on it!
-        // shouldn't contain any sizing
-        ...styles,
-        width: '100%',
-      }),
-      control: (styles) => ({
-        // need to remove styles here, since that implicitly sets a height of 38
-        // ...styles,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        background: 'transparent',
-        outline: 'none',
-        ':focus-within': {
-          outline: 'none',
-          border: 'none',
-        },
-      }),
-      valueContainer: () => ({
-        // the container for added options (tags) and input
-        // sibling to indicatorsContainer
-        // default styles mess with layout, so ignore them
-        display: 'flex',
-        alignItems: 'center',
-        gap: 4,
-        maxWidth: 0,
-      }),
-      multiValue: () => {
-        return {
-          cursor: 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          height: 18,
-          backgroundColor: theme.inverted.bg1.value,
+    const onChange = React.useCallback(
+      (newValue: Array<{ label: string; value: string }>) => {
+        if (elementPath != null) {
+          dispatch(
+            [
+              EditorActions.setProp_UNSAFE(
+                elementPath,
+                PP.create(['className']),
+                jsxAttributeValue(newValue.map((value) => value.value).join(' '), emptyComments),
+              ),
+            ],
+            'everyone',
+          )
         }
       },
-      multiValueLabel: () => ({
-        fontSize: 10,
-        padding: '2px 4px',
-        color: theme.inverted.textColor.value,
-      }),
-      multiValueRemove: (styles: React.CSSProperties, { data }) => ({
-        width: 11,
-        display: 'flex',
-        paddingTop: 2,
-        opacity: 0.4,
-        color: data.color,
-        ':hover': {
-          opacity: 1,
-          backgroundColor: data.color,
-          color: theme.inverted.textColor.value,
+      [dispatch, elementPath],
+    )
+
+    const optionAndSelectedColor: OptionAndSelectedColor = React.useMemo(() => {
+      const themePrimary = chroma(theme.primary.value)
+      return {
+        primary: {
+          optionColor: themePrimary,
+          selectedColor: chroma.contrast(themePrimary, 'white') > 2 ? 'white' : 'black',
         },
-        '& > svg': {
-          overflow: 'hidden',
+        regular: {
+          optionColor: chroma('black'),
+          selectedColor: 'white',
         },
-      }),
-      input: () => {
-        return {
-          fontSize: 11,
-          color: theme.inverted.textColor.value,
-          letterSpacing: 0.3,
+      }
+    }, [theme.primary.value])
+    const colourStyles: StylesConfig = React.useMemo(
+      () => ({
+        container: (styles: React.CSSProperties) => ({
+          // the outermost element. It contains the popup menu, so don't set a height on it!
+          // shouldn't contain any sizing
+          ...styles,
+          width: '100%',
+        }),
+        control: (styles) => ({
+          // need to remove styles here, since that implicitly sets a height of 38
+          // ...styles,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
           background: 'transparent',
-          display: 'flex',
-          alignItems: 'center',
-        }
-      },
-      indicatorsContainer: (styles) => ({
-        ...styles,
-        height: 20,
-      }),
-      option: (styles: React.CSSProperties, { data, isDisabled, isFocused, isSelected }) => {
-        // a single entry in the options list
-        const optionColors = getOptionColors(
-          optionAndSelectedColor,
-          isFocused,
-          isSelected,
-          isDisabled,
-          data,
-        )
-        return {
-          minHeight: 27,
-          display: 'flex',
-          alignItems: 'center',
-          paddingLeft: 8,
-          paddingRight: 8,
-          backgroundColor: optionColors.backgroundColor,
-          color: optionColors.color,
-          cursor: isDisabled ? 'not-allowed' : 'default',
-
-          ':active': {
-            ...(styles as any)[':active'],
-            backgroundColor: optionColors.activeBackgroundColor,
+          outline: 'none',
+          ':focus-within': {
+            outline: 'none',
+            border: 'none',
           },
-        }
-      },
-    }),
-    [theme, optionAndSelectedColor],
-  )
+        }),
+        valueContainer: () => ({
+          // the container for added options (tags) and input
+          // sibling to indicatorsContainer
+          // default styles mess with layout, so ignore them
+          display: 'flex',
+          alignItems: 'center',
+          gap: 4,
+          maxWidth: 0,
+        }),
+        multiValue: () => {
+          return {
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            height: 18,
+            backgroundColor: theme.inverted.bg1.value,
+          }
+        },
+        multiValueLabel: () => ({
+          fontSize: 10,
+          padding: '2px 4px',
+          color: theme.inverted.textColor.value,
+        }),
+        multiValueRemove: (styles: React.CSSProperties, { data }) => ({
+          width: 11,
+          display: 'flex',
+          paddingTop: 2,
+          opacity: 0.4,
+          color: data.color,
+          ':hover': {
+            opacity: 1,
+            backgroundColor: data.color,
+            color: theme.inverted.textColor.value,
+          },
+          '& > svg': {
+            overflow: 'hidden',
+          },
+        }),
+        input: () => {
+          return {
+            fontSize: 11,
+            color: theme.inverted.textColor.value,
+            letterSpacing: 0.3,
+            background: 'transparent',
+            display: 'flex',
+            alignItems: 'center',
+          }
+        },
+        indicatorsContainer: (styles) => ({
+          ...styles,
+          height: 20,
+        }),
+        option: (styles: React.CSSProperties, { data, isDisabled, isFocused, isSelected }) => {
+          // a single entry in the options list
+          const optionColors = getOptionColors(
+            optionAndSelectedColor,
+            isFocused,
+            isSelected,
+            isDisabled,
+            data,
+          )
+          return {
+            minHeight: 27,
+            display: 'flex',
+            alignItems: 'center',
+            paddingLeft: 8,
+            paddingRight: 8,
+            backgroundColor: optionColors.backgroundColor,
+            color: optionColors.color,
+            cursor: isDisabled ? 'not-allowed' : 'default',
 
-  return (
-    <div
-      css={{
-        height: 22,
-        borderRadius: 3,
-        position: 'relative',
-        padding: 4,
-        flexGrow: 1,
-        display: 'flex',
-        alignItems: 'center',
-        '&:focus-within': { boxShadow: `0px 0px 0px 1px ${theme.primary.value}` },
-      }}
-    >
-      <WindowedSelect
-        ariaLiveMessages={ariaLiveMessages}
-        autoFocus={true}
-        filterOption={filterOption}
-        formatOptionLabel={formatOptionLabel}
-        options={filteredOptions}
-        onChange={onChange}
-        onInputChange={setInput}
-        onMenuClose={clearFocusedOption}
-        value={selectedValues}
-        isMulti={true}
-        isDisabled={!isMenuEnabled}
-        openMenuOnFocus={true}
-        closeMenuOnSelect={false}
-        styles={colourStyles}
-        components={{
-          DropdownIndicator,
-          ClearIndicator,
-          IndicatorSeparator,
-          NoOptionsMessage,
-          Menu,
-          MultiValueContainer,
-          ValueContainer,
+            ':active': {
+              ...(styles as any)[':active'],
+              backgroundColor: optionColors.activeBackgroundColor,
+            },
+          }
+        },
+      }),
+      [theme, optionAndSelectedColor],
+    )
+
+    return (
+      <div
+        css={{
+          height: 22,
+          borderRadius: 3,
+          position: 'relative',
+          padding: 4,
+          flexGrow: 1,
+          display: 'flex',
+          alignItems: 'center',
+          '&:focus-within': { boxShadow: `0px 0px 0px 1px ${theme.primary.value}` },
         }}
-      />
-    </div>
-  )
-})
+      >
+        <WindowedSelect
+          ref={ref}
+          ariaLiveMessages={ariaLiveMessages}
+          filterOption={filterOption}
+          formatOptionLabel={formatOptionLabel}
+          openMenuOnFocus={true}
+          options={filteredOptions}
+          onChange={onChange}
+          onInputChange={setInput}
+          onMenuClose={clearFocusedOption}
+          value={selectedValues}
+          isMulti={true}
+          isDisabled={!isMenuEnabled}
+          closeMenuOnSelect={false}
+          styles={colourStyles}
+          components={{
+            DropdownIndicator,
+            ClearIndicator,
+            IndicatorSeparator,
+            NoOptionsMessage,
+            Menu,
+            MultiValueContainer,
+            ValueContainer,
+          }}
+        />
+      </div>
+    )
+  }),
+)

--- a/editor/src/components/canvas/controls/formula-bar.tsx
+++ b/editor/src/components/canvas/controls/formula-bar.tsx
@@ -154,7 +154,7 @@ export const FormulaBar = betterReactMemo('FormulaBar', () => {
       onKeyDown={onKeyDown}
     >
       {buttonsVisible ? <ModeToggleButton /> : null}
-      {classNameFieldVisible ? <ClassNameSelect /> : null}
+      {classNameFieldVisible ? <ClassNameSelect ref={inputRef} /> : null}
       {inputFieldVisible ? (
         <HeadlessStringInput
           ref={inputRef}

--- a/editor/src/components/canvas/controls/formula-bar.tsx
+++ b/editor/src/components/canvas/controls/formula-bar.tsx
@@ -119,8 +119,6 @@ export const FormulaBar = betterReactMemo('FormulaBar', () => {
       )
       handleShortcuts(namesByKey, event.nativeEvent, null, {
         [TOGGLE_FOCUSED_OMNIBOX_TAB]: () => {
-          event.stopPropagation()
-          event.preventDefault()
           dispatch([EditorActions.toggleFocusedOmniboxTab()])
 
           // We need this to happen in the next frame to ensure the field we want to focus exists

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -253,6 +253,10 @@ export type SetPanelVisibility = {
   visible: boolean
 }
 
+export type ToggleFocusedOmniboxTab = {
+  action: 'TOGGLE_FOCUSED_OMNIBOX_TAB'
+}
+
 export type TogglePane = {
   action: 'TOGGLE_PANE'
   target: EditorPanel | EditorPane
@@ -888,6 +892,7 @@ export type EditorAction =
   | RenameComponent
   | NavigatorReorder
   | SetPanelVisibility
+  | ToggleFocusedOmniboxTab
   | TogglePane
   | ClosePopup
   | OpenPopup

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -191,6 +191,7 @@ import type {
   OpenFloatingInsertMenu,
   CloseFloatingInsertMenu,
   InsertWithDefaults,
+  ToggleFocusedOmniboxTab,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -332,6 +333,12 @@ export function setPanelVisibility(
     action: 'SET_PANEL_VISIBILITY',
     target: target,
     visible: visible,
+  }
+}
+
+export function toggleFocusedOmniboxTab(): ToggleFocusedOmniboxTab {
+  return {
+    action: 'TOGGLE_FOCUSED_OMNIBOX_TAB',
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -26,6 +26,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SWITCH_EDITOR_MODE':
     case 'INSERT_IMAGE_INTO_UI':
     case 'SET_PANEL_VISIBILITY':
+    case 'TOGGLE_FOCUSED_OMNIBOX_TAB':
     case 'TOGGLE_PANE':
     case 'COPY_SELECTION_TO_CLIPBOARD':
     case 'OPEN_TEXT_EDITOR':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -2405,6 +2405,15 @@ export const UPDATE_FNS = {
         return editor
     }
   },
+  TOGGLE_FOCUSED_OMNIBOX_TAB: (editor: EditorModel): EditorModel => {
+    return {
+      ...editor,
+      topmenu: {
+        ...editor.topmenu,
+        formulaBarMode: editor.topmenu.formulaBarMode === 'css' ? 'content' : 'css',
+      },
+    }
+  },
   TOGGLE_PANE: (action: TogglePane, editor: EditorModel): EditorModel => {
     switch (action.target) {
       case 'leftmenu':

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -116,6 +116,7 @@ import {
   ADD_ELEMENT_SHORTCUT,
   GROUP_ELEMENT_PICKER_SHORTCUT,
   GROUP_ELEMENT_DEFAULT_SHORTCUT,
+  TOGGLE_FOCUSED_OMNIBOX_TAB,
 } from './shortcut-definitions'
 import { DerivedState, EditorState, getOpenFile } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
@@ -707,6 +708,9 @@ export function handleKeyDown(
       },
       [MOVE_ELEMENT_TO_FRONT_SHORTCUT]: () => {
         return isSelectMode(editor.mode) ? [EditorActions.moveSelectedToFront()] : []
+      },
+      [TOGGLE_FOCUSED_OMNIBOX_TAB]: () => {
+        return [EditorActions.focusFormulaBar()]
       },
       [TOGGLE_TEXT_UNDERLINE_SHORTCUT]: () => {
         return isSelectMode(editor.mode) ? toggleTextFormatting(editor, dispatch, 'underline') : []

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -85,6 +85,7 @@ export const MOVE_ELEMENT_FORWARD_SHORTCUT = 'move-element-forward'
 export const MOVE_ELEMENT_TO_FRONT_SHORTCUT = 'move-element-to-front'
 export const MOVE_ELEMENT_BACKWARD_SHORTCUT = 'move-element-backward'
 export const MOVE_ELEMENT_TO_BACK_SHORTCUT = 'move-element-to-back'
+export const TOGGLE_FOCUSED_OMNIBOX_TAB = 'toggle-focused-omnibox-tab'
 export const TOGGLE_TEXT_UNDERLINE_SHORTCUT = 'toggle-text-underline'
 export const TOGGLE_LEFT_MENU_SHORTCUT = 'toggle-left-menu'
 export const TOGGLE_RIGHT_MENU_SHORTCUT = 'toggle-right-menu'
@@ -261,6 +262,10 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
   [MOVE_ELEMENT_TO_BACK_SHORTCUT]: shortcut(
     'Move element to the back in relation to its siblings.',
     key('[', ['alt', 'cmd']),
+  ),
+  [TOGGLE_FOCUSED_OMNIBOX_TAB]: shortcut(
+    'Focus the omnibox or toggle its current tab.',
+    key('forwardslash', 'cmd'),
   ),
   [TOGGLE_TEXT_UNDERLINE_SHORTCUT]: shortcut(
     'Toggle the underline attribute of the current text element.',

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -95,6 +95,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.INSERT_JSX_ELEMENT(action, state)
     case 'SET_PANEL_VISIBILITY':
       return UPDATE_FNS.SET_PANEL_VISIBILITY(action, state)
+    case 'TOGGLE_FOCUSED_OMNIBOX_TAB':
+      return UPDATE_FNS.TOGGLE_FOCUSED_OMNIBOX_TAB(state)
     case 'TOGGLE_PANE':
       return UPDATE_FNS.TOGGLE_PANE(action, state)
     case 'RESIZE_INTERFACEDESIGNER_CODEPANE':


### PR DESCRIPTION
Fixes #1498 

**Problem:**
We want a quick way to focus the omnibox and toggle the selected tab

**Fix:**
Map the shortcut `cmd`+`/` to the action for focusing the topmenu, and also capture that shortcut when the topmenu is focused to trigger an action for changing the selected tab.

![omnibox-shortcut](https://user-images.githubusercontent.com/1044774/125661145-85089c1a-9a4a-4749-9a27-ee173833ea6b.gif)
