### PR TITLE
Tweak the dependencies for react-three in the internal listings.

### DIFF
--- a/editor/src/components/navigator/top1000NPMPackagesOptions.ts
+++ b/editor/src/components/navigator/top1000NPMPackagesOptions.ts
@@ -22,6 +22,8 @@ const designRelevantPackages = [
   { value: '@emotion/css', label: '@emotion/css', contents: ['css'] },
   { value: 'styled-components', label: 'styled-components', contents: ['styled', 'css'] },
   { value: 'leva', label: 'leva', contents: ['useControls'] },
+  { value: '@react-three/fiber', label: '@react-three/fiber' },
+  { value: '@react-three/drei', label: '@react-three/drei' },
   {
     value: '@react-three/cannon',
     label: '@react-three/cannon',
@@ -1395,6 +1397,5 @@ export const top1000NPMPackagesOptions = [
 
   // these are added in for fun:
   { value: '@types/chroma-js', label: '@types/chroma-js' },
-  { value: 'react-three-fiber', label: 'react-three-fiber' },
   { value: 'react-spring', label: 'react-spring' },
 ]


### PR DESCRIPTION
**Problem:**
The main dependency for `react-three-fiber` is that which is the old dependency name.

**Fix:**
Use the new dependency name of `@react-three/fiber` and also include the `@react-three/drei` package.