### PR TITLE
Fix/inspector component section paddings

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -200,7 +200,7 @@ const RowForInvalidControl = betterReactMemo(
     const warning =
       props.warningTooltip == null ? null : <WarningTooltip warning={props.warningTooltip} />
     return (
-      <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
+      <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
         <PropertyLabel target={propPath}>
           {warning}
           {props.title}
@@ -244,13 +244,13 @@ const RowForBaseControl = betterReactMemo('RowForBaseControl', (props: RowForBas
   const contextMenuItems = Utils.stripNulls([
     addOnUnsetValues([propName], propMetadata.onUnsetValues),
   ])
-  const warning = warningTooltip == null ? null : <WarningTooltip warning={warningTooltip} />
 
   const propertyLabel =
     props.label == null ? (
       <PropertyLabel target={[propPath]} style={{ textTransform: 'capitalize' }}>
-        {warning}
-        {title}
+        <Tooltip title={title}>
+          <span>{title}</span>
+        </Tooltip>
       </PropertyLabel>
     ) : (
       <props.label />
@@ -262,7 +262,7 @@ const RowForBaseControl = betterReactMemo('RowForBaseControl', (props: RowForBas
       items={contextMenuItems}
       data={null}
     >
-      <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
+      <UIGridRow padded={false} variant='<--1fr--><--1fr-->'>
         {propertyLabel}
         <ControlForProp
           propPath={propPath}

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -151,11 +151,10 @@ export const ControlForEnumProp = betterReactMemo(
   'ControlForEnumProp',
   (props: ControlForPropProps<EnumControlDescription>) => {
     const { propName, propMetadata, controlDescription } = props
-
-    const controlId = `${propName}-enum-property-control`
     const value = propMetadata.propertyStatus.set
       ? propMetadata.value
       : controlDescription.defaultValue
+
     const options: Array<SelectOption> = useKeepReferenceEqualityIfPossible(
       controlDescription.options.map((option, index) => {
         return {
@@ -168,20 +167,21 @@ export const ControlForEnumProp = betterReactMemo(
         }
       }),
     )
+    const currentValue = options.find((option) => {
+      return fastDeepEquals(option.value, value)
+    })
+
+    function submitValue(option: SelectOption): void {
+      propMetadata.onSubmitValue(option.value)
+    }
+
     return (
-      <SelectControl
-        style={{
-          fontWeight: 'normal',
-          marginLeft: 4,
-        }}
-        key={controlId}
-        id={controlId}
-        testId={controlId}
-        value={value}
-        onSubmitValue={propMetadata.onSubmitValue}
-        controlStatus={propMetadata.controlStatus}
-        controlStyles={propMetadata.controlStyles}
+      <PopupList
+        disabled={!propMetadata.controlStyles.interactive}
+        value={currentValue}
+        onSubmitValue={submitValue}
         options={options}
+        containerMode={'default'}
       />
     )
   },

--- a/editor/src/uuiui/widgets/popup-list/popup-list.tsx
+++ b/editor/src/uuiui/widgets/popup-list/popup-list.tsx
@@ -223,6 +223,7 @@ const MenuPortal = (props: MenuPortalProps<SelectOption>) => {
   const [popupHeight, setPopupHeight] = React.useState(0)
   const [popupTop, setPopupTop] = React.useState(0)
   const [popupLeft, setPopupLeft] = React.useState(0)
+  const [alignRight, setAlignRight] = React.useState(false)
   const [deltaSinceMouseDown, setDeltaSinceMouseDown] = React.useState(0)
   const [croppedTop, setCroppedTop] = React.useState(false)
   const [croppedBottom, setCroppedBottom] = React.useState(false)
@@ -297,9 +298,15 @@ const MenuPortal = (props: MenuPortalProps<SelectOption>) => {
           top: scrollTop,
         })
       }
+      const popupRect = refCurrent?.getBoundingClientRect()
+      if (popupRect != null && popupRect.width + popupRect.left > window.innerWidth) {
+        setAlignRight(true)
+      } else {
+        setPopupLeft(referenceRect.left)
+        setAlignRight(false)
+      }
       setPopupHeight(menuHeight + 20)
       setPopupTop(menuTop)
-      setPopupLeft(referenceRect.left)
       setCroppedTop(isCroppedTop)
       setCroppedBottom(isCroppedBottom)
     }
@@ -329,7 +336,8 @@ const MenuPortal = (props: MenuPortalProps<SelectOption>) => {
           position: 'absolute',
           height: popupHeight,
           top: popupTop,
-          left: popupLeft - CheckboxInset + ValueContainerLeftPadding,
+          left: alignRight ? undefined : popupLeft - CheckboxInset + ValueContainerLeftPadding,
+          right: alignRight ? ValueContainerLeftPadding : undefined,
           overflow: 'hidden',
           ...UtopiaStyles.popup,
         }}


### PR DESCRIPTION
Fixes #1751 

**Problem:**
In the component section long labels don't fit, the controls are too wide, but not wide enough for dropdowns.

**Fix:**
Changing the labels to be wider and also have a tooltip. Introduce right alignment for PopupList popup when it's out of screen.
Removing the orange warning circle.

**Commit Details:**
- changed grid sizing for controls
- added tooltip for labels
- removed the warning circle
- found an extra 8px padding on the side that is not needed
- replaced the select control with PopupList as it's more compact
- PopupList is positioned to the right edge when it doesn't fit the screen

<img width="256" alt="Screenshot 2021-08-19 at 18 27 49" src="https://user-images.githubusercontent.com/4403069/130106776-bf9c493e-1921-417f-8174-2102292e33fe.png">

