### PR TITLE
Minor fixes to focusing the classname section

### DIFF
--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -100,6 +100,7 @@ const menu: styleFn = (base) => ({
 
 const AlwaysTrue = () => true
 let queuedDispatchTimeout: number | undefined = undefined
+let queuedFocusTimeout: number | undefined = undefined
 
 const focusedOptionAtom = atomWithPubSub<string | null>({
   key: 'classNameSubsectionFocusedOption',
@@ -228,10 +229,13 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
 
   const expandSection = React.useCallback(() => {
     setIsExpanded(true)
-    window.setTimeout(() => inputRef.current?.focus(), 0)
+    queuedFocusTimeout = window.setTimeout(() => inputRef.current?.focus(), 0)
   }, [inputRef])
   const contractSection = React.useCallback(() => {
     setIsExpanded(false)
+    if (queuedFocusTimeout != null) {
+      window.clearTimeout(queuedFocusTimeout)
+    }
   }, [])
 
   const toggleIsExpanded = React.useCallback(() => {

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -228,7 +228,7 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
 
   const expandSection = React.useCallback(() => {
     setIsExpanded(true)
-    setTimeout(() => inputRef.current?.focus())
+    window.setTimeout(() => inputRef.current?.focus(), 0)
   }, [inputRef])
   const contractSection = React.useCallback(() => {
     setIsExpanded(false)

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -225,7 +225,31 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
   const isMenuEnabled = isSettable && elementPaths.length === 1
   const selectedOptionsLength = selectedOptions?.length ?? 0
   const [isExpanded, setIsExpanded] = React.useState(selectedOptionsLength > 0)
-  const toggleIsExpanded = React.useCallback(() => setIsExpanded((current) => !current), [])
+
+  const expandSection = React.useCallback(() => {
+    setIsExpanded(true)
+    setTimeout(() => inputRef.current?.focus())
+  }, [inputRef])
+  const contractSection = React.useCallback(() => {
+    setIsExpanded(false)
+  }, [])
+
+  const toggleIsExpanded = React.useCallback(() => {
+    if (isExpanded) {
+      contractSection()
+    } else {
+      expandSection()
+    }
+  }, [isExpanded, expandSection, contractSection])
+
+  const triggerCountRef = React.useRef(focusTriggerCount)
+
+  React.useEffect(() => {
+    if (!isExpanded && focusTriggerCount > triggerCountRef.current) {
+      triggerCountRef.current = focusTriggerCount
+      expandSection()
+    }
+  }, [focusTriggerCount, isExpanded, expandSection])
 
   const onChange = React.useCallback(
     (newValueType: ValueType<TailWindOption>) => {


### PR DESCRIPTION
Fixes #1620 
Fixes #1623 

**Problem:**
Expanding the classname section should focus the input control. Using the shortcut for the classname input field should ensure that the Inspector section is expanded.

**Fix:**
Added a `setTimeout` to focus the input ref when expanding the section. Compare the current `focusTriggerCount` with the previous to see if the section has been focused via the keyboard shortcut, and trigger the expanding logic if it wasn't already expanded.
