### PR TITLE
feature(canvas-controls) flex/grid parent outline

### DIFF
--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -229,7 +229,9 @@ export const OutlineControls = (props: OutlineControlsProps) => {
                 top: parentFrame.y + props.canvasOffset.y,
                 width: parentFrame.width,
                 height: parentFrame.height,
-                outline: `1px dotted ${colorTheme.primary.value}`,
+                outlineStyle: 'dotted',
+                outlineColor: colorTheme.primary.value,
+                outlineWidth: 1 / props.scale,
               }}
             ></div>
           )
@@ -241,6 +243,7 @@ export const OutlineControls = (props: OutlineControlsProps) => {
     props.canvasOffset.x,
     props.canvasOffset.y,
     props.componentMetadata,
+    props.scale,
     props.selectedViews,
   ])
 

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -233,7 +233,7 @@ export const OutlineControls = (props: OutlineControlsProps) => {
                 outlineColor: colorTheme.primary.value,
                 outlineWidth: 1 / props.scale,
               }}
-            ></div>
+            />
           )
         }
       }

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -235,7 +235,11 @@ export const OutlineControls = (props: OutlineControlsProps) => {
               }}
             />
           )
+        } else {
+          return null
         }
+      } else {
+        return null
       }
     })
   }, [

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -208,6 +208,42 @@ export const OutlineControls = (props: OutlineControlsProps) => {
     props.selectedViews,
   ])
 
+  const parentOutlines = React.useMemo(() => {
+    return props.selectedViews.map((view) => {
+      const parentPath = EP.parentPath(view)
+      const parentElement = MetadataUtils.findElementByElementPath(
+        props.componentMetadata,
+        parentPath,
+      )
+      const parentFrame = MetadataUtils.getFrameInCanvasCoords(parentPath, props.componentMetadata)
+      if (
+        MetadataUtils.isFlexLayoutedContainer(parentElement) ||
+        MetadataUtils.isGridLayoutedContainer(parentElement)
+      ) {
+        if (parentFrame != null) {
+          return (
+            <div
+              style={{
+                position: 'absolute',
+                left: parentFrame.x + props.canvasOffset.x,
+                top: parentFrame.y + props.canvasOffset.y,
+                width: parentFrame.width,
+                height: parentFrame.height,
+                outline: `1px dotted ${colorTheme.primary.value}`,
+              }}
+            ></div>
+          )
+        }
+      }
+    })
+  }, [
+    colorTheme.primary.value,
+    props.canvasOffset.x,
+    props.canvasOffset.y,
+    props.componentMetadata,
+    props.selectedViews,
+  ])
+
   let selectionOutlines: Array<JSX.Element> = getOverlayControls(props.selectedViews)
   const targetPaths =
     props.dragState != null ? props.dragState.draggedElements : props.selectedViews
@@ -289,6 +325,7 @@ export const OutlineControls = (props: OutlineControlsProps) => {
   }
   return (
     <>
+      {parentOutlines}
       {parentHighlights}
       {selectionOutlines}
       {multiSelectOutline}

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -19,6 +19,7 @@ import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { useColorTheme } from '../../../uuiui'
 import { useEditorState } from '../../editor/store/store-hook'
 import { KeysPressed } from '../../../utils/keyboard'
+import { stripNulls, uniqBy } from '../../../core/shared/array-utils'
 
 export function getSelectionColor(
   path: ElementPath,
@@ -208,9 +209,12 @@ export const OutlineControls = (props: OutlineControlsProps) => {
     props.selectedViews,
   ])
 
-  const parentOutlines = React.useMemo(() => {
-    return props.selectedViews.map((view) => {
-      const parentPath = EP.parentPath(view)
+  const parentOutlines: (JSX.Element | null)[] = React.useMemo(() => {
+    const targetParents = uniqBy(
+      stripNulls(props.selectedViews.map((view) => EP.parentPath(view))),
+      EP.pathsEqual,
+    )
+    return targetParents.map((parentPath) => {
       const parentElement = MetadataUtils.findElementByElementPath(
         props.componentMetadata,
         parentPath,
@@ -223,6 +227,7 @@ export const OutlineControls = (props: OutlineControlsProps) => {
         if (parentFrame != null) {
           return (
             <div
+              key={EP.toString(parentPath)}
               style={{
                 position: 'absolute',
                 left: parentFrame.x + props.canvasOffset.x,


### PR DESCRIPTION
**Problem:**
It is difficult to see how the selected element is layouted.

**Fix:**
Show parent outline for flex/grid elements

**Commit Details:**
- added outline
