### PR TITLE
fix(classname-menu) show focused value with a different background

### DIFF
--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -550,13 +550,15 @@ export const ClassNameSelect = betterReactMemo(
           gap: 4,
           maxWidth: 0,
         }),
-        multiValue: () => {
+        multiValue: (style, state) => {
           return {
             cursor: 'pointer',
             display: 'flex',
             alignItems: 'center',
             height: 18,
-            backgroundColor: theme.inverted.bg1.value,
+            backgroundColor: state.isFocused
+              ? theme.inverted.primary.value
+              : theme.inverted.bg1.value,
           }
         },
         multiValueLabel: () => ({


### PR DESCRIPTION
Fixes #1521

**Problem:**
In the classname menu it's possible to select values with the left arrow, but it's not visible what is selected.

**Commit Details:**
- use isFocused state in style settings 
