### PR TITLE
feature(classname-select) selected values are editable

### DIFF
--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -647,10 +647,13 @@ export const ClassNameSelect = betterReactMemo(
           if (focusedValueRef.current != null) {
             setInput(focusedValueRef.current)
             focusedValueRef.current = null
+            if (ref != null) {
+              ;(ref as any).current.focus()
+            }
           }
         }
       },
-      [setInput],
+      [setInput, ref],
     )
 
     return (

--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -326,7 +326,9 @@ function takeBestOptions<T>(orderedSparseArray: Array<Array<T>>, maxMatches: num
 }
 
 export const Input = (props: InputProps) => {
-  return <components.Input {...props} isHidden={false} />
+  const value = (props as any).value
+  const isHidden = value.length !== 0 ? false : props.isHidden
+  return <components.Input {...props} isHidden={isHidden} />
 }
 
 export const ClassNameSelect = betterReactMemo(


### PR DESCRIPTION
Fixes #1520

**Problem:**
Editing already existing value is not possible, if you want to change it a little you need to type the text again completely then delete the old tag.

**Fix:**
After selecting values with the left-right arrows, pressing backspace deletes the tag and the input field is filled with the deleted value, making it possible to edit it.
As I noticed this label selection effect only works when the input field is empty.

**Commit Details:**
- Using aria focus the focused value is stored in a ref
- keydown event listener for delete
- typing to the input field also clears the focused value ref
- fixed an issue with the input label customizing the components.Input, where input value passed from props is not updating the opacity to 1 until the user interacts.
