### PR TITLE
Pass through refs in spy wrapped elements

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -22617,6 +22617,7 @@ Object {
     "props": Object {
       "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "aaa app-entity",
+      "ref": [Function],
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -23210,6 +23211,7 @@ Object {
     "props": Object {
       "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "aaa app-entity",
+      "ref": [Function],
       "skipDeepFreeze": true,
       "style": Object {
         "bottom": 0,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -88,15 +88,19 @@ interface SpyWrapperProps {
   jsxFactoryFunctionName: string | null
   $$utopiaElementPath: ElementPath
 }
-const SpyWrapper: React.FunctionComponent<SpyWrapperProps> = (props) => {
+const SpyWrapper = React.forwardRef<any, SpyWrapperProps>((props, ref) => {
   const {
     spyCallback,
     elementToRender: ElementToRender,
     inScope,
     jsxFactoryFunctionName,
     $$utopiaElementPath,
-    ...passThroughProps
+    ...passThroughPropsFromProps
   } = props
+  const passThroughProps = {
+    ...passThroughPropsFromProps,
+    ...(ref == undefined ? {} : { ref: ref }),
+  }
   spyCallback(passThroughProps)
   return renderComponentUsingJsxFactoryFunction(
     inScope,
@@ -104,5 +108,5 @@ const SpyWrapper: React.FunctionComponent<SpyWrapperProps> = (props) => {
     ElementToRender,
     passThroughProps,
   )
-}
+})
 SpyWrapper.displayName = 'SpyWrapper'


### PR DESCRIPTION
Fixes #1707 

**Problem:**
When spy wrapping an element, the `SpyWrapper` wasn't forwarding refs

**Fix:**
Use a `React.forwardRef` to capture and pass on the refs