### PR TITLE
Wrap Content Option

### DIFF
--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -24,8 +24,8 @@ export const RenderAsRow = betterReactMemo('RenderAsRow', () => {
 
   const selectedElementName = useEditorState((store) => {
     return MetadataUtils.getJSXElementNameFromMetadata(
-      store.editor.selectedViews[0],
       store.editor.jsxMetadata,
+      store.editor.selectedViews[0],
     )
   }, 'RenderAsRow selectedElementName')
 

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -34,7 +34,10 @@ import {
   wrapInView,
   wrapInElement,
 } from '../../editor/actions/action-creators'
-import { generateUidWithExistingComponents } from '../../../core/model/element-template-utils'
+import {
+  elementOnlyHasSingleTextChild,
+  generateUidWithExistingComponents,
+} from '../../../core/model/element-template-utils'
 import {
   jsxAttributeValue,
   jsxElement,
@@ -53,6 +56,7 @@ import { when } from '../../../utils/react-conditionals'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { safeIndex } from '../../../core/shared/array-utils'
 import { LayoutSystem } from 'utopia-api'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 
 type InsertMenuItemValue = InsertableComponent & {
   source: InsertableComponentGroupType | null
@@ -400,8 +404,24 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
   const projectContentsRef = useRefEditorState((store) => store.editor.projectContents)
   const selectedViewsref = useRefEditorState((store) => store.editor.selectedViews)
   const insertableComponents = useGetInsertableComponents()
+  const shouldWrapContentsByDefault = useRefEditorState((store) => {
+    // We only care about this when the menu is first opened
+    const firstSelectedView = store.editor.selectedViews[0]
+    if (firstSelectedView != null) {
+      const selectedJSXElement = MetadataUtils.getJSXElementFromMetadata(
+        store.editor.jsxMetadata,
+        firstSelectedView,
+      )
+      return selectedJSXElement != null && elementOnlyHasSingleTextChild(selectedJSXElement)
+    }
+
+    return false
+  })
 
   const [addContentForInsertion, setAddContentForInsertion] = React.useState(false)
+  const [wrapContentForInsertion, setWrapContentForInsertion] = React.useState(
+    shouldWrapContentsByDefault.current,
+  )
   const [fixedSizeForInsertion, setFixedSizeForInsertion] = React.useState(false)
   const [preserveVisualPositionForWrap, setPreserveVisualPositionForWrap] = React.useState(false)
 
@@ -472,6 +492,7 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
                   targetParent,
                   elementToInsert,
                   fixedSizeForInsertion ? 'add-size' : 'do-not-add',
+                  wrapContentForInsertion ? 'wrap-content' : 'do-now-wrap-content',
                   floatingMenuState.indexPosition,
                 ),
               ]
@@ -506,6 +527,7 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
       selectedViewsref,
       fixedSizeForInsertion,
       addContentForInsertion,
+      wrapContentForInsertion,
       preserveVisualPositionForWrap,
     ],
   )
@@ -534,7 +556,7 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
         style={{
           ...UtopiaStyles.popup,
           width: 280,
-          height: 250,
+          height: 280,
           overflow: 'hidden',
         }}
       >
@@ -567,29 +589,46 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
           tabSelectsValue={false}
         />
         {showInsertionControls ? (
-          <FlexRow
-            css={{
-              height: UtopiaTheme.layout.rowHeight.normal,
-              paddingLeft: 8,
-              paddingRight: 8,
-              borderTop: `1px solid ${colorTheme.border1.value}`,
-            }}
-          >
-            <CheckboxRow
-              id='add-content-label'
-              checked={addContentForInsertion}
-              onChange={setAddContentForInsertion}
+          <FlexColumn>
+            <FlexRow
+              css={{
+                height: UtopiaTheme.layout.rowHeight.smaller,
+                paddingLeft: 8,
+                paddingRight: 8,
+                borderTop: `1px solid ${colorTheme.border1.value}`,
+              }}
             >
-              Add content
-            </CheckboxRow>
-            <CheckboxRow
-              id='fixed-dimensions-label'
-              checked={fixedSizeForInsertion}
-              onChange={setFixedSizeForInsertion}
+              <CheckboxRow
+                id='wrap-parents-content-label'
+                checked={wrapContentForInsertion}
+                onChange={setWrapContentForInsertion}
+              >
+                Wrap siblings
+              </CheckboxRow>
+            </FlexRow>
+            <FlexRow
+              css={{
+                height: UtopiaTheme.layout.rowHeight.smaller,
+                paddingLeft: 8,
+                paddingRight: 8,
+              }}
             >
-              Fixed dimensions
-            </CheckboxRow>
-          </FlexRow>
+              <CheckboxRow
+                id='add-content-label'
+                checked={addContentForInsertion}
+                onChange={setAddContentForInsertion}
+              >
+                Add content
+              </CheckboxRow>
+              <CheckboxRow
+                id='fixed-dimensions-label'
+                checked={fixedSizeForInsertion}
+                onChange={setFixedSizeForInsertion}
+              >
+                Fixed dimensions
+              </CheckboxRow>
+            </FlexRow>
+          </FlexColumn>
         ) : null}
         {when(
           showWrapControls,

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -147,7 +147,7 @@ export const setAsFocusedElement: ContextMenuItem<CanvasData> = {
   isHidden: (data) => {
     return data.selectedViews.every((view) => {
       const isFocused = EP.pathsEqual(data.focusedElementPath, view)
-      const elementName = MetadataUtils.getJSXElementFromMetadata(data.jsxMetadata, view)
+      const elementName = MetadataUtils.getJSXElementNameFromMetadata(data.jsxMetadata, view)
       return isFocused || (elementName != null ? isIntrinsicElement(elementName) : true)
     })
   },

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -52,7 +52,11 @@ import { BuildType } from '../../core/workers/ts/ts-worker'
 import { ParseResult } from '../../utils/value-parser-utils'
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import type { LoginState } from '../../common/user'
-import { InsertableComponent, StylePropOption } from '../shared/project-components'
+import {
+  InsertableComponent,
+  StylePropOption,
+  WrapContentOption,
+} from '../shared/project-components'
 import { LayoutTargetableProp } from '../../core/layout/layout-helpers-new'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
@@ -874,6 +878,7 @@ export interface InsertWithDefaults {
   targetParent: ElementPath
   toInsert: InsertableComponent
   styleProps: StylePropOption
+  wrapContent: WrapContentOption
   indexPosition: IndexPosition | null
 }
 

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -51,7 +51,11 @@ import type { CodeResultCache, PropertyControlsInfo } from '../../custom-code/co
 import type { ElementContextMenuInstance } from '../../element-context-menu'
 import type { FontSettings } from '../../inspector/common/css-utils'
 import type { CSSTarget } from '../../inspector/sections/header-section/target-selector'
-import { InsertableComponent, StylePropOption } from '../../shared/project-components'
+import {
+  InsertableComponent,
+  StylePropOption,
+  WrapContentOption,
+} from '../../shared/project-components'
 import type {
   AddFolder,
   AddMissingDimensions,
@@ -1416,6 +1420,7 @@ export function insertWithDefaults(
   targetParent: ElementPath,
   toInsert: InsertableComponent,
   styleProps: StylePropOption,
+  wrapContent: WrapContentOption,
   indexPosition: IndexPosition | null,
 ): InsertWithDefaults {
   return {
@@ -1423,6 +1428,7 @@ export function insertWithDefaults(
     targetParent: targetParent,
     toInsert: toInsert,
     styleProps: styleProps,
+    wrapContent: wrapContent,
     indexPosition: indexPosition,
   }
 }

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -1163,7 +1163,13 @@ describe('INSERT_WITH_DEFAULTS', () => {
       ['app-outer-div', 'card-instance'],
       ['card-outer-div'],
     ])
-    const action = insertWithDefaults(targetPath, menuInsertable, 'do-not-add', null)
+    const action = insertWithDefaults(
+      targetPath,
+      menuInsertable,
+      'do-not-add',
+      'do-now-wrap-content',
+      null,
+    )
     const actualResult = UPDATE_FNS.INSERT_WITH_DEFAULTS(action, editorState)
     const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
     if (isTextFile(cardFile)) {
@@ -1258,7 +1264,13 @@ describe('INSERT_WITH_DEFAULTS', () => {
       ['app-outer-div', 'card-instance'],
       ['card-outer-div'],
     ])
-    const action = insertWithDefaults(targetPath, menuInsertable, 'add-size', null)
+    const action = insertWithDefaults(
+      targetPath,
+      menuInsertable,
+      'add-size',
+      'do-now-wrap-content',
+      null,
+    )
     const actualResult = UPDATE_FNS.INSERT_WITH_DEFAULTS(action, editorState)
     const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
     if (isTextFile(cardFile)) {
@@ -1352,7 +1364,13 @@ describe('INSERT_WITH_DEFAULTS', () => {
       ['app-outer-div', 'card-instance'],
       ['card-outer-div'],
     ])
-    const action = insertWithDefaults(targetPath, imgInsertable, 'add-size', null)
+    const action = insertWithDefaults(
+      targetPath,
+      imgInsertable,
+      'add-size',
+      'do-now-wrap-content',
+      null,
+    )
     const actualResult = UPDATE_FNS.INSERT_WITH_DEFAULTS(action, editorState)
     const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
     if (isTextFile(cardFile)) {
@@ -1437,7 +1455,13 @@ describe('INSERT_WITH_DEFAULTS', () => {
       ['app-outer-div', 'card-instance'],
       ['card-outer-div'],
     ])
-    const action = insertWithDefaults(targetPath, imgInsertable, 'add-size', { type: 'back' })
+    const action = insertWithDefaults(
+      targetPath,
+      imgInsertable,
+      'add-size',
+      'do-now-wrap-content',
+      { type: 'back' },
+    )
     const actualResult = UPDATE_FNS.INSERT_WITH_DEFAULTS(action, editorState)
     const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
     if (isTextFile(cardFile)) {

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -1516,6 +1516,89 @@ describe('INSERT_WITH_DEFAULTS', () => {
       fail('File is not a text file.')
     }
   })
+
+  it('inserts a div into the project, wrapping the parents existing children if selected', () => {
+    const project = complexDefaultProject()
+    const editorState = editorModelFromPersistentModel(project, NO_OP)
+
+    const insertableGroups = getComponentGroups(
+      {},
+      {},
+      editorState.projectContents,
+      [],
+      StoryboardFilePath,
+    )
+    const htmlGroup = forceNotNull(
+      'Group should exist.',
+      insertableGroups.find((group) => {
+        return group.source.type === 'HTML_GROUP'
+      }),
+    )
+    const divInsertable = forceNotNull(
+      'Component should exist.',
+      htmlGroup.insertableComponents.find((insertable) => {
+        return insertable.name === 'div'
+      }),
+    )
+
+    const targetPath = EP.elementPath([
+      ['storyboard-entity', 'scene-1-entity', 'app-entity'],
+      ['app-outer-div', 'card-instance'],
+      ['card-outer-div'],
+    ])
+    const action = insertWithDefaults(targetPath, divInsertable, 'do-not-add', 'wrap-content', null)
+    const actualResult = UPDATE_FNS.INSERT_WITH_DEFAULTS(action, editorState)
+    const cardFile = getContentsTreeFileFromString(actualResult.projectContents, '/src/card.js')
+    if (isTextFile(cardFile)) {
+      const parsed = cardFile.fileContents.parsed
+      if (isParseSuccess(parsed)) {
+        const printedCode = printCode(
+          printCodeOptions(false, true, true, true),
+          parsed.imports,
+          parsed.topLevelElements,
+          parsed.jsxFactoryFunction,
+          parsed.exportsDetail,
+        )
+        expect(printedCode).toMatchInlineSnapshot(`
+          "import * as React from 'react'
+          import { Rectangle } from 'utopia-api'
+          export var Card = (props) => {
+            return (
+              <div style={{ ...props.style }}>
+                <div>
+                  <div
+                    style={{
+                      position: 'absolute',
+                      left: 0,
+                      top: 0,
+                      width: 50,
+                      height: 50,
+                      backgroundColor: 'red',
+                    }}
+                  />
+                  <Rectangle
+                    style={{
+                      position: 'absolute',
+                      left: 100,
+                      top: 200,
+                      width: 50,
+                      height: 50,
+                      backgroundColor: 'blue',
+                    }}
+                  />
+                </div>
+              </div>
+            )
+          }
+          "
+        `)
+      } else {
+        fail('File does not contain parse success.')
+      }
+    } else {
+      fail('File is not a text file.')
+    }
+  })
 })
 
 describe('SET_FOCUSED_ELEMENT', () => {

--- a/editor/src/components/inspector/common/name-and-icon-hook.ts
+++ b/editor/src/components/inspector/common/name-and-icon-hook.ts
@@ -57,7 +57,7 @@ function getNameAndIconResult(
   path: ElementPath,
   metadata: ElementInstanceMetadataMap,
 ): NameAndIconResult {
-  const elementName = MetadataUtils.getJSXElementFromMetadata(metadata, path)
+  const elementName = MetadataUtils.getJSXElementNameFromMetadata(metadata, path)
   return {
     path: path,
     name: elementName,

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -41,6 +41,7 @@ import { PropertyControlsInfo } from '../custom-code/code-file'
 import { getExportedComponentImports } from '../editor/export-utils'
 
 export type StylePropOption = 'do-not-add' | 'add-size'
+export type WrapContentOption = 'wrap-content' | 'do-now-wrap-content'
 
 export interface InsertableComponent {
   importsToAdd: Imports

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -950,6 +950,21 @@ export const MetadataUtils = {
     // Default catch all name, will probably avoid some odd cases in the future.
     return 'Element'
   },
+  getJSXElementFromMetadata(
+    metadata: ElementInstanceMetadataMap,
+    path: ElementPath,
+  ): JSXElement | null {
+    const element = MetadataUtils.findElementByElementPath(metadata, path)
+    if (element == null) {
+      return null
+    } else {
+      return foldEither(
+        (_) => null,
+        (e) => (isJSXElement(e) ? e : null),
+        element.element,
+      )
+    }
+  },
   getJSXElementName(jsxElement: JSXElementChild | null): JSXElementName | null {
     if (jsxElement != null) {
       if (isJSXElement(jsxElement)) {
@@ -961,26 +976,13 @@ export const MetadataUtils = {
       return null
     }
   },
-  getJSXElementFromMetadata(
-    metadata: ElementInstanceMetadataMap,
-    path: ElementPath,
-  ): JSXElementName | null {
-    const elementName = MetadataUtils.getJSXElementName(
-      maybeEitherToMaybe(MetadataUtils.findElementByElementPath(metadata, path)?.element),
-    )
-    return elementName
-  },
   getJSXElementNameFromMetadata(
-    path: ElementPath,
     metadata: ElementInstanceMetadataMap,
+    path: ElementPath,
   ): JSXElementName | null {
     const element = MetadataUtils.findElementByElementPath(metadata, path)
     if (element != null) {
-      if (isRight(element.element) && isJSXElement(element.element.value)) {
-        return element.element.value.name
-      } else {
-        return null
-      }
+      return MetadataUtils.getJSXElementName(eitherToMaybe(element.element))
     } else {
       return null
     }

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -471,3 +471,7 @@ export function getZIndexOfElement(
     return -1
   }
 }
+
+export function elementOnlyHasSingleTextChild(jsxElement: JSXElement): boolean {
+  return jsxElement.children.length === 1 && isJSXTextBlock(jsxElement.children[0])
+}


### PR DESCRIPTION
Fixes #1670

**Problem:**
When inserting a new `span` into an element that only has text (e.g. `<div>Hello</div>`), typically you'll want to wrap that existing text in the newly inserted element.

**Fix:**
Provide an extra option to "Wrap content" when inserting a new element from the floating menu, and default to that being enabled if the target parent only has text as its content.

**Commit Details:**
- Corrected the behaviour of `getJSXElementFromMetadata` (previously it was returning the element name, rather than the element), and switched existing uses of that function to the other (correctly named) version `getJSXElementNameFromMetadata`
- Added `WrapContentOption` to the `InsertWithDefaults` action, for specifying if the inserted element should wrap the target parent's content
- Added a new check box "Wrap content" to the bottom of the "Add Element" floating menu
- Default the value of that check box to `true` if the target parent only has a single text block child, using the new function `elementOnlyHasSingleTextChild`
- Updated the handler for the `INSERT_WITH_DEFAULTS` to move children from the target parent onto the newly inserted element if the `WrapContentOption` is 'wrap-content'
- Added a test to cover that updated action handling

**Screenshot:**
![Screenshot_20210805_173306](https://user-images.githubusercontent.com/1044774/128387254-e00b965b-42c9-4b4d-86d4-ac5a0835560e.png)
