### PR TITLE
adding FlexRow and FlexCol to utopia-api

### DIFF
--- a/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
+++ b/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
@@ -51,6 +51,7 @@ declare module 'utopia-api/index' {
   export * from 'utopia-api/layout/flex';
   export * from 'utopia-api/primitives/common';
   export * from 'utopia-api/primitives/view';
+  export * from 'utopia-api/primitives/flex-views';
   export * from 'utopia-api/primitives/text';
   export * from 'utopia-api/primitives/rectangle';
   export * from 'utopia-api/primitives/ellipse';
@@ -305,6 +306,19 @@ declare module 'utopia-api/primitives/ellipse' {
   export interface EllipseProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, UtopiaComponentProps {
   }
   export const Ellipse: React.FunctionComponent<EllipseProps>;
+
+}
+declare module 'utopia-api/primitives/flex-views' {
+  import { Interpolation, Theme } from '@emotion/react';
+  import React from 'react';
+  import { UtopiaComponentProps } from 'utopia-api/primitives/common';
+  export interface FlexRowProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, UtopiaComponentProps {
+      css: Interpolation<Theme>;
+  }
+  export const FlexRow: React.FunctionComponent<FlexRowProps>;
+  type FlexColProps = FlexRowProps;
+  export const FlexCol: React.FunctionComponent<FlexColProps>;
+  export {};
 
 }
 declare module 'utopia-api/primitives/rectangle' {

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -38,6 +38,8 @@ export const UtopiaApiComponents: DependencyBoundDescriptors = {
       createBasicUtopiaComponent('Rectangle', 'Rectangle', StyleObjectProps),
       createBasicUtopiaComponent('Text', 'Text', StyleObjectProps),
       createBasicUtopiaComponent('View', 'View', StyleObjectProps),
+      createBasicUtopiaComponent('FlexRow', 'FlexRow', StyleObjectProps),
+      createBasicUtopiaComponent('FlexCol', 'FlexCol', StyleObjectProps),
       createBasicUtopiaComponent('Scene', 'Scene', StyleObjectProps),
     ],
   },

--- a/utopia-api/src/index.ts
+++ b/utopia-api/src/index.ts
@@ -4,6 +4,7 @@ export * from './layout/flex'
 
 export * from './primitives/common'
 export * from './primitives/view'
+export * from './primitives/flex-views'
 export * from './primitives/text'
 export * from './primitives/rectangle'
 export * from './primitives/ellipse'

--- a/utopia-api/src/primitives/flex-views.tsx
+++ b/utopia-api/src/primitives/flex-views.tsx
@@ -1,0 +1,38 @@
+/** @jsx jsx */
+import { jsx, Interpolation, Theme } from '@emotion/react'
+import React from 'react'
+import { UtopiaComponentProps, addEventHandlersToDivProps } from './common'
+
+export interface FlexRowProps
+  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
+    UtopiaComponentProps {
+  css: Interpolation<Theme>
+}
+
+export const FlexRow: React.FunctionComponent<FlexRowProps> = (props: FlexRowProps) => {
+  return (
+    <div
+      {...props}
+      // we use Emotion css prop here so that it is overwritable with both classNames and style props
+      css={[{ display: 'flex', flexDirection: 'row' }, props.css]}
+    >
+      {props.children}
+    </div>
+  )
+}
+FlexRow.displayName = 'FlexRow'
+
+type FlexColProps = FlexRowProps
+
+export const FlexCol: React.FunctionComponent<FlexColProps> = (props: FlexColProps) => {
+  return (
+    <div
+      {...props}
+      // we use Emotion css prop here so that it is overwritable with both classNames and style props
+      css={[{ display: 'flex', flexDirection: 'column' }, props.css]}
+    >
+      {props.children}
+    </div>
+  )
+}
+FlexCol.displayName = 'FlexCol'


### PR DESCRIPTION
This PR adds FlexRow and FlexCol layout helper components. 

I decided to use Emotion inside them so that the flexDirection is overwriteable from CSS classnames or style prop.

so this: `<FlexRow className="flex-col" />` in a tailwind context turns it into a flexCol as expected.

(using props.style internally would mean that the style prop "wins" over the className)
