### PR TITLE
Feature/inspector layout section toggle visibility

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -27,7 +27,6 @@ import {
   useInspectorLayoutInfo,
 } from '../../../common/property-path-hooks'
 import { isNotUnsetDefaultOrDetected } from '../../../common/control-status'
-import { usePropControlledStateV2 } from '../../../common/inspector-utils'
 import { useEditorState } from '../../../../editor/store/store-hook'
 import { PropertyPath } from '../../../../../core/shared/project-file-types'
 
@@ -115,14 +114,12 @@ const MainAxisControls = betterReactMemo(
     const initialIsFixedSectionVisible = useInitialFixedSectionState(props.parentFlexDirection)
     const initialIsAdvancedSectionVisible = useInitialAdvancedSectionState()
 
-    const [fixedControlsOpen, setFixedControlsOpen] = usePropControlledStateV2(
-      initialIsFixedSectionVisible,
-    )
+    const [fixedControlsOpen, setFixedControlsOpen] = React.useState(initialIsFixedSectionVisible)
     const toggleFixedSection = React.useCallback(() => setFixedControlsOpen(!fixedControlsOpen), [
       fixedControlsOpen,
       setFixedControlsOpen,
     ])
-    const [advancedControlsOpen, setAdvancedControlsOpen] = usePropControlledStateV2(
+    const [advancedControlsOpen, setAdvancedControlsOpen] = React.useState(
       initialIsAdvancedSectionVisible,
     )
     const toggleAdvancedSection = React.useCallback(
@@ -259,9 +256,7 @@ const CrossAxisControls = betterReactMemo(
   (props: FlexElementSubsectionProps) => {
     const isCrossAxisVisible = useInitialCrossSectionState(props.parentFlexDirection)
 
-    const [crossAxisControlsOpen, setCrossAxisControlsOpen] = usePropControlledStateV2(
-      isCrossAxisVisible,
-    )
+    const [crossAxisControlsOpen, setCrossAxisControlsOpen] = React.useState(isCrossAxisVisible)
     const toggleSection = React.useCallback(
       () => setCrossAxisControlsOpen(!crossAxisControlsOpen),
       [crossAxisControlsOpen, setCrossAxisControlsOpen],

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -72,38 +72,48 @@ export const FlexElementSubsectionExperiment = betterReactMemo(
   },
 )
 
+export function useInitialFixedSectionState(parentFlexDirection: string | null): boolean {
+  const isRowLayouted = parentFlexDirection === 'row' || parentFlexDirection === 'row-reverse'
+
+  const width = useInspectorLayoutInfo('Width')
+  const minWidth = useInspectorLayoutInfo('minWidth')
+  const maxWidth = useInspectorLayoutInfo('maxWidth')
+  const height = useInspectorLayoutInfo('Height')
+  const minHeight = useInspectorLayoutInfo('minHeight')
+  const maxHeight = useInspectorLayoutInfo('maxHeight')
+
+  return isRowLayouted
+    ? isNotUnsetDefaultOrDetected(width.controlStatus) ||
+        isNotUnsetDefaultOrDetected(minWidth.controlStatus) ||
+        isNotUnsetDefaultOrDetected(maxWidth.controlStatus)
+    : isNotUnsetDefaultOrDetected(height.controlStatus) ||
+        isNotUnsetDefaultOrDetected(minHeight.controlStatus) ||
+        isNotUnsetDefaultOrDetected(maxHeight.controlStatus)
+}
+
+export function useInitialAdvancedSectionState(): boolean {
+  const alignSelf = useInspectorLayoutInfo('alignSelf')
+  return isNotUnsetDefaultOrDetected(alignSelf.controlStatus)
+}
+
+export function useInitialSizeSectionState(): boolean {
+  const flexBasis = useInspectorLayoutInfo('flexBasis')
+  const flexGrow = useInspectorLayoutInfo('flexGrow')
+  const flexShrink = useInspectorLayoutInfo('flexShrink')
+  return (
+    isNotUnsetDefaultOrDetected(flexBasis.controlStatus) ||
+    isNotUnsetDefaultOrDetected(flexGrow.controlStatus) ||
+    isNotUnsetDefaultOrDetected(flexShrink.controlStatus)
+  )
+}
+
 const MainAxisControls = betterReactMemo(
   'MainAxisControls',
   (props: FlexElementSubsectionProps) => {
     const colorTheme = useColorTheme()
-    const isRowLayouted =
-      props.parentFlexDirection === 'row' || props.parentFlexDirection === 'row-reverse'
 
-    const width = useInspectorLayoutInfo('Width')
-    const minWidth = useInspectorLayoutInfo('minWidth')
-    const maxWidth = useInspectorLayoutInfo('maxWidth')
-    const height = useInspectorLayoutInfo('Height')
-    const minHeight = useInspectorLayoutInfo('minHeight')
-    const maxHeight = useInspectorLayoutInfo('maxHeight')
-    const alignSelf = useInspectorLayoutInfo('alignSelf')
-    // const flexBasis = useInspectorLayoutInfo('flexBasis')
-    // const flexGrow = useInspectorLayoutInfo('flexGrow')
-    // const flexShrink = useInspectorLayoutInfo('flexShrink')
-
-    const initialIsFixedSectionVisible = isRowLayouted
-      ? isNotUnsetDefaultOrDetected(width.controlStatus) ||
-        isNotUnsetDefaultOrDetected(minWidth.controlStatus) ||
-        isNotUnsetDefaultOrDetected(maxWidth.controlStatus)
-      : isNotUnsetDefaultOrDetected(height.controlStatus) ||
-        isNotUnsetDefaultOrDetected(minHeight.controlStatus) ||
-        isNotUnsetDefaultOrDetected(maxHeight.controlStatus)
-
-    const initialIsAdvancedSectionVisible = isNotUnsetDefaultOrDetected(alignSelf.controlStatus)
-
-    // const isSizeSectionVisible =
-    //   isNotUnsetDefaultOrDetected(flexBasis.controlStatus) ||
-    //   isNotUnsetDefaultOrDetected(flexGrow.controlStatus) ||
-    //   isNotUnsetDefaultOrDetected(flexShrink.controlStatus)
+    const initialIsFixedSectionVisible = useInitialFixedSectionState(props.parentFlexDirection)
+    const initialIsAdvancedSectionVisible = useInitialAdvancedSectionState()
 
     const [fixedControlsOpen, setFixedControlsOpen] = usePropControlledStateV2(
       initialIsFixedSectionVisible,
@@ -224,26 +234,30 @@ const AdvancedSubsectionControls = betterReactMemo(
   },
 )
 
+export function useInitialCrossSectionState(parentFlexDirection: string | null): boolean {
+  const isColumnLayouted =
+    parentFlexDirection === 'column' || parentFlexDirection === 'column-reverse'
+
+  const width = useInspectorLayoutInfo('Width')
+  const minWidth = useInspectorLayoutInfo('minWidth')
+  const maxWidth = useInspectorLayoutInfo('maxWidth')
+  const height = useInspectorLayoutInfo('Height')
+  const minHeight = useInspectorLayoutInfo('minHeight')
+  const maxHeight = useInspectorLayoutInfo('maxHeight')
+
+  return isColumnLayouted
+    ? isNotUnsetDefaultOrDetected(width.controlStatus) ||
+        isNotUnsetDefaultOrDetected(minWidth.controlStatus) ||
+        isNotUnsetDefaultOrDetected(maxWidth.controlStatus)
+    : isNotUnsetDefaultOrDetected(height.controlStatus) ||
+        isNotUnsetDefaultOrDetected(minHeight.controlStatus) ||
+        isNotUnsetDefaultOrDetected(maxHeight.controlStatus)
+}
+
 const CrossAxisControls = betterReactMemo(
   'CrossAxisControls',
   (props: FlexElementSubsectionProps) => {
-    const isColumnLayouted =
-      props.parentFlexDirection === 'column' || props.parentFlexDirection === 'column-reverse'
-
-    const width = useInspectorLayoutInfo('Width')
-    const minWidth = useInspectorLayoutInfo('minWidth')
-    const maxWidth = useInspectorLayoutInfo('maxWidth')
-    const height = useInspectorLayoutInfo('Height')
-    const minHeight = useInspectorLayoutInfo('minHeight')
-    const maxHeight = useInspectorLayoutInfo('maxHeight')
-
-    const isCrossAxisVisible = isColumnLayouted
-      ? isNotUnsetDefaultOrDetected(width.controlStatus) ||
-        isNotUnsetDefaultOrDetected(minWidth.controlStatus) ||
-        isNotUnsetDefaultOrDetected(maxWidth.controlStatus)
-      : isNotUnsetDefaultOrDetected(height.controlStatus) ||
-        isNotUnsetDefaultOrDetected(minHeight.controlStatus) ||
-        isNotUnsetDefaultOrDetected(maxHeight.controlStatus)
+    const isCrossAxisVisible = useInitialCrossSectionState(props.parentFlexDirection)
 
     const [crossAxisControlsOpen, setCrossAxisControlsOpen] = usePropControlledStateV2(
       isCrossAxisVisible,
@@ -252,6 +266,8 @@ const CrossAxisControls = betterReactMemo(
       () => setCrossAxisControlsOpen(!crossAxisControlsOpen),
       [crossAxisControlsOpen, setCrossAxisControlsOpen],
     )
+    const isColumnLayouted =
+      props.parentFlexDirection === 'column' || props.parentFlexDirection === 'column-reverse'
     const widthOrHeightControls = isColumnLayouted ? <FlexWidthControls /> : <FlexHeightControls />
     return (
       <>

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -29,6 +29,7 @@ import {
 import { isNotUnsetDefaultOrDetected } from '../../../common/control-status'
 import { useEditorState } from '../../../../editor/store/store-hook'
 import { PropertyPath } from '../../../../../core/shared/project-file-types'
+import { usePropControlledStateV2 } from '../../../common/inspector-utils'
 
 const marginProps = [
   createLayoutPropertyPath('marginLeft'),
@@ -114,12 +115,14 @@ const MainAxisControls = betterReactMemo(
     const initialIsFixedSectionVisible = useInitialFixedSectionState(props.parentFlexDirection)
     const initialIsAdvancedSectionVisible = useInitialAdvancedSectionState()
 
-    const [fixedControlsOpen, setFixedControlsOpen] = React.useState(initialIsFixedSectionVisible)
+    const [fixedControlsOpen, setFixedControlsOpen] = usePropControlledStateV2(
+      initialIsFixedSectionVisible,
+    )
     const toggleFixedSection = React.useCallback(() => setFixedControlsOpen(!fixedControlsOpen), [
       fixedControlsOpen,
       setFixedControlsOpen,
     ])
-    const [advancedControlsOpen, setAdvancedControlsOpen] = React.useState(
+    const [advancedControlsOpen, setAdvancedControlsOpen] = usePropControlledStateV2(
       initialIsAdvancedSectionVisible,
     )
     const toggleAdvancedSection = React.useCallback(
@@ -256,7 +259,9 @@ const CrossAxisControls = betterReactMemo(
   (props: FlexElementSubsectionProps) => {
     const isCrossAxisVisible = useInitialCrossSectionState(props.parentFlexDirection)
 
-    const [crossAxisControlsOpen, setCrossAxisControlsOpen] = React.useState(isCrossAxisVisible)
+    const [crossAxisControlsOpen, setCrossAxisControlsOpen] = usePropControlledStateV2(
+      isCrossAxisVisible,
+    )
     const toggleSection = React.useCallback(
       () => setCrossAxisControlsOpen(!crossAxisControlsOpen),
       [crossAxisControlsOpen, setCrossAxisControlsOpen],

--- a/editor/src/components/inspector/sections/layout-section/layout-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-section.tsx
@@ -5,6 +5,7 @@ import { emptySpecialSizeMeasurements } from '../../../../core/shared/element-te
 import { betterReactMemo } from '../../../../uuiui-deps'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { fastForEach } from '../../../../core/shared/utils'
+import * as EP from '../../../../core/shared/element-path'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { SpecialSizeMeasurementsKeepDeepEquality } from '../../../editor/store/store-deep-equality-instances'
 import { isFeatureEnabled } from '../../../../utils/feature-switches'
@@ -34,11 +35,16 @@ export const LayoutSection = betterReactMemo('LayoutSection', (props: LayoutSect
     'LayoutSection specialSizeMeasurements',
     (old, next) => SpecialSizeMeasurementsKeepDeepEquality()(old, next).areEqual,
   )
+  const selectedViews = useEditorState(
+    (store) => store.editor.selectedViews,
+    'LayoutSection selectedViews',
+  )
 
   const dispatch = useEditorState((store) => store.dispatch, 'LayoutSection dispatch')
 
   const selfLayoutSection = isFeatureEnabled('Layout Section Experimental') ? (
     <LayoutSubsection
+      key={selectedViews.map(EP.toString).join('-')}
       position={specialSizeMeasurements.position}
       parentLayoutSystem={specialSizeMeasurements.parentLayoutSystem}
       parentFlexDirection={specialSizeMeasurements.parentFlexDirection}

--- a/editor/src/components/inspector/sections/layout-section/layout-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-section.tsx
@@ -35,16 +35,11 @@ export const LayoutSection = betterReactMemo('LayoutSection', (props: LayoutSect
     'LayoutSection specialSizeMeasurements',
     (old, next) => SpecialSizeMeasurementsKeepDeepEquality()(old, next).areEqual,
   )
-  const selectedViews = useEditorState(
-    (store) => store.editor.selectedViews,
-    'LayoutSection selectedViews',
-  )
 
   const dispatch = useEditorState((store) => store.dispatch, 'LayoutSection dispatch')
 
   const selfLayoutSection = isFeatureEnabled('Layout Section Experimental') ? (
     <LayoutSubsection
-      key={selectedViews.map(EP.toString).join('-')}
       position={specialSizeMeasurements.position}
       parentLayoutSystem={specialSizeMeasurements.parentLayoutSystem}
       parentFlexDirection={specialSizeMeasurements.parentFlexDirection}

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -102,6 +102,13 @@ export const LayoutSubsection = betterReactMemo(
       initialLayoutSectionOpen,
     )
 
+    const initialLayoutSectionOpenRef = React.useRef<boolean>(initialLayoutSectionOpen)
+    // changes in the hook(selected view, delete props) should update the toggle state
+    if (initialLayoutSectionOpenRef.current !== initialLayoutSectionOpen) {
+      initialLayoutSectionOpenRef.current = initialLayoutSectionOpen
+      setSelfLayoutSectionOpen(initialLayoutSectionOpen)
+    }
+
     const toggleSection = React.useCallback(
       () => setSelfLayoutSectionOpen(!selfLayoutSectionOpen),
       [selfLayoutSectionOpen, setSelfLayoutSectionOpen],

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -20,7 +20,13 @@ import { useEditorState, useRefEditorState } from '../../../../editor/store/stor
 import { ExpandableIndicator } from '../../../../navigator/navigator-item/expandable-indicator'
 import { CSSPosition } from '../../../common/css-utils'
 import * as EP from '../../../../../core/shared/element-path'
-import { FlexElementSubsectionExperiment } from '../flex-element-subsection/flex-element-subsection'
+import {
+  FlexElementSubsectionExperiment,
+  useInitialAdvancedSectionState,
+  useInitialCrossSectionState,
+  useInitialFixedSectionState,
+  useInitialSizeSectionState,
+} from '../flex-element-subsection/flex-element-subsection'
 import { GiganticSizePinsSubsection } from './gigantic-size-pins-subsection'
 import { selectComponents } from '../../../../editor/actions/action-creators'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
@@ -62,15 +68,44 @@ interface SelfLayoutSubsectionProps {
   toggleAspectRatioLock: () => void
 }
 
+const useLayoutSectionInitialToggleState = (
+  activeTab: SelfLayoutTab,
+  parentFlexDirection: string | null,
+): boolean => {
+  const initialCrossSectionState = useInitialCrossSectionState(parentFlexDirection)
+  const initialFixedSectionState = useInitialFixedSectionState(parentFlexDirection)
+  const initialAdvancedSectionState = useInitialAdvancedSectionState()
+  const initialSizeSectionState = useInitialSizeSectionState()
+  if (activeTab != 'flex') {
+    return true
+  } else {
+    return (
+      initialCrossSectionState ||
+      initialFixedSectionState ||
+      initialAdvancedSectionState ||
+      initialSizeSectionState
+    )
+  }
+}
+
 export const LayoutSubsection = betterReactMemo(
   'LayoutSubsection',
   (props: SelfLayoutSubsectionProps) => {
-    const [selfLayoutSectionOpen, setSelfLayoutSectionOpen] = React.useState(true)
+    const [activeTab, setActiveTab] = useActiveLayoutTab(props.position, props.parentLayoutSystem)
+
+    const initialLayoutSectionOpen = useLayoutSectionInitialToggleState(
+      activeTab,
+      props.parentFlexDirection,
+    )
+
+    const [selfLayoutSectionOpen, setSelfLayoutSectionOpen] = React.useState(
+      initialLayoutSectionOpen,
+    )
+
     const toggleSection = React.useCallback(
       () => setSelfLayoutSectionOpen(!selfLayoutSectionOpen),
       [selfLayoutSectionOpen, setSelfLayoutSectionOpen],
     )
-    const [activeTab, setActiveTab] = useActiveLayoutTab(props.position, props.parentLayoutSystem)
     return (
       <>
         <LayoutSectionHeader
@@ -85,7 +120,7 @@ export const LayoutSubsection = betterReactMemo(
 )
 
 export const LayoutSubsectionContent = betterReactMemo(
-  'LayoutSubsection',
+  'LayoutSubsectionContent',
   (props: SelfLayoutSubsectionProps) => {
     const [activeTab, setActiveTab] = useActiveLayoutTab(props.position, props.parentLayoutSystem)
     return (

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -38,6 +38,7 @@ import {
   StyleLayoutProp,
 } from '../../../../../core/layout/layout-helpers-new'
 import { emptyComments } from '../../../../../core/workers/parser-printer/parser-printer-comments'
+import { usePropControlledStateV2 } from '../../../common/inspector-utils'
 
 type SelfLayoutTab = 'absolute' | 'flex' | 'flow' | 'sticky'
 
@@ -98,16 +99,9 @@ export const LayoutSubsection = betterReactMemo(
       props.parentFlexDirection,
     )
 
-    const [selfLayoutSectionOpen, setSelfLayoutSectionOpen] = React.useState(
+    const [selfLayoutSectionOpen, setSelfLayoutSectionOpen] = usePropControlledStateV2(
       initialLayoutSectionOpen,
     )
-
-    const initialLayoutSectionOpenRef = React.useRef<boolean>(initialLayoutSectionOpen)
-    // changes in the hook(selected view, delete props) should update the toggle state
-    if (initialLayoutSectionOpenRef.current !== initialLayoutSectionOpen) {
-      initialLayoutSectionOpenRef.current = initialLayoutSectionOpen
-      setSelfLayoutSectionOpen(initialLayoutSectionOpen)
-    }
 
     const toggleSection = React.useCallback(
       () => setSelfLayoutSectionOpen(!selfLayoutSectionOpen),


### PR DESCRIPTION
**Problem:**
The flex element layout section shows subsections with empty values.

**Fix:**
Hide subsections that have no values set, the subsections can be opened with the button. Without values the buttons have 30% opacity. Toggled buttons have primary colored background with white text.
Hide flex element layout section when all of the controls are not set.
Performance is not optimized for this PR as this is still experimental.

**Commit Details:**
- this valuebased off toggle state is only for flex layout 
- lots of smaller hooks to find the initial value for each subsection
- one hook that uses the smaller hooks to find the initial value for the layout section
- the automatic toggling based on metadata is done with usePropControlledStateV2