### PR TITLE
Fork project assets when forking a project

### DIFF
--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -9,6 +9,7 @@ import {
   isParsedTextFile,
   isTextFile,
   isParseSuccess,
+  isAssetFile,
 } from '../core/shared/project-file-types'
 import { isDirectory, directory, isImageFile } from '../core/model/project-file-utils'
 import Utils from '../utils/utils'
@@ -17,27 +18,26 @@ import { fastForEach } from '../core/shared/utils'
 import { mapValues, propOrNull } from '../core/shared/object-utils'
 import { emptySet } from '../core/shared/set-utils'
 
-interface ImageAsset {
+export interface AssetFileWithFileName {
   assetPath: string
-  asset: ImageFile
+  asset: ImageFile | AssetFile
 }
 
-function imageAsset(assetPath: string, asset: ImageFile): ImageAsset {
-  return {
-    assetPath: assetPath,
-    asset: asset,
-  }
-}
+export function getAllProjectAssetFiles(
+  projectContents: ProjectContentTreeRoot,
+): Array<AssetFileWithFileName> {
+  let allProjectAssets: Array<AssetFileWithFileName> = []
 
-export function getImageAssets(projectContents: ProjectContents): Array<ImageAsset> {
-  const result: Array<ImageAsset> = []
-  Utils.fastForEach(Object.keys(projectContents), (projectContentKey) => {
-    const projectContent = projectContents[projectContentKey]
-    if (isImageFile(projectContent)) {
-      result.push(imageAsset(projectContentKey, projectContent))
+  walkContentsTree(projectContents, (fullPath, file) => {
+    if (isImageFile(file) || isAssetFile(file)) {
+      allProjectAssets.push({
+        assetPath: fullPath,
+        asset: file,
+      })
     }
   })
-  return result
+
+  return allProjectAssets
 }
 
 export type ProjectContentTreeRoot = { [key: string]: ProjectContentsTree }

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -19,8 +19,8 @@ import { mapValues, propOrNull } from '../core/shared/object-utils'
 import { emptySet } from '../core/shared/set-utils'
 
 export interface AssetFileWithFileName {
-  assetPath: string
-  asset: ImageFile | AssetFile
+  fileName: string
+  file: ImageFile | AssetFile
 }
 
 export function getAllProjectAssetFiles(
@@ -31,8 +31,8 @@ export function getAllProjectAssetFiles(
   walkContentsTree(projectContents, (fullPath, file) => {
     if (isImageFile(file) || isAssetFile(file)) {
       allProjectAssets.push({
-        assetPath: fullPath,
-        asset: file,
+        fileName: fullPath,
+        file: file,
       })
     }
   })

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3235,7 +3235,7 @@ export const UPDATE_FNS = {
     let projectFile: ProjectFile
     if (action.imageDetails == null) {
       // Assume stock ASSET_FILE case when there's no image details.
-      projectFile = assetFile()
+      projectFile = assetFile(undefined)
     } else {
       // Assume IMAGE_FILE otherwise.
       projectFile = imageFile(action.fileType, undefined, width, height, action.hash)

--- a/editor/src/components/editor/persistence-hooks.ts
+++ b/editor/src/components/editor/persistence-hooks.ts
@@ -1,11 +1,18 @@
 import * as React from 'react'
 import { triggerForkProject } from './persistence'
+import { persistentModelFromEditorModel } from './store/editor-state'
 import { useRefEditorState } from './store/store-hook'
 
 export function useTriggerForkProject(): () => void {
   const storeRef = useRefEditorState((store) => store)
   return React.useCallback(async () => {
     const store = storeRef.current
-    triggerForkProject(store.dispatch, store.editor, store.userState.loginState)
+    triggerForkProject(
+      store.dispatch,
+      persistentModelFromEditorModel(store.editor),
+      store.editor.id,
+      store.editor.projectName,
+      store.userState.loginState,
+    )
   }, [storeRef])
 }

--- a/editor/src/components/editor/persistence.spec.ts
+++ b/editor/src/components/editor/persistence.spec.ts
@@ -11,7 +11,7 @@ import { NO_OP } from '../../core/shared/utils'
 import { createPersistentModel, delay } from '../../utils/utils.test-utils'
 import { generateUID } from '../../core/shared/uid-utils'
 import { TextFile } from '../../core/shared/project-file-types'
-import { SaveProjectResponse } from './server'
+import { AssetToSave, SaveProjectResponse } from './server'
 import { localProjectKey } from '../../common/persistence'
 import { MockUtopiaTsWorkers } from '../../core/workers/workers'
 import { addFileToProjectContents, getContentsTreeFileFromString } from '../assets'
@@ -38,8 +38,8 @@ jest.mock('./server', () => ({
 
     return Promise.resolve({ id: projectId, ownerId: 'Owner' })
   },
-  saveImagesFromProject: async (projectId: string, persistentModel: PersistentModel) => {
-    return Promise.resolve(persistentModel)
+  saveAssets: async (_projectId: string, _assets: Array<AssetToSave>): Promise<void> => {
+    return Promise.resolve()
   },
 }))
 

--- a/editor/src/components/editor/persistence.spec.ts
+++ b/editor/src/components/editor/persistence.spec.ts
@@ -62,12 +62,12 @@ jest.mock('./server', () => ({
     allProjectAssets: Array<AssetFileWithFileName>,
   ): Promise<Array<AssetFileWithFileName>> => {
     const downloadedAssets = allProjectAssets
-      .filter((a) => a.asset.base64 == null)
-      .map((a) => a.assetPath)
+      .filter((a) => a.file.base64 == null)
+      .map((a) => a.fileName)
     mockDownloadedAssetsLog[projectId!] = downloadedAssets
     return allProjectAssets.map((assetWithFile) => ({
       ...assetWithFile,
-      asset: AssetFileWithBase64,
+      file: AssetFileWithBase64,
     }))
   },
   createNewProjectID: async (): Promise<string> => {

--- a/editor/src/components/editor/persistence.ts
+++ b/editor/src/components/editor/persistence.ts
@@ -330,16 +330,16 @@ export async function triggerForkProject(
 
   if (isLoggedIn(loginState)) {
     assetsToSave = mapDropNulls((fileWithName) => {
-      const fileType = getFileExtension(fileWithName.assetPath)
-      return fileWithName.asset.base64 == null
+      const fileType = getFileExtension(fileWithName.fileName)
+      return fileWithName.file.base64 == null
         ? null
-        : assetToSave(fileType, fileWithName.asset.base64, fileWithName.assetPath)
+        : assetToSave(fileType, fileWithName.file.base64, fileWithName.fileName)
     }, allProjectAssetsDownloaded)
-    updateFileActions = allProjectAssetsDownloaded.map(({ assetPath, asset }) =>
+    updateFileActions = allProjectAssetsDownloaded.map(({ fileName: assetPath, file: asset }) =>
       updateFile(assetPath, scrubBase64FromFile(asset), true),
     )
     updatedProjectContents = allProjectAssetsDownloaded.reduce(
-      (workingProjectContents, { assetPath, asset }) => {
+      (workingProjectContents, { fileName: assetPath, file: asset }) => {
         return addFileToProjectContents(
           workingProjectContents,
           assetPath,
@@ -349,11 +349,11 @@ export async function triggerForkProject(
       persistentModel.projectContents,
     )
   } else {
-    updateFileActions = allProjectAssetsDownloaded.map(({ assetPath, asset }) =>
+    updateFileActions = allProjectAssetsDownloaded.map(({ fileName: assetPath, file: asset }) =>
       updateFile(assetPath, asset, true),
     )
     updatedProjectContents = allProjectAssetsDownloaded.reduce(
-      (workingProjectContents, { assetPath, asset }) => {
+      (workingProjectContents, { fileName: assetPath, file: asset }) => {
         return addFileToProjectContents(workingProjectContents, assetPath, asset)
       },
       persistentModel.projectContents,
@@ -750,7 +750,7 @@ function prepareLocalProjectAssetsForUpload(
   let assetsToUpload: Array<AssetToSave> = []
 
   const updatedProjectContents = allProjectAssets.reduce(
-    (workingProjectContents, { assetPath, asset }) => {
+    (workingProjectContents, { fileName: assetPath, file: asset }) => {
       const fileType = getFileExtension(assetPath)
       if (asset.base64 != null) {
         assetsToUpload.push(assetToSave(fileType, asset.base64, assetPath))

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -428,11 +428,11 @@ async function downloadAssetFromProject(
   projectId: string,
   fileWithName: AssetFileWithFileName,
 ): Promise<AssetFileWithFileName> {
-  if (fileWithName.asset.base64 != undefined) {
+  if (fileWithName.file.base64 != undefined) {
     return fileWithName
   } else {
     const baseUrl = window.top.location.origin
-    const assetUrl = urljoin(baseUrl, 'p', projectId, fileWithName.assetPath)
+    const assetUrl = urljoin(baseUrl, 'p', projectId, fileWithName.fileName)
     const assetResponse = await fetch(assetUrl, {
       method: 'GET',
       credentials: 'include',
@@ -443,14 +443,14 @@ async function downloadAssetFromProject(
 
       return {
         ...fileWithName,
-        asset: {
-          ...fileWithName.asset,
+        file: {
+          ...fileWithName.file,
           base64: base64,
         },
       }
     } else {
       console.error(
-        `Failed to retrieve asset ${fileWithName.assetPath} (${assetResponse.status}): ${assetResponse.statusText}`,
+        `Failed to retrieve asset ${fileWithName.fileName} (${assetResponse.status}): ${assetResponse.statusText}`,
       )
       return fileWithName
     }

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -479,9 +479,10 @@ export function imageFile(
   }
 }
 
-export function assetFile(): AssetFile {
+export function assetFile(base64: string | undefined): AssetFile {
   return {
     type: 'ASSET_FILE',
+    base64: base64,
   }
 }
 

--- a/editor/src/core/model/project-import.ts
+++ b/editor/src/core/model/project-import.ts
@@ -101,7 +101,11 @@ export async function importZippedGitProject(
             hash: assetResult.hash,
             size: null,
           })
-          loadedProject = addFileToProjectContents(loadedProject, shiftedFileName, assetFile())
+          loadedProject = addFileToProjectContents(
+            loadedProject,
+            shiftedFileName,
+            assetFile(undefined),
+          )
           break
         }
         case 'IMAGE_FILE': {

--- a/editor/src/core/shared/file-utils.ts
+++ b/editor/src/core/shared/file-utils.ts
@@ -57,27 +57,12 @@ export function extractAsset(file: File): Promise<AssetResult> {
   })
 }
 
-function getMimeStrippedBase64(base64: string): string {
-  const splitBase64 = base64.split(',')
-  switch (splitBase64.length) {
-    case 1:
-      // No mime prefix.
-      return base64
-    case 2:
-      // Mime prefix.
-      return splitBase64[1]
-    default:
-      throw new Error('Invalid Base64 content for asset.')
-  }
-}
-
 export function assetResultForBase64(filename: string, base64: string): AssetResult {
-  const mimeStrippedBase64 = getMimeStrippedBase64(base64)
-  const hash = stringHash(mimeStrippedBase64)
+  const hash = stringHash(base64)
   return {
     type: 'ASSET_RESULT',
     filename: filename,
-    base64Bytes: mimeStrippedBase64,
+    base64Bytes: base64,
     hash: hash,
   }
 }
@@ -101,14 +86,8 @@ export async function imageResultForBase64(
   fileType: string,
   base64: string,
 ): Promise<ImageResult> {
-  const mimeStrippedBase64 = getMimeStrippedBase64(base64)
-  const hash = stringHash(mimeStrippedBase64)
-  let imageDataUrl: string
-  if (mimeStrippedBase64 === base64) {
-    imageDataUrl = `data:;base64,${base64}`
-  } else {
-    imageDataUrl = base64
-  }
+  const hash = stringHash(base64)
+  const imageDataUrl: string = base64
   let imageSize: Size
   if (fileType === '.svg') {
     // FIXME: SVGs may not have a viewbox or it may be specified
@@ -120,7 +99,7 @@ export async function imageResultForBase64(
   return {
     type: 'IMAGE_RESULT',
     filename: filename,
-    base64Bytes: mimeStrippedBase64,
+    base64Bytes: base64,
     size: imageSize,
     fileType: fileType,
     hash: hash,

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -530,6 +530,7 @@ export interface ImageFile {
 
 export interface AssetFile {
   type: 'ASSET_FILE'
+  base64?: string
 }
 
 export function isAssetFile(projectFile: ProjectFile | null): projectFile is AssetFile {


### PR DESCRIPTION
Fixes #1742 

**Problem:**
When forking a project, Utopia doesn't also fork the assets of that project.

**Fix:**
First this PR creates a single path for dealing with project forking (previously there were a few). When forking a project we will now download the base64 content for any assets or images that are missing that data, and then uploading that content against the new project ID if the user is signed in, or store it in the local project if the user isn't signed in (this required a change to the `AssetFile` file type since that previously had no way of storing the base64 locally). We also make sure that when uploading that asset data we also scrub the base64 from the project model.

As part of this work, I realised that we were over-eagerly stripping the mime-type data that prefixes the base64. The reason for this is that we don't want that prefix when uploading. However, we _do_ want that prefix when inlining base64 via the [file-loader](https://github.com/concrete-utopia/utopia/blob/baea4c4aa28439bcdfde7a0a0036ffde6815b76c/editor/src/core/webpack-loaders/file-loader.ts#L8). I've removed that code, so that now we only strip the mime-type prefix at the point of uploading the asset.

**Commit Details:**
- Updated the definition of `AssetFile` to include the base64 content
- Added a function `getAllProjectAssetFiles` which pulls out all asset files (along with their file paths) from a project (replacing a previously dead function)
- Added a function `downloadAssetFromProject` for downloading an asset's base64
- Moved the function `getMimeStrippedBase64` (which was previously stripping the mime-type) to `server.ts` so that it is only applied at the point of uploading an asset
- Updated `triggerForkProject` so that it now downloads any assets that require downloading, prepares them to be uploaded (if signed in), updates the project contents with the updated asset files, saves the forked project, and then uploads the assets (the upload has to happen after the initial server save as otherwise the user doesn't "own" that project yet)
- Made a corresponding change in the local project uploading that happens when signing in
- Added tests to cover the various project forking cases
