### PR TITLE
Flex contextual insertion.

### DIFF
--- a/editor/src/components/canvas/controls/insertion-plus-button.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.tsx
@@ -196,18 +196,23 @@ const PlusButton = betterReactMemo('PlusButton', (props: ButtonControlProps) => 
   const dispatch = useEditorState((store) => store.dispatch, 'PlusButton dispatch')
   const colorTheme = useColorTheme()
   const { parentPath, indexPosition } = props
-  const insertElement = React.useCallback(() => {
-    dispatch(
-      [
-        openFloatingInsertMenu({
-          insertMenuMode: 'insert',
-          parentPath: parentPath,
-          indexPosition: indexPosition,
-        }),
-      ],
-      'canvas',
-    )
-  }, [dispatch, parentPath, indexPosition])
+  const insertElement = React.useCallback(
+    (event) => {
+      event.stopPropagation()
+      event.preventDefault()
+      dispatch(
+        [
+          openFloatingInsertMenu({
+            insertMenuMode: 'insert',
+            parentPath: parentPath,
+            indexPosition: indexPosition,
+          }),
+        ],
+        'canvas',
+      )
+    },
+    [dispatch, parentPath, indexPosition],
+  )
   return (
     <div
       style={{

--- a/editor/src/components/canvas/controls/insertion-plus-button.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.tsx
@@ -1,0 +1,249 @@
+import { ControlProps } from './new-canvas-controls'
+import * as React from 'react'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { colorTheme } from '../../../uuiui'
+import { useEditorState } from '../../editor/store/store-hook'
+import uuid from 'uuid'
+import { IndexPosition } from '../../../utils/utils'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import * as EP from '../../../core/shared/element-path'
+import { openFloatingInsertMenu } from '../../editor/actions/action-creators'
+
+const InsertionButtonOffset = 10
+
+interface ButtonControlProps {
+  key: string
+  positionX: number
+  positionY: number
+  lineEndX: number
+  lineEndY: number
+  isHorizontalLine: boolean
+  parentPath: ElementPath
+  indexPosition: IndexPosition
+}
+
+export const InsertionControls: React.FunctionComponent<ControlProps> = (
+  props: ControlProps,
+): React.ReactElement | null => {
+  if (props.selectedViews.length !== 1) {
+    return null
+  }
+  const selectedView = props.selectedViews[0]
+  const parentPath = EP.parentPath(selectedView)
+  const parentFrame =
+    parentPath != null
+      ? MetadataUtils.getFrameInCanvasCoords(parentPath, props.componentMetadata)
+      : null
+
+  const parentElement = MetadataUtils.getParent(props.componentMetadata, selectedView)
+  if (parentPath == null || parentFrame == null || parentElement == null) {
+    return null
+  }
+  const children = MetadataUtils.getChildrenHandlingGroups(
+    props.componentMetadata,
+    parentPath,
+    false,
+  )
+  let controlProps: ButtonControlProps[] = []
+  children.forEach((child, index) => {
+    const childFrame = MetadataUtils.getFrameInCanvasCoords(
+      child.elementPath,
+      props.componentMetadata,
+    )
+    if (child.specialSizeMeasurements.position !== 'absolute' && childFrame != null) {
+      let direction: 'row' | 'column' =
+        child.specialSizeMeasurements.parentLayoutSystem === 'flex'
+          ? parentElement.props?.style?.flexDirection || 'row'
+          : 'column'
+      const positionX =
+        direction == 'column'
+          ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
+          : childFrame.x + childFrame.width + props.canvasOffset.x
+      const positionY =
+        direction == 'column'
+          ? childFrame.y + childFrame.height + props.canvasOffset.y
+          : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
+
+      const lineEndX =
+        direction == 'column'
+          ? parentFrame.x + parentFrame.width + props.canvasOffset.x
+          : childFrame.x + childFrame.width + props.canvasOffset.x
+      const lineEndY =
+        direction == 'column'
+          ? childFrame.y + childFrame.height + props.canvasOffset.y
+          : parentFrame.y + parentFrame.height + props.canvasOffset.y
+      controlProps.push({
+        key: EP.toString(child.elementPath),
+        positionX: positionX,
+        positionY: positionY,
+        lineEndX: lineEndX,
+        lineEndY: lineEndY,
+        isHorizontalLine: direction === 'column',
+        parentPath: parentPath,
+        indexPosition: {
+          type: 'absolute',
+          index: index + 1,
+        },
+      })
+      // first element has a plus button before the element too
+      if (index === 0) {
+        const beforeX =
+          direction == 'column'
+            ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
+            : childFrame.x + props.canvasOffset.x
+        const beforeY =
+          direction == 'column'
+            ? childFrame.y + props.canvasOffset.y
+            : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
+        const beforeLineEndX =
+          direction == 'column'
+            ? parentFrame.x + parentFrame.width + props.canvasOffset.x
+            : childFrame.x + props.canvasOffset.x
+        const beforeLineEndY =
+          direction == 'column'
+            ? childFrame.y + props.canvasOffset.y
+            : parentFrame.y + parentFrame.height + props.canvasOffset.y
+        controlProps.push({
+          key: EP.toString(child.elementPath) + '0',
+          positionX: beforeX,
+          positionY: beforeY,
+          lineEndX: beforeLineEndX,
+          lineEndY: beforeLineEndY,
+          isHorizontalLine: direction === 'column',
+          parentPath: parentPath,
+          indexPosition: {
+            type: 'absolute',
+            index: 0,
+          },
+        })
+      }
+    }
+  })
+  return (
+    <>
+      {controlProps.map((control) => (
+        <InsertionButtonContainer {...control} key={control.key} />
+      ))}
+    </>
+  )
+}
+
+const InsertionButtonContainer = (props: ButtonControlProps) => {
+  const [plusVisible, setPlusVisible] = React.useState(false)
+
+  const onMouseEnter = () => setPlusVisible(true)
+  const onMouseLeave = () => setPlusVisible(false)
+
+  return (
+    <div
+      key={props.key}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={{
+        position: 'absolute',
+        left: props.positionX,
+        top: props.positionY,
+      }}
+    >
+      {plusVisible ? (
+        <>
+          <Line {...props} />
+          <PlusButton {...props} />
+        </>
+      ) : (
+        <BlueDot {...props} />
+      )}
+    </div>
+  )
+}
+const BlueDotSize = 7
+const BlueDot = (props: ButtonControlProps) => {
+  return (
+    <div
+      style={{
+        marginLeft: -BlueDotSize / 2,
+        marginTop: -BlueDotSize / 2,
+        backgroundColor: 'white',
+        width: BlueDotSize,
+        height: BlueDotSize,
+        borderRadius: '50%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div
+        style={{
+          width: BlueDotSize - 2,
+          height: BlueDotSize - 2,
+          backgroundColor: colorTheme.canvasSelectionPrimaryOutline.value,
+          borderRadius: '50%',
+        }}
+      />
+    </div>
+  )
+}
+
+const ButtonSize = 12
+const PlusButton = (props: ButtonControlProps) => {
+  const dispatch = useEditorState((store) => store.dispatch, 'PlusButton dispatch')
+  const { parentPath, indexPosition } = props
+  const insertElement = React.useCallback(() => {
+    dispatch(
+      [
+        openFloatingInsertMenu({
+          insertMenuMode: 'insert',
+          parentPath: parentPath,
+          indexPosition: indexPosition,
+        }),
+      ],
+      'canvas',
+    )
+  }, [dispatch, parentPath, indexPosition])
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: -ButtonSize / 2,
+        left: -ButtonSize / 2,
+        backgroundColor: 'white',
+        width: ButtonSize,
+        height: ButtonSize,
+        borderRadius: '50%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      onMouseDown={insertElement}
+    >
+      <div
+        style={{
+          width: ButtonSize - 2,
+          height: ButtonSize - 2,
+          backgroundColor: colorTheme.canvasSelectionPrimaryOutline.value,
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <div style={{ color: 'white', fontSize: 10, marginBottom: 2 }}>+</div>
+      </div>
+    </div>
+  )
+}
+
+const Line = (props: ButtonControlProps) => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: -1,
+        left: -1,
+        width: props.isHorizontalLine ? props.lineEndX - props.positionX : 1,
+        height: props.isHorizontalLine ? 1 : props.lineEndY - props.positionY,
+        backgroundColor: colorTheme.canvasSelectionPrimaryOutline.value,
+      }}
+    />
+  )
+}

--- a/editor/src/components/canvas/controls/insertion-plus-button.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.tsx
@@ -1,13 +1,14 @@
 import { ControlProps } from './new-canvas-controls'
 import * as React from 'react'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { colorTheme } from '../../../uuiui'
 import { useEditorState } from '../../editor/store/store-hook'
 import uuid from 'uuid'
 import { IndexPosition } from '../../../utils/utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import * as EP from '../../../core/shared/element-path'
 import { openFloatingInsertMenu } from '../../editor/actions/action-creators'
+import { betterReactMemo } from '../../../utils/react-performance'
+import { useColorTheme } from '../../../uuiui/styles/theme'
 
 const InsertionButtonOffset = 10
 
@@ -22,142 +23,148 @@ interface ButtonControlProps {
   indexPosition: IndexPosition
 }
 
-export const InsertionControls: React.FunctionComponent<ControlProps> = (
-  props: ControlProps,
-): React.ReactElement | null => {
-  if (props.selectedViews.length !== 1) {
-    return null
-  }
-  const selectedView = props.selectedViews[0]
-  const parentPath = EP.parentPath(selectedView)
-  const parentFrame =
-    parentPath != null
-      ? MetadataUtils.getFrameInCanvasCoords(parentPath, props.componentMetadata)
-      : null
+export const InsertionControls: React.FunctionComponent<ControlProps> = betterReactMemo(
+  'InsertionControls',
+  (props: ControlProps): React.ReactElement | null => {
+    if (props.selectedViews.length !== 1) {
+      return null
+    }
+    const selectedView = props.selectedViews[0]
+    const parentPath = EP.parentPath(selectedView)
+    const parentFrame =
+      parentPath != null
+        ? MetadataUtils.getFrameInCanvasCoords(parentPath, props.componentMetadata)
+        : null
 
-  const parentElement = MetadataUtils.getParent(props.componentMetadata, selectedView)
-  if (parentPath == null || parentFrame == null || parentElement == null) {
-    return null
-  }
-  const children = MetadataUtils.getChildrenHandlingGroups(
-    props.componentMetadata,
-    parentPath,
-    false,
-  )
-  let controlProps: ButtonControlProps[] = []
-  children.forEach((child, index) => {
-    const childFrame = MetadataUtils.getFrameInCanvasCoords(
-      child.elementPath,
+    const parentElement = MetadataUtils.getParent(props.componentMetadata, selectedView)
+    if (parentPath == null || parentFrame == null || parentElement == null) {
+      return null
+    }
+    const children = MetadataUtils.getChildrenHandlingGroups(
       props.componentMetadata,
+      parentPath,
+      false,
     )
-    if (child.specialSizeMeasurements.position !== 'absolute' && childFrame != null) {
-      let direction: 'row' | 'column' =
-        child.specialSizeMeasurements.parentLayoutSystem === 'flex'
-          ? parentElement.props?.style?.flexDirection || 'row'
-          : 'column'
-      const positionX =
-        direction == 'column'
-          ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
-          : childFrame.x + childFrame.width + props.canvasOffset.x
-      const positionY =
-        direction == 'column'
-          ? childFrame.y + childFrame.height + props.canvasOffset.y
-          : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
-
-      const lineEndX =
-        direction == 'column'
-          ? parentFrame.x + parentFrame.width + props.canvasOffset.x
-          : childFrame.x + childFrame.width + props.canvasOffset.x
-      const lineEndY =
-        direction == 'column'
-          ? childFrame.y + childFrame.height + props.canvasOffset.y
-          : parentFrame.y + parentFrame.height + props.canvasOffset.y
-      controlProps.push({
-        key: EP.toString(child.elementPath),
-        positionX: positionX,
-        positionY: positionY,
-        lineEndX: lineEndX,
-        lineEndY: lineEndY,
-        isHorizontalLine: direction === 'column',
-        parentPath: parentPath,
-        indexPosition: {
-          type: 'absolute',
-          index: index + 1,
-        },
-      })
-      // first element has a plus button before the element too
-      if (index === 0) {
-        const beforeX =
+    let controlProps: ButtonControlProps[] = []
+    children.forEach((child, index) => {
+      const childFrame = MetadataUtils.getFrameInCanvasCoords(
+        child.elementPath,
+        props.componentMetadata,
+      )
+      if (child.specialSizeMeasurements.position !== 'absolute' && childFrame != null) {
+        let direction: 'row' | 'column' =
+          child.specialSizeMeasurements.parentLayoutSystem === 'flex'
+            ? parentElement.props?.style?.flexDirection || 'row'
+            : 'column'
+        const positionX =
           direction == 'column'
             ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
-            : childFrame.x + props.canvasOffset.x
-        const beforeY =
+            : childFrame.x + childFrame.width + props.canvasOffset.x
+        const positionY =
           direction == 'column'
-            ? childFrame.y + props.canvasOffset.y
+            ? childFrame.y + childFrame.height + props.canvasOffset.y
             : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
-        const beforeLineEndX =
+
+        const lineEndX =
           direction == 'column'
             ? parentFrame.x + parentFrame.width + props.canvasOffset.x
-            : childFrame.x + props.canvasOffset.x
-        const beforeLineEndY =
+            : childFrame.x + childFrame.width + props.canvasOffset.x
+        const lineEndY =
           direction == 'column'
-            ? childFrame.y + props.canvasOffset.y
+            ? childFrame.y + childFrame.height + props.canvasOffset.y
             : parentFrame.y + parentFrame.height + props.canvasOffset.y
         controlProps.push({
-          key: EP.toString(child.elementPath) + '0',
-          positionX: beforeX,
-          positionY: beforeY,
-          lineEndX: beforeLineEndX,
-          lineEndY: beforeLineEndY,
+          key: EP.toString(child.elementPath),
+          positionX: positionX,
+          positionY: positionY,
+          lineEndX: lineEndX,
+          lineEndY: lineEndY,
           isHorizontalLine: direction === 'column',
           parentPath: parentPath,
           indexPosition: {
             type: 'absolute',
-            index: 0,
+            index: index + 1,
           },
         })
+        // first element has a plus button before the element too
+        if (index === 0) {
+          const beforeX =
+            direction == 'column'
+              ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
+              : childFrame.x + props.canvasOffset.x
+          const beforeY =
+            direction == 'column'
+              ? childFrame.y + props.canvasOffset.y
+              : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
+          const beforeLineEndX =
+            direction == 'column'
+              ? parentFrame.x + parentFrame.width + props.canvasOffset.x
+              : childFrame.x + props.canvasOffset.x
+          const beforeLineEndY =
+            direction == 'column'
+              ? childFrame.y + props.canvasOffset.y
+              : parentFrame.y + parentFrame.height + props.canvasOffset.y
+          controlProps.push({
+            key: EP.toString(child.elementPath) + '0',
+            positionX: beforeX,
+            positionY: beforeY,
+            lineEndX: beforeLineEndX,
+            lineEndY: beforeLineEndY,
+            isHorizontalLine: direction === 'column',
+            parentPath: parentPath,
+            indexPosition: {
+              type: 'absolute',
+              index: 0,
+            },
+          })
+        }
       }
-    }
-  })
-  return (
-    <>
-      {controlProps.map((control) => (
-        <InsertionButtonContainer {...control} key={control.key} />
-      ))}
-    </>
-  )
-}
+    })
+    return (
+      <>
+        {controlProps.map((control) => (
+          <InsertionButtonContainer {...control} key={control.key} />
+        ))}
+      </>
+    )
+  },
+)
 
-const InsertionButtonContainer = (props: ButtonControlProps) => {
-  const [plusVisible, setPlusVisible] = React.useState(false)
+const InsertionButtonContainer = betterReactMemo(
+  'InsertionButtonContainer',
+  (props: ButtonControlProps) => {
+    const [plusVisible, setPlusVisible] = React.useState(false)
 
-  const onMouseEnter = () => setPlusVisible(true)
-  const onMouseLeave = () => setPlusVisible(false)
+    const onMouseEnter = () => setPlusVisible(true)
+    const onMouseLeave = () => setPlusVisible(false)
 
-  return (
-    <div
-      key={props.key}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-      style={{
-        position: 'absolute',
-        left: props.positionX,
-        top: props.positionY,
-      }}
-    >
-      {plusVisible ? (
-        <>
-          <Line {...props} />
-          <PlusButton {...props} />
-        </>
-      ) : (
-        <BlueDot {...props} />
-      )}
-    </div>
-  )
-}
+    return (
+      <div
+        key={props.key}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        style={{
+          position: 'absolute',
+          left: props.positionX,
+          top: props.positionY,
+        }}
+      >
+        {plusVisible ? (
+          <>
+            <Line {...props} />
+            <PlusButton {...props} />
+          </>
+        ) : (
+          <BlueDot {...props} />
+        )}
+      </div>
+    )
+  },
+)
+
 const BlueDotSize = 7
-const BlueDot = (props: ButtonControlProps) => {
+const BlueDot = betterReactMemo('BlueDot', (props: ButtonControlProps) => {
+  const colorTheme = useColorTheme()
   return (
     <div
       style={{
@@ -182,11 +189,12 @@ const BlueDot = (props: ButtonControlProps) => {
       />
     </div>
   )
-}
+})
 
 const ButtonSize = 12
-const PlusButton = (props: ButtonControlProps) => {
+const PlusButton = betterReactMemo('PlusButton', (props: ButtonControlProps) => {
   const dispatch = useEditorState((store) => store.dispatch, 'PlusButton dispatch')
+  const colorTheme = useColorTheme()
   const { parentPath, indexPosition } = props
   const insertElement = React.useCallback(() => {
     dispatch(
@@ -231,9 +239,10 @@ const PlusButton = (props: ButtonControlProps) => {
       </div>
     </div>
   )
-}
+})
 
-const Line = (props: ButtonControlProps) => {
+const Line = betterReactMemo('Line', (props: ButtonControlProps) => {
+  const colorTheme = useColorTheme()
   return (
     <div
       style={{
@@ -246,4 +255,4 @@ const Line = (props: ButtonControlProps) => {
       }}
     />
   )
-}
+})

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -27,6 +27,9 @@ import { getAllTargetsAtPoint } from '../dom-lookup'
 import { mapDropNulls } from '../../../core/shared/array-utils'
 import { isSceneAgainstImports, isSceneFromMetadata } from '../../../core/model/project-file-utils'
 import { foldEither, isRight } from '../../../core/shared/either'
+import { when } from '../../../utils/react-conditionals'
+import { InsertionControls } from './insertion-plus-button'
+import { isFeatureEnabled } from '../../../utils/feature-switches'
 
 function getDistanceGuidelines(
   highlightedView: ElementPath,
@@ -503,6 +506,7 @@ export class SelectModeControlContainer extends React.Component<
             </React.Fragment>
           )
         })}
+        {when(isFeatureEnabled('Insertion Plus Button'), <InsertionControls {...this.props} />)}
         {this.props.selectionEnabled ? (
           <>
             <OutlineControls {...this.props} />

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -47,6 +47,8 @@ import {
 } from '../../inspector/common/inspector-utils'
 import { EditorAction } from '../../editor/action-types'
 import { InspectorInputEmotionStyle } from '../../../uuiui/inputs/base-input'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import { safeIndex } from '../../../core/shared/array-utils'
 
 type InsertMenuItemValue = InsertableComponent & {
   source: InsertableComponentGroupType | null
@@ -357,14 +359,14 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
     }
   }, [])
 
-  const insertMenuMode = useEditorState(
-    (store) => store.editor.floatingInsertMenu.insertMenuMode,
-    'FloatingMenu insertMenuMode',
+  const floatingMenuState = useEditorState(
+    (store) => store.editor.floatingInsertMenu,
+    'FloatingMenu floatingMenuState',
   )
 
-  const showInsertionControls = insertMenuMode === 'insert'
+  const showInsertionControls = floatingMenuState.insertMenuMode === 'insert'
 
-  const menuTitle: string = getMenuTitle(insertMenuMode)
+  const menuTitle: string = getMenuTitle(floatingMenuState.insertMenuMode)
 
   const componentSelectorStyles = useComponentSelectorStyles()
   const dispatch = useEditorState((store) => store.dispatch, 'FloatingMenu dispatch')
@@ -383,62 +385,79 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
         const selectedViews = selectedViewsref.current
 
         let actionsToDispatch: Array<EditorAction> = []
-        if (insertMenuMode === 'wrap') {
-          const newUID = generateUidWithExistingComponents(projectContentsRef.current)
-          const newElement = jsxElement(
-            pickedInsertableComponent.element.name,
-            newUID,
-            setJSXAttributesAttribute(
-              pickedInsertableComponent.element.props,
-              'data-uid',
-              jsxAttributeValue(newUID, emptyComments),
-            ),
-            pickedInsertableComponent.element.children,
-          )
-
-          actionsToDispatch = [
-            wrapInView(selectedViews, {
-              element: newElement,
-              importsToAdd: pickedInsertableComponent.importsToAdd,
-            }),
-          ]
-        } else if (insertMenuMode === 'insert') {
-          let elementToInsert = pickedInsertableComponent
-          if (addContentForInsertion && pickedInsertableComponent.element.children.length === 0) {
-            elementToInsert = {
-              ...pickedInsertableComponent,
-              element: {
-                ...pickedInsertableComponent.element,
-                children: [jsxTextBlock('Utopia')],
-              },
-            }
-          }
-
-          // TODO multiselect?
-          actionsToDispatch = [
-            insertWithDefaults(
-              selectedViews[0],
-              elementToInsert,
-              fixedSizeForInsertion ? 'add-size' : 'do-not-add',
-            ),
-          ]
-        } else if (insertMenuMode === 'convert') {
-          // this is taken from render-as.tsx
-          const targetsForUpdates = getElementsToTarget(selectedViews)
-          actionsToDispatch = targetsForUpdates.flatMap((path) => {
-            return updateJSXElementName(
-              path,
+        switch (floatingMenuState.insertMenuMode) {
+          case 'wrap': {
+            const newUID = generateUidWithExistingComponents(projectContentsRef.current)
+            const newElement = jsxElement(
               pickedInsertableComponent.element.name,
-              pickedInsertableComponent.importsToAdd,
+              newUID,
+              setJSXAttributesAttribute(
+                pickedInsertableComponent.element.props,
+                'data-uid',
+                jsxAttributeValue(newUID, emptyComments),
+              ),
+              pickedInsertableComponent.element.children,
             )
-          })
+
+            actionsToDispatch = [
+              wrapInView(selectedViews, {
+                element: newElement,
+                importsToAdd: pickedInsertableComponent.importsToAdd,
+              }),
+            ]
+            break
+          }
+          case 'insert': {
+            let elementToInsert = pickedInsertableComponent
+            if (addContentForInsertion && pickedInsertableComponent.element.children.length === 0) {
+              elementToInsert = {
+                ...pickedInsertableComponent,
+                element: {
+                  ...pickedInsertableComponent.element,
+                  children: [jsxTextBlock('Utopia')],
+                },
+              }
+            }
+
+            const targetParent: ElementPath | null =
+              floatingMenuState.parentPath ?? safeIndex(selectedViews, 0) ?? null
+            if (targetParent != null) {
+              // TODO multiselect?
+              actionsToDispatch = [
+                insertWithDefaults(
+                  targetParent,
+                  elementToInsert,
+                  fixedSizeForInsertion ? 'add-size' : 'do-not-add',
+                  floatingMenuState.indexPosition,
+                ),
+              ]
+            }
+            break
+          }
+          case 'convert': {
+            // this is taken from render-as.tsx
+            const targetsForUpdates = getElementsToTarget(selectedViews)
+            actionsToDispatch = targetsForUpdates.flatMap((path) => {
+              return updateJSXElementName(
+                path,
+                pickedInsertableComponent.element.name,
+                pickedInsertableComponent.importsToAdd,
+              )
+            })
+            break
+          }
+          case 'closed':
+            break
+          default:
+            const _exhaustiveCheck: never = floatingMenuState
+            throw new Error(`Unhandled type ${JSON.stringify(floatingMenuState)}`)
         }
         dispatch([...actionsToDispatch, closeFloatingInsertMenu()])
       }
     },
     [
       dispatch,
-      insertMenuMode,
+      floatingMenuState,
       projectContentsRef,
       selectedViewsref,
       fixedSizeForInsertion,

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -199,7 +199,13 @@ export const insert: ContextMenuItem<CanvasData> = {
   shortcut: 'A',
   enabled: true,
   action: (data, dispatch) => {
-    requireDispatch(dispatch)([EditorActions.openFloatingInsertMenu('insert')])
+    requireDispatch(dispatch)([
+      EditorActions.openFloatingInsertMenu({
+        insertMenuMode: 'insert',
+        parentPath: null,
+        indexPosition: null,
+      }),
+    ])
   },
 }
 
@@ -208,7 +214,7 @@ export const convert: ContextMenuItem<CanvasData> = {
   shortcut: 'C',
   enabled: true,
   action: (data, dispatch) => {
-    requireDispatch(dispatch)([EditorActions.openFloatingInsertMenu('convert')])
+    requireDispatch(dispatch)([EditorActions.openFloatingInsertMenu({ insertMenuMode: 'convert' })])
   },
 }
 
@@ -240,7 +246,10 @@ export const wrapInPicker: ContextMenuItem<CanvasData> = {
   shortcut: 'G',
   enabled: true,
   action: (data, dispatch?: EditorDispatch) => {
-    requireDispatch(dispatch)([EditorActions.openFloatingInsertMenu('wrap')], 'everyone')
+    requireDispatch(dispatch)(
+      [EditorActions.openFloatingInsertMenu({ insertMenuMode: 'wrap' })],
+      'everyone',
+    )
   },
 }
 

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -38,6 +38,7 @@ import {
   DuplicationState,
   EditorState,
   ErrorMessages,
+  FloatingInsertMenuState,
   LeftMenuTab,
   ModalDialog,
   OriginalFrame,
@@ -425,7 +426,7 @@ export interface WrapInView {
 
 export interface OpenFloatingInsertMenu {
   action: 'OPEN_FLOATING_INSERT_MENU'
-  mode: 'insert' | 'convert' | 'wrap'
+  mode: FloatingInsertMenuState
 }
 
 export interface CloseFloatingInsertMenu {
@@ -861,6 +862,7 @@ export interface InsertWithDefaults {
   targetParent: ElementPath
   toInsert: InsertableComponent
   styleProps: StylePropOption
+  indexPosition: IndexPosition | null
 }
 
 export interface SetPropTransient {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -33,6 +33,7 @@ import type {
 } from '../../../core/shared/project-file-types'
 import type { BuildType } from '../../../core/workers/ts/ts-worker'
 import type { Key, KeysPressed } from '../../../utils/keyboard'
+import { IndexPosition } from '../../../utils/utils'
 import type { objectKeyParser, parseString } from '../../../utils/value-parser-utils'
 import type { CSSCursor } from '../../../uuiui-deps'
 import type {
@@ -200,6 +201,7 @@ import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } fro
 import type {
   DuplicationState,
   ErrorMessages,
+  FloatingInsertMenuState,
   LeftMenuTab,
   ModalDialog,
   OriginalFrame,
@@ -625,9 +627,7 @@ export function unwrapGroupOrView(target: ElementPath): UnwrapGroupOrView {
   }
 }
 
-export function openFloatingInsertMenu(
-  mode: 'insert' | 'convert' | 'wrap',
-): OpenFloatingInsertMenu {
+export function openFloatingInsertMenu(mode: FloatingInsertMenuState): OpenFloatingInsertMenu {
   return {
     action: 'OPEN_FLOATING_INSERT_MENU',
     mode: mode,
@@ -1390,12 +1390,14 @@ export function insertWithDefaults(
   targetParent: ElementPath,
   toInsert: InsertableComponent,
   styleProps: StylePropOption,
+  indexPosition: IndexPosition | null,
 ): InsertWithDefaults {
   return {
     action: 'INSERT_WITH_DEFAULTS',
     targetParent: targetParent,
     toInsert: toInsert,
     styleProps: styleProps,
+    indexPosition: indexPosition,
   }
 }
 

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -1144,7 +1144,7 @@ describe('INSERT_WITH_DEFAULTS', () => {
       ['app-outer-div', 'card-instance'],
       ['card-outer-div'],
     ])
-    const action = insertWithDefaults(targetPath, menuInsertable, 'do-not-add')
+    const action = insertWithDefaults(targetPath, menuInsertable, 'do-not-add', null)
     const actualResult = UPDATE_FNS.INSERT_WITH_DEFAULTS(action, editorState)
     const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
     if (isTextFile(cardFile)) {
@@ -1239,7 +1239,7 @@ describe('INSERT_WITH_DEFAULTS', () => {
       ['app-outer-div', 'card-instance'],
       ['card-outer-div'],
     ])
-    const action = insertWithDefaults(targetPath, menuInsertable, 'add-size')
+    const action = insertWithDefaults(targetPath, menuInsertable, 'add-size', null)
     const actualResult = UPDATE_FNS.INSERT_WITH_DEFAULTS(action, editorState)
     const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
     if (isTextFile(cardFile)) {
@@ -1333,7 +1333,7 @@ describe('INSERT_WITH_DEFAULTS', () => {
       ['app-outer-div', 'card-instance'],
       ['card-outer-div'],
     ])
-    const action = insertWithDefaults(targetPath, imgInsertable, 'add-size')
+    const action = insertWithDefaults(targetPath, imgInsertable, 'add-size', null)
     const actualResult = UPDATE_FNS.INSERT_WITH_DEFAULTS(action, editorState)
     const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
     if (isTextFile(cardFile)) {
@@ -1375,6 +1375,91 @@ describe('INSERT_WITH_DEFAULTS', () => {
                 <img
                   style={{ width: 100, height: 100 }}
                   src='/editor/icons/favicons/favicon128.png?hash=nocommit\\"'
+                />
+              </div>
+            )
+          }
+          "
+        `)
+      } else {
+        fail('File does not contain parse success.')
+      }
+    } else {
+      fail('File is not a text file.')
+    }
+  })
+
+  it('inserts an img element into the project, also adding style props, added at the back', () => {
+    const project = complexDefaultProject()
+    const editorState = editorModelFromPersistentModel(project, NO_OP)
+
+    const insertableGroups = getComponentGroups(
+      {},
+      {},
+      editorState.projectContents,
+      [],
+      StoryboardFilePath,
+    )
+    const htmlGroup = forceNotNull(
+      'Group should exist.',
+      insertableGroups.find((group) => {
+        return group.source.type === 'HTML_GROUP'
+      }),
+    )
+    const imgInsertable = forceNotNull(
+      'Component should exist.',
+      htmlGroup.insertableComponents.find((insertable) => {
+        return insertable.name === 'img'
+      }),
+    )
+
+    const targetPath = EP.elementPath([
+      ['storyboard-entity', 'scene-1-entity', 'app-entity'],
+      ['app-outer-div', 'card-instance'],
+      ['card-outer-div'],
+    ])
+    const action = insertWithDefaults(targetPath, imgInsertable, 'add-size', { type: 'back' })
+    const actualResult = UPDATE_FNS.INSERT_WITH_DEFAULTS(action, editorState)
+    const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
+    if (isTextFile(cardFile)) {
+      const parsed = cardFile.fileContents.parsed
+      if (isParseSuccess(parsed)) {
+        const printedCode = printCode(
+          printCodeOptions(false, true, true, true),
+          parsed.imports,
+          parsed.topLevelElements,
+          parsed.jsxFactoryFunction,
+          parsed.exportsDetail,
+        )
+        expect(printedCode).toMatchInlineSnapshot(`
+          "import * as React from 'react'
+          import { Rectangle } from 'utopia-api'
+          export var Card = (props) => {
+            return (
+              <div style={{ ...props.style }}>
+                <img
+                  style={{ width: 100, height: 100 }}
+                  src='/editor/icons/favicons/favicon128.png?hash=nocommit\\"'
+                />
+                <div
+                  style={{
+                    position: 'absolute',
+                    left: 0,
+                    top: 0,
+                    width: 50,
+                    height: 50,
+                    backgroundColor: 'red',
+                  }}
+                />
+                <Rectangle
+                  style={{
+                    position: 'absolute',
+                    left: 100,
+                    top: 200,
+                    width: 50,
+                    height: 50,
+                    backgroundColor: 'blue',
+                  }}
                 />
               </div>
             )

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -997,9 +997,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
       scrollAnimation: currentEditor.canvas.scrollAnimation,
       transientProperties: null,
     },
-    floatingInsertMenu: {
-      insertMenuMode: currentEditor.floatingInsertMenu.insertMenuMode,
-    },
+    floatingInsertMenu: currentEditor.floatingInsertMenu,
     inspector: {
       visible: currentEditor.inspector.visible,
     },
@@ -2223,10 +2221,7 @@ export const UPDATE_FNS = {
   OPEN_FLOATING_INSERT_MENU: (action: OpenFloatingInsertMenu, editor: EditorModel): EditorModel => {
     return {
       ...editor,
-      floatingInsertMenu: {
-        ...editor.floatingInsertMenu,
-        insertMenuMode: action.mode,
-      },
+      floatingInsertMenu: action.mode,
     }
   },
   CLOSE_FLOATING_INSERT_MENU: (
@@ -2236,7 +2231,6 @@ export const UPDATE_FNS = {
     return {
       ...editor,
       floatingInsertMenu: {
-        ...editor.floatingInsertMenu,
         insertMenuMode: 'closed',
       },
     }
@@ -4490,7 +4484,7 @@ export const UPDATE_FNS = {
             action.targetParent,
             element,
             utopiaComponents,
-            null,
+            action.indexPosition,
           )
 
           const newPath = EP.appendToPath(action.targetParent, newUID)

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -572,7 +572,7 @@ export function handleKeyDown(
       },
       [WRAP_ELEMENT_PICKER_SHORTCUT]: () => {
         return isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)
-          ? [EditorActions.openFloatingInsertMenu('wrap')]
+          ? [EditorActions.openFloatingInsertMenu({ insertMenuMode: 'wrap' })]
           : []
       },
       // For now, the "Group / G" shortcuts do the same as the Wrap Element shortcuts – until we have Grouping working again
@@ -583,7 +583,7 @@ export function handleKeyDown(
       },
       [GROUP_ELEMENT_PICKER_SHORTCUT]: () => {
         return isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)
-          ? [EditorActions.openFloatingInsertMenu('wrap')]
+          ? [EditorActions.openFloatingInsertMenu({ insertMenuMode: 'wrap' })]
           : []
       },
       [TOGGLE_HIDDEN_SHORTCUT]: () => {
@@ -748,14 +748,20 @@ export function handleKeyDown(
       },
       [CONVERT_ELEMENT_SHORTCUT]: () => {
         if (isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)) {
-          return [EditorActions.openFloatingInsertMenu('convert')]
+          return [EditorActions.openFloatingInsertMenu({ insertMenuMode: 'convert' })]
         } else {
           return []
         }
       },
       [ADD_ELEMENT_SHORTCUT]: () => {
         if (isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)) {
-          return [EditorActions.openFloatingInsertMenu('insert')]
+          return [
+            EditorActions.openFloatingInsertMenu({
+              insertMenuMode: 'insert',
+              parentPath: null,
+              indexPosition: null,
+            }),
+          ]
         } else {
           return []
         }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -289,6 +289,30 @@ export interface NavigatorState {
   position: 'hidden' | 'left' | 'right'
 }
 
+export interface FloatingInsertMenuStateClosed {
+  insertMenuMode: 'closed'
+}
+
+export interface FloatingInsertMenuStateInsert {
+  insertMenuMode: 'insert'
+  parentPath: ElementPath | null
+  indexPosition: IndexPosition | null
+}
+
+export interface FloatingInsertMenuStateConvert {
+  insertMenuMode: 'convert'
+}
+
+export interface FloatingInsertMenuStateWrap {
+  insertMenuMode: 'wrap'
+}
+
+export type FloatingInsertMenuState =
+  | FloatingInsertMenuStateClosed
+  | FloatingInsertMenuStateInsert
+  | FloatingInsertMenuStateConvert
+  | FloatingInsertMenuStateWrap
+
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
   id: string | null
@@ -363,9 +387,7 @@ export interface EditorState {
       attributesToUpdate: MapLike<JSXAttribute>
     }> | null
   }
-  floatingInsertMenu: {
-    insertMenuMode: 'closed' | 'insert' | 'convert' | 'wrap'
-  }
+  floatingInsertMenu: FloatingInsertMenuState
   inspector: {
     visible: boolean
   }

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -58,8 +58,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(400) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(410)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(410) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(420)
   })
 
   it('Changing the selected view', async () => {
@@ -111,7 +111,7 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(430) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(440)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(440) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(450)
   })
 })

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -12,6 +12,7 @@ export type FeatureName =
   | 'TopMenu ClassNames'
   | 'Click on empty canvas unfocuses'
   | 'Layout Section Experimental'
+  | 'Insertion Plus Button'
 
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
@@ -23,6 +24,7 @@ export const AllFeatureNames: FeatureName[] = [
   'TopMenu ClassNames',
   'Click on empty canvas unfocuses',
   'Layout Section Experimental',
+  'Insertion Plus Button',
 ]
 
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {
@@ -35,6 +37,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'TopMenu ClassNames': false,
   'Click on empty canvas unfocuses': true,
   'Layout Section Experimental': false,
+  'Insertion Plus Button': true,
 }
 
 function settingKeyForName(featureName: FeatureName): string {


### PR DESCRIPTION
![Screenshot Thu 22 Jul 15:37:59 BST 2021](https://user-images.githubusercontent.com/217400/126657887-4b5bc663-1505-4d02-bd7c-5e647150f60b.png)


Fixes #1548.

**Problem:**
It's hard to insert flex children in at the right place without creating them and moving them immediately afterwards.

**Fix:**
Extra controls are now provided when a flex child is selected which triggers the insert pop-up, which in turn will insert at the point indicated by the control selected.

**Commit Details:**
- Resurrects #636.
- Fixes #1548.
- Adds `Insertion Plus Button` feature switch.
- Refactored out the type of `EditorState.floatingInsertMenu` into
  a standalone type.
- Added `parentPath` and `indexPosition` fields to the `insert` case
  of `FloatingInsertMenuState`.
- `InsertionControls` component ported across from above experiment,
  with some minor tweaks.
