### PR TITLE
redux devtools: sanitize spy metadata which was too large

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -82,6 +82,7 @@ import { getParseSuccessOrTransientForFilePath, getValidElementPaths } from './c
 import { NO_OP } from '../../core/shared/utils'
 import { useTwind } from '../../core/tailwind/tailwind'
 import { atomWithPubSub, usePubSubAtomReadOnly } from '../../core/shared/atom-with-pub-sub'
+import { reduxDevtoolsLogMessage } from '../../core/shared/redux-devtools'
 
 applyUIDMonkeyPatch()
 
@@ -264,6 +265,7 @@ function useClearSpyMetadataOnRemount(
 export const UiJsxCanvas = betterReactMemo(
   'UiJsxCanvas',
   React.forwardRef<HTMLDivElement, UiJsxCanvasPropsWithErrorCallback>((props, ref) => {
+    reduxDevtoolsLogMessage('Canvas Render')
     const {
       offset,
       scale,

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -82,7 +82,6 @@ import { getParseSuccessOrTransientForFilePath, getValidElementPaths } from './c
 import { NO_OP } from '../../core/shared/utils'
 import { useTwind } from '../../core/tailwind/tailwind'
 import { atomWithPubSub, usePubSubAtomReadOnly } from '../../core/shared/atom-with-pub-sub'
-import { reduxDevtoolsLogMessage } from '../../core/shared/redux-devtools'
 
 applyUIDMonkeyPatch()
 
@@ -265,7 +264,6 @@ function useClearSpyMetadataOnRemount(
 export const UiJsxCanvas = betterReactMemo(
   'UiJsxCanvas',
   React.forwardRef<HTMLDivElement, UiJsxCanvasPropsWithErrorCallback>((props, ref) => {
-    reduxDevtoolsLogMessage('Canvas Render')
     const {
       offset,
       scale,


### PR DESCRIPTION
Fixing Redux Devtools logging so it is usable again, should someone need it
