### PR TITLE
project contents json import field

### DIFF
--- a/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
+++ b/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
@@ -113,16 +113,21 @@ export const SettingsPanel = betterReactMemo('SettingsPanel', () => {
 
   const loadProjectContentJson = React.useCallback(
     (value: string) => {
-      const persistentModel = json5.parse(value)
-      console.info('attempting to load new Project Contents JSON', persistentModel)
-      load(
-        dispatch,
-        persistentModel,
-        entireStateRef.current.editor.projectName,
-        entireStateRef.current.editor.id!,
-        entireStateRef.current.workers,
-        NO_OP,
+      const confirmed = window.confirm(
+        'If you press OK, the inserted code will override the current project. Are you sure?',
       )
+      if (confirmed) {
+        const persistentModel = json5.parse(value)
+        console.info('attempting to load new Project Contents JSON', persistentModel)
+        load(
+          dispatch,
+          persistentModel,
+          entireStateRef.current.editor.projectName,
+          entireStateRef.current.editor.id!,
+          entireStateRef.current.workers,
+          NO_OP,
+        )
+      }
     },
     [dispatch, entireStateRef],
   )

--- a/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
+++ b/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
@@ -17,8 +17,13 @@ import {
   FlexColumn,
   useColorTheme,
   Button,
+  StringInput,
+  HeadlessStringInput,
 } from '../../../../uuiui'
 import { betterReactMemo } from '../../../../uuiui-deps'
+import { load } from '../../../editor/actions/actions'
+import json5 from 'json5'
+import { NO_OP } from '../../../../core/shared/utils'
 
 const StyledFlexRow = styled(FlexRow)({
   height: UtopiaTheme.layout.rowHeight.normal,
@@ -103,6 +108,22 @@ export const SettingsPanel = betterReactMemo('SettingsPanel', () => {
     console.info('Latest metadata:', jsxMetadata.current)
   }, [jsxMetadata])
 
+  const loadProjectContentJson = React.useCallback(
+    (value: string) => {
+      const persistentModel = json5.parse(value)
+      console.info('attempting to load new Project Contents JSON', persistentModel)
+      load(
+        dispatch,
+        persistentModel,
+        entireStateRef.current.editor.projectName,
+        entireStateRef.current.editor.id!,
+        entireStateRef.current.workers,
+        NO_OP,
+      )
+    },
+    [dispatch, entireStateRef],
+  )
+
   return (
     <FlexColumn
       style={{
@@ -132,6 +153,10 @@ export const SettingsPanel = betterReactMemo('SettingsPanel', () => {
         <label htmlFor='toggleInterfaceDesignerAdditionalCanvasControls'>Additional controls</label>
       </StyledFlexRow>
       <br />
+      <HeadlessStringInput
+        placeholder='Project Contents JSON'
+        onSubmitValue={loadProjectContentJson}
+      />
       <FeatureSwitchesSection />
     </FlexColumn>
   )

--- a/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
+++ b/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
@@ -1,4 +1,6 @@
-import * as React from 'react'
+/** @jsx jsx */
+import React from 'react'
+import { jsx } from '@emotion/react'
 import * as EditorActions from '../../../editor/actions/action-creators'
 import styled from '@emotion/styled'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
@@ -20,10 +22,11 @@ import {
   StringInput,
   HeadlessStringInput,
 } from '../../../../uuiui'
-import { betterReactMemo } from '../../../../uuiui-deps'
+import { betterReactMemo, getControlStyles } from '../../../../uuiui-deps'
 import { load } from '../../../editor/actions/actions'
 import json5 from 'json5'
 import { NO_OP } from '../../../../core/shared/utils'
+import { InspectorInputEmotionStyle } from '../../../../uuiui/inputs/base-input'
 
 const StyledFlexRow = styled(FlexRow)({
   height: UtopiaTheme.layout.rowHeight.normal,
@@ -34,14 +37,14 @@ const StyledFlexRow = styled(FlexRow)({
 const FeatureSwitchesSection = betterReactMemo('Feature Switches', () => {
   if (AllFeatureNames.length > 0) {
     return (
-      <>
+      <React.Fragment>
         <StyledFlexRow style={{ marginTop: 8, marginBottom: 12, paddingLeft: 8 }}>
           <H2>Experimental Feature Toggles</H2>
         </StyledFlexRow>
         {AllFeatureNames.map((name) => (
           <FeatureSwitchRow key={`feature-switch-${name}`} name={name} />
         ))}
-      </>
+      </React.Fragment>
     )
   } else {
     return null
@@ -156,6 +159,10 @@ export const SettingsPanel = betterReactMemo('SettingsPanel', () => {
       <HeadlessStringInput
         placeholder='Project Contents JSON'
         onSubmitValue={loadProjectContentJson}
+        css={InspectorInputEmotionStyle({
+          hasLabel: false,
+          controlStyles: getControlStyles('simple'),
+        })}
       />
       <FeatureSwitchesSection />
     </FlexColumn>


### PR DESCRIPTION
**Problem:**
It's very hard for me to move a project between pizza to localhost to production. It's also hard to pass projects to each other.

**Fix:**
The dead simple solution for v1: just an input field where you can paste the project contents json. The JSON can be copied from
`https://utopia.app/v1/project/<id>/contents.json`

<img width="470" alt="image" src="https://user-images.githubusercontent.com/2226774/129562639-cb05ed44-680c-42bd-9089-009ed30a2ede.png">

It's an unstyled input field right above the Feature Toggles UI

you paste in the copied json, and press enter – voila

**Note:**
Does not support assets. 