### PR TITLE
Interactive resize controls.

### DIFF
--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -19,6 +19,11 @@ import { Mode } from '../editor/editor-modes'
 import { EditorState, OriginalCanvasAndLocalFrame } from '../editor/store/editor-state'
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import { xor } from '../../core/shared/utils'
+import {
+  LayoutFlexElementNumericProp,
+  LayoutFlexElementProp,
+  LayoutTargetableProp,
+} from '../../core/layout/layout-helpers-new'
 
 export const CanvasContainerID = 'canvas-container'
 
@@ -209,8 +214,8 @@ export interface FlexMoveChange {
 export interface FlexResizeChange {
   type: 'FLEX_RESIZE'
   target: ElementPath
-  newSize: Size
-  edgePosition: EdgePosition | null
+  targetProperty: LayoutTargetableProp
+  delta: number
 }
 
 export interface SingleResizeChange {
@@ -272,14 +277,14 @@ export function flexMoveChange(target: ElementPath, newIndex: number): FlexMoveC
 
 export function flexResizeChange(
   target: ElementPath,
-  newSize: Size,
-  edgePosition: EdgePosition | null = null,
+  targetProperty: LayoutTargetableProp,
+  delta: number,
 ): FlexResizeChange {
   return {
     type: 'FLEX_RESIZE',
     target: target,
-    newSize: newSize,
-    edgePosition: edgePosition,
+    targetProperty: targetProperty,
+    delta: delta,
   }
 }
 
@@ -428,6 +433,7 @@ export interface ResizeDragState {
   metadata: ElementInstanceMetadataMap
   draggedElements: ElementPath[]
   isMultiSelect: boolean
+  targetProperty: LayoutTargetableProp
 }
 
 export function resizeDragState(
@@ -443,6 +449,7 @@ export function resizeDragState(
   metadata: ElementInstanceMetadataMap,
   draggedElements: ElementPath[],
   isMultiSelect: boolean,
+  targetProperty: LayoutTargetableProp,
 ): ResizeDragState {
   return {
     type: 'RESIZE_DRAG_STATE',
@@ -458,12 +465,14 @@ export function resizeDragState(
     metadata: metadata,
     draggedElements: draggedElements,
     isMultiSelect: isMultiSelect,
+    targetProperty: targetProperty,
   }
 }
 
 export function updateResizeDragState(
   current: ResizeDragState,
   drag: CanvasVector | null | undefined,
+  targetProperty: LayoutTargetableProp,
   enableSnapping: boolean | undefined,
   centerBasedResize: boolean | undefined,
   keepAspectRatio: boolean | undefined,
@@ -475,6 +484,7 @@ export function updateResizeDragState(
     centerBasedResize:
       centerBasedResize === undefined ? current.centerBasedResize : centerBasedResize,
     keepAspectRatio: keepAspectRatio === undefined ? current.keepAspectRatio : keepAspectRatio,
+    targetProperty: targetProperty,
   })
 }
 

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -31,6 +31,7 @@ import {
 import {
   findElementAtPath,
   findJSXElementAtPath,
+  getSimpleAttributeAtPath,
   MetadataUtils,
 } from '../../core/model/element-metadata-utils'
 import {
@@ -446,36 +447,39 @@ export function updateFramesOfScenesAndComponents(
             if (parentElement == null) {
               throw new Error(`Unexpected result when looking for parent: ${parentElement}`)
             }
-            // Flex based layout.
-            const possibleFlexProps = FlexLayoutHelpers.convertWidthHeightToFlex(
-              frameAndTarget.newSize.width,
-              frameAndTarget.newSize.height,
-              element.props,
-              right(parentElement.props),
-              eitherToMaybe(FlexLayoutHelpers.getMainAxis(right(parentElement.props))),
-              frameAndTarget.edgePosition,
+
+            const currentAttributeToChange =
+              eitherToMaybe(
+                getSimpleAttributeAtPath(
+                  right(element.props),
+                  createLayoutPropertyPath(frameAndTarget.targetProperty),
+                ),
+              ) ?? 0
+
+            const newAttributeValue = jsxAttributeValue(
+              currentAttributeToChange + frameAndTarget.delta,
+              emptyComments,
             )
-            forEachRight(possibleFlexProps, (flexProps) => {
-              const { flexBasis, width, height } = flexProps
-              if (flexBasis != null) {
-                propsToSet.push({
-                  path: createLayoutPropertyPath('flexBasis'),
-                  value: jsxAttributeValue(flexBasis, emptyComments),
-                })
-              }
-              if (width != null) {
-                propsToSet.push({
-                  path: createLayoutPropertyPath('Width'),
-                  value: jsxAttributeValue(width, emptyComments),
-                })
-              }
-              if (height != null) {
-                propsToSet.push({
-                  path: createLayoutPropertyPath('Height'),
-                  value: jsxAttributeValue(height, emptyComments),
-                })
-              }
+
+            propsToSet.push({
+              path: createLayoutPropertyPath(frameAndTarget.targetProperty),
+              value: newAttributeValue,
             })
+
+            propsToSkip.push(
+              createLayoutPropertyPath('left'),
+              createLayoutPropertyPath('top'),
+              createLayoutPropertyPath('right'),
+              createLayoutPropertyPath('bottom'),
+              createLayoutPropertyPath('Width'),
+              createLayoutPropertyPath('Height'),
+              createLayoutPropertyPath('minWidth'),
+              createLayoutPropertyPath('minHeight'),
+              createLayoutPropertyPath('maxWidth'),
+              createLayoutPropertyPath('maxHeight'),
+              createLayoutPropertyPath('FlexCrossBasis'),
+              createLayoutPropertyPath('flexBasis'),
+            )
           }
           break
         default:
@@ -1447,11 +1451,11 @@ export function produceResizeCanvasTransientState(
               editorState.jsxMetadata,
             )
 
-            let change: PinOrFlexFrameChange
             if (isFlexContainer) {
-              framesAndTargets.push(
-                flexResizeChange(underlyingTarget, roundedFrame, dragState.edgePosition),
-              )
+              const newDelta = isTargetPropertyHorizontal(dragState.edgePosition)
+                ? dragState.drag?.x ?? 0
+                : dragState.drag?.y ?? 0
+              framesAndTargets.push(flexResizeChange(target, dragState.targetProperty, newDelta))
             } else {
               framesAndTargets.push(
                 pinFrameChange(underlyingTarget, roundedFrame, dragState.edgePosition),
@@ -1469,6 +1473,10 @@ export function produceResizeCanvasTransientState(
       elementsToTarget,
     )
   }
+}
+
+export function isTargetPropertyHorizontal(edgePosition: EdgePosition): boolean {
+  return edgePosition.x !== 0.5
 }
 
 export function produceResizeSingleSelectCanvasTransientState(
@@ -1512,9 +1520,16 @@ export function produceResizeSingleSelectCanvasTransientState(
           elementToTarget,
           editorState.jsxMetadata,
         )
-        if (isFlexContainer) {
+        if (
+          isFlexContainer ||
+          dragState.edgePosition.x === 0.5 ||
+          dragState.edgePosition.y === 0.5
+        ) {
+          const newDelta = isTargetPropertyHorizontal(dragState.edgePosition)
+            ? dragState.drag?.x ?? 0
+            : dragState.drag?.y ?? 0
           framesAndTargets.push(
-            flexResizeChange(elementToTarget, roundedFrame, dragState.edgePosition),
+            flexResizeChange(elementToTarget, dragState.targetProperty, newDelta),
           )
         } else {
           const edgePosition = dragState.centerBasedResize
@@ -1773,7 +1788,7 @@ export function getFrameChange(
   isParentFlex: boolean,
 ): PinOrFlexFrameChange {
   if (isParentFlex) {
-    return flexResizeChange(target, newFrame, null)
+    return flexResizeChange(target, 'flexBasis', 0) // KILLME
   } else {
     return pinFrameChange(target, newFrame, null)
   }

--- a/editor/src/components/canvas/controls/multiselect-resize-control.tsx
+++ b/editor/src/components/canvas/controls/multiselect-resize-control.tsx
@@ -16,6 +16,7 @@ import { GuidelineWithSnappingVector } from '../guideline'
 import { GuidelineControl } from './guideline-control'
 import { ControlProps } from './new-canvas-controls'
 import { ResizeRectangle } from './size-box'
+import { optionalMap } from '../../../core/shared/optional-utils'
 
 interface MultiselectResizeProps extends ControlProps {
   dragState: ResizeDragState | null
@@ -151,6 +152,7 @@ export class MultiselectResizeControl extends React.Component<
         return (
           <>
             <ResizeRectangle
+              targetComponentMetadata={null}
               dispatch={this.props.dispatch}
               scale={this.props.scale}
               canvasOffset={this.props.canvasOffset}
@@ -172,6 +174,15 @@ export class MultiselectResizeControl extends React.Component<
               onResizeStart={this.onResizeStart}
               testID={'component-resize-control-0'}
               maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
+              labels={
+                {
+                  vertical: 'Width',
+                  horizontal: 'Height',
+                } as const
+              }
+              propertyTargetOptions={this.props.propertyTargetOptions}
+              propertyTargetSelectedIndex={this.props.propertyTargetSelectedIndex}
+              setTargetOptionsArray={this.props.setTargetOptionsArray}
             />
             {guidelineElements}
           </>
@@ -200,12 +211,18 @@ export class SingleSelectResizeControls extends React.Component<SingleselectResi
 
   render() {
     return this.props.selectedViews.map((view, index) => {
-      const frame = MetadataUtils.getFrameInCanvasCoords(view, this.props.componentMetadata)
+      const labels = {
+        vertical: 'Width',
+        horizontal: 'Height',
+      } as const
+      const target = MetadataUtils.findElementByElementPath(this.props.componentMetadata, view)
+      const frame = optionalMap((metadata) => metadata.globalFrame, target)
       if (frame == null) {
         return null
       } else {
         return (
           <ResizeRectangle
+            targetComponentMetadata={target}
             key={`single-select-resize-controls-rect-${index}`}
             dispatch={this.props.dispatch}
             scale={this.props.scale}
@@ -228,6 +245,10 @@ export class SingleSelectResizeControls extends React.Component<SingleselectResi
             onResizeStart={this.props.onResizeStart}
             testID={`component-resize-control-${EP.toComponentId(view)}-${index}`}
             maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
+            labels={labels}
+            propertyTargetOptions={this.props.propertyTargetOptions}
+            propertyTargetSelectedIndex={this.props.propertyTargetSelectedIndex}
+            setTargetOptionsArray={this.props.setTargetOptionsArray}
           />
         )
       }

--- a/editor/src/components/canvas/controls/multiselect-resize-control.tsx
+++ b/editor/src/components/canvas/controls/multiselect-resize-control.tsx
@@ -180,9 +180,7 @@ export class MultiselectResizeControl extends React.Component<
                   horizontal: 'Height',
                 } as const
               }
-              propertyTargetOptions={this.props.propertyTargetOptions}
-              propertyTargetSelectedIndex={this.props.propertyTargetSelectedIndex}
-              setTargetOptionsArray={this.props.setTargetOptionsArray}
+              resizeOptions={this.props.resizeOptions}
             />
             {guidelineElements}
           </>
@@ -246,9 +244,7 @@ export class SingleSelectResizeControls extends React.Component<SingleselectResi
             testID={`component-resize-control-${EP.toComponentId(view)}-${index}`}
             maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
             labels={labels}
-            propertyTargetOptions={this.props.propertyTargetOptions}
-            propertyTargetSelectedIndex={this.props.propertyTargetSelectedIndex}
-            setTargetOptionsArray={this.props.setTargetOptionsArray}
+            resizeOptions={this.props.resizeOptions}
           />
         )
       }

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -121,20 +121,25 @@ function useArrayAndIndex(defaultTargets: LayoutTargetableProp[]) {
   const [targets, setTargets] = React.useState<LayoutTargetableProp[]>(defaultTargets)
   const [targetIndex, setTargetIndex] = React.useState(0)
 
-  function incrementTargetIndex() {
+  const incrementTargetIndex = React.useCallback(() => {
     if (targetIndex < targets.length - 1) {
-      setTargetIndex(targetIndex + 1)
+      setTargetIndex((current) => {
+        return Math.min(current + 1, targets.length)
+      })
     } else {
       setTargetIndex(0)
     }
-  }
+  }, [targetIndex, targets.length])
 
-  function setTargetsResetIndex(newTargets: LayoutTargetableProp[]) {
-    if (!shallowEqual(targets, newTargets)) {
-      setTargets(newTargets)
-      setTargetIndex(0)
-    }
-  }
+  const setTargetsResetIndex = React.useCallback(
+    (newTargets: LayoutTargetableProp[]) => {
+      if (!shallowEqual(targets, newTargets)) {
+        setTargets(newTargets)
+        setTargetIndex(0)
+      }
+    },
+    [targets],
+  )
 
   return [targets, targetIndex, setTargetsResetIndex, incrementTargetIndex] as const
 }

--- a/editor/src/components/canvas/controls/property-target-selector.tsx
+++ b/editor/src/components/canvas/controls/property-target-selector.tsx
@@ -6,6 +6,7 @@ import {
 import { getSimpleAttributeAtPath } from '../../../core/model/element-metadata-utils'
 import { bimapEither, eitherToMaybe, left, right } from '../../../core/shared/either'
 import { ElementInstanceMetadata } from '../../../core/shared/element-template'
+import { betterReactMemo } from '../../../utils/react-performance'
 import { useColorTheme } from '../../../uuiui'
 
 interface PropertyTargetSelectorProps {
@@ -17,44 +18,47 @@ interface PropertyTargetSelectorProps {
   setOptionsCallback: (options: Array<LayoutTargetableProp>) => void
 }
 
-export const PropertyTargetSelector = (props: PropertyTargetSelectorProps): JSX.Element => {
-  const colorTheme = useColorTheme()
-  props.setOptionsCallback(props.options)
+export const PropertyTargetSelector = betterReactMemo(
+  'PropertyTargetSelector',
+  (props: PropertyTargetSelectorProps): JSX.Element => {
+    const colorTheme = useColorTheme()
+    props.setOptionsCallback(props.options)
 
-  return (
-    <div
-      style={{
-        position: 'absolute',
-        backgroundColor: colorTheme.primary.shade(10).value,
-        border: `1px solid ${colorTheme.primary.value}`,
-        borderRadius: 5,
-        top: props.top,
-        left: props.left,
-      }}
-    >
-      {props.options.map((option, index) => {
-        const valueForProp =
-          eitherToMaybe(
-            getSimpleAttributeAtPath(
-              left(props.targetComponentMetadata?.props ?? {}),
-              createLayoutPropertyPath(option),
-            ),
-          ) ?? '—'
+    return (
+      <div
+        style={{
+          position: 'absolute',
+          backgroundColor: colorTheme.primary.shade(10).value,
+          border: `1px solid ${colorTheme.primary.value}`,
+          borderRadius: 5,
+          top: props.top,
+          left: props.left,
+        }}
+      >
+        {props.options.map((option, index) => {
+          const valueForProp =
+            eitherToMaybe(
+              getSimpleAttributeAtPath(
+                left(props.targetComponentMetadata?.props ?? {}),
+                createLayoutPropertyPath(option),
+              ),
+            ) ?? '—'
 
-        return (
-          <div
-            key={option}
-            style={{
-              padding: '0 3px',
-              color: props.selected === index ? 'white' : colorTheme.primary.value,
-              backgroundColor: props.selected === index ? colorTheme.primary.value : 'inherit',
-              borderRadius: 5,
-            }}
-          >
-            {option}: <span style={{ float: 'right' }}>{valueForProp}</span>
-          </div>
-        )
-      })}
-    </div>
-  )
-}
+          return (
+            <div
+              key={option}
+              style={{
+                padding: '0 3px',
+                color: props.selected === index ? 'white' : colorTheme.primary.value,
+                backgroundColor: props.selected === index ? colorTheme.primary.value : 'inherit',
+                borderRadius: 5,
+              }}
+            >
+              {option}: <span style={{ float: 'right' }}>{valueForProp}</span>
+            </div>
+          )
+        })}
+      </div>
+    )
+  },
+)

--- a/editor/src/components/canvas/controls/property-target-selector.tsx
+++ b/editor/src/components/canvas/controls/property-target-selector.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react'
+import {
+  createLayoutPropertyPath,
+  LayoutTargetableProp,
+} from '../../../core/layout/layout-helpers-new'
+import { getSimpleAttributeAtPath } from '../../../core/model/element-metadata-utils'
+import { bimapEither, eitherToMaybe, left, right } from '../../../core/shared/either'
+import { ElementInstanceMetadata } from '../../../core/shared/element-template'
+import { useColorTheme } from '../../../uuiui'
+
+interface PropertyTargetSelectorProps {
+  targetComponentMetadata: ElementInstanceMetadata | null
+  top: number
+  left: number
+  options: LayoutTargetableProp[]
+  selected: number
+  setOptionsCallback: (options: Array<LayoutTargetableProp>) => void
+}
+
+export const PropertyTargetSelector = (props: PropertyTargetSelectorProps): JSX.Element => {
+  const colorTheme = useColorTheme()
+  props.setOptionsCallback(props.options)
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        backgroundColor: colorTheme.primary.shade(10).value,
+        border: `1px solid ${colorTheme.primary.value}`,
+        borderRadius: 5,
+        top: props.top,
+        left: props.left,
+      }}
+    >
+      {props.options.map((option, index) => {
+        const valueForProp =
+          eitherToMaybe(
+            getSimpleAttributeAtPath(
+              left(props.targetComponentMetadata?.props ?? {}),
+              createLayoutPropertyPath(option),
+            ),
+          ) ?? '—'
+
+        return (
+          <div
+            key={option}
+            style={{
+              padding: '0 3px',
+              color: props.selected === index ? 'white' : colorTheme.primary.value,
+              backgroundColor: props.selected === index ? colorTheme.primary.value : 'inherit',
+              borderRadius: 5,
+            }}
+          >
+            {option}: <span style={{ float: 'right' }}>{valueForProp}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/editor/src/components/canvas/controls/property-target-selector.tsx
+++ b/editor/src/components/canvas/controls/property-target-selector.tsx
@@ -2,27 +2,61 @@ import * as React from 'react'
 import {
   createLayoutPropertyPath,
   LayoutTargetableProp,
+  StyleLayoutProp,
 } from '../../../core/layout/layout-helpers-new'
 import { getSimpleAttributeAtPath } from '../../../core/model/element-metadata-utils'
-import { bimapEither, eitherToMaybe, left, right } from '../../../core/shared/either'
+import { eitherToMaybe, left } from '../../../core/shared/either'
 import { ElementInstanceMetadata } from '../../../core/shared/element-template'
+import { LayoutTargetablePropArrayKeepDeepEquality } from '../../../utils/deep-equality-instances'
 import { betterReactMemo } from '../../../utils/react-performance'
 import { useColorTheme } from '../../../uuiui'
+import {
+  incrementResizeOptionsSelectedIndex,
+  setResizeOptionsTargetOptions,
+} from '../../editor/actions/action-creators'
+import { usePrevious } from '../../editor/hook-utils'
+import { useEditorState } from '../../editor/store/store-hook'
 
 interface PropertyTargetSelectorProps {
   targetComponentMetadata: ElementInstanceMetadata | null
   top: number
   left: number
-  options: LayoutTargetableProp[]
-  selected: number
-  setOptionsCallback: (options: Array<LayoutTargetableProp>) => void
+  options: Array<LayoutTargetableProp>
 }
 
 export const PropertyTargetSelector = betterReactMemo(
   'PropertyTargetSelector',
   (props: PropertyTargetSelectorProps): JSX.Element => {
     const colorTheme = useColorTheme()
-    props.setOptionsCallback(props.options)
+    const { resizeOptions, dispatch, shiftPressed } = useEditorState((editorState) => {
+      return {
+        resizeOptions: editorState.editor.canvas.resizeOptions,
+        dispatch: editorState.dispatch,
+        shiftPressed: editorState.editor.keysPressed.shift,
+      }
+    }, 'PropertyTargetSelector resizeOptions')
+
+    const previousShiftPressed = usePrevious(shiftPressed)
+
+    // Increment the position of the selector if shift has been depressed.
+    React.useEffect(() => {
+      if (shiftPressed && !previousShiftPressed) {
+        dispatch([incrementResizeOptionsSelectedIndex()], 'canvas')
+      }
+    }, [dispatch, previousShiftPressed, shiftPressed])
+
+    // Update the current options to be the ones listed against this control,
+    // but only if they're different to the current options.
+    React.useEffect(() => {
+      if (
+        !LayoutTargetablePropArrayKeepDeepEquality(
+          resizeOptions.propertyTargetOptions,
+          props.options,
+        ).areEqual
+      ) {
+        dispatch([setResizeOptionsTargetOptions(props.options)], 'canvas')
+      }
+    }, [dispatch, props.options, resizeOptions])
 
     return (
       <div
@@ -35,7 +69,7 @@ export const PropertyTargetSelector = betterReactMemo(
           left: props.left,
         }}
       >
-        {props.options.map((option, index) => {
+        {resizeOptions.propertyTargetOptions.map((option, index) => {
           const valueForProp =
             eitherToMaybe(
               getSimpleAttributeAtPath(
@@ -49,8 +83,14 @@ export const PropertyTargetSelector = betterReactMemo(
               key={option}
               style={{
                 padding: '0 3px',
-                color: props.selected === index ? 'white' : colorTheme.primary.value,
-                backgroundColor: props.selected === index ? colorTheme.primary.value : 'inherit',
+                color:
+                  resizeOptions.propertyTargetSelectedIndex === index
+                    ? 'white'
+                    : colorTheme.primary.value,
+                backgroundColor:
+                  resizeOptions.propertyTargetSelectedIndex === index
+                    ? colorTheme.primary.value
+                    : 'inherit',
                 borderRadius: 5,
               }}
             >

--- a/editor/src/components/canvas/controls/select-mode/move-utils.ts
+++ b/editor/src/components/canvas/controls/select-mode/move-utils.ts
@@ -255,7 +255,7 @@ export function adjustAllSelectedFrames(
             editor.jsxMetadata,
           )
           if (hasFlexParent) {
-            return flexResizeChange(view, newFrame)
+            return flexResizeChange(view, 'flexBasis', adjustment * directionModifier)
           } else {
             return pinFrameChange(view, newFrame)
           }

--- a/editor/src/components/canvas/controls/yoga-control.tsx
+++ b/editor/src/components/canvas/controls/yoga-control.tsx
@@ -4,7 +4,13 @@ import { FlexLayoutHelpers, LayoutHelpers } from '../../../core/layout/layout-he
 import { findJSXElementAtPath, MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadata } from '../../../core/shared/element-template'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import { defaultEither, eitherToMaybe, mapEither, right } from '../../../core/shared/either'
+import {
+  defaultEither,
+  eitherToMaybe,
+  forEachRight,
+  mapEither,
+  right,
+} from '../../../core/shared/either'
 import Utils from '../../../utils/utils'
 import { CanvasRectangle, canvasRectangle } from '../../../core/shared/math-utils'
 import * as EP from '../../../core/shared/element-path'
@@ -70,11 +76,11 @@ class YogaResizeControl extends React.Component<YogaResizeControlProps> {
       return null
     }
     let labels: {
-      vertical: 'flexBasis' | 'FlexCrossBasis'
-      horizontal: 'flexBasis' | 'FlexCrossBasis'
+      vertical: 'flexBasis' | 'Width' | 'Height'
+      horizontal: 'flexBasis' | 'Width' | 'Height'
     } = {
       vertical: 'flexBasis',
-      horizontal: 'FlexCrossBasis',
+      horizontal: 'Height',
     }
     const parentPath = EP.parentPath(this.props.target)
     const parentElement = withUnderlyingTarget(
@@ -88,19 +94,20 @@ class YogaResizeControl extends React.Component<YogaResizeControlProps> {
       },
     )
     if (parentElement != null) {
-      const flexDirection = eitherToMaybe(FlexLayoutHelpers.getMainAxis(right(parentElement.props)))
-      if (flexDirection === 'vertical') {
-        // column, column-reverse
-        labels = {
-          horizontal: 'FlexCrossBasis',
-          vertical: 'flexBasis',
+      forEachRight(FlexLayoutHelpers.getMainAxis(right(parentElement.props)), (flexDirection) => {
+        if (flexDirection === 'vertical') {
+          // column, column-reverse
+          labels = {
+            vertical: 'Width',
+            horizontal: 'flexBasis',
+          }
+        } else {
+          labels = {
+            vertical: 'flexBasis',
+            horizontal: 'Height',
+          }
         }
-      } else {
-        labels = {
-          vertical: 'flexBasis',
-          horizontal: 'FlexCrossBasis',
-        }
-      }
+      })
     }
     const yogaSize = this.getYogaSize(visualSize)
 

--- a/editor/src/components/canvas/controls/yoga-control.tsx
+++ b/editor/src/components/canvas/controls/yoga-control.tsx
@@ -133,9 +133,7 @@ class YogaResizeControl extends React.Component<YogaResizeControlProps> {
         testID={`component-resize-control-${EP.toComponentId(this.props.target)}-0`}
         maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
         labels={labels}
-        propertyTargetOptions={this.props.propertyTargetOptions}
-        propertyTargetSelectedIndex={this.props.propertyTargetSelectedIndex}
-        setTargetOptionsArray={this.props.setTargetOptionsArray}
+        resizeOptions={this.props.resizeOptions}
       />
     )
   }

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -53,6 +53,7 @@ import { ParseResult } from '../../utils/value-parser-utils'
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import type { LoginState } from '../../common/user'
 import { InsertableComponent, StylePropOption } from '../shared/project-components'
+import { LayoutTargetableProp } from '../../core/layout/layout-helpers-new'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -896,6 +897,15 @@ export interface SetInspectorLayoutSectionHovered {
   hovered: boolean
 }
 
+export interface IncrementResizeOptionsSelectedIndex {
+  action: 'INCREMENT_RESIZE_OPTIONS_SELECTED_INDEX'
+}
+
+export interface SetResizeOptionsTargetOptions {
+  action: 'SET_RESIZE_OPTIONS_TARGET_OPTIONS'
+  propertyTargetOptions: Array<LayoutTargetableProp>
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertScene
@@ -1045,6 +1055,8 @@ export type EditorAction =
   | ClearTransientProps
   | AddTailwindConfig
   | SetInspectorLayoutSectionHovered
+  | IncrementResizeOptionsSelectedIndex
+  | SetResizeOptionsTargetOptions
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1,6 +1,7 @@
 import { LayoutSystem } from 'utopia-api' // TODO fixme this imports utopia-api
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import type { LoginState } from '../../../common/user'
+import { LayoutTargetableProp, StyleLayoutProp } from '../../../core/layout/layout-helpers-new'
 import type { revertFile, saveFile } from '../../../core/model/project-file-utils'
 import type { foldEither } from '../../../core/shared/either'
 import type {
@@ -199,6 +200,8 @@ import type {
   FocusClassNameInput,
   WrapInElement,
   SetInspectorLayoutSectionHovered,
+  IncrementResizeOptionsSelectedIndex,
+  SetResizeOptionsTargetOptions,
 } from '../action-types'
 import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
 import type {
@@ -1436,5 +1439,20 @@ export function setInspectorLayoutSectionHovered(
   return {
     action: 'SET_INSPECTOR_LAYOUT_SECTION_HOVERED',
     hovered: hovered,
+  }
+}
+
+export function incrementResizeOptionsSelectedIndex(): IncrementResizeOptionsSelectedIndex {
+  return {
+    action: 'INCREMENT_RESIZE_OPTIONS_SELECTED_INDEX',
+  }
+}
+
+export function setResizeOptionsTargetOptions(
+  propertyTargetOptions: Array<LayoutTargetableProp>,
+): SetResizeOptionsTargetOptions {
+  return {
+    action: 'SET_RESIZE_OPTIONS_TARGET_OPTIONS',
+    propertyTargetOptions: propertyTargetOptions,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -100,6 +100,8 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_PROP_TRANSIENT':
     case 'CLEAR_TRANSIENT_PROPS':
     case 'SET_INSPECTOR_LAYOUT_SECTION_HOVERED':
+    case 'INCREMENT_RESIZE_OPTIONS_SELECTED_INDEX':
+    case 'SET_RESIZE_OPTIONS_TARGET_OPTIONS':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -371,6 +371,8 @@ import {
   FocusClassNameInput,
   WrapInElement,
   SetInspectorLayoutSectionHovered,
+  IncrementResizeOptionsSelectedIndex,
+  SetResizeOptionsTargetOptions,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -1004,6 +1006,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
       openFile: currentEditor.canvas.openFile,
       scrollAnimation: currentEditor.canvas.scrollAnimation,
       transientProperties: null,
+      resizeOptions: currentEditor.canvas.resizeOptions,
     },
     floatingInsertMenu: currentEditor.floatingInsertMenu,
     inspector: {
@@ -4775,6 +4778,36 @@ export const UPDATE_FNS = {
       inspector: {
         ...editor.inspector,
         layoutSectionHovered: action.hovered,
+      },
+    }
+  },
+  INCREMENT_RESIZE_OPTIONS_SELECTED_INDEX: (editor: EditorModel): EditorModel => {
+    const resizeOptions = editor.canvas.resizeOptions
+    return {
+      ...editor,
+      canvas: {
+        ...editor.canvas,
+        resizeOptions: {
+          ...resizeOptions,
+          propertyTargetSelectedIndex:
+            (resizeOptions.propertyTargetSelectedIndex + 1) %
+            resizeOptions.propertyTargetOptions.length,
+        },
+      },
+    }
+  },
+  SET_RESIZE_OPTIONS_TARGET_OPTIONS: (
+    action: SetResizeOptionsTargetOptions,
+    editor: EditorModel,
+  ): EditorModel => {
+    return {
+      ...editor,
+      canvas: {
+        ...editor.canvas,
+        resizeOptions: {
+          propertyTargetOptions: action.propertyTargetOptions,
+          propertyTargetSelectedIndex: 0,
+        },
       },
     }
   },

--- a/editor/src/components/editor/hook-utils.ts
+++ b/editor/src/components/editor/hook-utils.ts
@@ -13,13 +13,13 @@ export function useValueResetState<T>(
 }
 
 export function usePrevious<T>(currentValue: T): T | undefined {
-  const previousRef = React.useRef<T>()
+  const previousRef = React.useRef<T | undefined>(undefined)
 
-  React.useEffect(() => {
-    previousRef.current = currentValue
-  }, [currentValue])
+  const prev = previousRef.current
 
-  return previousRef.current
+  previousRef.current = currentValue
+
+  return prev
 }
 
 export function useForceUpdate() {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -143,6 +143,7 @@ import { defaultConfig, UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import * as OPI from 'object-path-immutable'
 import { ValueAtPath } from '../../../core/shared/jsx-attributes'
 import { MapLike } from 'typescript'
+import { LayoutTargetableProp, StyleLayoutProp } from '../../../core/layout/layout-helpers-new'
 const ObjectPathImmutable: any = OPI
 
 export enum LeftMenuTab {
@@ -313,6 +314,11 @@ export type FloatingInsertMenuState =
   | FloatingInsertMenuStateConvert
   | FloatingInsertMenuStateWrap
 
+export interface ResizeOptions {
+  propertyTargetOptions: Array<LayoutTargetableProp>
+  propertyTargetSelectedIndex: number
+}
+
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
   id: string | null
@@ -386,6 +392,7 @@ export interface EditorState {
       elementPath: ElementPath
       attributesToUpdate: MapLike<JSXAttribute>
     }> | null
+    resizeOptions: ResizeOptions
   }
   floatingInsertMenu: FloatingInsertMenuState
   inspector: {
@@ -1165,6 +1172,10 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
       },
       scrollAnimation: false,
       transientProperties: null,
+      resizeOptions: {
+        propertyTargetOptions: ['Width', 'Height'],
+        propertyTargetSelectedIndex: 0,
+      },
     },
     floatingInsertMenu: {
       insertMenuMode: 'closed',
@@ -1418,6 +1429,10 @@ export function editorModelFromPersistentModel(
       },
       scrollAnimation: false,
       transientProperties: null,
+      resizeOptions: {
+        propertyTargetOptions: ['Width', 'Height'],
+        propertyTargetSelectedIndex: 0,
+      },
     },
     floatingInsertMenu: {
       insertMenuMode: 'closed',

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -321,6 +321,10 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.ADD_TAILWIND_CONFIG(action, state, dispatch)
     case 'SET_INSPECTOR_LAYOUT_SECTION_HOVERED':
       return UPDATE_FNS.SET_INSPECTOR_LAYOUT_SECTION_HOVERED(action, state)
+    case 'INCREMENT_RESIZE_OPTIONS_SELECTED_INDEX':
+      return UPDATE_FNS.INCREMENT_RESIZE_OPTIONS_SELECTED_INDEX(state)
+    case 'SET_RESIZE_OPTIONS_TARGET_OPTIONS':
+      return UPDATE_FNS.SET_RESIZE_OPTIONS_TARGET_OPTIONS(action, state)
     default:
       return state
   }

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -12,6 +12,13 @@ export type LayoutFlexElementNumericProp = 'Width' | 'Height' | 'flexBasis' | 'F
 
 export type LayoutFlexElementProp = LayoutFlexElementNumericProp
 
+export type LayoutTargetableProp =
+  | LayoutFlexElementProp
+  | 'minWidth'
+  | 'maxWidth'
+  | 'minHeight'
+  | 'maxHeight'
+
 export type LayoutPinnedProp =
   | LayoutDimension
   | 'PinnedLeft'

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -14,10 +14,16 @@ export type LayoutFlexElementProp = LayoutFlexElementNumericProp
 
 export type LayoutTargetableProp =
   | LayoutFlexElementProp
+  | 'Width'
+  | 'Height'
   | 'minWidth'
   | 'maxWidth'
   | 'minHeight'
   | 'maxHeight'
+  | 'marginTop'
+  | 'marginBottom'
+  | 'marginLeft'
+  | 'marginRight'
 
 export type LayoutPinnedProp =
   | LayoutDimension

--- a/editor/src/core/model/performance-scripts.ts
+++ b/editor/src/core/model/performance-scripts.ts
@@ -92,6 +92,7 @@ export function useTriggerResizePerformanceTest(): () => void {
         metadata.current,
         [target],
         false,
+        'Width',
       )
       await dispatch([CanvasActions.createDragState(dragState)]).entireUpdateFinished
       performance.mark(`resize_dispatch_finished_${framesPassed}`)

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -59,7 +59,7 @@ describe('React Render Count Tests - ', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     expect(renderCountAfter - renderCountBefore).toBeGreaterThan(500) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(540)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(560)
   })
 
   it('Changing the selected view', async () => {

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -871,17 +871,38 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
               const elementAspectRatioLocked = this.getElementAspectRatioLocked()
               const keepAspectRatio = pressed || elementAspectRatioLocked
               fireDragStateUpdate(
-                updateResizeDragState(dragState, undefined, undefined, undefined, keepAspectRatio),
+                updateResizeDragState(
+                  dragState,
+                  undefined,
+                  dragState.targetProperty,
+                  undefined,
+                  undefined,
+                  keepAspectRatio,
+                ),
               )
               break
             case 'alt':
               fireDragStateUpdate(
-                updateResizeDragState(dragState, undefined, undefined, pressed, undefined),
+                updateResizeDragState(
+                  dragState,
+                  undefined,
+                  dragState.targetProperty,
+                  undefined,
+                  pressed,
+                  undefined,
+                ),
               )
               break
             case 'cmd':
               fireDragStateUpdate(
-                updateResizeDragState(dragState, undefined, !pressed, undefined, undefined),
+                updateResizeDragState(
+                  dragState,
+                  undefined,
+                  dragState.targetProperty,
+                  !pressed,
+                  undefined,
+                  undefined,
+                ),
               )
               break
             default:
@@ -1009,6 +1030,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
             newDragState = updateResizeDragState(
               dragState,
               exceededThreshold ? newDrag : undefined,
+              dragState.targetProperty,
               enableSnapping,
               centerBasedResize,
               keepAspectRatio,

--- a/editor/src/utils/deep-equality-instances.ts
+++ b/editor/src/utils/deep-equality-instances.ts
@@ -21,6 +21,7 @@ import { createCallFromIntrospectiveKeepDeep } from './react-performance'
 import { Either, foldEither, isLeft, left, right } from '../core/shared/either'
 import { NameAndIconResult } from '../components/inspector/common/name-and-icon-hook'
 import { DropTargetHint, NavigatorState } from '../components/editor/store/editor-state'
+import { LayoutTargetableProp } from '../core/layout/layout-helpers-new'
 
 export const ElementPathKeepDeepEquality: KeepDeepEqualityCall<ElementPath> = createCallFromEqualsFunction(
   (oldPath: ElementPath, newPath: ElementPath) => {
@@ -150,3 +151,7 @@ export const NavigatorStateKeepDeepEquality: KeepDeepEqualityCall<NavigatorState
     }
   },
 )
+
+export const LayoutTargetablePropArrayKeepDeepEquality: KeepDeepEqualityCall<Array<
+  LayoutTargetableProp
+>> = arrayDeepEquality(createCallWithTripleEquals())


### PR DESCRIPTION
Fixes #1603

**Problem:**
Currently it's hard for users to know what will happen when resizing an element.

**Fix:**
This provides a pop-up control during resizing which supports toggling which property will be changed and shows the current values for each property as it's being resized.

**Commit Details:**
- Fixes #1603.
- Resurrects #530.
- Reworked the interface `FlexMoveChange`, replacing `newSize` and
  `edgePosition` with `targetProperty` and `delta`.
- Added `PropertyTargetSelector` component for displaying the
  various fields to change when resizing.
- Added `targetProperty` to `ResizeDragState`.
- `ResizeRectangle` gained a few more properties to handle the selected
  field to operate on and what should be available for each axis.
- The left and top edge resize handles have been removed from
  `ResizeRectangle`.
- Added `useArrayAndIndex` hook.
- Added `useTargetSelector` hook.
- Fixed `usePrevious` hook.
