### PR TITLE
Re-export support.

### DIFF
--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -1502,7 +1502,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.14.5.tgz",
       "integrity": "sha512-g5POA32bXPMmSBu5Dx/iZGLGnKmKPc5AiY7qfZgurzrCYgIztDlHFbznSNCoQuv57YQLnQfaDi7dxCtLDIdXdA==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
@@ -1511,8 +1510,7 @@
         "@babel/helper-plugin-utils": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
-          "dev": true
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
         }
       }
     },
@@ -2075,7 +2073,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
       "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
@@ -4281,9 +4278,9 @@
       },
       "dependencies": {
         "@babel/helper-validator-identifier": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-          "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
         }
       }
     },

--- a/editor/package.json
+++ b/editor/package.json
@@ -91,6 +91,7 @@
     "@babel/code-frame": "7.5.5",
     "@babel/plugin-external-helpers": "7.8.3",
     "@babel/plugin-transform-modules-commonjs": "7.10.4",
+    "@babel/plugin-proposal-export-namespace-from": "7.14.5",
     "@babel/plugin-transform-react-jsx": "7.10.4",
     "@babel/plugin-transform-typescript": "7.11.0",
     "@babel/standalone": "7.9.5",

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -26230,7 +26230,7 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
   <div
     id=\\"canvas-container\\"
     style=\\"position: absolute;\\"
-    data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+    data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:b93 utopia-storyboard-uid/scene-aaa/app-entity:b93/2f0 utopia-storyboard-uid/scene-aaa/app-entity:b93/59c utopia-storyboard-uid/scene-aaa/app-entity:b93/54b utopia-storyboard-uid/scene-aaa/app-entity:b93/d18 utopia-storyboard-uid/scene-aaa/app-entity:b93/995 utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf utopia-storyboard-uid/scene-aaa/app-entity:b93/d00 utopia-storyboard-uid/scene-aaa/app-entity:b93/7d0 utopia-storyboard-uid/scene-aaa/app-entity:b93/4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f utopia-storyboard-uid/scene-aaa/app-entity:b93/315 utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9 utopia-storyboard-uid/scene-aaa/app-entity:b93/301 utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce utopia-storyboard-uid/scene-aaa/app-entity:b93/f77 utopia-storyboard-uid/scene-aaa/app-entity:b93/218 utopia-storyboard-uid/scene-aaa/app-entity:b93/a17 utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa\\"
     data-utopia-root-element-path=\\"utopia-storyboard-uid\\"
   >
     <div
@@ -26248,22 +26248,117 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-uid=\\"app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-uid=\\"b93 app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93 utopia-storyboard-uid/scene-aaa/app-entity\\"
       >
-        <div>Originally Unassigned</div>
-        <div>Originally Assigned</div>
-        <div>Named Function</div>
-        <div>Named Class</div>
-        <div>Named Export</div>
-        <div>Renamed Export</div>
-        <div>First In Structure</div>
-        <div>Second In Structure</div>
-        <div>The Number Is 4</div>
-        <div>Default Function</div>
-        <div>Export Default Class</div>
-        <div>Default Named Function</div>
-        <div>Named As Default</div>
+        <div
+          data-uid=\\"2f0\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/2f0\\"
+        >
+          Originally Unassigned
+        </div>
+        <div
+          data-uid=\\"4cf 59c\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/59c:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/59c\\"
+        >
+          Originally Assigned
+        </div>
+        <div
+          data-uid=\\"4cf 54b\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/54b:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/54b\\"
+        >
+          Named Function
+        </div>
+        <div
+          data-uid=\\"d18\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/d18\\"
+        >
+          Named Class
+        </div>
+        <div
+          data-uid=\\"4cf 995\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/995:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/995\\"
+        >
+          Named Export
+        </div>
+        <div
+          data-uid=\\"b93 0cf\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf:b93 utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf\\"
+        >
+          Renamed Export
+        </div>
+        <div
+          data-uid=\\"d00\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/d00\\"
+        >
+          First In Structure
+        </div>
+        <div
+          data-uid=\\"7d0\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/7d0\\"
+        >
+          Second In Structure
+        </div>
+        <div
+          data-uid=\\"4cf\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/4cf\\"
+        >
+          The Number Is 4
+        </div>
+        <div
+          data-uid=\\"4cf d7f\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f\\"
+        >
+          Default Function
+        </div>
+        <div
+          data-uid=\\"315\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/315\\"
+        >
+          Export Default Class
+        </div>
+        <div
+          data-uid=\\"4cf 5b9\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9\\"
+        >
+          Default Named Function
+        </div>
+        <div
+          data-uid=\\"4cf 301\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/301:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/301\\"
+        >
+          Named As Default
+        </div>
+        <div
+          data-uid=\\"4cf 8ce\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce\\"
+        >
+          Originally Assigned
+        </div>
+        <div
+          data-uid=\\"4cf f77\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/f77:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/f77\\"
+        >
+          Originally Assigned
+        </div>
+        <div
+          data-uid=\\"4cf 218\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/218:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/218\\"
+        >
+          Originally Assigned
+        </div>
+        <div
+          data-uid=\\"4cf a17\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/a17:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/a17\\"
+        >
+          Originally Assigned
+        </div>
+        <div
+          data-uid=\\"4cf 8aa\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa\\"
+        >
+          Default Function
+        </div>
       </div>
     </div>
   </div>
@@ -26532,12 +26627,2813 @@ Object {
     "props": Object {
       "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+        ],
+        "type": "elementpath",
+      },
       "skipDeepFreeze": true,
       "style": Object {
         "height": "100%",
         "position": "absolute",
         "width": "100%",
       },
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "OriginallyUnassigned1",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "2f0",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "2f0",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "OriginallyAssigned1",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "59c",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "59c",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "NamedFunction",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "54b",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "54b",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "NamedClass",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "d18",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "d18",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "NamedExport",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "995",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "995",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "RenamedExport",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "0cf",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "0cf",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "FirstInStructure",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "d00",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "d00",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "SecondInStructure",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "7d0",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "7d0",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "text": "The Number Is ",
+                "type": "JSX_TEXT_BLOCK",
+                "uniqueID": "",
+              },
+              Object {
+                "definedElsewhere": Array [
+                  "DefaultExpression",
+                ],
+                "elementsWithin": Object {},
+                "javascript": "DefaultExpression;",
+                "originalJavascript": "DefaultExpression",
+                "sourceMap": Object {
+                  "file": "code.tsx",
+                  "mappings": "OAAA,iBAACA",
+                  "names": Array [
+                    "DefaultExpression",
+                  ],
+                  "sources": Array [
+                    "code.tsx",
+                  ],
+                  "sourcesContent": Array [
+                    "import * as React from 'react'
+import { OriginallyUnassigned1 } from '/originallyunassigned'
+import { OriginallyAssigned1 } from '/originallyassigned'
+import { NamedFunction } from '/namedfunction'
+import { NamedClass } from '/namedclass'
+import { NamedExport, RenamedExport } from '/namedexport'
+import { FirstInStructure, SecondInStructure } from '/destructuredassignment'
+import DefaultExpression from '/defaultexpression'
+import DefaultFunction from '/defaultfunction'
+import DefaultClass from '/defaultclass'
+import DefaultNamedFunction from '/defaultnamedfunction'
+import NamedAsDefault from '/namedasdefault'
+import * as ReexportWildcard from '/reexportwildcard'
+import { assigned } from '/reexportmoduleintonamedexport'
+import { OriginallyAssigned1 as OriginallyAssigned2 } from '/reexportspecificnamed'
+import { NewlyAssigned } from '/reexportspecificrenamed'
+import DefaultFunction2 from '/reexportdefault'
+
+export var App = (props) => {
+  return (
+    <div>
+      <OriginallyUnassigned1 />
+      <OriginallyAssigned1 />
+      <NamedFunction />
+      <NamedClass />
+      <NamedExport />
+      <RenamedExport />
+      <FirstInStructure />
+      <SecondInStructure />
+      <div>The Number Is {DefaultExpression}</div>
+      <DefaultFunction />
+      <DefaultClass />
+      <DefaultNamedFunction />
+      <NamedAsDefault />
+      <ReexportWildcard.OriginallyAssigned1 />
+      <assigned.OriginallyAssigned1 />
+      <OriginallyAssigned2 />
+      <NewlyAssigned />
+      <DefaultFunction2 />
+    </div>
+  )
+}",
+                  ],
+                  "version": 3,
+                },
+                "transpiledJavascript": "return DefaultExpression;",
+                "type": "JSX_ARBITRARY_BLOCK",
+                "uniqueID": "",
+              },
+            ],
+            "name": Object {
+              "baseVariable": "div",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "4cf",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "4cf",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "DefaultFunction",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "d7f",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "d7f",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "DefaultClass",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "315",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "315",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "DefaultNamedFunction",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "5b9",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "5b9",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "NamedAsDefault",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "301",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "301",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "ReexportWildcard",
+              "propertyPath": Object {
+                "propertyElements": Array [
+                  "OriginallyAssigned1",
+                ],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "8ce",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "8ce",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "assigned",
+              "propertyPath": Object {
+                "propertyElements": Array [
+                  "OriginallyAssigned1",
+                ],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "f77",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "f77",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "OriginallyAssigned2",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "218",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "218",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "NewlyAssigned",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "a17",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "a17",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "DefaultFunction2",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "8aa",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "8aa",
+          },
+        ],
+        "name": Object {
+          "baseVariable": "div",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "b93",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "b93",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "LEFT",
+      "value": "NOT_IMPORTED",
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93 utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-uid": "b93 app-entity",
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "RenamedExport",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "0cf",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "0cf",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "0cf",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "RenamedExport",
+        "path": "/namedexport",
+        "variableName": "RenamedExport",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf",
+      "data-uid": "0cf",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "0cf",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/218": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "OriginallyAssigned2",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "218",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "218",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "218",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "OriginallyAssigned1",
+        "path": "/reexportspecificnamed",
+        "variableName": "OriginallyAssigned2",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/218",
+      "data-uid": "218",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "218",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/2f0": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "OriginallyUnassigned1",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "2f0",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "2f0",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "2f0",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "OriginallyUnassigned1",
+        "path": "/originallyunassigned",
+        "variableName": "OriginallyUnassigned1",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/2f0",
+      "data-uid": "2f0",
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/301": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "NamedAsDefault",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "301",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "301",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "301",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": null,
+        "path": "/namedasdefault",
+        "variableName": "NamedAsDefault",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/301",
+      "data-uid": "301",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "301",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/315": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "DefaultClass",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "315",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "315",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "315",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": null,
+        "path": "/defaultclass",
+        "variableName": "DefaultClass",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/315",
+      "data-uid": "315",
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/4cf": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [
+          Object {
+            "text": "The Number Is ",
+            "type": "JSX_TEXT_BLOCK",
+            "uniqueID": "",
+          },
+          Object {
+            "definedElsewhere": Array [
+              "DefaultExpression",
+            ],
+            "elementsWithin": Object {},
+            "javascript": "DefaultExpression;",
+            "originalJavascript": "DefaultExpression",
+            "sourceMap": Object {
+              "file": "code.tsx",
+              "mappings": "OAAA,iBAACA",
+              "names": Array [
+                "DefaultExpression",
+              ],
+              "sources": Array [
+                "code.tsx",
+              ],
+              "sourcesContent": Array [
+                "import * as React from 'react'
+import { OriginallyUnassigned1 } from '/originallyunassigned'
+import { OriginallyAssigned1 } from '/originallyassigned'
+import { NamedFunction } from '/namedfunction'
+import { NamedClass } from '/namedclass'
+import { NamedExport, RenamedExport } from '/namedexport'
+import { FirstInStructure, SecondInStructure } from '/destructuredassignment'
+import DefaultExpression from '/defaultexpression'
+import DefaultFunction from '/defaultfunction'
+import DefaultClass from '/defaultclass'
+import DefaultNamedFunction from '/defaultnamedfunction'
+import NamedAsDefault from '/namedasdefault'
+import * as ReexportWildcard from '/reexportwildcard'
+import { assigned } from '/reexportmoduleintonamedexport'
+import { OriginallyAssigned1 as OriginallyAssigned2 } from '/reexportspecificnamed'
+import { NewlyAssigned } from '/reexportspecificrenamed'
+import DefaultFunction2 from '/reexportdefault'
+
+export var App = (props) => {
+  return (
+    <div>
+      <OriginallyUnassigned1 />
+      <OriginallyAssigned1 />
+      <NamedFunction />
+      <NamedClass />
+      <NamedExport />
+      <RenamedExport />
+      <FirstInStructure />
+      <SecondInStructure />
+      <div>The Number Is {DefaultExpression}</div>
+      <DefaultFunction />
+      <DefaultClass />
+      <DefaultNamedFunction />
+      <NamedAsDefault />
+      <ReexportWildcard.OriginallyAssigned1 />
+      <assigned.OriginallyAssigned1 />
+      <OriginallyAssigned2 />
+      <NewlyAssigned />
+      <DefaultFunction2 />
+    </div>
+  )
+}",
+              ],
+              "version": 3,
+            },
+            "transpiledJavascript": "return DefaultExpression;",
+            "type": "JSX_ARBITRARY_BLOCK",
+            "uniqueID": "",
+          },
+        ],
+        "name": Object {
+          "baseVariable": "div",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "4cf",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "4cf",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "4cf",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "LEFT",
+      "value": "NOT_IMPORTED",
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/4cf",
+      "data-uid": "4cf",
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/54b": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "NamedFunction",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "54b",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "54b",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "54b",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "NamedFunction",
+        "path": "/namedfunction",
+        "variableName": "NamedFunction",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/54b",
+      "data-uid": "54b",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "54b",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/59c": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "OriginallyAssigned1",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "59c",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "59c",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "59c",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "OriginallyAssigned1",
+        "path": "/originallyassigned",
+        "variableName": "OriginallyAssigned1",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/59c",
+      "data-uid": "59c",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "59c",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "DefaultNamedFunction",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "5b9",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "5b9",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "5b9",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": null,
+        "path": "/defaultnamedfunction",
+        "variableName": "DefaultNamedFunction",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9",
+      "data-uid": "5b9",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "5b9",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/7d0": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "SecondInStructure",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "7d0",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "7d0",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "7d0",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "SecondInStructure",
+        "path": "/destructuredassignment",
+        "variableName": "SecondInStructure",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/7d0",
+      "data-uid": "7d0",
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "DefaultFunction2",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "8aa",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "8aa",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "8aa",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": null,
+        "path": "/reexportdefault",
+        "variableName": "DefaultFunction2",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa",
+      "data-uid": "8aa",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "8aa",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "ReexportWildcard",
+          "propertyPath": Object {
+            "propertyElements": Array [
+              "OriginallyAssigned1",
+            ],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "8ce",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "8ce",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "8ce",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": null,
+        "path": "/reexportwildcard",
+        "variableName": "ReexportWildcard",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce",
+      "data-uid": "8ce",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "8ce",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/995": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "NamedExport",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "995",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "995",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "995",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "NamedExport",
+        "path": "/namedexport",
+        "variableName": "NamedExport",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/995",
+      "data-uid": "995",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "995",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/a17": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "NewlyAssigned",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "a17",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "a17",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "a17",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "NewlyAssigned",
+        "path": "/reexportspecificrenamed",
+        "variableName": "NewlyAssigned",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/a17",
+      "data-uid": "a17",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "a17",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/d00": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "FirstInStructure",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "d00",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "d00",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "d00",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "FirstInStructure",
+        "path": "/destructuredassignment",
+        "variableName": "FirstInStructure",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/d00",
+      "data-uid": "d00",
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/d18": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "NamedClass",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "d18",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "d18",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "d18",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "NamedClass",
+        "path": "/namedclass",
+        "variableName": "NamedClass",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/d18",
+      "data-uid": "d18",
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "DefaultFunction",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "d7f",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "d7f",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "d7f",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": null,
+        "path": "/defaultfunction",
+        "variableName": "DefaultFunction",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f",
+      "data-uid": "d7f",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "d7f",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/f77": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "assigned",
+          "propertyPath": Object {
+            "propertyElements": Array [
+              "OriginallyAssigned1",
+            ],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "f77",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "f77",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "f77",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": "assigned",
+        "path": "/reexportmoduleintonamedexport",
+        "variableName": "assigned",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/f77",
+      "data-uid": "f77",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "f77",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,

--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -378,7 +378,7 @@ export default function () {
         <div
           id=\\"canvas-container\\"
           style=\\"position: absolute;\\"
-          data-utopia-valid-paths=\\"storyboard-entity storyboard-entity/scene-1-entity storyboard-entity/scene-1-entity/app-entity\\"
+          data-utopia-valid-paths=\\"storyboard-entity storyboard-entity/scene-1-entity storyboard-entity/scene-1-entity/app-entity storyboard-entity/scene-1-entity/app-entity:app-outer-div storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance storyboard-entity/scene-1-entity/app-entity:app-outer-div/d7f\\"
           data-utopia-root-element-path=\\"storyboard-entity\\"
         >
           <div
@@ -404,7 +404,7 @@ export default function () {
                 height: 100%;
                 background-color: #ffffff;
               \\"
-              data-paths=\\"storyboard-entity/scene-1-entity/app-entity\\"
+              data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div storyboard-entity/scene-1-entity/app-entity\\"
             >
               <div
                 data-uid=\\"card-outer-div card-instance\\"
@@ -415,6 +415,7 @@ export default function () {
                   width: 133px;
                   height: 300px;
                 \\"
+                data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance\\"
               >
                 <div
                   data-uid=\\"card-inner-div\\"
@@ -426,6 +427,7 @@ export default function () {
                     height: 50px;
                     background-color: red;
                   \\"
+                  data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-div\\"
                 ></div>
                 <div
                   style=\\"
@@ -436,12 +438,18 @@ export default function () {
                     height: 50px;
                     background-color: blue;
                   \\"
+                  data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle\\"
                   data-uid=\\"card-inner-rectangle\\"
                   data-utopia-do-not-traverse=\\"true\\"
                 ></div>
               </div>
               hello
-              <div>Default Function Time</div>
+              <div
+                data-uid=\\"4cf d7f\\"
+                data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/d7f:4cf storyboard-entity/scene-1-entity/app-entity:app-outer-div/d7f\\"
+              >
+                Default Function Time
+              </div>
             </div>
           </div>
         </div>

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -44,6 +44,11 @@ import DefaultFunction from '/defaultfunction'
 import DefaultClass from '/defaultclass'
 import DefaultNamedFunction from '/defaultnamedfunction'
 import NamedAsDefault from '/namedasdefault'
+import * as ReexportWildcard from '/reexportwildcard'
+import { assigned } from '/reexportmoduleintonamedexport'
+import { OriginallyAssigned1 as OriginallyAssigned2 } from '/reexportspecificnamed'
+import { NewlyAssigned } from '/reexportspecificrenamed'
+import DefaultFunction2 from '/reexportdefault'
 
 export var App = (props) => {
   return (
@@ -61,6 +66,11 @@ export var App = (props) => {
       <DefaultClass />
       <DefaultNamedFunction />
       <NamedAsDefault />
+      <ReexportWildcard.OriginallyAssigned1 />
+      <assigned.OriginallyAssigned1 />
+      <OriginallyAssigned2 />
+      <NewlyAssigned />
+      <DefaultFunction2 />
     </div>
   )
 }`,
@@ -91,6 +101,11 @@ export default function DefaultNamedFunction() { return <div>Default Named Funct
         '/namedasdefault.js': `import * as React from 'react'
 const ToBeDefaultExported = () => <div>Named As Default</div>
 export { ToBeDefaultExported as default }`,
+        '/reexportwildcard.js': `export * from '/originallyassigned'`,
+        '/reexportmoduleintonamedexport.js': `export * as assigned from '/originallyassigned'`,
+        '/reexportspecificnamed.js': `export { OriginallyAssigned1 } from '/originallyassigned'`,
+        '/reexportspecificrenamed.js': `export { OriginallyAssigned1 as NewlyAssigned } from '/originallyassigned'`,
+        '/reexportdefault.js': `export { default } from '/defaultfunction'`,
       },
     )
   })
@@ -1744,7 +1759,7 @@ describe('UiJsxCanvas render multifile projects', () => {
       null,
       `import * as React from 'react'
       import { Storyboard, Scene } from 'utopia-api'
-      import { App } from 'app.js'
+      import { App } from '/app'
 
       export var ${BakedInStoryboardVariableName} = (props) => {
         return (
@@ -1764,7 +1779,7 @@ describe('UiJsxCanvas render multifile projects', () => {
       }
       `,
       {
-        'app.js': `
+        '/app.js': `
       import * as React from 'react'
       export var App = (props) => {
         return <div data-uid='app-outer-div'>
@@ -1817,7 +1832,7 @@ describe('UiJsxCanvas render multifile projects', () => {
       null,
       `import * as React from 'react'
       import { Storyboard, Scene } from 'utopia-api'
-      import { App } from 'app.js'
+      import { App } from '/app'
 
       export var ${BakedInStoryboardVariableName} = (props) => {
         return (
@@ -1837,9 +1852,9 @@ describe('UiJsxCanvas render multifile projects', () => {
       }
       `,
       {
-        'app.js': `
+        '/app.js': `
       import * as React from 'react'
-      import { Card } from 'card.js'
+      import { Card } from '/card'
       export var App = (props) => {
         return <div data-uid='app-outer-div'>
           <Card data-uid='card-instance'>
@@ -1847,7 +1862,7 @@ describe('UiJsxCanvas render multifile projects', () => {
           </Card>
         </div>
       }`,
-        'card.js': `
+        '/card.js': `
         import * as React from 'react'
         export var Card = (props) => {
           return <div data-uid='card-outer-div'>
@@ -1912,7 +1927,7 @@ describe('UiJsxCanvas render multifile projects', () => {
       null,
       `import * as React from 'react'
       import { Storyboard, Scene } from 'utopia-api'
-      import App from './app'
+      import App from '/app'
 
       export var ${BakedInStoryboardVariableName} = (props) => {
         return (
@@ -1932,7 +1947,7 @@ describe('UiJsxCanvas render multifile projects', () => {
       }
       `,
       {
-        'app.js': `
+        '/app.js': `
       import * as React from 'react'
       export default class App extends React.Component {
         render() {
@@ -1983,7 +1998,7 @@ describe('UiJsxCanvas render multifile projects', () => {
       null,
       `import * as React from 'react'
       import { Storyboard, Scene } from 'utopia-api'
-      import { App } from './app'
+      import { App } from '/app'
 
       export var ${BakedInStoryboardVariableName} = (props) => {
         return (
@@ -2003,7 +2018,7 @@ describe('UiJsxCanvas render multifile projects', () => {
       }
       `,
       {
-        'app.js': `
+        '/app.js': `
       import * as React from 'react'
       export class App extends React.Component {
         render() {

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -52,6 +52,7 @@ import { MapLike } from 'typescript'
 import { getRequireFn } from '../../core/es-modules/package-manager/package-manager'
 import type { ScriptLine } from '../../third-party/react-error-overlay/utils/stack-frame'
 import type { CurriedResolveFn } from '../custom-code/code-file'
+import * as path from 'path'
 
 export interface PartialCanvasProps {
   offset: UiJsxCanvasProps['offset']
@@ -71,9 +72,18 @@ function resolveTestFiles(
   importOrigin: string,
   toImport: string,
 ): Either<string, string> {
-  const normalizedName = normalizeName(importOrigin, toImport)
-  if (filenames.includes(normalizedName)) {
-    return right(normalizedName)
+  let normalizedName = normalizeName(importOrigin, toImport)
+  // Partly restoring what `normalizeName` strips away.
+  if (toImport.startsWith('.')) {
+    normalizedName = path.normalize(`${importOrigin}/${normalizedName}`)
+  } else if (toImport.startsWith('/')) {
+    normalizedName = `/${normalizedName}`
+  }
+  for (const extension of ['.js', '.ts', '.jsx', '.tsx']) {
+    const filenameWithExtension = `${normalizedName}${extension}`
+    if (filenames.includes(filenameWithExtension)) {
+      return right(filenameWithExtension)
+    }
   }
   switch (normalizedName) {
     case 'utopia-api':

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -16,10 +16,8 @@ import {
   ElementPath,
   isParseSuccess,
   isTextFile,
-  isExportDefaultNamed,
-  isExportDefaultModifier,
-  isExportDefaultFunction,
-  isExportDefaultExpression,
+  isReexportExportDetail,
+  isExportDestructuredAssignment,
 } from '../../core/shared/project-file-types'
 import {
   Either,
@@ -86,6 +84,7 @@ import { getParseSuccessOrTransientForFilePath, getValidElementPaths } from './c
 import { NO_OP } from '../../core/shared/utils'
 import { useTwind } from '../../core/tailwind/tailwind'
 import { atomWithPubSub, usePubSubAtomReadOnly } from '../../core/shared/atom-with-pub-sub'
+import { omit } from '../../core/shared/object-utils'
 
 applyUIDMonkeyPatch()
 
@@ -346,7 +345,17 @@ export const UiJsxCanvas = betterReactMemo(
             resolvedFromThisOrigin.push(toImport)
             const projectFile = getContentsTreeFileFromString(projectContents, resolvedFilePath)
             if (isTextFile(projectFile) && isParseSuccess(projectFile.fileContents.parsed)) {
-              if (projectFile.fileContents.parsed.topLevelElements.some(isUtopiaJSXComponent)) {
+              const exportsDetail = projectFile.fileContents.parsed.exportsDetail
+              // Should only use the full scope and components support if the file contains components
+              // or if it does any kind of re-exporting as we can't guarantee that the re-exported
+              // files do not contain components.
+              // Exclude any file with the destructured assignment export style as they're quite problematic
+              // to support.
+              const shouldUseFileScope =
+                (projectFile.fileContents.parsed.topLevelElements.some(isUtopiaJSXComponent) ||
+                  exportsDetail.some(isReexportExportDetail)) &&
+                !exportsDetail.some(isExportDestructuredAssignment)
+              if (shouldUseFileScope) {
                 const { scope } = createExecutionScope(
                   resolvedFilePath,
                   customRequire,
@@ -361,29 +370,123 @@ export const UiJsxCanvas = betterReactMemo(
                   updateInvalidatedPaths,
                   shouldIncludeCanvasRootInTheSpy,
                 )
-                const exportsDetail = projectFile.fileContents.parsed.exportsDetail
                 let filteredScope: MapLike<any> = {
                   ...scope.module.exports,
                   __esModule: true,
                 }
-                for (const s of Object.keys(scope)) {
-                  if (s in exportsDetail.namedExports) {
-                    filteredScope[s] = scope[s]
-                  } else if (exportsDetail.defaultExport != null) {
-                    if (
-                      (isExportDefaultNamed(exportsDetail.defaultExport) ||
-                        isExportDefaultModifier(exportsDetail.defaultExport)) &&
-                      s === exportsDetail.defaultExport.name
-                    ) {
-                      filteredScope['default'] = scope[s]
-                    } else if (
-                      isExportDefaultFunction(exportsDetail.defaultExport) ||
-                      isExportDefaultExpression(exportsDetail.defaultExport)
-                    ) {
-                      filteredScope['default'] = scope['default']
-                    }
+
+                function addToFilteredScopeFromSpecificScope(
+                  filteredScopeKey: string,
+                  scopeKey: string,
+                  scopeToWorkWith: MapLike<any>,
+                ): void {
+                  if (scopeKey in scopeToWorkWith) {
+                    filteredScope[filteredScopeKey] = scopeToWorkWith[scopeKey]
                   }
                 }
+
+                function addToFilteredScope(filteredScopeKey: string, scopeKey: string): void {
+                  addToFilteredScopeFromSpecificScope(filteredScopeKey, scopeKey, scope)
+                }
+
+                for (const exportDetail of exportsDetail) {
+                  switch (exportDetail.type) {
+                    case 'EXPORT_DEFAULT_FUNCTION_OR_CLASS':
+                      if (exportDetail.name == null) {
+                        addToFilteredScope('default', 'default')
+                      } else {
+                        addToFilteredScope('default', exportDetail.name)
+                      }
+                      break
+                    case 'EXPORT_EXPRESSION':
+                      addToFilteredScope('default', 'default')
+                      break
+                    case 'EXPORT_CLASS':
+                      addToFilteredScope(exportDetail.className, exportDetail.className)
+                      break
+                    case 'EXPORT_FUNCTION':
+                      addToFilteredScope(exportDetail.functionName, exportDetail.functionName)
+                      break
+                    case 'EXPORT_VARIABLES':
+                      for (const exportVar of exportDetail.variables) {
+                        const exportName = exportVar.variableAlias ?? exportVar.variableName
+                        addToFilteredScope(exportName, exportVar.variableName)
+                      }
+                      break
+                    case 'EXPORT_DESTRUCTURED_ASSIGNMENT':
+                      throw new Error(
+                        `EXPORT_DESTRUCTURED_ASSIGNMENT cases should not be handled this way.`,
+                      )
+                    case 'REEXPORT_WILDCARD':
+                      {
+                        const reexportedModule = customRequire(
+                          resolvedFilePath,
+                          exportDetail.reexportedModule,
+                        )
+                        if (typeof reexportedModule === 'object') {
+                          if (exportDetail.namespacedVariable == null) {
+                            filteredScope = {
+                              ...filteredScope,
+                              ...omit(['default'], reexportedModule),
+                            }
+                          } else {
+                            filteredScope = {
+                              ...filteredScope,
+                              [exportDetail.namespacedVariable]: {
+                                ...omit(['default'], reexportedModule),
+                              },
+                            }
+                          }
+                        } else {
+                          if (exportDetail.namespacedVariable == null) {
+                            return left(
+                              `Unable to re-export ${exportDetail.reexportedModule} as it does not return an object.`,
+                            )
+                          } else {
+                            filteredScope = {
+                              ...filteredScope,
+                              [exportDetail.namespacedVariable]: omit(
+                                ['default'],
+                                reexportedModule,
+                              ),
+                            }
+                          }
+                        }
+                      }
+                      break
+                    case 'REEXPORT_VARIABLES':
+                      {
+                        const reexportedModule = customRequire(
+                          resolvedFilePath,
+                          exportDetail.reexportedModule,
+                        )
+                        if (typeof reexportedModule === 'object') {
+                          for (const exportVar of exportDetail.variables) {
+                            const exportName = exportVar.variableAlias ?? exportVar.variableName
+                            addToFilteredScopeFromSpecificScope(
+                              exportName,
+                              exportVar.variableName,
+                              reexportedModule,
+                            )
+                          }
+                        } else {
+                          return left(
+                            `Unable to re-export ${exportDetail.reexportedModule} as it does not return an object.`,
+                          )
+                        }
+                      }
+                      break
+                    case 'EXPORT_VARIABLES_WITH_MODIFIER':
+                      for (const exportVar of exportDetail.variables) {
+                        addToFilteredScope(exportVar, exportVar)
+                      }
+                      break
+                    default:
+                      const _exhaustiveCheck: never = exportDetail
+                      throw new Error(`Unhandled type ${JSON.stringify(exportDetail)}`)
+                  }
+                }
+
                 return right(filteredScope)
               } else {
                 return left(`File ${resolvedFilePath} contains no components`)

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -37,9 +37,11 @@ import {
   textFile,
   TextFileContents,
   unparsed,
-  addModifierExportToDetail,
   EmptyExportsDetail,
   importAlias,
+  exportVariable,
+  exportVariables,
+  exportFunction,
 } from '../../../core/shared/project-file-types'
 import {
   addImport,
@@ -224,7 +226,7 @@ const originalModel = deepFreeze(
     {},
     null,
     null,
-    addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+    [exportFunction('whatever')],
   ),
 )
 const testEditor: EditorState = deepFreeze({
@@ -337,7 +339,7 @@ describe('moveTemplate', () => {
         {},
         null,
         null,
-        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+        [exportFunction('whatever')],
       ),
     )
   }
@@ -938,7 +940,7 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     {},
     null,
     null,
-    addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+    [exportFunction('whatever')],
   )
 
   const fileForUI = textFile(

--- a/editor/src/core/es-modules/evaluator/evaluator.ts
+++ b/editor/src/core/es-modules/evaluator/evaluator.ts
@@ -1,6 +1,7 @@
 import { SafeFunction } from '../../shared/code-exec-utils'
 import * as Babel from '@babel/standalone'
 import * as BabelTransformCommonJS from '@babel/plugin-transform-modules-commonjs'
+import * as BabelExportNamespaceFrom from '@babel/plugin-proposal-export-namespace-from'
 import { FileEvaluationCache } from '../package-manager/package-manager'
 import { RawSourceMap } from '../../workers/ts/ts-typings/RawSourceMap'
 
@@ -24,7 +25,7 @@ function transformToCommonJS(
   filePath: string,
   moduleCode: string,
 ): { transpiledCode: string; sourceMap: RawSourceMap } {
-  const plugins = [BabelTransformCommonJS]
+  const plugins = [BabelTransformCommonJS, BabelExportNamespaceFrom]
   const result = Babel.transform(moduleCode, {
     presets: ['es2015', 'react'],
     plugins: plugins,

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -147,190 +147,181 @@ export function importsEquals(first: Imports, second: Imports): boolean {
   return objectEquals(first, second, importDetailsEquals)
 }
 
-export interface ExportDetailNamed {
-  type: 'EXPORT_DETAIL_NAMED'
-  name: string
-  moduleName: string | undefined
+// export let name1, name2, …, nameN; // also var, const
+// export let name1 = …, name2 = …, …, nameN; // also var, const
+export interface ExportVariablesWithModifier {
+  type: 'EXPORT_VARIABLES_WITH_MODIFIER'
+  variables: Array<string>
 }
 
-export function exportDetailNamed(name: string, moduleName: string | undefined): ExportDetailNamed {
+export function exportVariablesWithModifier(variables: Array<string>): ExportVariablesWithModifier {
   return {
-    type: 'EXPORT_DETAIL_NAMED',
+    type: 'EXPORT_VARIABLES_WITH_MODIFIER',
+    variables: variables,
+  }
+}
+
+// export function functionName(){...}
+export interface ExportFunction {
+  type: 'EXPORT_FUNCTION'
+  functionName: string
+}
+
+export function exportFunction(functionName: string): ExportFunction {
+  return {
+    type: 'EXPORT_FUNCTION',
+    functionName: functionName,
+  }
+}
+
+// export class ClassName {...}
+export interface ExportClass {
+  type: 'EXPORT_CLASS'
+  className: string
+}
+
+export function exportClass(className: string): ExportClass {
+  return {
+    type: 'EXPORT_CLASS',
+    className: className,
+  }
+}
+
+// export { name1, name2, …, nameN };
+// export { variable1 as name1, variable2 as name2, …, nameN };
+// export { name1 as default, … };
+export interface ExportVariable {
+  variableName: string
+  variableAlias: string | null
+}
+
+export function exportVariable(variableName: string, variableAlias: string | null): ExportVariable {
+  return {
+    variableName: variableName,
+    variableAlias: variableAlias,
+  }
+}
+
+export interface ExportVariables {
+  type: 'EXPORT_VARIABLES'
+  variables: Array<ExportVariable>
+}
+
+export function exportVariables(variables: Array<ExportVariable>): ExportVariables {
+  return {
+    type: 'EXPORT_VARIABLES',
+    variables: variables,
+  }
+}
+
+// export const { name1, name2: bar } = o;
+export interface ExportDestructuredAssignment {
+  type: 'EXPORT_DESTRUCTURED_ASSIGNMENT'
+  variables: Array<ExportVariable>
+}
+
+export function exportDestructuredAssignment(
+  variables: Array<ExportVariable>,
+): ExportDestructuredAssignment {
+  return {
+    type: 'EXPORT_DESTRUCTURED_ASSIGNMENT',
+    variables: variables,
+  }
+}
+
+// export default function (…) { … } // also class, function*
+// export default function name1(…) { … } // also class, function*
+export interface ExportDefaultFunctionOrClass {
+  type: 'EXPORT_DEFAULT_FUNCTION_OR_CLASS'
+  name: string | null
+}
+
+export function exportDefaultFunctionOrClass(name: string | null): ExportDefaultFunctionOrClass {
+  return {
+    type: 'EXPORT_DEFAULT_FUNCTION_OR_CLASS',
     name: name,
-    moduleName: moduleName,
   }
 }
 
-export interface ExportDetailModifier {
-  type: 'EXPORT_DETAIL_MODIFIER'
+// export default expression;
+export interface ExportExpression {
+  type: 'EXPORT_EXPRESSION'
 }
 
-export function exportDetailModifier(): ExportDetailModifier {
+export function exportExpression(): ExportExpression {
   return {
-    type: 'EXPORT_DETAIL_MODIFIER',
+    type: 'EXPORT_EXPRESSION',
   }
 }
 
-export interface ExportDefaultNamed {
-  type: 'EXPORT_DEFAULT_NAMED'
-  name: string
+// export * from …; // does not set the default export
+// export * as name1 from …; // Draft ECMAScript® 2O21
+export interface ReexportWildcard {
+  type: 'REEXPORT_WILDCARD'
+  reexportedModule: string
+  namespacedVariable: string | null
 }
 
-export function exportDefaultNamed(name: string): ExportDefaultNamed {
+export function reexportWildcard(
+  reexportedModule: string,
+  namespacedVariable: string | null,
+): ReexportWildcard {
   return {
-    type: 'EXPORT_DEFAULT_NAMED',
-    name: name,
+    type: 'REEXPORT_WILDCARD',
+    reexportedModule: reexportedModule,
+    namespacedVariable: namespacedVariable,
   }
 }
 
-export interface ExportDefaultModifier {
-  type: 'EXPORT_DEFAULT_MODIFIER'
-  name: string
+//export { name1, name2, …, nameN } from …;
+//export { import1 as name1, import2 as name2, …, nameN } from …;
+//export { default, … } from …;
+export interface ReexportVariables {
+  type: 'REEXPORT_VARIABLES'
+  reexportedModule: string
+  variables: Array<ExportVariable>
 }
 
-export function exportDefaultModifier(name: string): ExportDefaultModifier {
+export function reexportVariables(
+  reexportedModule: string,
+  variables: Array<ExportVariable>,
+): ReexportVariables {
   return {
-    type: 'EXPORT_DEFAULT_MODIFIER',
-    name: name,
+    type: 'REEXPORT_VARIABLES',
+    reexportedModule: reexportedModule,
+    variables: variables,
   }
 }
 
-export interface ExportDefaultExpression {
-  type: 'EXPORT_DEFAULT_EXPRESSION'
-}
+export type ExportDetail =
+  | ExportVariablesWithModifier
+  | ExportFunction
+  | ExportClass
+  | ExportVariables
+  | ExportDestructuredAssignment
+  | ExportDefaultFunctionOrClass
+  | ExportExpression
+  | ReexportWildcard
+  | ReexportVariables
 
-export function exportDefaultExpression(): ExportDefaultExpression {
-  return {
-    type: 'EXPORT_DEFAULT_EXPRESSION',
-  }
-}
+export type ExportsDetail = Array<ExportDetail>
 
-export interface ExportDefaultFunction {
-  type: 'EXPORT_DEFAULT_FUNCTION'
-}
-
-export function exportDefaultFunction(): ExportDefaultFunction {
-  return {
-    type: 'EXPORT_DEFAULT_FUNCTION',
-  }
-}
-
-export type ExportDetail = ExportDetailNamed | ExportDetailModifier
-export type ExportDefault =
-  | ExportDefaultNamed
-  | ExportDefaultModifier
-  | ExportDefaultExpression
-  | ExportDefaultFunction
-
-export function isExportDetailNamed(detail: ExportDetail): detail is ExportDetailNamed {
-  return detail.type === 'EXPORT_DETAIL_NAMED'
-}
-
-export function isExportDetailModifier(detail: ExportDetail): detail is ExportDetailModifier {
-  return detail.type === 'EXPORT_DETAIL_MODIFIER'
-}
-
-export function isExportDefaultNamed(detail: ExportDefault): detail is ExportDefaultNamed {
-  return detail.type === 'EXPORT_DEFAULT_NAMED'
-}
-
-export function isExportDefaultModifier(detail: ExportDefault): detail is ExportDefaultModifier {
-  return detail.type === 'EXPORT_DEFAULT_MODIFIER'
-}
-
-export function isExportDefaultExpression(
-  detail: ExportDefault | null | undefined,
-): detail is ExportDefaultExpression {
-  return detail?.type === 'EXPORT_DEFAULT_EXPRESSION'
-}
-
-export function isExportDefaultFunction(
-  detail: ExportDefault | null | undefined,
-): detail is ExportDefaultFunction {
-  return detail?.type === 'EXPORT_DEFAULT_FUNCTION'
-}
-
-export interface ExportsDetail {
-  defaultExport: ExportDefault | null
-  namedExports: Record<string, ExportDetail>
-}
-
-export function exportsDetail(
-  defaultExport: ExportDefault | null,
-  namedExports: Record<string, ExportDetail>,
-): ExportsDetail {
-  return {
-    defaultExport: defaultExport,
-    namedExports: namedExports,
-  }
-}
-
-export const EmptyExportsDetail: ExportsDetail = exportsDetail(null, {})
+export const EmptyExportsDetail: ExportsDetail = []
 
 export function mergeExportsDetail(first: ExportsDetail, second: ExportsDetail): ExportsDetail {
-  return {
-    defaultExport: second.defaultExport ?? first.defaultExport,
-    namedExports: {
-      ...first.namedExports,
-      ...second.namedExports,
-    },
-  }
+  return [...first, ...second]
 }
 
-export function addNamedExportToDetail(
-  detail: ExportsDetail,
-  name: string,
-  alias: string,
-  moduleName: string | undefined,
-): ExportsDetail {
-  return {
-    defaultExport: detail.defaultExport,
-    namedExports: {
-      ...detail.namedExports,
-      [name]: exportDetailNamed(alias, moduleName),
-    },
-  }
+export function isExportDestructuredAssignment(
+  exportDetail: ExportDetail,
+): exportDetail is ExportDestructuredAssignment {
+  return exportDetail.type === 'EXPORT_DESTRUCTURED_ASSIGNMENT'
 }
 
-export function addModifierExportToDetail(detail: ExportsDetail, name: string): ExportsDetail {
-  return {
-    defaultExport: detail.defaultExport,
-    namedExports: {
-      ...detail.namedExports,
-      [name]: exportDetailModifier(),
-    },
-  }
-}
-
-export function setNamedDefaultExportInDetail(detail: ExportsDetail, name: string): ExportsDetail {
-  return {
-    defaultExport: exportDefaultNamed(name),
-    namedExports: detail.namedExports,
-  }
-}
-
-export function setModifierDefaultExportInDetail(
-  detail: ExportsDetail,
-  name: string,
-): ExportsDetail {
-  return {
-    defaultExport: exportDefaultModifier(name),
-    namedExports: detail.namedExports,
-  }
-}
-
-export function setExpressionDefaultExportInDetail(detail: ExportsDetail): ExportsDetail {
-  return {
-    defaultExport: exportDefaultExpression(),
-    namedExports: detail.namedExports,
-  }
-}
-
-export function setFunctionDefaultExportInDetail(detail: ExportsDetail): ExportsDetail {
-  return {
-    defaultExport: exportDefaultFunction(),
-    namedExports: detail.namedExports,
-  }
+export function isReexportExportDetail(
+  exportDetail: ExportDetail,
+): exportDetail is ReexportWildcard | ReexportVariables {
+  return exportDetail.type === 'REEXPORT_WILDCARD' || exportDetail.type === 'REEXPORT_VARIABLES'
 }
 
 export interface HighlightBounds {

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.tsx.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer-arbitrary-elements.spec.tsx.snap
@@ -111,17 +111,16 @@ return { a: a, b: b };",
     "type": "ARBITRARY_JS_BLOCK",
     "uniqueID": "",
   },
-  "exportsDetail": Object {
-    "defaultExport": null,
-    "namedExports": Object {
-      "App": Object {
-        "type": "EXPORT_DETAIL_MODIFIER",
-      },
-      "storyboard": Object {
-        "type": "EXPORT_DETAIL_MODIFIER",
-      },
+  "exportsDetail": Array [
+    Object {
+      "functionName": "App",
+      "type": "EXPORT_FUNCTION",
     },
-  },
+    Object {
+      "functionName": "storyboard",
+      "type": "EXPORT_FUNCTION",
+    },
+  ],
   "highlightBounds": Object {
     "aaa": Object {
       "endCol": 26,

--- a/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
+++ b/editor/src/core/workers/parser-printer/__snapshots__/parser-printer.spec.ts.snap
@@ -143,14 +143,12 @@ return { cakeFn: cakeFn, otherFn: otherFn };",
     "type": "ARBITRARY_JS_BLOCK",
     "uniqueID": "",
   },
-  "exportsDetail": Object {
-    "defaultExport": null,
-    "namedExports": Object {
-      "whatever": Object {
-        "type": "EXPORT_DETAIL_MODIFIER",
-      },
+  "exportsDetail": Array [
+    Object {
+      "functionName": "whatever",
+      "type": "EXPORT_FUNCTION",
     },
-  },
+  ],
   "highlightBounds": Object {
     "aaa": Object {
       "endCol": 11,
@@ -632,14 +630,12 @@ return { a: a, b: b };",
     "type": "ARBITRARY_JS_BLOCK",
     "uniqueID": "",
   },
-  "exportsDetail": Object {
-    "defaultExport": null,
-    "namedExports": Object {
-      "whatever": Object {
-        "type": "EXPORT_DETAIL_MODIFIER",
-      },
+  "exportsDetail": Array [
+    Object {
+      "functionName": "whatever",
+      "type": "EXPORT_FUNCTION",
     },
-  },
+  ],
   "highlightBounds": Object {
     "aaa": Object {
       "endCol": 56,
@@ -908,14 +904,12 @@ return { a: a };",
     "type": "ARBITRARY_JS_BLOCK",
     "uniqueID": "",
   },
-  "exportsDetail": Object {
-    "defaultExport": null,
-    "namedExports": Object {
-      "App": Object {
-        "type": "EXPORT_DETAIL_MODIFIER",
-      },
+  "exportsDetail": Array [
+    Object {
+      "functionName": "App",
+      "type": "EXPORT_FUNCTION",
     },
-  },
+  ],
   "highlightBounds": Object {
     "bbb": Object {
       "endCol": 7,

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
@@ -20,9 +20,10 @@ import {
 import { setJSXValueAtPath } from '../../shared/jsx-attributes'
 import { forEachRight } from '../../shared/either'
 import {
-  addModifierExportToDetail,
-  addNamedExportToDetail,
   EmptyExportsDetail,
+  exportFunction,
+  exportVariable,
+  exportVariables,
   foldParsedTextFile,
   isParseFailure,
   isParseSuccess,
@@ -263,7 +264,7 @@ export var whatever = props => (
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -364,7 +365,7 @@ return { arr: arr };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -467,7 +468,7 @@ return { arr: arr };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -571,7 +572,7 @@ return { arr: arr };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -663,7 +664,7 @@ export var whatever = (props) => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -767,7 +768,7 @@ return { arr: arr };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -859,7 +860,7 @@ export var whatever = (props) => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -963,7 +964,7 @@ return { arr: arr };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })

--- a/editor/src/core/workers/parser-printer/parser-printer-exports.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-exports.spec.tsx
@@ -18,14 +18,12 @@ describe('parseCode', () => {
     expect(testPrintParsedTextFile(actualResult)).toEqual(code)
     const exports = Utils.path(['exportsDetail'], actualResult)
     expect(exports).toMatchInlineSnapshot(`
-      Object {
-        "defaultExport": null,
-        "namedExports": Object {
-          "whatever": Object {
-            "type": "EXPORT_DETAIL_MODIFIER",
-          },
+      Array [
+        Object {
+          "functionName": "whatever",
+          "type": "EXPORT_FUNCTION",
         },
-      }
+      ]
     `)
   })
   it('should parse a component exported handled with an external export clause', () => {
@@ -43,16 +41,17 @@ describe('parseCode', () => {
     expect(testPrintParsedTextFile(actualResult)).toEqual(code)
     const exports = Utils.path(['exportsDetail'], actualResult)
     expect(exports).toMatchInlineSnapshot(`
-      Object {
-        "defaultExport": null,
-        "namedExports": Object {
-          "whatever": Object {
-            "moduleName": undefined,
-            "name": "whatever",
-            "type": "EXPORT_DETAIL_NAMED",
-          },
+      Array [
+        Object {
+          "type": "EXPORT_VARIABLES",
+          "variables": Array [
+            Object {
+              "variableAlias": null,
+              "variableName": "whatever",
+            },
+          ],
         },
-      }
+      ]
     `)
   })
 
@@ -60,14 +59,7 @@ describe('parseCode', () => {
     const code = `export default 2 + 2`
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
-      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": Object {
-            "type": "EXPORT_DEFAULT_EXPRESSION",
-          },
-          "namedExports": Object {},
-        }
-      `)
+      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`Array []`)
     } else {
       fail('Did not parse successfully.')
     }
@@ -79,21 +71,21 @@ export const { name: firstName, surname } = entireValue`
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": null,
-          "namedExports": Object {
-            "name": Object {
-              "moduleName": undefined,
-              "name": "firstName",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-            "surname": Object {
-              "moduleName": undefined,
-              "name": "surname",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
+        Array [
+          Object {
+            "type": "EXPORT_DESTRUCTURED_ASSIGNMENT",
+            "variables": Array [
+              Object {
+                "variableAlias": "name",
+                "variableName": "firstName",
+              },
+              Object {
+                "variableAlias": null,
+                "variableName": "surname",
+              },
+            ],
           },
-        }
+        ]
       `)
     } else {
       fail('Did not parse successfully.')
@@ -107,21 +99,21 @@ export { thing1, thing2 }`
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": null,
-          "namedExports": Object {
-            "thing1": Object {
-              "moduleName": undefined,
-              "name": "thing1",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-            "thing2": Object {
-              "moduleName": undefined,
-              "name": "thing2",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
+        Array [
+          Object {
+            "type": "EXPORT_VARIABLES",
+            "variables": Array [
+              Object {
+                "variableAlias": null,
+                "variableName": "thing1",
+              },
+              Object {
+                "variableAlias": null,
+                "variableName": "thing2",
+              },
+            ],
           },
-        }
+        ]
       `)
     } else {
       fail('Did not parse successfully.')
@@ -135,21 +127,21 @@ export { thing1 as importantThing1, thing2 as importantThing2 }`
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": null,
-          "namedExports": Object {
-            "importantThing1": Object {
-              "moduleName": undefined,
-              "name": "thing1",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-            "importantThing2": Object {
-              "moduleName": undefined,
-              "name": "thing2",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
+        Array [
+          Object {
+            "type": "EXPORT_VARIABLES",
+            "variables": Array [
+              Object {
+                "variableAlias": "importantThing1",
+                "variableName": "thing1",
+              },
+              Object {
+                "variableAlias": "importantThing2",
+                "variableName": "thing2",
+              },
+            ],
           },
-        }
+        ]
       `)
     } else {
       fail('Did not parse successfully.')
@@ -163,19 +155,21 @@ export { thing1 as default, thing2 as importantThing2 }`
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": Object {
-            "name": "thing1",
-            "type": "EXPORT_DEFAULT_NAMED",
+        Array [
+          Object {
+            "type": "EXPORT_VARIABLES",
+            "variables": Array [
+              Object {
+                "variableAlias": "default",
+                "variableName": "thing1",
+              },
+              Object {
+                "variableAlias": "importantThing2",
+                "variableName": "thing2",
+              },
+            ],
           },
-          "namedExports": Object {
-            "importantThing2": Object {
-              "moduleName": undefined,
-              "name": "thing2",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-          },
-        }
+        ]
       `)
     } else {
       fail('Did not parse successfully.')
@@ -190,31 +184,32 @@ export let exportedLet1, exportedLet2;
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": null,
-          "namedExports": Object {
-            "exportedLet1": Object {
-              "moduleName": undefined,
-              "name": "exportedLet1",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-            "exportedLet2": Object {
-              "moduleName": undefined,
-              "name": "exportedLet2",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-            "exportedVar1": Object {
-              "moduleName": undefined,
-              "name": "exportedVar1",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-            "exportedVar2": Object {
-              "moduleName": undefined,
-              "name": "exportedVar2",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
+        Array [
+          Object {
+            "type": "EXPORT_VARIABLES_WITH_MODIFIER",
+            "variables": Array [
+              "exportedVar1",
+            ],
           },
-        }
+          Object {
+            "type": "EXPORT_VARIABLES_WITH_MODIFIER",
+            "variables": Array [
+              "exportedVar2",
+            ],
+          },
+          Object {
+            "type": "EXPORT_VARIABLES_WITH_MODIFIER",
+            "variables": Array [
+              "exportedLet1",
+            ],
+          },
+          Object {
+            "type": "EXPORT_VARIABLES_WITH_MODIFIER",
+            "variables": Array [
+              "exportedLet2",
+            ],
+          },
+        ]
       `)
     } else {
       fail('Did not parse successfully.')
@@ -230,41 +225,44 @@ export const exportedConst1 = 'const1', exportedConst2 = 'const2';
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": null,
-          "namedExports": Object {
-            "exportedConst1": Object {
-              "moduleName": undefined,
-              "name": "exportedConst1",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-            "exportedConst2": Object {
-              "moduleName": undefined,
-              "name": "exportedConst2",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-            "exportedLet1": Object {
-              "moduleName": undefined,
-              "name": "exportedLet1",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-            "exportedLet2": Object {
-              "moduleName": undefined,
-              "name": "exportedLet2",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-            "exportedVar1": Object {
-              "moduleName": undefined,
-              "name": "exportedVar1",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
-            "exportedVar2": Object {
-              "moduleName": undefined,
-              "name": "exportedVar2",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
+        Array [
+          Object {
+            "type": "EXPORT_VARIABLES_WITH_MODIFIER",
+            "variables": Array [
+              "exportedVar1",
+            ],
           },
-        }
+          Object {
+            "type": "EXPORT_VARIABLES_WITH_MODIFIER",
+            "variables": Array [
+              "exportedVar2",
+            ],
+          },
+          Object {
+            "type": "EXPORT_VARIABLES_WITH_MODIFIER",
+            "variables": Array [
+              "exportedLet1",
+            ],
+          },
+          Object {
+            "type": "EXPORT_VARIABLES_WITH_MODIFIER",
+            "variables": Array [
+              "exportedLet2",
+            ],
+          },
+          Object {
+            "type": "EXPORT_VARIABLES_WITH_MODIFIER",
+            "variables": Array [
+              "exportedConst1",
+            ],
+          },
+          Object {
+            "type": "EXPORT_VARIABLES_WITH_MODIFIER",
+            "variables": Array [
+              "exportedConst2",
+            ],
+          },
+        ]
       `)
     } else {
       fail('Did not parse successfully.')
@@ -280,14 +278,12 @@ export function App() {
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": null,
-          "namedExports": Object {
-            "App": Object {
-              "type": "EXPORT_DETAIL_MODIFIER",
-            },
+        Array [
+          Object {
+            "functionName": "App",
+            "type": "EXPORT_FUNCTION",
           },
-        }
+        ]
       `)
     } else {
       fail('Did not parse successfully.')
@@ -303,14 +299,12 @@ export function App() {
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": null,
-          "namedExports": Object {
-            "App": Object {
-              "type": "EXPORT_DETAIL_MODIFIER",
-            },
+        Array [
+          Object {
+            "functionName": "App",
+            "type": "EXPORT_FUNCTION",
           },
-        }
+        ]
       `)
     } else {
       fail('Did not parse successfully.')
@@ -324,16 +318,12 @@ export class App {}
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": null,
-          "namedExports": Object {
-            "App": Object {
-              "moduleName": undefined,
-              "name": "App",
-              "type": "EXPORT_DETAIL_NAMED",
-            },
+        Array [
+          Object {
+            "className": "App",
+            "type": "EXPORT_CLASS",
           },
-        }
+        ]
       `)
     } else {
       fail('Did not parse successfully.')
@@ -347,12 +337,12 @@ export default function() { return 5 }
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": Object {
-            "type": "EXPORT_DEFAULT_FUNCTION",
+        Array [
+          Object {
+            "name": null,
+            "type": "EXPORT_DEFAULT_FUNCTION_OR_CLASS",
           },
-          "namedExports": Object {},
-        }
+        ]
       `)
     } else {
       fail('Did not parse successfully.')
@@ -366,13 +356,12 @@ export default function addFive() { return 5 }
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": Object {
+        Array [
+          Object {
             "name": "addFive",
-            "type": "EXPORT_DEFAULT_MODIFIER",
+            "type": "EXPORT_DEFAULT_FUNCTION_OR_CLASS",
           },
-          "namedExports": Object {},
-        }
+        ]
       `)
     } else {
       fail('Did not parse successfully.')
@@ -386,16 +375,130 @@ export default class App {}
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Object {
-          "defaultExport": Object {
+        Array [
+          Object {
             "name": "App",
-            "type": "EXPORT_DEFAULT_MODIFIER",
+            "type": "EXPORT_DEFAULT_FUNCTION_OR_CLASS",
           },
-          "namedExports": Object {},
-        }
+        ]
       `)
     } else {
       fail('Did not parse successfully.')
     }
+  })
+  describe(`re-exports`, () => {
+    it(`parses a wildcard re-export from another module`, () => {
+      const code = `export * from 'othermodule'`
+
+      const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+      if (isParseSuccess(actualResult)) {
+        expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "namespacedVariable": null,
+              "reexportedModule": "othermodule",
+              "type": "REEXPORT_WILDCARD",
+            },
+          ]
+        `)
+      } else {
+        fail(actualResult)
+      }
+    })
+    it(`parses a wildcard re-export into a named value from another module`, () => {
+      const code = `export * as thatmodule from 'othermodule'`
+
+      const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+      if (isParseSuccess(actualResult)) {
+        expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "namespacedVariable": "thatmodule",
+              "reexportedModule": "othermodule",
+              "type": "REEXPORT_WILDCARD",
+            },
+          ]
+        `)
+      } else {
+        fail(actualResult)
+      }
+    })
+    it(`parses a re-export of specific named values from another module`, () => {
+      const code = `export { thing1, thing2 } from 'othermodule'`
+
+      const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+      if (isParseSuccess(actualResult)) {
+        expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "reexportedModule": "othermodule",
+              "type": "REEXPORT_VARIABLES",
+              "variables": Array [
+                Object {
+                  "variableAlias": null,
+                  "variableName": "thing1",
+                },
+                Object {
+                  "variableAlias": null,
+                  "variableName": "thing2",
+                },
+              ],
+            },
+          ]
+        `)
+      } else {
+        fail(actualResult)
+      }
+    })
+    it(`parses a re-export of specific named values from another module`, () => {
+      const code = `export { import1 as thing1, import2 as thing2 } from 'othermodule'`
+
+      const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+      if (isParseSuccess(actualResult)) {
+        expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "reexportedModule": "othermodule",
+              "type": "REEXPORT_VARIABLES",
+              "variables": Array [
+                Object {
+                  "variableAlias": "thing1",
+                  "variableName": "import1",
+                },
+                Object {
+                  "variableAlias": "thing2",
+                  "variableName": "import2",
+                },
+              ],
+            },
+          ]
+        `)
+      } else {
+        fail(actualResult)
+      }
+    })
+    it(`parses a re-export of the default export from another module`, () => {
+      const code = `export { default } from 'othermodule'`
+
+      const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
+      if (isParseSuccess(actualResult)) {
+        expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "reexportedModule": "othermodule",
+              "type": "REEXPORT_VARIABLES",
+              "variables": Array [
+                Object {
+                  "variableAlias": null,
+                  "variableName": "default",
+                },
+              ],
+            },
+          ]
+        `)
+      } else {
+        fail(actualResult)
+      }
+    })
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
@@ -21,9 +21,9 @@ import {
 import { parseSuccess } from '../common/project-file-utils'
 import { printCode, printCodeOptions } from './parser-printer'
 import {
-  addModifierExportToDetail,
-  addNamedExportToDetail,
-  EmptyExportsDetail,
+  exportFunction,
+  exportVariable,
+  exportVariables,
   isParseSuccess,
 } from '../../shared/project-file-types'
 import { emptyComments } from './parser-printer-comments'
@@ -197,7 +197,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -248,7 +248,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -285,7 +285,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -326,7 +326,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -373,7 +373,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
 
     expect(actualResult).toEqual(expectedResult)
@@ -415,7 +415,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -462,7 +462,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -505,7 +505,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -543,7 +543,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -587,7 +587,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -629,7 +629,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -684,7 +684,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -759,7 +759,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -799,7 +799,7 @@ describe('Parsing a function component with props', () => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -842,7 +842,7 @@ describe('Parsing a function component with props', () => {
         javascript: `function originalFn() {}`,
         definedWithin: ['originalFn'],
       }),
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -36,13 +36,11 @@ import {
   isParseSuccess,
   importAlias,
   foldParsedTextFile,
-  exportsDetail,
-  addNamedExportToDetail,
   EmptyExportsDetail,
-  setNamedDefaultExportInDetail,
-  addModifierExportToDetail,
-  setModifierDefaultExportInDetail,
-  setExpressionDefaultExportInDetail,
+  exportFunction,
+  exportDefaultFunctionOrClass,
+  exportVariables,
+  exportVariable,
 } from '../../shared/project-file-types'
 import {
   lintAndParse,
@@ -137,7 +135,7 @@ export var whatever = (props) => <View data-uid='aaa'>
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -199,7 +197,7 @@ export var whatever = () => <View data-uid='aaa'>
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -271,7 +269,7 @@ export function whatever(props) {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -337,7 +335,7 @@ export function whatever() {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -409,7 +407,7 @@ export default function whatever(props) {
       expect.objectContaining({}),
       null,
       null,
-      setModifierDefaultExportInDetail(EmptyExportsDetail, 'whatever'),
+      [exportDefaultFunctionOrClass('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -475,7 +473,7 @@ export default function whatever() {
       expect.objectContaining({}),
       null,
       null,
-      setModifierDefaultExportInDetail(EmptyExportsDetail, 'whatever'),
+      [exportDefaultFunctionOrClass('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -545,7 +543,7 @@ export var whatever = (props) => <View data-uid='aaa'>
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -628,7 +626,7 @@ export var whatever = (props) => <View data-uid='aaa'>
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   }),
@@ -696,7 +694,7 @@ export var whatever = (props) => <View data-uid='aaa'>
         expect.objectContaining({}),
         null,
         null,
-        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+        [exportFunction('whatever')],
       )
       expect(actualResult).toEqual(expectedResult)
     }),
@@ -781,7 +779,7 @@ export var whatever = (props) => <View data-uid='aaa'>
         expect.objectContaining({}),
         null,
         null,
-        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+        [exportFunction('whatever')],
       )
       expect(actualResult).toEqual(expectedResult)
     })
@@ -858,7 +856,7 @@ export var whatever = (props) => <View data-uid='aaa'>
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1006,7 +1004,7 @@ return { getSizing: getSizing, spacing: spacing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(combinedArbitraryBlock),
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1099,10 +1097,7 @@ return { getSizing: getSizing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
-      setModifierDefaultExportInDetail(
-        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
-        'getSizing',
-      ),
+      [exportDefaultFunctionOrClass('getSizing'), exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1211,10 +1206,7 @@ return { getSizing: getSizing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
-      addModifierExportToDetail(
-        addModifierExportToDetail(EmptyExportsDetail, 'getSizing'),
-        'whatever',
-      ),
+      [exportFunction('getSizing'), exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1307,7 +1299,7 @@ return {  };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(arbitraryBlock),
-      setExpressionDefaultExportInDetail(addModifierExportToDetail(EmptyExportsDetail, 'whatever')),
+      [exportDefaultFunctionOrClass(null), exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1395,7 +1387,7 @@ return { spacing: spacing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(jsVariable),
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1469,7 +1461,7 @@ return { bgs: bgs, bg: bg };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1544,7 +1536,7 @@ return { greys: greys };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1613,7 +1605,7 @@ return { a: a, b: b };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1685,7 +1677,7 @@ return { a: a, b: b, c: c };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1762,7 +1754,7 @@ return { a: a };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1833,7 +1825,7 @@ return { a: a, b: b };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1909,7 +1901,7 @@ return { bg: bg };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -1997,7 +1989,7 @@ return { count: count };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(jsVariable),
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2086,7 +2078,7 @@ return { use20: use20 };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(jsVariable),
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2147,7 +2139,7 @@ return { mySet: mySet };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(jsVariable),
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2236,7 +2228,7 @@ return { spacing: spacing };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(jsVariable),
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2337,7 +2329,7 @@ return { MyComp: MyComp };`
       expect.objectContaining({}),
       null,
       clearArbitraryJSBlockUniqueIDs(MyComp),
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2479,7 +2471,7 @@ export var whatever = props => (
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2616,7 +2608,7 @@ export var whatever = (props) => <View data-uid='aaa'>
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2679,7 +2671,7 @@ export var whatever = () => <View data-uid='aaa'>
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2728,7 +2720,7 @@ export var App = (props) => <View data-uid='bbb'>
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'App'),
+      [exportFunction('App')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -2791,7 +2783,7 @@ export var App = (props) => <View data-uid='bbb'>
       null,
       sampleImportsForTests,
     )
-    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
+    const detailOfExports = [exportFunction('whatever')]
     const printedCode = printCode(
       printCodeOptions(false, true, true),
       imports,
@@ -2915,7 +2907,7 @@ return { getSizing: getSizing, spacing: spacing };`
       null,
       sampleImportsForTests,
     )
-    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
+    const detailOfExports = [exportFunction('whatever')]
     const printedCode = printCode(
       printCodeOptions(false, true, true, false, true),
       imports,
@@ -2970,7 +2962,7 @@ return { getSizing: getSizing, spacing: spacing };`
       null,
       sampleImportsForTests,
     )
-    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
+    const detailOfExports = [exportFunction('whatever')]
     const printedCode = printCode(
       printCodeOptions(false, true, true),
       imports,
@@ -3054,7 +3046,7 @@ export var whatever = props => {
         sampleImportsForTests,
         parsedCode.topLevelElements,
         null,
-        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+        [exportFunction('whatever')],
       )
       expect(printedCode).toEqual(code)
     } else {
@@ -3097,7 +3089,7 @@ export var whatever = props => {
       null,
       sampleImportsForTests,
     )
-    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
+    const detailOfExports = [exportFunction('whatever')]
     const printedCode = printCode(
       printCodeOptions(false, true, true),
       imports,
@@ -3156,7 +3148,7 @@ export var whatever = props => {
       null,
       sampleImportsForTests,
     )
-    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
+    const detailOfExports = [exportFunction('whatever')]
     const printedCode = printCode(
       printCodeOptions(false, true, true),
       imports,
@@ -3246,7 +3238,7 @@ export var whatever = props => {
       null,
       sampleImportsForTests,
     )
-    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
+    const detailOfExports = [exportFunction('whatever')]
     const printedCode = printCode(
       printCodeOptions(false, true, true),
       imports,
@@ -3288,7 +3280,7 @@ export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInSto
         emptyImports(),
         parsedCode.topLevelElements,
         null,
-        addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+        [exportFunction('whatever')],
       )
       expect(printedCode).toEqual(expectedCode)
     } else {
@@ -3395,7 +3387,7 @@ return { test: test };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
 
     expect(actualResult).toEqual(expectedResult)
@@ -3491,10 +3483,7 @@ return { test: test };`
         ),
       ),
     ]
-    const detailOfExports = addModifierExportToDetail(
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
-      'storyboard',
-    )
+    const detailOfExports = [exportFunction('whatever'), exportFunction('storyboard')]
     const printedCode = printCode(
       printCodeOptions(false, true, true),
       imports,
@@ -3582,7 +3571,7 @@ export var App = props => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'App'),
+      [exportFunction('App')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -3630,7 +3619,7 @@ export var App = props => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'App'),
+      [exportFunction('App')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -3708,7 +3697,7 @@ export var App = props => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'App'),
+      [exportFunction('App')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -3765,7 +3754,7 @@ export var App = props => {
       false,
       emptyComments,
     )
-    const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'App')
+    const detailOfExports = [exportFunction('App')]
     const printedCode = printCode(
       printCodeOptions(false, true, true),
       sampleImportsForTests,
@@ -3961,7 +3950,7 @@ return { a: a, b: b, MyCustomCompomnent: MyCustomCompomnent };`,
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'App'),
+      [exportFunction('App')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -4011,7 +4000,7 @@ export var App = props => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'App'),
+      [exportFunction('App')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -4060,7 +4049,7 @@ export var whatever = props => {
       sampleImportsForTests,
       [exported],
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -4109,7 +4098,7 @@ export var whatever = props => {
       sampleImportsForTests,
       [exported],
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -4186,7 +4175,7 @@ return {  };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -4276,7 +4265,7 @@ return { result: result };`
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -4375,7 +4364,7 @@ export var whatever = props => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -4491,7 +4480,7 @@ return { a: a };`,
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })
@@ -4525,7 +4514,7 @@ export var whatever = props => {
       expect.objectContaining({}),
       null,
       null,
-      addModifierExportToDetail(EmptyExportsDetail, 'whatever'),
+      [exportFunction('whatever')],
     )
     expect(actualResult).toEqual(expectedResult)
   })

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -71,17 +71,15 @@ import {
   mapParsedTextFile,
   forEachParseSuccess,
   ExportsDetail,
-  exportsDetail,
-  ExportDetailNamed,
-  exportDetailNamed,
-  ExportDetailModifier,
-  exportDetailModifier,
   ExportDetail,
   EmptyExportsDetail,
   StaticElementPathPart,
   isParseSuccess,
   isTextFile,
   ProjectFile,
+  ExportVariables,
+  exportVariable,
+  exportVariables,
 } from '../../shared/project-file-types'
 import { lintAndParse, printCode, printCodeOptions } from './parser-printer'
 import { getUtopiaIDFromJSXElement } from '../../shared/uid-utils'
@@ -657,33 +655,21 @@ export function topLevelElementArbitrary(): Arbitrary<TopLevelElement> {
   )
 }
 
-export function exportDetailNamedArbitrary(
-  possibleNames: Array<string>,
-): Arbitrary<ExportDetailNamed> {
-  return FastCheck.constantFrom(...possibleNames).map((name) => exportDetailNamed(name, undefined))
-}
-
-export function exportDetailModifierArbitrary(): Arbitrary<ExportDetailModifier> {
-  return lowercaseStringArbitrary().map(exportDetailModifier)
+export function exportVariablesArbitrary(possibleNames: Array<string>): Arbitrary<ExportVariables> {
+  return FastCheck.array(
+    FastCheck.constantFrom(...possibleNames).map((name) => exportVariable(name, null)),
+  ).map(exportVariables)
 }
 
 export function exportDetailArbitrary(possibleNames: Array<string>): Arbitrary<ExportDetail> {
-  return FastCheck.oneof<ExportDetail>(
-    exportDetailNamedArbitrary(possibleNames),
-    exportDetailModifierArbitrary(),
-  )
+  return FastCheck.oneof<ExportDetail>(exportVariablesArbitrary(possibleNames))
 }
 
 export function exportsDetailArbitrary(possibleNames: Array<string>): Arbitrary<ExportsDetail> {
   if (possibleNames.length === 0) {
     return FastCheck.constant(EmptyExportsDetail)
   } else {
-    return FastCheck.tuple(
-      FastCheck.constant(null), //FastCheck.option(exportDetailNamedArbitrary(possibleNames)),
-      flatObjectArbitrary(lowercaseStringArbitrary(), exportDetailArbitrary(possibleNames)),
-    ).map(([defaultExport, namedExports]) => {
-      return exportsDetail(defaultExport, namedExports)
-    })
+    return FastCheck.array(exportDetailArbitrary(possibleNames))
   }
 }
 

--- a/editor/src/missing-types/index.d.ts
+++ b/editor/src/missing-types/index.d.ts
@@ -19,6 +19,7 @@ declare module 'babel-plugin-transform-react-jsx'
 declare module 'babel-plugin-syntax-jsx'
 declare module '@babel/standalone'
 declare module '@babel/plugin-transform-modules-commonjs'
+declare module '@babel/plugin-proposal-export-namespace-from'
 
 declare module 'lodash.clamp' {
   export const clamp = (number: number, lower: number, upper: number) => number


### PR DESCRIPTION
Fixes #1737

**Problem:**
Currently Utopia does not recognise or support module re-exports at all.

**Fix:**
This change reworks the entire set of export types so as to get a more granular and accurate representation of the various cases, as well as adding extra cases for re-exports which didn't particularly mesh well with the original types. One possible future for these new types is that they could be handled similarly to arbitrary blocks, being executed and then having their results accumulated at the end. As it's possible that the current handling does not handle particularly esoteric cases like a chain of destructured exports.

Re-exports in the canvas just defer onwards to the module that is being re-exported and then includes the values into the current scope.

**Limitations:**
Currently the `EXPORT_DESTRUCTURED_ASSIGNMENT` case will cause the functionality to degrade slightly in using the fallback require on the canvas. Handling those more correctly in the way exports have been handled so far would be difficult because of the dependency on an expression on the right hand side of the export statement.

**Commit Details:**
- Completes the fix for #1737.
- Adds `@babel/plugin-proposal-export-namespace-from` to support
  the ECMAScript 2021 re-export into a namespace.
- Changed `resolveTextFiles` to make it more closely approximate
  what real world projects would do and look like, along with
  fixing some of the test data that was affected by this change.
- Completely rewrote the various types that represent exports to be
  more specific to the various cases that arise, along with adding
  types for re-exports.
- Canvas export handling updated for new types.
- `getExportedComponentImports` fixed to handle new export types.
- `transformToCommonJS` utilises the above mentioned Babel plugin
  for namespaced imports.
- `addStoryboardFileToProject` updated for new export types.
- Fixed some of the `Arbitrary` instances to generate the updated types.
- Updated `getModifiersForComponent`, `detailsFromExportAssignment`,
  `detailsFromExportDeclaration` and `parseCode` to handle the new
  export types.