### PR TITLE
feature(classnames) - entire header toggle menu

### DIFF
--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -465,7 +465,9 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
       }}
     >
       <InspectorSubsectionHeader style={{ color: theme.primary.value }}>
-        <span style={{ flexGrow: 1 }}>Class Names</span>
+        <span style={{ flexGrow: 1, cursor: 'pointer' }} onClick={toggleIsExpanded}>
+          Class Names
+        </span>
         <SquareButton highlight onClick={toggleIsExpanded}>
           <ExpandableIndicator visible collapsed={!isExpanded} selected={false} />
         </SquareButton>


### PR DESCRIPTION
**Problem:**
Wanting to click on the header to open the menu doesn't work

**Fix:**
make label clickable