### PR TITLE
quickfix/toast-on-top

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -412,6 +412,7 @@ const ToastRenderer = betterReactMemo('ToastRenderer', () => {
         left: '30%',
         overflow: 'scroll',
         maxHeight: '50%',
+        zIndex: 100,
       }}
     >
       {toasts.map((toast, index) => (


### PR DESCRIPTION
**Problem:**
Toasts were no longer on top of the navigator

**Fix:**
Changed the toast-renderer z-index