### PR TITLE
Fix/wrap in element 1

### DIFF
--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -32,6 +32,7 @@ import {
   insertWithDefaults,
   updateJSXElementName,
   wrapInView,
+  wrapInElement,
 } from '../../editor/actions/action-creators'
 import { generateUidWithExistingComponents } from '../../../core/model/element-template-utils'
 import {
@@ -47,6 +48,7 @@ import {
 } from '../../inspector/common/inspector-utils'
 import { EditorAction } from '../../editor/action-types'
 import { InspectorInputEmotionStyle } from '../../../uuiui/inputs/base-input'
+import { when } from '../../../utils/react-conditionals'
 
 type InsertMenuItemValue = InsertableComponent & {
   source: InsertableComponentGroupType | null
@@ -363,6 +365,7 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
   )
 
   const showInsertionControls = insertMenuMode === 'insert'
+  const showWrapControls = insertMenuMode === 'wrap'
 
   const menuTitle: string = getMenuTitle(insertMenuMode)
 
@@ -375,6 +378,7 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
 
   const [addContentForInsertion, setAddContentForInsertion] = React.useState(false)
   const [fixedSizeForInsertion, setFixedSizeForInsertion] = React.useState(false)
+  const [preserveVisualPositionForWrap, setPreserveVisualPositionForWrap] = React.useState(false)
 
   const onChange = React.useCallback(
     (value: ValueType<InsertMenuItem, false>) => {
@@ -397,10 +401,15 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
           )
 
           actionsToDispatch = [
-            wrapInView(selectedViews, {
-              element: newElement,
-              importsToAdd: pickedInsertableComponent.importsToAdd,
-            }),
+            preserveVisualPositionForWrap
+              ? wrapInView(selectedViews, {
+                  element: newElement,
+                  importsToAdd: pickedInsertableComponent.importsToAdd,
+                })
+              : wrapInElement(selectedViews, {
+                  element: newElement,
+                  importsToAdd: pickedInsertableComponent.importsToAdd,
+                }),
           ]
         } else if (insertMenuMode === 'insert') {
           let elementToInsert = pickedInsertableComponent
@@ -443,6 +452,7 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
       selectedViewsref,
       fixedSizeForInsertion,
       addContentForInsertion,
+      preserveVisualPositionForWrap,
     ],
   )
 
@@ -527,6 +537,25 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
             </CheckboxRow>
           </FlexRow>
         ) : null}
+        {when(
+          showWrapControls,
+          <FlexRow
+            css={{
+              height: UtopiaTheme.layout.rowHeight.normal,
+              paddingLeft: 8,
+              paddingRight: 8,
+              borderTop: `1px solid ${colorTheme.border1.value}`,
+            }}
+          >
+            <CheckboxRow
+              id='preserve-visual-position-checkbox'
+              checked={preserveVisualPositionForWrap}
+              onChange={setPreserveVisualPositionForWrap}
+            >
+              Try to preserve visual position
+            </CheckboxRow>
+          </FlexRow>,
+        )}
       </FlexColumn>
     </div>
   )

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -423,6 +423,12 @@ export interface WrapInView {
   whatToWrapWith: { element: JSXElement; importsToAdd: Imports } | 'default-empty-div'
 }
 
+export interface WrapInElement {
+  action: 'WRAP_IN_ELEMENT'
+  targets: ElementPath[]
+  whatToWrapWith: { element: JSXElement; importsToAdd: Imports }
+}
+
 export interface OpenFloatingInsertMenu {
   action: 'OPEN_FLOATING_INSERT_MENU'
   mode: 'insert' | 'convert' | 'wrap'
@@ -935,6 +941,7 @@ export type EditorAction =
   | SaveAsset
   | ResetPins
   | WrapInView
+  | WrapInElement
   | OpenFloatingInsertMenu
   | CloseFloatingInsertMenu
   | UnwrapGroupOrView

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -195,6 +195,7 @@ import type {
   SetPropTransient,
   ClearTransientProps,
   AddTailwindConfig,
+  WrapInElement,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -642,6 +643,17 @@ export function wrapInView(
     action: 'WRAP_IN_VIEW',
     targets: targets,
     layoutSystem: LayoutSystem.PinSystem,
+    whatToWrapWith: whatToWrapWith,
+  }
+}
+
+export function wrapInElement(
+  targets: Array<ElementPath>,
+  whatToWrapWith: { element: JSXElement; importsToAdd: Imports },
+): WrapInElement {
+  return {
+    action: 'WRAP_IN_ELEMENT',
+    targets: targets,
     whatToWrapWith: whatToWrapWith,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -122,6 +122,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'deprecated_TOGGLE_ENABLED_PROPERTY':
     case 'RESET_PINS':
     case 'WRAP_IN_VIEW':
+    case 'WRAP_IN_ELEMENT':
     case 'UNWRAP_GROUP_OR_VIEW':
     case 'SET_CANVAS_FRAMES':
     case 'SET_PROJECT_NAME':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -860,6 +860,7 @@ export function editorReparentNoStyleChange(
   newParentPath: ElementPath,
   editor: EditorModel,
 ): EditorModel {
+  // this code structure with the two withUnderlyingTargetFromEditorStates is copied verbatim from canvas-utils.ts@moveTemplate
   return withUnderlyingTargetFromEditorState(
     target,
     editor,

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -2243,6 +2243,15 @@ export const UPDATE_FNS = {
           derived,
         )
         const parentPath = EP.getCommonParent(orderedActionTargets)
+        const indexInParent = optionalMap(
+          (firstPsthMatchingCommonParent) =>
+            MetadataUtils.getViewZIndexFromMetadata(
+              editor.jsxMetadata,
+              firstPsthMatchingCommonParent,
+            ),
+          orderedActionTargets.find((target) => EP.pathsEqual(EP.parentPath(target), parentPath)),
+        )
+
         if (parentPath === null) {
           return editor
         } else {
@@ -2254,8 +2263,6 @@ export const UPDATE_FNS = {
             uiFileKey,
             parentPath,
           )
-
-          const parent = MetadataUtils.findElementByElementPath(editor.jsxMetadata, parentPath)
 
           const targetSuccess = normalisePathSuccessOrThrowError(underlyingTarget)
 
@@ -2272,7 +2279,13 @@ export const UPDATE_FNS = {
                 parentPath,
                 elementToInsert,
                 utopiaJSXComponents,
-                null,
+                optionalMap(
+                  (index) => ({
+                    type: 'before',
+                    index: index,
+                  }),
+                  indexInParent,
+                ),
               )
 
               viewPath = EP.appendToPath(parentPath, newUID)

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -231,6 +231,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.DELETE_SELECTED(action, state, derivedState, dispatch)
     case 'WRAP_IN_VIEW':
       return UPDATE_FNS.WRAP_IN_VIEW(action, state, derivedState, dispatch)
+    case 'WRAP_IN_ELEMENT':
+      return UPDATE_FNS.WRAP_IN_ELEMENT(action, state, derivedState, dispatch)
     case 'OPEN_FLOATING_INSERT_MENU':
       return UPDATE_FNS.OPEN_FLOATING_INSERT_MENU(action, state)
     case 'UNWRAP_GROUP_OR_VIEW':


### PR DESCRIPTION
Fixes #1546

**Fix:**
WRAP_IN_ELEMENT action only wraps things and reparents things without touching their style object. This will work for most flex cases, and will not produce nice results for Pinned cases

**Commit Details:**
- made new `editorReparentNoStyleChange` which I copy-pasted from `moveTemplate`
- new WRAP_IN_ELEMENT action uses this instead of moveTemplate
- floating insert menu has a checkbox to switch between new WRAP_IN_ELEMENT and old WRAP_IN_VIEW behavior

<img width="297" alt="image" src="https://user-images.githubusercontent.com/2226774/126682755-82fcac4d-5321-451b-b783-5ae9ca0d5f19.png">

