### PR TITLE
Make menus scrollable to stop them offsetting the editor

### DIFF
--- a/editor/src/components/canvas/right-menu.tsx
+++ b/editor/src/components/canvas/right-menu.tsx
@@ -194,7 +194,7 @@ export const RightMenu = betterReactMemo('RightMenu', (props: RightMenuProps) =>
         width: 38,
       }}
     >
-      <FlexColumn style={{ flexGrow: 1 }}>
+      <FlexColumn style={{ flexGrow: 1, width: 38, overflowX: 'scroll' }}>
         <Tooltip title={'Inspector'} placement='left'>
           <span>
             <MenuTile

--- a/editor/src/components/menubar/menubar.tsx
+++ b/editor/src/components/menubar/menubar.tsx
@@ -205,6 +205,8 @@ export const Menubar = betterReactMemo('Menubar', () => {
       style={{
         flexGrow: 1,
         backgroundColor: UtopiaTheme.color.leftMenuBackground.value,
+        width: 44,
+        overflowX: 'scroll',
       }}
     >
       <FlexColumn style={{ flexGrow: 1 }}>


### PR DESCRIPTION
**Problem:**
When resizing the code pane on certain screen sizes it is possible (and often the case) that the editor will become permanently offset.

**Fix:**
I managed to track this issue down to the left and right menu panes. When resizing the code pane, those two can become slightly squished, causing them to stretch slightly, and potentially offset the editor. To fix this, I have given them both fixed widths and `overflowX: 'scroll'`.
