### PR TITLE
Handle user components called Scene.

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -132,7 +132,6 @@ import {
   transientFileState,
   getStoryboardElementPathFromEditorState,
   addSceneToJSXComponents,
-  getNumberOfScenes,
   StoryboardFilePath,
   modifyUnderlyingTarget,
   modifyParseSuccessAtPath,
@@ -2700,6 +2699,7 @@ export function getValidElementPaths(
     transientFilesState,
   )
   const importSource = importedFromWhere(filePath, topLevelElementName, topLevelElements, imports)
+    ?.filePath
   if (importSource != null) {
     const resolvedImportSource = resolve(filePath, importSource)
     if (isRight(resolvedImportSource)) {

--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -228,7 +228,7 @@ export default function App(props) {
         <div
           id=\\"canvas-container\\"
           style=\\"position: absolute;\\"
-          data-utopia-valid-paths=\\"storyboard-entity storyboard-entity/scene-1-entity storyboard-entity/scene-1-entity/app-entity storyboard-entity/scene-2-entity storyboard-entity/scene-2-entity/same-file-app-entity\\"
+          data-utopia-valid-paths=\\"storyboard-entity storyboard-entity/scene-1-entity storyboard-entity/scene-1-entity/app-entity storyboard-entity/scene-2-entity storyboard-entity/scene-2-entity/same-file-app-entity storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div\\"
           data-utopia-root-element-path=\\"storyboard-entity\\"
         >
           <div

--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -157,4 +157,132 @@ export default function App(props) {
       "
     `)
   })
+
+  it('#1717 - Works with user components called Scene', () => {
+    const result = testCanvasRenderInlineMultifile(
+      null,
+      `
+import * as React from 'react'
+import { Scene as SC, Storyboard } from 'utopia-api'
+import App from './app'
+
+export var Scene = (props) => {
+  return (
+    <div
+      data-uid='same-file-app-div'
+      data-label='Scene Thing'
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'blue',
+      }}
+    />
+  )
+}
+
+export var storyboard = (
+  <Storyboard data-uid='storyboard-entity'>
+    <SC
+      data-label='Imported App'
+      data-uid='scene-1-entity'
+      style={{
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 375,
+        height: 812,
+      }}
+    >
+      <App data-uid='app-entity' />
+    </SC>
+    <SC
+      data-label='Same File App'
+      data-uid='scene-2-entity'
+      style={{
+        position: 'absolute',
+        left: 400,
+        top: 0,
+        width: 375,
+        height: 812,
+      }}
+    >
+      <Scene data-uid='same-file-app-entity' />
+    </SC>
+  </Storyboard>
+)
+`,
+      {
+        'app.js': `
+import * as React from 'react'
+export default function App(props) {
+  return <div data-uid='app-outer-div'>
+    <div data-uid='inner-div'>hello</div>
+  </div>
+}`,
+      },
+    )
+
+    expect(result).toMatchInlineSnapshot(`
+      "<div style=\\"all: initial;\\">
+        <div
+          id=\\"canvas-container\\"
+          style=\\"position: absolute;\\"
+          data-utopia-valid-paths=\\"storyboard-entity storyboard-entity/scene-1-entity storyboard-entity/scene-1-entity/app-entity storyboard-entity/scene-2-entity storyboard-entity/scene-2-entity/same-file-app-entity\\"
+          data-utopia-root-element-path=\\"storyboard-entity\\"
+        >
+          <div
+            data-utopia-scene-id=\\"storyboard-entity/scene-1-entity\\"
+            data-paths=\\"storyboard-entity/scene-1-entity storyboard-entity\\"
+            style=\\"
+              position: absolute;
+              background-color: rgba(255, 255, 255, 1);
+              box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              left: 0;
+              top: 0;
+              width: 375px;
+              height: 812px;
+            \\"
+            data-uid=\\"scene-1-entity storyboard-entity\\"
+            data-label=\\"Imported App\\"
+          >
+            <div
+              data-uid=\\"app-outer-div app-entity\\"
+              data-paths=\\"storyboard-entity/scene-1-entity/app-entity\\"
+            >
+              <div data-uid=\\"inner-div\\">hello</div>
+            </div>
+          </div>
+          <div
+            data-utopia-scene-id=\\"storyboard-entity/scene-2-entity\\"
+            data-paths=\\"storyboard-entity/scene-2-entity storyboard-entity\\"
+            style=\\"
+              position: absolute;
+              background-color: rgba(255, 255, 255, 1);
+              box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              left: 400px;
+              top: 0;
+              width: 375px;
+              height: 812px;
+            \\"
+            data-uid=\\"scene-2-entity storyboard-entity\\"
+            data-label=\\"Same File App\\"
+          >
+            <div
+              data-uid=\\"same-file-app-div same-file-app-entity\\"
+              data-label=\\"Scene Thing\\"
+              style=\\"
+                position: relative;
+                width: 100%;
+                height: 100%;
+                background-color: blue;
+              \\"
+              data-paths=\\"storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div storyboard-entity/scene-2-entity/same-file-app-entity\\"
+            ></div>
+          </div>
+        </div>
+      </div>
+      "
+    `)
+  })
 })

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -192,7 +192,6 @@ export function createComponentRendererComponent(params: {
           realPassedProps['data-uid'],
           undefined,
           metadataContext,
-
           updateInvalidatedPaths,
           mutableContext.jsxFactoryFunctionName,
           codeError,

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -498,7 +498,11 @@ function lookupElementImport(
   if (importedFrom == null) {
     return normalisePathImportNotFound(elementBaseVariable)
   } else {
-    if (importedFrom === 'utopia-api' && elementBaseVariable === 'Scene') {
+    if (
+      importedFrom.type === 'IMPORTED_ORIGIN' &&
+      importedFrom.filePath === 'utopia-api' &&
+      importedFrom.exportedName === 'Scene'
+    ) {
       // Navigate around the scene with the special case handling.
       const componentAttr = getJSXAttribute(nonNullTargetElement.props, 'component')
       if (componentAttr != null && isJSXAttributeOtherJavaScript(componentAttr)) {
@@ -525,7 +529,7 @@ function lookupElementImport(
         projectContents,
         nodeModules,
         currentFilePath,
-        importedFrom,
+        importedFrom.filePath,
       )
       switch (resolutionResult.type) {
         case 'RESOLVE_SUCCESS':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -437,7 +437,6 @@ import {
   UIFileBase64Blobs,
   updateMainUIInEditorState,
   addNewScene,
-  getNumberOfScenes,
   addSceneToJSXComponents,
   UserState,
   UserConfiguration,
@@ -461,6 +460,7 @@ import {
   persistentModelFromEditorModel,
   getPackageJsonFromEditorState,
   transformElementAtPath,
+  getNewSceneName,
 } from '../store/editor-state'
 import { loadStoredState } from '../stored-state'
 import { applyMigrations } from './migrations/migrations'
@@ -1996,9 +1996,8 @@ export const UPDATE_FNS = {
     )
   },
   INSERT_SCENE: (action: InsertScene, editor: EditorModel): EditorModel => {
-    const numberOfScenes = getNumberOfScenes(editor)
     const sceneUID = generateUidWithExistingComponents(editor.projectContents)
-    const newSceneLabel = `Scene ${numberOfScenes}`
+    const newSceneLabel = getNewSceneName(editor)
     const newScene: JSXElement = defaultSceneElement(
       sceneUID,
       canvasFrameToNormalisedFrame(action.frame),

--- a/editor/src/components/editor/import-utils.ts
+++ b/editor/src/components/editor/import-utils.ts
@@ -2,22 +2,50 @@ import { TopLevelElement } from '../../core/shared/element-template'
 import { Imports, isParseSuccess, isTextFile } from '../../core/shared/project-file-types'
 import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../assets'
 
+interface SameFileOrigin {
+  type: 'SAME_FILE_ORIGIN'
+  filePath: string
+}
+
+function sameFileOrigin(filePath: string): SameFileOrigin {
+  return {
+    type: 'SAME_FILE_ORIGIN',
+    filePath: filePath,
+  }
+}
+
+interface ImportedOrigin {
+  type: 'IMPORTED_ORIGIN'
+  filePath: string
+  exportedName: string | null
+}
+
+function importedOrigin(filePath: string, exportedName: string | null): ImportedOrigin {
+  return {
+    type: 'IMPORTED_ORIGIN',
+    filePath: filePath,
+    exportedName: exportedName,
+  }
+}
+
+type ImportedFromWhereResult = SameFileOrigin | ImportedOrigin
+
 export function importedFromWhere(
   originFilePath: string,
   variableName: string,
   topLevelElements: Array<TopLevelElement>,
   importsToSearch: Imports,
-): string | null {
+): ImportedFromWhereResult | null {
   for (const topLevelElement of topLevelElements) {
     switch (topLevelElement.type) {
       case 'UTOPIA_JSX_COMPONENT':
         if (topLevelElement.name === variableName) {
-          return originFilePath
+          return sameFileOrigin(originFilePath)
         }
         break
       case 'ARBITRARY_JS_BLOCK':
         if (topLevelElement.definedWithin.includes(variableName)) {
-          return originFilePath
+          return sameFileOrigin(originFilePath)
         }
         break
       case 'UNPARSED_CODE':
@@ -32,13 +60,15 @@ export function importedFromWhere(
   for (const importSource of Object.keys(importsToSearch)) {
     const specificImport = importsToSearch[importSource]
     if (specificImport.importedAs === variableName) {
-      return importSource
+      return importedOrigin(importSource, null)
     }
     if (specificImport.importedWithName === variableName) {
-      return importSource
+      return importedOrigin(importSource, null)
     }
-    if (specificImport.importedFromWithin.some((within) => within.alias === variableName)) {
-      return importSource
+    for (const fromWithin of specificImport.importedFromWithin) {
+      if (fromWithin.alias === variableName) {
+        return importedOrigin(importSource, fromWithin.name)
+      }
     }
   }
   return null

--- a/editor/src/components/inspector/common/name-and-icon-hook.ts
+++ b/editor/src/components/inspector/common/name-and-icon-hook.ts
@@ -23,13 +23,6 @@ export function useMetadata(): ElementInstanceMetadataMap {
   return useEditorState((store) => store.editor.jsxMetadata, 'useMetadata')
 }
 
-const nameAndIconResultSelector = (path: ElementPath) => {
-  return createSelector(
-    (store: EditorStore) => store.editor.jsxMetadata,
-    (metadata) => getNameAndIconResult(path, metadata),
-  )
-}
-
 const namesAndIconsAllPathsResultSelector = createSelector(
   (store: EditorStore) => store.editor.jsxMetadata,
   (metadata) => {
@@ -38,13 +31,6 @@ const namesAndIconsAllPathsResultSelector = createSelector(
     })
   },
 )
-
-export function useNameAndIcon(path: ElementPath): NameAndIconResult {
-  const selector = React.useMemo(() => nameAndIconResultSelector(path), [path])
-  return useEditorState(selector, 'useNameAndIcon', (oldResult, newResult) => {
-    return NameAndIconResultKeepDeepEquality(oldResult, newResult).areEqual
-  })
-}
 
 export function useNamesAndIconsAllPaths(): NameAndIconResult[] {
   const selector = React.useMemo(() => namesAndIconsAllPathsResultSelector, [])

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -75,7 +75,6 @@ export function createLayoutOrElementIconResult(
   } else if (layoutIcon != null) {
     return {
       iconProps: layoutIcon,
-
       isPositionAbsolute: isPositionAbsolute,
     }
   } else {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -86,7 +86,7 @@ import {
 } from '../shared/project-file-types'
 import * as PP from '../shared/property-path'
 import * as EP from '../shared/element-path'
-import { findJSXElementChildAtPath, getUtopiaID } from './element-template-utils'
+import { findJSXElementChildAtPath, getUtopiaID, isSceneElement } from './element-template-utils'
 import {
   isImportedComponent,
   isAnimatedElement,
@@ -99,7 +99,7 @@ import {
   isGivenUtopiaElementFromMetadata,
   isImportedComponentNPM,
 } from './project-file-utils'
-import { isSceneElementIgnoringImports, ResizesContentProp } from './scene-utils'
+import { ResizesContentProp } from './scene-utils'
 import { fastForEach } from '../shared/utils'
 import { omit } from '../shared/object-utils'
 import { UTOPIA_LABEL_KEY } from './utopia-constants'
@@ -193,9 +193,12 @@ export const MetadataUtils = {
     const elementMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
     return (
       elementMetadata != null &&
-      isRight(elementMetadata.element) &&
-      isJSXElement(elementMetadata.element.value) &&
-      isSceneElementIgnoringImports(elementMetadata.element.value)
+      elementMetadata.importInfo != null &&
+      foldEither(
+        (_) => false,
+        (info) => info.path === 'utopia-api' && info.originalName === 'Scene',
+        elementMetadata.importInfo,
+      )
     )
   },
   findElements(

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -111,10 +111,12 @@ function isGivenUtopiaAPIElementFromName(
     return false
   } else {
     if (PP.depth(jsxElementName.propertyPath) === 0) {
-      return (
-        pluck(utopiaAPI.importedFromWithin, 'name').includes(jsxElementName.baseVariable) &&
-        jsxElementName.baseVariable === componentName
-      )
+      for (const fromWithin of utopiaAPI.importedFromWithin) {
+        if (fromWithin.alias === jsxElementName.baseVariable && fromWithin.name === componentName) {
+          return true
+        }
+      }
+      return false
     } else {
       return (
         utopiaAPI.importedAs === jsxElementName.baseVariable &&

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -22,6 +22,7 @@ import {
   ElementInstanceMetadataMap,
   jsxAttributesFromMap,
   ElementInstanceMetadata,
+  walkElements,
 } from '../shared/element-template'
 import * as EP from '../shared/element-path'
 import * as PP from '../shared/property-path'
@@ -272,11 +273,6 @@ export function sceneMetadata(
   }
 
   return scene
-}
-
-export function isSceneElementIgnoringImports(element: JSXElement): boolean {
-  // TODO SCENES, how to decide if something is a scene?
-  return element.name.baseVariable === 'Scene'
 }
 
 export function getStoryboardUID(openComponents: UtopiaJSXComponent[]): string | null {

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -448,7 +448,7 @@ export function getPropertyControlsForTarget(
           filenameForLookup = openFilePath.replace(/\.(js|jsx|ts|tsx)$/, '')
         }
       } else {
-        filenameForLookup = importedFrom
+        filenameForLookup = importedFrom.filePath
       }
 
       if (filenameForLookup == null) {


### PR DESCRIPTION
Fixes #1717

**Problem:**
If a user creates a component called `Scene` our canvas logic replaces it with our internal scene component which results in the canvas throwing an exception.

**Fix:**
Replaced the logic in a few places which relied on (in a lot of cases) just checking if the element name was `Scene`. For the canvas this means checking the import information related to an element and double checking the value imported and in scope.

**Commit Details:**
- Fixes #1717.
- Modified `importedFromWhere` to include the exported name of the
  value being imported if there is one.
- `renderJSXElement` uses the new information provided by `importedFromWhere`
  to identify the `Scene` component from `utopia-api`.
- `lookupElementImport` now also uses the new information from `importedFromWhere`.
- `INSERT_SCENE` action now uses `getNewSceneName` instead of the
  retired `getNumberOfScenes` function to get the new name.
- Deleted `getNumberOfScenes`, `getSceneElements` and
  `getSceneElementsFromParseSuccess`.
- Removed a couple of unused bits of selector code from `name-and-icon-hook.ts`.
- `isProbablySceneFromMetadata` now relies on the `importInfo` field
  to identify if it is a `Scene`.