### PR TITLE
Multiple module resolution fixes

### DIFF
--- a/editor/src/core/es-modules/evaluator/evaluator.ts
+++ b/editor/src/core/es-modules/evaluator/evaluator.ts
@@ -105,6 +105,8 @@ export function evaluator(
   const fileExtension = getFileExtension(filepath)
   switch (fileExtension) {
     case 'js':
+    case 'cjs':
+    case 'mjs':
       return evaluateJs(filepath, moduleCode, fileEvaluationCache, requireFn)
     default:
       throw new Error(`error evaluating file ${filepath} – unsupported file type ${fileExtension}`)

--- a/editor/src/core/es-modules/package-manager/module-resolution.ts
+++ b/editor/src/core/es-modules/package-manager/module-resolution.ts
@@ -216,15 +216,20 @@ function processPackageJson(
   return foldEither(
     (_) => resolveNotPresent,
     (packageJson) => {
-      const moduleName: string = packageJson.name ?? makePathFromParts(containerFolder)
+      const moduleName: string | null = packageJson.name ?? null
       const mainEntry: string | null = packageJson.main ?? null
       const moduleEntry: string | null = packageJson.module ?? null
-      if (moduleEntry != null && mainEntry == null) {
-        return resolveSuccess(normalizePath([...containerFolder, ...getPartsFromPath(moduleName)]))
-      }
+
       if (mainEntry != null) {
         return resolveSuccess(normalizePath([...containerFolder, ...getPartsFromPath(mainEntry)]))
+      } else if (moduleEntry != null) {
+        return resolveSuccess(normalizePath([...containerFolder, ...getPartsFromPath(moduleEntry)]))
+      } else if (moduleName != null) {
+        return resolveSuccess(normalizePath([...containerFolder, ...getPartsFromPath(moduleName)]))
+      } else if (containerFolder.length > 0) {
+        return resolveSuccess(normalizePath(containerFolder))
       }
+
       return resolveNotPresent
     },
     possiblePackageJson,

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -58,11 +58,7 @@ describe('ES Dependency Package Manager', () => {
     const reqFn = getRequireFn(
       NO_OP,
       {},
-      extractNodeModulesFromPackageResponse(
-        'mypackage',
-        npmVersion('0.0.1'),
-        fileNoImports as PackagerServerResponse,
-      ),
+      extractNodeModulesFromPackageResponse(fileNoImports as PackagerServerResponse),
       {},
       'canvas',
     )
@@ -75,7 +71,7 @@ describe('ES Dependency Package Manager', () => {
     const reqFn = getRequireFn(
       NO_OP,
       {},
-      extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
+      extractNodeModulesFromPackageResponse(fileWithImports),
       {},
       'canvas',
     )
@@ -88,7 +84,7 @@ describe('ES Dependency Package Manager', () => {
     const reqFn = getRequireFn(
       NO_OP,
       {},
-      extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithLocalImport),
+      extractNodeModulesFromPackageResponse(fileWithLocalImport),
       {},
       'canvas',
     )
@@ -101,7 +97,7 @@ describe('ES Dependency Package Manager', () => {
     const reqFn = getRequireFn(
       NO_OP,
       {},
-      extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
+      extractNodeModulesFromPackageResponse(fileWithImports),
       {},
       'canvas',
     )
@@ -115,7 +111,7 @@ describe('ES Dependency Package Manager', () => {
     const reqFn = getRequireFn(
       NO_OP,
       {},
-      extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
+      extractNodeModulesFromPackageResponse(fileWithImports),
       {},
       'canvas',
     )
@@ -131,7 +127,7 @@ describe('ES Dependency Package Manager', () => {
     const reqFn = getRequireFn(
       NO_OP,
       {},
-      extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
+      extractNodeModulesFromPackageResponse(fileWithImports),
       {},
       'canvas',
     )
@@ -148,7 +144,7 @@ describe('ES Dependency Package Manager', () => {
     const reqFn = getRequireFn(
       NO_OP,
       {},
-      extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
+      extractNodeModulesFromPackageResponse(fileWithImports),
       {},
       'canvas',
     )
@@ -163,7 +159,7 @@ describe('ES Dependency Manager — Cycles', () => {
     const reqFn = getRequireFn(
       NO_OP,
       {},
-      extractNodeModulesFromPackageResponse('mypackage', npmVersion('0.0.1'), fileWithImports),
+      extractNodeModulesFromPackageResponse(fileWithImports),
       {},
       'canvas',
       spyEvaluator,

--- a/editor/src/core/property-controls/property-controls-processor.spec.ts
+++ b/editor/src/core/property-controls/property-controls-processor.spec.ts
@@ -36,8 +36,6 @@ describe('Property Controls Processor', () => {
     const packageVersion = '4.2.5'
 
     const fakedPackagerResponse = extractNodeModulesFromPackageResponse(
-      packageName,
-      npmVersion(packageVersion),
       antdPackagerResponse as PackagerServerResponse,
     )
     const nodeModules = mangleNodeModulePaths('antd', fakedPackagerResponse)
@@ -75,8 +73,6 @@ describe('Property Controls Processor', () => {
     const packageVersion = '4.2.5'
 
     const fakedPackagerResponse = extractNodeModulesFromPackageResponse(
-      packageName,
-      npmVersion(packageVersion),
       antdPackagerResponse as PackagerServerResponse,
     )
     const nodeModules = mangleNodeModulePaths('antd', fakedPackagerResponse)

--- a/editor/src/core/webpack-loaders/default-loader.ts
+++ b/editor/src/core/webpack-loaders/default-loader.ts
@@ -1,7 +1,7 @@
 import { LoadModule, loadModuleResult, MatchFile, ModuleLoader } from './loader-types'
 
 const matchFile: MatchFile = (filename: string) => {
-  return ['.js', '.jsx', '.ts', '.tsx', '.d.ts', '.json'].some((extension) =>
+  return ['.cjs', '.mjs', '.js', '.jsx', '.ts', '.tsx', '.d.ts', '.json'].some((extension) =>
     filename.endsWith(extension),
   )
 }

--- a/editor/src/third-party/react-error-overlay/utils/parser.ts
+++ b/editor/src/third-party/react-error-overlay/utils/parser.ts
@@ -26,9 +26,15 @@ function extractLocation(token: string): [string, number, number] {
 const regexValidFrame_Chrome = /^\s*(at|in)\s.+(:\d+)/
 const regexValidFrame_FireFox = /(^|@)\S+:\d+|.+line\s+\d+\s+>\s+(eval|Function).+/
 
+const maxParseableErrorLength = 10000
+
 export function parseStack(stack: string[]): StackFrame[] {
   const frames = stack
-    .filter((e) => regexValidFrame_Chrome.test(e) || regexValidFrame_FireFox.test(e))
+    .filter(
+      (e) =>
+        e.length < maxParseableErrorLength &&
+        (regexValidFrame_Chrome.test(e) || regexValidFrame_FireFox.test(e)),
+    )
     .map((e) => {
       if (regexValidFrame_FireFox.test(e)) {
         // Strip eval, we don't care about it

--- a/server/src/Utopia/Web/Packager/NPM.hs
+++ b/server/src/Utopia/Web/Packager/NPM.hs
@@ -65,7 +65,7 @@ withInstalledProject semaphore versionedPackageName withInstalledPath = do
     withInstalledPath tempDir
 
 isRelevantFilename :: FilePath -> Bool
-isRelevantFilename path = isSuffixOf "package.json" path || isSuffixOf ".d.ts" path || isSuffixOf ".js" path
+isRelevantFilename path = isSuffixOf "package.json" path || isSuffixOf ".js" path || isSuffixOf ".cjs" path || isSuffixOf ".mjs" path
 
 data FileContentOrPlaceholder = FileContent BL.ByteString | Placeholder
                               deriving (Eq)

--- a/server/test/Test/Utopia/Web/Packager/NPM.hs
+++ b/server/test/Test/Utopia/Web/Packager/NPM.hs
@@ -15,38 +15,15 @@ import           Utopia.Web.Packager.NPM
 
 expectedFilenames :: [Text]
 expectedFilenames = [
-  "/node_modules/js-tokens/index.js",
-  "/node_modules/js-tokens/package.json",
-  "/node_modules/loose-envify/cli.js",
-  "/node_modules/loose-envify/custom.js",
-  "/node_modules/loose-envify/index.js",
-  "/node_modules/loose-envify/loose-envify.js",
-  "/node_modules/loose-envify/package.json",
-  "/node_modules/loose-envify/replace.js",
-  "/node_modules/object-assign/index.js",
-  "/node_modules/object-assign/package.json",
-  "/node_modules/prop-types/checkPropTypes.js",
-  "/node_modules/prop-types/factory.js",
-  "/node_modules/prop-types/factoryWithThrowingShims.js",
-  "/node_modules/prop-types/factoryWithTypeCheckers.js",
-  "/node_modules/prop-types/index.js",
-  "/node_modules/prop-types/lib/ReactPropTypesSecret.js",
-  "/node_modules/prop-types/package.json",
-  "/node_modules/prop-types/prop-types.js",
-  "/node_modules/prop-types/prop-types.min.js",
-  "/node_modules/react-is/cjs/react-is.development.js",
-  "/node_modules/react-is/cjs/react-is.production.min.js",
-  "/node_modules/react-is/index.js",
-  "/node_modules/react-is/package.json",
-  "/node_modules/react-is/umd/react-is.development.js",
-  "/node_modules/react-is/umd/react-is.production.min.js",
-  "/node_modules/react/cjs/react.development.js",
-  "/node_modules/react/cjs/react.production.min.js",
-  "/node_modules/react/index.js",
-  "/node_modules/react/package.json",
-  "/node_modules/react/umd/react.development.js",
-  "/node_modules/react/umd/react.production.min.js",
-  "/node_modules/react/umd/react.profiling.min.js"]
+  "/node_modules/fflate/esm/browser.js",
+  "/node_modules/fflate/esm/index.mjs",
+  "/node_modules/fflate/lib/browser.cjs",
+  "/node_modules/fflate/lib/index.cjs",
+  "/node_modules/fflate/lib/node-worker.cjs",
+  "/node_modules/fflate/lib/node.cjs",
+  "/node_modules/fflate/lib/worker.cjs",
+  "/node_modules/fflate/package.json",
+  "/node_modules/fflate/umd/index.js"]
 
 getNodeModulesSubDirectories :: FilePath -> ConduitT () FilePath (ResourceT IO) ()
 getNodeModulesSubDirectories projectFolder =
@@ -64,9 +41,9 @@ npmSpec = do
       semaphore <- newQSem 1
       (runResourceT $ sourceToList $ withInstalledProject semaphore "non-existent-project-that-will-never-exist@9.9.9.9.9.9" getNodeModulesSubDirectories) `shouldThrow` anyIOException
   describe "getModuleAndDependenciesFiles" $ do
-    it "should get a bunch of .js, .d.ts and package.json files" $ do
+    it "should get a bunch of .cjs, .js, .mjs and package.json files" $ do
       semaphore <- newQSem 1
-      result <- runResourceT $ sourceToList $ withInstalledProject semaphore "react@16.13.1" getModuleAndDependenciesFiles
+      result <- runResourceT $ sourceToList $ withInstalledProject semaphore "fflate@0.7.1" getModuleAndDependenciesFiles
       let filteredResult = filter (\(k, v) -> v /= encodedPlaceholder) result
       let sortedFilenames = sort $ fmap pack $ toListOf (traverse . _1) filteredResult
       sortedFilenames `shouldBe` expectedFilenames


### PR DESCRIPTION
Fixes #1694 

**Problem:**
Attempting to import from `@react-three/drei` fails with module resolution errors.

**Fix:**
There were a number of knock on issues causing this, which were fixed as follows:

1. No file loader was provided for .cjs files, so I have updated the `default-loader.ts` to support these (and .mjs files)
2. The evaluator only accepted .js files, so I have added .cjs and .mjs to the switch statement used in `evaluator.ts`
3. Remote placeholder files in transitive dependencies were not being correctly resolved, as we were trying to load them relative to the main dependencies on jsdelivr. Now we search for the relevant package.json file and determine the actual resolved package name and version (or git url) for a given file, and use that to determine the URL required to load it.
4. The server was replacing .cjs and .mjs files with remote placeholder files, so it now doesn't
5. The react error overlay parser struggles with parsing huge errors, so we no longer try to parse these (from https://github.com/concrete-utopia/utopia/pull/1461)
6. The module resolution logic was confusing when determining which package.json field to use, so I tidied that up (also from https://github.com/concrete-utopia/utopia/pull/1461)

One thing to note here, with the change around resolve remote placeholder files, there is a possibility that we can't find a package.json file, or that the package.json file we find doesn't have the fields we need. In this case I opted to resolve to a code file that throws an error stating that the file wasn't resolved, so that the error is presented in the error overlay. The alternative options would be to resolve to a fake url to trigger a 404 (which results in the module being an empty object), or throw an error (which would take down the editor). The 404 behaviour definitely needs improvement, after which _maybe_ that would make more sense.