### PR TITLE
feature(canvas) Add parent highlighting.

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -882,11 +882,18 @@ export interface SetPropTransient {
   propertyPath: PropertyPath
   value: JSXAttribute
 }
+
 export interface ClearTransientProps {
   action: 'CLEAR_TRANSIENT_PROPS'
 }
+
 export interface AddTailwindConfig {
   action: 'ADD_TAILWIND_CONFIG'
+}
+
+export interface SetInspectorLayoutSectionHovered {
+  action: 'SET_INSPECTOR_LAYOUT_SECTION_HOVERED'
+  hovered: boolean
 }
 
 export type EditorAction =
@@ -1037,6 +1044,7 @@ export type EditorAction =
   | SetPropTransient
   | ClearTransientProps
   | AddTailwindConfig
+  | SetInspectorLayoutSectionHovered
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -198,6 +198,7 @@ import type {
   AddTailwindConfig,
   FocusClassNameInput,
   WrapInElement,
+  SetInspectorLayoutSectionHovered,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -1426,5 +1427,14 @@ export function insertWithDefaults(
 export function addTailwindConfig(): AddTailwindConfig {
   return {
     action: 'ADD_TAILWIND_CONFIG',
+  }
+}
+
+export function setInspectorLayoutSectionHovered(
+  hovered: boolean,
+): SetInspectorLayoutSectionHovered {
+  return {
+    action: 'SET_INSPECTOR_LAYOUT_SECTION_HOVERED',
+    hovered: hovered,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -99,6 +99,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'CLOSE_FLOATING_INSERT_MENU':
     case 'SET_PROP_TRANSIENT':
     case 'CLEAR_TRANSIENT_PROPS':
+    case 'SET_INSPECTOR_LAYOUT_SECTION_HOVERED':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -370,6 +370,7 @@ import {
   AddTailwindConfig,
   FocusClassNameInput,
   WrapInElement,
+  SetInspectorLayoutSectionHovered,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -1008,6 +1009,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     inspector: {
       visible: currentEditor.inspector.visible,
       classnameFocusCounter: currentEditor.inspector.classnameFocusCounter,
+      layoutSectionHovered: currentEditor.inspector.layoutSectionHovered,
     },
     fileBrowser: {
       minimised: currentEditor.fileBrowser.minimised,
@@ -4761,6 +4763,18 @@ export const UPDATE_FNS = {
             tailwindcss: { status: 'loading' },
           },
         },
+      },
+    }
+  },
+  SET_INSPECTOR_LAYOUT_SECTION_HOVERED: (
+    action: SetInspectorLayoutSectionHovered,
+    editor: EditorModel,
+  ): EditorModel => {
+    return {
+      ...editor,
+      inspector: {
+        ...editor.inspector,
+        layoutSectionHovered: action.hovered,
       },
     }
   },

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -391,6 +391,7 @@ export interface EditorState {
   inspector: {
     visible: boolean
     classnameFocusCounter: number
+    layoutSectionHovered: boolean
   }
   fileBrowser: {
     minimised: boolean
@@ -1171,6 +1172,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     inspector: {
       visible: true,
       classnameFocusCounter: 0,
+      layoutSectionHovered: false,
     },
     dependencyList: {
       minimised: false,
@@ -1423,6 +1425,7 @@ export function editorModelFromPersistentModel(
     inspector: {
       visible: true,
       classnameFocusCounter: 0,
+      layoutSectionHovered: false,
     },
     dependencyList: persistentModel.dependencyList,
     genericExternalResources: {

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -319,6 +319,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.CLEAR_TRANSIENT_PROPS(action, state)
     case 'ADD_TAILWIND_CONFIG':
       return UPDATE_FNS.ADD_TAILWIND_CONFIG(action, state, dispatch)
+    case 'SET_INSPECTOR_LAYOUT_SECTION_HOVERED':
+      return UPDATE_FNS.SET_INSPECTOR_LAYOUT_SECTION_HOVERED(action, state)
     default:
       return state
   }

--- a/editor/src/components/inspector/sections/layout-section/layout-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-section.tsx
@@ -9,6 +9,7 @@ import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { SpecialSizeMeasurementsKeepDeepEquality } from '../../../editor/store/store-deep-equality-instances'
 import { isFeatureEnabled } from '../../../../utils/feature-switches'
 import { LayoutSubsection } from './self-layout-subsection/self-layout-subsection'
+import { setInspectorLayoutSectionHovered } from '../../../editor/actions/action-creators'
 
 interface LayoutSectionProps {
   hasNonDefaultPositionAttributes: boolean
@@ -30,9 +31,11 @@ export const LayoutSection = betterReactMemo('LayoutSection', (props: LayoutSect
       })
       return foundSpecialSizeMeasurements
     },
-    'RenderedLayoutSection specialSizeMeasurements',
+    'LayoutSection specialSizeMeasurements',
     (old, next) => SpecialSizeMeasurementsKeepDeepEquality()(old, next).areEqual,
   )
+
+  const dispatch = useEditorState((store) => store.dispatch, 'LayoutSection dispatch')
 
   const selfLayoutSection = isFeatureEnabled('Layout Section Experimental') ? (
     <LayoutSubsection
@@ -53,9 +56,16 @@ export const LayoutSection = betterReactMemo('LayoutSection', (props: LayoutSect
   )
 
   return (
-    <>
+    <div
+      onMouseOver={() => {
+        dispatch([setInspectorLayoutSectionHovered(true)], 'everyone')
+      }}
+      onMouseOut={() => {
+        dispatch([setInspectorLayoutSectionHovered(false)], 'everyone')
+      }}
+    >
       {selfLayoutSection}
       <LayoutSystemSubsection specialSizeMeasurements={specialSizeMeasurements} />
-    </>
+    </div>
   )
 })


### PR DESCRIPTION
Fixes #1604

**Problem:**
When adjusting the layout of an element, users want to be able to see the parent dimensions they're adjusting the layout in relation to the child's dimensions.

**Fix:**
When either `cmd` is pressed or if the layout section is hovered we display an indicator showing the 4 corners of the parent.

**Commit Details:**
- Fixes #1604.
- Partly resurrects #514.
- Added `layoutSectionHovered` property to `EditorState.inspector`.
- Added action for updating `layoutSectionHovered`.
- Added a div around the layout section to capture mouse over and out.
- Added parent highlights to the `OutlineControl` component, optionally
  depending on if `cmd` is pressed or if the layout section is hovered.
