### PR TITLE
Prevent repeated forking

### DIFF
--- a/editor/src/components/editor/persistence.spec.ts
+++ b/editor/src/components/editor/persistence.spec.ts
@@ -370,7 +370,7 @@ describe('Forking a project', () => {
     const dispatchFn: EditorDispatch = (actions: ReadonlyArray<EditorAction>) => {
       fastForEach(actions, (action) => {
         if (action.action === 'SET_PROJECT_ID') {
-          if (capturedData.newProjectId != undefined) {
+          if (capturedData.newProjectId != undefined && capturedData.newProjectId !== action.id) {
             fail(`Trying to repeatedly change the project ID`)
           }
           capturedData.newProjectId = action.id

--- a/editor/src/components/editor/persistence.ts
+++ b/editor/src/components/editor/persistence.ts
@@ -389,6 +389,7 @@ export async function triggerForkProject(
   }
 
   dispatch([
+    setProjectID(newProjectId),
     setProjectName(updatedName),
     setForkedFromProjectID(oldProjectId),
     ...updateFileActions,


### PR DESCRIPTION
**Problem:**
Making a code change will accidentally result in the forking logic `triggerForkProject` running twice (once with the code change, then again once more after the parse result has come in). Right now Utopia doesn't guard against that, meaning two new projects will be created, leading to problems around which one the assets are uploaded to.

**Fix:**
Guard against another fork starting until the previous has completed. I have also removed an extra `setProjectID` dispatch, since that's happening as part of the `onFirstSaveCompleted` logic.