### PR TITLE
ux(layout section) - legibility and interaction improvements

### DIFF
--- a/editor/src/components/inspector/common/layout-property-path-hooks.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.ts
@@ -153,6 +153,7 @@ export function changePin(
   const toggleToRelative =
     pinInfoForProp.propertyStatus.identical &&
     pinInfoForProp.value != null &&
+    pinInfoForProp.value.unit != 'px' &&
     !isPercentPin(cssNumberToString(pinInfoForProp.value, true))
 
   let pinsToSet: Array<PinToSet> = []

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -6,12 +6,10 @@ import { PropertyLabel } from '../../../widgets/property-label'
 import { createLayoutPropertyPath } from '../../../../../core/layout/layout-helpers-new'
 import { betterReactMemo } from '../../../../../uuiui-deps'
 import {
-  Button,
   FunctionIcons,
   Icons,
   InspectorSubsectionHeader,
   SquareButton,
-  ToggleButton,
   useColorTheme,
 } from '../../../../../uuiui'
 import { ExpandableIndicator } from '../../../../navigator/navigator-item/expandable-indicator'
@@ -21,7 +19,7 @@ import {
   FlexStyleNumberControl,
   PinsLayoutNumberControl,
 } from '../self-layout-subsection/gigantic-size-pins-subsection'
-import { InlineButton, InlineLink, InlineToggleButton } from '../../../../../uuiui/inline-button'
+import { InlineLink, InlineToggleButton } from '../../../../../uuiui/inline-button'
 import { when } from '../../../../../utils/react-conditionals'
 import {
   InspectorCallbackContext,

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -8,6 +8,7 @@ import { betterReactMemo } from '../../../../../uuiui-deps'
 import {
   Button,
   FunctionIcons,
+  Icons,
   InspectorSubsectionHeader,
   SquareButton,
   ToggleButton,
@@ -20,7 +21,7 @@ import {
   FlexStyleNumberControl,
   PinsLayoutNumberControl,
 } from '../self-layout-subsection/gigantic-size-pins-subsection'
-import { InlineLink } from '../../../../../uuiui/inline-button'
+import { InlineButton, InlineLink, InlineToggleButton } from '../../../../../uuiui/inline-button'
 import { when } from '../../../../../utils/react-conditionals'
 import {
   InspectorCallbackContext,
@@ -110,8 +111,6 @@ export function useInitialSizeSectionState(): boolean {
 const MainAxisControls = betterReactMemo(
   'MainAxisControls',
   (props: FlexElementSubsectionProps) => {
-    const colorTheme = useColorTheme()
-
     const initialIsFixedSectionVisible = useInitialFixedSectionState(props.parentFlexDirection)
     const initialIsAdvancedSectionVisible = useInitialAdvancedSectionState()
 
@@ -133,33 +132,36 @@ const MainAxisControls = betterReactMemo(
       <>
         <InspectorSubsectionHeader style={{ display: 'flex', justifyContent: 'space-between' }}>
           <span>Main Axis</span>
-          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <Button highlight onClick={toggleFixedSection} primary={fixedControlsOpen}>
-              <InlineLink
-                style={{
-                  color: fixedControlsOpen ? colorTheme.white.value : colorTheme.primary.value,
-                  opacity: !initialIsFixedSectionVisible && !fixedControlsOpen ? 0.3 : 1,
-                }}
-              >
-                Fixed
-              </InlineLink>
-            </Button>
-            <Button highlight onClick={toggleAdvancedSection} primary={advancedControlsOpen}>
-              <InlineLink
-                style={{
-                  color: advancedControlsOpen ? colorTheme.white.value : colorTheme.primary.value,
-                  opacity: !initialIsAdvancedSectionVisible && !advancedControlsOpen ? 0.3 : 1,
-                }}
-              >
-                Advanced
-              </InlineLink>
-            </Button>
+          <div
+            style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 4 }}
+          >
+            <InlineToggleButton
+              toggleValue={fixedControlsOpen}
+              onClick={toggleFixedSection}
+              style={{
+                fontSize: 10,
+              }}
+            >
+              Fixed
+            </InlineToggleButton>
+            <InlineToggleButton
+              toggleValue={advancedControlsOpen}
+              onClick={toggleAdvancedSection}
+              style={{
+                fontSize: 10,
+              }}
+            >
+              Advanced
+            </InlineToggleButton>
+            <SquareButton highlight>
+              <Icons.Cross />
+            </SquareButton>
           </div>
         </InspectorSubsectionHeader>
+        <FlexGrowShrinkRow />
         <UIGridRow padded={true} variant='<-------------1fr------------->'>
           <FlexBasisShorthandCSSNumberControl label='B' />
         </UIGridRow>
-        <FlexGrowShrinkRow />
         {when(fixedControlsOpen, <FixedSubsectionControls {...props} />)}
         {when(advancedControlsOpen, <AdvancedSubsectionControls {...props} />)}
       </>
@@ -194,6 +196,7 @@ const FixedSubsectionControls = betterReactMemo(
         <FlexHeightControls />
       )
 
+    const colorTheme = useColorTheme()
     const { onUnsetValue } = React.useContext(InspectorCallbackContext)
     const deleteFixedProps = React.useCallback(() => {
       onUnsetValue(mainAxisFixedProps(props.parentFlexDirection), false)
@@ -202,7 +205,7 @@ const FixedSubsectionControls = betterReactMemo(
     return (
       <>
         <InspectorSubsectionHeader>
-          <InlineLink>Fixed</InlineLink>
+          <span style={{ color: colorTheme.primary.value, fontSize: 10, flexGrow: 1 }}>Fixed</span>
           <SquareButton highlight onClick={deleteFixedProps}>
             <FunctionIcons.Delete />
           </SquareButton>
@@ -220,10 +223,13 @@ const AdvancedSubsectionControls = betterReactMemo(
     const deleteAdvancedProps = React.useCallback(() => {
       onUnsetValue(mainAxisAdvancedProps, false)
     }, [onUnsetValue])
+    const colorTheme = useColorTheme()
     return (
       <>
         <InspectorSubsectionHeader>
-          <InlineLink>Advanced</InlineLink>
+          <span style={{ color: colorTheme.primary.value, fontSize: 10, flexGrow: 1 }}>
+            Advanced
+          </span>
           <SquareButton highlight onClick={deleteAdvancedProps}>
             <FunctionIcons.Delete />
           </SquareButton>

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -205,6 +205,7 @@ export const PaddingControl = betterReactMemo('PaddingControl', () => {
           DEPRECATED_labelBelow: 'T',
           minimum: 0,
           onSubmitValue: paddingTopOnSubmitValue,
+          onTransientSubmitValue: paddingTopOnTransientSubmitValue,
           controlStatus: paddingTop.controlStatus,
           numberType: 'LengthPercent',
           defaultUnitToHide: 'px',

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
@@ -34,13 +34,8 @@ export const LayoutSystemSubsection = betterReactMemo<LayoutSystemSubsectionProp
   'LayoutSystemSubsection',
   (props) => {
     const isFlexParent = props.specialSizeMeasurements.layoutSystemForChildren === 'flex'
-    const paddings = useInspectorInfoLonghandShorthand(
-      ['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft'],
-      'padding',
-      createLayoutPropertyPath,
-    )
-    const hasAnyLayoutProps =
-      isFlexParent || Object.values(paddings).some((i) => isNotUnsetOrDefault(i.controlStatus))
+
+    const hasAnyLayoutProps = isFlexParent
     const [layoutSectionOpen, setLayoutSectionOpen] = usePropControlledStateV2(hasAnyLayoutProps)
 
     const openSection = React.useCallback(() => setLayoutSectionOpen(true), [setLayoutSectionOpen])

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -390,20 +390,12 @@ const WidthHeightRow = betterReactMemo('WidthHeightRow', (props: WidthHeightRowP
           justifyContent: 'space-between',
         }}
       >
-        {layoutType === 'absolute' ? (
-          <>
-            <PinWidthControl
-              framePins={framePins}
-              toggleWidth={toggleWidth}
-              controlStatus='simple'
-            />
-            <PinHeightControl
-              framePins={framePins}
-              toggleHeight={toggleHeight}
-              controlStatus='simple'
-            />
-          </>
-        ) : null}
+        <PinWidthControl framePins={framePins} toggleWidth={toggleWidth} controlStatus='simple' />
+        <PinHeightControl
+          framePins={framePins}
+          toggleHeight={toggleHeight}
+          controlStatus='simple'
+        />
       </div>
       <UIGridRow padded={false} variant='|--67px--||16px||--67px--||16px|'>
         {widthControl}

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -321,7 +321,7 @@ const ChildrenOrContentIndicator = () => {
 
   return (
     <InlineIndicator
-      value={hasChildren || hasContent}
+      shouldIndicate={hasChildren || hasContent}
       style={{
         fontSize: 10,
         paddingLeft: 0,

--- a/editor/src/uuiui/inline-button.tsx
+++ b/editor/src/uuiui/inline-button.tsx
@@ -60,9 +60,9 @@ export const InlineIndicator = styled.div<{
 }))
 
 export const InlineToggleButton = styled(InlineButton)<{
-  value: boolean
+  toggleValue: boolean
 }>((props) => ({
-  color: props.value ? colorTheme.primary.value : colorTheme.primary.shade(30).value,
+  color: props.toggleValue ? colorTheme.primary.value : colorTheme.primary.shade(30).value,
   '&:hover': {
     background: colorTheme.primary.shade(5).value,
     color: colorTheme.primary.shade(90).value,

--- a/editor/src/uuiui/inline-button.tsx
+++ b/editor/src/uuiui/inline-button.tsx
@@ -46,20 +46,28 @@ export const InlineButton = styled.button({
   },
 })
 
+export const InlineIndicator = styled.div<{
+  value: boolean
+}>((props) => ({
+  fontSize: 11,
+  fontFamily: 'utopian-inter',
+  background: 'transparent',
+  border: 'none',
+  outline: 'none',
+  paddingLeft: 2,
+  paddingRight: 2,
+  color: props.value ? colorTheme.primary.value : colorTheme.primary.shade(30).value,
+}))
+
 export const InlineToggleButton = styled(InlineButton)<{
   value: boolean
 }>((props) => ({
-  background: props.value ? colorTheme.primary.value : 'transparent',
-  color: props.value ? colorTheme.neutralInvertedForeground.value : colorTheme.primary.value,
+  color: props.value ? colorTheme.primary.value : colorTheme.primary.shade(30).value,
   '&:hover': {
-    background: props.value
-      ? colorTheme.primary.shade(90).value
-      : colorTheme.primary.shade(10).value,
-    // color: props.value ? colorTheme.primary.shade(90).value : colorTheme.primary.shade(50).value,
+    background: colorTheme.primary.shade(5).value,
+    color: colorTheme.primary.shade(90).value,
   },
   '&:active': {
-    background: props.value
-      ? colorTheme.primary.shade(80).value
-      : colorTheme.primary.shade(15).value,
+    background: colorTheme.primary.shade(10).value,
   },
 }))

--- a/editor/src/uuiui/inline-button.tsx
+++ b/editor/src/uuiui/inline-button.tsx
@@ -47,7 +47,7 @@ export const InlineButton = styled.button({
 })
 
 export const InlineIndicator = styled.div<{
-  value: boolean
+  shouldIndicate: boolean
 }>((props) => ({
   fontSize: 11,
   fontFamily: 'utopian-inter',
@@ -56,7 +56,7 @@ export const InlineIndicator = styled.div<{
   outline: 'none',
   paddingLeft: 2,
   paddingRight: 2,
-  color: props.value ? colorTheme.primary.value : colorTheme.primary.shade(30).value,
+  color: props.shouldIndicate ? colorTheme.primary.value : colorTheme.primary.shade(30).value,
 }))
 
 export const InlineToggleButton = styled(InlineButton)<{

--- a/editor/src/uuiui/inline-button.tsx
+++ b/editor/src/uuiui/inline-button.tsx
@@ -37,8 +37,6 @@ export const InlineButton = styled.button({
     background: colorTheme.primary.shade(10).value,
   },
   '&:focus': {
-    background: colorTheme.primary.value,
-    color: colorTheme.neutralInvertedForeground.value,
     outline: 'none',
   },
   '&:active': {
@@ -47,3 +45,21 @@ export const InlineButton = styled.button({
     outline: 'none',
   },
 })
+
+export const InlineToggleButton = styled(InlineButton)<{
+  value: boolean
+}>((props) => ({
+  background: props.value ? colorTheme.primary.value : 'transparent',
+  color: props.value ? colorTheme.neutralInvertedForeground.value : colorTheme.primary.value,
+  '&:hover': {
+    background: props.value
+      ? colorTheme.primary.shade(90).value
+      : colorTheme.primary.shade(10).value,
+    // color: props.value ? colorTheme.primary.shade(90).value : colorTheme.primary.shade(50).value,
+  },
+  '&:active': {
+    background: props.value
+      ? colorTheme.primary.shade(80).value
+      : colorTheme.primary.shade(15).value,
+  },
+}))


### PR DESCRIPTION
**Problem:**

- the subsection toggles weren't clear enough
- the indicator labels sometimes were incorrect (eg showing presence of children or content when there wasn't any)
- there was a gap in the `flow` width / height row 
- the × button in the layout section also removed width and height. Annoying especially if empty.
- there was a missing icon for the infobox for flex layouts


**Fix:**
- adds new  `InlineToggleButton` and `InlineIndicator` components, uses them in the inspector
- always shows the buttons for the absolute/relative part of height
- makes the × button in the layout section not unset width and height
- uses an available icon for the flex layouts

![image](https://user-images.githubusercontent.com/2945037/128334453-8fd827ee-2dfe-4f97-9259-0fb6e2340abe.png)



