### PR TITLE
Expanded export support.

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -26225,6 +26225,358 @@ Object {
 }
 `;
 
+exports[`UiJsxCanvas render renders a canvas testing a multitude of export styles 1`] = `
+"<div style=\\"all: initial;\\">
+  <div
+    id=\\"canvas-container\\"
+    style=\\"position: absolute;\\"
+    data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+    data-utopia-root-element-path=\\"utopia-storyboard-uid\\"
+  >
+    <div
+      data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      style=\\"
+        position: absolute;
+        background-color: rgba(255, 255, 255, 1);
+        box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        height: 600px;
+        left: 0;
+        width: 600px;
+        top: 0;
+      \\"
+      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+    >
+      <div
+        data-uid=\\"app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity\\"
+      >
+        <div>Originally Unassigned</div>
+        <div>Originally Assigned</div>
+        <div>Named Function</div>
+        <div>Named Class</div>
+        <div>Named Export</div>
+        <div>Renamed Export</div>
+        <div>First In Structure</div>
+        <div>Second In Structure</div>
+        <div>The Number Is 4</div>
+        <div>Default Function</div>
+        <div>Default Named Function</div>
+        <div>Named As Default</div>
+      </div>
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`UiJsxCanvas render renders a canvas testing a multitude of export styles 2`] = `
+Object {
+  "utopia-storyboard-uid/scene-aaa": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "App",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "app-entity",
+                },
+              },
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "style",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": Object {
+                    "height": "100%",
+                    "position": "absolute",
+                    "width": "100%",
+                  },
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "app-entity",
+          },
+        ],
+        "name": Object {
+          "baseVariable": "Scene",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": Object {
+                "height": 600,
+                "left": 0,
+                "position": "absolute",
+                "top": 0,
+                "width": 600,
+              },
+            },
+          },
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "scene-aaa",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "scene-aaa",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "Scene",
+        "path": "utopia-api",
+        "variableName": "Scene",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
+      "skipDeepFreeze": true,
+      "style": Object {
+        "height": 600,
+        "left": 0,
+        "position": "absolute",
+        "top": 0,
+        "width": 600,
+      },
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "App",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "app-entity",
+            },
+          },
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "style",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": Object {
+                "height": "100%",
+                "position": "absolute",
+                "width": "100%",
+              },
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "app-entity",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "App",
+        "path": "/app",
+        "variableName": "App",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-uid": "app-entity",
+      "skipDeepFreeze": true,
+      "style": Object {
+        "height": "100%",
+        "position": "absolute",
+        "width": "100%",
+      },
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+}
+`;
+
 exports[`UiJsxCanvas render renders a component used in an arbitrary block correctly 1`] = `
 "<div style=\\"all: initial;\\">
   <div

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -26261,6 +26261,7 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
         <div>Second In Structure</div>
         <div>The Number Is 4</div>
         <div>Default Function</div>
+        <div>Export Default Class</div>
         <div>Default Named Function</div>
         <div>Named As Default</div>
       </div>

--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -285,4 +285,168 @@ export default function App(props) {
       "
     `)
   })
+  it(`#1737 - Parser is broken for 'export const thing = "hello"'`, () => {
+    const result = testCanvasRenderInlineMultifile(
+      null,
+      `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+import { App } from '/src/app'
+
+export var storyboard = (
+  <Storyboard data-uid='storyboard-entity'>
+    <Scene
+      data-label='Imported App'
+      data-uid='scene-1-entity'
+      style={{ position: 'absolute', left: 0, top: 0, width: 375, height: 812 }}
+    >
+      <App data-uid='app-entity' />
+    </Scene>
+  </Storyboard>
+)`,
+      {
+        '/src/app.js': `import * as React from 'react'
+import DefaultFunction, { Card, thing } from '/src/card.js'
+export var App = (props) => {
+  return (
+    <div
+      data-uid='app-outer-div'
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        backgroundColor: '#FFFFFF',
+      }}
+    >
+      <Card
+        data-uid='card-instance'
+        style={{
+          position: 'absolute',
+          left: 67,
+          top: 0,
+          width: 133,
+          height: 300,
+        }}
+      />
+      {thing}
+      <DefaultFunction />
+    </div>
+  )
+}`,
+        '/src/card.js': `import * as React from 'react'
+import { Rectangle } from 'utopia-api'
+export var Card = (props) => {
+  return (
+    <div
+      data-uid='card-outer-div'
+      style={{ ...props.style }}
+    >
+      <div
+        data-uid='card-inner-div'
+        style={{
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 50,
+          height: 50,
+          backgroundColor: 'red',
+        }}
+      />
+      <Rectangle
+        data-uid='card-inner-rectangle'
+        style={{
+          position: 'absolute',
+          left: 100,
+          top: 200,
+          width: 50,
+          height: 50,
+          backgroundColor: 'blue',
+        }}
+      />
+    </div>
+  )
+}
+
+export const thing = 'hello'
+
+export default function () {
+  return <div>Default Function Time</div>
+}`,
+      },
+    )
+    expect(result).toMatchInlineSnapshot(`
+      "<div style=\\"all: initial;\\">
+        <div
+          id=\\"canvas-container\\"
+          style=\\"position: absolute;\\"
+          data-utopia-valid-paths=\\"storyboard-entity storyboard-entity/scene-1-entity storyboard-entity/scene-1-entity/app-entity\\"
+          data-utopia-root-element-path=\\"storyboard-entity\\"
+        >
+          <div
+            data-utopia-scene-id=\\"storyboard-entity/scene-1-entity\\"
+            data-paths=\\"storyboard-entity/scene-1-entity storyboard-entity\\"
+            style=\\"
+              position: absolute;
+              background-color: rgba(255, 255, 255, 1);
+              box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              left: 0;
+              top: 0;
+              width: 375px;
+              height: 812px;
+            \\"
+            data-uid=\\"scene-1-entity storyboard-entity\\"
+            data-label=\\"Imported App\\"
+          >
+            <div
+              data-uid=\\"app-outer-div app-entity\\"
+              style=\\"
+                position: relative;
+                width: 100%;
+                height: 100%;
+                background-color: #ffffff;
+              \\"
+              data-paths=\\"storyboard-entity/scene-1-entity/app-entity\\"
+            >
+              <div
+                data-uid=\\"card-outer-div card-instance\\"
+                style=\\"
+                  position: absolute;
+                  left: 67px;
+                  top: 0;
+                  width: 133px;
+                  height: 300px;
+                \\"
+              >
+                <div
+                  data-uid=\\"card-inner-div\\"
+                  style=\\"
+                    position: absolute;
+                    left: 0;
+                    top: 0;
+                    width: 50px;
+                    height: 50px;
+                    background-color: red;
+                  \\"
+                ></div>
+                <div
+                  style=\\"
+                    position: absolute;
+                    left: 100px;
+                    top: 200px;
+                    width: 50px;
+                    height: 50px;
+                    background-color: blue;
+                  \\"
+                  data-uid=\\"card-inner-rectangle\\"
+                  data-utopia-do-not-traverse=\\"true\\"
+                ></div>
+              </div>
+              hello
+              <div>Default Function Time</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      "
+    `)
+  })
 })

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -41,8 +41,9 @@ export type ComponentRendererComponent = React.ComponentType<{
   [UTOPIA_INSTANCE_PATH]: ElementPath
   [UTOPIA_PATHS_KEY]?: string
 }> & {
-  topLevelElementName: string
+  topLevelElementName: string | null
   propertyControls?: PropertyControls
+  utopiaType: 'UTOPIA_COMPONENT_RENDERER_COMPONENT'
 }
 
 export function isComponentRendererComponent(
@@ -51,12 +52,11 @@ export function isComponentRendererComponent(
   return (
     component != null &&
     typeof component === 'function' &&
-    (component as ComponentRendererComponent).topLevelElementName != null
+    (component as ComponentRendererComponent).utopiaType === 'UTOPIA_COMPONENT_RENDERER_COMPONENT'
   )
 }
 
 function tryToGetInstancePath(
-  topLevelElementName: string,
   maybePath: ElementPath | null,
   pathsString: string | null,
 ): ElementPath | null {
@@ -71,7 +71,7 @@ function tryToGetInstancePath(
 }
 
 export function createComponentRendererComponent(params: {
-  topLevelElementName: string
+  topLevelElementName: string | null
   filePath: string
   mutableContextRef: React.MutableRefObject<MutableUtopiaCtxRefData>
 }): ComponentRendererComponent {
@@ -126,11 +126,7 @@ export function createComponentRendererComponent(params: {
 
     let codeError: Error | null = null
 
-    const instancePath: ElementPath | null = tryToGetInstancePath(
-      params.topLevelElementName,
-      instancePathAny,
-      pathsString,
-    )
+    const instancePath: ElementPath | null = tryToGetInstancePath(instancePathAny, pathsString)
 
     const rootElementPath = optionalMap(
       (path) => EP.appendNewElementPath(path, getUtopiaID(utopiaJsxComponent.rootElement)),
@@ -214,5 +210,6 @@ export function createComponentRendererComponent(params: {
   }
   Component.displayName = `ComponentRenderer(${params.topLevelElementName})`
   Component.topLevelElementName = params.topLevelElementName
+  Component.utopiaType = 'UTOPIA_COMPONENT_RENDERER_COMPONENT' as const
   return Component
 }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.tsx
@@ -63,7 +63,7 @@ export function createExecutionScope(
   shouldIncludeCanvasRootInTheSpy: boolean,
 ): {
   scope: MapLike<any>
-  topLevelJsxComponents: Map<string, UtopiaJSXComponent>
+  topLevelJsxComponents: Map<string | null, UtopiaJSXComponent>
   requireResult: MapLike<any>
 } {
   if (!(filePath in topLevelComponentRendererComponents.current)) {
@@ -106,16 +106,15 @@ export function createExecutionScope(
   }
   // TODO All of this is run on every interaction o_O
 
-  let topLevelJsxComponents: Map<string, UtopiaJSXComponent> = new Map()
+  let topLevelJsxComponents: Map<string | null, UtopiaJSXComponent> = new Map()
 
   // Make sure there is something in scope for all of the top level components
   fastForEach(topLevelElements, (topLevelElement) => {
     if (isUtopiaJSXComponent(topLevelElement)) {
       topLevelJsxComponents.set(topLevelElement.name, topLevelElement)
-      if (!(topLevelElement.name in topLevelComponentRendererComponentsForFile)) {
-        topLevelComponentRendererComponentsForFile[
-          topLevelElement.name
-        ] = createComponentRendererComponent({
+      const elementName = topLevelElement.name ?? 'default'
+      if (!(elementName in topLevelComponentRendererComponentsForFile)) {
+        topLevelComponentRendererComponentsForFile[elementName] = createComponentRendererComponent({
           topLevelElementName: topLevelElement.name,
           mutableContextRef: mutableContextRef,
           filePath: filePath,
@@ -159,7 +158,6 @@ export function createExecutionScope(
 
     runBlockUpdatingScope(requireResult, combinedTopLevelArbitraryBlock, executionScope)
   }
-
   // WARNING: mutating the mutableContextRef
   updateMutableUtopiaCtxRefWithNewProps(mutableContextRef, {
     ...mutableContextRef.current,

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -41,6 +41,7 @@ import { NamedExport, RenamedExport } from '/namedexport'
 import { FirstInStructure, SecondInStructure } from '/destructuredassignment'
 import DefaultExpression from '/defaultexpression'
 import DefaultFunction from '/defaultfunction'
+import DefaultClass from '/defaultclass'
 import DefaultNamedFunction from '/defaultnamedfunction'
 import NamedAsDefault from '/namedasdefault'
 
@@ -57,6 +58,7 @@ export var App = (props) => {
       <SecondInStructure />
       <div>The Number Is {DefaultExpression}</div>
       <DefaultFunction />
+      <DefaultClass />
       <DefaultNamedFunction />
       <NamedAsDefault />
     </div>
@@ -82,6 +84,8 @@ const toDestructure = { FirstInStructure: () => <div>First In Structure</div>, S
 export default 2 + 2`,
         '/defaultfunction.js': `import * as React from 'react'
 export default function() { return <div>Default Function</div> }`,
+        '/defaultclass.js': `import * as React from 'react'
+export default class DefaultClass extends React.Component { render() { return <div>Export Default Class</div> } }`,
         '/defaultnamedfunction.js': `import * as React from 'react'
 export default function DefaultNamedFunction() { return <div>Default Named Function</div> }`,
         '/namedasdefault.js': `import * as React from 'react'

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -9,6 +9,88 @@ import {
 import { TestAppUID, TestSceneUID } from './ui-jsx.test-utils'
 
 describe('UiJsxCanvas render', () => {
+  it('renders a canvas testing a multitude of export styles', () => {
+    testCanvasRenderMultifile(
+      null,
+      `
+      import { Storyboard, Scene } from 'utopia-api'
+      import { App } from '/app'
+      export var ${BakedInStoryboardVariableName} = (props) => {
+        return (
+          <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+            <Scene
+              style={{ position: 'absolute', height: 600, left: 0, width: 600, top: 0 }}
+              data-uid={'${TestSceneUID}'}
+            >
+              <App
+                data-uid='${TestAppUID}'
+                style={{ position: 'absolute', height: '100%', width: '100%' }}
+              />
+            </Scene>
+          </Storyboard>
+        )
+      }
+      `,
+      {
+        '/app.js': `import * as React from 'react'
+import { OriginallyUnassigned1 } from '/originallyunassigned'
+import { OriginallyAssigned1 } from '/originallyassigned'
+import { NamedFunction } from '/namedfunction'
+import { NamedClass } from '/namedclass'
+import { NamedExport, RenamedExport } from '/namedexport'
+import { FirstInStructure, SecondInStructure } from '/destructuredassignment'
+import DefaultExpression from '/defaultexpression'
+import DefaultFunction from '/defaultfunction'
+import DefaultNamedFunction from '/defaultnamedfunction'
+import NamedAsDefault from '/namedasdefault'
+
+export var App = (props) => {
+  return (
+    <div>
+      <OriginallyUnassigned1 />
+      <OriginallyAssigned1 />
+      <NamedFunction />
+      <NamedClass />
+      <NamedExport />
+      <RenamedExport />
+      <FirstInStructure />
+      <SecondInStructure />
+      <div>The Number Is {DefaultExpression}</div>
+      <DefaultFunction />
+      <DefaultNamedFunction />
+      <NamedAsDefault />
+    </div>
+  )
+}`,
+        '/originallyunassigned.js': `import * as React from 'react'
+export let OriginallyUnassigned1
+OriginallyUnassigned1 = () => <div>Originally Unassigned</div>`,
+        '/originallyassigned.js': `import * as React from 'react'
+export let OriginallyAssigned1 = () => <div>Originally Assigned</div>`,
+        '/namedfunction.js': `import * as React from 'react'
+export function NamedFunction() { return <div>Named Function</div> }`,
+        '/namedclass.js': `import * as React from 'react'
+export class NamedClass extends React.Component { render() { return <div>Named Class</div> } }`,
+        '/namedexport.js': `import * as React from 'react'
+const NamedExport = () => <div>Named Export</div>
+const ToBeRenamedExport = () => <div>Renamed Export</div>
+export { NamedExport, ToBeRenamedExport as RenamedExport }`,
+        '/destructuredassignment.js': `import * as React from 'react'
+const toDestructure = { FirstInStructure: () => <div>First In Structure</div>, SceodnInStructure: () => <div>Second In Structure</div> }
+        export const { FirstInStructure, SceodnInStructure: SecondInStructure } = toDestructure`,
+        '/defaultexpression.js': `import * as React from 'react'
+export default 2 + 2`,
+        '/defaultfunction.js': `import * as React from 'react'
+export default function() { return <div>Default Function</div> }`,
+        '/defaultnamedfunction.js': `import * as React from 'react'
+export default function DefaultNamedFunction() { return <div>Default Named Function</div> }`,
+        '/namedasdefault.js': `import * as React from 'react'
+const ToBeDefaultExported = () => <div>Named As Default</div>
+export { ToBeDefaultExported as default }`,
+      },
+    )
+  })
+
   it('renders a canvas reliant on another file that uses module.exports', () => {
     testCanvasRenderMultifile(
       null,

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -16,6 +16,10 @@ import {
   ElementPath,
   isParseSuccess,
   isTextFile,
+  isExportDefaultNamed,
+  isExportDefaultModifier,
+  isExportDefaultFunction,
+  isExportDefaultExpression,
 } from '../../core/shared/project-file-types'
 import {
   Either,
@@ -365,8 +369,19 @@ export const UiJsxCanvas = betterReactMemo(
                 for (const s of Object.keys(scope)) {
                   if (s in exportsDetail.namedExports) {
                     filteredScope[s] = scope[s]
-                  } else if (s === exportsDetail.defaultExport?.name) {
-                    filteredScope['default'] = scope[s]
+                  } else if (exportsDetail.defaultExport != null) {
+                    if (
+                      (isExportDefaultNamed(exportsDetail.defaultExport) ||
+                        isExportDefaultModifier(exportsDetail.defaultExport)) &&
+                      s === exportsDetail.defaultExport.name
+                    ) {
+                      filteredScope['default'] = scope[s]
+                    } else if (
+                      isExportDefaultFunction(exportsDetail.defaultExport) ||
+                      isExportDefaultExpression(exportsDetail.defaultExport)
+                    ) {
+                      filteredScope['default'] = scope['default']
+                    }
                   }
                 }
                 return right(filteredScope)
@@ -496,7 +511,7 @@ export const UiJsxCanvas = betterReactMemo(
 
 function useGetStoryboardRoot(
   focusedElementPath: ElementPath | null,
-  topLevelElementsMap: Map<string, UtopiaJSXComponent>,
+  topLevelElementsMap: Map<string | null, UtopiaJSXComponent>,
   executionScope: MapLike<any>,
   projectContents: ProjectContentTreeRoot,
   uiFilePath: string,

--- a/editor/src/components/editor/import-utils.ts
+++ b/editor/src/components/editor/import-utils.ts
@@ -73,3 +73,18 @@ export function importedFromWhere(
   }
   return null
 }
+
+export function getTopLevelName(
+  fromWhere: ImportedFromWhereResult,
+  originalTopLevelName: string | null,
+): string | null {
+  switch (fromWhere.type) {
+    case 'IMPORTED_ORIGIN':
+      return fromWhere.exportedName
+    case 'SAME_FILE_ORIGIN':
+      return originalTopLevelName
+    default:
+      const _exhaustiveCheck: never = fromWhere
+      throw new Error(`Unhandled type ${JSON.stringify(fromWhere)}`)
+  }
+}

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -325,7 +325,7 @@ export function applyUtopiaJSXComponentsChanges(
   // newly updated result with the same name.
   // If it doesn't exist in the updated result, delete it.
   // For any new items in the updated result, add them in.
-  const addedSoFar: Set<string> = emptySet()
+  const addedSoFar: Set<string | null> = emptySet()
   let newTopLevelElements: Array<TopLevelElement> = []
   fastForEach(topLevelElements, (oldTopLevelElement) => {
     if (isUtopiaJSXComponent(oldTopLevelElement)) {

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -31,6 +31,8 @@ import {
   ExportDetail,
   forEachParseSuccess,
   importAlias,
+  isExportDefaultModifier,
+  isExportDefaultNamed,
   isParsedTextFile,
   isParseSuccess,
   isTextFile,
@@ -192,13 +194,15 @@ export function addStoryboardFileToProject(editorModel: EditorModel): EditorMode
               // Exported as the default, so exclude it.
               if (
                 success.exportsDetail.defaultExport != null &&
+                (isExportDefaultNamed(success.exportsDetail.defaultExport) ||
+                  isExportDefaultModifier(success.exportsDetail.defaultExport)) &&
                 success.exportsDetail.defaultExport.name === topLevelElement.name
               ) {
                 continue
               }
 
               // Exported by name, so exclude it.
-              if (namedExportKeys.includes(topLevelElement.name)) {
+              if (topLevelElement.name == null || namedExportKeys.includes(topLevelElement.name)) {
                 continue
               }
 

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1065,7 +1065,7 @@ export function jsxElementWithoutUID(
 }
 
 export function utopiaJSXComponent(
-  name: string,
+  name: string | null,
   isFunction: boolean,
   declarationSyntax: FunctionDeclarationSyntax,
   blockOrExpression: BlockOrExpression,
@@ -1267,7 +1267,7 @@ export type BlockOrExpression = 'block' | 'parenthesized-expression' | 'expressi
 
 export interface UtopiaJSXComponent {
   type: 'UTOPIA_JSX_COMPONENT'
-  name: string
+  name: string | null
   /**
    * isFunction is true if we are talking about a Function Component
    * isFunction false means that this is an exported Element with no props

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -1,6 +1,12 @@
 import * as TS from 'typescript'
 import { NormalisedFrame } from 'utopia-api'
-import { ArbitraryJSBlock, ImportStatement, TopLevelElement } from './element-template'
+import {
+  ArbitraryJSBlock,
+  ImportStatement,
+  JSXAttribute,
+  JSXAttributeOtherJavaScript,
+  TopLevelElement,
+} from './element-template'
 import { ErrorMessage } from './error-messages'
 import { arrayEquals, objectEquals } from './utils'
 
@@ -189,8 +195,32 @@ export function exportDefaultModifier(name: string): ExportDefaultModifier {
   }
 }
 
+export interface ExportDefaultExpression {
+  type: 'EXPORT_DEFAULT_EXPRESSION'
+}
+
+export function exportDefaultExpression(): ExportDefaultExpression {
+  return {
+    type: 'EXPORT_DEFAULT_EXPRESSION',
+  }
+}
+
+export interface ExportDefaultFunction {
+  type: 'EXPORT_DEFAULT_FUNCTION'
+}
+
+export function exportDefaultFunction(): ExportDefaultFunction {
+  return {
+    type: 'EXPORT_DEFAULT_FUNCTION',
+  }
+}
+
 export type ExportDetail = ExportDetailNamed | ExportDetailModifier
-export type ExportDefault = ExportDefaultNamed | ExportDefaultModifier
+export type ExportDefault =
+  | ExportDefaultNamed
+  | ExportDefaultModifier
+  | ExportDefaultExpression
+  | ExportDefaultFunction
 
 export function isExportDetailNamed(detail: ExportDetail): detail is ExportDetailNamed {
   return detail.type === 'EXPORT_DETAIL_NAMED'
@@ -206,6 +236,18 @@ export function isExportDefaultNamed(detail: ExportDefault): detail is ExportDef
 
 export function isExportDefaultModifier(detail: ExportDefault): detail is ExportDefaultModifier {
   return detail.type === 'EXPORT_DEFAULT_MODIFIER'
+}
+
+export function isExportDefaultExpression(
+  detail: ExportDefault | null | undefined,
+): detail is ExportDefaultExpression {
+  return detail?.type === 'EXPORT_DEFAULT_EXPRESSION'
+}
+
+export function isExportDefaultFunction(
+  detail: ExportDefault | null | undefined,
+): detail is ExportDefaultFunction {
+  return detail?.type === 'EXPORT_DEFAULT_FUNCTION'
 }
 
 export interface ExportsDetail {
@@ -273,6 +315,20 @@ export function setModifierDefaultExportInDetail(
 ): ExportsDetail {
   return {
     defaultExport: exportDefaultModifier(name),
+    namedExports: detail.namedExports,
+  }
+}
+
+export function setExpressionDefaultExportInDetail(detail: ExportsDetail): ExportsDetail {
+  return {
+    defaultExport: exportDefaultExpression(),
+    namedExports: detail.namedExports,
+  }
+}
+
+export function setFunctionDefaultExportInDetail(detail: ExportsDetail): ExportsDetail {
+  return {
+    defaultExport: exportDefaultFunction(),
     namedExports: detail.namedExports,
   }
 }

--- a/editor/src/core/shared/set-utils.ts
+++ b/editor/src/core/shared/set-utils.ts
@@ -1,5 +1,5 @@
 // Should allow us to guard against a type being refactored into something
 // which Set allows but gives us nonsense results.
-export function emptySet<T extends string | boolean | number>(): Set<T> {
+export function emptySet<T extends string | boolean | number | null | undefined>(): Set<T> {
   return new Set()
 }

--- a/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
@@ -282,7 +282,8 @@ export default function () {
       <div>Default Function Time</div>
     </div>
   )
-}`
+}
+`
 
     testParseThenPrintWithoutUids(spreadCode, spreadCode)
   })

--- a/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
@@ -273,6 +273,19 @@ export var ${BakedInStoryboardVariableName} = <Storyboard />
 
     testParseThenPrintWithoutUids(spreadCode, spreadCode)
   })
+
+  it('#1737 - Produces the same value for an exported default function', () => {
+    const spreadCode = `import * as React from 'react'
+export default function () {
+  return (
+    <div>
+      <div>Default Function Time</div>
+    </div>
+  )
+}`
+
+    testParseThenPrintWithoutUids(spreadCode, spreadCode)
+  })
 })
 
 describe('Imports', () => {

--- a/editor/src/core/workers/parser-printer/parser-printer-exports.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-exports.spec.tsx
@@ -2,6 +2,7 @@ import { clearParseResultUniqueIDsAndEmptyBlocks, testParseCode } from './parser
 import Utils from '../../../utils/utils'
 import { applyPrettier } from 'utopia-vscode-common'
 import { testPrintParsedTextFile } from '../../../components/canvas/ui-jsx.test-utils'
+import { isParseSuccess } from '../../shared/project-file-types'
 
 describe('parseCode', () => {
   it('should parse a directly exported component', () => {
@@ -54,31 +55,347 @@ describe('parseCode', () => {
       }
     `)
   })
-  it('should parse a component exported handled with an external export clause, with a different name', () => {
-    const code = applyPrettier(
-      `
-    var whatever = (props) => {
-      return <div data-uid='aaa' />
-    }
-    
-    export { whatever as otherThing }
-`,
-      false,
-    ).formatted
+
+  it(`parses an exported default expression`, () => {
+    const code = `export default 2 + 2`
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
-    expect(testPrintParsedTextFile(actualResult)).toEqual(code)
-    const exports = Utils.path(['exportsDetail'], actualResult)
-    expect(exports).toMatchInlineSnapshot(`
-      Object {
-        "defaultExport": null,
-        "namedExports": Object {
-          "otherThing": Object {
-            "moduleName": undefined,
-            "name": "whatever",
-            "type": "EXPORT_DETAIL_NAMED",
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": Object {
+            "type": "EXPORT_DEFAULT_EXPRESSION",
           },
-        },
-      }
-    `)
+          "namedExports": Object {},
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+
+  it(`parses a destructured assignment with renaming`, () => {
+    const code = `const entireValue = { name: 'Sean', surname: 'Parsons' }
+export const { name: firstName, surname } = entireValue`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": null,
+          "namedExports": Object {
+            "name": Object {
+              "moduleName": undefined,
+              "name": "firstName",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+            "surname": Object {
+              "moduleName": undefined,
+              "name": "surname",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+          },
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+
+  it(`parses an export object`, () => {
+    const code = `const thing1 = 1
+const thing2 = 2
+export { thing1, thing2 }`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": null,
+          "namedExports": Object {
+            "thing1": Object {
+              "moduleName": undefined,
+              "name": "thing1",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+            "thing2": Object {
+              "moduleName": undefined,
+              "name": "thing2",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+          },
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+
+  it(`parses an export object with renamed fields`, () => {
+    const code = `const thing1 = 1
+const thing2 = 2
+export { thing1 as importantThing1, thing2 as importantThing2 }`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": null,
+          "namedExports": Object {
+            "importantThing1": Object {
+              "moduleName": undefined,
+              "name": "thing1",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+            "importantThing2": Object {
+              "moduleName": undefined,
+              "name": "thing2",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+          },
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+
+  it(`parses an export object with renamed fields, where one is specified as 'default'`, () => {
+    const code = `const thing1 = 1
+const thing2 = 2
+export { thing1 as default, thing2 as importantThing2 }`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": Object {
+            "name": "thing1",
+            "type": "EXPORT_DEFAULT_NAMED",
+          },
+          "namedExports": Object {
+            "importantThing2": Object {
+              "moduleName": undefined,
+              "name": "thing2",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+          },
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+
+  it(`parses unassigned variable names`, () => {
+    const code = `import * as React from "react";
+export var exportedVar1, exportedVar2;
+export let exportedLet1, exportedLet2;
+`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": null,
+          "namedExports": Object {
+            "exportedLet1": Object {
+              "moduleName": undefined,
+              "name": "exportedLet1",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+            "exportedLet2": Object {
+              "moduleName": undefined,
+              "name": "exportedLet2",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+            "exportedVar1": Object {
+              "moduleName": undefined,
+              "name": "exportedVar1",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+            "exportedVar2": Object {
+              "moduleName": undefined,
+              "name": "exportedVar2",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+          },
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+
+  it(`parses assigned variable names`, () => {
+    const code = `import * as React from "react";
+export var exportedVar1 = 'var1', exportedVar2 = 'var2';
+export let exportedLet1 = 'let1', exportedLet2 = 'let2';
+export const exportedConst1 = 'const1', exportedConst2 = 'const2';
+`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": null,
+          "namedExports": Object {
+            "exportedConst1": Object {
+              "moduleName": undefined,
+              "name": "exportedConst1",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+            "exportedConst2": Object {
+              "moduleName": undefined,
+              "name": "exportedConst2",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+            "exportedLet1": Object {
+              "moduleName": undefined,
+              "name": "exportedLet1",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+            "exportedLet2": Object {
+              "moduleName": undefined,
+              "name": "exportedLet2",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+            "exportedVar1": Object {
+              "moduleName": undefined,
+              "name": "exportedVar1",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+            "exportedVar2": Object {
+              "moduleName": undefined,
+              "name": "exportedVar2",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+          },
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+
+  it(`parses 'export function' marked values`, () => {
+    const code = `import * as React from "react";
+export function App() {
+  return <div />
+}
+`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": null,
+          "namedExports": Object {
+            "App": Object {
+              "type": "EXPORT_DETAIL_MODIFIER",
+            },
+          },
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+
+  it(`parses 'export function' marked values`, () => {
+    const code = `import * as React from "react";
+export function App() {
+  return <div />
+}
+`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": null,
+          "namedExports": Object {
+            "App": Object {
+              "type": "EXPORT_DETAIL_MODIFIER",
+            },
+          },
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+
+  it(`parses 'export class' marked values`, () => {
+    const code = `import * as React from "react";
+export class App {}
+`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": null,
+          "namedExports": Object {
+            "App": Object {
+              "moduleName": undefined,
+              "name": "App",
+              "type": "EXPORT_DETAIL_NAMED",
+            },
+          },
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+
+  it(`parses 'export default function'`, () => {
+    const code = `import * as React from "react";
+export default function() { return 5 }
+`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": Object {
+            "type": "EXPORT_DEFAULT_FUNCTION",
+          },
+          "namedExports": Object {},
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+
+  it(`parses 'export default function <functionname>'`, () => {
+    const code = `import * as React from "react";
+export default function addFive() { return 5 }
+`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": Object {
+            "name": "addFive",
+            "type": "EXPORT_DEFAULT_MODIFIER",
+          },
+          "namedExports": Object {},
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
+  })
+
+  it(`parses 'export default class' marked components`, () => {
+    const code = `import * as React from "react";
+export default class App {}
+`
+    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+    if (isParseSuccess(actualResult)) {
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+        Object {
+          "defaultExport": Object {
+            "name": "App",
+            "type": "EXPORT_DEFAULT_MODIFIER",
+          },
+          "namedExports": Object {},
+        }
+      `)
+    } else {
+      fail('Did not parse successfully.')
+    }
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -433,7 +433,7 @@ function turnCodeSnippetIntoSourceMapNodes(
         currentStringBuffer === 'function' &&
         FunctionStart.test(sourceCode.substr(i))
       ) {
-        currentStringBuffer = 'function defaultFunctionName'
+        currentStringBuffer = 'function utopia_defaultFunctionName'
       }
       const node = new SourceNode(
         bufferStartLine + 1,

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -42,6 +42,7 @@ import {
   setNamedDefaultExportInDetail,
   addModifierExportToDetail,
   setModifierDefaultExportInDetail,
+  setExpressionDefaultExportInDetail,
 } from '../../shared/project-file-types'
 import {
   lintAndParse,
@@ -72,47 +73,6 @@ import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from './parser-printer-utils'
 import { emptySet } from '../../shared/set-utils'
 
 describe('JSX parser', () => {
-  it(`parses 'export class' marked components`, () => {
-    const code = `import * as React from "react";
-export class App {}
-`
-    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
-    if (isParseSuccess(actualResult)) {
-      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": null,
-          "namedExports": Object {
-            "App": Object {
-              "moduleName": undefined,
-              "name": "App",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-          },
-        }
-      `)
-    } else {
-      fail('Did not parse successfully.')
-    }
-  })
-  it(`parses 'export default class' marked components`, () => {
-    const code = `import * as React from "react";
-export default class App {}
-`
-    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
-    if (isParseSuccess(actualResult)) {
-      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": Object {
-            "name": "App",
-            "type": "EXPORT_DEFAULT_MODIFIER",
-          },
-          "namedExports": Object {},
-        }
-      `)
-    } else {
-      fail('Did not parse successfully.')
-    }
-  })
   it('parses the code when it is a var', () => {
     const code = `import * as React from "react";
 import {
@@ -1347,7 +1307,7 @@ return {  };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      setExpressionDefaultExportInDetail(addModifierExportToDetail(EmptyExportsDetail, 'whatever')),
     )
     expect(actualResult).toEqual(expectedResult)
   })

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -47,7 +47,6 @@ import {
   UtopiaJSXComponent,
   utopiaJSXComponent,
   defaultPropsParam,
-  clearArbitraryJSBlockUniqueIDs,
   SingleLineComment,
   MultiLineComment,
   Comment,
@@ -91,7 +90,6 @@ import { addUniquely, flatMapArray } from '../../shared/array-utils'
 import { optionalMap } from '../../shared/optional-utils'
 import { getUtopiaID } from '../../model/element-template-utils'
 import { emptyComments, parsedComments, ParsedComments } from './parser-printer-comments'
-import { node } from 'prop-types'
 import { emptySet } from '../../shared/set-utils'
 
 export const singleLineCommentArbitrary: Arbitrary<SingleLineComment> = lowercaseStringArbitrary().map(
@@ -864,7 +862,11 @@ export function printableProjectContentArbitrary(): Arbitrary<PrintableProjectCo
         if (topLevelElement.isFunction) {
           return []
         } else {
-          return [topLevelElement.name]
+          if (topLevelElement.name == null) {
+            return []
+          } else {
+            return [topLevelElement.name]
+          }
         }
       } else {
         return []

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -90,6 +90,8 @@ import {
   isExportDetailModifier,
   isExportDefaultNamed,
   TextFile,
+  setExpressionDefaultExportInDetail,
+  setFunctionDefaultExportInDetail,
 } from '../../shared/project-file-types'
 import * as PP from '../../shared/property-path'
 import { fastForEach, NO_OP } from '../../shared/utils'
@@ -109,9 +111,11 @@ import {
   parseAttributeOtherJavaScript,
   withParserMetadata,
   isExported,
-  isDefaultExport,
   expressionTypeForExpression,
   extractPrefixedCode,
+  parseAttributeExpression,
+  markedAsExported,
+  markedAsDefault,
 } from './parser-printer-parsing'
 import { getBoundsOfNodes, guaranteeUniqueUidsFromTopLevel } from './parser-printer-utils'
 import { ParseOrPrint, ParseOrPrintResult, ParsePrintResultMessage } from './parser-printer-worker'
@@ -530,9 +534,13 @@ function getModifersForComponent(
     isExportedAsDefault = true
     isExportedDirectly = true
   } else {
-    const componentExport = detailOfExports.namedExports[element.name]
-    if (componentExport != null && isExportDetailModifier(componentExport)) {
+    if (element.name == null) {
       isExportedDirectly = true
+    } else {
+      const componentExport = detailOfExports.namedExports[element.name]
+      if (componentExport != null && isExportDetailModifier(componentExport)) {
+        isExportedDirectly = true
+      }
     }
   }
 
@@ -596,7 +604,7 @@ function printUtopiaJSXComponent(
           undefined,
           modifiers,
           undefined,
-          element.name,
+          element.name ?? undefined,
           undefined,
           functionParams,
           undefined,
@@ -611,14 +619,22 @@ function printUtopiaJSXComponent(
           undefined,
           bodyForArrowFunction(),
         )
-        const varDec = TS.createVariableDeclaration(element.name, undefined, arrowFunction)
+        if (element.name == null) {
+          elementNode = TS.createExportAssignment(undefined, modifiers, undefined, arrowFunction)
+        } else {
+          const varDec = TS.createVariableDeclaration(element.name, undefined, arrowFunction)
+          const varDecList = TS.createVariableDeclarationList([varDec], nodeFlags)
+          elementNode = TS.createVariableStatement(modifiers, varDecList)
+        }
+      }
+    } else {
+      if (element.name == null) {
+        elementNode = TS.createExportAssignment(undefined, modifiers, undefined, asJSX)
+      } else {
+        const varDec = TS.createVariableDeclaration(element.name, undefined, asJSX)
         const varDecList = TS.createVariableDeclarationList([varDec], nodeFlags)
         elementNode = TS.createVariableStatement(modifiers, varDecList)
       }
-    } else {
-      const varDec = TS.createVariableDeclaration(element.name, undefined, asJSX)
-      const varDecList = TS.createVariableDeclarationList([varDec], nodeFlags)
-      elementNode = TS.createVariableStatement(modifiers, varDecList)
     }
 
     return elementNode
@@ -867,14 +883,14 @@ function possibleCanvasContentsExpression(
 
 interface PossibleCanvasContentsFunction {
   type: 'POSSIBLE_CANVAS_CONTENTS_FUNCTION'
-  name: string
+  name: string | null
   parameters: TS.NodeArray<TS.ParameterDeclaration>
   body: TS.ConciseBody
   declarationSyntax: FunctionDeclarationSyntax
 }
 
 function possibleCanvasContentsFunction(
-  name: string,
+  name: string | null,
   parameters: TS.NodeArray<TS.ParameterDeclaration>,
   body: TS.ConciseBody,
   declarationSyntax: FunctionDeclarationSyntax,
@@ -951,8 +967,8 @@ export function looksLikeCanvasElements(
       }
     }
   } else if (TS.isFunctionDeclaration(node)) {
-    if (node.name != null && node.body != null) {
-      const name = node.name.getText(sourceFile)
+    if (node.body != null) {
+      const name = node.name == null ? null : node.name.getText(sourceFile)
       return right(possibleCanvasContentsFunction(name, node.parameters, node.body, 'function'))
     }
   }
@@ -1001,15 +1017,23 @@ function detailsFromExportDeclaration(
     const result = exportClause.elements.reduce((workingResult, specifier) => {
       const specifierName = specifier.name.getText(sourceFile)
       if (specifier.propertyName == null) {
-        return addNamedExportToDetail(workingResult, specifierName, specifierName, moduleName)
+        if (specifierName === 'default') {
+          return setNamedDefaultExportInDetail(workingResult, specifierName)
+        } else {
+          return addNamedExportToDetail(workingResult, specifierName, specifierName, moduleName)
+        }
       } else {
         const specifierPropertyName = specifier.propertyName.getText(sourceFile)
-        return addNamedExportToDetail(
-          workingResult,
-          specifierName,
-          specifierPropertyName,
-          moduleName,
-        )
+        if (specifierName === 'default') {
+          return setNamedDefaultExportInDetail(workingResult, specifierPropertyName)
+        } else {
+          return addNamedExportToDetail(
+            workingResult,
+            specifierName,
+            specifierPropertyName,
+            moduleName,
+          )
+        }
       }
     }, exportsDetail(null, {}))
     return right(result)
@@ -1021,7 +1045,7 @@ function detailsFromExportDeclaration(
 export function getComponentsRenderedWithReactDOM(
   sourceFile: TS.SourceFile,
   node: TS.Node,
-): Array<string> {
+): Array<string | null> {
   if (TS.isExpressionStatement(node)) {
     const expressionStatement: TS.ExpressionStatement = node
     if (TS.isCallExpression(expressionStatement.expression)) {
@@ -1187,6 +1211,22 @@ export function parseCode(
         })
         // Unable to parse it so treat it as an arbitrary node.
         forEachLeft(fromAssignment, (exportDeclaration) => {
+          // Check for an exported default expression.
+          const possibleExpression = parseAttributeExpression(
+            sourceFile,
+            sourceText,
+            filename,
+            imports,
+            topLevelNames,
+            null,
+            topLevelElement.expression,
+            highlightBounds,
+            alreadyExistingUIDs_MUTABLE,
+            [],
+          )
+          forEachRight(possibleExpression, () => {
+            detailOfExports = setExpressionDefaultExportInDetail(detailOfExports)
+          })
           pushArbitraryNode(exportDeclaration)
         })
       } else if (TS.isExportDeclaration(topLevelElement)) {
@@ -1201,18 +1241,11 @@ export function parseCode(
         forEachLeft(fromDeclaration, (exportDeclaration) => {
           pushArbitraryNode(exportDeclaration)
         })
-      } else if (
-        TS.isClassDeclaration(topLevelElement) &&
-        topLevelElement.modifiers != null &&
-        topLevelElement.modifiers.some((modifier) => modifier.kind === TS.SyntaxKind.ExportKeyword)
-      ) {
+      } else if (TS.isClassDeclaration(topLevelElement) && markedAsExported(topLevelElement)) {
         // Handle classes.
-        // Check if this is the 'default' export, which is to say the entire export for the file.
-        if (
-          topLevelElement.modifiers.some(
-            (modifier) => modifier.kind === TS.SyntaxKind.DefaultKeyword,
-          )
-        ) {
+        // Check if this is the 'default' export, which is to say what the caller will get if not
+        // specifying a particular value from the module.
+        if (markedAsDefault(topLevelElement)) {
           if (topLevelElement.name != null) {
             detailOfExports = setModifierDefaultExportInDetail(
               detailOfExports,
@@ -1358,11 +1391,15 @@ export function parseCode(
           if (isLeft(parsedContents) || (isFunction && isLeft(parsedFunctionParam))) {
             pushArbitraryNode(topLevelElement)
             if (isExported(topLevelElement)) {
-              const defaultExport = isDefaultExport(topLevelElement)
-              if (defaultExport) {
-                detailOfExports = setModifierDefaultExportInDetail(detailOfExports, name)
+              if (name == null) {
+                detailOfExports = setFunctionDefaultExportInDetail(detailOfExports)
               } else {
-                detailOfExports = addModifierExportToDetail(detailOfExports, name)
+                const defaultExport = markedAsDefault(topLevelElement)
+                if (defaultExport) {
+                  detailOfExports = setModifierDefaultExportInDetail(detailOfExports, name)
+                } else {
+                  detailOfExports = addModifierExportToDetail(detailOfExports, name)
+                }
               }
             }
           } else {
@@ -1394,12 +1431,20 @@ export function parseCode(
                 contents.returnStatementComments,
               )
 
-              const defaultExport = isDefaultExport(topLevelElement)
+              const defaultExport = markedAsDefault(topLevelElement)
               if (exported) {
-                if (defaultExport) {
-                  detailOfExports = setModifierDefaultExportInDetail(detailOfExports, name)
+                if (name == null) {
+                  if (isFunction) {
+                    detailOfExports = setFunctionDefaultExportInDetail(detailOfExports)
+                  } else {
+                    detailOfExports = setExpressionDefaultExportInDetail(detailOfExports)
+                  }
                 } else {
-                  detailOfExports = addModifierExportToDetail(detailOfExports, name)
+                  if (defaultExport) {
+                    detailOfExports = setModifierDefaultExportInDetail(detailOfExports, name)
+                  } else {
+                    detailOfExports = addModifierExportToDetail(detailOfExports, name)
+                  }
                 }
               }
 
@@ -1409,7 +1454,94 @@ export function parseCode(
             }
           }
         } else {
-          pushArbitraryNode(topLevelElement)
+          // Fallback for things which don't parse but may be similar to those
+          // node types which do.
+          if (TS.isVariableStatement(topLevelElement)) {
+            if (
+              topLevelElement.modifiers != null &&
+              topLevelElement.modifiers.some(
+                (modifier) => modifier.kind === TS.SyntaxKind.ExportKeyword,
+              )
+            ) {
+              // Handle variable statements.
+              // Check if this is the 'default' export, which is to say what the caller will get if not
+              // specifying a particular value from the module.
+              const isDefault = topLevelElement.modifiers.some(
+                (modifier) => modifier.kind === TS.SyntaxKind.DefaultKeyword,
+              )
+
+              function pushToExports(bindingOrName: TS.Identifier | TS.BindingElement): void {
+                let nameToUse: string
+                let aliasToUse: string
+                if (TS.isIdentifier(bindingOrName)) {
+                  nameToUse = bindingOrName.getText(sourceFile)
+                  aliasToUse = nameToUse
+                } else {
+                  if (bindingOrName.propertyName == null) {
+                    nameToUse = bindingOrName.name.getText(sourceFile)
+                    aliasToUse = nameToUse
+                  } else {
+                    nameToUse = bindingOrName.propertyName.getText(sourceFile)
+                    aliasToUse = bindingOrName.name.getText(sourceFile)
+                  }
+                }
+
+                if (isDefault) {
+                  detailOfExports = setModifierDefaultExportInDetail(detailOfExports, nameToUse)
+                } else {
+                  if (aliasToUse === 'default') {
+                    detailOfExports = setNamedDefaultExportInDetail(detailOfExports, nameToUse)
+                  } else {
+                    detailOfExports = addNamedExportToDetail(
+                      detailOfExports,
+                      nameToUse,
+                      aliasToUse,
+                      undefined,
+                    )
+                  }
+                }
+              }
+
+              function addDeclaration(name: TS.BindingName): void {
+                if (TS.isIdentifier(name)) {
+                  pushToExports(name)
+                } else if (TS.isObjectBindingPattern(name)) {
+                  for (const element of name.elements) {
+                    pushToExports(element)
+                  }
+                }
+              }
+
+              for (const declaration of topLevelElement.declarationList.declarations) {
+                addDeclaration(declaration.name)
+              }
+            }
+            pushArbitraryNode(topLevelElement)
+          } else if (
+            TS.isFunctionDeclaration(topLevelElement) &&
+            topLevelElement.name == null &&
+            markedAsDefault(topLevelElement) &&
+            markedAsExported(topLevelElement)
+          ) {
+            const possibleExpression = parseAttributeOtherJavaScript(
+              sourceFile,
+              sourceText,
+              filename,
+              imports,
+              topLevelNames,
+              null,
+              topLevelElement,
+              highlightBounds,
+              alreadyExistingUIDs_MUTABLE,
+            )
+            forEachRight(possibleExpression, () => {
+              detailOfExports = setFunctionDefaultExportInDetail(detailOfExports)
+            })
+            pushUnparsedCode(topLevelElement.getText(sourceFile))
+          } else {
+            // If all else fails add it as just an arbitrary node.
+            pushArbitraryNode(topLevelElement)
+          }
         }
       }
     }

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -536,6 +536,7 @@ function getModifersForComponent(
   } else {
     if (element.name == null) {
       isExportedDirectly = true
+      isExportedAsDefault = true
     } else {
       const componentExport = detailOfExports.namedExports[element.name]
       if (componentExport != null && isExportDetailModifier(componentExport)) {

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -211,7 +211,7 @@ export function createFakeMetadataForComponents(
   Utils.fastForEach(topLevelElements, (component, index) => {
     if (isUtopiaJSXComponent(component)) {
       const sceneUID = createSceneUidFromIndex(index)
-      const componentUID = `${component.name}-${index}`
+      const componentUID = `${component.name ?? 'default'}-${index}`
       const frame = { x: 0, y: 0, width: 100, height: 100 }
       const fakeScene = defaultSceneElement(
         sceneUID,
@@ -219,7 +219,7 @@ export function createFakeMetadataForComponents(
         `Scene ${index}`,
         [
           jsxElement(
-            component.name,
+            component.name ?? 'default',
             componentUID,
             jsxAttributesFromMap({
               'data-uid': jsxAttributeValue(componentUID, emptyComments),


### PR DESCRIPTION
Mostly fixes #1737.

**Problem:**
Utopia does not support a few of the many different styles of export that are possible in JavaScript modules.

**Fix:**
Primarily this work has been to test that the various exports work, with the bulk of the changes being to handle `export default function...` as a lot of the canvas especially is designed around the assumption that a component would have a name.

**Notes:**
This does not currently address or test re-exports, which should be done in follow up work.

**Commit Details:**
- Mostly addresses #1737.
- `UtopiaJSXComponent.name` is now nullable, which indicates a component exported
  as the default exported component for a module with no fixed name.
- Added `ExportDefaultExpression` and `ExportDefaultFunction` as additional
  cases for the default export.
- Made `ComponentRendererComponent.topLevelElementName` nullable and modified
  the type guard to use a different property to identify the component.
- Removed `topLevelElementName` parameter from `tryToGetInstancePath` as it
  wasn't being used.
- Return value from `createExecutionScope` allows for top level components that
  are keyed against the value null as well as a string for the name.
- In `createExecutionScope` use `default` as the name for inserting into the scope
  for a component with no name.
- `UiJsxCanvas` handles the new cases for a `defaultExport`.
- `useGetStoryboardRoot` allows for null keyed top level components.
- `turnCodeSnippetIntoSourceMapNodes` includes a fix to get around the issue
  of attempting to transpile a function without a name or export modifiers.
- Small fix to `addStoryboardFileToProject` around handling the new export types.
- Added `markedAsExported` and `markedAsDefault` functions and standardised around
  those in a couple of places.
- Modified `printUtopiaJSXComponent` to handle components with a null name.
- `detailsFromExportDeclaration` handles `default` specifier names correctly, as well
  as null names.
- `parseCode` has some additional cases to pick up on the export types that were
  missing.
