### PR TITLE
Safer focusing handling.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
@@ -678,6 +678,18 @@ describe('Spy Wrapper Template Path Tests', () => {
           EP.elementPath([
             ['storyboard', 'scene-1', 'app'],
             ['other-app-root', 'other-inner-div', 'other-card-instance'],
+          ]),
+        ),
+      ],
+      true,
+    )
+
+    await dispatch(
+      [
+        setFocusedElement(
+          EP.elementPath([
+            ['storyboard', 'scene-1', 'app'],
+            ['other-app-root', 'other-inner-div', 'other-card-instance'],
             ['other-button-instance'],
           ]),
         ),
@@ -999,6 +1011,18 @@ describe('Spy Wrapper Template Path Tests', () => {
 
   it('a generated component instance is focused inside a component instance inside the main App component', async () => {
     const { dispatch, getEditorState } = await createExampleProject()
+    await dispatch(
+      [
+        setFocusedElement(
+          EP.elementPath([
+            ['storyboard', 'scene-1', 'app'],
+            ['other-app-root', 'other-inner-div', 'other-card-instance'],
+          ]),
+        ),
+      ],
+      true,
+    )
+
     await dispatch(
       [
         setFocusedElement(
@@ -1698,6 +1722,18 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
           EP.elementPath([
             ['storyboard', 'scene-2', 'app2'],
             ['app-outer-div', 'card-instance'],
+          ]),
+        ),
+      ],
+      true,
+    )
+
+    await dispatch(
+      [
+        setFocusedElement(
+          EP.elementPath([
+            ['storyboard', 'scene-2', 'app2'],
+            ['app-outer-div', 'card-instance'],
             ['button-instance'],
           ]),
         ),
@@ -2019,6 +2055,18 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
 
   it('a generated component instance is focused inside a component instance inside the main App component', async () => {
     const { dispatch, getEditorState } = await createExampleProject()
+    await dispatch(
+      [
+        setFocusedElement(
+          EP.elementPath([
+            ['storyboard', 'scene-2', 'app2'],
+            ['app-outer-div', 'card-instance'],
+          ]),
+        ),
+      ],
+      true,
+    )
+
     await dispatch(
       [
         setFocusedElement(
@@ -2402,6 +2450,18 @@ describe('Spy Wrapper Multifile With Cyclic Dependencies', () => {
           EP.elementPath([
             ['storyboard', 'scene-2', 'app2'],
             ['app-outer-div', 'card-instance'],
+          ]),
+        ),
+      ],
+      true,
+    )
+
+    await dispatch(
+      [
+        setFocusedElement(
+          EP.elementPath([
+            ['storyboard', 'scene-2', 'app2'],
+            ['app-outer-div', 'card-instance'],
             ['button-instance', 'hi-element~~~2'],
           ]),
         ),
@@ -2777,6 +2837,31 @@ describe('Spy Wrapper Multifile With Cyclic Dependencies', () => {
           );
         };`,
     })
+
+    await dispatch(
+      [
+        setFocusedElement(
+          EP.elementPath([
+            ['storyboard', 'scene-2', 'app2'],
+            ['app-outer-div', 'card-instance'],
+          ]),
+        ),
+      ],
+      true,
+    )
+
+    await dispatch(
+      [
+        setFocusedElement(
+          EP.elementPath([
+            ['storyboard', 'scene-2', 'app2'],
+            ['app-outer-div', 'card-instance'],
+            ['button-instance', 'hi-element~~~2'],
+          ]),
+        ),
+      ],
+      true,
+    )
 
     await dispatch(
       [

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -404,9 +404,7 @@ export function normalisePathToUnderlyingTarget(
 ): NormalisePathResult {
   const currentFile = getContentsTreeFileFromString(projectContents, currentFilePath)
   if (isTextFile(currentFile)) {
-    if (!isParseSuccess(currentFile.fileContents.parsed)) {
-      return normalisePathUnableToProceed(currentFilePath)
-    } else {
+    if (isParseSuccess(currentFile.fileContents.parsed)) {
       const staticPath = elementPath == null ? null : EP.dynamicPathToStaticPath(elementPath)
       const potentiallyDroppedFirstPathElementResult = EP.dropFirstPathElement(staticPath)
       if (potentiallyDroppedFirstPathElementResult.droppedPathElements == null) {
@@ -463,6 +461,8 @@ export function normalisePathToUnderlyingTarget(
           }
         }
       }
+    } else {
+      return normalisePathUnableToProceed(currentFilePath)
     }
   } else {
     return normalisePathUnableToProceed(currentFilePath)

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4401,17 +4401,27 @@ export const UPDATE_FNS = {
     return editor
   },
   SET_FOCUSED_ELEMENT: (action: SetFocusedElement, editor: EditorModel): EditorModel => {
+    let shouldApplyChange: boolean = false
+    if (action.focusedElementPath == null) {
+      shouldApplyChange = true
+    } else if (MetadataUtils.isFocusableComponent(action.focusedElementPath, editor.jsxMetadata)) {
+      shouldApplyChange = true
+    }
     if (EP.pathsEqual(editor.focusedElementPath, action.focusedElementPath)) {
-      return editor
+      shouldApplyChange = false
     }
 
-    return {
-      ...editor,
-      focusedElementPath: action.focusedElementPath,
-      canvas: {
-        ...editor.canvas,
-        domWalkerInvalidateCount: editor.canvas.domWalkerInvalidateCount + 1,
-      },
+    if (shouldApplyChange) {
+      return {
+        ...editor,
+        focusedElementPath: action.focusedElementPath,
+        canvas: {
+          ...editor.canvas,
+          domWalkerInvalidateCount: editor.canvas.domWalkerInvalidateCount + 1,
+        },
+      }
+    } else {
+      return editor
     }
   },
   SCROLL_TO_ELEMENT: (

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -314,8 +314,10 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
       [dispatch, elementPath, selected, isHighlighted],
     )
     const focusComponent = React.useCallback(() => {
-      dispatch([EditorActions.setFocusedElement(elementPath)])
-    }, [dispatch, elementPath])
+      if (isFocusedComponent) {
+        dispatch([EditorActions.setFocusedElement(elementPath)])
+      }
+    }, [dispatch, elementPath, isFocusedComponent])
 
     const containerStyle: React.CSSProperties = React.useMemo(() => {
       return {

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -314,10 +314,10 @@ export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = b
       [dispatch, elementPath, selected, isHighlighted],
     )
     const focusComponent = React.useCallback(() => {
-      if (isFocusedComponent) {
+      if (isFocusableComponent) {
         dispatch([EditorActions.setFocusedElement(elementPath)])
       }
-    }, [dispatch, elementPath, isFocusedComponent])
+    }, [dispatch, elementPath, isFocusableComponent])
 
     const containerStyle: React.CSSProperties = React.useMemo(() => {
       return {


### PR DESCRIPTION
Fixes #1632

**Problem:**
It's possible to focus elements that shouldn't be focusable.

**Fix:**
Prevent the navigator items from attempting to focus ineligible items but also make the focusing action defend against rogue invocations as a final insurance measure.

**Commit Details:**
- Fixes #1632.
- Make the `focusComponent` handler in `NavigatorItem` only attempt to
  focus a component that is focusable.
- Made the `SET_FOCUSED_ELEMENT` more defensive by having it check if
  an element is focusable.
- Flip an if condition in `normalisePathToUnderlyingTarget` to avoid
  a double negative.
