### PR TITLE
Blur classname select when pressing esc

### DIFF
--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -310,6 +310,10 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
         }
       }
 
+      if (event.key === 'Escape') {
+        inputRef.current?.blur()
+      }
+
       const namesByKey = applyShortcutConfigurationToDefaults(
         editorStoreRef.current.userState.shortcutConfig,
       )
@@ -322,7 +326,7 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
         },
       })
     },
-    [clearFocusedOption, dispatch, editorStoreRef, filter, selectedOptions],
+    [clearFocusedOption, dispatch, editorStoreRef, filter, inputRef, selectedOptions],
   )
 
   const multiValueLabel: styleFn = React.useCallback(


### PR DESCRIPTION
Fixes #1586 

**Problem:**
react-select doesn't blur when hitting `esc`

**Fix:**
Manually handle that key in the same place we have added other custom key logic
