### PR TITLE
Prevent preview on focus in certain cases

### DIFF
--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -337,20 +337,20 @@ export const ClassNameSelect = betterReactMemo(
       dispatch([EditorActions.clearTransientProps()], 'canvas')
     }, [updateFocusedOption, dispatch])
 
-    const isMenuOpen = React.useRef(false)
-    const shouldPreviewOnFocus = React.useRef(false)
+    const isMenuOpenRef = React.useRef(false)
+    const shouldPreviewOnFocusRef = React.useRef(false)
     const onMenuClose = React.useCallback(() => {
-      shouldPreviewOnFocus.current = false
-      isMenuOpen.current = false
+      shouldPreviewOnFocusRef.current = false
+      isMenuOpenRef.current = false
       clearFocusedOption()
     }, [clearFocusedOption])
     const onMenuOpen = React.useCallback(() => {
-      isMenuOpen.current = true
+      isMenuOpenRef.current = true
     }, [])
     const onInputChange = React.useCallback(
       (newInput: string) => {
         if (newInput === '') {
-          shouldPreviewOnFocus.current = false
+          shouldPreviewOnFocusRef.current = false
           dispatch([EditorActions.clearTransientProps()], 'canvas')
         }
         setInput(newInput)
@@ -504,8 +504,8 @@ export const ClassNameSelect = betterReactMemo(
 
     const ariaOnFocus = React.useCallback(
       ({ focused }: { focused: TailWindOption }) => {
-        if (isMenuOpen.current) {
-          if (shouldPreviewOnFocus.current && targets.length === 1) {
+        if (isMenuOpenRef.current) {
+          if (shouldPreviewOnFocusRef.current && targets.length === 1) {
             const newClassNameString =
               selectedValues?.map((v) => v.label).join(' ') + ' ' + focused.label
             dispatch(
@@ -519,7 +519,7 @@ export const ClassNameSelect = betterReactMemo(
               'canvas',
             )
           }
-          shouldPreviewOnFocus.current = true
+          shouldPreviewOnFocusRef.current = true
           updateFocusedOption(focused)
         }
       },
@@ -541,7 +541,7 @@ export const ClassNameSelect = betterReactMemo(
             ],
             'everyone',
           )
-          shouldPreviewOnFocus.current = false
+          shouldPreviewOnFocusRef.current = false
         }
       },
       [dispatch, elementPath],
@@ -651,7 +651,7 @@ export const ClassNameSelect = betterReactMemo(
 
     const handleKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
       if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-        shouldPreviewOnFocus.current = true
+        shouldPreviewOnFocusRef.current = true
       }
     }, [])
 

--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -340,7 +340,7 @@ export const ClassNameSelect = betterReactMemo(
     const isMenuOpen = React.useRef(false)
     const shouldPreviewOnFocus = React.useRef(false)
     const onMenuClose = React.useCallback(() => {
-      shouldPreviewOnFocus.current = true
+      shouldPreviewOnFocus.current = false
       isMenuOpen.current = false
       clearFocusedOption()
     }, [clearFocusedOption])
@@ -649,6 +649,12 @@ export const ClassNameSelect = betterReactMemo(
       [theme],
     )
 
+    const handleKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        shouldPreviewOnFocus.current = true
+      }
+    }, [])
+
     return (
       <div
         css={{
@@ -661,6 +667,7 @@ export const ClassNameSelect = betterReactMemo(
           alignItems: 'center',
           '&:focus-within': { boxShadow: `0px 0px 0px 1px ${theme.primary.value}` },
         }}
+        onKeyDown={handleKeyDown}
       >
         <WindowedSelect
           ref={ref}


### PR DESCRIPTION
Fixes #1514 

**Problem:**
When focusing the CSS bar, we open the react-select menu, which triggers a preview of the first option in the menu

**Fix:**
Use a pair of refs to track whether the menu is open, and whether we want to allow previewing on focus. Then we only preview on focus if both are true.

I initially went with the assumption that we never want to trigger it when the menu is opened, but after having played with it a bit I realised the situation was a bit more complex, since:

1. If the topbar is closed, but the input field is focused, pressing an arrow key to open the menu should enable previewing, but clicking the menu to open it shouldn't
2. Typing to filter should immediately trigger previewing
3. Clearing the typed filter shouldn't leave the last focused option previewed
4. Selecting an option or deleting a set value shouldn't trigger a preview of whatever row is focused now

These settings feel very close to right to me, though there are still 2 edge cases that feel wrong that I'm struggling to code for:

1. Opening the menu with a click shouldn't trigger previewing of the first row, but hovering that row with the mouse should - I think this can be fixed but would tackle that in an immediate follow up PR
2. Pressing the left arrow key when nothing is typed will move focus to a previously set element and so clear the current row's focus (which definitely feels correct). That's by default in react-select. But pressing the right arrow key doesn't do that and feels wrong.

I did capture a video but it's very misleading since it doesn't show when I'm opening via the arrow keys or the shortcut key, so really the best option is to try it on pizza
