### PR TITLE
Versions endpoint caching.

### DIFF
--- a/server/test/Test/Utopia/Web/Executors/Test.hs
+++ b/server/test/Test/Utopia/Web/Executors/Test.hs
@@ -15,6 +15,7 @@ import           Utopia.Web.Executors.Common
 import qualified Utopia.Web.Executors.Common      as C
 import           Utopia.Web.Executors.Development
 import qualified Utopia.Web.Executors.Development as D
+import           Utopia.Web.Packager.NPM
 
 initialiseTestResources :: IO DevServerResources
 initialiseTestResources = do
@@ -27,6 +28,7 @@ initialiseTestResources = do
   testAssetsCaches <- emptyAssetsCaches []
   semaphoreForNode <- newQSem 1
   locksRef <- newIORef mempty
+  matchingVersionsCache <- newMatchingVersionsCache
   return $ DevServerResources
          { _commitHash = "nocommit"
          , _projectPool = pool
@@ -44,6 +46,7 @@ initialiseTestResources = do
          , _nodeSemaphore = semaphoreForNode
          , _locksRef = locksRef
          , _branchDownloads = Nothing
+         , _matchingVersionsCache = matchingVersionsCache
          }
 
 testEnvironmentRuntime :: EnvironmentRuntime DevServerResources


### PR DESCRIPTION
Fixes #1781

**Problem:**
The package versions endpoint always calls `npm` every time it is called which introduces a lot of unnecessary latency.

**Fix:**
The endpoint is now wrapped with some internal caching so that repeated calls will be served with the same response.

**Limitations:**
This lacks any kind of dogpile protection so very quick requests to the endpoint when there's no value would cause the requests to potentially queue up still but this would necessitate a very high level of traffic.

**Commit Details:**
- Fixes #1781.
- Implemented `fetchVersionWithCache` to handle caching around the
  lookup.
- Modified `findMatchingVersions` to wrap the main logic with the
  `fetchVersionWithCode` function.
- Added the stateful cache to the server resources types of the server.
