### PR TITLE
Ensure the monkey patch is applied to React before creating the built in dependencies list

### DIFF
--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -9,7 +9,9 @@ import * as EmotionStyled from '@emotion/styled'
 
 import * as editorPackageJSON from '../../../../package.json'
 import * as utopiaAPIPackageJSON from '../../../../../utopia-api/package.json'
-import { NO_OP } from '../../shared/utils'
+import { applyUIDMonkeyPatch } from '../../../utils/canvas-react-utils'
+
+applyUIDMonkeyPatch()
 
 export interface BuiltInDependency {
   moduleName: string
@@ -30,6 +32,8 @@ function builtInDependency(
     }
   } else {
     // if the module does not have a default, spread one in there to simulate Synthetic Defaults
+    // IMPORTANT this object spread means that the default points to the real base module, which previously
+    // caused issues with the monkey patching of react, hence the explicit patching above
     return {
       moduleName: moduleName,
       nodeModule: {

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -28,6 +28,7 @@ export function applyUIDMonkeyPatch(): void {
   if (!uidMonkeyPatchApplied) {
     uidMonkeyPatchApplied = true
     ;(React as any).createElement = patchedCreateReactElement
+    ;(React as any).monkeyPatched = true
   }
 }
 


### PR DESCRIPTION
Fixes #1735 

**Problem:**
Because of an object spread inside the `builtInDependency` factory function, the built in version of react that we provide to imported modules when running on the Canvas wasn't using the patched createElement function.

**Fix:**
Ensure that the monkey patch is applied before creating the built in dependencies array.
