### PR TITLE
Fixed importing of tailwind config

### DIFF
--- a/editor/src/core/tailwind/tailwind.ts
+++ b/editor/src/core/tailwind/tailwind.ts
@@ -94,8 +94,7 @@ function getTailwindConfig(
 ): Either<any, Configuration> {
   if (tailwindFile != null && isTextFile(tailwindFile)) {
     try {
-      const requireResult = requireFn('/', TailwindConfigPath)
-      const rawConfig = importDefault(requireResult)
+      const rawConfig = requireFn('/', TailwindConfigPath)
       if (rawConfig != null) {
         const twindConfig = convertTailwindToTwindConfig(rawConfig)
         return right(twindConfig)


### PR DESCRIPTION
**Problem:**
Tailwind's config files are typically defined using `module.exports =` syntax, which no longer works with our commonjs interop code after the addition of [this line](https://github.com/concrete-utopia/utopia/pull/1706/files#diff-2a00d32e35df8b5d898c7648edd30df500ea4ff9f9016f22f88b5faaf81405e8R357)

**Fix:**
Remove the `importDefault` that was previously being used.