### PR TITLE
Explicitly communicate when a remote dependency is being downloaded

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -210,10 +210,7 @@ export class RemoteDependencyBoundary extends React.Component<
     }
   }
 
-  componentDidUpdate(
-    prevProps: RemoteDependencyBoundaryProps,
-    _prevState: RemoteDependencyBoundaryState,
-  ): void {
+  componentDidUpdate(prevProps: RemoteDependencyBoundaryProps): void {
     if (
       prevProps.projectContents !== this.props.projectContents ||
       prevProps.requireFn !== this.props.requireFn
@@ -223,7 +220,7 @@ export class RemoteDependencyBoundary extends React.Component<
     }
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+  componentDidCatch(error: Error): void {
     if (error?.name !== ResolvingRemoteDependencyErrorName) {
       throw error
     }

--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -23,6 +23,7 @@ import {
 import { ProjectContentTreeRoot } from '../assets'
 import { processErrorWithSourceMap } from '../../core/shared/code-exec-utils'
 import { DomWalkerProps, useDomWalker } from './dom-walker'
+import { ResolvingRemoteDependencyErrorName } from '../../core/es-modules/package-manager/package-manager'
 
 interface CanvasComponentEntryProps {}
 
@@ -75,7 +76,12 @@ export const CanvasComponentEntry = betterReactMemo(
             requireFn={canvasProps.curriedRequireFn}
             key={`canvas-error-boundary-${canvasProps.mountCount}`}
           >
-            <DomWalkerWrapper {...canvasProps} clearErrors={clearRuntimeErrors} />
+            <RemoteDependencyBoundary
+              projectContents={canvasProps.projectContents}
+              requireFn={canvasProps.curriedRequireFn}
+            >
+              <DomWalkerWrapper {...canvasProps} clearErrors={clearRuntimeErrors} />
+            </RemoteDependencyBoundary>
           </CanvasErrorBoundary>
         </div>
       )
@@ -167,6 +173,65 @@ export class CanvasErrorBoundary extends React.Component<
   render(): React.ReactNode {
     if (this.state.hasError) {
       return null
+    } else {
+      return this.props.children
+    }
+  }
+}
+
+interface RemoteDependencyBoundaryProps {
+  projectContents: ProjectContentTreeRoot
+  requireFn: CurriedUtopiaRequireFn | null
+}
+
+function maybeGetResolvingMessage(error: any): string | null {
+  if (error?.name === ResolvingRemoteDependencyErrorName && error?.message != null) {
+    return error.message
+  } else {
+    return null
+  }
+}
+
+interface RemoteDependencyBoundaryState {
+  resolvingMessage: string | null
+}
+export class RemoteDependencyBoundary extends React.Component<
+  RemoteDependencyBoundaryProps,
+  RemoteDependencyBoundaryState
+> {
+  constructor(props: RemoteDependencyBoundaryProps) {
+    super(props)
+    this.state = { resolvingMessage: null }
+  }
+
+  static getDerivedStateFromError(e: any): RemoteDependencyBoundaryState {
+    return {
+      resolvingMessage: maybeGetResolvingMessage(e),
+    }
+  }
+
+  componentDidUpdate(
+    prevProps: RemoteDependencyBoundaryProps,
+    _prevState: RemoteDependencyBoundaryState,
+  ): void {
+    if (
+      prevProps.projectContents !== this.props.projectContents ||
+      prevProps.requireFn !== this.props.requireFn
+    ) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ resolvingMessage: null })
+    }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    if (error?.name !== ResolvingRemoteDependencyErrorName) {
+      throw error
+    }
+  }
+
+  render(): React.ReactNode {
+    if (this.state.resolvingMessage != null) {
+      return <div>{this.state.resolvingMessage}</div>
     } else {
       return this.props.children
     }

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -3,7 +3,11 @@ import * as fileWithImports from '../test-cases/file-with-imports.json'
 import * as fileWithLocalImport from '../test-cases/file-with-local-import.json'
 import * as reactSpringServerResponse from '../test-cases/react-spring-server-response.json'
 import * as antdPackagerResponse from '../test-cases/antd-packager-response.json'
-import { getRequireFn, getDependencyTypeDefinitions } from './package-manager'
+import {
+  getRequireFn,
+  getDependencyTypeDefinitions,
+  createResolvingRemoteDependencyError,
+} from './package-manager'
 import { evaluator } from '../evaluator/evaluator'
 import {
   extractNodeModulesFromPackageResponse,
@@ -237,7 +241,9 @@ describe('ES Dependency Manager — Real-life packages', () => {
       const antd = req('/src/index.js', 'antd')
       expect(Object.keys(antd)).not.toHaveLength(0)
       expect(antd).toHaveProperty('Button')
-      req('/src/index.js', 'antd/dist/antd.css')
+      expect(() => req('/src/index.js', 'antd/dist/antd.css')).toThrow(
+        createResolvingRemoteDependencyError('antd/dist/antd.css'),
+      )
     })
   })
 })
@@ -316,8 +322,9 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
         }
 
         const req = getRequireFn(onRemoteModuleDownload, {}, nodeModules, {})
-        const styleCss = req('/src/index.js', 'mypackage/dist/style.css')
-        expect(Object.keys(styleCss)).toHaveLength(0)
+        expect(() => req('/src/index.js', 'mypackage/dist/style.css')).toThrow(
+          createResolvingRemoteDependencyError('mypackage/dist/style.css'),
+        )
       },
     )
   })

--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -7,6 +7,12 @@
       type="image/png"
       href="/editor/icons/favicons/favicon-192.png?hash=%UTOPIA_SHA%"
     />
+    <link
+      rel="preload"
+      type="image/png"
+      href="/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
+      as="image"
+    />
     <link rel="preload" type="image/png" href="/editor/fills/light-primaryblue-p3.png" as="image" />
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="use-credentials" />
     <link

--- a/editor/src/templates/preview.html
+++ b/editor/src/templates/preview.html
@@ -2,10 +2,79 @@
 <html lang="en">
   <head>
     <!-- ogTags -->
+    <link
+      rel="preload"
+      type="image/png"
+      href="/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
+      as="image"
+    />
+    <style>
+      @keyframes animation-keyframes {
+        from {
+          transform: translateX(-212px);
+        }
+        to {
+          transform: translateX(0px);
+        }
+      }
+
+      .animation-progress {
+        animation-name: animation-keyframes;
+        animation-duration: 10s;
+        animation-iteration-count: infinite;
+        animation-direction: alternate;
+      }
+    </style>
   </head>
   <body>
     <!-- projectIDScript -->
-    <div id="preview"></div>
+    <div id="preview">
+      <!-- loading content-->
+      <div
+        style="
+          position: fixed;
+          left: 0px;
+          top: 0px;
+          bottom: 0px;
+          right: 0px;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+        "
+      >
+        <img
+          src="/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
+          height="128px"
+          alt="Utopia
+        Logo "
+        />
+
+        <div
+          class="progress-bar-shell"
+          style="
+            margin-top: 64px;
+            width: 212px;
+            height: 11px;
+            border: 1px solid black;
+            border-radius: 8px;
+            overflow: hidden;
+            box-sizing: border-box !important;
+          "
+        >
+          <div
+            class="progress-bar-progress animation-progress"
+            style="
+              background-color: black;
+              border-radius: 6px;
+              height: 9px;
+              transform: translateX(-212px);
+            "
+          />
+        </div>
+      </div>
+      <!-- ends loading content-->
+    </div>
     <div id="preview-ui"></div>
   </body>
 </html>


### PR DESCRIPTION
**Problem:**
The Canvas and Preview will both blindly evaluate code even if it depends on a remote dependency that hasn't been downloaded yet. This is because the package manager will return an empty object for the remote module placeholder.

**Fix:**
Throw an error specifically created for this case at the point of attempting to evaluate the placeholder file, then catch and handle that both in the Preview (in this case we add a div to the dom and include the message in that) and in the Canvas (using another error boundary specifically for catching and handling this error). In both cases the message is cleared when the dependency is downloaded (in the Preview this happens when `rerenderPreview` is called, which completely rewrites the document).

The styling of the message is far from ideal, but I wanted to open this PR up so that the approach could be commented on first.

This PR also adds the loading screen to the preview, and adds a preload tag for the logo to both the preview and the main editor.

**Screenshots:**

Canvas:
![Screenshot_20210824_101334](https://user-images.githubusercontent.com/1044774/130590630-6b0287a7-d77e-4c50-9360-85efbbab0f76.png)

Preview:
![Screenshot_20210824_101354](https://user-images.githubusercontent.com/1044774/130590646-98d85bcc-a956-429d-95b5-7fb7c75dbb87.png)

