### PR TITLE
feature(on-canvas parent control) - improve UX, reduce confusion

### DIFF
--- a/editor/src/components/canvas/controls/layout-parent-control.tsx
+++ b/editor/src/components/canvas/controls/layout-parent-control.tsx
@@ -141,52 +141,59 @@ export const LayoutParentControl = betterReactMemo(
     return (
       <div
         style={{
-          borderRadius: 5,
-          boxShadow: `${colorTheme.canvasControlsSizeBoxShadowColor.o(50).value} 0px 0px ${
+          position: 'absolute',
+          borderRadius: 2,
+          left: parentFrame.x + canvasOffset.x,
+          top: parentFrame.y + canvasOffset.y - 16,
+          transform: 'translateX(calc(-100% - 42px)) ',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'stretch',
+          justifyContent: 'flex-start',
+          boxShadow: `${colorTheme.canvasControlsSizeBoxShadowColor.o(20).value} 0px 0px ${
             1 / scale
           }px, ${colorTheme.canvasControlsSizeBoxShadowColor.o(21).value} 0px ${1 / scale}px ${
             2 / scale
           }px ${1 / scale}px`,
-          height: 25,
-          backgroundColor: '#f5f5f5',
-          position: 'absolute',
-          left: parentFrame.x + canvasOffset.x,
-          top: parentFrame.y + canvasOffset.y - 25 - 8,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'flex-start',
+          backgroundColor: colorTheme.inspectorBackground.value,
           textTransform: 'capitalize',
         }}
         onMouseDown={onControlMouseDown}
       >
-        <InlineLink style={{ padding: '0 10px' }}>{parentLayout}</InlineLink>
-        {when(
-          flexDirectionIcon != null && parentLayout === 'flex',
-          <div
-            style={{
-              padding: '0 5px',
-            }}
-            onClick={flexDirectionClicked}
-          >
-            <Icn {...(flexDirectionIcon as IcnProps)} />
-          </div>,
-        )}
-        {when(
-          flexDirectionIcon != null && parentLayout === 'flex',
-          <div
-            style={{
-              padding: '0 5px',
-            }}
-          >
-            {selectedAlignment ? (
-              <PopupList
-                options={allAlignmentOptions}
-                value={selectedAlignment}
-                onSubmitValue={onSubmitValueAlignment}
-              />
-            ) : null}
-          </div>,
-        )}
+        <svg
+          style={{ position: 'absolute', left: 'calc(100% + 8px)', top: 2 }}
+          width='30px'
+          height='11px'
+          viewBox='0 0 30 11'
+        >
+          <g stroke='none' strokeWidth='1' fill='none' fillRule='evenodd' strokeLinecap='round'>
+            <polyline stroke='#979797' points='0.5 0.5 15.5 0.5 30 10'></polyline>
+          </g>
+        </svg>
+        <div style={{ display: 'flex' }}>
+          <span style={{ padding: '0px 4px', fontSize: 8, color: '#007aff' }}>Parent</span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '0px 4px' }}>
+          <span style={{ fontSize: 10, fontWeight: 500, color: colorTheme.fg4.value }}>
+            {parentLayout}
+          </span>
+          {when(
+            flexDirectionIcon != null && parentLayout === 'flex',
+            <Icn onClick={flexDirectionClicked} {...(flexDirectionIcon as IcnProps)} />,
+          )}
+          {when(
+            flexDirectionIcon != null && parentLayout === 'flex',
+            <div>
+              {selectedAlignment ? (
+                <PopupList
+                  options={allAlignmentOptions}
+                  value={selectedAlignment}
+                  onSubmitValue={onSubmitValueAlignment}
+                />
+              ) : null}
+            </div>,
+          )}
+        </div>
       </div>
     )
   },

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -516,7 +516,7 @@ export const flexDirectionOptions = (flexWrap: FlexWrap) => {
       icon: {
         category: 'layout/flex',
         type: `flexDirection-row-${flexWrapReverse}-${flexDirectionWrap}`,
-        color: 'secondary',
+        color: 'main',
         width: 16,
         height: 16,
       },
@@ -527,7 +527,7 @@ export const flexDirectionOptions = (flexWrap: FlexWrap) => {
       icon: {
         category: 'layout/flex',
         type: `flexDirection-column-${flexWrapReverse}-${flexDirectionWrap}`,
-        color: 'secondary',
+        color: 'main',
         width: 16,
         height: 16,
       },

--- a/editor/src/uuiui/icn.tsx
+++ b/editor/src/uuiui/icn.tsx
@@ -38,7 +38,7 @@ function useIconColor(intent: IcnColor): IcnResultingColor {
       case 'secondary':
         return 'gray'
       case 'subdued':
-        return 'white'
+        return 'lightgray'
       case 'primary':
         return 'blue'
       case 'warning':


### PR DESCRIPTION
**Problem:**
The on-canvas _parent_ layout controls caused confusion what exactly they were configuring (the selected thing? the parent?)

**Solution**
Tidy them up
for parent Flow:
![image](https://user-images.githubusercontent.com/2945037/128369793-86438dd5-7f17-4945-b7d4-8a52f0bb8c42.png)

for parent Flex:
![image](https://user-images.githubusercontent.com/2945037/128369920-3c15360d-8899-4354-9c93-0ccfb602afb7.png)


