### PR TITLE
r3f controls should work if react-three-fiber is imported

### DIFF
--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -435,7 +435,13 @@ export function getPropertyControlsForTarget(
             // you can add more intrinsic (ie not imported) element types here
             const packageJsonFile = packageJsonFileFromProjectContents(projectContents)
             const dependencies = dependenciesFromPackageJson(packageJsonFile, 'combined')
-            if (dependencies.some((dependency) => dependency.name === '@react-three/fiber')) {
+            if (
+              dependencies.some(
+                (dependency) =>
+                  dependency.name === '@react-three/fiber' ||
+                  dependency.name === 'react-three-fiber',
+              )
+            ) {
               if (ReactThreeFiberControls[element.name.baseVariable] != null) {
                 return ReactThreeFiberControls[element.name.baseVariable]
               }


### PR DESCRIPTION
**Problem:**
We only apply the propertyControls for react-three-fiber host elements if @react-three/fiber is in the package.json. But some older projects use the `react-three-fiber` package instead of the `@react-three/fiber` package. We should support both.

**Fix:**
Support both