### PR TITLE
navigator resize fixes

### DIFF
--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -9,8 +9,8 @@ import {
   getAllCodeEditorErrors,
   getOpenUIJSFile,
   getOpenUIJSFileKey,
-  LeftPaneDefaultWidth,
   parseFailureAsErrorMessages,
+  NavigatorWidthAtom,
 } from '../editor/store/editor-state'
 import { useEditorState } from '../editor/store/store-hook'
 import ErrorOverlay from '../../third-party/react-error-overlay/components/ErrorOverlay'
@@ -24,6 +24,7 @@ import { useReadOnlyRuntimeErrors } from '../../core/shared/runtime-report-logs'
 import StackFrame from '../../third-party/react-error-overlay/utils/stack-frame'
 import { ModeSelectButtons } from './mode-select-buttons'
 import { FloatingInsertMenu } from './ui/floating-insert-menu'
+import { atomWithPubSub, usePubSubAtomReadOnly } from '../../core/shared/atom-with-pub-sub'
 
 interface CanvasWrapperComponentProps {}
 
@@ -51,6 +52,8 @@ export const CanvasWrapperComponent = betterReactMemo(
       (store) => !store.editor.navigator.minimised,
       'ErrorOverlayComponent isOverlappingWithNavigator',
     )
+
+    const navigatorWidth = usePubSubAtomReadOnly(NavigatorWidthAtom)
 
     return (
       <FlexColumn
@@ -83,7 +86,7 @@ export const CanvasWrapperComponent = betterReactMemo(
         >
           <div
             style={{
-              width: isNavigatorOverCanvas ? LeftPaneDefaultWidth : 0,
+              width: isNavigatorOverCanvas ? navigatorWidth : 0,
             }}
           />
           <FlexColumn

--- a/editor/src/components/canvas/move-template.spec.browser.tsx
+++ b/editor/src/components/canvas/move-template.spec.browser.tsx
@@ -1270,7 +1270,7 @@ describe('moveTemplate', () => {
               style={{
                 backgroundColor: '#0091FFAA',
                 position: 'absolute',
-                left: -160,
+                left: -260,
                 top: -60,
                 width: 60,
                 height: 50,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1081,7 +1081,7 @@ export function createNewProjectName(): string {
 }
 
 export const BaseSnappingThreshold = 5
-export const BaseCanvasOffset = { x: 60, y: 60 } as CanvasPoint
+export const BaseCanvasOffset = { x: 100, y: 60 } as CanvasPoint
 export const BaseCanvasOffsetLeftPane = {
   x: BaseCanvasOffset.x + DefaultNavigatorWidth,
   y: BaseCanvasOffset.y,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -148,6 +148,7 @@ import { ValueAtPath } from '../../../core/shared/jsx-attributes'
 import { MapLike } from 'typescript'
 import { pick } from '../../../core/shared/object-utils'
 import { LayoutTargetableProp, StyleLayoutProp } from '../../../core/layout/layout-helpers-new'
+import { atomWithPubSub } from '../../../core/shared/atom-with-pub-sub'
 const ObjectPathImmutable: any = OPI
 
 export enum LeftMenuTab {
@@ -163,6 +164,12 @@ export enum LeftMenuTab {
 export const LeftPaneMinimumWidth = 5
 
 export const LeftPaneDefaultWidth = 260
+
+const DefaultNavigatorWidth = 280
+export const NavigatorWidthAtom = atomWithPubSub({
+  key: 'NavigatorWidthAtom',
+  defaultValue: DefaultNavigatorWidth,
+})
 
 export enum RightMenuTab {
   Insert = 'insert',
@@ -1074,9 +1081,9 @@ export function createNewProjectName(): string {
 }
 
 export const BaseSnappingThreshold = 5
-export const BaseCanvasOffset = { x: 20, y: 60 } as CanvasPoint
+export const BaseCanvasOffset = { x: 60, y: 60 } as CanvasPoint
 export const BaseCanvasOffsetLeftPane = {
-  x: BaseCanvasOffset.x + LeftPaneDefaultWidth,
+  x: BaseCanvasOffset.x + DefaultNavigatorWidth,
   y: BaseCanvasOffset.y,
 } as CanvasPoint
 

--- a/editor/src/components/editor/top-menu.tsx
+++ b/editor/src/components/editor/top-menu.tsx
@@ -17,8 +17,9 @@ import CanvasActions from '../canvas/canvas-actions'
 import { EditorAction } from './action-types'
 import { ComponentOrInstanceIndicator } from '../editor/component-button'
 import { IconToggleButton } from '../../uuiui/icon-toggle-button'
-import { LeftPaneDefaultWidth, RightMenuTab } from './store/editor-state'
+import { LeftPaneDefaultWidth, RightMenuTab, NavigatorWidthAtom } from './store/editor-state'
 import { CanvasVector } from '../../core/shared/math-utils'
+import { usePubSubAtomReadOnly } from '../../core/shared/atom-with-pub-sub'
 
 function useShouldResetCanvas(invalidateCount: number): [boolean, (value: boolean) => void] {
   const [shouldResetCanvas, setShouldResetCanvas] = React.useState(false)
@@ -39,15 +40,17 @@ const TopMenuLeftControls = betterReactMemo('TopMenuLeftControls', () => {
     'TopMenuLeftControls navigatorVisible',
   )
 
+  const navigatorWidth = usePubSubAtomReadOnly(NavigatorWidthAtom)
+
   const onClickNavigateTab = React.useCallback(() => {
     let actions: EditorAction[] = [EditorActions.togglePanel('navigator')]
     if (navigatorVisible) {
-      actions.push(CanvasActions.scrollCanvas({ x: LeftPaneDefaultWidth, y: 0 } as CanvasVector))
+      actions.push(CanvasActions.scrollCanvas({ x: navigatorWidth, y: 0 } as CanvasVector))
     } else {
-      actions.push(CanvasActions.scrollCanvas({ x: -LeftPaneDefaultWidth, y: 0 } as CanvasVector))
+      actions.push(CanvasActions.scrollCanvas({ x: -navigatorWidth, y: 0 } as CanvasVector))
     }
     dispatch(actions)
-  }, [dispatch, navigatorVisible])
+  }, [dispatch, navigatorVisible, navigatorWidth])
 
   const followSelection = useEditorState(
     (store) => store.editor.config.followSelection,

--- a/editor/src/core/shared/atom-with-pub-sub.ts
+++ b/editor/src/core/shared/atom-with-pub-sub.ts
@@ -34,7 +34,7 @@ export function atomWithPubSub<T>(options: { key: string; defaultValue: T }): At
           updateAtomSynchronously(() => value)
         })
       })
-      return <>{children}</>
+      return React.createElement(React.Fragment, {}, children)
     },
   }
   GlobalAtomMap[key] = newAtom


### PR DESCRIPTION
**Problem:**
The navigator hides part of the error overlay.

**Fix:**
Turns out the navigator size has recently been changed, but a few places used the wrong constant (`LeftPaneDefaultWidth`) and so the navigator was 20 pixels wider than the canvas was expecting it. I also realized that the navigator can resize, so while there I fixed the following things:

**Commit Details:**
- Navigator default width codified into new constant and Atom
- Update the `NavigatorWidthAtom` when the navigator is resized
- Update the canvas offset when navigator is resized
- Changed the default canvas offset so that the new "parent floating UI" thingy fits on the screen
- Use the new `NavigatorWidthAtom` wherever needed
