### PR TITLE
Handle class exports.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1820,4 +1820,146 @@ describe('UiJsxCanvas render multifile projects', () => {
       "
     `)
   })
+
+  it('renders a canvas with App a class imported as the default import', () => {
+    const printedDom = testCanvasRenderInlineMultifile(
+      null,
+      `import * as React from 'react'
+      import { Storyboard, Scene } from 'utopia-api'
+      import App from 'app.js'
+
+      export var ${BakedInStoryboardVariableName} = (props) => {
+        return (
+          <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+            <Scene
+              style={{ position: 'absolute', height: 200, left: 59, width: 200, top: 79 }}
+              data-uid={'${TestSceneUID}'}
+            >
+              <App
+                data-uid='${TestAppUID}'
+                style={{ position: 'absolute', height: '100%', width: '100%' }}
+                title={'Hi there!'}
+              />
+            </Scene>
+          </Storyboard>
+        )
+      }
+      `,
+      {
+        'app.js': `
+      import * as React from 'react'
+      export default class App extends React.Component {
+        render() {
+          return <div data-uid='app-outer-div'>
+            <div data-uid='inner-div'>{this.props.title}</div>
+          </div>
+        }
+      }`,
+      },
+    )
+    expect(printedDom).toMatchInlineSnapshot(`
+      "<div style=\\"all: initial;\\">
+        <div
+          id=\\"canvas-container\\"
+          style=\\"position: absolute;\\"
+          data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+          data-utopia-root-element-path=\\"utopia-storyboard-uid\\"
+        >
+          <div
+            data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
+            data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+            style=\\"
+              position: absolute;
+              background-color: rgba(255, 255, 255, 1);
+              box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              height: 200px;
+              left: 59px;
+              width: 200px;
+              top: 79px;
+            \\"
+            data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+          >
+            <div
+              data-uid=\\"app-outer-div app-entity\\"
+              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity\\"
+            >
+              <div data-uid=\\"inner-div\\">Hi there!</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      "
+    `)
+  })
+
+  it('renders a canvas with App a class imported by name', () => {
+    const printedDom = testCanvasRenderInlineMultifile(
+      null,
+      `import * as React from 'react'
+      import { Storyboard, Scene } from 'utopia-api'
+      import { App } from 'app.js'
+
+      export var ${BakedInStoryboardVariableName} = (props) => {
+        return (
+          <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+            <Scene
+              style={{ position: 'absolute', height: 200, left: 59, width: 200, top: 79 }}
+              data-uid={'${TestSceneUID}'}
+            >
+              <App
+                data-uid='${TestAppUID}'
+                style={{ position: 'absolute', height: '100%', width: '100%' }}
+                title={'Hi there!'}
+              />
+            </Scene>
+          </Storyboard>
+        )
+      }
+      `,
+      {
+        'app.js': `
+      import * as React from 'react'
+      export class App extends React.Component {
+        render() {
+          return <div data-uid='app-outer-div'>
+            <div data-uid='inner-div'>{this.props.title}</div>
+          </div>
+        }
+      }`,
+      },
+    )
+    expect(printedDom).toMatchInlineSnapshot(`
+      "<div style=\\"all: initial;\\">
+        <div
+          id=\\"canvas-container\\"
+          style=\\"position: absolute;\\"
+          data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+          data-utopia-root-element-path=\\"utopia-storyboard-uid\\"
+        >
+          <div
+            data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
+            data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+            style=\\"
+              position: absolute;
+              background-color: rgba(255, 255, 255, 1);
+              box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              height: 200px;
+              left: 59px;
+              width: 200px;
+              top: 79px;
+            \\"
+            data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+          >
+            <div
+              data-uid=\\"app-outer-div app-entity\\"
+              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity\\"
+            >
+              <div data-uid=\\"inner-div\\">Hi there!</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      "
+    `)
+  })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -72,6 +72,47 @@ import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from './parser-printer-utils'
 import { emptySet } from '../../shared/set-utils'
 
 describe('JSX parser', () => {
+  it(`parses 'export class' marked components`, () => {
+    const code = `import * as React from "react";
+export class App {}
+`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": null,
+          "namedExports": Object {
+            "App": Object {
+              "moduleName": undefined,
+              "name": "App",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+          },
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+  it(`parses 'export default class' marked components`, () => {
+    const code = `import * as React from "react";
+export default class App {}
+`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": Object {
+            "name": "App",
+            "type": "EXPORT_DEFAULT_MODIFIER",
+          },
+          "namedExports": Object {},
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
   it('parses the code when it is a var', () => {
     const code = `import * as React from "react";
 import {


### PR DESCRIPTION
Fixes #1713

**Problem:**
If a class component is exported like `export class App` or `export default class App` it doesn't get exposed appropriately so that the canvas will supply the values when imported.

**Fix:**
Include class declarations in the pass which collates the exports, as they're flagged against class declarations with a modifier rather than export declarations.

**Commit Details:**
- Fixes #1713.
- `parseCode` now handles class declarations in the export details
  by checking if the declaration has the export keyword attached to it.
