### PR TITLE
Multi-option resize.

### DIFF
--- a/editor/src/components/canvas/controls/multiselect-resize-control.tsx
+++ b/editor/src/components/canvas/controls/multiselect-resize-control.tsx
@@ -18,11 +18,11 @@ import { ControlProps } from './new-canvas-controls'
 import { ResizeRectangle } from './size-box'
 import { optionalMap } from '../../../core/shared/optional-utils'
 
-interface MultiselectResizeProps extends ControlProps {
+interface MultiSelectResizeProps extends ControlProps {
   dragState: ResizeDragState | null
 }
 
-interface SingleselectResizeProps extends MultiselectResizeProps {
+interface SingleSelectResizeProps extends MultiSelectResizeProps {
   obtainOriginalFrames: () => OriginalCanvasAndLocalFrame[]
   onResizeStart: (originalSize: CanvasRectangle, draggedPoint: EdgePosition) => void
 }
@@ -33,10 +33,10 @@ interface ConstraintsControlState {
 }
 
 export class MultiselectResizeControl extends React.Component<
-  MultiselectResizeProps,
+  MultiSelectResizeProps,
   ConstraintsControlState
 > {
-  constructor(props: MultiselectResizeProps) {
+  constructor(props: MultiSelectResizeProps) {
     super(props)
     this.state = {
       originalBoundingBox: Utils.zeroRectangle as CanvasRectangle,
@@ -174,13 +174,8 @@ export class MultiselectResizeControl extends React.Component<
               onResizeStart={this.onResizeStart}
               testID={'component-resize-control-0'}
               maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
-              labels={
-                {
-                  vertical: 'Width',
-                  horizontal: 'Height',
-                } as const
-              }
-              resizeOptions={this.props.resizeOptions}
+              flexDirection={null}
+              propertyTargetSelectedIndex={this.props.resizeOptions.propertyTargetSelectedIndex}
             />
             {guidelineElements}
           </>
@@ -202,17 +197,13 @@ export class MultiselectResizeControl extends React.Component<
   }
 }
 
-export class SingleSelectResizeControls extends React.Component<SingleselectResizeProps> {
-  constructor(props: SingleselectResizeProps) {
+export class SingleSelectResizeControls extends React.Component<SingleSelectResizeProps> {
+  constructor(props: SingleSelectResizeProps) {
     super(props)
   }
 
   render() {
     return this.props.selectedViews.map((view, index) => {
-      const labels = {
-        vertical: 'Width',
-        horizontal: 'Height',
-      } as const
       const target = MetadataUtils.findElementByElementPath(this.props.componentMetadata, view)
       const frame = optionalMap((metadata) => metadata.globalFrame, target)
       if (frame == null) {
@@ -243,8 +234,8 @@ export class SingleSelectResizeControls extends React.Component<SingleselectResi
             onResizeStart={this.props.onResizeStart}
             testID={`component-resize-control-${EP.toComponentId(view)}-${index}`}
             maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
-            labels={labels}
-            resizeOptions={this.props.resizeOptions}
+            flexDirection={null}
+            propertyTargetSelectedIndex={this.props.resizeOptions.propertyTargetSelectedIndex}
           />
         )
       }

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -57,6 +57,7 @@ import { shallowEqual } from '../../../core/shared/equality-utils'
 import { KeysPressed } from '../../../utils/keyboard'
 import { usePrevious } from '../../editor/hook-utils'
 import { LayoutTargetableProp } from '../../../core/layout/layout-helpers-new'
+import { getDragStateStart } from '../canvas-utils'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -126,7 +127,9 @@ export const NewCanvasControls = betterReactMemo(
         derived: store.derived,
         canvasOffset: store.editor.canvas.roundedCanvasOffset,
         animationEnabled:
-          (store.editor.canvas.dragState == null || store.editor.canvas.dragState.start == null) &&
+          (store.editor.canvas.dragState == null ||
+            getDragStateStart(store.editor.canvas.dragState, store.editor.canvas.resizeOptions) ==
+              null) &&
           store.editor.canvas.animationsEnabled,
 
         controls: store.derived.canvas.controls,
@@ -238,8 +241,8 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
 
   const componentMetadata = getMetadata(props.editor)
 
-  const resizing = isResizing(props.editor.canvas.dragState)
-  const dragging = isDragging(props.editor.canvas.dragState)
+  const resizing = isResizing(props.editor)
+  const dragging = isDragging(props.editor)
   const selectionEnabled = pickSelectionEnabled(props.editor.canvas, props.editor.keysPressed)
   const draggingEnabled = !isSelectLiteMode(props.editor.mode)
   const contextMenuEnabled = !isLiveMode(props.editor.mode)

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -27,7 +27,11 @@ import { EditorState } from '../../../editor/store/editor-state'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
 import { DragState, moveDragState } from '../../canvas-types'
-import { createDuplicationNewUIDs, getOriginalCanvasFrames } from '../../canvas-utils'
+import {
+  createDuplicationNewUIDs,
+  getDragStateDrag,
+  getOriginalCanvasFrames,
+} from '../../canvas-utils'
 import {
   findFirstParentWithValidElementPath,
   getAllTargetsAtPoint,
@@ -40,16 +44,28 @@ import { isFeatureEnabled } from '../../../../utils/feature-switches'
 
 const DRAG_START_TRESHOLD = 2
 
-export function isResizing(dragState: DragState | null): boolean {
-  return dragState != null && dragState.type === 'RESIZE_DRAG_STATE' && dragState.drag != null
+export function isResizing(editorState: EditorState): boolean {
+  const dragState = editorState.canvas.dragState
+  return (
+    dragState?.type === 'RESIZE_DRAG_STATE' &&
+    getDragStateDrag(dragState, editorState.canvas.resizeOptions) != null
+  )
 }
 
-export function isDragging(dragState: DragState | null): boolean {
-  return dragState != null && dragState.type === 'MOVE_DRAG_STATE' && dragState.drag != null
+export function isDragging(editorState: EditorState): boolean {
+  const dragState = editorState.canvas.dragState
+  return (
+    dragState?.type === 'MOVE_DRAG_STATE' &&
+    getDragStateDrag(dragState, editorState.canvas.resizeOptions) != null
+  )
 }
 
-export function isInserting(dragState: DragState | null): boolean {
-  return dragState != null && dragState.type === 'INSERT_DRAG_STATE' && dragState.drag != null
+export function isInserting(editorState: EditorState): boolean {
+  const dragState = editorState.canvas.dragState
+  return (
+    dragState?.type === 'INSERT_DRAG_STATE' &&
+    getDragStateDrag(dragState, editorState.canvas.resizeOptions) != null
+  )
 }
 
 export function pickSelectionEnabled(
@@ -69,10 +85,10 @@ export function useMaybeHighlightElement(): {
   const stateRef = useRefEditorState((store) => {
     return {
       dispatch: store.dispatch,
-      resizing: isResizing(store.editor.canvas.dragState),
-      dragging: isDragging(store.editor.canvas.dragState),
+      resizing: isResizing(store.editor),
+      dragging: isDragging(store.editor),
       selectionEnabled: pickSelectionEnabled(store.editor.canvas, store.editor.keysPressed),
-      inserting: isInserting(store.editor.canvas.dragState),
+      inserting: isInserting(store.editor),
     }
   })
 

--- a/editor/src/components/canvas/controls/yoga-control.tsx
+++ b/editor/src/components/canvas/controls/yoga-control.tsx
@@ -75,13 +75,6 @@ class YogaResizeControl extends React.Component<YogaResizeControlProps> {
       // TODO check me
       return null
     }
-    let labels: {
-      vertical: 'flexBasis' | 'Width' | 'Height'
-      horizontal: 'flexBasis' | 'Width' | 'Height'
-    } = {
-      vertical: 'flexBasis',
-      horizontal: 'Height',
-    }
     const parentPath = EP.parentPath(this.props.target)
     const parentElement = withUnderlyingTarget(
       parentPath,
@@ -93,20 +86,10 @@ class YogaResizeControl extends React.Component<YogaResizeControlProps> {
         return element
       },
     )
+    let flexDirection: 'horizontal' | 'vertical' | null = null
     if (parentElement != null) {
-      forEachRight(FlexLayoutHelpers.getMainAxis(right(parentElement.props)), (flexDirection) => {
-        if (flexDirection === 'vertical') {
-          // column, column-reverse
-          labels = {
-            vertical: 'Width',
-            horizontal: 'flexBasis',
-          }
-        } else {
-          labels = {
-            vertical: 'flexBasis',
-            horizontal: 'Height',
-          }
-        }
+      forEachRight(FlexLayoutHelpers.getMainAxis(right(parentElement.props)), (direction) => {
+        flexDirection = direction
       })
     }
     const yogaSize = this.getYogaSize(visualSize)
@@ -132,8 +115,8 @@ class YogaResizeControl extends React.Component<YogaResizeControlProps> {
         onResizeStart={Utils.NO_OP}
         testID={`component-resize-control-${EP.toComponentId(this.props.target)}-0`}
         maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
-        labels={labels}
-        resizeOptions={this.props.resizeOptions}
+        flexDirection={flexDirection}
+        propertyTargetSelectedIndex={this.props.resizeOptions.propertyTargetSelectedIndex}
       />
     )
   }

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -121,6 +121,7 @@ import {
 } from './shortcut-definitions'
 import { DerivedState, EditorState, getOpenFile } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
+import { getDragStateStart } from '../canvas/canvas-utils'
 
 function updateKeysPressed(
   keysPressed: KeysPressed,
@@ -439,7 +440,10 @@ export function handleKeyDown(
             CanvasActions.clearDragState(false),
             EditorActions.clearHighlightedViews(),
           ]
-        } else if (editor.canvas.dragState != null && editor.canvas.dragState.start != null) {
+        } else if (
+          editor.canvas.dragState != null &&
+          getDragStateStart(editor.canvas.dragState, editor.canvas.resizeOptions) != null
+        ) {
           return [CanvasActions.clearDragState(false)]
         } else if (isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)) {
           return jumpToParentActions(editor.selectedViews)

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -24,6 +24,8 @@ export type LayoutTargetableProp =
   | 'marginBottom'
   | 'marginLeft'
   | 'marginRight'
+  | 'flexGrow'
+  | 'flexShrink'
 
 export type LayoutPinnedProp =
   | LayoutDimension

--- a/editor/src/core/model/performance-scripts.ts
+++ b/editor/src/core/model/performance-scripts.ts
@@ -15,7 +15,7 @@ import {
   zeroPoint,
   zeroRectangle,
 } from '../shared/math-utils'
-import { resizeDragState } from '../../components/canvas/canvas-types'
+import { resizeDragState, updateResizeDragState } from '../../components/canvas/canvas-types'
 import { MetadataUtils } from './element-metadata-utils'
 import { getOriginalFrames } from '../../components/canvas/canvas-utils'
 import * as EP from '../shared/element-path'
@@ -79,20 +79,23 @@ export function useTriggerResizePerformanceTest(): () => void {
     let framesPassed = 0
     async function step() {
       performance.mark(`resize_step_${framesPassed}`)
-      const dragState = resizeDragState(
+      const dragState = updateResizeDragState(
+        resizeDragState(
+          targetFrame ?? (zeroRectangle as CanvasRectangle),
+          originalFrames,
+          { x: 1, y: 1 },
+          { x: 1, y: 1 },
+          metadata.current,
+          [target],
+          false,
+          [],
+        ),
         targetStartPoint,
         { x: framesPassed % 100, y: framesPassed % 100 } as CanvasVector,
+        'Width',
         true,
         false,
         false,
-        targetFrame ?? (zeroRectangle as CanvasRectangle),
-        originalFrames,
-        { x: 1, y: 1 },
-        { x: 1, y: 1 },
-        metadata.current,
-        [target],
-        false,
-        'Width',
       )
       await dispatch([CanvasActions.createDragState(dragState)]).entireUpdateFinished
       performance.mark(`resize_dispatch_finished_${framesPassed}`)

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -164,6 +164,7 @@ export const zeroRectangle = {
 }
 export const zeroCanvasRect = zeroRectangle as CanvasRectangle
 export const zeroLocalRect = zeroRectangle as LocalRectangle
+export const zeroCanvasPoint = zeroPoint as CanvasPoint
 
 export function zeroRectangleAtPoint<C extends CoordinateMarker>(p: Point<C>): Rectangle<C> {
   return {


### PR DESCRIPTION
Fixes #1654

**Problem:**
The resize options are a bit awkward if only one setting can be changed at a time.

Since classes can also be used to set a width of an element, it doesn't make sense to treat an element as having a zero or otherwise width for example and start modifying it using zero as the base value. It would be better to start with the observable dimensions instead if those exist.

**Fix:**
Resizing using the resize options now keeps multiple properties modified in-flight simultaneously.

The observable values for the resize options (where they exist or make sense) are used as the starting value when applying the delta from the mouse movement.

There are also some small fixes which have been done to the mouse handling, like extracting out the resize options into a function which can be invoked at will instead of those values only being attached to components. This was necessary to fix an issue with changing vertical axis properties as the resize options were being set _after_ the mouse down was triggered, that resulted in the wrong property being handled for a brief moment.

**Notes:**
One potential oddity might exist around handling subsequent changes to properties that have already been changed and switched away from. For example modifying the width, then margin-left, then width again. As the original starting point is used each time, changing the margin-left will have put the mouse potentially further along the axis so that when the width is changed again it will "jump" in value.

**Commit Details:**
- Fixes #1654.
- Extracted out `DragStatePositions` as a common interface.
- Created `ResizeDragStatePropertyChange` to hold the specific
  parts of the resize for each property being changed. An array
  of these now lives in `ResizeDragState`.
- Implemented `updatedResizeDragStatePropertyChange` to support
  the changes necessary in `updateResizeDragState`.
- Added `getDragStatePositions`, `getDragStateDrag`,
  `getDragStateStart`, `anyDragStarted`, `anyDragMovement`,
  `getResizeOptions`, `dragExceededThreshold`,
  `getObservableValueForLayoutProp`, `getTargetableProp` and
  `findResizePropertyChange` utility functions.
- Functions like `clearDragState` and `updateFramesOfScenesAndComponents`
  have been reworked using the above functions to handle multiple
  simultaneous changes in a resize.
- Removed the `labels` props that have been used in a bunch of
  React components to use `getResizeOptions` in their place.
- `isResizing`, `isDragging` and `isInserting` rewritten to use
  `getDragStateDrag`.
- `ResizeControl` now handles the differing types of resize.
- Added `flexGrow` and `flexShrink` to `LayoutTargetableProp`.
- Mouse handling logic in the `EditorCanvas` component had a fairly
  major reworking to correctly handle multi-option resize and also
  to fix a first mouse down issue when changing vertical coordinates.
