### PR TITLE
Fixed parsing of certain variable declarations in components

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -828,6 +828,8 @@ function parseOtherJavaScript<E extends TS.Node, T>(
               )
             } else if (TS.isTypeOfExpression(node)) {
               addIfDefinedElsewhere(scope, node.expression, false)
+            } else if (TS.isVariableDeclaration(node) && node.initializer != null) {
+              addIfDefinedElsewhere(scope, node.initializer, false)
             } else if (TS.isVoidExpression(node)) {
               addIfDefinedElsewhere(scope, node.expression, false)
             } else if (TS.isYieldExpression(node)) {


### PR DESCRIPTION
Fixes #1740 
Fixes #1741 

**Problem:**
There was an edge case where the parser wasn't adding to the `definedElsewhere` array used when parsing assignments of the form `var a = b`, resulting in potentially missing values in the scope.

**Fix:**
Add handling for that case, as well as a couple of tests for it.