### PR TITLE
Fix tailwind media queries bug

### DIFF
--- a/editor/src/core/tailwind/tailwind.spec.ts
+++ b/editor/src/core/tailwind/tailwind.spec.ts
@@ -8,7 +8,7 @@ describe('adjustRuleScope', () => {
     expect(output).toEqual(expected)
   })
 
-  it('Returns a rule unchanged if it is a keyframe', () => {
+  it('Returns a rule unchanged if it is an at-rule but not a media query', () => {
     const input = '@keyframes spin{to{transform:rotate(360deg)}}'
     const output = adjustRuleScopeImpl(input, '#canvas-container')
     const expected = input

--- a/editor/src/core/tailwind/tailwind.spec.ts
+++ b/editor/src/core/tailwind/tailwind.spec.ts
@@ -1,0 +1,55 @@
+import { adjustRuleScopeImpl } from './tailwind'
+
+describe('adjustRuleScope', () => {
+  it('Returns a rule unchanged if no prefix is provided', () => {
+    const input = '.container{width:100%}'
+    const output = adjustRuleScopeImpl(input, null)
+    const expected = input
+    expect(output).toEqual(expected)
+  })
+
+  it('Returns a rule unchanged if it is a keyframe', () => {
+    const input = '@keyframes spin{to{transform:rotate(360deg)}}'
+    const output = adjustRuleScopeImpl(input, '#canvas-container')
+    const expected = input
+    expect(output).toEqual(expected)
+  })
+
+  it('Prefixes a regular selector', () => {
+    const input = '.container{width:100%}'
+    const output = adjustRuleScopeImpl(input, '#canvas-container')
+    const expected = '#canvas-container .container{width:100%}'
+    expect(output).toEqual(expected)
+  })
+
+  it('Handles comma separated selectors', () => {
+    const input = '.container,.other-container{width:100%}'
+    const output = adjustRuleScopeImpl(input, '#canvas-container')
+    const expected = '#canvas-container .container,#canvas-container .other-container{width:100%}'
+    expect(output).toEqual(expected)
+  })
+
+  it('Replaces :root, html, or head with the provided prefix', () => {
+    const rootOutput = adjustRuleScopeImpl(':root{width:100%}', '#canvas-container')
+    const htmlOutput = adjustRuleScopeImpl('html{width:100%}', '#canvas-container')
+    const headOutput = adjustRuleScopeImpl('head{width:100%}', '#canvas-container')
+    const expected = '#canvas-container{width:100%}'
+    expect(rootOutput).toEqual(expected)
+    expect(htmlOutput).toEqual(expected)
+    expect(headOutput).toEqual(expected)
+  })
+
+  it('Replaces body with a selector for children of the provided prefix', () => {
+    const input = 'body{width:100%}'
+    const output = adjustRuleScopeImpl(input, '#canvas-container')
+    const expected = '#canvas-container > *{width:100%}'
+    expect(output).toEqual(expected)
+  })
+
+  it('Handles a media query', () => {
+    const input = '@media (min-width:640px){.container{max-width:640px}}'
+    const output = adjustRuleScopeImpl(input, '#canvas-container')
+    const expected = '@media (min-width:640px){#canvas-container .container{max-width:640px}}'
+    expect(output).toEqual(expected)
+  })
+})

--- a/editor/src/core/tailwind/tailwind.ts
+++ b/editor/src/core/tailwind/tailwind.ts
@@ -148,10 +148,13 @@ function clearTwind() {
 }
 
 export function adjustRuleScopeImpl(rule: string, prefixSelector: string | null): string {
-  if (prefixSelector == null || rule.startsWith('@keyframes')) {
+  // TODO Use css-tree to handle more complex cases. That doesn't seem necessary right now since Tailwind
+  // as at 2.2.4 only uses @media and @keyframes
+  const isMediaQuery = rule.startsWith('@media')
+  const isOtherAtRule = rule.startsWith('@') && !isMediaQuery
+  if (prefixSelector == null || isOtherAtRule) {
     return rule
   } else {
-    const isMediaQuery = rule.startsWith('@media')
     const splitOnBrace = rule.split('{')
     const selectorIndex = isMediaQuery ? 1 : 0
     const splitSelectors = splitOnBrace[selectorIndex].split(',')

--- a/editor/src/core/tailwind/tailwind.ts
+++ b/editor/src/core/tailwind/tailwind.ts
@@ -147,39 +147,38 @@ function clearTwind() {
   }
 }
 
-const adjustRuleScope = memoize(
-  (rule: string, prefixSelector: string | null): string => {
-    if (prefixSelector == null || rule.startsWith('@keyframes')) {
-      return rule
-    } else {
-      const isMediaQuery = rule.startsWith('@media')
-      const splitOnBrace = rule.split('{')
-      const selectorIndex = isMediaQuery ? 1 : 0
-      const splitSelectors = splitOnBrace[selectorIndex].split(',')
-      const scopedSelectors = splitSelectors.map((s) => {
-        const lowerCaseSelector = s.toLowerCase().trim()
+export function adjustRuleScopeImpl(rule: string, prefixSelector: string | null): string {
+  if (prefixSelector == null || rule.startsWith('@keyframes')) {
+    return rule
+  } else {
+    const isMediaQuery = rule.startsWith('@media')
+    const splitOnBrace = rule.split('{')
+    const selectorIndex = isMediaQuery ? 1 : 0
+    const splitSelectors = splitOnBrace[selectorIndex].split(',')
+    const scopedSelectors = splitSelectors.map((s) => {
+      const lowerCaseSelector = s.toLowerCase().trim()
 
-        if (
-          lowerCaseSelector === ':root' ||
-          lowerCaseSelector === 'html' ||
-          lowerCaseSelector === 'head'
-        ) {
-          return prefixSelector
-        } else if (lowerCaseSelector === 'body') {
-          return `${prefixSelector} > *`
-        } else {
-          return `${prefixSelector} ${s}`
-        }
-      })
-      const joinedSelectors = scopedSelectors.join(',')
-      const theRest = splitOnBrace.slice(selectorIndex + 1)
-      const front = splitOnBrace.slice(0, selectorIndex)
-      const finalRule = [...front, joinedSelectors, ...theRest].join('{')
-      return finalRule
-    }
-  },
-  { maxSize: 100, equals: (a, b) => a === b },
-)
+      if (
+        lowerCaseSelector === ':root' ||
+        lowerCaseSelector === 'html' ||
+        lowerCaseSelector === 'head'
+      ) {
+        return prefixSelector
+      } else if (lowerCaseSelector === 'body') {
+        return `${prefixSelector} > *`
+      } else {
+        return `${prefixSelector} ${s}`
+      }
+    })
+    const joinedSelectors = scopedSelectors.join(',')
+    const theRest = splitOnBrace.slice(selectorIndex + 1)
+    const front = splitOnBrace.slice(0, selectorIndex)
+    const finalRule = [...front, joinedSelectors, ...theRest].join('{')
+    return finalRule
+  }
+}
+
+const adjustRuleScope = memoize(adjustRuleScopeImpl, { maxSize: 100, equals: (a, b) => a === b })
 
 function updateTwind(config: Configuration, prefixSelector: string | null) {
   const element = document.head.appendChild(document.createElement('style'))

--- a/editor/src/core/tailwind/tailwind.ts
+++ b/editor/src/core/tailwind/tailwind.ts
@@ -149,11 +149,13 @@ function clearTwind() {
 
 const adjustRuleScope = memoize(
   (rule: string, prefixSelector: string | null): string => {
-    if (prefixSelector == null) {
+    if (prefixSelector == null || rule.startsWith('@keyframes')) {
       return rule
     } else {
+      const isMediaQuery = rule.startsWith('@media')
       const splitOnBrace = rule.split('{')
-      const splitSelectors = splitOnBrace[0].split(',')
+      const selectorIndex = isMediaQuery ? 1 : 0
+      const splitSelectors = splitOnBrace[selectorIndex].split(',')
       const scopedSelectors = splitSelectors.map((s) => {
         const lowerCaseSelector = s.toLowerCase().trim()
 
@@ -170,8 +172,9 @@ const adjustRuleScope = memoize(
         }
       })
       const joinedSelectors = scopedSelectors.join(',')
-      const afterBrace = splitOnBrace.slice(1)
-      const finalRule = [joinedSelectors, ...afterBrace].join('{')
+      const theRest = splitOnBrace.slice(selectorIndex + 1)
+      const front = splitOnBrace.slice(0, selectorIndex)
+      const finalRule = [...front, joinedSelectors, ...theRest].join('{')
       return finalRule
     }
   },


### PR DESCRIPTION
**Problem:**
The CSS rule selector scoping was being incorrectly applied to `@media` rules

**Fix:**
Corrected the logic to offset the index when looking for the selectors in `@media` rules, and completely skip other `@` rules (the only other one used by tailwindcss is `@keyframes`, as mentioned in the comment). Also added tests.