### PR TITLE
fix(inspector) align self row can have unset label

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-controls.tsx
@@ -8,6 +8,9 @@ import { stylePropPathMappingFn, useInspectorLayoutInfo } from '../../../common/
 import { useWrappedEmptyOrUnknownOnSubmitValue, ChainedNumberInput } from '../../../../../uuiui'
 import { betterReactMemo } from '../../../../../uuiui-deps'
 import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
+import { GridRowProps, UIGridRow } from '../../../widgets/ui-grid-row'
+import { PropertyLabel } from '../../../widgets/property-label'
+import { createLayoutPropertyPath } from '../../../../../core/layout/layout-helpers-new'
 
 export const PositionControl = betterReactMemo('PositionControl', () => {
   const position = useInspectorLayoutInfo('position')
@@ -60,51 +63,63 @@ export const PositionControl = betterReactMemo('PositionControl', () => {
   )
 })
 
-export const AlignSelfControl = betterReactMemo('AlignSelfControl', () => {
-  const alignSelf = useInspectorLayoutInfo('alignSelf')
+const alignSelfProp = [createLayoutPropertyPath('alignSelf')]
 
-  return (
-    <InspectorContextMenuWrapper
-      id={`align-self-context-menu`}
-      items={[unsetPropertyMenuItem('Align Self', alignSelf.onUnsetValues)]}
-      data={{}}
-    >
-      <SelectControl
-        id='flex.element.alignSelf'
-        key='flex.element.alignSelf'
-        testId='flex.element.alignSelf'
-        options={
-          [
-            {
-              value: 'auto',
-              label: 'Auto',
-            },
-            {
-              value: 'flex-start',
-              label: 'Flex Start',
-            },
-            {
-              value: 'center',
-              label: 'Center',
-            },
-            {
-              value: 'flex-end',
-              label: 'Flex End',
-            },
-            {
-              value: 'stretch',
-              label: 'Stretch',
-            },
-          ] as Array<SelectOption>
-        }
-        value={alignSelf.value}
-        onSubmitValue={alignSelf.onSubmitValue}
-        controlStatus={alignSelf.controlStatus}
-        controlStyles={alignSelf.controlStyles}
-      />
-    </InspectorContextMenuWrapper>
-  )
-})
+interface AlignSelfControlProps {
+  variant: GridRowProps['variant']
+}
+
+export const AlignSelfControl = betterReactMemo(
+  'AlignSelfControl',
+  (props: AlignSelfControlProps) => {
+    const alignSelf = useInspectorLayoutInfo('alignSelf')
+
+    return (
+      <InspectorContextMenuWrapper
+        id={`align-self-context-menu`}
+        items={[unsetPropertyMenuItem('Align Self', alignSelf.onUnsetValues)]}
+        data={{}}
+      >
+        <UIGridRow padded={true} variant={props.variant}>
+          <PropertyLabel target={alignSelfProp}>Align Self</PropertyLabel>
+          <SelectControl
+            id='flex.element.alignSelf'
+            key='flex.element.alignSelf'
+            testId='flex.element.alignSelf'
+            options={
+              [
+                {
+                  value: 'auto',
+                  label: 'Auto',
+                },
+                {
+                  value: 'flex-start',
+                  label: 'Flex Start',
+                },
+                {
+                  value: 'center',
+                  label: 'Center',
+                },
+                {
+                  value: 'flex-end',
+                  label: 'Flex End',
+                },
+                {
+                  value: 'stretch',
+                  label: 'Stretch',
+                },
+              ] as Array<SelectOption>
+            }
+            value={alignSelf.value}
+            onSubmitValue={alignSelf.onSubmitValue}
+            controlStatus={alignSelf.controlStatus}
+            controlStyles={alignSelf.controlStyles}
+          />
+        </UIGridRow>
+      </InspectorContextMenuWrapper>
+    )
+  },
+)
 
 export const MarginControl = betterReactMemo('MarginControl', () => {
   const { marginTop, marginRight, marginBottom, marginLeft } = useInspectorInfoLonghandShorthand(

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -31,8 +31,6 @@ const marginProps = [
   createLayoutPropertyPath('marginBottom'),
 ]
 
-const alignSelfProp = [createLayoutPropertyPath('alignSelf')]
-
 export const FlexElementSubsection = betterReactMemo('FlexElementSubsection', () => {
   return (
     <>
@@ -46,10 +44,7 @@ export const FlexElementSubsection = betterReactMemo('FlexElementSubsection', ()
         </PropertyLabel>
         <MarginControl />
       </UIGridRow>
-      <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
-        <PropertyLabel target={alignSelfProp}>Align Self</PropertyLabel>
-        <AlignSelfControl />
-      </UIGridRow>
+      <AlignSelfControl variant='<---1fr--->|------172px-------|' />
     </>
   )
 })
@@ -181,10 +176,7 @@ const MainAxisControlsContent = betterReactMemo(
             <FunctionIcons.Delete />
           </SquareButton>
         </InspectorSubsectionHeader>
-        <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
-          <PropertyLabel target={alignSelfProp}>Align Self</PropertyLabel>
-          <AlignSelfControl />
-        </UIGridRow>
+        <AlignSelfControl variant='<--1fr--><--1fr-->' />
       </>
     )
   },


### PR DESCRIPTION
**Problem:**
This PR fixes a bug where in the self-layout inspector section shows the align-self row label as set with empty value.

**Fix:**
Move the whole align-self row into the context menu wrapper to apply the hover effect.
