### PR TITLE
Eagerly create a new project ID when creating a new project

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -405,6 +405,7 @@ import {
   saveAsset as saveAssetToServer,
   updateAssetFileName,
   saveUserConfiguration,
+  createNewProjectID,
 } from '../server'
 import {
   areGeneratedElementsTargeted,
@@ -506,6 +507,7 @@ import {
   addImports,
   setScrollAnimation,
   updatePackageJson,
+  setProjectID,
 } from './action-creators'
 import { emptyComments } from '../../../core/workers/parser-printer/parser-printer-comments'
 import { getAllTargetsAtPoint } from '../../canvas/dom-lookup'
@@ -5076,6 +5078,7 @@ export async function newProject(
 ): Promise<void> {
   const defaultPersistentModel = defaultProject()
   const npmDependencies = dependenciesWithEditorRequirements(defaultPersistentModel.projectContents)
+  const projectId = await createNewProjectID()
   const fetchNodeModulesResult = await fetchNodeModules(npmDependencies)
 
   const nodeModules: NodeModules = fetchNodeModulesResult.nodeModules
@@ -5107,6 +5110,7 @@ export async function newProject(
         codeResultCache: codeResultCache,
         packageResult: packageResult,
       },
+      setProjectID(projectId),
     ],
     'everyone',
   )


### PR DESCRIPTION
**Problem:**
Creating a new project (deliberately) results in a save, which in turn generates a new project ID. However, there is a race condition here as a separate action can be triggered before that save completes, resulting in another new project ID being created, and another save using that project ID.

**Fix:**
Eagerly create the project ID as part of the new project creation flow, to ensure that it is set on the model before any saving can take place.
