### PR TITLE
Reduce navigator renders during reparenting.

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -518,6 +518,7 @@ import {
   PostCSSPath,
   TailwindConfigPath,
 } from '../../../core/tailwind/tailwind-config'
+import { NavigatorStateKeepDeepEquality } from '../../../utils/deep-equality-instances'
 
 export function updateSelectedLeftMenuTab(editorState: EditorState, tab: LeftMenuTab): EditorState {
   return {
@@ -2728,23 +2729,23 @@ export const UPDATE_FNS = {
 
   TOGGLE_COLLAPSE: (action: ToggleCollapse, editor: EditorModel): EditorModel => {
     if (editor.navigator.collapsedViews.some((element) => EP.pathsEqual(element, action.target))) {
-      return update(editor, {
-        navigator: {
-          collapsedViews: {
-            $set: editor.navigator.collapsedViews.filter(
-              (element) => !EP.pathsEqual(element, action.target),
-            ),
-          },
-        },
-      })
+      return {
+        ...editor,
+        navigator: NavigatorStateKeepDeepEquality(editor.navigator, {
+          ...editor.navigator,
+          collapsedViews: editor.navigator.collapsedViews.filter(
+            (element) => !EP.pathsEqual(element, action.target),
+          ),
+        }).value,
+      }
     } else {
-      return update(editor, {
-        navigator: {
-          collapsedViews: {
-            $set: editor.navigator.collapsedViews.concat(action.target),
-          },
-        },
-      })
+      return {
+        ...editor,
+        navigator: NavigatorStateKeepDeepEquality(editor.navigator, {
+          ...editor.navigator,
+          collapsedViews: editor.navigator.collapsedViews.concat(action.target),
+        }).value,
+      }
     }
   },
   UPDATE_KEYS_PRESSED: (action: UpdateKeysPressed, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -105,7 +105,6 @@ import {
 } from '../../custom-code/code-file'
 import { convertModeToSavedMode, EditorModes, Mode, PersistedMode } from '../editor-modes'
 import { FontSettings } from '../../inspector/common/css-utils'
-import { DropTargetHint } from '../../navigator/navigator'
 import { DebugDispatch, EditorDispatch, LoginState, ProjectListing } from '../action-types'
 import { CURRENT_PROJECT_VERSION } from '../actions/migrations/migrations'
 import { StateHistory } from '../history'
@@ -275,6 +274,21 @@ export interface DesignerFile {
 
 export type Theme = 'light' | 'dark'
 
+export type DropTargetType = 'before' | 'after' | 'reparent' | null
+
+export interface DropTargetHint {
+  target: ElementPath | null
+  type: DropTargetType
+}
+
+export interface NavigatorState {
+  minimised: boolean
+  dropTargetHint: DropTargetHint
+  collapsedViews: ElementPath[]
+  renamingTarget: ElementPath | null
+  position: 'hidden' | 'left' | 'right'
+}
+
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
   id: string | null
@@ -372,13 +386,7 @@ export interface EditorState {
   projectSettings: {
     minimised: boolean
   }
-  navigator: {
-    minimised: boolean
-    dropTargetHint: DropTargetHint
-    collapsedViews: ElementPath[]
-    renamingTarget: ElementPath | null
-    position: 'hidden' | 'left' | 'right'
-  }
+  navigator: NavigatorState
   topmenu: {
     formulaBarMode: 'css' | 'content'
     formulaBarFocusCounter: number

--- a/editor/src/components/navigator/actions/index.ts
+++ b/editor/src/components/navigator/actions/index.ts
@@ -1,6 +1,6 @@
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { NavigatorReorder, RenameComponent } from '../../editor/action-types'
-import { DropTargetType } from '../navigator'
+import { DropTargetType } from '../../editor/store/editor-state'
 
 export function reparentComponents(
   draggedComponents: Array<ElementPath>,

--- a/editor/src/components/navigator/navigator-item/expandable-indicator.tsx
+++ b/editor/src/components/navigator/navigator-item/expandable-indicator.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Icn, Icons } from '../../../uuiui'
+import { betterReactMemo } from '../../../uuiui-deps'
 
 export const ExpansionArrowWidth = 8
 export const ExpansionArrowHeight = 8
@@ -13,16 +14,21 @@ interface ExpandableIndicatorProps {
   testId?: string
 }
 
-export const ExpandableIndicator: React.StatelessComponent<ExpandableIndicatorProps> = (props) => (
-  <div data-testid={props.testId} style={{ width: 16, height: 16 }}>
-    {props.visible ? (
-      <Icn
-        category='semantic'
-        type={`expansionarrow-${props.collapsed ? 'right' : 'down'}`}
-        color={props.selected ? 'white' : 'black'}
-        onMouseDown={props.onMouseDown}
-        onClick={props.onClick}
-      />
-    ) : null}
-  </div>
+export const ExpandableIndicator: React.FunctionComponent<ExpandableIndicatorProps> = betterReactMemo(
+  'ExpandableIndicator',
+  (props) => {
+    return (
+      <div data-testid={props.testId} style={{ width: 16, height: 16 }}>
+        {props.visible ? (
+          <Icn
+            category='semantic'
+            type={`expansionarrow-${props.collapsed ? 'right' : 'down'}`}
+            color={props.selected ? 'white' : 'black'}
+            onMouseDown={props.onMouseDown}
+            onClick={props.onClick}
+          />
+        ) : null}
+      </div>
+    )
+  },
 )

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -6,59 +6,62 @@ import { EditorDispatch } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
 import * as EP from '../../../core/shared/element-path'
 import { useColorTheme, Button, Icons, SectionActionSheet } from '../../../uuiui'
-import { DropTargetType } from '../../editor/store/editor-state'
+import { betterReactMemo } from '../../../uuiui-deps'
 
 interface NavigatorHintProps {
-  isOver: boolean
-  dropTargetType: DropTargetType
+  shouldBeShown: boolean
   getMarginForHint: () => number
 }
 
-export const NavigatorHintTop: React.FunctionComponent<NavigatorHintProps> = (props) => {
-  const colorTheme = useColorTheme()
-  if (props.isOver && props.dropTargetType != null && props.dropTargetType === 'before') {
-    return (
-      <div
-        style={{
-          marginLeft: props.getMarginForHint(),
-          backgroundColor: colorTheme.navigatorResizeHintBorder.value,
-          height: 2,
-          position: 'absolute',
-          top: 0,
-          width: '100%',
-          borderRadius: '2px',
-          overflow: 'hidden',
-        }}
-      />
-    )
-  } else {
-    return null
-  }
-}
-NavigatorHintTop.displayName = 'NavigatorHintTop'
+export const NavigatorHintTop: React.FunctionComponent<NavigatorHintProps> = betterReactMemo(
+  'NavigatorHintTop',
+  (props) => {
+    const colorTheme = useColorTheme()
+    if (props.shouldBeShown) {
+      return (
+        <div
+          style={{
+            marginLeft: props.getMarginForHint(),
+            backgroundColor: colorTheme.navigatorResizeHintBorder.value,
+            height: 2,
+            position: 'absolute',
+            top: 0,
+            width: '100%',
+            borderRadius: '2px',
+            overflow: 'hidden',
+          }}
+        />
+      )
+    } else {
+      return null
+    }
+  },
+)
 
-export const NavigatorHintBottom: React.FunctionComponent<NavigatorHintProps> = (props) => {
-  const colorTheme = useColorTheme()
-  if (props.isOver && props.dropTargetType != null && props.dropTargetType === 'after') {
-    return (
-      <div
-        style={{
-          marginLeft: props.getMarginForHint(),
-          backgroundColor: colorTheme.navigatorResizeHintBorder.value,
-          height: 2,
-          position: 'absolute',
-          bottom: 0,
-          width: '100%',
-          borderRadius: '2px',
-          overflow: 'hidden',
-        }}
-      />
-    )
-  } else {
-    return null
-  }
-}
-NavigatorHintBottom.displayName = 'NavigatorHintBottom'
+export const NavigatorHintBottom: React.FunctionComponent<NavigatorHintProps> = betterReactMemo(
+  'NavigatorHintBottom',
+  (props) => {
+    const colorTheme = useColorTheme()
+    if (props.shouldBeShown) {
+      return (
+        <div
+          style={{
+            marginLeft: props.getMarginForHint(),
+            backgroundColor: colorTheme.navigatorResizeHintBorder.value,
+            height: 2,
+            position: 'absolute',
+            bottom: 0,
+            width: '100%',
+            borderRadius: '2px',
+            overflow: 'hidden',
+          }}
+        />
+      )
+    } else {
+      return null
+    }
+  },
+)
 
 interface VisiblityIndicatorProps {
   shouldShow: boolean
@@ -67,54 +70,56 @@ interface VisiblityIndicatorProps {
   onClick: () => void
 }
 
-export const VisibilityIndicator: React.FunctionComponent<VisiblityIndicatorProps> = (props) => {
-  const color = props.selected ? 'white' : 'gray'
+export const VisibilityIndicator: React.FunctionComponent<VisiblityIndicatorProps> = betterReactMemo(
+  'VisibilityIndicator',
+  (props) => {
+    const color = props.selected ? 'white' : 'gray'
 
-  return (
-    <Button
-      onClick={props.onClick}
-      style={{
-        marginRight: 4,
-        height: 18,
-        width: 18,
-        opacity: props.shouldShow ? 1 : 0,
-      }}
-    >
-      {props.visibilityEnabled ? (
-        <Icons.EyeOpen color={color} style={{ transform: 'scale(.85)' }} />
-      ) : (
-        <Icons.EyeStrikethrough color={color} />
-      )}
-    </Button>
-  )
-}
-VisibilityIndicator.displayName = 'VisibilityIndicator'
+    return (
+      <Button
+        onClick={props.onClick}
+        style={{
+          marginRight: 4,
+          height: 18,
+          width: 18,
+          opacity: props.shouldShow ? 1 : 0,
+        }}
+      >
+        {props.visibilityEnabled ? (
+          <Icons.EyeOpen color={color} style={{ transform: 'scale(.85)' }} />
+        ) : (
+          <Icons.EyeStrikethrough color={color} />
+        )}
+      </Button>
+    )
+  },
+)
 
 interface OriginalComponentNameLabelProps {
   selected: boolean
   instanceOriginalComponentName: string | null
 }
 
-export const OriginalComponentNameLabel: React.FunctionComponent<OriginalComponentNameLabelProps> = (
-  props,
-) => {
-  const colorTheme = useColorTheme()
-  return (
-    <div
-      style={{
-        fontStyle: 'normal',
-        paddingRight: 4,
-        paddingLeft: 4,
-        fontSize: 10,
-        color: props.selected ? colorTheme.white.value : colorTheme.navigatorComponentName.value,
-        display: props.instanceOriginalComponentName == null ? 'none' : undefined,
-      }}
-    >
-      {props.instanceOriginalComponentName}
-    </div>
-  )
-}
-OriginalComponentNameLabel.displayName = 'OriginalComponentNameLabel'
+export const OriginalComponentNameLabel: React.FunctionComponent<OriginalComponentNameLabelProps> = betterReactMemo(
+  'OriginalComponentNameLabel',
+  (props) => {
+    const colorTheme = useColorTheme()
+    return (
+      <div
+        style={{
+          fontStyle: 'normal',
+          paddingRight: 4,
+          paddingLeft: 4,
+          fontSize: 10,
+          color: props.selected ? colorTheme.white.value : colorTheme.navigatorComponentName.value,
+          display: props.instanceOriginalComponentName == null ? 'none' : undefined,
+        }}
+      >
+        {props.instanceOriginalComponentName}
+      </div>
+    )
+  },
+)
 
 interface NavigatorItemActionSheetProps {
   selected: boolean
@@ -125,28 +130,28 @@ interface NavigatorItemActionSheetProps {
   dispatch: EditorDispatch
 }
 
-export const NavigatorItemActionSheet: React.FunctionComponent<NavigatorItemActionSheetProps> = (
-  props,
-) => {
-  const { elementPath, dispatch } = props
+export const NavigatorItemActionSheet: React.FunctionComponent<NavigatorItemActionSheetProps> = betterReactMemo(
+  'NavigatorItemActionSheet',
+  (props) => {
+    const { elementPath, dispatch } = props
 
-  const toggleHidden = React.useCallback(() => {
-    dispatch([EditorActions.toggleHidden([elementPath])], 'everyone')
-  }, [dispatch, elementPath])
-  return (
-    <SectionActionSheet>
-      <OriginalComponentNameLabel
-        selected={props.selected}
-        instanceOriginalComponentName={props.instanceOriginalComponentName}
-      />
-      <VisibilityIndicator
-        key={`visibility-indicator-${EP.toVarSafeComponentId(elementPath)}`}
-        shouldShow={props.highlighted || props.selected || !props.isVisibleOnCanvas}
-        visibilityEnabled={props.isVisibleOnCanvas}
-        selected={props.selected}
-        onClick={toggleHidden}
-      />
-    </SectionActionSheet>
-  )
-}
-NavigatorItemActionSheet.displayName = 'NavigatorItemActionSheet'
+    const toggleHidden = React.useCallback(() => {
+      dispatch([EditorActions.toggleHidden([elementPath])], 'everyone')
+    }, [dispatch, elementPath])
+    return (
+      <SectionActionSheet>
+        <OriginalComponentNameLabel
+          selected={props.selected}
+          instanceOriginalComponentName={props.instanceOriginalComponentName}
+        />
+        <VisibilityIndicator
+          key={`visibility-indicator-${EP.toVarSafeComponentId(elementPath)}`}
+          shouldShow={props.highlighted || props.selected || !props.isVisibleOnCanvas}
+          visibilityEnabled={props.isVisibleOnCanvas}
+          selected={props.selected}
+          onClick={toggleHidden}
+        />
+      </SectionActionSheet>
+    )
+  },
+)

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -5,8 +5,8 @@ import { ElementPath } from '../../../core/shared/project-file-types'
 import { EditorDispatch } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
 import * as EP from '../../../core/shared/element-path'
-import { DropTargetType } from '../navigator'
 import { useColorTheme, Button, Icons, SectionActionSheet } from '../../../uuiui'
+import { DropTargetType } from '../../editor/store/editor-state'
 
 interface NavigatorHintProps {
   isOver: boolean

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -23,12 +23,11 @@ import {
   isCursorInTopArea,
   onDragActions,
 } from '../drag-and-drop-utils'
-import { DropTargetHint } from '../navigator'
 import { ExpansionArrowWidth } from './expandable-indicator'
 import { BasePaddingUnit, getElementPadding, NavigatorItem } from './navigator-item'
 import { NavigatorHintBottom, NavigatorHintTop } from './navigator-item-components'
 import { JSXElementName } from '../../../core/shared/element-template'
-import { ElementWarnings } from '../../editor/store/editor-state'
+import { DropTargetHint, ElementWarnings } from '../../editor/store/editor-state'
 
 const BaseRowHeight = 35
 const PreviewIconSize = BaseRowHeight
@@ -41,7 +40,7 @@ export interface DragSelection {
 export interface NavigatorItemDragAndDropWrapperProps {
   index: number
   elementPath: ElementPath
-  dropTargetHint: DropTargetHint
+  appropriateDropTargetHint: DropTargetHint | null
   editorDispatch: EditorDispatch
   selected: boolean
   highlighted: boolean // TODO are we sure about this?
@@ -79,10 +78,9 @@ function onDrop(
     )
     const draggedElements = filteredSelections.map((selection) => selection.elementPath)
     const clearHintAction = showNavigatorDropTargetHint(null, null)
-    const target =
-      props.dropTargetHint.target != null ? props.dropTargetHint.target : props.elementPath
+    const target = props.appropriateDropTargetHint?.target ?? props.elementPath
 
-    switch (props.dropTargetHint.type) {
+    switch (props.appropriateDropTargetHint?.type) {
       case 'before':
         return props.editorDispatch(
           [placeComponentsBefore(draggedElements, target), clearHintAction],
@@ -148,7 +146,7 @@ function onHover(
     }
 
     if (isCursorInTopArea(dropTargetRectangle, cursor.y, numberOfAreasToCut)) {
-      if (props.dropTargetHint.type !== 'before') {
+      if (props.appropriateDropTargetHint?.type !== 'before') {
         props.editorDispatch(
           [...targetAction, showNavigatorDropTargetHint('before', component.props.elementPath)],
           'leftpane',
@@ -167,8 +165,8 @@ function onHover(
         const targetDistance = Math.min(cursorTargetDepth, maximumTargetDepth)
         const targetTP = EP.getNthParent(props.elementPath, targetDistance)
         if (
-          props.dropTargetHint.type !== 'after' ||
-          !EP.pathsEqual(props.dropTargetHint.target, targetTP)
+          props.appropriateDropTargetHint?.type !== 'after' ||
+          !EP.pathsEqual(props.appropriateDropTargetHint?.target, targetTP)
         ) {
           props.editorDispatch(
             [...targetAction, showNavigatorDropTargetHint('after', targetTP)],
@@ -176,8 +174,8 @@ function onHover(
           )
         }
       } else if (
-        props.dropTargetHint.type !== 'after' ||
-        !EP.pathsEqual(props.dropTargetHint.target, component.props.elementPath)
+        props.appropriateDropTargetHint?.type !== 'after' ||
+        !EP.pathsEqual(props.appropriateDropTargetHint?.target, component.props.elementPath)
       ) {
         props.editorDispatch(
           [...targetAction, showNavigatorDropTargetHint('after', component.props.elementPath)],
@@ -185,13 +183,13 @@ function onHover(
         )
       }
     } else if (canReparent) {
-      if (props.dropTargetHint.type !== 'reparent') {
+      if (props.appropriateDropTargetHint?.type !== 'reparent') {
         props.editorDispatch(
           [...targetAction, showNavigatorDropTargetHint('reparent', component.props.elementPath)],
           'leftpane',
         )
       }
-    } else if (props.dropTargetHint.type !== null) {
+    } else if (props.appropriateDropTargetHint?.type !== null) {
       props.editorDispatch([showNavigatorDropTargetHint(null, null)], 'leftpane')
     }
   }
@@ -220,10 +218,10 @@ export class NavigatorItemDndWrapper extends PureComponent<
   getMarginForHint = (): number => {
     if (
       this.props.isOver &&
-      this.props.dropTargetHint.target != null &&
-      this.props.dropTargetHint.type !== 'reparent'
+      this.props.appropriateDropTargetHint?.target != null &&
+      this.props.appropriateDropTargetHint?.type !== 'reparent'
     ) {
-      return getHintPadding(this.props.dropTargetHint.target)
+      return getHintPadding(this.props.appropriateDropTargetHint.target)
     } else {
       return 0
     }
@@ -258,12 +256,12 @@ export class NavigatorItemDndWrapper extends PureComponent<
         />
         <NavigatorHintTop
           isOver={this.props.isOver}
-          dropTargetType={this.props.dropTargetHint.type}
+          dropTargetType={this.props.appropriateDropTargetHint?.type ?? null}
           getMarginForHint={this.getMarginForHint}
         />
         <NavigatorHintBottom
           isOver={this.props.isOver}
-          dropTargetType={this.props.dropTargetHint.type}
+          dropTargetType={this.props.appropriateDropTargetHint?.type ?? null}
           getMarginForHint={this.getMarginForHint}
         />
       </div>

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -255,13 +255,15 @@ export class NavigatorItemDndWrapper extends PureComponent<
           elementWarnings={this.props.elementWarnings}
         />
         <NavigatorHintTop
-          isOver={this.props.isOver}
-          dropTargetType={this.props.appropriateDropTargetHint?.type ?? null}
+          shouldBeShown={
+            this.props.isOver && this.props.appropriateDropTargetHint?.type === 'before'
+          }
           getMarginForHint={this.getMarginForHint}
         />
         <NavigatorHintBottom
-          isOver={this.props.isOver}
-          dropTargetType={this.props.appropriateDropTargetHint?.type ?? null}
+          shouldBeShown={
+            this.props.isOver && this.props.appropriateDropTargetHint?.type === 'after'
+          }
           getMarginForHint={this.getMarginForHint}
         />
       </div>

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -349,8 +349,12 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
             onMouseDown={collapse}
           />
           <NavigatorRowLabel
-            {...props}
-            collapse={collapse}
+            elementPath={elementPath}
+            label={props.label}
+            renamingTarget={props.renamingTarget}
+            selected={props.selected}
+            elementOriginType={props.elementOriginType}
+            dispatch={props.dispatch}
             isDynamic={isDynamic}
             iconColor={resultingStyle.iconColor}
             warningText={warningText}
@@ -370,14 +374,19 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
 )
 NavigatorItem.displayName = 'NavigatorItem'
 
-interface NavigatorRowProps extends NavigatorItemInnerProps {
-  collapse: (event: any) => void
-  isDynamic: boolean
+interface NavigatorRowLabelProps {
+  elementPath: ElementPath
   iconColor: IcnProps['color']
   warningText: string | null
+  label: string
+  isDynamic: boolean
+  renamingTarget: ElementPath | null
+  selected: boolean
+  elementOriginType: ElementOriginType
+  dispatch: EditorDispatch
 }
 
-const NavigatorRowLabel = betterReactMemo('NavigatorRowLabel', (props: NavigatorRowProps) => {
+const NavigatorRowLabel = betterReactMemo('NavigatorRowLabel', (props: NavigatorRowLabelProps) => {
   return (
     <React.Fragment>
       <LayoutIcon

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -24,13 +24,6 @@ const AutoSizer = require('react-virtualized-auto-sizer')
 const AutoSizerComponent: typeof AutoSizer =
   (AutoSizer as any)['default'] == null ? AutoSizer : (AutoSizer as any)['default']
 
-export interface DropTargetHint {
-  target: ElementPath | null
-  type: DropTargetType
-}
-
-export type DropTargetType = 'before' | 'after' | 'reparent' | null
-
 const NavigatorContainerId = 'navigator'
 
 export const NavigatorComponent = betterReactMemo(

--- a/editor/src/templates/editor-navigator.ts
+++ b/editor/src/templates/editor-navigator.ts
@@ -1,10 +1,10 @@
-import update from 'immutability-helper'
 import { ElementPath } from '../core/shared/project-file-types'
 import { DerivedState, EditorState } from '../components/editor/store/editor-state'
 import { LocalNavigatorAction } from '../components/navigator/actions'
 import { DragSelection } from '../components/navigator/navigator-item/navigator-item-dnd-container'
 import * as EP from '../core/shared/element-path'
 import Utils from '../utils/utils'
+import { NavigatorStateKeepDeepEquality } from '../utils/deep-equality-instances'
 
 export function createDragSelections(
   elementPaths: ElementPath[],
@@ -28,17 +28,16 @@ export const runLocalNavigatorAction = function (
 ): EditorState {
   switch (action.action) {
     case 'DROP_TARGET_HINT':
-      return update(model, {
-        navigator: {
+      return {
+        ...model,
+        navigator: NavigatorStateKeepDeepEquality(model.navigator, {
+          ...model.navigator,
           dropTargetHint: {
-            $set: {
-              target: action.target,
-              type: action.type,
-            },
+            target: action.target,
+            type: action.type,
           },
-        },
-      })
-
+        }).value,
+      }
     default:
       return model
   }

--- a/editor/src/utils/deep-equality-instances.ts
+++ b/editor/src/utils/deep-equality-instances.ts
@@ -2,6 +2,7 @@ import {
   arrayDeepEquality,
   combine2EqualityCalls,
   combine4EqualityCalls,
+  combine5EqualityCalls,
   createCallFromEqualsFunction,
   createCallWithShallowEquals,
   createCallWithTripleEquals,
@@ -9,6 +10,7 @@ import {
   KeepDeepEqualityResult,
   keepDeepEqualityResult,
   mapKeepDeepEqualityResult,
+  nullableDeepEquality,
 } from './deep-equality'
 import * as EP from '../core/shared/element-path'
 import * as PP from '../core/shared/property-path'
@@ -18,6 +20,7 @@ import { ElementPath, PropertyPath } from '../core/shared/project-file-types'
 import { createCallFromIntrospectiveKeepDeep } from './react-performance'
 import { Either, foldEither, isLeft, left, right } from '../core/shared/either'
 import { NameAndIconResult } from '../components/inspector/common/name-and-icon-hook'
+import { DropTargetHint, NavigatorState } from '../components/editor/store/editor-state'
 
 export const ElementPathKeepDeepEquality: KeepDeepEqualityCall<ElementPath> = createCallFromEqualsFunction(
   (oldPath: ElementPath, newPath: ElementPath) => {
@@ -112,3 +115,38 @@ export const NameAndIconResultKeepDeepEquality: KeepDeepEqualityCall<NameAndIcon
 export const NameAndIconResultArrayKeepDeepEquality: KeepDeepEqualityCall<Array<
   NameAndIconResult
 >> = arrayDeepEquality(NameAndIconResultKeepDeepEquality)
+
+export const DropTargetHintKeepDeepEquality: KeepDeepEqualityCall<DropTargetHint> = combine2EqualityCalls(
+  (hint) => hint.target,
+  nullableDeepEquality(ElementPathKeepDeepEquality),
+  (hint) => hint.type,
+  createCallWithTripleEquals(),
+  (target, type) => {
+    return {
+      target: target,
+      type: type,
+    }
+  },
+)
+
+export const NavigatorStateKeepDeepEquality: KeepDeepEqualityCall<NavigatorState> = combine5EqualityCalls(
+  (state) => state.minimised,
+  createCallWithTripleEquals(),
+  (state) => state.dropTargetHint,
+  DropTargetHintKeepDeepEquality,
+  (state) => state.collapsedViews,
+  ElementPathArrayKeepDeepEquality,
+  (state) => state.renamingTarget,
+  nullableDeepEquality(ElementPathKeepDeepEquality),
+  (state) => state.position,
+  createCallWithTripleEquals(),
+  (minimised, dropTargetHint, collapsedViews, renamingTarget, position) => {
+    return {
+      minimised: minimised,
+      dropTargetHint: dropTargetHint,
+      collapsedViews: collapsedViews,
+      renamingTarget: renamingTarget,
+      position: position,
+    }
+  },
+)


### PR DESCRIPTION
Fixes #1545

**Problem:**
Currently re-parenting is surprisingly slow, to the point of making it slowly replay the previous movements once you stop moving it.

**Fix:**
The primary fix in this is to make the `dropTargetHint` value only be present when the target matches the current item in the navigator. Previously as the value changed (3 times approximately if an item is dragged over fully), that would cause every single item in the navigator to be re-rendered.

**Commit Details:**
- Fixes #1545.
- Separated out the type of the `navigator` field in `EditorState`.
- Moved `DropTargetType` and `DropTargetHint` to live next to the
  newly created `NavigatorState` type.
- Made `NavigatorItemDragAndDropWrapperProps.dropTargetHint` be a
  nullable value and renamed it slightly to give some indication
  that it would only be there if relevant.
- `NavigatorItemWrapper` only includes the (previously named)
  `dropTargetHint` value if it points to the same path as the current
  element. Previously when this changed as the user dragged around
  the entire navigator was re-rendered.
- Created a `KeepDeepEqualityCall` instance for the `NavigatorState`
  and used it in the actions in place of `immutability-helper`.
