### PR TITLE
Correctly handle wrapping the root element

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -2156,9 +2156,7 @@ export const UPDATE_FNS = {
             editor.projectContents,
             editor.nodeModules.files,
             uiFileKey,
-            targetThatIsRootElementOfCommonParent != null
-              ? targetThatIsRootElementOfCommonParent
-              : parentPath,
+            targetThatIsRootElementOfCommonParent ?? parentPath,
           )
 
           const parent = MetadataUtils.findElementByElementPath(editor.jsxMetadata, parentPath)


### PR DESCRIPTION
Fixes #1638 

**Problem:**
When attempting to use the "Wrap in" options from the floating menu whilst targeting the root element of a component, the result is a new element added as a child of an instance of the component.

**Fix:**
The problem here is that we are blindly using the parent parent, and not checking if that parent path is on the instance. I think we might have some other cases of this problem elsewhere in the code, but for now I've fixed the handling of that parent path here by explicitly checking if the target was the root element of the insertion parent, and if so we use `transformJSXComponentAtPath` to insert a new root element above that.
