### PR TITLE
fix(editor) Support updating attributes containing a spread operator

### DIFF
--- a/editor/src/core/shared/element-template.spec.ts
+++ b/editor/src/core/shared/element-template.spec.ts
@@ -1,0 +1,65 @@
+import { emptyComments } from '../workers/parser-printer/parser-printer-comments'
+import {
+  deleteJSXAttribute,
+  jsxAttributesEntry,
+  jsxAttributesSpread,
+  jsxAttributeValue,
+  setJSXAttributesAttribute,
+} from './element-template'
+
+describe('setJSXAttributesAttribute', () => {
+  const startingAttributesEntry = jsxAttributesEntry(
+    'one',
+    jsxAttributeValue('thing', emptyComments),
+    emptyComments,
+  )
+  const startingAttributesSpread = jsxAttributesSpread(
+    jsxAttributeValue('theRest', emptyComments),
+    emptyComments,
+  )
+  const startingAttributes = [startingAttributesEntry, startingAttributesSpread]
+
+  it('Setting a value on a new key adds it to the attributes', () => {
+    const newKey = 'newKey'
+    const newValue = jsxAttributeValue('newValue', emptyComments)
+    const expected = [...startingAttributes, jsxAttributesEntry(newKey, newValue, emptyComments)]
+    const actual = setJSXAttributesAttribute(startingAttributes, newKey, newValue)
+    expect(actual).toEqual(expected)
+  })
+
+  it('Setting a value on an existing key updates the attributes', () => {
+    const existingKey = 'one'
+    const newValue = jsxAttributeValue('newValue', emptyComments)
+    const expected = [
+      jsxAttributesEntry(existingKey, newValue, emptyComments),
+      startingAttributesSpread,
+    ]
+    const actual = setJSXAttributesAttribute(startingAttributes, existingKey, newValue)
+    expect(actual).toEqual(expected)
+  })
+})
+
+describe('deleteJSXAttribute', () => {
+  const startingAttributesEntry = jsxAttributesEntry(
+    'one',
+    jsxAttributeValue('thing', emptyComments),
+    emptyComments,
+  )
+  const startingAttributesSpread = jsxAttributesSpread(
+    jsxAttributeValue('theRest', emptyComments),
+    emptyComments,
+  )
+  const startingAttributes = [startingAttributesEntry, startingAttributesSpread]
+
+  it('deleting a non-existent key leaves the attributes unchanged', () => {
+    const actual = deleteJSXAttribute(startingAttributes, 'nonExistentKey')
+    expect(actual).toEqual(startingAttributes)
+  })
+
+  it('deleting an existing key updates the attributes', () => {
+    const existingKey = 'one'
+    const expected = [startingAttributesSpread]
+    const actual = deleteJSXAttribute(startingAttributes, existingKey)
+    expect(actual).toEqual(expected)
+  })
+})

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -696,7 +696,7 @@ export function deleteJSXAttribute(attributes: JSXAttributes, key: string): JSXA
         }
         break
       case 'JSX_ATTRIBUTES_SPREAD':
-        // Skip these for now.
+        newAttributes.push(attrPart)
         break
       default:
         const _exhaustiveCheck: never = attrPart
@@ -726,7 +726,7 @@ export function setJSXAttributesAttribute(
         }
         break
       case 'JSX_ATTRIBUTES_SPREAD':
-        // Ignore these for now.
+        result.push(attrPart)
         break
       default:
         const _exhaustiveCheck: never = attrPart

--- a/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
@@ -12,6 +12,7 @@ import {
   elementsStructure,
   testParseCode,
   testParseThenPrint,
+  testParseThenPrintWithoutUids,
 } from './parser-printer.test-utils'
 import { objectMap, omit } from '../../shared/object-utils'
 import { BakedInStoryboardVariableName, BakedInStoryboardUID } from '../../model/scene-utils'
@@ -254,6 +255,23 @@ export var ${BakedInStoryboardVariableName} = (
 `
 
     testParseThenPrint(spreadCode, spreadCode)
+  })
+  it('parses elements that use props spreading without an explicit uid - #1515', () => {
+    const spreadCode = `import * as React from 'react'
+const Test = (props) => {
+  return (
+    <div>
+      {props.data.map((entry) => (
+        <div {...entry} style={{ flexBasis: 50 }} />
+      ))}
+    </div>
+  )
+}
+
+export var ${BakedInStoryboardVariableName} = <Storyboard />
+`
+
+    testParseThenPrintWithoutUids(spreadCode, spreadCode)
   })
 })
 

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -213,18 +213,28 @@ export function testParseThenPrint(originalCode: string, expectedFinalCode: stri
   return testParseModifyPrint(originalCode, expectedFinalCode, (ps) => ps)
 }
 
+export function testParseThenPrintWithoutUids(
+  originalCode: string,
+  expectedFinalCode: string,
+): void {
+  const printedCode = parseModifyPrint(originalCode, (ps) => ps, true)
+  expect(printedCode).toEqual(expectedFinalCode)
+}
+
 export function testParseModifyPrint(
   originalCode: string,
   expectedFinalCode: string,
   transform: (parseSuccess: ParseSuccess) => ParseSuccess,
+  stripUids?: boolean,
 ): void {
-  const printedCode = parseModifyPrint(originalCode, transform)
+  const printedCode = parseModifyPrint(originalCode, transform, stripUids)
   expect(printedCode).toEqual(expectedFinalCode)
 }
 
 function parseModifyPrint(
   originalCode: string,
   transform: (parseSuccess: ParseSuccess) => ParseSuccess,
+  stripUids?: boolean,
 ): string {
   const initialParseResult = testParseCode(originalCode)
   return foldParsedTextFile(
@@ -232,7 +242,7 @@ function parseModifyPrint(
     (initialParseSuccess) => {
       const transformed = transform(initialParseSuccess)
       const printedCode = printCode(
-        printCodeOptions(false, true, true),
+        printCodeOptions(false, true, true, stripUids),
         transformed.imports,
         transformed.topLevelElements,
         transformed.jsxFactoryFunction,


### PR DESCRIPTION
Fixes #1515 

**Problem:**
When we add a uid to a parsed element, we update that parsed element's attributes. As we had a missing implementation for how to handle that update when a spread operator is present, the spread was being lost from the parsed model.

**Fix:**
Actually implement it. When setting or deleting an attribute we leave the spread unchanged. This does mean there's an edge case where updating an existing attribute might result in no visible change due to a spread operator coming after it, so _maybe_ there could be an argument that that warrants moving updated attributes to the end, but then that would mess up the user's code.

**Note:** There is still a missing implementation for fetching the value of an attribute where a spread is involved, but that's a lot more complicated as we need to have the runtime values for those. Having dug through the code, that functionality is only effectively used by the Inspector.
