### PR TITLE
More assorted tweaks.

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -42,18 +42,16 @@ export const CanvasComponentEntry = betterReactMemo(
     const { onRuntimeError, clearRuntimeErrors } = useWriteOnlyRuntimeErrors()
     const { addToConsoleLogs, clearConsoleLogs } = useWriteOnlyConsoleLogs()
 
-    const canvasProps = useEditorState(
-      (store) =>
-        pickUiJsxCanvasProps(
-          store.editor,
-          store.derived,
-          true,
-          onDomReport,
-          clearConsoleLogs,
-          addToConsoleLogs,
-        ),
-      'CanvasComponentEntry canvasProps',
-    )
+    const canvasProps = useEditorState((store) => {
+      return pickUiJsxCanvasProps(
+        store.editor,
+        store.derived,
+        true,
+        onDomReport,
+        clearConsoleLogs,
+        addToConsoleLogs,
+      )
+    }, 'CanvasComponentEntry canvasProps')
 
     if (canvasProps == null) {
       return null
@@ -86,8 +84,12 @@ export const CanvasComponentEntry = betterReactMemo(
 )
 
 function DomWalkerWrapper(props: UiJsxCanvasPropsWithErrorCallback) {
+  const selectedViews = useEditorState(
+    (store) => store.editor.selectedViews,
+    'DomWalkerWrapper selectedViews',
+  )
   let [updateInvalidatedPaths, updateInvalidatedScenes, containerRef] = useDomWalker({
-    selectedViews: props.selectedViews,
+    selectedViews: selectedViews,
     canvasInteractionHappening: props.transientFilesState != null,
     mountCount: props.mountCount,
     domWalkerInvalidateCount: props.domWalkerInvalidateCount,

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -186,7 +186,6 @@ export function renderCanvasReturnResultAndError(
   if (possibleProps == null) {
     canvasProps = {
       uiFilePath: UiFilePath,
-      selectedViews: [],
       requireFn: requireFn,
       resolve: dumbResolveFn(Object.keys(codeFilesString)),
       base64FileBlobs: {},
@@ -214,7 +213,6 @@ export function renderCanvasReturnResultAndError(
     canvasProps = {
       ...possibleProps,
       uiFilePath: UiFilePath,
-      selectedViews: [],
       requireFn: requireFn,
       resolve: dumbResolveFn(Object.keys(codeFilesString)),
       base64FileBlobs: {},

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -121,7 +121,6 @@ export interface UiJsxCanvasProps {
   offset: CanvasVector
   scale: number
   uiFilePath: string
-  selectedViews: Array<ElementPath>
   requireFn: UtopiaRequireFn
   resolve: (importOrigin: string, toImport: string) => Either<string, string>
   hiddenInstances: ElementPath[]
@@ -205,7 +204,6 @@ export function pickUiJsxCanvasProps(
       offset: editor.canvas.roundedCanvasOffset,
       scale: editor.canvas.scale,
       uiFilePath: uiFilePath,
-      selectedViews: editor.selectedViews,
       requireFn: requireFn,
       resolve: editor.codeResultCache.resolve,
       hiddenInstances: hiddenInstances,
@@ -463,7 +461,6 @@ export const UiJsxCanvas = betterReactMemo(
                   mountCount={props.mountCount}
                   domWalkerInvalidateCount={props.domWalkerInvalidateCount}
                   walkDOM={walkDOM}
-                  selectedViews={props.selectedViews}
                   scale={scale}
                   offset={offset}
                   onDomReport={onDomReport}
@@ -540,7 +537,6 @@ function useGetStoryboardRoot(
 
 export interface CanvasContainerProps {
   walkDOM: boolean
-  selectedViews: Array<ElementPath>
   scale: number
   offset: CanvasVector
   onDomReport: (

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -681,13 +681,14 @@ export function modifyOpenJsxElementAtStaticPath(
 
 function getImportedUtopiaJSXComponents(
   filePath: string,
-  model: EditorState,
+  projectContents: ProjectContentTreeRoot,
+  resolve: ResolveFn,
   pathsToFilter: string[],
 ): Array<UtopiaJSXComponent> {
-  const file = getContentsTreeFileFromString(model.projectContents, filePath)
+  const file = getContentsTreeFileFromString(projectContents, filePath)
   if (isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
     const resolvedFilePaths = Object.keys(file.fileContents.parsed.imports)
-      .map((toImport) => model.codeResultCache.resolve(filePath, toImport))
+      .map((toImport) => resolve(filePath, toImport))
       .filter(isRight)
       .map((r) => r.value)
       .filter((v) => !pathsToFilter.includes(v))
@@ -695,7 +696,10 @@ function getImportedUtopiaJSXComponents(
     return [
       ...getUtopiaJSXComponentsFromSuccess(file.fileContents.parsed),
       ...resolvedFilePaths.flatMap((path) =>
-        getImportedUtopiaJSXComponents(path, model, [...pathsToFilter, ...resolvedFilePaths]),
+        getImportedUtopiaJSXComponents(path, projectContents, resolve, [
+          ...pathsToFilter,
+          ...resolvedFilePaths,
+        ]),
       ),
     ]
   } else {
@@ -704,13 +708,14 @@ function getImportedUtopiaJSXComponents(
 }
 
 export function getOpenUtopiaJSXComponentsFromStateMultifile(
-  model: EditorState,
+  projectContents: ProjectContentTreeRoot,
+  resolve: ResolveFn,
+  openFilePath: string | null,
 ): Array<UtopiaJSXComponent> {
-  const openUIJSFilePath = getOpenUIJSFileKey(model)
-  if (openUIJSFilePath == null) {
+  if (openFilePath == null) {
     return []
   } else {
-    return getImportedUtopiaJSXComponents(openUIJSFilePath, model, [])
+    return getImportedUtopiaJSXComponents(openFilePath, projectContents, resolve, [])
   }
 }
 

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -111,7 +111,7 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(470) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(480)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(430) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(440)
   })
 })


### PR DESCRIPTION
Further addresses #1519.

**Problem:**
Similar to #1541 this focuses on focus performance, but primarily attempts to improve selection performance.

**Fix:**
A lot of the fixes here relate to parts that re-render on selection changing when they really shouldn't, as prior to this the canvas re-rendered when selection changed for one example.

**Commit Details:**
- Further addresses #1519.
- Extracted `selectedViews` from the main canvas properties, resulting
  in changes to that not incurring a re-render of the canvas contents.
- `getImportedUtopiaJSXComponents` now takes parts of `EditorState`
  instead of the entirety of it.
- `getOpenUtopiaJSXComponentsFromStateMultifile` also takes parts of
  `EditorState` instead of the entirety of it.
- `rootComponents` in `InspectorContextProvider` now uses `createSelector`
  from `reselect` which means that the value isn't reconstructed on
  every single change to `EditorState`.
- The "Root View" part of the inspector is now gone forever.
- Memoized the value to string and string to value functions in
  `NumberInput`.
- Removed the `form` element around the `NumberInput` component.
