### PR TITLE
always use the absolute path for looking up property controls info

### DIFF
--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -53,6 +53,7 @@ import { getUtopiaJSXComponentsFromSuccess } from '../model/project-file-utils'
 import { importedFromWhere } from '../../components/editor/import-utils'
 import { dependenciesFromPackageJson } from '../../components/editor/npm-dependency/npm-dependency'
 import { ReactThreeFiberControls } from './third-party-property-controls/react-three-fiber-controls'
+import { absolutePathFromRelativePath } from '../../utils/path-utils'
 
 export interface FullNodeModulesUpdate {
   type: 'FULL_NODE_MODULES_UPDATE'
@@ -462,10 +463,16 @@ export function getPropertyControlsForTarget(
       if (filenameForLookup == null) {
         return null
       } else {
+        const absolutePath = absolutePathFromRelativePath(
+          underlyingFilePath,
+          false,
+          filenameForLookup,
+        )
         // If it's pointing at a path (as opposed to a package), strip off the filename extension.
-        const trimmedPath = filenameForLookup.startsWith('/')
-          ? filenameForLookup.replace(/\.(js|jsx|ts|tsx)$/, '')
-          : filenameForLookup
+        const trimmedPath = absolutePath.includes('/')
+          ? absolutePath.replace(/\.(js|jsx|ts|tsx)$/, '')
+          : absolutePath
+
         const nameLastPart = getJSXElementNameLastPart(element.name)
         if (
           propertyControlsInfo[trimmedPath] != null &&


### PR DESCRIPTION
Fixes #1524

**Problem:**
The propertyControls / component inspector would not work for some components.


**Fix:**
It turns out the problem was the way of importing them... if the import was relative, we missed a piece of code that would convert it into an absolute path


**Commit Details:**
- Convert the imported file into an absolute path