### PR TITLE
Made the add file and folder buttons consistent.

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -597,6 +597,7 @@ export interface ClearImageFileBlob {
 export interface AddFolder {
   action: 'ADD_FOLDER'
   parentPath: string
+  fileName: string
 }
 
 export interface DeleteFile {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -877,10 +877,11 @@ export function deleteFile(filename: string): DeleteFile {
   }
 }
 
-export function addFolder(parentPath: string): AddFolder {
+export function addFolder(parentPath: string, fileName: string): AddFolder {
   return {
     action: 'ADD_FOLDER',
     parentPath: parentPath,
+    fileName: fileName,
   }
 }
 

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3659,14 +3659,13 @@ export const UPDATE_FNS = {
   },
   ADD_FOLDER: (action: AddFolder, editor: EditorModel): EditorModel => {
     const pathPrefix = action.parentPath == '' ? '' : action.parentPath + '/'
-    const newFolderKey = uniqueProjectContentID(pathPrefix + 'folder', editor.projectContents)
+    const newFolderKey = uniqueProjectContentID(
+      pathPrefix + action.fileName,
+      editor.projectContents,
+    )
     return {
       ...editor,
       projectContents: addFileToProjectContents(editor.projectContents, newFolderKey, directory()),
-      fileBrowser: {
-        ...editor.fileBrowser,
-        renamingTarget: newFolderKey,
-      },
     }
   },
   ADD_TEXT_FILE: (action: AddTextFile, editor: EditorModel): EditorModel => {
@@ -3684,10 +3683,6 @@ export const UPDATE_FNS = {
     const updatedEditor: EditorModel = {
       ...editor,
       projectContents: updatedProjectContents,
-      fileBrowser: {
-        ...editor.fileBrowser,
-        renamingTarget: newFileKey,
-      },
     }
     return UPDATE_FNS.OPEN_CODE_EDITOR_FILE(openCodeEditorFile(newFileKey, false), updatedEditor)
   },

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -39,6 +39,7 @@ import {
 } from '../../uuiui'
 import { notice } from '../common/notice'
 import { appendToPath, getParentDirectory } from '../../utils/path-utils'
+import { AddingFile, applyAddingFile } from './filepath-utils'
 
 export interface FileBrowserItemProps extends FileBrowserItemInfo {
   isSelected: boolean
@@ -48,16 +49,14 @@ export interface FileBrowserItemProps extends FileBrowserItemInfo {
   collapsed: boolean
   dropTarget: string | null
   toggleCollapse: (filePath: string) => void
-  Expand: (filePath: string) => void
+  expand: (filePath: string) => void
   setSelected: (selectedItem: FileBrowserItemInfo | null) => void
 }
 
 interface FileBrowserItemState {
   isRenaming: boolean
   isHovered: boolean
-  isAddingChild: boolean
-  addingChildName: string
-  isAddingChildNameValid: boolean
+  adding: AddingFile | null
   // we need the following to keep track of 'internal' exits,
   // eg when moving from the outer folder div to a span with the folder name inside it
   // see https://medium.com/@650egor/simple-drag-and-drop-file-upload-in-react-2cb409d88929
@@ -203,6 +202,37 @@ const isFile = (fileBrowserItem: FileBrowserItemInfo) => {
   return fileBrowserItem.type === 'file'
 }
 
+export function addingChildElement(
+  indentation: number,
+  addingChildName: string,
+  onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void,
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void,
+  onBlur: () => void,
+): React.ReactNode {
+  return (
+    <SimpleFlexRow
+      style={{
+        // make it look indented, plus extra to account for missing icon
+        paddingLeft: (indentation + 1) * BaseIndentationPadding + 20,
+        paddingTop: 3,
+        paddingBottom: 3,
+        height: 32,
+        display: 'flex',
+        alignItems: 'center',
+      }}
+    >
+      <StringInput
+        testId=''
+        value={addingChildName}
+        autoFocus
+        onKeyDown={onKeyDown}
+        onChange={onChange}
+        onBlur={onBlur}
+      />
+    </SimpleFlexRow>
+  )
+}
+
 interface FileBrowserItemDragProps {
   isDragging: boolean
   isOver: boolean
@@ -219,9 +249,7 @@ class FileBrowserItemInner extends React.PureComponent<
     this.state = {
       isRenaming: false,
       isHovered: false,
-      isAddingChild: false,
-      addingChildName: '',
-      isAddingChildNameValid: true,
+      adding: null,
       currentExternalFilesDragEventCounter: 0,
       externalFilesDraggedIn: false,
       filename: '',
@@ -406,19 +434,6 @@ class FileBrowserItemInner extends React.PureComponent<
     }
   }
 
-  addFolder = () => {
-    this.props.Expand(this.props.path)
-    this.props.dispatch([EditorActions.addFolder(this.props.path)], 'everyone')
-  }
-
-  addTextFile = () => {
-    this.props.Expand(this.props.path)
-    this.props.dispatch(
-      [EditorActions.addTextFile(this.props.path, this.state.addingChildName)],
-      'everyone',
-    )
-  }
-
   delete = () => {
     this.props.dispatch(
       [
@@ -529,36 +544,48 @@ class FileBrowserItemInner extends React.PureComponent<
     })
   }
 
-  showAddingFileRow = () =>
+  showAddingFileRow = () => {
     this.setState({
-      isAddingChild: true,
-      isAddingChildNameValid: true,
-      addingChildName: '',
+      adding: {
+        fileOrFolder: 'file',
+        filename: '',
+      },
     })
+  }
+
+  showAddingFolderRow = () => {
+    this.setState({
+      adding: {
+        fileOrFolder: 'folder',
+        filename: '',
+      },
+    })
+  }
 
   confirmAddingFile = () => {
-    this.props.Expand(this.props.path)
-    this.props.dispatch(
-      [EditorActions.addTextFile(this.props.path, this.state.addingChildName)],
-      'everyone',
-    )
+    this.props.expand(this.props.path)
+    applyAddingFile(this.props.dispatch, this.props.path, this.state.adding)
     this.setState({
-      isAddingChild: false,
-      addingChildName: '',
-      isAddingChildNameValid: true,
+      adding: null,
     })
   }
 
   inputLabelChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ addingChildName: event.target.value })
+    if (this.state.adding != null) {
+      this.setState({
+        adding: {
+          ...this.state.adding,
+          filename: event.target.value,
+        },
+      })
+    }
   }
 
-  abandonAddingFile = () =>
+  abandonAddingFile = () => {
     this.setState({
-      isAddingChild: false,
-      isAddingChildNameValid: true,
-      addingChildName: '',
+      adding: null,
     })
+  }
 
   inputLabelKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
@@ -675,7 +702,7 @@ class FileBrowserItemInner extends React.PureComponent<
           {this.props.type === 'file' ? (
             <SimpleFlexRow style={{ position: 'absolute', right: '0px' }}>
               {displayAddFolder ? (
-                <Button style={{ marginRight: '2px' }} onClick={this.addFolder}>
+                <Button style={{ marginRight: '2px' }} onClick={this.showAddingFolderRow}>
                   <Icons.NewFolder style={fileIconStyle} tooltipText='Add New Folder' />
                 </Button>
               ) : null}
@@ -698,28 +725,15 @@ class FileBrowserItemInner extends React.PureComponent<
             </SimpleFlexRow>
           ) : null}
         </div>
-        {this.state.isAddingChild ? (
-          <SimpleFlexRow
-            style={{
-              // make it look indented, plus extra to account for missing icon
-              paddingLeft: (indentation + 1) * BaseIndentationPadding + 20,
-              paddingTop: 3,
-              paddingBottom: 3,
-              height: 32,
-              display: 'flex',
-              alignItems: 'center',
-            }}
-          >
-            <StringInput
-              testId=''
-              value={this.state.addingChildName}
-              autoFocus
-              onKeyDown={this.inputLabelKeyDown}
-              onChange={this.inputLabelChange}
-              onBlur={this.abandonAddingFile}
-            />
-          </SimpleFlexRow>
-        ) : null}
+        {this.state.adding == null
+          ? null
+          : addingChildElement(
+              indentation,
+              this.state.adding.filename,
+              this.inputLabelKeyDown,
+              this.inputLabelChange,
+              this.abandonAddingFile,
+            )}
       </div>
     )
 

--- a/editor/src/components/filebrowser/filepath-utils.ts
+++ b/editor/src/components/filebrowser/filepath-utils.ts
@@ -1,4 +1,6 @@
 import Utils from '../../utils/utils'
+import { EditorDispatch } from '../editor/action-types'
+import { addFolder, addTextFile } from '../editor/actions/action-creators'
 
 // Important: getFilePathToImport uses file paths with a leading `/`!
 export function getFilePathToImport(importFromPath: string, targetFilePath: string): string {
@@ -53,5 +55,30 @@ export function dropLeadingSlash(path: string): string {
     return path.slice(1)
   } else {
     return path
+  }
+}
+
+export interface AddingFile {
+  fileOrFolder: 'file' | 'folder'
+  filename: string
+}
+
+export function applyAddingFile(
+  dispatch: EditorDispatch,
+  parentPath: string,
+  addingFile: AddingFile | null,
+): void {
+  if (addingFile != null) {
+    switch (addingFile.fileOrFolder) {
+      case 'file':
+        dispatch([addTextFile(parentPath, addingFile.filename)], 'everyone')
+        break
+      case 'folder':
+        dispatch([addFolder(parentPath, addingFile.filename)], 'everyone')
+        break
+      default:
+        const _exhaustiveCheck: never = addingFile.fileOrFolder
+        throw new Error(`Unhandled type ${JSON.stringify(addingFile)}`)
+    }
   }
 }

--- a/editor/src/utils/react-conditionals.ts
+++ b/editor/src/utils/react-conditionals.ts
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { ReactNode } from 'react'
+
+function elementFromElementOrFunction(element: ReactNode | (() => ReactNode)): ReactNode {
+  if (React.isValidElement(element)) {
+    return element
+  } else if (typeof element === 'function') {
+    return element()
+  } else {
+    return element
+  }
+}
+
+export function when(condition: boolean, element: ReactNode | (() => ReactNode)): ReactNode {
+  if (condition) {
+    return elementFromElementOrFunction(element)
+  } else {
+    return null
+  }
+}
+
+export function unless(condition: boolean, element: ReactNode | (() => ReactNode)): ReactNode {
+  if (condition) {
+    return null
+  } else {
+    return elementFromElementOrFunction(element)
+  }
+}


### PR DESCRIPTION
Fixes #1478 
Fixes #1425 

**Problem:**
The add file and folder buttons for the root don't open a file after creating it. In the process of fixing this it was also discovered that the add file and folder buttons also work inconsistently for non-root items.

**Fix:**
Most of the changes were around making the buttons for root items and the non-root items use the same logic. But also making them consistent with each other, for example having the `ADD_FOLDER` action also supply a filename the way the `ADD_TEXT_FILE` action.

**Commit Details:**
- Fixes #1478.
- Refactored the logic for displaying the new name input field
  into a function `addingChildElement`.
- The `FileBrowser` component now includes some callbacks for
  manipulating root element insertion.
- Created an interface `AddingFile` for maintaining the state of
  what is being added.
- `applyAddingFile` is the common function for actioning an instance
  of `AddingFile`.
- Removed `isAddingChildNameValid` as it was completely unused.
- The add folder button for items not at the root level is consistent
  with the add file button, whereby it now doesn't create the folder
  eagerly.
- Stopped setting `renamingTarget` in `ADD_TEXT_FILE` and `ADD_FOLDER`
  as that was causing them to be editable after they had been created.
- Added `when` and `unless` functions which can be used in-place of ternaries
  in JSX.