### PR TITLE
Re-enable the use of ReactDOM.render in the Canvas

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -159,7 +159,7 @@ export function renderCanvasReturnResultAndError(
   const updatedContents = contentsToTree(projectContents)
 
   const curriedRequireFn = (innerProjectContents: ProjectContentTreeRoot) =>
-    getRequireFn(NO_OP, innerProjectContents, {}, {}, 'canvas')
+    getRequireFn(NO_OP, innerProjectContents, {}, {})
 
   storeHookForTest.updateStore((store) => {
     const updatedEditor = {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3660,7 +3660,7 @@ export const UPDATE_FNS = {
           return packageStatus
         }, {})
 
-        fetchNodeModules(deps, 'canvas').then((fetchNodeModulesResult) => {
+        fetchNodeModules(deps).then((fetchNodeModulesResult) => {
           const loadedPackagesStatus = createLoadedPackageStatusMapFromDependencies(
             deps,
             fetchNodeModulesResult.dependenciesWithError,
@@ -4779,7 +4779,7 @@ export const UPDATE_FNS = {
               requestedNpmDependency('tailwindcss', tailwindVersion.version),
               requestedNpmDependency('postcss', postcssVersion.version),
             ]
-            fetchNodeModules(updatedNpmDeps, 'canvas').then((fetchNodeModulesResult) => {
+            fetchNodeModules(updatedNpmDeps).then((fetchNodeModulesResult) => {
               const loadedPackagesStatus = createLoadedPackageStatusMapFromDependencies(
                 updatedNpmDeps,
                 fetchNodeModulesResult.dependenciesWithError,
@@ -5076,7 +5076,7 @@ export async function newProject(
 ): Promise<void> {
   const defaultPersistentModel = defaultProject()
   const npmDependencies = dependenciesWithEditorRequirements(defaultPersistentModel.projectContents)
-  const fetchNodeModulesResult = await fetchNodeModules(npmDependencies, 'canvas')
+  const fetchNodeModulesResult = await fetchNodeModules(npmDependencies)
 
   const nodeModules: NodeModules = fetchNodeModulesResult.nodeModules
   const packageResult: PackageStatusMap = createLoadedPackageStatusMapFromDependencies(
@@ -5139,11 +5139,7 @@ export async function load(
   // this action is now async!
   const migratedModel = applyMigrations(model)
   const npmDependencies = dependenciesWithEditorRequirements(migratedModel.projectContents)
-  const fetchNodeModulesResult = await fetchNodeModules(
-    npmDependencies,
-    'canvas',
-    retryFetchNodeModules,
-  )
+  const fetchNodeModulesResult = await fetchNodeModules(npmDependencies, retryFetchNodeModules)
 
   const nodeModules: NodeModules = fetchNodeModulesResult.nodeModules
   const packageResult: PackageStatusMap = createLoadedPackageStatusMapFromDependencies(

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -57,7 +57,6 @@ import {
   PackageStatus,
 } from '../../core/shared/npm-dependency-types'
 import { getThirdPartyComponents } from '../../core/third-party/third-party-components'
-import { isBuiltInDependency } from '../../core/es-modules/package-manager/built-in-dependencies'
 import { NpmDependencyVersionAndStatusIndicator } from '../navigator/dependecy-version-status-indicator'
 import { PropertyControlsInfo } from '../custom-code/code-file'
 import { emptyComments } from '../../core/workers/parser-printer/parser-printer-comments'

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -170,7 +170,7 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
 
       this.props.editorDispatch([EditorActions.updatePackageJson(npmDependencies)])
 
-      fetchNodeModules(npmDependencies, 'canvas').then((fetchNodeModulesResult) => {
+      fetchNodeModules(npmDependencies).then((fetchNodeModulesResult) => {
         if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
           this.packagesUpdateFailed(
             `Failed to download the following dependencies: ${JSON.stringify(
@@ -331,10 +331,7 @@ class DependencyListInner extends React.PureComponent<DependencyListProps, Depen
                 EditorActions.setPackageStatus(editedPackageName, loadingOrUpdating),
                 EditorActions.updatePackageJson(updatedNpmDeps),
               ])
-              fetchNodeModules(
-                [requestedNpmDependency(editedPackageName, editedPackageVersion!)],
-                'canvas',
-              )
+              fetchNodeModules([requestedNpmDependency(editedPackageName, editedPackageVersion!)])
                 .then((fetchNodeModulesResult) => {
                   if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
                     this.packagesUpdateFailed(

--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -41,26 +41,13 @@ function builtInDependency(
   }
 }
 
-// Prevent ReactDOM.render from running in the canvas/editor because it's
-// entirely likely to cause either havoc or just break.
-export const SafeReactDOM = (mode: 'preview' | 'canvas') => {
-  if (mode === 'canvas') {
-    return {
-      ...ReactDOM,
-      render: NO_OP,
-    }
-  } else {
-    return ReactDOM
-  }
-}
-
-export const BuiltInDependencies = (mode: 'preview' | 'canvas'): Array<BuiltInDependency> => [
+export const BuiltInDependencies: Array<BuiltInDependency> = [
   builtInDependency('utopia-api', UtopiaAPI, utopiaAPIPackageJSON.version),
   builtInDependency('uuiui', UUIUI, editorPackageJSON.version),
   builtInDependency('uuiui-deps', UUIUIDeps, editorPackageJSON.version),
   builtInDependency('react/jsx-runtime', ReactJsxRuntime, editorPackageJSON.dependencies.react),
   builtInDependency('react', React, editorPackageJSON.dependencies.react),
-  builtInDependency('react-dom', SafeReactDOM(mode), editorPackageJSON.dependencies['react-dom']),
+  builtInDependency('react-dom', ReactDOM, editorPackageJSON.dependencies['react-dom']),
   builtInDependency(
     '@emotion/react',
     EmotionReact,

--- a/editor/src/core/es-modules/package-manager/built-in-dependencies.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies.ts
@@ -1,26 +1,17 @@
 import { BuiltInDependencies, BuiltInDependency } from './built-in-dependencies-list'
 
-function findBuiltInForName(
-  moduleName: string,
-  mode: 'preview' | 'canvas',
-): BuiltInDependency | undefined {
-  return BuiltInDependencies(mode).find((builtIn) => builtIn.moduleName === moduleName)
+function findBuiltInForName(moduleName: string): BuiltInDependency | undefined {
+  return BuiltInDependencies.find((builtIn) => builtIn.moduleName === moduleName)
 }
 
-export function isBuiltInDependency(moduleName: string, mode: 'preview' | 'canvas'): boolean {
-  return findBuiltInForName(moduleName, mode) != null
+export function isBuiltInDependency(moduleName: string): boolean {
+  return findBuiltInForName(moduleName) != null
 }
 
-export function resolveBuiltInDependency(
-  moduleName: string,
-  mode: 'preview' | 'canvas',
-): any | undefined {
-  return findBuiltInForName(moduleName, mode)?.nodeModule
+export function resolveBuiltInDependency(moduleName: string): any | undefined {
+  return findBuiltInForName(moduleName)?.nodeModule
 }
 
-export function versionForBuiltInDependency(
-  moduleName: string,
-  mode: 'preview' | 'canvas',
-): string | undefined {
-  return findBuiltInForName(moduleName, mode)?.version
+export function versionForBuiltInDependency(moduleName: string): string | undefined {
+  return findBuiltInForName(moduleName)?.version
 }

--- a/editor/src/core/es-modules/package-manager/fetch-packages.ts
+++ b/editor/src/core/es-modules/package-manager/fetch-packages.ts
@@ -274,10 +274,9 @@ function failError(dependency: RequestedNpmDependency): DependencyFetchError {
 
 export async function fetchNodeModules(
   newDeps: Array<RequestedNpmDependency>,
-  mode: 'canvas' | 'preview',
   shouldRetry: boolean = true,
 ): Promise<NodeFetchResult> {
-  const dependenciesToDownload = newDeps.filter((d) => !isBuiltInDependency(d.name, mode))
+  const dependenciesToDownload = newDeps.filter((d) => !isBuiltInDependency(d.name))
   const nodeModulesArr = await Promise.all(
     dependenciesToDownload.map(
       async (newDep): Promise<Either<DependencyFetchError, NodeModules>> => {

--- a/editor/src/core/es-modules/package-manager/package-manager.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.ts
@@ -44,7 +44,7 @@ export const getCurriedEditorRequireFn = (
     )
   }
   return (projectContents: ProjectContentTreeRoot) =>
-    getRequireFn(onRemoteModuleDownload, projectContents, nodeModules, evaluationCache, 'canvas')
+    getRequireFn(onRemoteModuleDownload, projectContents, nodeModules, evaluationCache)
 }
 
 export function getRequireFn(
@@ -52,11 +52,10 @@ export function getRequireFn(
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
   evaluationCache: EvaluationCache,
-  mode: 'canvas' | 'preview',
   injectedEvaluator = evaluator,
 ): RequireFn {
   return function require(importOrigin, toImport): unknown {
-    const builtInDependency = resolveBuiltInDependency(toImport, mode)
+    const builtInDependency = resolveBuiltInDependency(toImport)
     if (builtInDependency != null) {
       return builtInDependency
     }

--- a/editor/src/core/property-controls/property-controls-processor.ts
+++ b/editor/src/core/property-controls/property-controls-processor.ts
@@ -71,7 +71,6 @@ export const initPropertyControlsProcessor = (
       projectContents,
       currentNodeModules,
       evaluationCache,
-      'canvas',
     )
 
     const exportValues = getExportValuesFromAllModules(bundledProjectFiles, requireFn)

--- a/editor/src/core/shared/utils.ts
+++ b/editor/src/core/shared/utils.ts
@@ -4,7 +4,7 @@ const urljoin = require('url-join')
 import { appendHash } from './dom-utils'
 
 // This file shouldn't import anything as it is for exporting simple shared utility functions between various projects
-export const EditorID = 'editor'
+export const EditorID = 'utopia-editor-root'
 export const PortalTargetID = 'portal-target'
 export const CanvasContextMenuPortalTargetID = 'canvas-contextmenu-portal-target'
 

--- a/editor/src/core/third-party/third-party-components.ts
+++ b/editor/src/core/third-party/third-party-components.ts
@@ -62,7 +62,7 @@ export function resolvedDependencyVersions(
 ): Array<PossiblyUnversionedNpmDependency> {
   let result: Array<PossiblyUnversionedNpmDependency> = []
   fastForEach(dependencies, (dependency) => {
-    const builtInVersion = versionForBuiltInDependency(dependency.name, 'canvas')
+    const builtInVersion = versionForBuiltInDependency(dependency.name)
     const version = builtInVersion ?? parseDependencyVersionFromNodeModules(files, dependency.name)
     if (version == null) {
       result.push(unversionedNpmDependency(dependency.name))

--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -63,7 +63,7 @@
       style="position: absolute; left: 0px; top: 0px; right: 0px; bottom: 0px;"
     >
       <div
-        id="editor"
+        id="utopia-editor-root"
         class="body"
         style="
           display: flex;

--- a/editor/src/templates/preview.tsx
+++ b/editor/src/templates/preview.tsx
@@ -202,7 +202,7 @@ const initPreview = () => {
       if (fastDeepEquals(lastDependencies, npmDependencies)) {
         nodeModules = { ...cachedDependencies }
       } else {
-        const fetchNodeModulesResult = await fetchNodeModules(npmDependencies, 'preview', true)
+        const fetchNodeModulesResult = await fetchNodeModules(npmDependencies, true)
 
         if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
           const errorToThrow = Error(
@@ -239,13 +239,7 @@ const initPreview = () => {
 
     incorporateBuildResult(nodeModules, projectContents, bundledProjectFiles)
 
-    const requireFn = getRequireFn(
-      onRemoteModuleDownload,
-      projectContents,
-      nodeModules,
-      {},
-      'preview',
-    )
+    const requireFn = getRequireFn(onRemoteModuleDownload, projectContents, nodeModules, {})
 
     // replacing the document body first
     const previewHTMLFileName = getMainHTMLFilename(projectContents)


### PR DESCRIPTION
Fixes #1722 

**Problem:**
We replace `ReactDOM.render` in the canvas with a no-op. The reason for this was so that nobody would unintentionally break the editor by replacing the root element, but by doing this it means legitimate use of `ReactDOM.render` is not possible.

**Fix:**
Remove the restriction, and make the root element's ID more explicitly to guard against it being accidentally replaced.

**Commit Details:**
- Updated the root element's ID from `'editor'` to `'utopia-editor-root'` in `utils.ts`
- Removed the `SafeReactDOM` function from `built-in-dependencies-list.ts`
- Removed all threading through of the mode (preview or canvas) that was previously required to support the above
