### PR TITLE
Corrected the observed value being used when resizing

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -3020,7 +3020,7 @@ export function getObservableValueForLayoutProp(
       case 'Height':
       case 'minHeight':
       case 'maxHeight':
-        return elementMetadata.localFrame?.width
+        return elementMetadata.localFrame?.height
       case 'flexBasis':
       case 'FlexCrossBasis':
       case 'flexGrow':


### PR DESCRIPTION
Fixes #1679 

**Problem:**
When resizing the height via the new canvas menu controls, we were incorrectly using the wrong observed value

**Fix:**
`width` -> `height`
