### PR TITLE
Fix Code Editor Highlighting Synchronisation Bug

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -51,6 +51,7 @@ import {
   HighlightBoundsForUids,
   HighlightBoundsWithFile,
   PropertyPath,
+  HighlightBoundsWithFileForUids,
 } from '../../../core/shared/project-file-types'
 import { diagnosticToErrorMessage } from '../../../core/workers/ts/ts-utils'
 import { ExportsInfo, MultiFileBuildResult } from '../../../core/workers/ts/ts-worker'
@@ -143,6 +144,7 @@ import { defaultConfig, UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import * as OPI from 'object-path-immutable'
 import { ValueAtPath } from '../../../core/shared/jsx-attributes'
 import { MapLike } from 'typescript'
+import { pick } from '../../../core/shared/object-utils'
 const ObjectPathImmutable: any = OPI
 
 export enum LeftMenuTab {
@@ -1839,6 +1841,15 @@ export function getHighlightBoundsForElementPath(
   }
 
   return null
+}
+
+export function getHighlightBoundsForElementPaths(
+  paths: Array<ElementPath>,
+  editorState: EditorState,
+): HighlightBoundsWithFileForUids {
+  const targetUIDs = paths.map((path) => toUid(EP.dynamicPathToStaticPath(path)))
+  const projectHighlightBounds = getHighlightBoundsForProject(editorState.projectContents)
+  return pick(targetUIDs, projectHighlightBounds)
 }
 
 export function getElementPathsInBounds(

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -62,6 +62,7 @@ import { emptySet } from '../shared/set-utils'
 import { fastForEach } from '../shared/utils'
 import { foldEither, isLeft, isRight, maybeEitherToMaybe } from '../shared/either'
 import { splitAt } from '../shared/string-utils'
+import { memoize } from '../shared/memoize'
 
 export const sceneMetadata = _sceneMetadata // This is a hotfix for a circular dependency AND a leaking of utopia-api into the workers
 
@@ -361,7 +362,7 @@ export function getHighlightBoundsFromParseResult(
   )
 }
 
-export function getHighlightBoundsForProject(
+function getHighlightBoundsForProjectImpl(
   allFiles: ProjectContentTreeRoot,
 ): HighlightBoundsWithFileForUids {
   let allHighlightBounds: HighlightBoundsWithFileForUids = {}
@@ -378,6 +379,11 @@ export function getHighlightBoundsForProject(
 
   return allHighlightBounds
 }
+
+export const getHighlightBoundsForProject = memoize(getHighlightBoundsForProjectImpl, {
+  maxSize: 2,
+  equals: (a, b) => a === b,
+})
 
 export function updateParsedTextFileHighlightBounds(
   result: ParsedTextFile,

--- a/utopia-vscode-extension/package.json
+++ b/utopia-vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "utopia vscode extension",
   "publisher": "concrete-utopia",
   "description": "For providing communication between Utopia and VS Code",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "enableProposedApi": true,
   "private": true,


### PR DESCRIPTION
Fixes #1633 

**Problem:**
When inserting an element via the canvas (or wrapping or anything else that results in a new element with a new UID), the highlighting in the code editor will be out of sync from the canvas.

**Fix:**
There were two problems here that were both causing this:

1. The check we made to see if highlight bounds had changed was only checking the bounds of the "currently open file", which translates to the file open in the canvas (the storyboard file), and not necessarily the one up in the code editor pane (e.g. `App.js`), meaning we'd often be checking the wrong file for changes. This was fixed by changing the check to compare the highlight bounds of the currently highlighted and selected elements.
2. The check made to see if selection had changed wouldn't send the update if the selection had no highlight bounds, which is the case when inserting something new since we hadn't generated the highlight bounds yet. This was fixed by also checking if the highlight bounds of the selected element have changed.

During this I also discovered that we had an issue that was being hidden by this issue - updating the highlight bounds or selection in VS Code, followed by immediately updating the code, would offset the highlight and selection. This was previously always fine because we were never sending across highlight bounds and a selection for newly inserted code (because of the above). To fix this, when receiving updated (unsaved) code from Utopia the extension will now also reset the highlight bounds and selection.
