### PR TITLE
Feature/components expression enum control

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -705,6 +705,7 @@ export interface UpdateJSXElementName {
 
 export interface AddImports {
   action: 'ADD_IMPORTS'
+  target: ElementPath
   importsToAdd: Imports
 }
 

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1153,9 +1153,10 @@ export function updateJSXElementName(
   }
 }
 
-export function addImports(importsToAdd: Imports): AddImports {
+export function addImports(importsToAdd: Imports, target: ElementPath): AddImports {
   return {
     action: 'ADD_IMPORTS',
+    target: target,
     importsToAdd: importsToAdd,
   }
 }

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4107,7 +4107,10 @@ export const UPDATE_FNS = {
     }, editor)
   },
   UPDATE_JSX_ELEMENT_NAME: (action: UpdateJSXElementName, editor: EditorModel): EditorModel => {
-    const updatedEditor = UPDATE_FNS.ADD_IMPORTS(addImports(action.importsToAdd), editor)
+    const updatedEditor = UPDATE_FNS.ADD_IMPORTS(
+      addImports(action.importsToAdd, action.target),
+      editor,
+    )
 
     return modifyOpenJsxElementAtPath(
       action.target,
@@ -4121,12 +4124,18 @@ export const UPDATE_FNS = {
     )
   },
   ADD_IMPORTS: (action: AddImports, editor: EditorModel): EditorModel => {
-    return modifyOpenParseSuccess((success, _, underlyingFilePath) => {
-      return {
-        ...success,
-        imports: mergeImports(underlyingFilePath, success.imports, action.importsToAdd),
-      }
-    }, editor)
+    return modifyUnderlyingTarget(
+      action.target,
+      forceNotNull('Missing open file', editor.canvas.openFile?.filename),
+      editor,
+      (element) => element,
+      (success, _, underlyingFilePath) => {
+        return {
+          ...success,
+          imports: mergeImports(underlyingFilePath, success.imports, action.importsToAdd),
+        }
+      },
+    )
   },
   SET_ASPECT_RATIO_LOCK: (action: SetAspectRatioLock, editor: EditorModel): EditorModel => {
     return modifyOpenJsxElementAtPath(

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -79,6 +79,7 @@ import {
   ControlForComponentInstanceProp,
   ControlForEnumProp,
   ControlForEventHandlerProp,
+  ControlForExpressionEnumProp,
   ControlForImageProp,
   ControlForNumberProp,
   ControlForOptionsProp,
@@ -127,6 +128,8 @@ const ControlForProp = betterReactMemo(
           )
         case 'enum':
           return <ControlForEnumProp {...props} controlDescription={controlDescription} />
+        case 'expression-enum':
+          return <ControlForExpressionEnumProp {...props} controlDescription={controlDescription} />
         case 'eventhandler':
           return <ControlForEventHandlerProp {...props} controlDescription={controlDescription} />
         case 'ignore':

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -207,29 +207,29 @@ export const ControlForExpressionEnumProp = betterReactMemo(
     const target = forceNotNull('Inspector control without selected element', selectedViews[0])
     const { propMetadata, controlDescription } = props
 
-    const detectedValueInOptions = controlDescription.options.findIndex((option) =>
-      fastDeepEquals(option, propMetadata.value),
-    )
-    const detectedValue = controlDescription.expressionOptions[detectedValueInOptions]?.value
-    const value =
-      propMetadata.propertyStatus.set && detectedValue != null
-        ? detectedValue
-        : controlDescription.defaultValue?.value
+    const detectedExpression = controlDescription.options.find((option) =>
+      fastDeepEquals(option.value, propMetadata.value),
+    )?.expression
+
+    const selectedExpression =
+      propMetadata.propertyStatus.set && detectedExpression != null
+        ? detectedExpression
+        : controlDescription.defaultValue?.expression
 
     const options: Array<SelectOption> = useKeepReferenceEqualityIfPossible(
-      controlDescription.expressionOptions.map((option, index) => {
+      controlDescription.options.map((option, index) => {
         return {
-          value: option.value,
+          value: option.expression,
           label:
             controlDescription.optionTitles == null ||
             typeof controlDescription.optionTitles === 'function'
-              ? option.value
+              ? option.expression
               : (controlDescription.optionTitles[index] as string),
         }
       }),
     )
     const currentValue = options.find((option) => {
-      return fastDeepEquals(option.value, value)
+      return fastDeepEquals(option.value, selectedExpression)
     })
 
     function submitValue(option: SelectOption): void {
@@ -240,13 +240,11 @@ export const ControlForExpressionEnumProp = betterReactMemo(
           jsxAttributeOtherJavaScript(option.value, `return ${option.value}`, [], null, {}),
         ),
       ]
-      const expressionOption = controlDescription.expressionOptions.find(
-        (o) => o.value === option.value,
-      )
+      const expressionOption = controlDescription.options.find((o) => o.expression === option.value)
       if (expressionOption != null && expressionOption.import != null) {
         const importOption = expressionOption.import
         const importToAdd: Imports = {
-          [expressionOption.import.source]: importDetails(
+          [importOption.source]: importDetails(
             importOption.type === 'default' ? importOption.name : null,
             importOption.type == null
               ? [{ name: importOption.name, alias: importOption.name }]

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -206,9 +206,15 @@ export const ControlForExpressionEnumProp = betterReactMemo(
     )
     const target = forceNotNull('Inspector control without selected element', selectedViews[0])
     const { propMetadata, controlDescription } = props
-    const value = propMetadata.propertyStatus.set
-      ? propMetadata.value
-      : controlDescription.defaultValue
+
+    const detectedValueInOptions = controlDescription.options.findIndex((option) =>
+      fastDeepEquals(option, propMetadata.value),
+    )
+    const detectedValue = controlDescription.expressionOptions[detectedValueInOptions]?.value
+    const value =
+      propMetadata.propertyStatus.set && detectedValue != null
+        ? detectedValue
+        : controlDescription.defaultValue?.value
 
     const options: Array<SelectOption> = useKeepReferenceEqualityIfPossible(
       controlDescription.expressionOptions.map((option, index) => {

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -8,6 +8,7 @@ import {
   ComponentInstanceDescription,
   EnumControlDescription,
   EventHandlerControlDescription,
+  ExpressionEnumControlDescription,
   ImageControlDescription,
   NumberControlDescription,
   OptionsControlDescription,
@@ -44,7 +45,12 @@ import { EventHandlerControl } from '../event-handlers-section/event-handlers-se
 import { OptionChainControl } from '../../controls/option-chain-control'
 import { useKeepReferenceEqualityIfPossible } from '../../../../utils/react-performance'
 import { UIGridRow } from '../../widgets/ui-grid-row'
-import { PropertyPath } from '../../../../core/shared/project-file-types'
+import { importDetails, Imports, PropertyPath } from '../../../../core/shared/project-file-types'
+import { useEditorState } from '../../../editor/store/store-hook'
+import { addImports, setProp_UNSAFE } from '../../../editor/actions/action-creators'
+import { jsxAttributeOtherJavaScript } from '../../../../core/shared/element-template'
+import { EditorAction } from '../../../editor/action-types'
+import { forceNotNull } from '../../../../core/shared/optional-utils'
 
 export interface ControlForPropProps<T extends BaseControlDescription> {
   propPath: PropertyPath
@@ -173,6 +179,78 @@ export const ControlForEnumProp = betterReactMemo(
 
     function submitValue(option: SelectOption): void {
       propMetadata.onSubmitValue(option.value)
+    }
+
+    return (
+      <PopupList
+        disabled={!propMetadata.controlStyles.interactive}
+        value={currentValue}
+        onSubmitValue={submitValue}
+        options={options}
+        containerMode={'default'}
+      />
+    )
+  },
+)
+
+export const ControlForExpressionEnumProp = betterReactMemo(
+  'ControlForEnumProp',
+  (props: ControlForPropProps<ExpressionEnumControlDescription>) => {
+    const dispatch = useEditorState(
+      (store) => store.dispatch,
+      'ControlForExpressionEnumProp dispatch',
+    )
+    const selectedViews = useEditorState(
+      (store) => store.editor.selectedViews,
+      'ControlForExpressionEnumProp selectedViews',
+    )
+    const target = forceNotNull('Inspector control without selected element', selectedViews[0])
+    const { propMetadata, controlDescription } = props
+    const value = propMetadata.propertyStatus.set
+      ? propMetadata.value
+      : controlDescription.defaultValue
+
+    const options: Array<SelectOption> = useKeepReferenceEqualityIfPossible(
+      controlDescription.expressionOptions.map((option, index) => {
+        return {
+          value: option.value,
+          label:
+            controlDescription.optionTitles == null ||
+            typeof controlDescription.optionTitles === 'function'
+              ? option.value
+              : (controlDescription.optionTitles[index] as string),
+        }
+      }),
+    )
+    const currentValue = options.find((option) => {
+      return fastDeepEquals(option.value, value)
+    })
+
+    function submitValue(option: SelectOption): void {
+      const actions: EditorAction[] = [
+        setProp_UNSAFE(
+          target,
+          props.propPath,
+          jsxAttributeOtherJavaScript(option.value, `return ${option.value}`, [], null, {}),
+        ),
+      ]
+      const expressionOption = controlDescription.expressionOptions.find(
+        (o) => o.value === option.value,
+      )
+      if (expressionOption != null && expressionOption.import != null) {
+        const importOption = expressionOption.import
+        const importToAdd: Imports = {
+          [expressionOption.import.source]: importDetails(
+            importOption.type === 'default' ? importOption.name : null,
+            importOption.type == null
+              ? [{ name: importOption.name, alias: importOption.name }]
+              : [],
+            importOption.type === 'star' ? importOption.name : null,
+          ),
+        }
+        actions.push(addImports(importToAdd, target))
+      }
+      dispatch(actions, 'everyone')
     }
 
     return (

--- a/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
+++ b/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
@@ -407,13 +407,13 @@ declare module 'utopia-api/property-controls/property-controls' {
       type: 'star' | 'default' | null;
   }
   export interface ExpressionEnum {
-      value: string;
+      value: AllowedEnumType;
+      expression: string;
       import?: ImportType;
   }
   export interface ExpressionEnumControlDescription extends AbstractBaseControlDescription<'expression-enum'> {
       defaultValue?: ExpressionEnum;
-      options: AllowedEnumType[];
-      expressionOptions: ExpressionEnum[];
+      options: ExpressionEnum[];
       optionTitles?: string[] | ((props: unknown | null) => string[]);
   }
   export interface EventHandlerControlDescription extends AbstractBaseControlDescription<'eventhandler'> {
@@ -499,7 +499,10 @@ declare module 'utopia-api/property-controls/property-controls' {
   export function getDefaultProps(propertyControls: PropertyControls): {
       [prop: string]: unknown;
   };
-  export function expression(value: string, source: string, name: string, type: 'star' | 'default' | null): ExpressionEnum;
+  export function expression(value: AllowedEnumType, expression: string, toImport: ImportType): ExpressionEnum;
+  export function importStar(source: string, name: string): ImportType;
+  export function importDefault(source: string, name: string): ImportType;
+  export function importNamed(source: string, name: string): ImportType;
   export {};
 
 }

--- a/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
+++ b/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
@@ -404,7 +404,7 @@ declare module 'utopia-api/property-controls/property-controls' {
   export interface ImportType {
       source: string;
       name: string;
-      type: 'star' | 'default';
+      type: 'star' | 'default' | null;
   }
   export interface ExpressionEnum {
       value: string;
@@ -499,7 +499,7 @@ declare module 'utopia-api/property-controls/property-controls' {
   export function getDefaultProps(propertyControls: PropertyControls): {
       [prop: string]: unknown;
   };
-  export function expression(value: string, source: string, name: string, type: 'star' | 'default'): ExpressionEnum;
+  export function expression(value: string, source: string, name: string, type: 'star' | 'default' | null): ExpressionEnum;
   export {};
 
 }

--- a/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
+++ b/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
@@ -375,7 +375,7 @@ declare module 'utopia-api/primitives/view' {
 }
 declare module 'utopia-api/property-controls/property-controls' {
   import type { CSSProperties } from 'react';
-  export type BaseControlType = 'boolean' | 'color' | 'componentinstance' | 'enum' | 'eventhandler' | 'ignore' | 'image' | 'number' | 'options' | 'popuplist' | 'slider' | 'string' | 'styleobject' | 'vector2' | 'vector3';
+  export type BaseControlType = 'boolean' | 'color' | 'componentinstance' | 'enum' | 'expression-enum' | 'eventhandler' | 'ignore' | 'image' | 'number' | 'options' | 'popuplist' | 'slider' | 'string' | 'styleobject' | 'vector2' | 'vector3';
   interface AbstractControlDescription<T extends ControlType> {
       title?: string;
       type: T;
@@ -400,6 +400,21 @@ declare module 'utopia-api/property-controls/property-controls' {
       options: AllowedEnumType[];
       optionTitles?: string[] | ((props: unknown | null) => string[]);
       displaySegmentedControl?: boolean;
+  }
+  export interface ImportType {
+      source: string;
+      name: string;
+      type: 'star' | 'default';
+  }
+  export interface ExpressionEnum {
+      value: string;
+      import?: ImportType;
+  }
+  export interface ExpressionEnumControlDescription extends AbstractBaseControlDescription<'expression-enum'> {
+      defaultValue?: ExpressionEnum;
+      options: AllowedEnumType[];
+      expressionOptions: ExpressionEnum[];
+      optionTitles?: string[] | ((props: unknown | null) => string[]);
   }
   export interface EventHandlerControlDescription extends AbstractBaseControlDescription<'eventhandler'> {
       defaultValue?: never;
@@ -453,7 +468,7 @@ declare module 'utopia-api/property-controls/property-controls' {
   export interface Vector3ControlDescription extends AbstractBaseControlDescription<'vector3'> {
       defaultValue?: [number, number, number];
   }
-  export type BaseControlDescription = BooleanControlDescription | ColorControlDescription | ComponentInstanceDescription | EnumControlDescription | EventHandlerControlDescription | IgnoreControlDescription | ImageControlDescription | NumberControlDescription | OptionsControlDescription | PopUpListControlDescription | SliderControlDescription | StringControlDescription | StyleObjectControlDescription | Vector2ControlDescription | Vector3ControlDescription;
+  export type BaseControlDescription = BooleanControlDescription | ColorControlDescription | ComponentInstanceDescription | EnumControlDescription | ExpressionEnumControlDescription | EventHandlerControlDescription | IgnoreControlDescription | ImageControlDescription | NumberControlDescription | OptionsControlDescription | PopUpListControlDescription | SliderControlDescription | StringControlDescription | StyleObjectControlDescription | Vector2ControlDescription | Vector3ControlDescription;
   export type HigherLevelControlType = 'array' | 'object' | 'union';
   export type ControlType = BaseControlType | HigherLevelControlType;
   interface AbstractHigherLevelControlDescription<T extends HigherLevelControlType> extends AbstractControlDescription<T> {
@@ -484,6 +499,7 @@ declare module 'utopia-api/property-controls/property-controls' {
   export function getDefaultProps(propertyControls: PropertyControls): {
       [prop: string]: unknown;
   };
+  export function expression(value: string, source: string, name: string, type: 'star' | 'default'): ExpressionEnum;
   export {};
 
 }

--- a/editor/src/core/property-controls/property-control-values.ts
+++ b/editor/src/core/property-controls/property-control-values.ts
@@ -240,6 +240,8 @@ export function unwrapperAndParserForBaseControl(
       return jsUnwrapFirst(parseAny)
     case 'enum':
       return defaultUnwrapFirst(parseAllowedEnum(control.options))
+    case 'expression-enum':
+      return defaultUnwrapFirst(parseAllowedEnum(control.options))
     case 'eventhandler':
       return jsUnwrapFirst(parseAny)
     case 'ignore':
@@ -275,6 +277,7 @@ export function unwrapperAndParserForPropertyControl(
     case 'color':
     case 'componentinstance':
     case 'enum':
+    case 'expression-enum':
     case 'eventhandler':
     case 'ignore':
     case 'image':
@@ -348,6 +351,8 @@ export function printerForBasePropertyControl(control: BaseControlDescription): 
       return printJS
     case 'enum':
       return printSimple
+    case 'expression-enum':
+      return printSimple
     case 'eventhandler':
       return printJS
     case 'ignore':
@@ -415,6 +420,7 @@ export function printerForPropertyControl(control: ControlDescription): Printer<
     case 'color':
     case 'componentinstance':
     case 'enum':
+    case 'expression-enum':
     case 'eventhandler':
     case 'ignore':
     case 'image':

--- a/editor/src/core/property-controls/property-control-values.ts
+++ b/editor/src/core/property-controls/property-control-values.ts
@@ -241,7 +241,7 @@ export function unwrapperAndParserForBaseControl(
     case 'enum':
       return defaultUnwrapFirst(parseAllowedEnum(control.options))
     case 'expression-enum':
-      return defaultUnwrapFirst(parseAllowedEnum(control.options))
+      return defaultUnwrapFirst(parseAny)
     case 'eventhandler':
       return jsUnwrapFirst(parseAny)
     case 'ignore':

--- a/editor/src/core/property-controls/property-controls-parser.ts
+++ b/editor/src/core/property-controls/property-controls-parser.ts
@@ -121,12 +121,11 @@ export function parseEnumControlDescription(value: unknown): ParseResult<EnumCon
 export function parseExpressionEnumControlDescription(
   value: unknown,
 ): ParseResult<ExpressionEnumControlDescription> {
-  return applicative6Either(
-    (title, type, defaultValue, options, optionTitles, expressionOptions) => {
+  return applicative5Either(
+    (title, type, defaultValue, options, optionTitles) => {
       let enumControlDescription: ExpressionEnumControlDescription = {
         type: type,
         options: options,
-        expressionOptions: expressionOptions,
       }
       setOptionalProp(enumControlDescription, 'title', title)
       setOptionalProp(enumControlDescription, 'defaultValue', defaultValue)
@@ -137,9 +136,8 @@ export function parseExpressionEnumControlDescription(
     optionalObjectKeyParser(parseString, 'title')(value),
     objectKeyParser(parseEnum(['expression-enum']), 'type')(value),
     optionalObjectKeyParser(parseExpressionEnum, 'defaultValue')(value),
-    objectKeyParser(parseArray(parseEnumValue), 'options')(value),
+    objectKeyParser(parseArray(parseExpressionEnum), 'options')(value),
     optionalObjectKeyParser(parseOptionTitles, 'optionTitles')(value),
-    objectKeyParser(parseArray(parseExpressionEnum), 'expressionOptions')(value),
   )
 }
 
@@ -165,16 +163,18 @@ const parseImportType: Parser<ImportType> = (value: unknown) => {
   )
 }
 
-const parseExpressionEnum: Parser<ExpressionEnum> = (value: unknown) => {
-  return applicative2Either(
-    (expressionValue, importType) => {
+export function parseExpressionEnum(value: unknown): ParseResult<ExpressionEnum> {
+  return applicative3Either(
+    (enumValue, expression, importType) => {
       let expressionEnum: ExpressionEnum = {
-        value: expressionValue,
+        value: enumValue,
+        expression: expression,
       }
       setOptionalProp(expressionEnum, 'import', importType)
       return expressionEnum
     },
-    objectKeyParser(parseString, 'value')(value),
+    objectKeyParser(parseEnumValue, 'value')(value),
+    objectKeyParser(parseString, 'expression')(value),
     optionalObjectKeyParser(parseImportType, 'import')(value),
   )
 }

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -286,6 +286,7 @@ export function getDescriptionUnsetOptionalFields(
       addIfFieldEmpty(controlDescription, 'optionTitles')
       addIfFieldEmpty(controlDescription, 'displaySegmentedControl')
       break
+    case 'expression-enum':
     case 'eventhandler':
     case 'ignore':
     case 'image':

--- a/editor/src/core/property-controls/third-party-property-controls/react-three-fiber-controls.ts
+++ b/editor/src/core/property-controls/third-party-property-controls/react-three-fiber-controls.ts
@@ -6,6 +6,7 @@ import {
   Vector3ControlDescription,
   PropertyControls,
   expression,
+  importStar,
 } from 'utopia-api'
 
 const Vector3: Vector3ControlDescription = {
@@ -327,7 +328,6 @@ const materialControls: PropertyControls = {
   },
   blending: {
     type: 'expression-enum',
-    options: [0, 1, 2, 3, 4, 5],
     optionTitles: [
       'NoBlending',
       'NormalBlending',
@@ -336,15 +336,15 @@ const materialControls: PropertyControls = {
       'MultiplyBlending',
       'CustomBlending',
     ],
-    expressionOptions: [
-      expression('THREE.NoBlending', 'three', 'THREE', 'star'),
-      expression('THREE.NormalBlending', 'three', 'THREE', 'star'),
-      expression('THREE.AdditiveBlending', 'three', 'THREE', 'star'),
-      expression('THREE.SubtractiveBlending', 'three', 'THREE', 'star'),
-      expression('THREE.MultiplyBlending', 'three', 'THREE', 'star'),
-      expression('THREE.CustomBlending', 'three', 'THREE', 'star'),
+    options: [
+      expression(0, 'THREE.NoBlending', importStar('three', 'THREE')),
+      expression(1, 'THREE.NormalBlending', importStar('three', 'THREE')),
+      expression(2, 'THREE.AdditiveBlending', importStar('three', 'THREE')),
+      expression(3, 'THREE.SubtractiveBlending', importStar('three', 'THREE')),
+      expression(4, 'THREE.MultiplyBlending', importStar('three', 'THREE')),
+      expression(5, 'THREE.CustomBlending', importStar('three', 'THREE')),
     ],
-    defaultValue: expression('THREE.NoBlending', 'three', 'THREE', 'star'),
+    defaultValue: expression(0, 'THREE.NoBlending', importStar('three', 'THREE')),
   },
   blendSrc: {
     type: 'enum',

--- a/editor/src/core/property-controls/third-party-property-controls/react-three-fiber-controls.ts
+++ b/editor/src/core/property-controls/third-party-property-controls/react-three-fiber-controls.ts
@@ -5,6 +5,7 @@ import {
   Vector2ControlDescription,
   Vector3ControlDescription,
   PropertyControls,
+  expression,
 } from 'utopia-api'
 
 const Vector3: Vector3ControlDescription = {
@@ -325,7 +326,7 @@ const materialControls: PropertyControls = {
     defaultValue: null,
   },
   blending: {
-    type: 'enum',
+    type: 'expression-enum',
     options: [0, 1, 2, 3, 4, 5],
     optionTitles: [
       'NoBlending',
@@ -335,7 +336,15 @@ const materialControls: PropertyControls = {
       'MultiplyBlending',
       'CustomBlending',
     ],
-    defaultValue: 1,
+    expressionOptions: [
+      expression('THREE.NoBlending', 'three', 'THREE', 'star'),
+      expression('THREE.NormalBlending', 'three', 'THREE', 'star'),
+      expression('THREE.AdditiveBlending', 'three', 'THREE', 'star'),
+      expression('THREE.SubtractiveBlending', 'three', 'THREE', 'star'),
+      expression('THREE.MultiplyBlending', 'three', 'THREE', 'star'),
+      expression('THREE.CustomBlending', 'three', 'THREE', 'star'),
+    ],
+    defaultValue: expression('THREE.NoBlending', 'three', 'THREE', 'star'),
   },
   blendSrc: {
     type: 'enum',

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -8,6 +8,7 @@ export type BaseControlType =
   | 'color'
   | 'componentinstance'
   | 'enum'
+  | 'expression-enum'
   | 'eventhandler'
   | 'ignore'
   | 'image'
@@ -51,6 +52,25 @@ export interface EnumControlDescription extends AbstractBaseControlDescription<'
   options: AllowedEnumType[]
   optionTitles?: string[] | ((props: unknown | null) => string[])
   displaySegmentedControl?: boolean
+}
+
+export interface ImportType {
+  source: string // importSource
+  name: string
+  type: 'star' | 'default'
+}
+
+export interface ExpressionEnum {
+  value: string
+  import?: ImportType
+}
+
+export interface ExpressionEnumControlDescription
+  extends AbstractBaseControlDescription<'expression-enum'> {
+  defaultValue?: ExpressionEnum
+  options: AllowedEnumType[]
+  expressionOptions: ExpressionEnum[]
+  optionTitles?: string[] | ((props: unknown | null) => string[])
 }
 
 export interface EventHandlerControlDescription
@@ -122,6 +142,7 @@ export type BaseControlDescription =
   | ColorControlDescription
   | ComponentInstanceDescription
   | EnumControlDescription
+  | ExpressionEnumControlDescription
   | EventHandlerControlDescription
   | IgnoreControlDescription
   | ImageControlDescription
@@ -176,6 +197,7 @@ export function isBaseControlDescription(
     case 'color':
     case 'componentinstance':
     case 'enum':
+    case 'expression-enum':
     case 'eventhandler':
     case 'ignore':
     case 'image':
@@ -206,6 +228,7 @@ export function isHigherLevelControlDescription(
     case 'color':
     case 'componentinstance':
     case 'enum':
+    case 'expression-enum':
     case 'eventhandler':
     case 'ignore':
     case 'image':
@@ -248,4 +271,20 @@ export function getDefaultProps(propertyControls: PropertyControls): { [prop: st
     }
   })
   return defaults
+}
+
+export function expression(
+  value: string,
+  source: string,
+  name: string,
+  type: 'star' | 'default',
+): ExpressionEnum {
+  return {
+    value: value,
+    import: {
+      source: source,
+      name: name,
+      type: type,
+    },
+  }
 }

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -61,15 +61,15 @@ export interface ImportType {
 }
 
 export interface ExpressionEnum {
-  value: string
+  value: AllowedEnumType
+  expression: string
   import?: ImportType
 }
 
 export interface ExpressionEnumControlDescription
   extends AbstractBaseControlDescription<'expression-enum'> {
   defaultValue?: ExpressionEnum
-  options: AllowedEnumType[]
-  expressionOptions: ExpressionEnum[]
+  options: ExpressionEnum[]
   optionTitles?: string[] | ((props: unknown | null) => string[])
 }
 
@@ -274,17 +274,35 @@ export function getDefaultProps(propertyControls: PropertyControls): { [prop: st
 }
 
 export function expression(
-  value: string,
-  source: string,
-  name: string,
-  type: 'star' | 'default' | null,
+  value: AllowedEnumType,
+  expression: string,
+  toImport: ImportType,
 ): ExpressionEnum {
   return {
     value: value,
-    import: {
-      source: source,
-      name: name,
-      type: type,
-    },
+    expression: expression,
+    import: toImport,
+  }
+}
+
+export function importStar(source: string, name: string): ImportType {
+  return {
+    source: source,
+    name: name,
+    type: 'star',
+  }
+}
+export function importDefault(source: string, name: string): ImportType {
+  return {
+    source: source,
+    name: name,
+    type: 'default',
+  }
+}
+export function importNamed(source: string, name: string): ImportType {
+  return {
+    source: source,
+    name: name,
+    type: null,
   }
 }

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -57,7 +57,7 @@ export interface EnumControlDescription extends AbstractBaseControlDescription<'
 export interface ImportType {
   source: string // importSource
   name: string
-  type: 'star' | 'default'
+  type: 'star' | 'default' | null
 }
 
 export interface ExpressionEnum {
@@ -277,7 +277,7 @@ export function expression(
   value: string,
   source: string,
   name: string,
-  type: 'star' | 'default',
+  type: 'star' | 'default' | null,
 ): ExpressionEnum {
   return {
     value: value,


### PR DESCRIPTION
Fixes #1767 

**Problem:**
Inspector enum controls use nice dropdown with titles to read the options, the selected value is inserted as a number. In some examples it's possible that the value is an expression, the property controls should allow to define them with expressions.

**Fix:**
Extending utopia-api with a new property control that contains the expression and an optional import information. For the import the editor already has a nice Import type, but I chose a shorter version for defining the controls.

**Commit Details:**
- fixing a bug about the AddImport action, it was not using the elementpath to find the target filepath, but automatically inserted the import statement to storyboard.js
- new control type in utopia-api
- the inspector control is a bit special because it's not using its onSubmit callback but fires actions to add the property as arbitrary js attribute and include the import 
- only one control definiton is updated so far, that can be in the next PR
