### PR TITLE
Feature/dependencies button to add tailwind

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -871,6 +871,9 @@ export interface SetPropTransient {
 export interface ClearTransientProps {
   action: 'CLEAR_TRANSIENT_PROPS'
 }
+export interface AddTailwindConfig {
+  action: 'ADD_TAILWIND_CONFIG'
+}
 
 export type EditorAction =
   | ClearSelection
@@ -1017,6 +1020,7 @@ export type EditorAction =
   | InsertWithDefaults
   | SetPropTransient
   | ClearTransientProps
+  | AddTailwindConfig
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -194,6 +194,7 @@ import type {
   ToggleFocusedOmniboxTab,
   SetPropTransient,
   ClearTransientProps,
+  AddTailwindConfig,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -1394,5 +1395,11 @@ export function insertWithDefaults(
     targetParent: targetParent,
     toInsert: toInsert,
     styleProps: styleProps,
+  }
+}
+
+export function addTailwindConfig(): AddTailwindConfig {
+  return {
+    action: 'ADD_TAILWIND_CONFIG',
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -154,6 +154,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'ADD_STORYBOARD_FILE':
     case 'UPDATE_CHILD_TEXT':
     case 'INSERT_WITH_DEFAULTS':
+    case 'ADD_TAILWIND_CONFIG':
       return false
     case 'SAVE_ASSET':
       return (

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -121,12 +121,13 @@ import {
   forceRight,
   traverseEither,
 } from '../../../core/shared/either'
-import type {
+import {
   RequireFn,
   TypeDefinitions,
   PackageStatus,
   PackageStatusMap,
   RequestedNpmDependency,
+  requestedNpmDependency,
 } from '../../../core/shared/npm-dependency-types'
 import {
   isParseSuccess,
@@ -365,6 +366,7 @@ import {
   InsertWithDefaults,
   SetPropTransient,
   ClearTransientProps,
+  AddTailwindConfig,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -383,6 +385,7 @@ import {
   updateDependenciesInEditorState,
   updateDependenciesInPackageJson,
   createLoadedPackageStatusMapFromDependencies,
+  dependenciesFromPackageJson,
 } from '../npm-dependency/npm-dependency'
 import { updateRemoteThumbnail } from '../persistence'
 import {
@@ -444,6 +447,7 @@ import {
   LeftMenuTab,
   RightMenuTab,
   persistentModelFromEditorModel,
+  getPackageJsonFromEditorState,
 } from '../store/editor-state'
 import { loadStoredState } from '../stored-state'
 import { applyMigrations } from './migrations/migrations'
@@ -488,6 +492,7 @@ import {
   markVSCodeBridgeReady,
   addImports,
   setScrollAnimation,
+  updatePackageJson,
 } from './action-creators'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
 import { getAllTargetsAtPoint } from '../../canvas/dom-lookup'
@@ -507,6 +512,14 @@ import { absolutePathFromRelativePath, stripLeadingSlash } from '../../../utils/
 import { resolveModule } from '../../../core/es-modules/package-manager/module-resolution'
 import { reverse, uniqBy } from '../../../core/shared/array-utils'
 import { UTOPIA_UIDS_KEY } from '../../../core/model/utopia-constants'
+import {
+  DefaultPostCSSConfig,
+  DefaultTailwindConfig,
+  PostCSSPath,
+  PostCSSVersion,
+  TailwindConfigPath,
+  TailwindCSSVersion,
+} from '../../../core/tailwind/tailwind-config'
 
 export function updateSelectedLeftMenuTab(editorState: EditorState, tab: LeftMenuTab): EditorState {
   return {
@@ -4530,6 +4543,61 @@ export const UPDATE_FNS = {
         transientProperties: null,
       },
     }
+  },
+  ADD_TAILWIND_CONFIG: (
+    action: AddTailwindConfig,
+    editor: EditorModel,
+    dispatch: EditorDispatch,
+  ): EditorModel => {
+    const packageJsonFile = getContentsTreeFileFromString(editor.projectContents, '/package.json')
+    const currentNpmDeps = dependenciesFromPackageJson(packageJsonFile, 'regular-only')
+    const updatedNpmDeps = [
+      ...currentNpmDeps,
+      requestedNpmDependency('postcss', PostCSSVersion),
+      requestedNpmDependency('tailwindcss', TailwindCSSVersion),
+    ]
+
+    fetchNodeModules(updatedNpmDeps, 'canvas').then((fetchNodeModulesResult) => {
+      const loadedPackagesStatus = createLoadedPackageStatusMapFromDependencies(
+        updatedNpmDeps,
+        fetchNodeModulesResult.dependenciesWithError,
+        fetchNodeModulesResult.dependenciesNotFound,
+      )
+      const packageErrorActions = Object.keys(loadedPackagesStatus).map((dependencyName) =>
+        setPackageStatus(dependencyName, loadedPackagesStatus[dependencyName].status),
+      )
+      dispatch([
+        ...packageErrorActions,
+        updateNodeModulesContents(fetchNodeModulesResult.nodeModules, 'full-build'),
+      ])
+    })
+
+    const projectContentsWithTailwind = addFileToProjectContents(
+      editor.projectContents,
+      TailwindConfigPath,
+      DefaultTailwindConfig(),
+    )
+    const updatedProjectContents = addFileToProjectContents(
+      projectContentsWithTailwind,
+      PostCSSPath,
+      DefaultPostCSSConfig(),
+    )
+
+    const packageJsonUpdateAction = updatePackageJson(updatedNpmDeps)
+    return UPDATE_FNS.UPDATE_PACKAGE_JSON(packageJsonUpdateAction, {
+      ...editor,
+      projectContents: updatedProjectContents,
+      nodeModules: {
+        ...editor.nodeModules,
+        packageStatus: {
+          ...editor.nodeModules.packageStatus,
+          ...{
+            postcss: { status: 'loading' },
+            tailwindcss: { status: 'loading' },
+          },
+        },
+      },
+    })
   },
 }
 

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -313,6 +313,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SET_PROP_TRANSIENT(action, state)
     case 'CLEAR_TRANSIENT_PROPS':
       return UPDATE_FNS.CLEAR_TRANSIENT_PROPS(action, state)
+    case 'ADD_TAILWIND_CONFIG':
+      return UPDATE_FNS.ADD_TAILWIND_CONFIG(action, state, dispatch)
     default:
       return state
   }

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -37,6 +37,7 @@ import {
   SectionBodyArea,
   Section,
   FlexColumn,
+  Button,
 } from '../../uuiui'
 import { notice } from '../common/notice'
 
@@ -429,6 +430,7 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
               role='listContainer'
               style={{ paddingLeft: 8, paddingRight: 8, paddingTop: 4, paddingBottom: 4 }}
             >
+              <AddTailwindButton packagesWithStatus={packagesWithStatus} />
               <DependencyListItems
                 packages={packagesWithStatus}
                 editingLocked={this.state.dependencyLoadingStatus != 'not-loading'}
@@ -446,4 +448,38 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
       </Section>
     )
   }
+}
+
+interface AddTailwindButtonProps {
+  packagesWithStatus: DependencyPackageDetails[]
+}
+
+const AddTailwindButton = (props: AddTailwindButtonProps) => {
+  const dispatch = useEditorState((store) => store.dispatch, 'AddTailwindButton')
+  const onButtonClicked = React.useCallback(() => {
+    dispatch([EditorActions.addTailwindConfig()])
+  }, [dispatch])
+
+  const tailwindAlreadyAdded =
+    props.packagesWithStatus.find((p) => p.name === 'tailwindcss') &&
+    props.packagesWithStatus.find((p) => p.name === 'postcss')
+  if (tailwindAlreadyAdded) {
+    return null
+  }
+  return (
+    <Button
+      primary
+      highlight
+      style={{
+        margin: 8,
+        height: 24,
+        backgroundImage: 'linear-gradient(3deg, #92ABFF 0%, #1FCCB7 99%)',
+        boxShadow: 'inset 0 0 0 1px rgba(94,94,94,0.20)',
+        borderRadius: 2,
+      }}
+      onClick={onButtonClicked}
+    >
+      Add &nbsp;<b>Tailwind</b>&nbsp; To Project
+    </Button>
+  )
 }

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -40,6 +40,7 @@ import {
   Button,
 } from '../../uuiui'
 import { notice } from '../common/notice'
+import { isFeatureEnabled } from '../../utils/feature-switches'
 
 type DependencyListProps = {
   editorDispatch: EditorDispatch
@@ -463,7 +464,7 @@ const AddTailwindButton = (props: AddTailwindButtonProps) => {
   const tailwindAlreadyAdded =
     props.packagesWithStatus.find((p) => p.name === 'tailwindcss') &&
     props.packagesWithStatus.find((p) => p.name === 'postcss')
-  if (tailwindAlreadyAdded) {
+  if (tailwindAlreadyAdded || !isFeatureEnabled('TopMenu ClassNames')) {
     return null
   }
   return (

--- a/editor/src/core/tailwind/tailwind-config.ts
+++ b/editor/src/core/tailwind/tailwind-config.ts
@@ -15,7 +15,7 @@ module.exports = {
   plugins: [],
 }`
 
-const PostCSSConfigJs = `// postcss.config.js
+const PostCSSConfigJs = `
 module.exports = {
   plugins: {
     tailwindcss: {},

--- a/editor/src/core/tailwind/tailwind-config.ts
+++ b/editor/src/core/tailwind/tailwind-config.ts
@@ -1,0 +1,49 @@
+import { RevisionsState, TextFile, textFile, textFileContents } from '../shared/project-file-types'
+import { lintAndParse } from '../workers/parser-printer/parser-printer'
+
+export const PostCSSPath = '/postcss.config.js'
+export const TailwindConfigPath = '/tailwind.config.js'
+
+export const TailwindCSSVersion = '2.2.4'
+export const PostCSSVersion = '8.3.5'
+
+const TailwindConfigJs = `// tailwind.config.js
+module.exports = {
+  purge: [],
+  darkMode: false, // or 'media' or 'class'
+  theme: {
+    extend: {},
+  },
+  variants: {},
+  plugins: [],
+}`
+
+const PostCSSConfigJs = `// postcss.config.js
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  }
+}`
+
+export const DefaultTailwindConfig = (): TextFile =>
+  textFile(
+    textFileContents(
+      TailwindConfigJs,
+      lintAndParse(TailwindConfigPath, TailwindConfigJs, null, new Set()),
+      RevisionsState.BothMatch,
+    ),
+    null,
+    Date.now(),
+  )
+
+export const DefaultPostCSSConfig = (): TextFile =>
+  textFile(
+    textFileContents(
+      PostCSSConfigJs,
+      lintAndParse(PostCSSPath, PostCSSConfigJs, null, new Set()),
+      RevisionsState.BothMatch,
+    ),
+    null,
+    Date.now(),
+  )

--- a/editor/src/core/tailwind/tailwind-config.ts
+++ b/editor/src/core/tailwind/tailwind-config.ts
@@ -4,9 +4,6 @@ import { lintAndParse } from '../workers/parser-printer/parser-printer'
 export const PostCSSPath = '/postcss.config.js'
 export const TailwindConfigPath = '/tailwind.config.js'
 
-export const TailwindCSSVersion = '2.2.4'
-export const PostCSSVersion = '8.3.5'
-
 const TailwindConfigJs = `// tailwind.config.js
 module.exports = {
   purge: [],
@@ -22,7 +19,6 @@ const PostCSSConfigJs = `// postcss.config.js
 module.exports = {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {},
   }
 }`
 

--- a/editor/src/core/tailwind/tailwind-config.ts
+++ b/editor/src/core/tailwind/tailwind-config.ts
@@ -4,7 +4,7 @@ import { lintAndParse } from '../workers/parser-printer/parser-printer'
 export const PostCSSPath = '/postcss.config.js'
 export const TailwindConfigPath = '/tailwind.config.js'
 
-const TailwindConfigJs = `// tailwind.config.js
+const TailwindConfigJs = `
 module.exports = {
   purge: [],
   darkMode: false, // or 'media' or 'class'

--- a/editor/src/core/tailwind/tailwind.ts
+++ b/editor/src/core/tailwind/tailwind.ts
@@ -10,9 +10,7 @@ import { includesDependency } from '../../components/editor/npm-dependency/npm-d
 import { propOrNull } from '../shared/object-utils'
 import { memoize } from '../shared/memoize'
 import { importDefault } from '../es-modules/commonjs-interop'
-
-const PostCSSPath = '/postcss.config.js'
-const TailwindConfigPath = '/tailwind.config.js'
+import { PostCSSPath, TailwindConfigPath } from './tailwind-config'
 
 function hasRequiredDependenciesForTailwind(packageJsonFile: ProjectFile): boolean {
   const hasTailwindDependency = includesDependency(packageJsonFile, 'tailwindcss')


### PR DESCRIPTION
**Fix:**
Added a button to dependencies menu that creates the default tailwind config files and adds the 2 dependencies to the package.json

**Commit Details:**
- new button in dependencies
- action that handles fetching the dependencies, adding the 2 new files and updating the package.json
