### PR TITLE
Fix/feature switch redux measure

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -60,6 +60,7 @@ import { mapDropNulls, pluck, uniqBy } from '../../core/shared/array-utils'
 import { optionalMap } from '../../core/shared/optional-utils'
 import { fastForEach } from '../../core/shared/utils'
 import { MapLike } from 'typescript'
+import { isFeatureEnabled } from '../../utils/feature-switches'
 
 const MutationObserverConfig = { attributes: true, childList: true, subtree: true }
 const ObserversAvailable = (window as any).MutationObserver != null && ResizeObserver != null
@@ -125,7 +126,9 @@ function findParentScene(target: HTMLElement): string | null {
   }
 }
 
-const LogDomWalkerPerformance = !PRODUCTION_ENV && typeof window.performance.mark === 'function'
+const LogDomWalkerPerformance =
+  isFeatureEnabled('Debug mode – Performance Marks') &&
+  typeof window.performance.mark === 'function'
 
 function lazyValue<T>(getter: () => T) {
   let alreadyResolved = false

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -52,7 +52,7 @@ import {
 } from '../../core/model/utopia-constants'
 
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
-import { PRODUCTION_ENV } from '../../common/env-vars'
+import { PERFORMANCE_MARKS_ALLOWED, PRODUCTION_ENV } from '../../common/env-vars'
 import { CanvasContainerID } from './canvas-types'
 import { emptySet } from '../../core/shared/set-utils'
 import { getPathWithStringsOnDomElement, PathWithString } from '../../core/shared/uid-utils'
@@ -125,10 +125,6 @@ function findParentScene(target: HTMLElement): string | null {
     }
   }
 }
-
-const LogDomWalkerPerformance =
-  isFeatureEnabled('Debug mode – Performance Marks') &&
-  typeof window.performance.mark === 'function'
 
 function lazyValue<T>(getter: () => T) {
   let alreadyResolved = false
@@ -438,6 +434,9 @@ export function useDomWalker(
   const containerRef = React.useRef<HTMLDivElement>(null)
 
   const fireThrottledCallback = useThrottledCallback(() => {
+    const LogDomWalkerPerformance =
+      isFeatureEnabled('Debug mode – Performance Marks') && PERFORMANCE_MARKS_ALLOWED
+
     if (containerRef.current != null) {
       if (LogDomWalkerPerformance) {
         performance.mark('DOM_WALKER_START')

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -2,7 +2,7 @@ import * as deepEquals from 'fast-deep-equal'
 import { produce } from 'immer'
 import * as React from 'react'
 import * as ReactDOMServer from 'react-dom/server'
-import { PRODUCTION_ENV } from '../../../common/env-vars'
+import { PERFORMANCE_MARKS_ALLOWED, PRODUCTION_ENV } from '../../../common/env-vars'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import { getAllUniqueUids } from '../../../core/model/element-template-utils'
@@ -511,10 +511,6 @@ export function editorDispatch(
   return finalStore
 }
 
-const MeasureDispatchTime =
-  isFeatureEnabled('Debug mode – Performance Marks') &&
-  typeof window.performance.mark === 'function'
-
 function editorDispatchInner(
   boundDispatch: EditorDispatch,
   dispatchedActions: EditorAction[],
@@ -523,6 +519,9 @@ function editorDispatchInner(
   spyCollector: UiJsxCanvasContextData,
 ): DispatchResult {
   // console.log('DISPATCH', simpleStringifyActions(dispatchedActions))
+
+  const MeasureDispatchTime =
+    isFeatureEnabled('Debug mode – Performance Marks') && PERFORMANCE_MARKS_ALLOWED
 
   if (MeasureDispatchTime) {
     window.performance.mark('dispatch_begin')

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -3,6 +3,7 @@ import type { EditorStore } from './editor-state'
 import { UseStore, StoreApi, EqualityChecker } from 'zustand'
 import { shallowEqual } from '../../../core/shared/equality-utils'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
+import { PERFORMANCE_MARKS_ALLOWED } from '../../../common/env-vars'
 
 type StateSelector<T, U> = (state: T) => U
 
@@ -31,10 +32,6 @@ export const useEditorState = <U>(
   return context.useStore(wrappedSelector, equalityFn as EqualityChecker<U>)
 }
 
-const LogSelectorPerformance =
-  isFeatureEnabled('Debug mode – Performance Marks') &&
-  typeof window.performance.mark === 'function'
-
 function useWrapSelectorInPerformanceMeasureBlock<U>(
   selector: StateSelector<EditorStore, U>,
   selectorName: string,
@@ -48,6 +45,9 @@ function useWrapSelectorInPerformanceMeasureBlock<U>(
   } else {
     // let's create a new wrapped selector
     const wrappedSelector = (state: EditorStore) => {
+      const LogSelectorPerformance =
+        isFeatureEnabled('Debug mode – Performance Marks') && PERFORMANCE_MARKS_ALLOWED
+
       if (LogSelectorPerformance) {
         window.performance.mark('selector_begin')
       }

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import type { EditorStore } from './editor-state'
 import { UseStore, StoreApi, EqualityChecker } from 'zustand'
-import { PRODUCTION_ENV } from '../../../common/env-vars'
 import { shallowEqual } from '../../../core/shared/equality-utils'
+import { isFeatureEnabled } from '../../../utils/feature-switches'
 
 type StateSelector<T, U> = (state: T) => U
 
@@ -31,7 +31,9 @@ export const useEditorState = <U>(
   return context.useStore(wrappedSelector, equalityFn as EqualityChecker<U>)
 }
 
-const LogSelectorPerformance = !PRODUCTION_ENV && typeof window.performance.mark === 'function'
+const LogSelectorPerformance =
+  isFeatureEnabled('Debug mode – Performance Marks') &&
+  typeof window.performance.mark === 'function'
 
 function useWrapSelectorInPerformanceMeasureBlock<U>(
   selector: StateSelector<EditorStore, U>,

--- a/editor/src/core/shared/redux-devtools.ts
+++ b/editor/src/core/shared/redux-devtools.ts
@@ -1,5 +1,6 @@
 import type { EditorAction } from '../../components/editor/action-types'
 import type { EditorStore } from '../../components/editor/store/editor-state'
+import { isFeatureEnabled } from '../../utils/feature-switches'
 import { pluck } from './array-utils'
 
 interface Connection {
@@ -14,7 +15,8 @@ function connectDevToolsExtension(): Connection | null {
   if (
     window != null &&
     (window as any).__REDUX_DEVTOOLS_EXTENSION__ != null &&
-    (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect != null
+    (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect != null &&
+    isFeatureEnabled('Debug mode – Redux Devtools')
   ) {
     return (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect({
       maxAge: 50, // maximum allowed actions to be stored in the history tree. It's critical for performance

--- a/editor/src/core/shared/redux-devtools.ts
+++ b/editor/src/core/shared/redux-devtools.ts
@@ -15,8 +15,7 @@ function connectDevToolsExtension(): Connection | null {
   if (
     window != null &&
     (window as any).__REDUX_DEVTOOLS_EXTENSION__ != null &&
-    (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect != null &&
-    isFeatureEnabled('Debug mode – Redux Devtools')
+    (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect != null
   ) {
     return (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect({
       maxAge: 50, // maximum allowed actions to be stored in the history tree. It's critical for performance
@@ -94,7 +93,11 @@ export function reduxDevtoolsSendActions(
   actions: Array<Array<EditorAction>>,
   newStore: EditorStore,
 ): void {
-  if (maybeDevTools != null && sendActionUpdates) {
+  if (
+    maybeDevTools != null &&
+    sendActionUpdates &&
+    isFeatureEnabled('Debug mode – Redux Devtools')
+  ) {
     // filter out the actions we are not interested in
     const filteredActions = actions
       .flat()
@@ -109,25 +112,37 @@ export function reduxDevtoolsSendActions(
 }
 
 export function reduxDevtoolsSendInitialState(newStore: EditorStore): void {
-  if (maybeDevTools != null && sendActionUpdates) {
+  if (maybeDevTools != null) {
     maybeDevTools.init(newStore)
   }
 }
 
 export function reduxDevtoolsLogMessage(message: string, optionalPayload?: any): void {
-  if (maybeDevTools != null && sendActionUpdates) {
+  if (
+    maybeDevTools != null &&
+    sendActionUpdates &&
+    isFeatureEnabled('Debug mode – Redux Devtools')
+  ) {
     maybeDevTools.send({ type: `🟢 ${message}`, payload: optionalPayload }, lastDispatchedStore)
   }
 }
 
 export function reduxDevtoolsLogError(message: string, optionalPayload?: any): void {
-  if (maybeDevTools != null && sendActionUpdates) {
+  if (
+    maybeDevTools != null &&
+    sendActionUpdates &&
+    isFeatureEnabled('Debug mode – Redux Devtools')
+  ) {
     maybeDevTools.send({ type: `🔴 ${message}`, payload: optionalPayload }, lastDispatchedStore)
   }
 }
 
 export function reduxDevtoolsUpdateState(message: string, newStore: EditorStore): void {
-  if (maybeDevTools != null && sendActionUpdates) {
+  if (
+    maybeDevTools != null &&
+    sendActionUpdates &&
+    isFeatureEnabled('Debug mode – Redux Devtools')
+  ) {
     const sanitizedStore = sanitizeLoggedState(newStore)
     maybeDevTools.send(`🟣 ${message}`, sanitizedStore)
     lastDispatchedStore = sanitizedStore

--- a/editor/src/templates/editor-entry-point.tsx
+++ b/editor/src/templates/editor-entry-point.tsx
@@ -4,6 +4,9 @@
 //   trackAllPureComponents: true,
 // })
 
+// import feature switches so they are loaded before anything else can read them
+import '../utils/feature-switches'
+
 // Fire off server requests that later block, to improve initial load on slower connections. These will still block,
 // but this gives us a chance to cache the result first
 import { getLoginState } from '../common/server'

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -1,3 +1,6 @@
+// import feature switches so they are loaded before anything else can read them
+import '../utils/feature-switches'
+
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { hot } from 'react-hot-loader/root'

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -14,6 +14,7 @@ import {
 import { v4 } from 'uuid'
 import { appendToUidString } from '../core/shared/uid-utils'
 import { isFeatureEnabled } from './feature-switches'
+import { PERFORMANCE_MARKS_ALLOWED } from '../common/env-vars'
 
 const realCreateElement = React.createElement
 
@@ -121,17 +122,15 @@ function attachDataUidToRoot(
   }
 }
 
-const MeasureRenderTimes =
-  isFeatureEnabled('Debug mode – Performance Marks') &&
-  typeof window.performance.mark === 'function'
-
 const mangleFunctionType = Utils.memoize(
   (type: unknown): React.FunctionComponent => {
-    const uuid = MeasureRenderTimes ? v4() : ''
     const mangledFunctionName = `UtopiaSpiedFunctionComponent(${getDisplayName(type)})`
 
     const mangledFunction = {
       [mangledFunctionName]: (p: any, context?: any) => {
+        const MeasureRenderTimes =
+          isFeatureEnabled('Debug mode – Performance Marks') && PERFORMANCE_MARKS_ALLOWED
+        const uuid = MeasureRenderTimes ? v4() : ''
         if (MeasureRenderTimes) {
           performance.mark(`render_start_${uuid}`)
         }
@@ -165,10 +164,12 @@ const mangleFunctionType = Utils.memoize(
 
 const mangleClassType = Utils.memoize(
   (type: any) => {
-    const uuid = MeasureRenderTimes ? v4() : ''
     const originalRender = type.prototype.render
     // mutation
     type.prototype.render = function monkeyRender() {
+      const MeasureRenderTimes =
+        isFeatureEnabled('Debug mode – Performance Marks') && PERFORMANCE_MARKS_ALLOWED
+      const uuid = MeasureRenderTimes ? v4() : ''
       if (MeasureRenderTimes) {
         performance.mark(`render_start_${uuid}`)
       }

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -12,8 +12,8 @@ import {
   UTOPIA_UID_PARENTS_KEY,
 } from '../core/model/utopia-constants'
 import { v4 } from 'uuid'
-import { PRODUCTION_ENV } from '../common/env-vars'
 import { appendToUidString } from '../core/shared/uid-utils'
+import { isFeatureEnabled } from './feature-switches'
 
 const realCreateElement = React.createElement
 
@@ -121,7 +121,9 @@ function attachDataUidToRoot(
   }
 }
 
-const MeasureRenderTimes = !PRODUCTION_ENV && typeof window.performance.mark === 'function'
+const MeasureRenderTimes =
+  isFeatureEnabled('Debug mode – Performance Marks') &&
+  typeof window.performance.mark === 'function'
 
 const mangleFunctionType = Utils.memoize(
   (type: unknown): React.FunctionComponent => {

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -3,6 +3,8 @@ import { PRODUCTION_CONFIG } from '../common/env-vars'
 import { fastForEach, isBrowserEnvironment } from '../core/shared/utils'
 
 export type FeatureName =
+  | 'Debug mode – Redux Devtools'
+  | 'Debug mode – Performance Marks'
   | 'Dragging Reparents By Default'
   | 'Dragging Shows Overlay'
   | 'Advanced Resize Box'
@@ -15,6 +17,8 @@ export type FeatureName =
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
   // 'Dragging Shows Overlay', // Removing this option so that we can experiment on this later
+  'Debug mode – Redux Devtools',
+  'Debug mode – Performance Marks',
   'Advanced Resize Box',
   'Re-parse Project Button',
   'Performance Test Triggers',
@@ -24,6 +28,8 @@ export const AllFeatureNames: FeatureName[] = [
 ]
 
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {
+  'Debug mode – Redux Devtools': false,
+  'Debug mode – Performance Marks': false,
   'Dragging Reparents By Default': false,
   'Dragging Shows Overlay': false,
   'Advanced Resize Box': false,

--- a/website-next/components/common/env-vars.ts
+++ b/website-next/components/common/env-vars.ts
@@ -129,3 +129,5 @@ export function isEmbedded(): boolean {
     return false
   }
 }
+
+export const PERFORMANCE_MARKS_ALLOWED = typeof window.performance.mark === 'function'

--- a/website-next/components/common/env-vars.ts
+++ b/website-next/components/common/env-vars.ts
@@ -130,4 +130,5 @@ export function isEmbedded(): boolean {
   }
 }
 
-export const PERFORMANCE_MARKS_ALLOWED = typeof window.performance.mark === 'function'
+export const PERFORMANCE_MARKS_ALLOWED =
+  typeof window !== 'undefined' && typeof window?.performance?.mark === 'function'


### PR DESCRIPTION
Fixes #1550 and Fixes #1556

**Problem:**
Redux devtools logging is very slow. Performance.marks and Performance.measures (in development mode only) are also pretty slow. Bonus problem: sometimes we would like performance.marks in production for debugging!

**Fix:**
Put redux devtools logging and performance.measures behind feature switches.

**Note:**
Because the feature switches are extracted a few moments after the editor loads, I had to move some code around and get the feature switch right before the code would redux log or performance.mark. This shouldn't be a major performance issue because checking the value of a feature switch just returns an object's property.