### PR TITLE
Don't attach data-* props to non-html intrinsic elements wrapped in fragments

### DIFF
--- a/editor/src/utils/canvas-react-utils.spec.tsx
+++ b/editor/src/utils/canvas-react-utils.spec.tsx
@@ -638,4 +638,30 @@ describe('Monkey Function', () => {
       "
     `)
   })
+
+  it('Does not add a uid to a non-html intrinsic element', () => {
+    const Component = () => {
+      return <mesh />
+    }
+
+    expect(renderToFormattedString(<Component data-uid={'test1'} />)).toMatchInlineSnapshot(`
+      "<mesh></mesh>
+      "
+    `)
+  })
+
+  it('Does not add a uid to a non-html intrinsic element wrapped in a fragment', () => {
+    const Component = () => {
+      return (
+        <>
+          <mesh />
+        </>
+      )
+    }
+
+    expect(renderToFormattedString(<Component data-uid={'test1'} />)).toMatchInlineSnapshot(`
+      "<mesh></mesh>
+      "
+    `)
+  })
 })

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -205,7 +205,7 @@ const mangleExoticType = Utils.memoize(
       dataUids: string | null,
       paths: string | null,
     ) {
-      if (child == null) {
+      if (child == null || !shouldIncludeDataUID(child.type)) {
         return child
       }
       const existingChildUIDs = child.props?.[UTOPIA_UIDS_KEY]


### PR DESCRIPTION
Fixes #1698 

**Problem:**
We explicitly exclude our internal `data-*` props when working with intrinsic elements that aren't from a specific set of HTML elements, as we found that clashes with some logic in R3F (there is logic around providing a way to set a nested prop by using dashes), which was originally fixed [here](https://github.com/concrete-utopia/utopia/pull/346). However, there was an edge case that we were missing when dealing with fragments.

**Fix:**
Patch that edge case and add a test.
