### PR TITLE
Fix/classname menu transient clear

### DIFF
--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -383,10 +383,12 @@ export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNa
   }, [input, clearFocusedOption])
 
   React.useEffect(() => {
-    return () => {
+    return function cleanup() {
       dispatch([EditorActions.clearTransientProps()], 'canvas')
     }
-  })
+    /** deps is explicitly empty */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const { classNameFromAttributes, elementPath, isMenuEnabled } = useEditorState((store) => {
     const openUIJSFileKey = getOpenUIJSFileKey(store.editor)

--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -382,6 +382,12 @@ export const ClassNameSelect: React.FunctionComponent = betterReactMemo('ClassNa
     return results
   }, [input, clearFocusedOption])
 
+  React.useEffect(() => {
+    return () => {
+      dispatch([EditorActions.clearTransientProps()], 'canvas')
+    }
+  })
+
   const { classNameFromAttributes, elementPath, isMenuEnabled } = useEditorState((store) => {
     const openUIJSFileKey = getOpenUIJSFileKey(store.editor)
     if (openUIJSFileKey == null || store.editor.selectedViews.length !== 1) {


### PR DESCRIPTION
**Problem:**
Class menu mouseover transient state can get stuck when the react-select unmounts. This is especially visible on the shortcut PR when toggling between the different topmenu states. #1509 

**Fix:**
Dispatch clearing the transient state in useEffect callback

