### PR TITLE
Scale flex grow / shrink drags

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -473,9 +473,15 @@ export function updateFramesOfScenesAndComponents(
             )
             // Defer through these in order: observable value >>> value from attribute >>> 0.
             const currentAttributeToChange = valueFromDOM ?? valueFromAttributes ?? 0
+            const shouldScaleDelta =
+              frameAndTarget.targetProperty === 'flexGrow' ||
+              frameAndTarget.targetProperty === 'flexShrink'
+            const scaledDelta = shouldScaleDelta
+              ? Math.floor(frameAndTarget.delta / 50)
+              : frameAndTarget.delta
 
             const newAttributeValue = jsxAttributeValue(
-              currentAttributeToChange + frameAndTarget.delta,
+              currentAttributeToChange + scaledDelta,
               emptyComments,
             )
 

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -477,7 +477,7 @@ export function updateFramesOfScenesAndComponents(
               frameAndTarget.targetProperty === 'flexGrow' ||
               frameAndTarget.targetProperty === 'flexShrink'
             const scaledDelta = shouldScaleDelta
-              ? Math.floor(frameAndTarget.delta / 50)
+              ? Math.floor(frameAndTarget.delta / 100)
               : frameAndTarget.delta
 
             const newAttributeValue = jsxAttributeValue(


### PR DESCRIPTION
**Problem:**
Dragging to increment the `flexGrow` or `flexShrink` props by 1 per 1px drag feels very wrong

**Fix:**
Scale the applied delta so that it only increments by units of 1 per 100px drag.

I also tried with 10px, 50px, and also incrementing in units of 0.5 rather than 1. Incrementing in whole units rather than 0.5 certainly feels right. The only think I'm not 100% certain on is the 1/100 scaling - it feels right to me, but I'm not sure if to others that will feel like it's too far (especially on your first attempt at updating the `flexGrow` via this). 1/10 is way too fine grained, and 1/50 feels OK but still a bit too fine grained.
