### PR TITLE
Fixed parsing of intrinsic elements in arbitrary JS blocks inside JSX

### DIFF
--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -847,10 +847,14 @@ export function jsxElementNameEquals(first: JSXElementName, second: JSXElementNa
   )
 }
 
-export function isIntrinsicElement(name: JSXElementName): boolean {
+export function isIntrinsicElementFromString(name: string): boolean {
   // Elements with a lowercase first character are assumed to be intrinsic, since React treats them differently
   // https://reactjs.org/docs/jsx-in-depth.html#user-defined-components-must-be-capitalized
-  return PP.depth(name.propertyPath) === 0 && firstLetterIsLowerCase(name.baseVariable)
+  return firstLetterIsLowerCase(name) && !name.includes('.')
+}
+
+export function isIntrinsicElement(name: JSXElementName): boolean {
+  return PP.depth(name.propertyPath) === 0 && isIntrinsicElementFromString(name.baseVariable)
 }
 
 export function isIntrinsicHTMLElementString(name: string): boolean {

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -7,7 +7,6 @@ import {
   stripNulls,
   traverseArray,
 } from '../../shared/array-utils'
-import { intrinsicHTMLElementNamesAsStrings } from '../../shared/dom-utils'
 import {
   applicative2Either,
   bimapEither,
@@ -63,6 +62,7 @@ import {
   jsxAttributesEntry,
   setJSXAttributesAttribute,
   jsxAttributesSpread,
+  isIntrinsicElementFromString,
 } from '../../shared/element-template'
 import { maybeToArray, forceNotNull } from '../../shared/optional-utils'
 import {
@@ -545,7 +545,7 @@ function parseOtherJavaScript<E extends TS.Node, T>(
       if (TS.isIdentifier(nodeToCheck)) {
         const nameToAdd = nodeToCheck.getText(sourceFile)
         if (nodeIsJSXElement) {
-          if (!intrinsicHTMLElementNamesAsStrings.includes(nameToAdd)) {
+          if (!isIntrinsicElementFromString(nameToAdd)) {
             pushToDefinedElsewhereIfNotThere(inScope, nameToAdd)
             return true
           }


### PR DESCRIPTION
Fixes #1747 

**Problem:**
If an arbitrary JSX block contained an intrinsic element, we were incorrectly treating that as something that should be in scope when parsing it.

**Fix:**
We were already filtering intrinsic HTML elements here, so I've replaced that with a filter for all intrinsic elements. Plus a test.
