### PR TITLE
Make the classname section expandable

### DIFF
--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -16,6 +16,7 @@ import {
   FlexColumn,
   FlexRow,
   colorTheme,
+  SquareButton,
 } from '../../../../../uuiui'
 import { betterReactMemo } from '../../../../../uuiui-deps'
 import {
@@ -42,6 +43,8 @@ import {
   REDO_CHANGES_SHORTCUT,
   UNDO_CHANGES_SHORTCUT,
 } from '../../../../editor/shortcut-definitions'
+import { ExpandableIndicator } from '../../../../navigator/navigator-item/expandable-indicator'
+import { when } from '../../../../../utils/react-conditionals'
 
 const IndicatorsContainer: React.FunctionComponent<IndicatorContainerProps<TailWindOption>> = () =>
   null
@@ -233,6 +236,9 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
   }, [])
 
   const { selectedOptions, elementPath, isMenuEnabled } = useGetSelectedTailwindOptions()
+  const selectedOptionsLength = selectedOptions?.length ?? 0
+  const [isExpanded, setIsExpanded] = React.useState(selectedOptionsLength > 0)
+  const toggleIsExpanded = React.useCallback(() => setIsExpanded((current) => !current), [])
 
   const onChange = React.useCallback(
     (newValueType: ValueType<TailWindOption>) => {
@@ -447,48 +453,56 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
       }}
     >
       <InspectorSubsectionHeader style={{ color: theme.primary.value }}>
-        Class Names
+        <span style={{ flexGrow: 1 }}>Class Names</span>
+        <SquareButton highlight onClick={toggleIsExpanded}>
+          <ExpandableIndicator visible collapsed={!isExpanded} selected={false} />
+        </SquareButton>
       </InspectorSubsectionHeader>
-      <UIGridRow padded variant='<-------------1fr------------->'>
-        <CreatableSelect
-          ref={inputRef}
-          autoFocus={false}
-          placeholder='Add class…'
-          isMulti
-          value={selectedOptions}
-          isDisabled={!isMenuEnabled}
-          onChange={onChange}
-          onInputChange={onInputChange}
-          components={{
-            IndicatorsContainer,
-            Input,
-            MultiValueRemove,
-          }}
-          className='className-inspector-control'
-          styles={{
-            container,
-            control,
-            valueContainer,
-            multiValue,
-            multiValueLabel,
-            multiValueRemove,
-            placeholder,
-            menu,
-            option,
-          }}
-          filterOption={AlwaysTrue}
-          options={options}
-          menuIsOpen={true}
-          onBlur={onBlur}
-          onFocus={onFocus}
-          escapeClearsValue={true}
-          formatOptionLabel={formatOptionLabel}
-          onKeyDown={handleKeyDown}
-          maxMenuHeight={199}
-          inputValue={filter}
-        />
-      </UIGridRow>
-      <FooterSection options={options} filter={filter} />
+      {when(
+        isExpanded,
+        <React.Fragment>
+          <UIGridRow padded variant='<-------------1fr------------->'>
+            <CreatableSelect
+              ref={inputRef}
+              autoFocus={false}
+              placeholder='Add class…'
+              isMulti
+              value={selectedOptions}
+              isDisabled={!isMenuEnabled}
+              onChange={onChange}
+              onInputChange={onInputChange}
+              components={{
+                IndicatorsContainer,
+                Input,
+                MultiValueRemove,
+              }}
+              className='className-inspector-control'
+              styles={{
+                container,
+                control,
+                valueContainer,
+                multiValue,
+                multiValueLabel,
+                multiValueRemove,
+                placeholder,
+                menu,
+                option,
+              }}
+              filterOption={AlwaysTrue}
+              options={options}
+              menuIsOpen={true}
+              onBlur={onBlur}
+              onFocus={onFocus}
+              escapeClearsValue={true}
+              formatOptionLabel={formatOptionLabel}
+              onKeyDown={handleKeyDown}
+              maxMenuHeight={199}
+              inputValue={filter}
+            />
+          </UIGridRow>
+          <FooterSection options={options} filter={filter} />
+        </React.Fragment>,
+      )}
     </div>
   )
 })


### PR DESCRIPTION
**Problem:**
We don't always want the classname section to be expanded

**Fix:**
Make it expandable, and only have it expanded by default if the selected element has class names

**Screenshots:**
![Screenshot_20210723_152242](https://user-images.githubusercontent.com/1044774/126796509-906597e8-a479-4410-a181-c6acd82536a8.png)
![Screenshot_20210723_152641](https://user-images.githubusercontent.com/1044774/126796708-1ae68177-adc0-419e-b636-44076761b97f.png)


