### PR TITLE
design(borders) - fix too prominent ones, my bad

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -227,7 +227,6 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
           overflowX: 'hidden',
           flexGrow: 1,
           flexShrink: 0,
-          borderRight: `1px solid ${UtopiaTheme.color.subduedBorder.value}`,
         }}
       >
         {!isCanvasVisible && !interfaceDesigner.codePaneVisible ? (

--- a/editor/src/components/canvas/right-menu.tsx
+++ b/editor/src/components/canvas/right-menu.tsx
@@ -190,7 +190,7 @@ export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) =>
       id='canvas-menu'
       style={{
         alignSelf: 'stretch',
-        borderLeft: `1px solid ${colorTheme.neutralBorder.value}`,
+        borderLeft: `1px solid ${colorTheme.subduedBorder.value}`,
         width: 38,
       }}
     >

--- a/editor/src/components/menubar/menubar.tsx
+++ b/editor/src/components/menubar/menubar.tsx
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
 import styled from '@emotion/styled'
-import { IconMap } from 'antd/lib/result'
 import * as React from 'react'
 import { FLOATING_PREVIEW_BASE_URL } from '../../common/env-vars'
 import {
@@ -61,7 +60,9 @@ export const MenuTile: React.FunctionComponent<MenuTileProps> = (props) => {
         height: 44,
         transition: 'all .1s ease-in-out',
         borderLeft:
-          props.menuExpanded && props.selected ? '2px solid darkgray' : '1px solid transparent',
+          props.menuExpanded && props.selected
+            ? `2px solid ${UtopiaTheme.color.primary.value}`
+            : '1px solid transparent',
         cursor: 'pointer',
         '& > *': {
           opacity: props.selected ? 1 : 0.33,
@@ -92,7 +93,7 @@ export const MenuTile: React.FunctionComponent<MenuTileProps> = (props) => {
         }}
       >
         {React.cloneElement(props.icon, {
-          color: foregroundColor,
+          color: props.selected ? 'blue' : 'darkgray',
         })}
       </div>
     </Tile>

--- a/editor/src/uuiui/styles/theme.ts
+++ b/editor/src/uuiui/styles/theme.ts
@@ -67,9 +67,9 @@ const lightPrimitives = {
   verySubduedForeground: lightBase.fg8,
   neutralInvertedForeground: lightBase.bg0,
 
-  neutralBorder: lightBase.border1,
+  neutralBorder: lightBase.border3,
   secondaryBorder: lightBase.border2,
-  subduedBorder: lightBase.border3,
+  subduedBorder: lightBase.border1,
 }
 
 const lightErrorStates = {


### PR DESCRIPTION
**Problem:**
I screwed up the border styles when doing the big theme refactor, making them look unnecessarily divisive

**Fix:**
Borders so soft, you barely notice they're there. Also, flip-flopping to blue icons, which will in any event be obviated by pulling those from the theme
