### PR TITLE
Update global-shortcuts.ts

### DIFF
--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -810,22 +810,13 @@ export function handleKeyUp(
   // Ensure that any key presses are appropriately recorded.
   const key = Keyboard.keyCharacterForCode(event.keyCode)
   const editorTargeted = editorIsTarget(event, editor)
-  let updatedKeysPressed: KeysPressed
-  if (editorTargeted) {
-    updatedKeysPressed = updateKeysPressed(
-      editor.keysPressed,
-      key,
-      false,
-      Modifier.modifiersForKeyboardEvent(event),
-    )
-  } else {
-    updatedKeysPressed = updateKeysPressed(
-      editor.keysPressed,
-      key,
-      false,
-      Modifier.modifiersForKeyboardEvent(event),
-    )
-  }
+  const updatedKeysPressed = updateKeysPressed(
+    editor.keysPressed,
+    key,
+    false,
+    Modifier.modifiersForKeyboardEvent(event),
+  )
+
   const updateKeysAction = EditorActions.updateKeys(updatedKeysPressed)
 
   function getUIFileActions(): Array<EditorAction> {

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -812,8 +812,10 @@ export function handleKeyUp(
   const editorTargeted = editorIsTarget(event, editor)
   let updatedKeysPressed: KeysPressed
   if (editorTargeted) {
-    updatedKeysPressed = updateModifiers(
+    updatedKeysPressed = updateKeysPressed(
       editor.keysPressed,
+      key,
+      false,
       Modifier.modifiersForKeyboardEvent(event),
     )
   } else {


### PR DESCRIPTION
**Problem:**
The canvas got stuck in zoom in / out mode triggered by `z` key. Diagnosing it revealed it's because we weren't clearing the `z` key on key up.

**Fix:**
Clear the key. I don't know why we weren't doing this before. Perhaps it conflicted with draftJS?
