### PR TITLE
Workaround to support top level JSX variables

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -2632,7 +2632,7 @@ import {
   Scene
 } from "utopia-api";
 import { cake } from 'cake'
-export var whatever = <View data-uid='aaa'>
+export var whatever = () => <View data-uid='aaa'>
 <cake data-uid='aab' style={{backgroundColor: 'red'}} />
 </View>
 `
@@ -2654,7 +2654,7 @@ export var whatever = <View data-uid='aaa'>
     )
     const exported = utopiaJSXComponent(
       'whatever',
-      false,
+      true,
       'var',
       'expression',
       null,
@@ -2772,7 +2772,7 @@ export var App = (props) => <View data-uid='bbb'>
     )
     const exported = utopiaJSXComponent(
       'whatever',
-      false,
+      true,
       'var',
       'parenthesized-expression',
       null,
@@ -2951,7 +2951,7 @@ return { getSizing: getSizing, spacing: spacing };`
     )
     const exported = utopiaJSXComponent(
       'whatever',
-      false,
+      true,
       'var',
       'parenthesized-expression',
       null,

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -129,6 +129,7 @@ import { replaceAll } from '../../shared/string-utils'
 import { WorkerCodeUpdate, WorkerParsedUpdate } from '../../../components/editor/action-types'
 import { fixParseSuccessUIDs } from './uid-fix'
 import { applyPrettier } from 'utopia-vscode-common'
+import { BakedInStoryboardVariableName } from '../../model/scene-utils'
 
 function buildPropertyCallingFunction(
   functionName: string,
@@ -939,7 +940,10 @@ export function looksLikeCanvasElements(
               varLetOrConst,
             ),
           )
-        } else {
+        } else if (name === BakedInStoryboardVariableName) {
+          // FIXME The below case should result in a parsed top level *element*, but instead it is treated
+          // as a *component*. Unfortunately our use of the storyboard incorrectly relies on it being treated
+          // as a component. See https://github.com/concrete-utopia/utopia/issues/1718 for more info
           return right(
             possibleCanvasContentsExpression(name, variableDeclaration.initializer, varLetOrConst),
           )


### PR DESCRIPTION
Fixes #1715 

**Problem:**
Top level JSX variables (e.g. `const a = <div/>`) are being incorrectly converted into components during execution in the Canvas

**Fix:**
The actual underlying issue is covered in more depth in #1718. As a work around here, I have put in a check to stop us parsing a top level JSX variable as a `UtopiaJSXComponent` unless it is the `storyboard`, since we rely on that being a `UtopiaJSXComponent`. Any other top level variables will be treated as an arbitrary JS block.
