### PR TITLE
fix tailwind

### DIFF
--- a/editor/src/core/tailwind/tailwind.ts
+++ b/editor/src/core/tailwind/tailwind.ts
@@ -35,8 +35,7 @@ function postCSSIncludesTailwindPlugin(postCSSFile: ProjectFile, requireFn: Requ
   if (isTextFile(postCSSFile)) {
     try {
       const requireResult = requireFn('/', PostCSSPath)
-      const defaultImport = importDefault(requireResult)
-      const plugins = (defaultImport as any)?.plugins
+      const plugins = (requireResult as any)?.plugins
       return plugins?.tailwindcss != null
     } catch (e) {
       /* Do nothing */


### PR DESCRIPTION
**Problem:**
#1706 changed how we load files, and it unearthed a bug in the code that detects tailwind.

The bug: the function `postCSSIncludesTailwindPlugin` would try to get the _default export_ of `postcss.config.js` whereas the file has a regular export. This used to be not a problem but then we started treating regular js files as ES modules, changing how the default import works. (in #1706) 

**Fix:**
Use the regular import instead of the default import.

**Note:**
We should have some basic end-to-end tests for the tailwind integration, because this regression happened 4 days ago and we didn't catch it