### PR TITLE
Feature/inspector layout section buttons

### DIFF
--- a/editor/src/components/inspector/common/control-status.ts
+++ b/editor/src/components/inspector/common/control-status.ts
@@ -551,3 +551,11 @@ export function calculateMultiStringPropertyStatusForSelection(
 export function isNotUnsetOrDefault(controlStatus: ControlStatus): boolean {
   return controlStatus !== 'unset' && controlStatus !== 'trivial-default' && controlStatus !== 'off'
 }
+
+export function isNotUnsetDefaultOrDetected(controlStatus: ControlStatus): boolean {
+  return (
+    isNotUnsetOrDefault(controlStatus) &&
+    controlStatus !== 'detected' &&
+    controlStatus !== 'detected-fromcss'
+  )
+}

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -13,6 +13,7 @@ import {
   FlexStyleNumberControl,
 } from '../self-layout-subsection/gigantic-size-pins-subsection'
 import { InlineLink } from '../../../../../uuiui/inline-button'
+import { when } from '../../../../../utils/react-conditionals'
 
 const marginProps = [
   createLayoutPropertyPath('marginLeft'),
@@ -63,6 +64,33 @@ export const FlexElementSubsectionExperiment = betterReactMemo(
 const MainAxisControls = betterReactMemo(
   'MainAxisControls',
   (props: FlexElementSubsectionProps) => {
+    const [mainAxisControlsOpen, setMainAxisControlsOpen] = React.useState(true)
+    const toggleSection = React.useCallback(() => setMainAxisControlsOpen(!mainAxisControlsOpen), [
+      mainAxisControlsOpen,
+      setMainAxisControlsOpen,
+    ])
+    return (
+      <>
+        <InspectorSubsectionHeader style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <span>Main Axis</span>{' '}
+          <SquareButton highlight onClick={toggleSection}>
+            <ExpandableIndicator
+              testId='flex-element-subsection'
+              visible
+              collapsed={!mainAxisControlsOpen}
+              selected={false}
+            />
+          </SquareButton>
+        </InspectorSubsectionHeader>
+        {when(mainAxisControlsOpen, <MainAxisControlsContent {...props} />)}
+      </>
+    )
+  },
+)
+
+const MainAxisControlsContent = betterReactMemo(
+  'MainAxisControlsContent',
+  (props: FlexElementSubsectionProps) => {
     const widthOrHeightControls =
       props.parentFlexDirection === 'row' || props.parentFlexDirection === 'row-reverse' ? (
         <FlexWidthControls />
@@ -71,17 +99,6 @@ const MainAxisControls = betterReactMemo(
       )
     return (
       <>
-        <InspectorSubsectionHeader style={{ display: 'flex', justifyContent: 'space-between' }}>
-          <span>Main Axis</span>{' '}
-          <SquareButton highlight>
-            <ExpandableIndicator
-              testId='flex-element-subsection'
-              visible
-              collapsed={false}
-              selected={false}
-            />
-          </SquareButton>
-        </InspectorSubsectionHeader>
         <UIGridRow padded={true} variant='<-------------1fr------------->'>
           <FlexBasisShorthandCSSNumberControl label='B' />
         </UIGridRow>
@@ -111,6 +128,11 @@ const MainAxisControls = betterReactMemo(
 const CrossAxisControls = betterReactMemo(
   'CrossAxisControls',
   (props: FlexElementSubsectionProps) => {
+    const [crossAxisControlsOpen, setCrossAxisControlsOpen] = React.useState(true)
+    const toggleSection = React.useCallback(
+      () => setCrossAxisControlsOpen(!crossAxisControlsOpen),
+      [crossAxisControlsOpen, setCrossAxisControlsOpen],
+    )
     const widthOrHeightControls =
       props.parentFlexDirection === 'column' || props.parentFlexDirection === 'column-reverse' ? (
         <FlexHeightControls />
@@ -123,17 +145,17 @@ const CrossAxisControls = betterReactMemo(
           <div style={{ justifySelf: 'flex-start' }}>Cross Axis</div>
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <InlineLink>+</InlineLink>
-            <SquareButton highlight>
+            <SquareButton highlight onClick={toggleSection}>
               <ExpandableIndicator
                 testId='flex-element-subsection'
                 visible
-                collapsed={false}
+                collapsed={!crossAxisControlsOpen}
                 selected={false}
               />
             </SquareButton>
           </div>
         </InspectorSubsectionHeader>
-        {widthOrHeightControls}
+        {when(crossAxisControlsOpen, widthOrHeightControls)}
       </>
     )
   },

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -11,9 +11,13 @@ import {
   FlexBasisShorthandCSSNumberControl,
   FlexShorthandNumberControl,
   FlexStyleNumberControl,
+  PinsLayoutNumberControl,
 } from '../self-layout-subsection/gigantic-size-pins-subsection'
 import { InlineLink } from '../../../../../uuiui/inline-button'
 import { when } from '../../../../../utils/react-conditionals'
+import { useInspectorLayoutInfo } from '../../../common/property-path-hooks'
+import { isNotUnsetDefaultOrDetected } from '../../../common/control-status'
+import { usePropControlledStateV2 } from '../../../common/inspector-utils'
 
 const marginProps = [
   createLayoutPropertyPath('marginLeft'),
@@ -64,7 +68,38 @@ export const FlexElementSubsectionExperiment = betterReactMemo(
 const MainAxisControls = betterReactMemo(
   'MainAxisControls',
   (props: FlexElementSubsectionProps) => {
-    const [mainAxisControlsOpen, setMainAxisControlsOpen] = React.useState(true)
+    const isRowLayouted =
+      props.parentFlexDirection === 'row' || props.parentFlexDirection === 'row-reverse'
+
+    const width = useInspectorLayoutInfo('Width')
+    const minWidth = useInspectorLayoutInfo('minWidth')
+    const maxWidth = useInspectorLayoutInfo('maxWidth')
+    const height = useInspectorLayoutInfo('Height')
+    const minHeight = useInspectorLayoutInfo('minHeight')
+    const maxHeight = useInspectorLayoutInfo('maxHeight')
+    const alignSelf = useInspectorLayoutInfo('alignSelf')
+    const flexBasis = useInspectorLayoutInfo('flexBasis')
+    const flexGrow = useInspectorLayoutInfo('flexGrow')
+    const flexShrink = useInspectorLayoutInfo('flexShrink')
+
+    const isMainAxisVisibleForFlexDirection = isRowLayouted
+      ? isNotUnsetDefaultOrDetected(width.controlStatus) ||
+        isNotUnsetDefaultOrDetected(minWidth.controlStatus) ||
+        isNotUnsetDefaultOrDetected(maxWidth.controlStatus)
+      : isNotUnsetDefaultOrDetected(height.controlStatus) ||
+        isNotUnsetDefaultOrDetected(minHeight.controlStatus) ||
+        isNotUnsetDefaultOrDetected(maxHeight.controlStatus)
+
+    const isMainAxisVisible =
+      isMainAxisVisibleForFlexDirection ||
+      isNotUnsetDefaultOrDetected(alignSelf.controlStatus) ||
+      isNotUnsetDefaultOrDetected(flexBasis.controlStatus) ||
+      isNotUnsetDefaultOrDetected(flexGrow.controlStatus) ||
+      isNotUnsetDefaultOrDetected(flexShrink.controlStatus)
+
+    const [mainAxisControlsOpen, setMainAxisControlsOpen] = usePropControlledStateV2(
+      isMainAxisVisible,
+    )
     const toggleSection = React.useCallback(() => setMainAxisControlsOpen(!mainAxisControlsOpen), [
       mainAxisControlsOpen,
       setMainAxisControlsOpen,
@@ -72,7 +107,7 @@ const MainAxisControls = betterReactMemo(
     return (
       <>
         <InspectorSubsectionHeader style={{ display: 'flex', justifyContent: 'space-between' }}>
-          <span>Main Axis</span>{' '}
+          <span>Main Axis</span>
           <SquareButton highlight onClick={toggleSection}>
             <ExpandableIndicator
               testId='flex-element-subsection'
@@ -128,17 +163,32 @@ const MainAxisControlsContent = betterReactMemo(
 const CrossAxisControls = betterReactMemo(
   'CrossAxisControls',
   (props: FlexElementSubsectionProps) => {
-    const [crossAxisControlsOpen, setCrossAxisControlsOpen] = React.useState(true)
+    const isColumnLayouted =
+      props.parentFlexDirection === 'column' || props.parentFlexDirection === 'column-reverse'
+
+    const width = useInspectorLayoutInfo('Width')
+    const minWidth = useInspectorLayoutInfo('minWidth')
+    const maxWidth = useInspectorLayoutInfo('maxWidth')
+    const height = useInspectorLayoutInfo('Height')
+    const minHeight = useInspectorLayoutInfo('minHeight')
+    const maxHeight = useInspectorLayoutInfo('maxHeight')
+
+    const isCrossAxisVisible = isColumnLayouted
+      ? isNotUnsetDefaultOrDetected(width.controlStatus) ||
+        isNotUnsetDefaultOrDetected(minWidth.controlStatus) ||
+        isNotUnsetDefaultOrDetected(maxWidth.controlStatus)
+      : isNotUnsetDefaultOrDetected(height.controlStatus) ||
+        isNotUnsetDefaultOrDetected(minHeight.controlStatus) ||
+        isNotUnsetDefaultOrDetected(maxHeight.controlStatus)
+
+    const [crossAxisControlsOpen, setCrossAxisControlsOpen] = usePropControlledStateV2(
+      isCrossAxisVisible,
+    )
     const toggleSection = React.useCallback(
       () => setCrossAxisControlsOpen(!crossAxisControlsOpen),
       [crossAxisControlsOpen, setCrossAxisControlsOpen],
     )
-    const widthOrHeightControls =
-      props.parentFlexDirection === 'column' || props.parentFlexDirection === 'column-reverse' ? (
-        <FlexHeightControls />
-      ) : (
-        <FlexWidthControls />
-      )
+    const widthOrHeightControls = isColumnLayouted ? <FlexWidthControls /> : <FlexHeightControls />
     return (
       <>
         <InspectorSubsectionHeader style={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -165,7 +215,7 @@ const FlexWidthControls = betterReactMemo('FlexWidthControls', () => {
   return (
     <>
       <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
-        <FlexBasisShorthandCSSNumberControl label='W' />
+        <PinsLayoutNumberControl label='W' prop='Width' />
       </UIGridRow>
       <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
         <FlexStyleNumberControl label='min' styleProp='minWidth' />
@@ -178,7 +228,7 @@ const FlexHeightControls = betterReactMemo('FlexWidthControls', () => {
   return (
     <>
       <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
-        <FlexBasisShorthandCSSNumberControl label='H' />
+        <PinsLayoutNumberControl label='H' prop='Height' />
       </UIGridRow>
       <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
         <FlexStyleNumberControl label='min' styleProp='minHeight' />

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -15,9 +15,14 @@ import {
 } from '../self-layout-subsection/gigantic-size-pins-subsection'
 import { InlineLink } from '../../../../../uuiui/inline-button'
 import { when } from '../../../../../utils/react-conditionals'
-import { useInspectorLayoutInfo } from '../../../common/property-path-hooks'
+import {
+  InspectorCallbackContext,
+  useInspectorLayoutInfo,
+} from '../../../common/property-path-hooks'
 import { isNotUnsetDefaultOrDetected } from '../../../common/control-status'
 import { usePropControlledStateV2 } from '../../../common/inspector-utils'
+import { useEditorState } from '../../../../editor/store/store-hook'
+import { PropertyPath } from '../../../../../core/shared/project-file-types'
 
 const marginProps = [
   createLayoutPropertyPath('marginLeft'),
@@ -123,6 +128,23 @@ const MainAxisControls = betterReactMemo(
   },
 )
 
+const mainAxisFixedProps = (parentFlexDirection: string | null): PropertyPath[] => {
+  if (parentFlexDirection === 'row' || parentFlexDirection === 'row-reverse') {
+    return [
+      createLayoutPropertyPath('Width'),
+      createLayoutPropertyPath('minWidth'),
+      createLayoutPropertyPath('maxWidth'),
+    ]
+  } else {
+    return [
+      createLayoutPropertyPath('Height'),
+      createLayoutPropertyPath('minHeight'),
+      createLayoutPropertyPath('maxHeight'),
+    ]
+  }
+}
+const mainAxisAdvancedProps: PropertyPath[] = [createLayoutPropertyPath('alignSelf')]
+
 const MainAxisControlsContent = betterReactMemo(
   'MainAxisControlsContent',
   (props: FlexElementSubsectionProps) => {
@@ -132,6 +154,14 @@ const MainAxisControlsContent = betterReactMemo(
       ) : (
         <FlexHeightControls />
       )
+
+    const { onUnsetValue } = React.useContext(InspectorCallbackContext)
+    const deleteFixedProps = React.useCallback(() => {
+      onUnsetValue(mainAxisFixedProps(props.parentFlexDirection), false)
+    }, [props.parentFlexDirection, onUnsetValue])
+    const deleteAdvancedProps = React.useCallback(() => {
+      onUnsetValue(mainAxisAdvancedProps, false)
+    }, [onUnsetValue])
     return (
       <>
         <UIGridRow padded={true} variant='<-------------1fr------------->'>
@@ -140,14 +170,14 @@ const MainAxisControlsContent = betterReactMemo(
         <FlexGrowShrinkRow />
         <InspectorSubsectionHeader>
           <InlineLink>Fixed</InlineLink>
-          <SquareButton highlight>
+          <SquareButton highlight onClick={deleteFixedProps}>
             <FunctionIcons.Delete />
           </SquareButton>
         </InspectorSubsectionHeader>
         {widthOrHeightControls}
         <InspectorSubsectionHeader>
           <InlineLink>Advanced</InlineLink>
-          <SquareButton highlight>
+          <SquareButton highlight onClick={deleteAdvancedProps}>
             <FunctionIcons.Delete />
           </SquareButton>
         </InspectorSubsectionHeader>

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -60,10 +60,31 @@ interface SelfLayoutSubsectionProps {
 export const LayoutSubsection = betterReactMemo(
   'LayoutSubsection',
   (props: SelfLayoutSubsectionProps) => {
+    const [selfLayoutSectionOpen, setSelfLayoutSectionOpen] = React.useState(true)
+    const toggleSection = React.useCallback(
+      () => setSelfLayoutSectionOpen(!selfLayoutSectionOpen),
+      [selfLayoutSectionOpen, setSelfLayoutSectionOpen],
+    )
     const [activeTab, setActiveTab] = useActiveLayoutTab(props.position, props.parentLayoutSystem)
     return (
       <>
-        <LayoutSectionHeader layoutType={activeTab} />
+        <LayoutSectionHeader
+          layoutType={activeTab}
+          toggleSection={toggleSection}
+          selfLayoutSectionOpen={selfLayoutSectionOpen}
+        />
+        {when(selfLayoutSectionOpen, <LayoutSubsectionContent {...props} />)}
+      </>
+    )
+  },
+)
+
+export const LayoutSubsectionContent = betterReactMemo(
+  'LayoutSubsection',
+  (props: SelfLayoutSubsectionProps) => {
+    const [activeTab, setActiveTab] = useActiveLayoutTab(props.position, props.parentLayoutSystem)
+    return (
+      <>
         {when(activeTab === 'flex', <FlexInfoBox />)}
         {unless(
           activeTab === 'flex',
@@ -85,6 +106,8 @@ export const LayoutSubsection = betterReactMemo(
 
 interface LayoutSectionHeaderProps {
   layoutType: SelfLayoutTab | 'grid'
+  selfLayoutSectionOpen: boolean
+  toggleSection: () => void
 }
 
 const selfLayoutProperties: Array<LayoutProp | StyleLayoutProp> = [
@@ -133,7 +156,9 @@ function useDeleteAllSelfLayoutConfig() {
 const LayoutSectionHeader = betterReactMemo(
   'LayoutSectionHeader',
   (props: LayoutSectionHeaderProps) => {
+    const { layoutType, selfLayoutSectionOpen, toggleSection } = props
     const onDeleteAllConfig = useDeleteAllSelfLayoutConfig()
+
     return (
       <InspectorSubsectionHeader>
         <div style={{ flexGrow: 1, display: 'flex', gap: 8 }}>
@@ -144,20 +169,23 @@ const LayoutSectionHeader = betterReactMemo(
               paddingRight: 8,
             }}
           >
-            {props.layoutType}
+            {layoutType}
           </InlineLink>
           <ParentLink />
           <SelfLink />
           <ChildrenOrContentLink />
         </div>
-        <SquareButton highlight onClick={onDeleteAllConfig}>
-          <FunctionIcons.Delete />
-        </SquareButton>
-        <SquareButton highlight>
+        {when(
+          selfLayoutSectionOpen,
+          <SquareButton highlight onClick={onDeleteAllConfig}>
+            <FunctionIcons.Delete />
+          </SquareButton>,
+        )}
+        <SquareButton highlight onClick={toggleSection}>
           <ExpandableIndicator
             testId='layout-system-expand'
             visible
-            collapsed={false}
+            collapsed={!selfLayoutSectionOpen}
             selected={false}
           />
         </SquareButton>

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import { MetadataUtils } from '../../../../../core/model/element-metadata-utils'
-import { DetectedLayoutSystem } from '../../../../../core/shared/element-template'
+import {
+  DetectedLayoutSystem,
+  jsxAttributeValue,
+} from '../../../../../core/shared/element-template'
 import { shallowEqual } from '../../../../../core/shared/equality-utils'
 import { fastForEach } from '../../../../../core/shared/utils'
 import {
@@ -8,6 +11,7 @@ import {
   Icn,
   InspectorSubsectionHeader,
   SquareButton,
+  Tooltip,
   useColorTheme,
 } from '../../../../../uuiui'
 import { usePropControlledState, betterReactMemo } from '../../../../../uuiui-deps'
@@ -27,6 +31,7 @@ import {
   LayoutProp,
   StyleLayoutProp,
 } from '../../../../../core/layout/layout-helpers-new'
+import { emptyComments } from '../../../../../core/workers/parser-printer/parser-printer-comments'
 
 type SelfLayoutTab = 'absolute' | 'flex' | 'flow' | 'sticky'
 
@@ -152,12 +157,24 @@ function useDeleteAllSelfLayoutConfig() {
     onUnsetValue(selfLayoutConfigPropertyPaths, false)
   }, [onUnsetValue])
 }
+function useAddPositionAbsolute() {
+  const { onSubmitValue } = React.useContext(InspectorCallbackContext)
+  return React.useCallback(() => {
+    onSubmitValue(
+      jsxAttributeValue('absolute', emptyComments),
+      createLayoutPropertyPath('position'),
+      false,
+    )
+  }, [onSubmitValue])
+}
 
 const LayoutSectionHeader = betterReactMemo(
   'LayoutSectionHeader',
   (props: LayoutSectionHeaderProps) => {
+    const colorTheme = useColorTheme()
     const { layoutType, selfLayoutSectionOpen, toggleSection } = props
     const onDeleteAllConfig = useDeleteAllSelfLayoutConfig()
+    const onAbsoluteButtonClick = useAddPositionAbsolute()
 
     return (
       <InspectorSubsectionHeader>
@@ -175,6 +192,14 @@ const LayoutSectionHeader = betterReactMemo(
           <SelfLink />
           <ChildrenOrContentLink />
         </div>
+        {when(
+          selfLayoutSectionOpen && layoutType !== 'absolute',
+          <Tooltip title='Use Absolute Positioning' placement='bottom'>
+            <SquareButton highlight onClick={onAbsoluteButtonClick}>
+              <div style={{ color: colorTheme.brandNeonPink.value }}>*</div>
+            </SquareButton>
+          </Tooltip>,
+        )}
         {when(
           selfLayoutSectionOpen,
           <SquareButton highlight onClick={onDeleteAllConfig}>


### PR DESCRIPTION
**Problem:**
The new inspector layout section has buttons that are not interactive.

**Fix:**
Add new position absolute button for header row and the 2 delete button in flex element subsection now deletes the properties that are shown in the subsection.

**Commit Details:**
- new button in header row
- 2 delete buttons
