### PR TITLE
Shortcut for focusing the classname input

### DIFF
--- a/editor/src/components/canvas/controls/formula-bar.tsx
+++ b/editor/src/components/canvas/controls/formula-bar.tsx
@@ -21,17 +21,7 @@ import {
   handleShortcuts,
   TOGGLE_FOCUSED_OMNIBOX_TAB,
 } from '../../editor/shortcut-definitions'
-
-function useFocusOnCountIncrease(triggerCount: number): React.RefObject<HTMLInputElement> {
-  const ref = React.useRef<HTMLInputElement>(null)
-  const previousTriggerCountRef = React.useRef(triggerCount)
-  if (previousTriggerCountRef.current !== triggerCount) {
-    previousTriggerCountRef.current = triggerCount
-    // eslint-disable-next-line no-unused-expressions
-    ref.current?.focus()
-  }
-  return ref
-}
+import { useInputFocusOnCountIncrease } from '../../editor/hook-utils'
 
 export const FormulaBar = betterReactMemo('FormulaBar', () => {
   const saveTimerRef = React.useRef<any>(null)
@@ -56,7 +46,7 @@ export const FormulaBar = betterReactMemo('FormulaBar', () => {
     'FormulaBar formulaBarFocusCounter',
   )
 
-  const inputRef = useFocusOnCountIncrease(focusTriggerCount)
+  const inputRef = useInputFocusOnCountIncrease<HTMLInputElement>(focusTriggerCount)
 
   const colorTheme = useColorTheme()
   const [simpleText, setSimpleText] = React.useState('')

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -847,6 +847,10 @@ export interface SetCurrentTheme {
   theme: Theme
 }
 
+export interface FocusClassNameInput {
+  action: 'FOCUS_CLASS_NAME_INPUT'
+}
+
 export interface FocusFormulaBar {
   action: 'FOCUS_FORMULA_BAR'
 }
@@ -1016,6 +1020,7 @@ export type EditorAction =
   | ResetCanvas
   | SetFilebrowserDropTarget
   | SetCurrentTheme
+  | FocusClassNameInput
   | FocusFormulaBar
   | UpdateFormulaBarMode
   | InsertWithDefaults

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -195,6 +195,7 @@ import type {
   SetPropTransient,
   ClearTransientProps,
   AddTailwindConfig,
+  FocusClassNameInput,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -1370,6 +1371,12 @@ export function setCurrentTheme(theme: Theme): SetCurrentTheme {
   return {
     action: 'SET_CURRENT_THEME',
     theme: theme,
+  }
+}
+
+export function focusClassNameInput(): FocusClassNameInput {
+  return {
+    action: 'FOCUS_CLASS_NAME_INPUT',
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -92,6 +92,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_FILEBROWSER_DROPTARGET':
     case 'SET_FORKED_FROM_PROJECT_ID':
     case 'SET_CURRENT_THEME':
+    case 'FOCUS_CLASS_NAME_INPUT':
     case 'FOCUS_FORMULA_BAR':
     case 'UPDATE_FORMULA_BAR_MODE':
     case 'OPEN_FLOATING_INSERT_MENU':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -367,6 +367,7 @@ import {
   SetPropTransient,
   ClearTransientProps,
   AddTailwindConfig,
+  FocusClassNameInput,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -1002,6 +1003,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     },
     inspector: {
       visible: currentEditor.inspector.visible,
+      classnameFocusCounter: currentEditor.inspector.classnameFocusCounter,
     },
     fileBrowser: {
       minimised: currentEditor.fileBrowser.minimised,
@@ -4418,7 +4420,16 @@ export const UPDATE_FNS = {
       theme: action.theme,
     }
   },
-  FOCUS_FORMULA_BAR: (action: FocusFormulaBar, editor: EditorModel): EditorModel => {
+  FOCUS_CLASS_NAME_INPUT: (editor: EditorModel): EditorModel => {
+    return {
+      ...editor,
+      inspector: {
+        ...editor.inspector,
+        classnameFocusCounter: editor.inspector.classnameFocusCounter + 1,
+      },
+    }
+  },
+  FOCUS_FORMULA_BAR: (editor: EditorModel): EditorModel => {
     return {
       ...editor,
       topmenu: {

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -117,6 +117,7 @@ import {
   GROUP_ELEMENT_PICKER_SHORTCUT,
   GROUP_ELEMENT_DEFAULT_SHORTCUT,
   TOGGLE_FOCUSED_OMNIBOX_TAB,
+  FOCUS_CLASS_NAME_INPUT,
 } from './shortcut-definitions'
 import { DerivedState, EditorState, getOpenFile } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
@@ -724,6 +725,9 @@ export function handleKeyDown(
         return isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)
           ? [EditorActions.moveSelectedToFront()]
           : []
+      },
+      [FOCUS_CLASS_NAME_INPUT]: () => {
+        return [EditorActions.focusClassNameInput()]
       },
       [TOGGLE_FOCUSED_OMNIBOX_TAB]: () => {
         return [EditorActions.focusFormulaBar()]

--- a/editor/src/components/editor/hook-utils.ts
+++ b/editor/src/components/editor/hook-utils.ts
@@ -26,3 +26,15 @@ export function useForceUpdate() {
   const [, forceUpdate] = React.useReducer((c) => c + 1, 0)
   return forceUpdate
 }
+
+export function useInputFocusOnCountIncrease<T extends { focus: () => void }>(
+  triggerCount: number,
+): React.RefObject<T> {
+  const ref = React.useRef<T>(null)
+  const previousTriggerCountRef = React.useRef(triggerCount)
+  if (previousTriggerCountRef.current !== triggerCount) {
+    previousTriggerCountRef.current = triggerCount
+    ref.current?.focus()
+  }
+  return ref
+}

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -85,6 +85,7 @@ export const MOVE_ELEMENT_FORWARD_SHORTCUT = 'move-element-forward'
 export const MOVE_ELEMENT_TO_FRONT_SHORTCUT = 'move-element-to-front'
 export const MOVE_ELEMENT_BACKWARD_SHORTCUT = 'move-element-backward'
 export const MOVE_ELEMENT_TO_BACK_SHORTCUT = 'move-element-to-back'
+export const FOCUS_CLASS_NAME_INPUT = 'focus-inspector-class-name-input'
 export const TOGGLE_FOCUSED_OMNIBOX_TAB = 'toggle-focused-omnibox-tab'
 export const TOGGLE_TEXT_UNDERLINE_SHORTCUT = 'toggle-text-underline'
 export const TOGGLE_LEFT_MENU_SHORTCUT = 'toggle-left-menu'
@@ -262,6 +263,10 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
   [MOVE_ELEMENT_TO_BACK_SHORTCUT]: shortcut(
     'Move element to the back in relation to its siblings.',
     key('[', ['alt', 'cmd']),
+  ),
+  [FOCUS_CLASS_NAME_INPUT]: shortcut(
+    'Focus the classname input field in the inspector.',
+    key('forwardslash', ['alt', 'cmd']),
   ),
   [TOGGLE_FOCUSED_OMNIBOX_TAB]: shortcut(
     'Focus the omnibox or toggle its current tab.',

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -368,6 +368,7 @@ export interface EditorState {
   }
   inspector: {
     visible: boolean
+    classnameFocusCounter: number
   }
   fileBrowser: {
     minimised: boolean
@@ -1147,6 +1148,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     },
     inspector: {
       visible: true,
+      classnameFocusCounter: 0,
     },
     dependencyList: {
       minimised: false,
@@ -1398,6 +1400,7 @@ export function editorModelFromPersistentModel(
     },
     inspector: {
       visible: true,
+      classnameFocusCounter: 0,
     },
     dependencyList: persistentModel.dependencyList,
     genericExternalResources: {

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -301,8 +301,10 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SET_FORKED_FROM_PROJECT_ID(action, state)
     case 'SET_CURRENT_THEME':
       return UPDATE_FNS.SET_CURRENT_THEME(action, state)
+    case 'FOCUS_CLASS_NAME_INPUT':
+      return UPDATE_FNS.FOCUS_CLASS_NAME_INPUT(state)
     case 'FOCUS_FORMULA_BAR':
-      return UPDATE_FNS.FOCUS_FORMULA_BAR(action, state)
+      return UPDATE_FNS.FOCUS_FORMULA_BAR(state)
     case 'UPDATE_FORMULA_BAR_MODE':
       return UPDATE_FNS.UPDATE_FORMULA_BAR_MODE(action, state)
     case 'CLOSE_FLOATING_INSERT_MENU':

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -35,6 +35,7 @@ import {
   usePubSubAtomWriteOnly,
 } from '../../../../../core/shared/atom-with-pub-sub'
 import { last } from '../../../../../core/shared/array-utils'
+import { useInputFocusOnCountIncrease } from '../../../../editor/hook-utils'
 
 const IndicatorsContainer: React.FunctionComponent<IndicatorContainerProps<TailWindOption>> = () =>
   null
@@ -191,6 +192,12 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
   const shouldPreviewOnFocusRef = React.useRef(false)
   const updateFocusedOption = usePubSubAtomWriteOnly(focusedOptionAtom)
   const focusedValueRef = React.useRef<string | null>(null)
+
+  const focusTriggerCount = useEditorState(
+    (store) => store.editor.inspector.classnameFocusCounter,
+    'ClassNameSubsection classnameFocusCounter',
+  )
+  const inputRef = useInputFocusOnCountIncrease<CreatableSelect<TailWindOption>>(focusTriggerCount)
 
   const clearFocusedOption = React.useCallback(() => {
     shouldPreviewOnFocusRef.current = false
@@ -413,6 +420,7 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
       </InspectorSubsectionHeader>
       <UIGridRow padded variant='<-------------1fr------------->'>
         <CreatableSelect
+          ref={inputRef}
           autoFocus={false}
           placeholder='Add class…'
           isMulti


### PR DESCRIPTION
Fixes #1563 

**Problem:**
We need a shortcut for focusing the classname input

**Fix:**
Add a mapping from `cmd`+`alt`+`/` to trigger it. I've also extracted a useful hook we were using in the formula bar for this.
