### PR TITLE
Fix/inspector delete layout config

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -18,7 +18,11 @@ import {
   ControlStyles,
 } from '../../../common/control-status'
 import { LayoutSystem } from 'utopia-api'
-import { createLayoutPropertyPath } from '../../../../../core/layout/layout-helpers-new'
+import {
+  createLayoutPropertyPath,
+  LayoutProp,
+  StyleLayoutProp,
+} from '../../../../../core/layout/layout-helpers-new'
 import {
   DetectedLayoutSystem,
   SettableLayoutSystem,
@@ -263,20 +267,22 @@ export const FlexPaddingControl = betterReactMemo('FlexPaddingControl', () => {
   )
 })
 
-const layoutSystemConfigPropertyPaths = [
-  createLayoutPropertyPath('LayoutSystem'),
-  PP.create(['style', 'display']),
-  createLayoutPropertyPath('flexDirection'),
-  createLayoutPropertyPath('FlexGap'),
-  createLayoutPropertyPath('flexWrap'),
-  createLayoutPropertyPath('justifyContent'),
-  createLayoutPropertyPath('alignItems'),
-  createLayoutPropertyPath('alignContent'),
-  createLayoutPropertyPath('paddingLeft'),
-  createLayoutPropertyPath('paddingTop'),
-  createLayoutPropertyPath('paddingRight'),
-  createLayoutPropertyPath('paddingBottom'),
+const layoutSystemProperties: Array<LayoutProp | StyleLayoutProp> = [
+  'alignContent',
+  'alignItems',
+  'display',
+  'flexDirection',
+  'flexWrap',
+  'justifyContent',
+  'marginBottom',
+  'marginLeft',
+  'marginRight',
+  'marginTop',
 ]
+
+const layoutSystemConfigPropertyPaths = layoutSystemProperties.map((name) =>
+  createLayoutPropertyPath(name),
+)
 
 function useDeleteAllLayoutConfig() {
   const { onUnsetValue } = React.useContext(InspectorCallbackContext)

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -273,11 +273,13 @@ const layoutSystemProperties: Array<LayoutProp | StyleLayoutProp> = [
   'display',
   'flexDirection',
   'flexWrap',
+  'FlexGap',
   'justifyContent',
   'marginBottom',
   'marginLeft',
   'marginRight',
   'marginTop',
+  'margin',
 ]
 
 const layoutSystemConfigPropertyPaths = layoutSystemProperties.map((name) =>

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -87,7 +87,7 @@ interface LayoutSectionHeaderProps {
   layoutType: SelfLayoutTab | 'grid'
 }
 
-const layoutSystemProperties: Array<LayoutProp | StyleLayoutProp> = [
+const selfLayoutProperties: Array<LayoutProp | StyleLayoutProp> = [
   'alignSelf',
   'bottom',
   'flex',
@@ -119,7 +119,7 @@ const layoutSystemProperties: Array<LayoutProp | StyleLayoutProp> = [
   'PinnedBottom',
 ]
 
-const selfLayoutConfigPropertyPaths = layoutSystemProperties.map((name) =>
+const selfLayoutConfigPropertyPaths = selfLayoutProperties.map((name) =>
   createLayoutPropertyPath(name),
 )
 

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -21,6 +21,12 @@ import { GiganticSizePinsSubsection } from './gigantic-size-pins-subsection'
 import { selectComponents } from '../../../../editor/actions/action-creators'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import { unless, when } from '../../../../../utils/react-conditionals'
+import { InspectorCallbackContext } from '../../../common/property-path-hooks'
+import {
+  createLayoutPropertyPath,
+  LayoutProp,
+  StyleLayoutProp,
+} from '../../../../../core/layout/layout-helpers-new'
 
 type SelfLayoutTab = 'absolute' | 'flex' | 'flow' | 'sticky'
 
@@ -81,9 +87,53 @@ interface LayoutSectionHeaderProps {
   layoutType: SelfLayoutTab | 'grid'
 }
 
+const layoutSystemProperties: Array<LayoutProp | StyleLayoutProp> = [
+  'alignSelf',
+  'bottom',
+  'flex',
+  'flexBasis',
+  'flexGrow',
+  'flexShrink',
+  'left',
+  'marginBottom',
+  'marginLeft',
+  'marginRight',
+  'marginTop',
+  'maxHeight',
+  'maxWidth',
+  'minHeight',
+  'minWidth',
+  'paddingBottom',
+  'paddingLeft',
+  'paddingRight',
+  'paddingTop',
+  'padding',
+  'position',
+  'right',
+  'top',
+  'Width',
+  'Height',
+  'PinnedLeft',
+  'PinnedTop',
+  'PinnedRight',
+  'PinnedBottom',
+]
+
+const selfLayoutConfigPropertyPaths = layoutSystemProperties.map((name) =>
+  createLayoutPropertyPath(name),
+)
+
+function useDeleteAllSelfLayoutConfig() {
+  const { onUnsetValue } = React.useContext(InspectorCallbackContext)
+  return React.useCallback(() => {
+    onUnsetValue(selfLayoutConfigPropertyPaths, false)
+  }, [onUnsetValue])
+}
+
 const LayoutSectionHeader = betterReactMemo(
   'LayoutSectionHeader',
   (props: LayoutSectionHeaderProps) => {
+    const onDeleteAllConfig = useDeleteAllSelfLayoutConfig()
     return (
       <InspectorSubsectionHeader>
         <div style={{ flexGrow: 1, display: 'flex', gap: 8 }}>
@@ -100,7 +150,7 @@ const LayoutSectionHeader = betterReactMemo(
           <SelfLink />
           <ChildrenOrContentLink />
         </div>
-        <SquareButton highlight>
+        <SquareButton highlight onClick={onDeleteAllConfig}>
           <FunctionIcons.Delete />
         </SquareButton>
         <SquareButton highlight>

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -60,6 +60,7 @@ export type StyleLayoutProp =
   | 'marginRight'
   | 'marginBottom'
   | 'marginLeft'
+  | 'margin'
   | 'display'
 
 export type LayoutProp =
@@ -155,6 +156,7 @@ const LayoutPathMap: { [key in LayoutProp | StyleLayoutProp]: Array<PropertyPath
   marginRight: ['style', 'marginRight'],
   marginBottom: ['style', 'marginBottom'],
   marginLeft: ['style', 'marginLeft'],
+  margin: ['style', 'margin'],
   padding: ['style', 'padding'],
   paddingTop: ['style', 'paddingTop'],
   paddingRight: ['style', 'paddingRight'],


### PR DESCRIPTION
Fixes the inspector, allows deleting layout properties.

**Problem:**
An element style set to `position: absolute` can be deleted only using the code editor.

**Fix:**
Updating the current layout system list, because it still had the old layoutSystem in it.
Adding the ability to unset from the new experimental layout section for self layout properties.
The list is not complete yet, it contains style properties that we were already showing in the inspector.
