### PR TITLE
More precise spying

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -389,9 +389,9 @@ function renderJSXElement(
     [UTOPIA_PATHS_KEY]: optionalMap(EP.toString, elementPath),
   }
 
-  const staticElementPathForGeneratedElement = optionalMap(EP.dynamicPathToStaticPath, elementPath)
+  const staticElementPathForGeneratedElement = optionalMap(EP.makeLastPartOfPathStatic, elementPath)
 
-  const staticValidPaths = validPaths.map(EP.dynamicPathToStaticPath)
+  const staticValidPaths = validPaths.map(EP.makeLastPartOfPathStatic)
 
   if (FinalElement == null) {
     throw canvasMissingJSXElementError(jsxFactoryFunctionName, code, jsx, filePath, highlightBounds)

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
@@ -1099,16 +1099,6 @@ describe('Spy Wrapper Template Path Tests', () => {
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1:hi-element-fragment-child-1": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1:hi-element-fragment-child-2": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
@@ -1127,16 +1117,6 @@ describe('Spy Wrapper Template Path Tests', () => {
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3:hi-element-fragment-child-1": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3:hi-element-fragment-child-2": Object {
-          "children": Array [],
-          "name": "div",
           "rootElements": Array [],
         },
         "storyboard/scene-2": Object {
@@ -1333,16 +1313,6 @@ describe('Spy Wrapper Template Path Tests', () => {
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1:hi-element-fragment-child-1": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~1:hi-element-fragment-child-2": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
@@ -1364,16 +1334,6 @@ describe('Spy Wrapper Template Path Tests', () => {
         "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3:hi-element-fragment-child-1": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-1/app:other-app-root/other-inner-div/other-card-instance:other-button-instance/other-hi-element~~~3:hi-element-fragment-child-2": Object {
-          "children": Array [],
-          "name": "div",
           "rootElements": Array [],
         },
         "storyboard/scene-2": Object {
@@ -2167,11 +2127,6 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
         "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
@@ -2185,11 +2140,6 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
         "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
           "rootElements": Array [],
         },
       }
@@ -2382,11 +2332,6 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
         "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
@@ -2402,11 +2347,6 @@ describe('Spy Wrapper Multifile Template Path Tests', () => {
         "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
           "rootElements": Array [],
         },
       }
@@ -2556,11 +2496,6 @@ describe('Spy Wrapper Multifile With Cyclic Dependencies', () => {
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
         "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
@@ -2574,11 +2509,6 @@ describe('Spy Wrapper Multifile With Cyclic Dependencies', () => {
         "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
           "rootElements": Array [],
         },
       }
@@ -2771,11 +2701,6 @@ describe('Spy Wrapper Multifile With Cyclic Dependencies', () => {
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
         "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
@@ -2791,11 +2716,6 @@ describe('Spy Wrapper Multifile With Cyclic Dependencies', () => {
         "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
           "rootElements": Array [],
         },
       }
@@ -2964,21 +2884,6 @@ describe('Spy Wrapper Multifile With Cyclic Dependencies', () => {
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1:hi-element-root/hi-element-inner": Object {
-          "children": Array [],
-          "name": "HiElementInner",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1:hi-element-root/hi-element-inner:hi-element-inner-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
         "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
@@ -3004,21 +2909,6 @@ describe('Spy Wrapper Multifile With Cyclic Dependencies', () => {
         "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3:hi-element-root/hi-element-inner": Object {
-          "children": Array [],
-          "name": "HiElementInner",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3:hi-element-root/hi-element-inner:hi-element-inner-root": Object {
-          "children": Array [],
-          "name": "div",
           "rootElements": Array [],
         },
       }
@@ -3225,21 +3115,6 @@ describe('Spy Wrapper Multifile With Cyclic Dependencies', () => {
           "name": "HiElement",
           "rootElements": Array [],
         },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1:hi-element-root/hi-element-inner": Object {
-          "children": Array [],
-          "name": "HiElementInner",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~1:hi-element-root/hi-element-inner:hi-element-inner-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
         "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~2": Object {
           "children": Array [],
           "name": "HiElement",
@@ -3269,21 +3144,6 @@ describe('Spy Wrapper Multifile With Cyclic Dependencies', () => {
         "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3": Object {
           "children": Array [],
           "name": "HiElement",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3:hi-element-root": Object {
-          "children": Array [],
-          "name": "div",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3:hi-element-root/hi-element-inner": Object {
-          "children": Array [],
-          "name": "HiElementInner",
-          "rootElements": Array [],
-        },
-        "storyboard/scene-2/app2:app-outer-div/card-instance:button-instance/hi-element~~~3:hi-element-root/hi-element-inner:hi-element-inner-root": Object {
-          "children": Array [],
-          "name": "div",
           "rootElements": Array [],
         },
       }

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -37,6 +37,7 @@ function emptyElementPathCache(): ElementPathCache {
 }
 
 let dynamicToStaticPathCache: Map<ElementPath, StaticElementPath> = new Map()
+let dynamicToStaticLastElementPathPartCache: Map<ElementPath, ElementPath> = new Map()
 let dynamicElementPathToStaticElementPathCache: Map<
   ElementPathPart,
   StaticElementPathPart
@@ -725,12 +726,20 @@ export function dynamicPathToStaticPath(path: ElementPath): StaticElementPath {
 }
 
 export function makeLastPartOfPathStatic(path: ElementPath): ElementPath {
-  const dynamicLastPart = last(path.parts)
-  if (dynamicLastPart == null) {
-    return path
+  const existing = dynamicToStaticLastElementPathPartCache.get(path)
+  if (existing == null) {
+    const dynamicLastPart = last(path.parts)
+    let result: ElementPath
+    if (dynamicLastPart == null) {
+      result = path
+    } else {
+      const staticLastPart = dynamicElementPathToStaticElementPath(dynamicLastPart)
+      result = elementPath([...dropLast(path.parts), staticLastPart])
+    }
+    dynamicToStaticLastElementPathPartCache.set(path, result)
+    return result
   } else {
-    const staticLastPart = dynamicElementPathToStaticElementPath(dynamicLastPart)
-    return elementPath([...dropLast(path.parts), staticLastPart])
+    return existing
   }
 }
 


### PR DESCRIPTION
**Problem:**
The canvas Spy was applied to a too broad list of targets. These unnecessarily spied elements would be filtered out using the dom-walker, but they don't need to be there in the first place. (furthermore, if the dom-walker cannot be used, like in the case of react-three-fiber, the spied list would be wrong.)

Example:

```javascript
function Card() {
  return <div>hi!</div>
}

function App() {
  return (<>{[1, 2, 3].map(_ => <Card />)}</>)
}
```

If Card~~~2 is focused, we want to spy on App:Card~~~2:div, but on current master, we are also spying on App:Card~~~1:div and App:Card~~~3:div.

**Fix:**
Only spy on elements if their ancestor components match the valid path, including their dynamic path.

**Commit Details:**
- in element-renderer-utils, only turn the last path part static when comparing with validPaths
