### PR TITLE
Fix/floating insert menu

### DIFF
--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -380,6 +380,7 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
     // when the user "tabs out" to the checkboxes, prevent react-select from clearing the input text
     if (actionMeta.action !== 'input-blur' && actionMeta.action !== 'menu-close') {
       setFilterInputValue(newValue)
+      activelySelectedInsertOptionRef.current = null
     }
   }, [])
 

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -265,7 +265,10 @@ export function getComponentGroups(
         file.fileContents.parsed,
       )
       if (possibleExportedComponents != null) {
-        const insertableComponents = possibleExportedComponents.map((exportedComponent) => {
+        const componentsWithoutApp_KILLME = possibleExportedComponents.filter(
+          (c) => c.listingName !== 'App', // TODO make this filtering smarter. Filter out the component(s) that we are currently inserting into instead of this
+        )
+        const insertableComponents = componentsWithoutApp_KILLME.map((exportedComponent) => {
           const pathWithoutExtension = dropFileExtension(fullPath)
           const { defaultProps, parsedControls } = defaultPropertiesForComponentInFile(
             exportedComponent.listingName,


### PR DESCRIPTION
Two small fixes for the insert menu:

* filter out App from the list (hard coded by name)
* clear out the last highlighted element so that if the list becomes empty, Enter doesn't insert anything