### PR TITLE
Fix Focus Component Issues

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -36,6 +36,7 @@ import {
 import { useWindowToCanvasCoordinates } from '../../dom-lookup-hooks'
 import { useInsertModeSelectAndHover } from './insert-mode-hooks'
 import { WindowMousePositionRaw } from '../../../../utils/global-positions'
+import { isFeatureEnabled } from '../../../../utils/feature-switches'
 
 const DRAG_START_TRESHOLD = 2
 
@@ -497,7 +498,13 @@ function useSelectOrLiveModeSelectAndHover(
             requestAnimationFrame(() => {
               // then we set the selected views for the editor state, 1 frame later
               if (updatedSelection.length === 0) {
-                dispatch([clearSelection(), setFocusedElement(null)])
+                const clearFocusedElementIfFeatureSwitchEnabled = isFeatureEnabled(
+                  'Click on empty canvas unfocuses',
+                )
+                  ? [setFocusedElement(null)]
+                  : []
+
+                dispatch([clearSelection(), ...clearFocusedElementIfFeatureSwitchEnabled])
               } else {
                 dispatch([selectComponents(updatedSelection, event.shiftKey)])
               }

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -313,6 +313,10 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
       () => highlightItem(dispatch, elementPath, selected, isHighlighted),
       [dispatch, elementPath, selected, isHighlighted],
     )
+    const focusComponent = React.useCallback(() => {
+      dispatch([EditorActions.setFocusedElement(elementPath)])
+    }, [dispatch, elementPath])
+
     const containerStyle: React.CSSProperties = React.useMemo(() => {
       return {
         opacity: isElementVisible ? undefined : 0.5,
@@ -329,7 +333,13 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
     })
 
     return (
-      <FlexRow ref={domElementRef} style={rowStyle} onMouseDown={select} onMouseMove={highlight}>
+      <FlexRow
+        ref={domElementRef}
+        style={rowStyle}
+        onMouseDown={select}
+        onMouseMove={highlight}
+        onDoubleClick={focusComponent}
+      >
         <FlexRow style={containerStyle}>
           <ExpandableIndicator
             key='expandable-indicator'

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -10,6 +10,8 @@ export type FeatureName =
   | 'Re-parse Project Button'
   | 'Performance Test Triggers'
   | 'TopMenu ClassNames'
+  | 'Click on empty canvas unfocuses'
+
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
   // 'Dragging Shows Overlay', // Removing this option so that we can experiment on this later
@@ -18,9 +20,10 @@ export const AllFeatureNames: FeatureName[] = [
   'Re-parse Project Button',
   'Performance Test Triggers',
   'TopMenu ClassNames',
+  'Click on empty canvas unfocuses',
 ]
 
-let FeatureSwitches: { [feature: string]: boolean } = {
+let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Dragging Reparents By Default': false,
   'Dragging Shows Overlay': false,
   'Invisible Element Controls': false,
@@ -28,6 +31,7 @@ let FeatureSwitches: { [feature: string]: boolean } = {
   'Re-parse Project Button': !(PRODUCTION_CONFIG as boolean),
   'Performance Test Triggers': !(PRODUCTION_CONFIG as boolean),
   'TopMenu ClassNames': false,
+  'Click on empty canvas unfocuses': true,
 }
 
 function settingKeyForName(featureName: FeatureName): string {


### PR DESCRIPTION
**Commit Details:**
- Double click to focus on component works in the non-label parts of the navigator row
- New feature switch called `Click on empty canvas unfocuses`. It's set to true by default to keep current behavior
