### PR TITLE
Fix Stale Navigator Icons

### DIFF
--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -27,7 +27,7 @@ export function useLayoutOrElementIcon(path: ElementPath): LayoutIconResult {
     'useLayoutOrElementIcon',
     (oldResult: LayoutIconResult, newResult: LayoutIconResult) => {
       return (
-        oldResult.isPositionAbsolute === newResult.isPositionAbsolute ||
+        oldResult.isPositionAbsolute === newResult.isPositionAbsolute &&
         shallowEqual(oldResult.iconProps, newResult.iconProps)
       )
     },


### PR DESCRIPTION
Fixes #1621 

**Problem:**
When switching between flex and flow layouts, the navigator icon (which should indicate flex layouts) was not updating.

**Fix:**
The issue was an incorrect equality check in the `useLayoutOrElementIcon` hook.