### PR TITLE
Only display resize options on mouse down.

### DIFF
--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -128,9 +128,7 @@ interface ResizeEdgeProps {
   dragState: DragState | null
 }
 
-interface ResizeEdgeState {
-  showLabel: boolean
-}
+interface ResizeEdgeState {}
 
 function allowsInteractiveResize(layoutSystem: DetectedLayoutSystem): boolean {
   switch (layoutSystem) {
@@ -165,21 +163,8 @@ function shiftPropertyTargetSelectorAxis(
 class ResizeEdge extends React.Component<ResizeEdgeProps, ResizeEdgeState> {
   constructor(props: ResizeEdgeProps) {
     super(props)
-    this.state = {
-      showLabel: false,
-    }
-    this.mouseOver = this.mouseOver.bind(this)
-    this.mouseOut = this.mouseOut.bind(this)
   }
   reference = React.createRef<HTMLDivElement>()
-
-  mouseOver() {
-    this.setState({ showLabel: true })
-  }
-
-  mouseOut() {
-    this.setState({ showLabel: false })
-  }
 
   render() {
     if (this.props.resizeStatus != 'enabled') {
@@ -224,8 +209,6 @@ class ResizeEdge extends React.Component<ResizeEdgeProps, ResizeEdgeState> {
       <React.Fragment>
         <div
           ref={this.reference}
-          onMouseOver={this.mouseOver}
-          onMouseOut={this.mouseOut}
           style={{
             pointerEvents: 'initial',
             position: 'absolute',
@@ -239,7 +222,7 @@ class ResizeEdge extends React.Component<ResizeEdgeProps, ResizeEdgeState> {
           }}
         />
         {when(
-          (this.state.showLabel || isEdgeDragged) && interactiveResize,
+          isEdgeDragged && interactiveResize,
           <PropertyTargetSelector
             top={top + shiftPropertyTargetSelectorAxis('horizontal', this.props.direction, edge)}
             left={left + shiftPropertyTargetSelectorAxis('vertical', this.props.direction, edge)}

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -258,7 +258,6 @@ interface ResizeLinesProps {
 
 const LineOffset = 6
 const ResizeLines = betterReactMemo('ResizeLines', (props: ResizeLinesProps) => {
-  const [showLabel, setShowLabel] = React.useState(false)
   const reference = React.createRef<HTMLDivElement>()
   const LineSVGComponent =
     props.position.y === 0.5 ? DimensionableControlVertical : DimensionableControlHorizontal
@@ -278,20 +277,10 @@ const ResizeLines = betterReactMemo('ResizeLines', (props: ResizeLinesProps) => 
 
   const catchmentSize = 12 / props.scale
 
-  const mouseEnter = React.useCallback(() => {
-    setShowLabel(true)
-  }, [])
-
-  const mouseLeave = React.useCallback(() => {
-    setShowLabel(false)
-  }, [])
-
   const mouseCatcher =
     props.resizeStatus !== 'enabled' ? null : (
       <div
         ref={reference}
-        onMouseEnter={mouseEnter}
-        onMouseLeave={mouseLeave}
         style={{
           pointerEvents: 'initial',
           position: 'absolute',
@@ -324,7 +313,7 @@ const ResizeLines = betterReactMemo('ResizeLines', (props: ResizeLinesProps) => 
         color={props.color}
       />
       {when(
-        (showLabel || isEdgeDragged) && interactiveResize,
+        isEdgeDragged && interactiveResize,
         <PropertyTargetSelector
           top={top + shiftPropertyTargetSelectorAxis('horizontal', props.direction, edge)}
           left={left + shiftPropertyTargetSelectorAxis('vertical', props.direction, edge)}

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4793,15 +4793,15 @@ export const UPDATE_FNS = {
   },
   INCREMENT_RESIZE_OPTIONS_SELECTED_INDEX: (editor: EditorModel): EditorModel => {
     const resizeOptions = editor.canvas.resizeOptions
+    const newIndex =
+      (resizeOptions.propertyTargetSelectedIndex + 1) % resizeOptions.propertyTargetOptions.length
     return {
       ...editor,
       canvas: {
         ...editor.canvas,
         resizeOptions: {
           ...resizeOptions,
-          propertyTargetSelectedIndex:
-            (resizeOptions.propertyTargetSelectedIndex + 1) %
-            resizeOptions.propertyTargetOptions.length,
+          propertyTargetSelectedIndex: newIndex,
         },
       },
     }

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -866,6 +866,9 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
           }
           break
         case 'RESIZE_DRAG_STATE':
+          const resizeOptions = this.props.editor.canvas.resizeOptions
+          const targetProperty =
+            resizeOptions.propertyTargetOptions[resizeOptions.propertyTargetSelectedIndex]
           switch (key) {
             case 'shift':
               const elementAspectRatioLocked = this.getElementAspectRatioLocked()
@@ -874,7 +877,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
                 updateResizeDragState(
                   dragState,
                   undefined,
-                  dragState.targetProperty,
+                  targetProperty,
                   undefined,
                   undefined,
                   keepAspectRatio,
@@ -886,7 +889,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
                 updateResizeDragState(
                   dragState,
                   undefined,
-                  dragState.targetProperty,
+                  targetProperty,
                   undefined,
                   pressed,
                   undefined,
@@ -898,7 +901,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
                 updateResizeDragState(
                   dragState,
                   undefined,
-                  dragState.targetProperty,
+                  targetProperty,
                   !pressed,
                   undefined,
                   undefined,
@@ -1027,10 +1030,13 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
             const centerBasedResize = event.altKey
             const enableSnapping = !event.metaKey
 
+            const resizeOptions = this.props.editor.canvas.resizeOptions
+            const targetProperty =
+              resizeOptions.propertyTargetOptions[resizeOptions.propertyTargetSelectedIndex]
             newDragState = updateResizeDragState(
               dragState,
               exceededThreshold ? newDrag : undefined,
-              dragState.targetProperty,
+              targetProperty,
               enableSnapping,
               centerBasedResize,
               keepAspectRatio,


### PR DESCRIPTION
Fixes #1649.

**Problem:**
Displaying the resize options was too aggressive as they would show on mouse over of an edge.

**Fix:**
Mouse over no longer triggers the resize options and also a bug with not updating the target property mid-drag has also been fixed.

**Commit Details:**
- Fixes #1649.
- Removed `ResizeEdgeState.showLabel` completely, along with the
  mouse event handlers that changed the value.
- Trigger for displaying `PropertyTargetSelector` is only triggered
  when the edge is being dragged.
- `ResizeDragState.targetProperty` is updated each time
  `updateResizeDragState` is called so that it can be changed while
  dragging the edge.
