### PR TITLE
cull the spy accumulator based on the current valid paths

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -17,17 +17,6 @@ import { renderComponentUsingJsxFactoryFunction } from './ui-jsx-canvas-element-
 import { importInfoFromImportDetails } from '../../../core/model/project-file-utils'
 import { fastForEach } from '../../../core/shared/utils'
 
-function clearDescendantsForPath(
-  metadataToMutate: ElementInstanceMetadataMap,
-  pathPrefixToDelete: string,
-): void {
-  fastForEach(Object.keys(metadataToMutate), (pathString) => {
-    if (pathString.startsWith(pathPrefixToDelete)) {
-      delete metadataToMutate[pathString]
-    }
-  })
-}
-
 export function buildSpyWrappedElement(
   jsx: JSXElement,
   finalProps: any,
@@ -70,7 +59,6 @@ export function buildSpyWrappedElement(
       // TODO right now we don't actually invalidate the path, just let the dom-walker know it should walk again
       updateInvalidatedPaths((current) => current, 'invalidate')
       const elementPathString = EP.toComponentId(elementPath)
-      clearDescendantsForPath(metadataContext.current.spyValues.metadata, elementPathString)
       metadataContext.current.spyValues.metadata[elementPathString] = instanceMetadata
     }
   }


### PR DESCRIPTION
**Problem:**
We are deleting the spy accumulator too often, which leads to a blinking navigator.

**Fix:**
We realized that we don't need to delete the entire spy accumulator for every canvas render. It is actually enough to use the `validPaths`, calculated by the Canvas to cull the spy accumulator. This eliminates the unnecessary blinking. Yay!
