### PR TITLE
feature(inspector) new flex element subsection

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -5,6 +5,14 @@ import { PositionControl, MarginControl, AlignSelfControl } from './flex-element
 import { PropertyLabel } from '../../../widgets/property-label'
 import { createLayoutPropertyPath } from '../../../../../core/layout/layout-helpers-new'
 import { betterReactMemo } from '../../../../../uuiui-deps'
+import { FunctionIcons, InspectorSubsectionHeader, SquareButton } from '../../../../../uuiui'
+import { ExpandableIndicator } from '../../../../navigator/navigator-item/expandable-indicator'
+import {
+  FlexBasisShorthandCSSNumberControl,
+  FlexShorthandNumberControl,
+  FlexStyleNumberControl,
+} from '../self-layout-subsection/gigantic-size-pins-subsection'
+import { InlineLink } from '../../../../../uuiui/inline-button'
 
 const marginProps = [
   createLayoutPropertyPath('marginLeft'),
@@ -33,5 +41,135 @@ export const FlexElementSubsection = betterReactMemo('FlexElementSubsection', ()
         <AlignSelfControl />
       </UIGridRow>
     </>
+  )
+})
+
+interface FlexElementSubsectionProps {
+  parentFlexDirection: string | null
+}
+
+export const FlexElementSubsectionExperiment = betterReactMemo(
+  'FlexElementSubsectionExperiment',
+  (props: FlexElementSubsectionProps) => {
+    return (
+      <>
+        <MainAxisControls {...props} />
+        <CrossAxisControls {...props} />
+      </>
+    )
+  },
+)
+
+const MainAxisControls = betterReactMemo(
+  'MainAxisControls',
+  (props: FlexElementSubsectionProps) => {
+    const widthOrHeightControls =
+      props.parentFlexDirection === 'row' || props.parentFlexDirection === 'row-reverse' ? (
+        <FlexWidthControls />
+      ) : (
+        <FlexHeightControls />
+      )
+    return (
+      <>
+        <InspectorSubsectionHeader style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <span>Main Axis</span>{' '}
+          <SquareButton highlight>
+            <ExpandableIndicator
+              testId='flex-element-subsection'
+              visible
+              collapsed={false}
+              selected={false}
+            />
+          </SquareButton>
+        </InspectorSubsectionHeader>
+        <UIGridRow padded={true} variant='<-------------1fr------------->'>
+          <FlexBasisShorthandCSSNumberControl label='B' />
+        </UIGridRow>
+        <FlexGrowShrinkRow />
+        <InspectorSubsectionHeader>
+          <InlineLink>Fixed</InlineLink>
+          <SquareButton highlight>
+            <FunctionIcons.Delete />
+          </SquareButton>
+        </InspectorSubsectionHeader>
+        {widthOrHeightControls}
+        <InspectorSubsectionHeader>
+          <InlineLink>Advanced</InlineLink>
+          <SquareButton highlight>
+            <FunctionIcons.Delete />
+          </SquareButton>
+        </InspectorSubsectionHeader>
+        <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
+          <PropertyLabel target={alignSelfProp}>Align Self</PropertyLabel>
+          <AlignSelfControl />
+        </UIGridRow>
+      </>
+    )
+  },
+)
+
+const CrossAxisControls = betterReactMemo(
+  'CrossAxisControls',
+  (props: FlexElementSubsectionProps) => {
+    const widthOrHeightControls =
+      props.parentFlexDirection === 'column' || props.parentFlexDirection === 'column-reverse' ? (
+        <FlexHeightControls />
+      ) : (
+        <FlexWidthControls />
+      )
+    return (
+      <>
+        <InspectorSubsectionHeader style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div style={{ justifySelf: 'flex-start' }}>Cross Axis</div>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <InlineLink>+</InlineLink>
+            <SquareButton highlight>
+              <ExpandableIndicator
+                testId='flex-element-subsection'
+                visible
+                collapsed={false}
+                selected={false}
+              />
+            </SquareButton>
+          </div>
+        </InspectorSubsectionHeader>
+        {widthOrHeightControls}
+      </>
+    )
+  },
+)
+
+const FlexWidthControls = betterReactMemo('FlexWidthControls', () => {
+  return (
+    <>
+      <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
+        <FlexBasisShorthandCSSNumberControl label='W' />
+      </UIGridRow>
+      <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
+        <FlexStyleNumberControl label='min' styleProp='minWidth' />
+        <FlexStyleNumberControl label='max' styleProp='maxWidth' />
+      </UIGridRow>
+    </>
+  )
+})
+const FlexHeightControls = betterReactMemo('FlexWidthControls', () => {
+  return (
+    <>
+      <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
+        <FlexBasisShorthandCSSNumberControl label='H' />
+      </UIGridRow>
+      <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
+        <FlexStyleNumberControl label='min' styleProp='minHeight' />
+        <FlexStyleNumberControl label='max' styleProp='maxHeight' />
+      </UIGridRow>
+    </>
+  )
+})
+const FlexGrowShrinkRow = betterReactMemo('FlexGrowShrinkRow', () => {
+  return (
+    <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
+      <FlexShorthandNumberControl label='G' styleProp='flexGrow' />
+      <FlexShorthandNumberControl label='S' styleProp='flexShrink' />
+    </UIGridRow>
   )
 })

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -481,7 +481,7 @@ const flexGrowShrinkProps = [
   createLayoutPropertyPath('flexShrink'),
 ]
 
-export const FlexGrowShrinkRow = betterReactMemo('FlexGrowShrinkRow', () => {
+const FlexGrowShrinkRow = betterReactMemo('FlexGrowShrinkRow', () => {
   return (
     <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
       <PropertyLabel target={flexGrowShrinkProps}>Flex</PropertyLabel>

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -481,7 +481,7 @@ const flexGrowShrinkProps = [
   createLayoutPropertyPath('flexShrink'),
 ]
 
-const FlexGrowShrinkRow = betterReactMemo('FlexGrowShrinkRow', () => {
+export const FlexGrowShrinkRow = betterReactMemo('FlexGrowShrinkRow', () => {
   return (
     <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
       <PropertyLabel target={flexGrowShrinkProps}>Flex</PropertyLabel>

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -16,7 +16,7 @@ import { useEditorState, useRefEditorState } from '../../../../editor/store/stor
 import { ExpandableIndicator } from '../../../../navigator/navigator-item/expandable-indicator'
 import { CSSPosition } from '../../../common/css-utils'
 import * as EP from '../../../../../core/shared/element-path'
-import { FlexElementSubsection } from '../flex-element-subsection/flex-element-subsection'
+import { FlexElementSubsectionExperiment } from '../flex-element-subsection/flex-element-subsection'
 import { GiganticSizePinsSubsection } from './gigantic-size-pins-subsection'
 import { selectComponents } from '../../../../editor/actions/action-creators'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
@@ -59,13 +59,19 @@ export const LayoutSubsection = betterReactMemo(
       <>
         <LayoutSectionHeader layoutType={activeTab} />
         {when(activeTab === 'flex', <FlexInfoBox />)}
-        <GiganticSizePinsSubsection
-          layoutType={activeTab}
-          parentFlexDirection={props.parentFlexDirection}
-          aspectRatioLocked={props.aspectRatioLocked}
-          toggleAspectRatioLock={props.toggleAspectRatioLock}
-        />
-        {activeTab === 'flex' ? <FlexElementSubsection /> : null}
+        {when(
+          activeTab !== 'flex',
+          <GiganticSizePinsSubsection
+            layoutType={activeTab}
+            parentFlexDirection={props.parentFlexDirection}
+            aspectRatioLocked={props.aspectRatioLocked}
+            toggleAspectRatioLock={props.toggleAspectRatioLock}
+          />,
+        )}
+        {when(
+          activeTab === 'flex',
+          <FlexElementSubsectionExperiment parentFlexDirection={props.parentFlexDirection} />,
+        )}
       </>
     )
   },

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -20,7 +20,7 @@ import { FlexElementSubsectionExperiment } from '../flex-element-subsection/flex
 import { GiganticSizePinsSubsection } from './gigantic-size-pins-subsection'
 import { selectComponents } from '../../../../editor/actions/action-creators'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
-import { when } from '../../../../../utils/react-conditionals'
+import { unless, when } from '../../../../../utils/react-conditionals'
 
 type SelfLayoutTab = 'absolute' | 'flex' | 'flow' | 'sticky'
 
@@ -59,8 +59,8 @@ export const LayoutSubsection = betterReactMemo(
       <>
         <LayoutSectionHeader layoutType={activeTab} />
         {when(activeTab === 'flex', <FlexInfoBox />)}
-        {when(
-          activeTab !== 'flex',
+        {unless(
+          activeTab === 'flex',
           <GiganticSizePinsSubsection
             layoutType={activeTab}
             parentFlexDirection={props.parentFlexDirection}


### PR DESCRIPTION
**Problem:**
Continuing https://github.com/concrete-utopia/utopia/pull/1552. This time the flex element section is rearranged.

This is all behind the Layout Section feature switch

**Commit Details:**
<img width="297" alt="Screenshot 2021-07-22 at 17 06 28" src="https://user-images.githubusercontent.com/4403069/126662440-60b01ee8-6991-41c7-acea-3a73ebd9a437.png">

