### PR TITLE
Adding the tailwind classname select into the Inspector

### DIFF
--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -1,14 +1,9 @@
 /** @jsx jsx */
 
-import React from 'react'
 import { jsx } from '@emotion/react'
 import styled from '@emotion/styled'
-
-import {
-  AllAttributes,
-  AttributeToClassNames,
-  ClassNameToAttributes,
-} from '../../../core/third-party/tailwind-defaults'
+import React from 'react'
+import type { StylesConfig } from 'react-select'
 import WindowedSelect, {
   components,
   FormatOptionLabelMeta,
@@ -19,75 +14,37 @@ import WindowedSelect, {
   MultiValueProps,
   ValueContainerProps,
 } from 'react-windowed-select'
-import type { StylesConfig } from 'react-select'
-
-import * as EditorActions from '../../editor/actions/action-creators'
-import { betterReactMemo } from '../../../uuiui-deps'
-import { colorTheme, FlexColumn, FlexRow, useColorTheme } from '../../../uuiui'
-import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 import { findElementAtPath, MetadataUtils } from '../../../core/model/element-metadata-utils'
-import * as PP from '../../../core/shared/property-path'
+import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
 import {
-  ElementInstanceMetadata,
+  atomWithPubSub,
+  usePubSubAtomReadOnly,
+  usePubSubAtomWriteOnly,
+} from '../../../core/shared/atom-with-pub-sub'
+import { eitherToMaybe } from '../../../core/shared/either'
+import {
   isJSXAttributeNotFound,
   isJSXAttributeValue,
   isJSXElement,
   jsxAttributeValue,
   JSXElementChild,
 } from '../../../core/shared/element-template'
-import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
-import { eitherToMaybe, isRight } from '../../../core/shared/either'
-import {
-  getModifiableJSXAttributeAtPath,
-  ModifiableAttribute,
-} from '../../../core/shared/jsx-attributes'
-import {
-  atomWithPubSub,
-  usePubSubAtomReadOnly,
-  usePubSubAtomWriteOnly,
-} from '../../../core/shared/atom-with-pub-sub'
-import { stripNulls } from '../../../core/shared/array-utils'
-import { mapToArray, mapValues } from '../../../core/shared/object-utils'
-import { getOpenUIJSFileKey } from '../../editor/store/editor-state'
-import { normalisePathToUnderlyingTarget } from '../../custom-code/code-file'
-import { getContentsTreeFileFromString } from '../../assets'
+import { getModifiableJSXAttributeAtPath } from '../../../core/shared/jsx-attributes'
 import { isParseSuccess, isTextFile } from '../../../core/shared/project-file-types'
-import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
-import Highlighter from 'react-highlight-words'
-
-interface TailWindOption {
-  label: string
-  value: string
-  attributes?: string[]
-  categories?: string[]
-}
-
-let TailWindOptions: Array<TailWindOption> = []
-let AttributeOptionLookup: { [attribute: string]: Array<TailWindOption> }
-
-async function loadTailwindOptions() {
-  return new Promise<void>((resolve) => {
-    TailWindOptions = mapToArray(
-      (attributes, className) => ({
-        label: className,
-        value: className,
-        attributes: attributes,
-      }),
-      ClassNameToAttributes,
-    )
-
-    AttributeOptionLookup = mapValues((classNames: Array<string>) => {
-      const matchingOptions = classNames.map((className) =>
-        TailWindOptions.find((option) => option.value === className),
-      )
-      return stripNulls(matchingOptions)
-    }, AttributeToClassNames)
-
-    resolve()
-  })
-}
-
-loadTailwindOptions()
+import * as PP from '../../../core/shared/property-path'
+import {
+  MatchHighlighter,
+  TailWindOption,
+  useFilteredOptions,
+} from '../../../core/tailwind/tailwind-options'
+import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
+import { colorTheme, FlexColumn, FlexRow, useColorTheme } from '../../../uuiui'
+import { betterReactMemo } from '../../../uuiui-deps'
+import { getContentsTreeFileFromString } from '../../assets'
+import { normalisePathToUnderlyingTarget } from '../../custom-code/code-file'
+import * as EditorActions from '../../editor/actions/action-creators'
+import { getOpenUIJSFileKey } from '../../editor/store/editor-state'
+import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 
 const DropdownIndicator = betterReactMemo(
   'DropdownIndicator',
@@ -155,25 +112,6 @@ const focusedOptionAtom = atomWithPubSub<TailWindOption | null>({
   key: 'classNameSelectFocusedOption',
   defaultValue: null,
 })
-
-const Bold = betterReactMemo('Bold', ({ children }: { children: React.ReactNode }) => {
-  return <strong>{children}</strong>
-})
-
-const MatchHighlighter = betterReactMemo(
-  'MatchHighlighter',
-  ({ text, searchString }: { text: string; searchString: string | null | undefined }) => {
-    const searchTerms = searchStringToIndividualTerms(searchString ?? '')
-    return (
-      <Highlighter
-        highlightTag={Bold}
-        searchWords={searchTerms}
-        autoEscape={true}
-        textToHighlight={text}
-      />
-    )
-  },
-)
 
 function formatOptionLabel(
   { label }: TailWindOption,
@@ -280,51 +218,6 @@ const ValueContainer = betterReactMemo(
 const filterOption = () => true
 const MaxResults = 500
 
-function searchStringToIndividualTerms(searchString: string): Array<string> {
-  return searchString.trim().toLowerCase().split(' ')
-}
-
-function findMatchingOptions<T>(
-  searchTerms: Array<string>,
-  options: Array<T>,
-  toString: (t: T) => string,
-  maxPerfectMatches: number,
-): Array<Array<T>> {
-  let orderedMatchedResults: Array<Array<T>> = []
-  let perfectMatchCount = 0
-  for (var i = 0; i < options.length && perfectMatchCount < maxPerfectMatches; i++) {
-    const nextOption = options[i]
-    const asString = toString(nextOption)
-    const splitInputIndexResult = searchTerms.map((s) => asString.indexOf(s))
-    const minimumIndexOf = Math.min(...splitInputIndexResult)
-    if (minimumIndexOf > -1) {
-      let existingMatched = orderedMatchedResults[minimumIndexOf] ?? []
-      existingMatched.push(nextOption)
-      orderedMatchedResults[minimumIndexOf] = existingMatched
-      if (minimumIndexOf === 0) {
-        perfectMatchCount++
-      }
-    }
-  }
-
-  return orderedMatchedResults
-}
-
-function takeBestOptions<T>(orderedSparseArray: Array<Array<T>>, maxMatches: number): Set<T> {
-  let matchedResults: Set<T> = new Set()
-  let matchCount = 0
-  for (var i = 0; i < orderedSparseArray.length && matchCount < maxMatches; i++) {
-    const nextMatches = orderedSparseArray[i]
-    if (nextMatches != null) {
-      const maxNextMatches = nextMatches.slice(0, maxMatches - matchCount)
-      maxNextMatches.forEach((m) => matchedResults.add(m))
-      matchCount = matchedResults.size
-    }
-  }
-
-  return matchedResults
-}
-
 export const Input = (props: InputProps) => {
   const value = (props as any).value
   const isHidden = value.length !== 0 ? false : props.isHidden
@@ -347,9 +240,7 @@ export const ClassNameSelect = betterReactMemo(
     }, [updateFocusedOption, dispatch])
 
     const isMenuOpenRef = React.useRef(false)
-    const shouldPreviewOnFocusRef = React.useRef(false)
     const onMenuClose = React.useCallback(() => {
-      shouldPreviewOnFocusRef.current = false
       isMenuOpenRef.current = false
       clearFocusedOption()
     }, [clearFocusedOption])
@@ -357,53 +248,7 @@ export const ClassNameSelect = betterReactMemo(
       isMenuOpenRef.current = true
     }, [])
 
-    const filteredOptions = React.useMemo(() => {
-      const searchTerms = searchStringToIndividualTerms(input)
-      let results: Array<TailWindOption>
-
-      if (searchTerms.length === 0) {
-        results = TailWindOptions.slice(0, MaxResults)
-      } else {
-        // First find all matches, and use a sparse array to keep the best matches at the front
-        const orderedMatchedResults = findMatchingOptions(
-          searchTerms,
-          TailWindOptions,
-          (option) => option.label,
-          MaxResults,
-        )
-
-        // Now go through and take the first n best matches
-        let matchedResults = takeBestOptions(orderedMatchedResults, MaxResults)
-
-        // Next if we haven't hit our max result count, we find matches based on attributes
-        const remainingAllowedMatches = MaxResults - matchedResults.size
-        if (remainingAllowedMatches > 0) {
-          const orderedAttributeMatchedResults = findMatchingOptions(
-            searchTerms,
-            AllAttributes,
-            (a) => a,
-            remainingAllowedMatches,
-          )
-          const bestMatchedAttributes = takeBestOptions(
-            orderedAttributeMatchedResults,
-            remainingAllowedMatches,
-          )
-
-          bestMatchedAttributes.forEach((attribute) => {
-            const matchingOptions = AttributeOptionLookup[attribute] ?? []
-            matchingOptions.forEach((option) => matchedResults.add(option))
-          })
-        }
-
-        results = Array.from(matchedResults)
-      }
-
-      if (results.length === 0) {
-        clearFocusedOption()
-      }
-
-      return results
-    }, [input, clearFocusedOption])
+    const filteredOptions = useFilteredOptions(input, MaxResults, clearFocusedOption)
 
     React.useEffect(() => {
       return function cleanup() {
@@ -505,7 +350,7 @@ export const ClassNameSelect = betterReactMemo(
       ({ focused, context }: { focused: TailWindOption; context: 'menu' | 'value' }) => {
         if (context === 'menu') {
           if (isMenuOpenRef.current) {
-            if (shouldPreviewOnFocusRef.current && targets.length === 1) {
+            if (targets.length === 1) {
               const newClassNameString =
                 selectedValues?.map((v) => v.label).join(' ') + ' ' + focused.label
               if (queuedDispatchTimeout != null) {
@@ -525,7 +370,6 @@ export const ClassNameSelect = betterReactMemo(
               }, 10)
             }
             updateFocusedOption(focused)
-            shouldPreviewOnFocusRef.current = true
           }
         } else if (context === 'value') {
           focusedValueRef.current = focused.value
@@ -554,7 +398,6 @@ export const ClassNameSelect = betterReactMemo(
             ],
             'everyone',
           )
-          shouldPreviewOnFocusRef.current = false
         }
       },
       [dispatch, elementPath],
@@ -665,7 +508,6 @@ export const ClassNameSelect = betterReactMemo(
     const onInputChange = React.useCallback(
       (newInput, actionMeta: InputActionMeta) => {
         if (newInput === '') {
-          shouldPreviewOnFocusRef.current = false
           dispatch([EditorActions.clearTransientProps()], 'canvas')
         }
         setInput(newInput)
@@ -676,9 +518,6 @@ export const ClassNameSelect = betterReactMemo(
 
     const handleKeyDown = React.useCallback(
       (event: React.KeyboardEvent<HTMLDivElement>) => {
-        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-          shouldPreviewOnFocusRef.current = true
-        }
         if (event.key === 'Backspace') {
           if (focusedValueRef.current != null) {
             setInput(focusedValueRef.current)
@@ -711,7 +550,6 @@ export const ClassNameSelect = betterReactMemo(
           ariaLiveMessages={ariaLiveMessages}
           filterOption={filterOption}
           formatOptionLabel={formatOptionLabel}
-          openMenuOnFocus={true}
           options={filteredOptions}
           onChange={onChange}
           onInputChange={onInputChange}
@@ -721,7 +559,7 @@ export const ClassNameSelect = betterReactMemo(
           value={selectedValues}
           isMulti={true}
           isDisabled={!isMenuEnabled}
-          closeMenuOnSelect={false}
+          maxMenuHeight={138}
           styles={colourStyles}
           components={{
             DropdownIndicator,
@@ -730,7 +568,7 @@ export const ClassNameSelect = betterReactMemo(
             NoOptionsMessage,
             Menu,
             MultiValueContainer,
-            ValueContainer,
+            // ValueContainer,
             Input,
           }}
         />

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -294,6 +294,7 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
     } else {
       return (
         <React.Fragment>
+          <ClassNameSubsection />
           <AlignmentButtons numberOfTargets={selectedViews.length} />
           {anyComponents ? <ComponentSection isScene={false} /> : null}
           <LayoutSection
@@ -312,7 +313,6 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
             onStyleSelectorDelete={props.onStyleSelectorDelete}
             onStyleSelectorInsert={props.onStyleSelectorInsert}
           />
-          <ClassNameSubsection />
           <EventHandlersSection />
         </React.Fragment>
       )

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -1,21 +1,18 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/react'
-import styled from '@emotion/styled'
 import * as React from 'react'
 import { FormatOptionLabelMeta, MenuProps, ValueType, components } from 'react-select'
 import CreatableSelect from 'react-select/creatable'
 import { IndicatorContainerProps } from 'react-select/src/components/containers'
 import { MultiValueRemoveProps } from 'react-select/src/components/MultiValue'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
-import { useGetSubsectionHeaderStyle } from '../../../common/inspector-utils'
 import { useInspectorElementInfo } from '../../../common/property-path-hooks'
 import { styleFn } from 'react-select/src/styles'
 import { CustomReactSelectInput, SelectOption } from '../../../controls/select-control'
 import {
   UtopiaTheme,
   UNSAFE_getIconURL,
-  Section,
   InspectorSectionHeader,
   useColorTheme,
   FlexColumn,
@@ -414,7 +411,6 @@ export const ClassNameSubsection = betterReactMemo('ClassNameSubSection', () => 
           overflow: 'visible',
         }}
       >
-        {/* <ClassNameSelect container='inspector' /> */}
         <ClassNameControl
           values={values}
           controlStyles={controlStyles}

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -404,13 +404,7 @@ export const ClassNameSubsection = betterReactMemo('ClassNameSubSection', () => 
   return (
     <React.Fragment>
       <InspectorSectionHeader>Class names</InspectorSectionHeader>
-      <UIGridRow
-        padded
-        variant='<-------------1fr------------->'
-        style={{
-          overflow: 'visible',
-        }}
-      >
+      <UIGridRow padded variant='<-------------1fr------------->'>
         <ClassNameControl
           values={values}
           controlStyles={controlStyles}

--- a/editor/src/core/tailwind/tailwind-options.tsx
+++ b/editor/src/core/tailwind/tailwind-options.tsx
@@ -1,0 +1,163 @@
+import React from 'react'
+import { betterReactMemo } from '../../uuiui-deps'
+import { stripNulls } from '../shared/array-utils'
+import { mapToArray, mapValues } from '../shared/object-utils'
+import { NO_OP } from '../shared/utils'
+import {
+  AllAttributes,
+  AttributeToClassNames,
+  ClassNameToAttributes,
+} from '../third-party/tailwind-defaults'
+import Highlighter from 'react-highlight-words'
+
+export interface TailWindOption {
+  label: string
+  value: string
+  attributes?: string[]
+  categories?: string[]
+}
+
+export let TailWindOptions: Array<TailWindOption> = []
+export let AttributeOptionLookup: { [attribute: string]: Array<TailWindOption> }
+
+async function loadTailwindOptions() {
+  return new Promise<void>((resolve) => {
+    TailWindOptions = mapToArray(
+      (attributes, className) => ({
+        label: className,
+        value: className,
+        attributes: attributes,
+      }),
+      ClassNameToAttributes,
+    )
+
+    AttributeOptionLookup = mapValues((classNames: Array<string>) => {
+      const matchingOptions = classNames.map((className) =>
+        TailWindOptions.find((option) => option.value === className),
+      )
+      return stripNulls(matchingOptions)
+    }, AttributeToClassNames)
+
+    resolve()
+  })
+}
+
+loadTailwindOptions()
+
+export function searchStringToIndividualTerms(searchString: string): Array<string> {
+  return searchString.trim().toLowerCase().split(' ')
+}
+
+function findMatchingOptions<T>(
+  searchTerms: Array<string>,
+  options: Array<T>,
+  toString: (t: T) => string,
+  maxPerfectMatches: number,
+): Array<Array<T>> {
+  let orderedMatchedResults: Array<Array<T>> = []
+  let perfectMatchCount = 0
+  for (var i = 0; i < options.length && perfectMatchCount < maxPerfectMatches; i++) {
+    const nextOption = options[i]
+    const asString = toString(nextOption)
+    const splitInputIndexResult = searchTerms.map((s) => asString.indexOf(s))
+    const minimumIndexOf = Math.min(...splitInputIndexResult)
+    if (minimumIndexOf > -1) {
+      let existingMatched = orderedMatchedResults[minimumIndexOf] ?? []
+      existingMatched.push(nextOption)
+      orderedMatchedResults[minimumIndexOf] = existingMatched
+      if (minimumIndexOf === 0) {
+        perfectMatchCount++
+      }
+    }
+  }
+
+  return orderedMatchedResults
+}
+
+function takeBestOptions<T>(orderedSparseArray: Array<Array<T>>, maxMatches: number): Set<T> {
+  let matchedResults: Set<T> = new Set()
+  let matchCount = 0
+  for (var i = 0; i < orderedSparseArray.length && matchCount < maxMatches; i++) {
+    const nextMatches = orderedSparseArray[i]
+    if (nextMatches != null) {
+      const maxNextMatches = nextMatches.slice(0, maxMatches - matchCount)
+      maxNextMatches.forEach((m) => matchedResults.add(m))
+      matchCount = matchedResults.size
+    }
+  }
+
+  return matchedResults
+}
+
+export function useFilteredOptions(
+  filter: string,
+  maxResults: number,
+  onEmptyResults: () => void = NO_OP,
+): Array<TailWindOption> {
+  return React.useMemo(() => {
+    const searchTerms = searchStringToIndividualTerms(filter)
+    let results: Array<TailWindOption>
+
+    if (searchTerms.length === 0) {
+      results = TailWindOptions.slice(0, maxResults)
+    } else {
+      // First find all matches, and use a sparse array to keep the best matches at the front
+      const orderedMatchedResults = findMatchingOptions(
+        searchTerms,
+        TailWindOptions,
+        (option) => option.label,
+        maxResults,
+      )
+
+      // Now go through and take the first n best matches
+      let matchedResults = takeBestOptions(orderedMatchedResults, maxResults)
+
+      // Next if we haven't hit our max result count, we find matches based on attributes
+      const remainingAllowedMatches = maxResults - matchedResults.size
+      if (remainingAllowedMatches > 0) {
+        const orderedAttributeMatchedResults = findMatchingOptions(
+          searchTerms,
+          AllAttributes,
+          (a) => a,
+          remainingAllowedMatches,
+        )
+        const bestMatchedAttributes = takeBestOptions(
+          orderedAttributeMatchedResults,
+          remainingAllowedMatches,
+        )
+
+        bestMatchedAttributes.forEach((attribute) => {
+          const matchingOptions = AttributeOptionLookup[attribute] ?? []
+          matchingOptions.forEach((option) => matchedResults.add(option))
+        })
+      }
+
+      results = Array.from(matchedResults)
+    }
+
+    if (results.length === 0) {
+      onEmptyResults()
+    }
+
+    return results
+  }, [filter, maxResults, onEmptyResults])
+}
+
+const Bold = betterReactMemo('Bold', ({ children }: { children: React.ReactNode }) => {
+  return <strong>{children}</strong>
+})
+
+export const MatchHighlighter = betterReactMemo(
+  'MatchHighlighter',
+  ({ text, searchString }: { text: string; searchString: string | null | undefined }) => {
+    const searchTerms = searchStringToIndividualTerms(searchString ?? '')
+    return (
+      <Highlighter
+        highlightTag={Bold}
+        searchWords={searchTerms}
+        autoEscape={true}
+        textToHighlight={text}
+      />
+    )
+  },
+)


### PR DESCRIPTION
**Problem:**
We want a similar experience to the omnibar's tailwind classname selector in the Inspector

**Fix:**
This PR extracts the core functionality from the existing tailwind classname select, and re-uses it in the inspector's existing classname subsection. It also does the following:

- In the Omnibar:
  - Only opens the menu after a deliberate user action
  - Closes the menu on selection
  - Reduces the menu size to 5 rows + the footer
- In the Inspector section:
  - Always shows the menu, with 9 rows shown (maybe that's too much tbh). The choice to always have this open is deliberate.
  - Moves the classname subsection to the very top
  - Uses similar auto-previewing of the focused element, albeit hooked in slightly differently since this is stuck using the older version of `react-select` as it's using the createable version to allow users to add their own classes)
  - Restricts auto-previewing so that it only starts acting when the user performs a keyboard interaction (to ensure that it is a deliberate thing)
    - This to me feels right, though it also feels like it should also happen on a mouse over of the menu itself when the component is focused, which will require a little extra work

Note that this is still using the original styling of that section. I wanted to get this working first so we could evaluate it before tweaking the styling to match the omnibar. It also still has the dot prefix, though that's easy to remove.

**Screenshots:**
![Screenshot_20210720_161929](https://user-images.githubusercontent.com/1044774/126352015-b2855523-de54-4a83-9480-6e78d3a96cbe.png)
![Screenshot_20210720_161943](https://user-images.githubusercontent.com/1044774/126352022-714a4c2c-e310-4518-ab68-73e9ec4438f7.png)
