### PR TITLE
Fix/props.children

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -425,13 +425,12 @@ function renderJSXElement(
       imports,
     )
   } else {
-    const childrenOrNull = childrenElements.length !== 0 ? childrenElements : null
     return renderComponentUsingJsxFactoryFunction(
       inScope,
       jsxFactoryFunctionName,
       FinalElement,
       finalPropsIcludingElementPath,
-      childrenOrNull,
+      ...childrenElements,
     )
   }
 }
@@ -518,14 +517,7 @@ export function renderComponentUsingJsxFactoryFunction(
       throw new Error(`Unable to find factory function ${factoryFunctionName} in scope.`)
     }
   }
-  // This is disgusting, but we want to make sure that if there is only one child it isn't wrapped in an array,
-  // since that code that uses `React.Children.only`
-  const childrenToRender = children.map((innerChildren) =>
-    innerChildren != null && Array.isArray(innerChildren) && innerChildren.length === 1
-      ? innerChildren[0]
-      : innerChildren,
-  )
-  return factoryFunction.call(null, type, fixedProps, ...childrenToRender)
+  return factoryFunction.call(null, type, fixedProps, ...children)
 }
 
 function fixStyleObjectRemoveCommentOnlyValues(props: Readonly<unknown>): any {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -32,7 +32,6 @@ export function buildSpyWrappedElement(
     ...finalProps,
     key: EP.toComponentId(elementPath),
   }
-  const childrenElementsOrNull = childrenElements.length > 0 ? childrenElements : null
   const spyCallback = (reportedProps: any) => {
     /** This is not so nice, but the way to know if something is an emotion component is
      * that it adds some extra properties to the Element itself, like __emotion_base,
@@ -75,7 +74,7 @@ export function buildSpyWrappedElement(
       ...props,
       ...spyWrapperProps,
     },
-    childrenElementsOrNull,
+    ...childrenElements,
   )
 }
 

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1962,4 +1962,109 @@ describe('UiJsxCanvas render multifile projects', () => {
       "
     `)
   })
+
+  it('Properly renders an element that uses props.children', () => {
+    const printedDom = testCanvasRenderInline(
+      null,
+      `
+      import * as React from 'react'
+      import { View, Storyboard, Scene } from 'utopia-api'
+
+      export var App = (props) => {
+        return (
+          <div
+            data-uid='outer-div'
+          >
+            <div
+              data-uid='aaa'
+              children={<div
+                data-uid='bbb'
+              />}
+            />
+            <div
+              data-uid='ccc'
+              children={[
+                <div
+                  data-uid='ddd'
+                />,
+                <div
+                  data-uid='eee'
+                />
+              ]}
+            />
+          </div>
+        )
+      }
+      export var ${BakedInStoryboardVariableName} = (props) => {
+        return (
+          <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+            <Scene
+              style={{ position: 'absolute', left: 0, top: 0, width: 400, height: 400 }}
+              data-uid={'${TestSceneUID}'}
+            >
+              <App
+                data-uid='${TestAppUID}'
+                style={{ position: 'absolute', bottom: 0, left: 0, right: 0, top: 0 }}
+              />
+            </Scene>
+          </Storyboard>
+        )
+      }
+      `,
+    )
+    expect(printedDom).toMatchInlineSnapshot(`
+      "<div style=\\"all: initial;\\">
+        <div
+          id=\\"canvas-container\\"
+          style=\\"position: absolute;\\"
+          data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:outer-div utopia-storyboard-uid/scene-aaa/app-entity:outer-div/aaa utopia-storyboard-uid/scene-aaa/app-entity:outer-div/ccc\\"
+          data-utopia-root-element-path=\\"utopia-storyboard-uid\\"
+        >
+          <div
+            data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
+            data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+            style=\\"
+              position: absolute;
+              background-color: rgba(255, 255, 255, 1);
+              box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              left: 0;
+              top: 0;
+              width: 400px;
+              height: 400px;
+            \\"
+            data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+          >
+            <div
+              data-uid=\\"outer-div app-entity\\"
+              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div utopia-storyboard-uid/scene-aaa/app-entity\\"
+            >
+              <div
+                data-uid=\\"aaa\\"
+                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/aaa\\"
+              >
+                <div
+                  data-uid=\\"bbb~~~1\\"
+                  data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/bbb~~~1\\"
+                ></div>
+              </div>
+              <div
+                data-uid=\\"ccc\\"
+                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/ccc\\"
+              >
+                <div
+                  data-uid=\\"ddd~~~1\\"
+                  data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/ddd~~~1\\"
+                ></div>
+                <div
+                  data-uid=\\"eee~~~2\\"
+                  data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/eee~~~2\\"
+                ></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      "
+    `)
+  })
 })


### PR DESCRIPTION
Fixes #1754

**Problem:**
The children div with Sigh will not render on the Canvas:
```javascript
<div
  children={
    <div>Sigh</div>
  }
/>
```

**Issue:**
The root of the problem is twofold:
1. Most importantly, we were kind of confusing the following cases:
```javascript
// JSX:
<div />
// transpiled javascript:
React.createElement('div', {})
```
```javascript
// JSX:
<div>{null}</div>
// transpiled javascript:
React.createElement('div', {}, null)
```
```javascript
// JSX:
<div><ChildOne /></div>
// transpiled javascript:
React.createElement('div', {}, React.crateElement(ChildOne, {}))
```
```javascript
// JSX:
<div>{[<ChildOne />]}</div>
// transpiled javascript:
React.createElement('div', {}, [ React.crateElement(ChildOne, {}) ])
```
```javascript
// JSX:
<div><ChildOne /><ChildTwo /></div>
// transpiled javascript:
React.createElement('div', {}, React.crateElement(ChildOne, {}), React.crateElement(ChildTwo, {}))
```
```javascript
// JSX:
<div>{[<ChildOne />, <ChildTwo />]}</div>
// transpiled javascript:
React.createElement('div', {}, [ React.crateElement(ChildOne, {}), React.crateElement(ChildTwo, {}) ])
```
2. For this code snippet: `<div data-uid='no-children' />` our render helper code would end up calling a createElement with null passed in as children prop, instead of nothing passed in as children prop:
```javascript
// for this JSX
<div data-uid='no-children' />
// we'd call this:
React.createElement('div', {'data-uid': 'no-children'}, null)
// instead of this:
React.createElement('div', {'data-uid': 'no-children'})
```

Now that's an issue because the _props_ might have a children key!
This is valid and happy react that renders a child:
```javascript
// JSX:
<div children={'child-one'} />
// transpiled javascript:
React.createElement('div', {children: 'child-one'})
```
This react is sad because the children prop gets overridden with a null:
```javascript
React.createElement('div', {children: 'child-one'}, null)
```

**Fix:**
I cleaned up the code that passes through the jsx children elements, removed the helper code which would pass down `null` children, and removed the helper code which was trying to unwrap `['one-child']` to `'one-child'`

**Commit Details:**
- Remove childrenOrNull and spread childrenElements in renderJSXElement
- Remove childrenElementsOrNull and spread childrenElements in the spy wrapper
- Now that we are spreading the children elements, I could remove the code that was unwrapping arrays in `renderComponentUsingJsxFactoryFunction`
- Added a test

**Note:**
This PR fixes the rendering of props.children on the canvas. But we are not properly spying these elements! They are not going to appear in the navigator, and they are not editable by the Canvas yet. I think it's not urgent to fix that, but I'm going to create a follow up ticket.