### PR TITLE
Fix: merge imports

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1542,7 +1542,11 @@ export function produceCanvasTransientState(
                   type: 'front',
                 },
               )
-              const updatedImports: Imports = mergeImports(parseSuccess.imports, importsToAdd)
+              const updatedImports: Imports = mergeImports(
+                underlyingFilePath,
+                parseSuccess.imports,
+                importsToAdd,
+              )
 
               // Sync these back up.
               const topLevelElements = applyUtopiaJSXComponentsChanges(

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -172,6 +172,7 @@ function storyboardComponent(numberOfScenes: number): UtopiaJSXComponent {
 const originalModel = deepFreeze(
   parseSuccess(
     addImport(
+      '/code.js',
       'utopia-api',
       null,
       [importAlias('View'), importAlias('Scene'), importAlias('Storyboard')],

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -2018,7 +2018,7 @@ export const UPDATE_FNS = {
       forceNotNull('Should originate from a designer', editor.canvas.openFile?.filename),
       editor,
       (element) => element,
-      (success) => {
+      (success, _, underlyingFilePath) => {
         const utopiaComponents = getUtopiaJSXComponentsFromSuccess(success)
         const targetParent =
           action.parent == null
@@ -2052,7 +2052,11 @@ export const UPDATE_FNS = {
           withInsertedElement,
         )
 
-        const updatedImports = mergeImports(success.imports, action.importsToAdd)
+        const updatedImports = mergeImports(
+          underlyingFilePath,
+          success.imports,
+          action.importsToAdd,
+        )
         return {
           ...success,
           topLevelElements: updatedTopLevelElements,
@@ -2171,7 +2175,7 @@ export const UPDATE_FNS = {
                 return {
                   ...success,
                   utopiaComponents: withTargetAdded,
-                  imports: mergeImports(success.imports, importsToAdd),
+                  imports: mergeImports(targetSuccess.filePath, success.imports, importsToAdd),
                 }
               }, parseSuccess)
             },
@@ -3933,10 +3937,10 @@ export const UPDATE_FNS = {
     )
   },
   ADD_IMPORTS: (action: AddImports, editor: EditorModel): EditorModel => {
-    return modifyOpenParseSuccess((success) => {
+    return modifyOpenParseSuccess((success, _, underlyingFilePath) => {
       return {
         ...success,
-        imports: mergeImports(success.imports, action.importsToAdd),
+        imports: mergeImports(underlyingFilePath, success.imports, action.importsToAdd),
       }
     }, editor)
   },
@@ -4438,7 +4442,7 @@ export const UPDATE_FNS = {
         openFilename,
         editor,
         (element) => element,
-        (success) => {
+        (success, _, underlyingFilePath) => {
           const utopiaComponents = getUtopiaJSXComponentsFromSuccess(success)
           const newUID = generateUidWithExistingComponents(editor.projectContents)
 
@@ -4492,7 +4496,11 @@ export const UPDATE_FNS = {
             withInsertedElement,
           )
 
-          const updatedImports = mergeImports(success.imports, action.toInsert.importsToAdd)
+          const updatedImports = mergeImports(
+            underlyingFilePath,
+            success.imports,
+            action.toInsert.importsToAdd,
+          )
           return {
             ...success,
             topLevelElements: updatedTopLevelElements,

--- a/editor/src/components/editor/store/editor-state.spec.ts
+++ b/editor/src/components/editor/store/editor-state.spec.ts
@@ -112,7 +112,7 @@ describe('modifyUnderlyingTarget', () => {
     const codeFile = getTextFileByPath(actualResult.projectContents, '/src/card.js')
     const parsed = codeFile.fileContents.parsed
     if (isParseSuccess(parsed)) {
-      expect(parsed.imports).toEqual(addImport('react', null, [], 'React', emptyImports()))
+      expect(parsed.imports).toEqual(addImport('', 'react', null, [], 'React', emptyImports()))
     } else {
       throw new Error('No parsed version of the file.')
     }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -560,7 +560,11 @@ export interface ParseSuccessAndEditorChanges<T> {
 }
 
 export function modifyOpenParseSuccess(
-  transform: (success: ParseSuccess) => ParseSuccess,
+  transform: (
+    parseSuccess: ParseSuccess,
+    underlying: StaticElementPath | null,
+    underlyingFilePath: string,
+  ) => ParseSuccess,
   model: EditorState,
 ): EditorState {
   return modifyUnderlyingTarget(

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -208,7 +208,7 @@ function makeHTMLDescriptor(
     }
   }
   return componentDescriptor(
-    addImport('react', null, [], 'React', emptyImportsValue),
+    addImport('', 'react', null, [], 'React', emptyImportsValue),
     jsxElementWithoutUID(tag, defaultProps, []),
     tag,
     propertyControls,

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -224,8 +224,9 @@ function addStoryboardFileForComponent(
   editorModel: EditorState,
 ): EditorState {
   // Add import of storyboard and scene components.
-  let imports = addImport('react', null, [], 'React', {})
+  let imports = addImport(StoryboardFilePath, 'react', null, [], 'React', {})
   imports = addImport(
+    StoryboardFilePath,
     'utopia-api',
     null,
     [importAlias('Storyboard'), importAlias('Scene')],
@@ -243,6 +244,7 @@ function addStoryboardFileForComponent(
         'scene-1',
       )
       imports = addImport(
+        StoryboardFilePath,
         createFileWithComponent.path,
         null,
         [importAlias(createFileWithComponent.toImport)],
@@ -252,7 +254,14 @@ function addStoryboardFileForComponent(
       break
     case 'DEFAULT_COMPONENT_TO_IMPORT':
       sceneElement = createSceneFromComponent(StoryboardFilePath, 'StoryboardComponent', 'scene-1')
-      imports = addImport(createFileWithComponent.path, 'StoryboardComponent', [], null, imports)
+      imports = addImport(
+        StoryboardFilePath,
+        createFileWithComponent.path,
+        'StoryboardComponent',
+        [],
+        null,
+        imports,
+      )
       break
     case 'UNEXPORTED_RENDERED_COMPONENT':
       sceneElement = createSceneFromComponent(
@@ -261,6 +270,7 @@ function addStoryboardFileForComponent(
         'scene-1',
       )
       imports = addImport(
+        StoryboardFilePath,
         createFileWithComponent.path,
         null,
         [importAlias(createFileWithComponent.elementName)],

--- a/editor/src/core/model/test-ui-js-file.test-utils.ts
+++ b/editor/src/core/model/test-ui-js-file.test-utils.ts
@@ -35,7 +35,7 @@ export const onlyImportReact: Imports = {
   },
 }
 
-export const sampleDefaultImports: Imports = mergeImports(onlyImportReact, {
+export const sampleDefaultImports: Imports = mergeImports('/code.js', onlyImportReact, {
   'utopia-api': {
     importedWithName: null,
     importedFromWithin: [importAlias('UtopiaUtils')],
@@ -44,10 +44,11 @@ export const sampleDefaultImports: Imports = mergeImports(onlyImportReact, {
 })
 
 export const sampleImportsForTests: Imports = mergeImports(
+  '/code.js',
   sampleDefaultImports,
   sampleIncludedElementTypes.reduce<Imports>(
     (working, elementType) =>
-      addImport('utopia-api', null, [importAlias(elementType)], null, working),
+      addImport('/code.js', 'utopia-api', null, [importAlias(elementType)], null, working),
     emptyImports(),
   ),
 )

--- a/editor/src/core/workers/common/project-file-utils.spec.ts
+++ b/editor/src/core/workers/common/project-file-utils.spec.ts
@@ -78,6 +78,20 @@ describe('mergeImports', () => {
     })
   })
 
+  it('combines the same thing imported smartly, even if the relative path are written differently, with omitted file extension', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      { '/src/fileA.js': importDetails(null, [importAlias('Card')], null) },
+      {
+        '../src/fileA': importDetails(null, [importAlias('FlexRow')], null),
+      },
+    )
+
+    expect(result).toEqual({
+      '/src/fileA.js': importDetails(null, [importAlias('Card'), importAlias('FlexRow')], null),
+    })
+  })
+
   it('default import doesnt override existing default import', () => {
     const result = mergeImports(
       '/src/code.js',

--- a/editor/src/core/workers/common/project-file-utils.spec.ts
+++ b/editor/src/core/workers/common/project-file-utils.spec.ts
@@ -1,0 +1,114 @@
+import { importAlias, importDetails } from '../../shared/project-file-types'
+import { mergeImports } from './project-file-utils'
+
+describe('mergeImports', () => {
+  it('can merge an empty imports', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      { '/src/fileA.js': importDetails(null, [importAlias('Card')], null) },
+      {},
+    )
+
+    expect(result).toEqual({
+      '/src/fileA.js': importDetails(null, [importAlias('Card')], null),
+    })
+  })
+
+  it('combines two separate imports', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      { '/src/fileA.js': importDetails(null, [importAlias('Card')], null) },
+      { '/src/fileB.js': importDetails(null, [importAlias('FlexRow')], null) },
+    )
+
+    expect(result).toEqual({
+      '/src/fileA.js': importDetails(null, [importAlias('Card')], null),
+      '/src/fileB.js': importDetails(null, [importAlias('FlexRow')], null),
+    })
+  })
+
+  it('combines two imports pointing to the same file', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      { '/src/fileA.js': importDetails(null, [importAlias('Card')], null) },
+      { '/src/fileA.js': importDetails(null, [importAlias('FlexRow')], null) },
+    )
+
+    expect(result).toEqual({
+      '/src/fileA.js': importDetails(null, [importAlias('Card'), importAlias('FlexRow')], null),
+    })
+  })
+
+  it('combines two imports pointing to the same file, even if the relative path are written differently', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      { '/src/fileA.js': importDetails(null, [importAlias('Card')], null) },
+      { './fileA.js': importDetails(null, [importAlias('FlexRow')], null) },
+    )
+
+    expect(result).toEqual({
+      '/src/fileA.js': importDetails(null, [importAlias('Card'), importAlias('FlexRow')], null),
+    })
+  })
+
+  it('combines the same thing imported smartly', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      { '/src/fileA.js': importDetails(null, [importAlias('Card')], null) },
+      { '/src/fileA.js': importDetails(null, [importAlias('Card')], null) },
+    )
+
+    expect(result).toEqual({
+      '/src/fileA.js': importDetails(null, [importAlias('Card')], null),
+    })
+  })
+
+  it('combines the same thing imported smartly, even if the relative path are written differently', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      { '/src/fileA.js': importDetails(null, [importAlias('Card')], null) },
+      { './fileA.js': importDetails(null, [importAlias('Card')], null) },
+    )
+
+    expect(result).toEqual({
+      '/src/fileA.js': importDetails(null, [importAlias('Card')], null),
+    })
+  })
+
+  it('default import doesnt override existing default import', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      { '/src/fileA.js': importDetails('Card', [], null) },
+      { '/src/fileA.js': importDetails('Flexrow', [], null) },
+    )
+
+    expect(result).toEqual({
+      '/src/fileA.js': importDetails('Card', [], null),
+    })
+  })
+
+  it('adds non-relative import with ease', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      { '/src/fileA.js': importDetails('Card', [], null) },
+      { 'component-library': importDetails('Flexrow', [], null) },
+    )
+
+    expect(result).toEqual({
+      '/src/fileA.js': importDetails('Card', [], null),
+      'component-library': importDetails('Flexrow', [], null),
+    })
+  })
+
+  it('combines non-relative import with ease', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      { 'component-library': importDetails(null, [importAlias('Card')], null) },
+      { 'component-library': importDetails(null, [importAlias('FlexRow')], null) },
+    )
+
+    expect(result).toEqual({
+      'component-library': importDetails(null, [importAlias('Card'), importAlias('FlexRow')], null),
+    })
+  })
+})

--- a/editor/src/core/workers/common/project-file-utils.spec.ts
+++ b/editor/src/core/workers/common/project-file-utils.spec.ts
@@ -43,7 +43,7 @@ describe('mergeImports', () => {
     const result = mergeImports(
       '/src/code.js',
       { '/src/fileA.js': importDetails(null, [importAlias('Card')], null) },
-      { './fileA.js': importDetails(null, [importAlias('FlexRow')], null) },
+      { './fileA': importDetails(null, [importAlias('FlexRow')], null) },
     )
 
     expect(result).toEqual({
@@ -67,11 +67,14 @@ describe('mergeImports', () => {
     const result = mergeImports(
       '/src/code.js',
       { '/src/fileA.js': importDetails(null, [importAlias('Card')], null) },
-      { './fileA.js': importDetails(null, [importAlias('Card')], null) },
+      {
+        './fileA.js': importDetails(null, [importAlias('Card')], null),
+        '../src/fileA.js': importDetails(null, [importAlias('FlexRow')], null),
+      },
     )
 
     expect(result).toEqual({
-      '/src/fileA.js': importDetails(null, [importAlias('Card')], null),
+      '/src/fileA.js': importDetails(null, [importAlias('Card'), importAlias('FlexRow')], null),
     })
   })
 

--- a/editor/src/core/workers/common/project-file-utils.ts
+++ b/editor/src/core/workers/common/project-file-utils.ts
@@ -74,7 +74,7 @@ function mergeImportDetails(first: ImportDetails, second: ImportDetails): Import
   }
 }
 
-export function mergeImports(first: Imports, second: Imports): Imports {
+export function mergeImports(fileUri: string, first: Imports, second: Imports): Imports {
   let combinedKeys: Array<string> = Object.keys(first)
   fastForEach(Object.keys(second), (s) => {
     if (!combinedKeys.includes(s)) {
@@ -101,6 +101,7 @@ export function mergeImports(first: Imports, second: Imports): Imports {
 }
 
 export function addImport(
+  fileUri: string,
   importedFrom: string,
   importedWithName: string | null,
   importedFromWithin: Array<ImportAlias>,
@@ -114,7 +115,7 @@ export function addImport(
       importedAs: importedAs,
     },
   }
-  return mergeImports(imports, toAdd)
+  return mergeImports(fileUri, imports, toAdd)
 }
 
 export function parseSuccess(

--- a/editor/src/core/workers/common/project-file-utils.ts
+++ b/editor/src/core/workers/common/project-file-utils.ts
@@ -21,6 +21,7 @@ import { printCode, printCodeOptions } from '../parser-printer/parser-printer'
 import { ArbitraryJSBlock, Comment, TopLevelElement } from '../../shared/element-template'
 import { emptySet } from '../../shared/set-utils'
 import { absolutePathFromRelativePath } from '../../../utils/path-utils'
+import { stripExtension } from '../../../components/custom-code/custom-code-utils'
 
 export function codeNeedsPrinting(revisionsState: RevisionsState): boolean {
   return revisionsState === RevisionsState.ParsedAhead
@@ -82,7 +83,7 @@ export function mergeImports(fileUri: string, first: Imports, second: Imports): 
   let imports: Imports = {}
   allKeys.forEach((key) => {
     let existingKeyToUse = key
-    const absoluteKey = absolutePathFromRelativePath(fileUri, false, key)
+    const absoluteKey = stripExtension(absolutePathFromRelativePath(fileUri, false, key))
     if (absoluteKeysToRelativeKeys[absoluteKey] != null) {
       existingKeyToUse = absoluteKeysToRelativeKeys[absoluteKey]
     } else {

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -122,7 +122,14 @@ export var whatever = (props) => <View data-uid='aaa'>
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining([exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)),
@@ -177,7 +184,14 @@ export var whatever = () => <View data-uid='aaa'>
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining([exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)),
@@ -242,7 +256,14 @@ export function whatever(props) {
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining([exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)),
@@ -301,7 +322,14 @@ export function whatever() {
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining([exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)),
@@ -366,7 +394,14 @@ export default function whatever(props) {
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining([exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)),
@@ -425,7 +460,14 @@ export default function whatever() {
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining([exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)),
@@ -487,8 +529,15 @@ export var whatever = (props) => <View data-uid='aaa'>
       false,
       emptyComments,
     )
-    const importsWithCake = addImport('cake', 'cake', [], null, sampleImportsForTests)
-    const importsWithStylecss = addImport('./style.css', null, [], null, importsWithCake)
+    const importsWithCake = addImport('/code.js', 'cake', 'cake', [], null, sampleImportsForTests)
+    const importsWithStylecss = addImport(
+      '/code.js',
+      './style.css',
+      null,
+      [],
+      null,
+      importsWithCake,
+    )
     const expectedResult = parseSuccess(
       importsWithStylecss,
       expect.arrayContaining([exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)),
@@ -564,7 +613,14 @@ export var whatever = (props) => <View data-uid='aaa'>
       false,
       emptyComments,
     )
-    const imports = addImport('cake', 'cake', [importAlias('cake2')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      'cake',
+      [importAlias('cake2')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining([exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)),
@@ -626,6 +682,7 @@ export var whatever = (props) => <View data-uid='aaa'>
         emptyComments,
       )
       const imports = addImport(
+        '/code.js',
         'cake',
         null,
         [importAlias('cake', 'cake2')],
@@ -709,7 +766,14 @@ export var whatever = (props) => <View data-uid='aaa'>
         false,
         emptyComments,
       )
-      const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+      const imports = addImport(
+        '/code.js',
+        'cake',
+        null,
+        [importAlias('cake')],
+        null,
+        sampleImportsForTests,
+      )
       const expectedResult = parseSuccess(
         imports,
         expect.arrayContaining([exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)),
@@ -779,7 +843,14 @@ export var whatever = (props) => <View data-uid='aaa'>
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining([exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)),
@@ -920,7 +991,14 @@ return { getSizing: getSizing, spacing: spacing };`
     const topLevelElements = [arbitraryBlock1, arbitraryBlock2, exported].map(
       clearTopLevelElementUniqueIDsAndEmptyBlocks,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining(topLevelElements),
@@ -1006,7 +1084,14 @@ return { getSizing: getSizing };`
     const topLevelElements = [arbitraryBlock, exported].map(
       clearTopLevelElementUniqueIDsAndEmptyBlocks,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining(topLevelElements),
@@ -1111,7 +1196,14 @@ return { getSizing: getSizing };`
     const topLevelElements = [arbitraryBlock, exported].map(
       clearTopLevelElementUniqueIDsAndEmptyBlocks,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining(topLevelElements),
@@ -1200,7 +1292,14 @@ return {  };`
     const topLevelElements = [arbitraryBlock, exported].map(
       clearTopLevelElementUniqueIDsAndEmptyBlocks,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining(topLevelElements),
@@ -1281,7 +1380,14 @@ return { spacing: spacing };`
       {},
     )
     const topLevelElements = [jsVariable, exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining(topLevelElements),
@@ -1876,7 +1982,14 @@ return { count: count };`
       {},
     )
     const topLevelElements = [jsVariable, exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining(topLevelElements),
@@ -1958,7 +2071,14 @@ return { use20: use20 };`
       {},
     )
     const topLevelElements = [jsVariable, exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining(topLevelElements),
@@ -2101,7 +2221,14 @@ return { spacing: spacing };`
       {},
     )
     const topLevelElements = [jsVariable, exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining(topLevelElements),
@@ -2474,7 +2601,14 @@ export var whatever = (props) => <View data-uid='aaa'>
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining([exported].map(clearTopLevelElementUniqueIDsAndEmptyBlocks)),
@@ -2530,7 +2664,14 @@ export var whatever = <View data-uid='aaa'>
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const expectedResult = parseSuccess(
       imports,
       expect.arrayContaining([exported]),
@@ -2641,7 +2782,14 @@ export var App = (props) => <View data-uid='bbb'>
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
       printCodeOptions(false, true, true),
@@ -2758,7 +2906,14 @@ return { getSizing: getSizing, spacing: spacing };`
     const topLevelElements = [arbitraryBlock1, arbitraryBlock2, exported].map(
       clearTopLevelElementUniqueIDsAndEmptyBlocks,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
       printCodeOptions(false, true, true, false, true),
@@ -2806,7 +2961,14 @@ return { getSizing: getSizing, spacing: spacing };`
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
       printCodeOptions(false, true, true),
@@ -2926,7 +3088,14 @@ export var whatever = props => {
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
       printCodeOptions(false, true, true),
@@ -2978,7 +3147,14 @@ export var whatever = props => {
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
       printCodeOptions(false, true, true),
@@ -3061,7 +3237,14 @@ export var whatever = props => {
       false,
       emptyComments,
     )
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
       printCodeOptions(false, true, true),
@@ -3143,7 +3326,14 @@ export var whatever = props => {
 }
 return { test: test };`
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      '/code.js',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const arbitraryBlock = arbitraryJSBlock(
       jsCode,
       transpiledJSCode,
@@ -3217,7 +3407,14 @@ return { test: test };`
   return n * 2;
 }
 return { test: test };`
-    const imports = addImport('cake', null, [importAlias('cake')], null, sampleImportsForTests)
+    const imports = addImport(
+      'code.jsx',
+      'cake',
+      null,
+      [importAlias('cake')],
+      null,
+      sampleImportsForTests,
+    )
     const components = [
       clearTopLevelElementUniqueIDsAndEmptyBlocks(
         utopiaJSXComponent(

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -885,7 +885,7 @@ export function printableProjectContentArbitrary(): Arbitrary<PrintableProjectCo
         }
       }, topLevelElements)
       const imports: Imports = allBaseVariables.reduce((workingImports, baseVariable) => {
-        return addImport('testlib', baseVariable, [], null, workingImports)
+        return addImport('code.jsx', 'testlib', baseVariable, [], null, workingImports)
       }, JustImportViewAndReact)
       return {
         imports: imports,

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -1235,7 +1235,14 @@ export function parseCode(
 
           // this import looks like `import Cat from './src/cats'`
           const importedWithName = optionalMap((n) => n.getText(sourceFile), importClause?.name)
-          imports = addImport(importFrom, importedWithName, importedFromWithin, importedAs, imports)
+          imports = addImport(
+            filename,
+            importFrom,
+            importedWithName,
+            importedFromWithin,
+            importedAs,
+            imports,
+          )
           const rawImportStatement = importStatement(
             topLevelElement.getText(sourceFile),
             importedAs != null,

--- a/editor/src/utils/path-utils.spec.ts
+++ b/editor/src/utils/path-utils.spec.ts
@@ -25,4 +25,9 @@ describe('absolutePathFromRelativePath', () => {
     const actualResult = absolutePathFromRelativePath('/src/', true, './other/../path/.././card.js')
     expect(actualResult).toEqual('/src/card.js')
   })
+
+  it('handles non-relative path', () => {
+    const actualResult = absolutePathFromRelativePath('/src/', true, 'component-library')
+    expect(actualResult).toEqual('component-library')
+  })
 })

--- a/editor/src/utils/path-utils.ts
+++ b/editor/src/utils/path-utils.ts
@@ -44,7 +44,7 @@ export function absolutePathFromRelativePath(
   originIsDir: boolean,
   relativePath: string,
 ): string {
-  if (relativePath.startsWith('/')) {
+  if (relativePath.startsWith('/') || !relativePath.includes('/')) {
     // Not actually relative in this case.
     return relativePath
   } else {


### PR DESCRIPTION
Fixes #1531 

**Problem:**
`mergeImports` would break on this:
```javascript
import { Card } from './utils'
import { OtherCard } from '/src/utils.js'
```

Because it used the import source as an absolute key, and did not consider that for relative paths, there's an infinite way of writing the same path.

**Fix:**
Convert paths to absolute when comparing with existing paths. Use first existing relative path for all subsequent relative paths.

**Commit Details:**
- Wrote tests for quick testing of `mergeImports`
- Added `fileUri` parameter to `mergeImports` and `addImport` so we can calculate absolute path (this changed a dozen files)
- Use absolute path as the comparison method for two relative paths