### PR TITLE
file loader is the default fallback loader

### DIFF
--- a/editor/src/core/webpack-loaders/file-loader.ts
+++ b/editor/src/core/webpack-loaders/file-loader.ts
@@ -1,9 +1,7 @@
 import { LoadModule, loadModuleResult, MatchFile, ModuleLoader } from './loader-types'
 
 const matchFile: MatchFile = (filename: string) => {
-  return ['.avif', '.bmp', '.gif', '.jpg', '.jpeg', '.png'].some((extension) =>
-    filename.endsWith(extension),
-  )
+  return true
 }
 
 const loadModule: LoadModule = (filename: string, contents: string) => {

--- a/editor/src/core/webpack-loaders/loaders.spec.ts
+++ b/editor/src/core/webpack-loaders/loaders.spec.ts
@@ -46,6 +46,10 @@ describe('Applying loaders', () => {
     '{}',
   )
   verifyCorrectLoaderUsed(JSONLoader, ['.json'], '{}')
-  verifyCorrectLoaderUsed(FileLoader, ['.avif', '.bmp', '.gif', '.jpg', '.jpeg', '.png'], '')
+  verifyCorrectLoaderUsed(
+    FileLoader,
+    ['.avif', '.bmp', '.gif', '.jpg', '.jpeg', '.png', '.glb', '.data', '.cica'],
+    '',
+  )
   verifyCorrectLoaderUsed(SVGLoader, ['.svg'], '<svg/>')
 })

--- a/editor/src/core/webpack-loaders/loaders.ts
+++ b/editor/src/core/webpack-loaders/loaders.ts
@@ -7,10 +7,10 @@ import { loadModuleResult, LoadModuleResult, ModuleLoader } from './loader-types
 
 const moduleLoaders: Array<ModuleLoader> = [
   SVGLoader,
-  FileLoader,
   CSSLoader,
   JSONLoader,
   DefaultLoader,
+  FileLoader,
 ]
 
 export function filenameWithoutJSSuffix(filename: string): string | undefined {
@@ -19,27 +19,19 @@ export function filenameWithoutJSSuffix(filename: string): string | undefined {
   return filename.endsWith('.js') ? filename.slice(0, -3) : undefined
 }
 
-function loadersForFile(filename: string): Array<ModuleLoader> {
-  return moduleLoaders.filter((loader) => loader.match(filename))
-}
-
-function applyMatchedLoaders(
-  filename: string,
-  contents: string,
-  matchedLoaders: Array<ModuleLoader>,
-): LoadModuleResult {
-  return matchedLoaders.reduce(
-    (loadedModuleResult, nextLoader) =>
-      nextLoader.load(loadedModuleResult.filename, loadedModuleResult.loadedContents),
-    loadModuleResult(filename, contents),
-  )
+function loaderForFile(filename: string): ModuleLoader | undefined {
+  return moduleLoaders.find((loader) => loader.match(filename))
 }
 
 export function loaderExistsForFile(filename: string): boolean {
-  return loadersForFile(filename).length > 0
+  return loaderForFile(filename) != null
 }
 
 export function applyLoaders(filename: string, contents: string): LoadModuleResult {
-  const matchingLoaders = loadersForFile(filename)
-  return applyMatchedLoaders(filename, contents, matchingLoaders)
+  const matchedLoader = loaderForFile(filename)
+  if (matchedLoader != null) {
+    return matchedLoader.load(filename, contents)
+  } else {
+    return loadModuleResult(filename, contents)
+  }
 }


### PR DESCRIPTION
Fixes #1724

**Problem:**
In a create-react-app app, you can "import" any asset file, and the import will return an url string.

```javascript
import cica from './assets/cica.jpg'
console.log(cica) // will log '/assets/cica.jpg' or something similar
```

We have this support, but only for a limited set of file extensions.

**Fix:**
Instead of file extensions, let's make the `FileLoader` the default fallback for any file extension we did not match with other loaders.

**Commit Details:**
- Only run the first matching loader for a given file instead of reducing on the matched loaders.
- Move FileLoader to the last position
- Return `true` for any file extension in FileLoader
