### PR TITLE
Only use the custom require when importing files that define components

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1826,7 +1826,7 @@ describe('UiJsxCanvas render multifile projects', () => {
       null,
       `import * as React from 'react'
       import { Storyboard, Scene } from 'utopia-api'
-      import App from 'app.js'
+      import App from './app'
 
       export var ${BakedInStoryboardVariableName} = (props) => {
         return (
@@ -1897,7 +1897,7 @@ describe('UiJsxCanvas render multifile projects', () => {
       null,
       `import * as React from 'react'
       import { Storyboard, Scene } from 'utopia-api'
-      import { App } from 'app.js'
+      import { App } from './app'
 
       export var ${BakedInStoryboardVariableName} = (props) => {
         return (

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -342,33 +342,37 @@ export const UiJsxCanvas = betterReactMemo(
             resolvedFromThisOrigin.push(toImport)
             const projectFile = getContentsTreeFileFromString(projectContents, resolvedFilePath)
             if (isTextFile(projectFile) && isParseSuccess(projectFile.fileContents.parsed)) {
-              const { scope } = createExecutionScope(
-                resolvedFilePath,
-                customRequire,
-                mutableContextRef,
-                topLevelComponentRendererComponents,
-                projectContents,
-                uiFilePath,
-                transientFilesState,
-                base64FileBlobs,
-                hiddenInstances,
-                metadataContext,
-                updateInvalidatedPaths,
-                shouldIncludeCanvasRootInTheSpy,
-              )
-              const exportsDetail = projectFile.fileContents.parsed.exportsDetail
-              let filteredScope: MapLike<any> = {
-                ...scope.module.exports,
-                __esModule: true,
-              }
-              for (const s of Object.keys(scope)) {
-                if (s in exportsDetail.namedExports) {
-                  filteredScope[s] = scope[s]
-                } else if (s === exportsDetail.defaultExport?.name) {
-                  filteredScope['default'] = scope[s]
+              if (projectFile.fileContents.parsed.topLevelElements.some(isUtopiaJSXComponent)) {
+                const { scope } = createExecutionScope(
+                  resolvedFilePath,
+                  customRequire,
+                  mutableContextRef,
+                  topLevelComponentRendererComponents,
+                  projectContents,
+                  uiFilePath,
+                  transientFilesState,
+                  base64FileBlobs,
+                  hiddenInstances,
+                  metadataContext,
+                  updateInvalidatedPaths,
+                  shouldIncludeCanvasRootInTheSpy,
+                )
+                const exportsDetail = projectFile.fileContents.parsed.exportsDetail
+                let filteredScope: MapLike<any> = {
+                  ...scope.module.exports,
+                  __esModule: true,
                 }
+                for (const s of Object.keys(scope)) {
+                  if (s in exportsDetail.namedExports) {
+                    filteredScope[s] = scope[s]
+                  } else if (s === exportsDetail.defaultExport?.name) {
+                    filteredScope['default'] = scope[s]
+                  }
+                }
+                return right(filteredScope)
+              } else {
+                return left(`File ${resolvedFilePath} contains no components`)
               }
-              return right(filteredScope)
             } else {
               return left(`File ${resolvedFilePath} is not a ParseSuccess`)
             }

--- a/editor/src/core/tailwind/tailwind.ts
+++ b/editor/src/core/tailwind/tailwind.ts
@@ -35,7 +35,8 @@ function postCSSIncludesTailwindPlugin(postCSSFile: ProjectFile, requireFn: Requ
   if (isTextFile(postCSSFile)) {
     try {
       const requireResult = requireFn('/', PostCSSPath)
-      const plugins = (requireResult as any)?.plugins
+      const rawConfig = importDefault(requireResult)
+      const plugins = (rawConfig as any)?.plugins
       return plugins?.tailwindcss != null
     } catch (e) {
       /* Do nothing */
@@ -94,7 +95,8 @@ function getTailwindConfig(
 ): Either<any, Configuration> {
   if (tailwindFile != null && isTextFile(tailwindFile)) {
     try {
-      const rawConfig = requireFn('/', TailwindConfigPath)
+      const requireResult = requireFn('/', TailwindConfigPath)
+      const rawConfig = importDefault(requireResult)
       if (rawConfig != null) {
         const twindConfig = convertTailwindToTwindConfig(rawConfig)
         return right(twindConfig)


### PR DESCRIPTION
Fixes #1730 

**Problem:**
The Canvas uses a custom require function when importing from other files from the same project, so that we can provide special handling for imported components. However, this custom require function assumes esm type exports, which are rarely used in e.g. config files (which are typically defined using `module.exports = {...`

**Fix:**
As part of the custom require function, check that the file we're attempting to resolve actually defines components. If it doesn't fall back to the regular require function.

Also fixed a test that is broken by this because it was actually using an invalid import statement.
