### PR TITLE
Feature/layout system section reduced

### DIFF
--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
@@ -68,25 +68,25 @@ describe('inspector tests with real metadata', () => {
 
     const metadata = renderResult.getEditorState().editor.jsxMetadata[EP.toString(targetPath)]
 
-    const flexPaddingTopControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-T',
+    const paddingTopControl = (await renderResult.renderedDOM.findByTestId(
+      'padding-T',
     )) as HTMLInputElement
-    const flexPaddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+    const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
+      'padding-L',
     )) as HTMLInputElement
 
     // Padding top is coming from the shorthand `padding` value.
     expect(metadata.computedStyle?.['paddingTop']).toMatchInlineSnapshot(`"20px"`)
-    expect(flexPaddingTopControl.value).toMatchInlineSnapshot(`"20"`)
+    expect(paddingTopControl.value).toMatchInlineSnapshot(`"20"`)
     expect(
-      flexPaddingTopControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+      paddingTopControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"simple"`)
 
     // Padding left is coming from the `paddingLeft` value.
     expect(metadata.computedStyle?.['paddingLeft']).toMatchInlineSnapshot(`"15px"`)
-    expect(flexPaddingLeftControl.value).toMatchInlineSnapshot(`"15"`)
+    expect(paddingLeftControl.value).toMatchInlineSnapshot(`"15"`)
     expect(
-      flexPaddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+      paddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"simple"`)
   })
   it('TLWH layout controls', async () => {
@@ -458,10 +458,10 @@ describe('inspector tests with real metadata', () => {
       'position-Height-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+      'padding-L',
     )) as HTMLInputElement
     const paddingRightControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-R',
+      'padding-R',
     )) as HTMLInputElement
     const opacityControl = (await renderResult.renderedDOM.findByTestId(
       'opacity-number-control',
@@ -546,10 +546,10 @@ describe('inspector tests with real metadata', () => {
       'position-PinnedLeft-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+      'padding-L',
     )) as HTMLInputElement
     const paddingRightControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-R',
+      'padding-R',
     )) as HTMLInputElement
     const radiusControl = (await renderResult.renderedDOM.findByTestId(
       'radius-all-number-input',
@@ -665,10 +665,10 @@ describe('inspector tests with real metadata', () => {
       'position-PinnedLeft-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+      'padding-L',
     )) as HTMLInputElement
     const paddingRightControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-R',
+      'padding-R',
     )) as HTMLInputElement
     const radiusControl = (await renderResult.renderedDOM.findByTestId(
       'radius-all-number-input',
@@ -758,10 +758,10 @@ describe('inspector tests with real metadata', () => {
       'position-PinnedLeft-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+      'padding-L',
     )) as HTMLInputElement
     const paddingRightControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-R',
+      'padding-R',
     )) as HTMLInputElement
     const radiusControl = (await renderResult.renderedDOM.findByTestId(
       'radius-all-number-input',
@@ -851,10 +851,10 @@ describe('inspector tests with real metadata', () => {
       'position-PinnedLeft-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+      'padding-L',
     )) as HTMLInputElement
     const paddingRightControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-R',
+      'padding-R',
     )) as HTMLInputElement
     const radiusControl = (await renderResult.renderedDOM.findByTestId(
       'radius-all-number-input',
@@ -944,10 +944,10 @@ describe('inspector tests with real metadata', () => {
       'position-PinnedLeft-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+      'padding-L',
     )) as HTMLInputElement
     const paddingRightControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-R',
+      'padding-R',
     )) as HTMLInputElement
     const radiusControl = (await renderResult.renderedDOM.findByTestId(
       'radius-all-number-input',
@@ -1069,10 +1069,10 @@ describe('inspector tests with real metadata', () => {
       'position-PinnedLeft-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+      'padding-L',
     )) as HTMLInputElement
     const paddingRightControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-R',
+      'padding-R',
     )) as HTMLInputElement
     const radiusControl = (await renderResult.renderedDOM.findByTestId(
       'radius-all-number-input',
@@ -1173,10 +1173,10 @@ describe('inspector tests with real metadata', () => {
       'position-Height-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+      'padding-L',
     )) as HTMLInputElement
     const paddingRightControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-R',
+      'padding-R',
     )) as HTMLInputElement
     const opacityControl = (await renderResult.renderedDOM.findByTestId(
       'opacity-number-control',
@@ -1261,10 +1261,10 @@ describe('inspector tests with real metadata', () => {
       'position-Height-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+      'padding-L',
     )) as HTMLInputElement
     const paddingRightControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-R',
+      'padding-R',
     )) as HTMLInputElement
     const radiusControl = (await renderResult.renderedDOM.findByTestId(
       'radius-all-number-input',
@@ -1372,7 +1372,7 @@ describe('inspector tests with real metadata', () => {
       'position-Height-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+      'padding-L',
     )) as HTMLInputElement
     const radiusControl = (await renderResult.renderedDOM.findByTestId(
       'radius-all-number-input',
@@ -1476,9 +1476,7 @@ describe('inspector tests with real metadata', () => {
       await screen.findByTestId('toggle-min-max-button')
       fireEvent.click(screen.getByTestId('toggle-min-max-button'))
       await screen.findByTestId('position-maxWidth-number-input')
-      await screen.findByTestId('layout-system-expand')
-      fireEvent.click(screen.getByTestId('layout-system-expand'))
-      await screen.findByTestId('flexPadding-L')
+      await screen.findByTestId('padding-L')
     })
 
     const metadata = renderResult.getEditorState().editor.jsxMetadata[EP.toString(targetPath)]
@@ -1490,7 +1488,7 @@ describe('inspector tests with real metadata', () => {
       'position-maxWidth-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+      'padding-L',
     )) as HTMLInputElement
     const radiusControl = (await renderResult.renderedDOM.findByTestId(
       'radius-all-number-input',
@@ -1583,9 +1581,7 @@ describe('inspector tests with real metadata', () => {
       await screen.findByTestId('toggle-min-max-button')
       fireEvent.click(screen.getByTestId('toggle-min-max-button'))
       await screen.findByTestId('position-maxWidth-number-input')
-      await screen.findByTestId('layout-system-expand')
-      fireEvent.click(screen.getByTestId('layout-system-expand'))
-      await screen.findByTestId('flexPadding-L')
+      await screen.findByTestId('padding-L')
     })
 
     const metadata = renderResult.getEditorState().editor.jsxMetadata[EP.toString(targetPath)]
@@ -1597,7 +1593,7 @@ describe('inspector tests with real metadata', () => {
       'position-maxHeight-number-input',
     )) as HTMLInputElement
     const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+      'padding-L',
     )) as HTMLInputElement
     const radiusControl = (await renderResult.renderedDOM.findByTestId(
       'radius-all-number-input',
@@ -1844,25 +1840,25 @@ describe('inspector tests with real metadata', () => {
 
     const metadata = renderResult.getEditorState().editor.jsxMetadata[EP.toString(targetPath)]
 
-    const flexPaddingTopControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-T',
+    const paddingTopControl = (await renderResult.renderedDOM.findByTestId(
+      'padding-T',
     )) as HTMLInputElement
-    const flexPaddingLeftControl = (await renderResult.renderedDOM.findByTestId(
-      'flexPadding-L',
+    const paddingLeftControl = (await renderResult.renderedDOM.findByTestId(
+      'padding-L',
     )) as HTMLInputElement
 
     // Padding top is coming from the shorthand `padding` value.
     expect(metadata.computedStyle?.['paddingTop']).toMatchInlineSnapshot(`"8px"`)
-    expect(flexPaddingTopControl.value).toMatchInlineSnapshot(`"8"`)
+    expect(paddingTopControl.value).toMatchInlineSnapshot(`"8"`)
     expect(
-      flexPaddingTopControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+      paddingTopControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"simple"`)
 
     // Padding left is coming from the `paddingLeft` value.
     expect(metadata.computedStyle?.['paddingLeft']).toMatchInlineSnapshot(`"10px"`)
-    expect(flexPaddingLeftControl.value).toMatchInlineSnapshot(`"10"`)
+    expect(paddingLeftControl.value).toMatchInlineSnapshot(`"10"`)
     expect(
-      flexPaddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
+      paddingLeftControl.attributes.getNamedItemNS(null, 'data-controlstatus')?.value,
     ).toMatchInlineSnapshot(`"simple"`)
   })
 })

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -151,7 +151,7 @@ export const paddingPropsToUnset = [
   createLayoutPropertyPath('paddingBottom'),
 ]
 
-export const FlexPaddingControl = betterReactMemo('FlexPaddingControl', () => {
+export const PaddingControl = betterReactMemo('PaddingControl', () => {
   const {
     paddingTop,
     paddingRight,
@@ -163,85 +163,85 @@ export const FlexPaddingControl = betterReactMemo('FlexPaddingControl', () => {
     createLayoutPropertyPath,
   )
 
-  const flexPaddingTopOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+  const paddingTopOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
     paddingTop.onSubmitValue,
     paddingTop.onUnsetValues,
   )
-  const flexPaddingTopOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+  const paddingTopOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
     paddingTop.onTransientSubmitValue,
     paddingTop.onUnsetValues,
   )
-  const flexPaddingRightOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+  const paddingRightOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
     paddingRight.onSubmitValue,
     paddingRight.onUnsetValues,
   )
-  const flexPaddingRightOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+  const paddingRightOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
     paddingRight.onTransientSubmitValue,
     paddingRight.onUnsetValues,
   )
-  const flexPaddingBottomOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+  const paddingBottomOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
     paddingBottom.onSubmitValue,
     paddingBottom.onUnsetValues,
   )
-  const flexPaddingBottomOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+  const paddingBottomOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
     paddingBottom.onTransientSubmitValue,
     paddingBottom.onUnsetValues,
   )
-  const flexPaddingLeftOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+  const paddingLeftOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
     paddingLeft.onSubmitValue,
     paddingLeft.onUnsetValues,
   )
-  const flexPaddingLeftOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+  const paddingLeftOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
     paddingLeft.onTransientSubmitValue,
     paddingLeft.onUnsetValues,
   )
 
   return (
     <ChainedNumberInput
-      idPrefix='flexPadding'
+      idPrefix='padding'
       propsArray={[
         {
           value: paddingTop.value,
           DEPRECATED_labelBelow: 'T',
           minimum: 0,
-          onSubmitValue: flexPaddingTopOnSubmitValue,
+          onSubmitValue: paddingTopOnSubmitValue,
           controlStatus: paddingTop.controlStatus,
           numberType: 'LengthPercent',
           defaultUnitToHide: 'px',
-          testId: 'flexPadding-T',
+          testId: 'padding-T',
         },
         {
           value: paddingRight.value,
           DEPRECATED_labelBelow: 'R',
           minimum: 0,
-          onSubmitValue: flexPaddingRightOnSubmitValue,
-          onTransientSubmitValue: flexPaddingRightOnTransientSubmitValue,
+          onSubmitValue: paddingRightOnSubmitValue,
+          onTransientSubmitValue: paddingRightOnTransientSubmitValue,
           controlStatus: paddingRight.controlStatus,
           numberType: 'LengthPercent',
           defaultUnitToHide: 'px',
-          testId: 'flexPadding-R',
+          testId: 'padding-R',
         },
         {
           value: paddingBottom.value,
           DEPRECATED_labelBelow: 'B',
           minimum: 0,
-          onSubmitValue: flexPaddingBottomOnSubmitValue,
-          onTransientSubmitValue: flexPaddingBottomOnTransientSubmitValue,
+          onSubmitValue: paddingBottomOnSubmitValue,
+          onTransientSubmitValue: paddingBottomOnTransientSubmitValue,
           controlStatus: paddingBottom.controlStatus,
           numberType: 'LengthPercent',
           defaultUnitToHide: 'px',
-          testId: 'flexPadding-B',
+          testId: 'padding-B',
         },
         {
           value: paddingLeft.value,
           DEPRECATED_labelBelow: 'L',
           minimum: 0,
-          onSubmitValue: flexPaddingLeftOnSubmitValue,
-          onTransientSubmitValue: flexPaddingLeftOnTransientSubmitValue,
+          onSubmitValue: paddingLeftOnSubmitValue,
+          onTransientSubmitValue: paddingLeftOnTransientSubmitValue,
           controlStatus: paddingLeft.controlStatus,
           numberType: 'LengthPercent',
           defaultUnitToHide: 'px',
-          testId: 'flexPadding-L',
+          testId: 'padding-L',
         },
       ]}
     />

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -71,7 +71,7 @@ function useDefaultedLayoutSystemInfo(): {
   }
 }
 
-function useLayoutSystemData() {
+export function useLayoutSystemData() {
   const dispatch = useEditorState((store) => store.dispatch, 'useLayoutSystemData dispatch')
 
   const onLayoutSystemChange = React.useCallback(
@@ -113,11 +113,7 @@ export const LayoutSystemControl = betterReactMemo(
   'LayoutSystemControl',
   (props: LayoutSystemControlProps) => {
     const layoutSystemData = useLayoutSystemData()
-    const isDetectedLayoutSystemPinSystem =
-      props.layoutSystem === 'flow' && props.providesCoordinateSystemForChildren
-    const detectedLayoutSystem = isDetectedLayoutSystemPinSystem
-      ? 'pinSystem'
-      : props.layoutSystem ?? layoutSystemData.value
+    const detectedLayoutSystem = props.layoutSystem ?? layoutSystemData.value
     return (
       <OptionChainControl
         id={'layoutSystem'}
@@ -133,32 +129,17 @@ export const LayoutSystemControl = betterReactMemo(
   },
 )
 
-// for now, 'flow', 'grid' and 'group' are not clickable buttons, they only have an indicative role
 const layoutSystemOptions = [
-  {
-    value: 'flow',
-    tooltip: 'Default CSS Normal Flow Layout',
-    label: 'Flow',
-  },
   {
     value: 'flex',
     tooltip: 'Layout children with flexbox',
     label: 'Flex',
   },
-  {
-    value: 'pinSystem',
-    tooltip: 'Layout children with pins',
-    label: 'Pins',
-  },
+
   {
     value: 'grid',
     tooltip: 'Layout children with grid',
     label: 'Grid',
-  },
-  {
-    value: 'group',
-    tooltip: 'Group children',
-    label: 'Group',
   },
 ]
 

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
@@ -4,8 +4,6 @@ import { jsx, css } from '@emotion/react'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import {
   LayoutSystemControl,
-  FlexPaddingControl,
-  paddingPropsToUnset,
   DeleteAllLayoutSystemConfigButton,
   useLayoutSystemData,
 } from './layout-system-controls'
@@ -97,16 +95,6 @@ export const LayoutSystemSubsection = betterReactMemo<LayoutSystemSubsectionProp
               />
             </UIGridRow>
             {isFlexParent ? <FlexContainerControls seeMoreVisible={true} /> : null}
-            <UIGridRow tall padded={true} variant='<---1fr--->|------172px-------|'>
-              <PropertyLabel
-                target={paddingPropsToUnset}
-                propNamesToUnset={['all paddings']}
-                style={{ paddingBottom: 12 }}
-              >
-                Padding
-              </PropertyLabel>
-              <FlexPaddingControl />
-            </UIGridRow>
           </React.Fragment>
         ) : null}
       </React.Fragment>

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
@@ -1,10 +1,13 @@
+/** @jsx jsx */
 import * as React from 'react'
+import { jsx, css } from '@emotion/react'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import {
   LayoutSystemControl,
   FlexPaddingControl,
   paddingPropsToUnset,
   DeleteAllLayoutSystemConfigButton,
+  useLayoutSystemData,
 } from './layout-system-controls'
 import { FlexContainerControls } from '../flex-container-subsection/flex-container-subsection'
 import { PropertyLabel } from '../../../widgets/property-label'
@@ -12,12 +15,17 @@ import {
   DetectedLayoutSystem,
   SpecialSizeMeasurements,
 } from '../../../../../core/shared/element-template'
-import { InspectorSubsectionHeader, SquareButton } from '../../../../../uuiui'
+import {
+  FlexRow,
+  Icons,
+  InspectorSectionHeader,
+  SquareButton,
+  useColorTheme,
+} from '../../../../../uuiui'
 import { betterReactMemo } from '../../../../../uuiui-deps'
 import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
 import { createLayoutPropertyPath } from '../../../../../core/layout/layout-helpers-new'
 import { isNotUnsetOrDefault } from '../../../common/control-status'
-import { ExpandableIndicator } from '../../../../navigator/navigator-item/expandable-indicator'
 import { usePropControlledStateV2 } from '../../../common/inspector-utils'
 
 interface LayoutSystemSubsectionProps {
@@ -37,27 +45,49 @@ export const LayoutSystemSubsection = betterReactMemo<LayoutSystemSubsectionProp
       isFlexParent || Object.values(paddings).some((i) => isNotUnsetOrDefault(i.controlStatus))
     const [layoutSectionOpen, setLayoutSectionOpen] = usePropControlledStateV2(hasAnyLayoutProps)
 
-    const toggleSection = React.useCallback(() => setLayoutSectionOpen(!layoutSectionOpen), [
-      layoutSectionOpen,
-      setLayoutSectionOpen,
-    ])
+    const openSection = React.useCallback(() => setLayoutSectionOpen(true), [setLayoutSectionOpen])
+
+    const layoutSystemData = useLayoutSystemData()
+
+    const handleAddLayoutSystemClick = React.useCallback(() => {
+      layoutSystemData.onSubmitValue('flex')
+      openSection()
+    }, [layoutSystemData, openSection])
+
+    const colorTheme = useColorTheme()
 
     return (
-      <>
-        <InspectorSubsectionHeader>
-          <span style={{ flexGrow: 1 }}>Layout System</span>
+      <React.Fragment>
+        <InspectorSectionHeader
+          css={{
+            marginTop: 8,
+            transition: 'color .1s ease-in-out',
+            color: layoutSectionOpen ? colorTheme.fg1.value : colorTheme.fg7.value,
+            '--buttonContentOpacity': 0.3,
+            '&:hover': {
+              color: colorTheme.fg1.value,
+              '--buttonContentOpacity': 1,
+            },
+          }}
+        >
+          <FlexRow
+            onClick={handleAddLayoutSystemClick}
+            style={{
+              flexGrow: 1,
+              alignSelf: 'stretch',
+            }}
+          >
+            Layout System
+          </FlexRow>
           {layoutSectionOpen && <DeleteAllLayoutSystemConfigButton />}
-          <SquareButton highlight onClick={toggleSection}>
-            <ExpandableIndicator
-              testId='layout-system-expand'
-              visible
-              collapsed={!layoutSectionOpen}
-              selected={false}
-            />
-          </SquareButton>
-        </InspectorSubsectionHeader>
+          {!layoutSectionOpen && (
+            <SquareButton highlight onClick={handleAddLayoutSystemClick}>
+              <Icons.Plus style={{ opacity: 'var(--buttonContentOpacity)' }} />
+            </SquareButton>
+          )}
+        </InspectorSectionHeader>
         {layoutSectionOpen ? (
-          <>
+          <React.Fragment>
             <UIGridRow padded={true} variant='<-------------1fr------------->'>
               <LayoutSystemControl
                 layoutSystem={props.specialSizeMeasurements.layoutSystemForChildren}
@@ -77,9 +107,9 @@ export const LayoutSystemSubsection = betterReactMemo<LayoutSystemSubsectionProp
               </PropertyLabel>
               <FlexPaddingControl />
             </UIGridRow>
-          </>
+          </React.Fragment>
         ) : null}
-      </>
+      </React.Fragment>
     )
   },
 )

--- a/editor/src/components/inspector/sections/style-section/containter-subsection/container-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/containter-subsection/container-subsection.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react'
 import { H2 } from '../../../../../uuiui'
 import { betterReactMemo } from '../../../../../uuiui-deps'
+import { PropertyLabel } from '../../../widgets/property-label'
 import { SeeMoreButton, SeeMoreHOC, useToggle } from '../../../widgets/see-more'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
+import {
+  PaddingControl,
+  paddingPropsToUnset,
+} from '../../layout-section/layout-system-subsection/layout-system-controls'
 import { BlendModeRow } from './blendmode-row'
 import { OpacityRow } from './opacity-row'
 import { OverflowRow } from './overflow-row'
@@ -22,6 +27,16 @@ export const ContainerSubsection = betterReactMemo('ContainerSubsection', () => 
       <OpacityRow />
       <OverflowRow />
       <RadiusRow />
+      <UIGridRow tall padded={true} variant='<---1fr--->|------172px-------|'>
+        <PropertyLabel
+          target={paddingPropsToUnset}
+          propNamesToUnset={['all paddings']}
+          style={{ paddingBottom: 12 }}
+        >
+          Padding
+        </PropertyLabel>
+        <PaddingControl />
+      </UIGridRow>
       <SeeMoreHOC visible={seeMoreVisible}>
         <BlendModeRow />
       </SeeMoreHOC>

--- a/editor/src/uuiui/widgets/headings/headings.tsx
+++ b/editor/src/uuiui/widgets/headings/headings.tsx
@@ -53,7 +53,7 @@ export const VerySubdued = styled(Subdued)({
 
 export const InspectorSectionHeader = styled(H1)({
   label: 'section-header',
-  height: 34,
+  height: UtopiaTheme.layout.rowHeight.large,
   padding: `6px ${UtopiaTheme.layout.inspectorXPadding}px 6px ${UtopiaTheme.layout.inspectorXPadding}px`,
 })
 InspectorSectionHeader.displayName = 'InspectorSectionHeader'


### PR DESCRIPTION
**Problem:**
The Layout System section was not clear enough, and behaves differently from *cough* other famous design tools. Specifically, clicking on it didn't add a system, the "systems" it could add included flow which caused the thing itself to be laid out via flow, some of the buttons didn't do anything etc.

**Fix:**
1. I made the section header interactive. Clicking on it now _adds a flex system_ as the default. It's what you want all the time, 70% of the time.
2. I removed 'flow' and 'pin system' as options.
3. Clicking the layout system "-" button now actually removes it. 

NB There's almost certainly a cleaner implementation, and I didn't clean up the code around the "layout systems" - just removed how it's exposed here. 
