### PR TITLE
Preserve comments in empty JSX blocks

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
@@ -27,6 +27,7 @@ describe('Parsing and printing code with comments', () => {
     commentAtStartOfJSXExpression: '/* Comment at start of JSX expression */',
     commentInsideJSXExpression: '/* Comment inside JSX expression */',
     commentAtEndOfJSXExpression: '/* Comment at end of JSX expression */',
+    commentInsideAnEmptyJSXExpression: '/* Comment inside an empty JSX expression */',
     commentBeforeExports: '// Comment before exports',
     commentInsideExports: '// Comment inside exports',
     commentAfterExports: '// Comment after exports',
@@ -96,6 +97,7 @@ describe('Parsing and printing code with comments', () => {
             : <div/>
             ${comments.commentAtEndOfJSXExpression}
           }
+          {${comments.commentInsideAnEmptyJSXExpression}}
         </div>
       ) ${comments.commentAfterReturnStatement}
     } ${comments.commentAfterComponent}
@@ -175,6 +177,7 @@ describe('Parsing and printing code with comments', () => {
                 <div data-uid='b93' />
               ) /* Comment at end of JSX expression */
             }
+            {/* Comment inside an empty JSX expression */}
           </div>
         ) // Comment after return statement
       } // Comment after component

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -1028,8 +1028,8 @@ function parseJSXArbitraryBlock(
       if (code === '') {
         return right(
           jsxArbitraryBlock(
-            code,
-            '',
+            expressionFullText,
+            expressionFullText,
             'return undefined',
             definedElsewhere,
             null,

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -434,7 +434,7 @@ function jsxElementToExpression(
     }
     case 'JSX_ARBITRARY_BLOCK': {
       const maybeExpressionStatement = rawCodeToExpressionStatement(element.javascript)
-      let rawCode: string = ''
+      let rawCode: string = element.javascript // Fallback for the case where the code is simply a comment
       if (maybeExpressionStatement != null) {
         const { statement, sourceFile } = maybeExpressionStatement
         const lastToken = statement.getLastToken(sourceFile)


### PR DESCRIPTION
**Problem:**
Empty JSX blocks used purely for comments were being cleared, as our parser wasn't capturing the comments in that case, and our printer also wasn't printing anything inside the block (since there was no expression within).

**Fix:**
Ensure that if nothing is parsed we still capture the full text of the JSX block, and then when printing we will fall back to inserting the original code if no expression was captured.