### PR TITLE
Move flex insert control above other selection controls

### DIFF
--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -506,7 +506,6 @@ export class SelectModeControlContainer extends React.Component<
             </React.Fragment>
           )
         })}
-        {when(isFeatureEnabled('Insertion Plus Button'), <InsertionControls {...this.props} />)}
         {this.props.selectionEnabled ? (
           <>
             <OutlineControls {...this.props} />
@@ -530,6 +529,7 @@ export class SelectModeControlContainer extends React.Component<
             ) : null}
           </>
         ) : null}
+        {when(isFeatureEnabled('Insertion Plus Button'), <InsertionControls {...this.props} />)}
         {this.getMoveGuidelines()}
         {this.getDistanceGuidelines()}
         {this.getBoundingMarks()}


### PR DESCRIPTION
Fixes #1665 

**Problem:**
The Flex insertion control was sometimes not clickable

**Fix:**
Move it above the other selection controls
