### PR TITLE
Hide canvas controls when changing the Tailwind classnames.

### DIFF
--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -236,6 +236,10 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
 
   const onChange = React.useCallback(
     (newValueType: ValueType<TailWindOption>) => {
+      // As the value of the dropdown is changing, hide the selection
+      // controls so they can see the results of what they're doing.
+      EditorActions.hideAndShowSelectionControls(dispatch)
+
       const newValue = valueTypeAsArray(newValueType)
       if (elementPath != null) {
         if (queuedDispatchTimeout != null) {
@@ -272,6 +276,10 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
+      // As someone is typing, hide the selection
+      // controls so they can see the results of what they're doing.
+      EditorActions.hideAndShowSelectionControls(dispatch)
+
       const shouldStopPreviewing =
         filter === '' && (event.key === 'ArrowLeft' || event.key === 'ArrowRight')
 


### PR DESCRIPTION
Fixes #1561

**Problem:**
The canvas controls can obscure the result of changing the Tailwind classnames.

**Fix:**
Use our existing functionality for hiding the canvas controls in a couple of the event handlers tied to changing the classnames.

**Commit Details:**
- Fixes #1561.
- Added some calls to `hideAndShowSelectionControls` in event handlers.