### PR TITLE
Support element deletion whilst in select mode

### DIFF
--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -392,7 +392,9 @@ export function handleKeyDown(
     }
     return handleShortcuts<Array<EditorAction>>(namesByKey, event, [], {
       [DELETE_SELECTED_SHORTCUT]: () => {
-        return isSelectMode(editor.mode) ? [EditorActions.deleteSelected()] : []
+        return isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)
+          ? [EditorActions.deleteSelected()]
+          : []
       },
       [RESET_CANVAS_ZOOM_SHORTCUT]: () => {
         return [CanvasActions.zoom(1)]


### PR DESCRIPTION
Fixes #1558 
Fixes #1530 

**Problem:**
We had previously prevented deletion via the backspace or delete keys whilst in select mode, which no longer really makes sense

**Fix:**
Remove that restriction
