### PR TITLE
fix(canvas-controls) absolute position controls scale with zoom

### DIFF
--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -309,7 +309,13 @@ export const OutlineControls = (props: OutlineControlsProps) => {
 
     if (MetadataUtils.isPositionAbsolute(instance)) {
       selectionOutlines.push(
-        <PositionOutline key={`${keyPrefix}-position-outline`} frame={rect} path={selectedView} />,
+        <PositionOutline
+          key={`${keyPrefix}-position-outline`}
+          frame={rect}
+          path={selectedView}
+          scale={props.scale}
+          canvasOffset={props.canvasOffset}
+        />,
       )
     }
 


### PR DESCRIPTION
**Problem:**
The new control for absolute positioning was not aware of the canvas zoom level.

**Fix:**
Scale the position controls.

**Commit Details:**
- fixed a bug where the absolute position line was visible on Scene elements,
- added scale to props
