### PR TITLE
Rendering intrinsic elements shouldn't use scoped variables

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -1,4 +1,4 @@
-import { testCanvasRender } from './ui-jsx-canvas.test-utils'
+import { testCanvasRender, testCanvasRenderInline } from './ui-jsx-canvas.test-utils'
 
 describe('UiJsxCanvas', () => {
   it('#747 - DOM object constructor cannot be called as a function', () => {
@@ -32,5 +32,62 @@ export var storyboard = (
 )
     `,
     )
+  })
+  it('Supports in-scope variables with the same names as intrinsic components', () => {
+    const result = testCanvasRenderInline(
+      null,
+      `
+import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export const App = () => {
+  const div = React.useRef()
+  return <div data-uid='app-root' ref={div} />
+}
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      data-uid='scene'
+      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+    >
+      <App data-uid='app' />
+    </Scene>
+  </Storyboard>
+)
+    `,
+    )
+
+    expect(result).toMatchInlineSnapshot(`
+      "<div style=\\"all: initial;\\">
+        <div
+          id=\\"canvas-container\\"
+          style=\\"position: absolute;\\"
+          data-utopia-valid-paths=\\"sb sb/scene sb/scene/app sb/scene/app:app-root\\"
+          data-utopia-root-element-path=\\"sb\\"
+        >
+          <div
+            data-utopia-scene-id=\\"sb/scene\\"
+            data-paths=\\"sb/scene sb\\"
+            style=\\"
+              position: absolute;
+              background-color: rgba(255, 255, 255, 1);
+              box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              left: 0;
+              top: 0;
+              width: 375px;
+              height: 812px;
+            \\"
+            data-uid=\\"scene sb\\"
+          >
+            <div
+              data-uid=\\"app-root app\\"
+              data-paths=\\"sb/scene/app:app-root sb/scene/app\\"
+            ></div>
+          </div>
+        </div>
+      </div>
+      "
+    `)
   })
 })

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -361,14 +361,13 @@ function renderJSXElement(
   }
 
   const childrenElements = jsx.children.map(createChildrenElement)
-  const elementInScope = getElementFromScope(jsx, inScope)
-  const elementFromImport = getElementFromScope(jsx, requireResult)
-  const elementFromScopeOrImport = Utils.defaultIfNull(elementFromImport, elementInScope)
-  const elementIsScene = isSceneElementIgnoringImports(jsx)
-  const elementOrScene = elementIsScene ? SceneComponent : elementFromScopeOrImport
-  const elementIsIntrinsic =
-    !elementIsScene && elementFromScopeOrImport == null && isIntrinsicElement(jsx.name)
+  const elementIsIntrinsic = isIntrinsicElement(jsx.name)
   const elementIsBaseHTML = elementIsIntrinsic && isIntrinsicHTMLElement(jsx.name)
+  const elementInScope = elementIsIntrinsic ? null : getElementFromScope(jsx, inScope)
+  const elementFromImport = elementIsIntrinsic ? null : getElementFromScope(jsx, requireResult)
+  const elementFromScopeOrImport = Utils.defaultIfNull(elementFromImport, elementInScope)
+  const elementIsScene = !elementIsIntrinsic && isSceneElementIgnoringImports(jsx)
+  const elementOrScene = elementIsScene ? SceneComponent : elementFromScopeOrImport
   const FinalElement = elementIsIntrinsic ? jsx.name.baseVariable : elementOrScene
 
   const elementPropsWithScenePath = isComponentRendererComponent(FinalElement)


### PR DESCRIPTION
Fixes #1690 

**Problem:**
When rendering elements, Utopia will always prioritise whatever is in scope, meaning that e.g. a locally declared `div` would be used over the intrinsic HTML element.

**Fix:**
Check if the element is intrinsic first so that we don't do that. I've also added a test to cover this.
