### PR TITLE
WRAP_IN_VIEW fixes

### DIFF
--- a/editor/src/components/canvas/canvas-utils.spec.browser.tsx
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.tsx
@@ -965,7 +965,6 @@ describe('moveTemplate', () => {
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       makeTestProjectCodeWithSnippet(`
       <View style={{ ...props.style }} data-uid='aaa'>
-        <View data-uid='eee' />
         <div
           style={{ position: 'absolute', left: 52, top: 61, width: 256, height: 202 }}
           data-uid='${NewUID}'
@@ -979,6 +978,7 @@ describe('moveTemplate', () => {
             </View>
           </View>
         </div>
+        <View data-uid='eee' />
       </View>
       `),
     )

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -48,6 +48,7 @@ import {
   isJSXArbitraryBlock,
   isJSXFragment,
   isUtopiaJSXComponent,
+  SettableLayoutSystem,
 } from '../../core/shared/element-template'
 import {
   getAllUniqueUids,
@@ -451,6 +452,7 @@ export function updateFramesOfScenesAndComponents(
               frameAndTarget.newSize.height,
               element.props,
               right(parentElement.props),
+              eitherToMaybe(FlexLayoutHelpers.getMainAxis(right(parentElement.props))),
               frameAndTarget.edgePosition,
             )
             forEachRight(possibleFlexProps, (flexProps) => {
@@ -1862,7 +1864,8 @@ export function moveTemplate(
   componentMetadata: ElementInstanceMetadataMap,
   selectedViews: Array<ElementPath>,
   highlightedViews: Array<ElementPath>,
-  newParentLayoutSystem: LayoutSystem | null,
+  newParentLayoutSystem: SettableLayoutSystem | null,
+  newParentMainAxis: 'horizontal' | 'vertical' | null,
 ): MoveTemplateResult {
   function noChanges(): MoveTemplateResult {
     return {
@@ -1911,6 +1914,7 @@ export function moveTemplate(
               utopiaComponentsIncludingScenes,
               parentFrame,
               newParentLayoutSystem,
+              newParentMainAxis,
             )
             const updatedUnderlyingElement = findElementAtPath(
               underlyingTarget,
@@ -2137,6 +2141,7 @@ function produceMoveTransientCanvasState(
           workingEditorState.jsxMetadata,
           selectedViews,
           workingEditorState.highlightedViews,
+          null,
           null,
         )
         selectedViews = reparentResult.updatedEditorState.selectedViews

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -38,6 +38,7 @@ import { generateUidWithExistingComponents } from '../../../core/model/element-t
 import {
   jsxAttributeValue,
   jsxElement,
+  JSXElementName,
   jsxTextBlock,
   setJSXAttributesAttribute,
 } from '../../../core/shared/element-template'
@@ -51,6 +52,7 @@ import { InspectorInputEmotionStyle } from '../../../uuiui/inputs/base-input'
 import { when } from '../../../utils/react-conditionals'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { safeIndex } from '../../../core/shared/array-utils'
+import { LayoutSystem } from 'utopia-api'
 
 type InsertMenuItemValue = InsertableComponent & {
   source: InsertableComponentGroupType | null
@@ -124,6 +126,26 @@ function useGetInsertableComponents(): InsertableComponentFlatList {
   }, [packageStatus, propertyControlsInfo, projectContents, dependencies, fullPath])
 
   return insertableComponents
+}
+
+function getIsFlexBasedOnName_KILLME_EXPERIMENTAL(name: JSXElementName): boolean {
+  return (
+    name.propertyPath.propertyElements.length === 0 &&
+    (name.baseVariable === 'FlexRow' || name.baseVariable === 'FlexCol')
+  )
+}
+
+function getIsFlexDirectionBasedOnName_KILLME_SERIOUSLY_EXPERIMENTAL(
+  name: JSXElementName,
+): 'horizontal' | 'vertical' | null {
+  if (name.propertyPath.propertyElements.length === 0) {
+    if (name.baseVariable === 'FlexRow') {
+      return 'horizontal'
+    } else if (name.baseVariable === 'FlexCol') {
+      return 'vertical'
+    }
+  }
+  return null
 }
 
 function useComponentSelectorStyles(): StylesConfig<InsertMenuItem, false> {
@@ -403,12 +425,24 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
               pickedInsertableComponent.element.children,
             )
 
+            const isFlexLayoutSystemMaybe_KILLME = getIsFlexBasedOnName_KILLME_EXPERIMENTAL(
+              newElement.name,
+            )
+            const flexDirection_KILLME = getIsFlexDirectionBasedOnName_KILLME_SERIOUSLY_EXPERIMENTAL(
+              newElement.name,
+            )
+
             actionsToDispatch = [
               preserveVisualPositionForWrap
-                ? wrapInView(selectedViews, {
-                    element: newElement,
-                    importsToAdd: pickedInsertableComponent.importsToAdd,
-                  })
+                ? wrapInView(
+                    selectedViews,
+                    {
+                      element: newElement,
+                      importsToAdd: pickedInsertableComponent.importsToAdd,
+                    },
+                    isFlexLayoutSystemMaybe_KILLME ? 'flex' : LayoutSystem.PinSystem,
+                    flexDirection_KILLME,
+                  )
                 : wrapInElement(selectedViews, {
                     element: newElement,
                     importsToAdd: pickedInsertableComponent.importsToAdd,

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -420,7 +420,8 @@ export type ResetPins = {
 export interface WrapInView {
   action: 'WRAP_IN_VIEW'
   targets: ElementPath[]
-  layoutSystem: LayoutSystem
+  layoutSystem: SettableLayoutSystem
+  newParentMainAxis: 'horizontal' | 'vertical' | null
   whatToWrapWith: { element: JSXElement; importsToAdd: Imports } | 'default-empty-div'
 }
 

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -638,11 +638,14 @@ export function openFloatingInsertMenu(mode: FloatingInsertMenuState): OpenFloat
 export function wrapInView(
   targets: Array<ElementPath>,
   whatToWrapWith: { element: JSXElement; importsToAdd: Imports } | 'default-empty-div',
+  layoutSystem: SettableLayoutSystem = LayoutSystem.PinSystem,
+  newParentMainAxis: 'horizontal' | 'vertical' | null = null,
 ): WrapInView {
   return {
     action: 'WRAP_IN_VIEW',
     targets: targets,
-    layoutSystem: LayoutSystem.PinSystem,
+    layoutSystem: layoutSystem,
+    newParentMainAxis: newParentMainAxis,
     whatToWrapWith: whatToWrapWith,
   }
 }

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -422,6 +422,7 @@ describe('moveTemplate', () => {
       null,
       editor,
       null,
+      null,
     ).editor
 
     const newUiJsFile = getContentsTreeFileFromString(
@@ -465,6 +466,7 @@ describe('moveTemplate', () => {
         height: 100,
       } as CanvasRectangle,
       editor,
+      null,
       null,
     ).editor
 
@@ -514,6 +516,7 @@ describe('moveTemplate', () => {
       } as CanvasRectangle,
       editor,
       null,
+      null,
     ).editor
 
     const newUiJsFile = getContentsTreeFileFromString(
@@ -548,6 +551,7 @@ describe('moveTemplate', () => {
       null,
       editor,
       null,
+      null,
     ).editor
 
     const newUiJsFile = getContentsTreeFileFromString(
@@ -580,6 +584,7 @@ describe('moveTemplate', () => {
       EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa']),
       null,
       editor,
+      null,
       null,
     ).editor
 
@@ -615,6 +620,7 @@ describe('moveTemplate', () => {
       null,
       editor,
       null,
+      null,
     ).editor
 
     const newUiJsFile = getContentsTreeFileFromString(
@@ -647,6 +653,7 @@ describe('moveTemplate', () => {
       EP.appendNewElementPath(ScenePath1ForTestUiJsFile, ['ccc']),
       null,
       editor,
+      null,
       null,
     ).editor
 
@@ -700,6 +707,7 @@ describe('moveTemplate', () => {
       groupFrame,
       editor,
       LayoutSystem.Group,
+      null,
     ).editor
 
     const newUiJsFile = getContentsTreeFileFromString(
@@ -760,6 +768,7 @@ describe('moveTemplate', () => {
       null,
       editor,
       null,
+      null,
     ).editor
 
     const newUiJsFile = getContentsTreeFileFromString(
@@ -811,6 +820,7 @@ describe('moveTemplate', () => {
       EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa']),
       null,
       editor,
+      null,
       null,
     ).editor
 

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -2101,10 +2101,10 @@ export const UPDATE_FNS = {
         )
         const parentPath = EP.getCommonParent(orderedActionTargets)
         const indexInParent = optionalMap(
-          (firstPsthMatchingCommonParent) =>
+          (firstPathMatchingCommonParent) =>
             MetadataUtils.getViewZIndexFromMetadata(
               editor.jsxMetadata,
-              firstPsthMatchingCommonParent,
+              firstPathMatchingCommonParent,
             ),
           orderedActionTargets.find((target) => EP.pathsEqual(EP.parentPath(target), parentPath)),
         )
@@ -2267,10 +2267,10 @@ export const UPDATE_FNS = {
         )
         const parentPath = EP.getCommonParent(orderedActionTargets)
         const indexInParent = optionalMap(
-          (firstPsthMatchingCommonParent) =>
+          (firstPathMatchingCommonParent) =>
             MetadataUtils.getViewZIndexFromMetadata(
               editor.jsxMetadata,
-              firstPsthMatchingCommonParent,
+              firstPathMatchingCommonParent,
             ),
           orderedActionTargets.find((target) => EP.pathsEqual(EP.parentPath(target), parentPath)),
         )

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -2190,9 +2190,9 @@ export const UPDATE_FNS = {
             return editor
           }
 
-          const frameChanges: Array<PinOrFlexFrameChange> = [
-            getFrameChange(viewPath, boundingBox, isParentFlex),
-          ]
+          const frameChanges: Array<PinOrFlexFrameChange> = isParentFlex
+            ? [] // if we are wrapping something in a Flex parent, try not adding frames here
+            : [getFrameChange(viewPath, boundingBox, isParentFlex)]
           const withWrapperViewAdded = {
             ...setCanvasFramesInnerNew(withWrapperViewAddedNoFrame, frameChanges, null),
           }

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -861,7 +861,8 @@ export function editorMoveMultiSelectedTemplates(
   newParentPath: ElementPath | null,
   parentFrame: CanvasRectangle | null,
   editor: EditorModel,
-  newParentLayoutType: LayoutSystem | null,
+  newParentLayoutType: SettableLayoutSystem | null,
+  newParentMainAxis: 'horizontal' | 'vertical' | null,
 ): {
   editor: EditorModel
   newPaths: Array<ElementPath>
@@ -881,6 +882,7 @@ export function editorMoveMultiSelectedTemplates(
       parentFrame,
       working,
       newParentLayoutType,
+      newParentMainAxis,
     )
     if (newPath != null) {
       // when moving multiselected elements that are in a hierarchy the editor has the ancestor with a new path
@@ -907,7 +909,8 @@ export function editorMoveTemplate(
   newParentPath: ElementPath | null,
   parentFrame: CanvasRectangle | null,
   editor: EditorModel,
-  newParentLayoutSystem: LayoutSystem | null,
+  newParentLayoutSystem: SettableLayoutSystem | null,
+  newParentMainAxis: 'horizontal' | 'vertical' | null,
 ): {
   editor: EditorModel
   newPath: ElementPath | null
@@ -924,6 +927,7 @@ export function editorMoveTemplate(
     editor.selectedViews,
     editor.highlightedViews,
     newParentLayoutSystem,
+    newParentMainAxis,
   )
   return {
     newPath: moveResult.newPath,
@@ -1185,6 +1189,7 @@ function setZIndexOnSelected(
         EP.parentPath(selectedView),
         null,
         editor,
+        null,
         null,
       ).editor
     },
@@ -1720,6 +1725,7 @@ export const UPDATE_FNS = {
       newParentSize,
       editor,
       null,
+      null,
     )
 
     return {
@@ -1737,6 +1743,7 @@ export const UPDATE_FNS = {
       EP.parentPath(action.target),
       null,
       editor,
+      null,
       null,
     ).editor
   },
@@ -2208,6 +2215,7 @@ export const UPDATE_FNS = {
             parentBounds,
             withWrapperViewAdded,
             action.layoutSystem,
+            action.newParentMainAxis,
           ).editor
 
           return {
@@ -2396,6 +2404,7 @@ export const UPDATE_FNS = {
             parentPath,
             parentFrame,
             working,
+            null,
             null,
           )
           if (result.newPath != null) {
@@ -2744,6 +2753,7 @@ export const UPDATE_FNS = {
                 action.targetOriginalContextMetadata,
                 workingEditorState.jsxMetadata,
                 components,
+                null,
                 null,
                 null,
               )

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -2100,6 +2100,15 @@ export const UPDATE_FNS = {
           derived,
         )
         const parentPath = EP.getCommonParent(orderedActionTargets)
+        const indexInParent = optionalMap(
+          (firstPsthMatchingCommonParent) =>
+            MetadataUtils.getViewZIndexFromMetadata(
+              editor.jsxMetadata,
+              firstPsthMatchingCommonParent,
+            ),
+          orderedActionTargets.find((target) => EP.pathsEqual(EP.parentPath(target), parentPath)),
+        )
+
         if (parentPath === null) {
           return editor
         } else {
@@ -2166,7 +2175,13 @@ export const UPDATE_FNS = {
                 parentPath,
                 elementToInsertWithPositionAttribute,
                 utopiaJSXComponents,
-                null,
+                optionalMap(
+                  (index) => ({
+                    type: 'before',
+                    index: index,
+                  }),
+                  indexInParent,
+                ),
               )
 
               viewPath = EP.appendToPath(parentPath, newUID)

--- a/editor/src/core/layout/layout-helpers.ts
+++ b/editor/src/core/layout/layout-helpers.ts
@@ -231,7 +231,6 @@ export const FlexLayoutHelpers = {
     possibleMainAxis: 'horizontal' | 'vertical' | null,
     edgePosition: EdgePosition | null,
   ): Either<string, FixedAndBases> => {
-    // const possibleMainAxis = FlexLayoutHelpers.getMainAxis(parentProps)
     const currentFlexBasis = eitherToMaybe(getSimpleAttributeAtPath(right(props), FlexBasisPath))
     const currentWidth = eitherToMaybe(
       getSimpleAttributeAtPath(right(props), createLayoutPropertyPath('Width')),

--- a/editor/src/core/layout/layout-helpers.ts
+++ b/editor/src/core/layout/layout-helpers.ts
@@ -22,6 +22,7 @@ import {
   reduceWithEither,
   right,
   eitherToMaybe,
+  eitherFromMaybe,
 } from '../shared/either'
 import {
   ElementInstanceMetadata,
@@ -145,7 +146,14 @@ export const FlexLayoutHelpers = {
           return setJSXValuesAtPaths(props, propsToSet)
         },
         withoutLayoutProps,
-        FlexLayoutHelpers.convertWidthHeightToFlex(width, height, elementProps, parentProps, null),
+        FlexLayoutHelpers.convertWidthHeightToFlex(
+          width,
+          height,
+          elementProps,
+          parentProps,
+          eitherToMaybe(FlexLayoutHelpers.getMainAxis(parentProps)),
+          null,
+        ),
       ),
     )
   },
@@ -220,9 +228,10 @@ export const FlexLayoutHelpers = {
     height: number,
     props: JSXAttributes,
     parentProps: PropsOrJSXAttributes,
+    possibleMainAxis: 'horizontal' | 'vertical' | null,
     edgePosition: EdgePosition | null,
   ): Either<string, FixedAndBases> => {
-    const possibleMainAxis = FlexLayoutHelpers.getMainAxis(parentProps)
+    // const possibleMainAxis = FlexLayoutHelpers.getMainAxis(parentProps)
     const currentFlexBasis = eitherToMaybe(getSimpleAttributeAtPath(right(props), FlexBasisPath))
     const currentWidth = eitherToMaybe(
       getSimpleAttributeAtPath(right(props), createLayoutPropertyPath('Width')),
@@ -250,7 +259,7 @@ export const FlexLayoutHelpers = {
             ? height
             : null,
       }
-    }, possibleMainAxis)
+    }, eitherFromMaybe('no main axis provided', possibleMainAxis))
   },
   getUnstretchedWidthHeight: (
     props: UtopiaComponentProps,


### PR DESCRIPTION
**Problem:**
WRAP_IN_VIEW is the old wrapping function, (can be enabled if you pick 'Try to preserve visual position' in the floating wrapper menu)
<img width="318" alt="image" src="https://user-images.githubusercontent.com/2226774/126768754-d47eb5b6-9db8-4beb-b4bf-6eae1b738687.png">
the old wrapping function was built in an absolute positioned world. The flex functionality was sort of slapped on it from an absolute positioning POV. Back then we didn't respect the idea that a lot of flex elements **should not have any explicit size properties at all.**

**Fix:**
For specific cases of flex-to-flex reparenting, try not to insert size properties if they weren't there before. If there is a flexBasis or width or height, then we run the old code. If none of the three is present, we don't forcefully insert them.

**Commit Details:**
- Fixed the wrapping index position I already fixed for WRAP_IN_ELEMENT
- Added new conversion function for flex-to-flex layout change, if the flexDimension is different
- Wired through the "new parent flex direction" property so we don't try to fish it out of the metadata, which would fail for obvious reasons during insertion

**Note:**
This is one of the messiest part of the code base. I think that my fix is not harmful, and in the context of working with flex layouts it brings a significant improvements. But the code quality around here deteriorates quickly with every change. I think as we work on more fixes in this area, it's worth considering to not use `moveTemplate` for any new feature ever again because of the incredible baggage.
