### PR TITLE
Make inspector text options more widely available.

### DIFF
--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -989,6 +989,9 @@ export function useIsSubSectionVisible(sectionName: string): boolean {
               return !subSectionAvailable.deniedElementTypes.includes(type)
             case 'allowall':
               return true
+            default:
+              const _exhaustiveCheck: never = subSectionAvailable
+              throw new Error(`Unhandled type ${JSON.stringify(subSectionAvailable)}`)
           }
         }
       }

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -975,29 +975,70 @@ export function useIsSubSectionVisible(sectionName: string): boolean {
       )
     })
     return types.every((type) => {
-      const allowedTypes = StyleSubSectionForType[sectionName]
-      if (allowedTypes == null) {
+      const subSectionAvailable = StyleSubSectionForType[sectionName]
+      if (subSectionAvailable == null) {
         return false
       } else {
-        if (typeof allowedTypes === 'boolean') {
-          return allowedTypes
+        if (type == null) {
+          return true
         } else {
-          return allowedTypes.find((t) => t === type)
+          switch (subSectionAvailable.type) {
+            case 'permit':
+              return subSectionAvailable.allowedElementTypes.includes(type)
+            case 'deny':
+              return !subSectionAvailable.deniedElementTypes.includes(type)
+            case 'allowall':
+              return true
+          }
         }
       }
     })
   }, 'useIsSubSectionVisible')
 }
 
-const StyleSubSectionForType: { [key: string]: string[] | boolean } = {
-  text: ['div', 'span', 'text'],
-  textShadow: ['div', 'span', 'text'],
-  shadow: true,
-  border: true,
-  opacity: true,
-  background: true,
-  img: ['img'],
-  transform: true,
+interface SubSectionPermitList {
+  type: 'permit'
+  allowedElementTypes: Array<string>
+}
+
+function subSectionPermitList(allowedElementTypes: Array<string>): SubSectionPermitList {
+  return {
+    type: 'permit',
+    allowedElementTypes: allowedElementTypes,
+  }
+}
+
+interface SubSectionDenyList {
+  type: 'deny'
+  deniedElementTypes: Array<string>
+}
+
+function subSectionDenyList(deniedElementTypes: Array<string>): SubSectionDenyList {
+  return {
+    type: 'deny',
+    deniedElementTypes: deniedElementTypes,
+  }
+}
+
+interface SubSectionAllowAll {
+  type: 'allowall'
+}
+
+const subSectionAllowAll: SubSectionAllowAll = {
+  type: 'allowall',
+}
+
+type SubSectionAvailable = SubSectionPermitList | SubSectionDenyList | SubSectionAllowAll
+
+const StyleSubSectionForType: { [key: string]: SubSectionAvailable } = {
+  text: subSectionDenyList(['img', 'video']),
+  textShadow: subSectionDenyList(['img', 'video']),
+  shadow: subSectionAllowAll,
+  border: subSectionAllowAll,
+  opacity: subSectionAllowAll,
+  background: subSectionAllowAll,
+  img: subSectionPermitList(['img']),
+  transform: subSectionAllowAll,
 }
 
 export function useSelectedPropertyControls(

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -58,8 +58,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(400) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(410)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(520) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(530)
   })
 
   it('Changing the selected view', async () => {
@@ -111,7 +111,7 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(430) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(440)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(490) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(500)
   })
 })


### PR DESCRIPTION
Fixes #1562

**Problem:**
We've been using a permit list for the inspector sections, which means it's easy to miss out elements that ideally should have sections like the font sections.

**Fix:**
For the text sections we now use a deny list, with only `img` and `video` in it.

**Commit Details:**
- Fixes #1562.
- Reworked `StyleSubSectionForType` to support permit, deny or allow all
  options.
- Updated `useIsSubSectionVisible` with the above changes.
- Put `img` and `video` in as deny options for the `text` and `textShadow`
  inspector sections.
- Put `img` in for the permit list of the `img` inspector section.
- Every other inspector section set with the allow all option.
