### PR TITLE
Support unfocusing a component via the context menu

### DIFF
--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -24,6 +24,7 @@ import {
   scrollToElement,
   insert,
   convert,
+  removeAsFocusedElement,
 } from './context-menu-items'
 import { MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState } from './editor/store/store-hook'
@@ -49,6 +50,7 @@ interface ElementContextMenuProps {
 
 const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
   setAsFocusedElement,
+  removeAsFocusedElement,
   lineSeparator,
   scrollToElement,
   cutElements,
@@ -189,6 +191,7 @@ export const ElementContextMenu = betterReactMemo(
         resolve: store.editor.codeResultCache.resolve,
         hiddenInstances: store.editor.hiddenInstances,
         scale: store.editor.canvas.scale,
+        focusedElementPath: store.editor.focusedElementPath,
       }
     })
 
@@ -204,6 +207,7 @@ export const ElementContextMenu = betterReactMemo(
         resolve: currentEditor.resolve,
         hiddenInstances: currentEditor.hiddenInstances,
         scale: currentEditor.scale,
+        focusedElementPath: currentEditor.focusedElementPath,
       }
     }, [editorSliceRef])
 


### PR DESCRIPTION
Fixes #1534 

**Problem:**
We can focus a component from the context menu but can't unfocus it.

**Fix:**
Add a menu item to support unfocusing the selected component. Set the `isHidden` behaviour to only show that option if the selected element is focused. Update the `isHidden` behaviour to hide the "Edit Component" option if the selected element is already focused.