### PR TITLE
fix(editor) Handle the same import with multiple different paths.

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -285,6 +285,7 @@ export function getPrintedUiJsCodeWithoutUIDs(store: EditorStore): string {
   const file = getContentsTreeFileFromString(store.editor.projectContents, StoryboardFilePath)
   if (isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
     return printCode(
+      StoryboardFilePath,
       printCodeOptions(false, true, false, true),
       file.fileContents.parsed.imports,
       file.fileContents.parsed.topLevelElements,
@@ -417,8 +418,12 @@ export function editorStateToParseSuccess(
   }
 }
 
-export function testPrintCodeFromParseSuccess(parseSuccess: ParseSuccess): string {
+export function testPrintCodeFromParseSuccess(
+  filename: string,
+  parseSuccess: ParseSuccess,
+): string {
   return printCode(
+    filename,
     printCodeOptions(false, true, true),
     parseSuccess.imports,
     parseSuccess.topLevelElements,
@@ -432,13 +437,13 @@ export function testPrintCodeFromEditorState(
   filePath: string = StoryboardFilePath,
 ): string {
   const parseSuccess = editorStateToParseSuccess(editorState, filePath)
-  return testPrintCodeFromParseSuccess(parseSuccess)
+  return testPrintCodeFromParseSuccess(filePath, parseSuccess)
 }
 
-export function testPrintParsedTextFile(parsedTextFile: ParsedTextFile): string {
+export function testPrintParsedTextFile(filename: string, parsedTextFile: ParsedTextFile): string {
   return foldParsedTextFile(
     (_) => 'FAILURE',
-    testPrintCodeFromParseSuccess,
+    (success) => testPrintCodeFromParseSuccess(filename, success),
     (_) => 'UNPARSED',
     parsedTextFile,
   )

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -1172,6 +1172,7 @@ describe('INSERT_WITH_DEFAULTS', () => {
       const parsed = cardFile.fileContents.parsed
       if (isParseSuccess(parsed)) {
         const printedCode = printCode(
+          '/src/card.js',
           printCodeOptions(false, true, true, true),
           parsed.imports,
           parsed.topLevelElements,
@@ -1273,6 +1274,7 @@ describe('INSERT_WITH_DEFAULTS', () => {
       const parsed = cardFile.fileContents.parsed
       if (isParseSuccess(parsed)) {
         const printedCode = printCode(
+          '/src/card.js',
           printCodeOptions(false, true, true, true),
           parsed.imports,
           parsed.topLevelElements,
@@ -1373,6 +1375,7 @@ describe('INSERT_WITH_DEFAULTS', () => {
       const parsed = cardFile.fileContents.parsed
       if (isParseSuccess(parsed)) {
         const printedCode = printCode(
+          '/src/card.js',
           printCodeOptions(false, true, true, true),
           parsed.imports,
           parsed.topLevelElements,
@@ -1464,6 +1467,7 @@ describe('INSERT_WITH_DEFAULTS', () => {
       const parsed = cardFile.fileContents.parsed
       if (isParseSuccess(parsed)) {
         const printedCode = printCode(
+          '/src/card.js',
           printCodeOptions(false, true, true, true),
           parsed.imports,
           parsed.topLevelElements,
@@ -1549,6 +1553,7 @@ describe('INSERT_WITH_DEFAULTS', () => {
       const parsed = cardFile.fileContents.parsed
       if (isParseSuccess(parsed)) {
         const printedCode = printCode(
+          '/src/card.js',
           printCodeOptions(false, true, true, true),
           parsed.imports,
           parsed.topLevelElements,

--- a/editor/src/components/editor/store/editor-state.spec.ts
+++ b/editor/src/components/editor/store/editor-state.spec.ts
@@ -30,6 +30,7 @@ function getCodeForFile(actualResult: EditorState, filename: string): string {
   const parsed = codeFile.fileContents.parsed
   if (isParseSuccess(parsed)) {
     return printCode(
+      filename,
       printCodeOptions(false, true, false, true),
       parsed.imports,
       parsed.topLevelElements,

--- a/editor/src/core/workers/common/project-file-utils.spec.ts
+++ b/editor/src/core/workers/common/project-file-utils.spec.ts
@@ -128,4 +128,20 @@ describe('mergeImports', () => {
       'component-library': importDetails(null, [importAlias('Card'), importAlias('FlexRow')], null),
     })
   })
+
+  it('handles multiple imports for the same file with different paths', () => {
+    const result = mergeImports(
+      '/src/code.js',
+      {
+        '/src/fileA.js': importDetails(null, [importAlias('Card')], null),
+        './fileA.js': importDetails(null, [importAlias('OtherCard')], null),
+      },
+      { '/src/fileB.js': importDetails(null, [importAlias('FlexRow')], null) },
+    )
+
+    expect(result).toEqual({
+      '/src/fileA.js': importDetails(null, [importAlias('Card'), importAlias('OtherCard')], null),
+      '/src/fileB.js': importDetails(null, [importAlias('FlexRow')], null),
+    })
+  })
 })

--- a/editor/src/core/workers/common/project-file-utils.spec.ts
+++ b/editor/src/core/workers/common/project-file-utils.spec.ts
@@ -133,15 +133,15 @@ describe('mergeImports', () => {
     const result = mergeImports(
       '/src/code.js',
       {
-        '/src/fileA.js': importDetails(null, [importAlias('Card')], null),
-        './fileA.js': importDetails(null, [importAlias('OtherCard')], null),
+        '/src/fileA': importDetails(null, [importAlias('Card')], null),
+        './fileA': importDetails(null, [importAlias('OtherCard')], null),
       },
-      { '/src/fileB.js': importDetails(null, [importAlias('FlexRow')], null) },
+      { '/src/fileB': importDetails(null, [importAlias('FlexRow')], null) },
     )
 
     expect(result).toEqual({
-      '/src/fileA.js': importDetails(null, [importAlias('Card'), importAlias('OtherCard')], null),
-      '/src/fileB.js': importDetails(null, [importAlias('FlexRow')], null),
+      '/src/fileA': importDetails(null, [importAlias('Card'), importAlias('OtherCard')], null),
+      '/src/fileB': importDetails(null, [importAlias('FlexRow')], null),
     })
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
@@ -164,7 +164,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       false,
     ).formatted
 
-    testParseModifyPrint(code, expectedCode, (success: ParseSuccess) => {
+    testParseModifyPrint('/index.js', code, expectedCode, (success: ParseSuccess) => {
       const firstComponent = success.topLevelElements.find(isUtopiaJSXComponent)
       if (firstComponent != null) {
         const view = firstComponent.rootElement

--- a/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
@@ -166,7 +166,7 @@ export var ${BakedInStoryboardVariableName} = (
   <Storyboard data-uid='${BakedInStoryboardUID}' />
 )
 `
-    testParseThenPrint(code, code)
+    testParseThenPrint('/index.js', code, code)
   })
   it('components are not reordered when printing', () => {
     const code = `import * as React from 'react'
@@ -184,7 +184,7 @@ export var ${BakedInStoryboardVariableName} = (
   <Storyboard data-uid='${BakedInStoryboardUID}' />
 )
 `
-    testParseThenPrint(code, code)
+    testParseThenPrint('/index.js', code, code)
   })
 
   it('object property names with special characters should be printed in string quotes', () => {
@@ -209,7 +209,7 @@ export var ${BakedInStoryboardVariableName} = (
   <Storyboard data-uid='${BakedInStoryboardUID}' />
 )
 `
-    testParseThenPrint(code, code)
+    testParseThenPrint('/index.js', code, code)
   })
 
   it('definedWithin and definedElsewhere are mutually exclusive properties', () => {
@@ -231,7 +231,7 @@ export var ${BakedInStoryboardVariableName} = (
   <Storyboard data-uid='${BakedInStoryboardUID}' />
 )
 `
-    testParseThenPrint(code, code)
+    testParseThenPrint('/index.js', code, code)
   })
   it('parses elements that use props spreading - #1365', () => {
     const spreadCode = `import * as React from 'react'
@@ -254,7 +254,7 @@ export var ${BakedInStoryboardVariableName} = (
 )
 `
 
-    testParseThenPrint(spreadCode, spreadCode)
+    testParseThenPrint('/index.js', spreadCode, spreadCode)
   })
   it('parses elements that use props spreading without an explicit uid - #1515', () => {
     const spreadCode = `import * as React from 'react'
@@ -271,7 +271,7 @@ const Test = (props) => {
 export var ${BakedInStoryboardVariableName} = <Storyboard />
 `
 
-    testParseThenPrintWithoutUids(spreadCode, spreadCode)
+    testParseThenPrintWithoutUids('/index.js', spreadCode, spreadCode)
   })
 
   it('#1737 - Produces the same value for an exported default function', () => {
@@ -285,7 +285,23 @@ export default function () {
 }
 `
 
-    testParseThenPrintWithoutUids(spreadCode, spreadCode)
+    testParseThenPrintWithoutUids('/index.js', spreadCode, spreadCode)
+  })
+
+  it('#1773 - Handles imports which relate to the same file but have differing paths.', () => {
+    const spreadCode = `import * as React from 'react'
+import { FirstComponent } from './components.js'
+import { SecondComponent } from '/components.js'
+export default function () {
+  return (
+    <div>
+      <div>Default Function Time</div>
+    </div>
+  )
+}
+`
+
+    testParseThenPrintWithoutUids('/index.js', spreadCode, spreadCode)
   })
 })
 
@@ -310,6 +326,6 @@ export var ${BakedInStoryboardVariableName} = (
   <Storyboard data-uid='${BakedInStoryboardUID}' />
 )
 `
-    testParseThenPrint(code, code)
+    testParseThenPrint('/index.js', code, code)
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-code-preservation.spec.ts
@@ -11,7 +11,7 @@ describe('Parsing and then printing code', () => {
         false,
       ).formatted
 
-      const parsedThenPrinted = parseThenPrint(code)
+      const parsedThenPrinted = parseThenPrint('/index.js', code)
       expect(parsedThenPrinted).toEqual(code)
     })
   })
@@ -24,7 +24,7 @@ describe('Parsing and then printing code', () => {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -36,7 +36,7 @@ describe('Parsing and then printing code', () => {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -44,7 +44,7 @@ describe('Parsing and then printing code', () => {
     const code = applyPrettier(`export const whatever = (props) => <div data-uid='aaa' />`, false)
       .formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -56,7 +56,7 @@ describe('Parsing and then printing code', () => {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -68,7 +68,7 @@ describe('Parsing and then printing code', () => {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -96,7 +96,7 @@ function Picker() {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -108,7 +108,7 @@ function Picker() {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -122,7 +122,7 @@ function Picker() {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -134,7 +134,7 @@ function Picker() {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -156,7 +156,7 @@ function Picker() {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -179,7 +179,7 @@ function Picker() {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -205,7 +205,7 @@ function Picker() {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -219,7 +219,7 @@ function Picker() {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 
@@ -290,7 +290,7 @@ function Picker() {
       false,
     ).formatted
 
-    const parsedThenPrinted = parseThenPrint(code)
+    const parsedThenPrinted = parseThenPrint('/index.js', code)
     expect(parsedThenPrinted).toEqual(code)
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
@@ -112,7 +112,7 @@ describe('Parsing and printing code with comments', () => {
     false,
   ).formatted
 
-  const parsedThenPrinted = parseThenPrint(code)
+  const parsedThenPrinted = parseThenPrint('/index.js', code)
 
   forEachValue((commentText, commentKey) => {
     const testFn = notYetSupported.includes(commentKey) ? xit : it

--- a/editor/src/core/workers/parser-printer/parser-printer-component-based-canvas.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-component-based-canvas.spec.ts
@@ -58,6 +58,6 @@ export var ${BakedInStoryboardVariableName} = (props) => {
   )
 }
 `
-    testParseThenPrint(originalCode, originalCode)
+    testParseThenPrint('/index.js', originalCode, originalCode)
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-dot-notation.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-dot-notation.spec.tsx
@@ -107,6 +107,6 @@ export var storyboard = (props) => {
   )
 }
 `
-    testParseThenPrint(originalCode, printedCode)
+    testParseThenPrint('/index.js', originalCode, printedCode)
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-event-handlers.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-event-handlers.spec.tsx
@@ -44,6 +44,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
     const parseResult = testParseCode(code)
     if (isParseSuccess(parseResult)) {
       const printedCode = printCode(
+        '/index.js',
         printCodeOptions(false, true, true),
         parseResult.imports,
         parseResult.topLevelElements,

--- a/editor/src/core/workers/parser-printer/parser-printer-exports.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-exports.spec.tsx
@@ -15,7 +15,7 @@ describe('parseCode', () => {
       false,
     ).formatted
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
-    expect(testPrintParsedTextFile(actualResult)).toEqual(code)
+    expect(testPrintParsedTextFile('/index.js', actualResult)).toEqual(code)
     const exports = Utils.path(['exportsDetail'], actualResult)
     expect(exports).toMatchInlineSnapshot(`
       Object {
@@ -40,7 +40,7 @@ describe('parseCode', () => {
       false,
     ).formatted
     const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
-    expect(testPrintParsedTextFile(actualResult)).toEqual(code)
+    expect(testPrintParsedTextFile('/index.js', actualResult)).toEqual(code)
     const exports = Utils.path(['exportsDetail'], actualResult)
     expect(exports).toMatchInlineSnapshot(`
       Object {

--- a/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
@@ -39,6 +39,7 @@ describe('JSX parser', () => {
       `)
 
       const printedCode = printCode(
+        '/index.js',
         printCodeOptions(false, true, true),
         parseResult.imports,
         parseResult.topLevelElements,

--- a/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
@@ -862,6 +862,7 @@ describe('Parsing, printing, reparsing a function component with props', () => {
     const firstAsParseSuccess = firstParse
 
     const printed = printCode(
+      '/index.js',
       printCodeOptions(false, true, true),
       firstAsParseSuccess.imports,
       firstAsParseSuccess.topLevelElements,

--- a/editor/src/core/workers/parser-printer/parser-printer-pragma.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-pragma.spec.ts
@@ -60,7 +60,7 @@ describe('Parsing JSX Pragma:', () => {
     }`,
       false,
     ).formatted
-    testParseThenPrint(code, code)
+    testParseThenPrint('/index.js', code, code)
   })
 
   it('parses a pragma with dot notation', () => {

--- a/editor/src/core/workers/parser-printer/parser-printer-uids.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-uids.spec.tsx
@@ -311,6 +311,7 @@ export var app = (props) => {
           return tle
         })
         return printCode(
+          '/index.js',
           printCodeOptions(false, true, false, true),
           success.imports,
           updatedTopLevelElements,

--- a/editor/src/core/workers/parser-printer/parser-printer-worker.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-worker.ts
@@ -207,6 +207,7 @@ function getPrintCodeResult(
   lastRevisedTime: number,
 ): PrintCodeResult {
   const withUIDs = printCode(
+    filename,
     printCodeOptions(false, true, true, false),
     parseSuccess.imports,
     parseSuccess.topLevelElements,
@@ -216,6 +217,7 @@ function getPrintCodeResult(
   const highlightBoundsWithUID = getHighlightBoundsWithUID('with-uids', withUIDs)
 
   const withoutUIDs = printCode(
+    filename,
     printCodeOptions(false, true, true, stripUIDs),
     parseSuccess.imports,
     parseSuccess.topLevelElements,

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -2793,6 +2793,7 @@ export var App = (props) => <View data-uid='bbb'>
     )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
+      '/index.js',
       printCodeOptions(false, true, true),
       imports,
       [exported],
@@ -2917,6 +2918,7 @@ return { getSizing: getSizing, spacing: spacing };`
     )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
+      '/index.js',
       printCodeOptions(false, true, true, false, true),
       imports,
       [...topLevelElements],
@@ -2972,6 +2974,7 @@ return { getSizing: getSizing, spacing: spacing };`
     )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
+      '/index.js',
       printCodeOptions(false, true, true),
       imports,
       [exported],
@@ -3050,6 +3053,7 @@ export var whatever = props => {
     const parsedCode = testParseCode(code)
     if (isParseSuccess(parsedCode)) {
       const printedCode = printCode(
+        '/index.js',
         printCodeOptions(false, true, true),
         sampleImportsForTests,
         parsedCode.topLevelElements,
@@ -3099,6 +3103,7 @@ export var whatever = props => {
     )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
+      '/index.js',
       printCodeOptions(false, true, true),
       imports,
       [exported],
@@ -3158,6 +3163,7 @@ export var whatever = props => {
     )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
+      '/index.js',
       printCodeOptions(false, true, true),
       imports,
       [exported],
@@ -3248,6 +3254,7 @@ export var whatever = props => {
     )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'whatever')
     const printedCode = printCode(
+      '/index.js',
       printCodeOptions(false, true, true),
       imports,
       [exported],
@@ -3284,6 +3291,7 @@ export var ${BakedInStoryboardVariableName} = <Storyboard data-uid='${BakedInSto
     const parsedCode = testParseCode(code)
     if (isParseSuccess(parsedCode)) {
       const printedCode = printCode(
+        '/index.js',
         printCodeOptions(false, true, true),
         emptyImports(),
         parsedCode.topLevelElements,
@@ -3496,6 +3504,7 @@ return { test: test };`
       'storyboard',
     )
     const printedCode = printCode(
+      '/index.js',
       printCodeOptions(false, true, true),
       imports,
       components,
@@ -3767,6 +3776,7 @@ export var App = props => {
     )
     const detailOfExports = addModifierExportToDetail(EmptyExportsDetail, 'App')
     const printedCode = printCode(
+      '/index.js',
       printCodeOptions(false, true, true),
       sampleImportsForTests,
       [component],
@@ -4056,6 +4066,7 @@ export var whatever = props => {
       emptyComments,
     )
     const actualResult = printCode(
+      '/index.js',
       printCodeOptions(false, true, true),
       sampleImportsForTests,
       [exported],
@@ -4105,6 +4116,7 @@ export var whatever = props => {
       emptyComments,
     )
     const actualResult = printCode(
+      '/index.js',
       printCodeOptions(false, true, true),
       sampleImportsForTests,
       [exported],
@@ -4571,6 +4583,7 @@ export var whatever2 = (props) => <View data-uid='aaa'>
   it('inserts data-uid into elements as part of the parse', () => {
     function checkDataUIDsPopulated(printableProjectContent: PrintableProjectContent): boolean {
       const printedCode = printCode(
+        '/index.js',
         printCodeOptions(false, true, false, false, true),
         printableProjectContent.imports,
         printableProjectContent.topLevelElements,

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -203,33 +203,40 @@ export function testParseCode(contents: string): ParsedTextFile {
   return result
 }
 
-export function parseThenPrint(originalCode: string): string {
-  return parseModifyPrint(originalCode, (ps) => ps)
+export function parseThenPrint(filename: string, originalCode: string): string {
+  return parseModifyPrint(filename, originalCode, (ps) => ps)
 }
 
-export function testParseThenPrint(originalCode: string, expectedFinalCode: string): void {
-  return testParseModifyPrint(originalCode, expectedFinalCode, (ps) => ps)
-}
-
-export function testParseThenPrintWithoutUids(
+export function testParseThenPrint(
+  filename: string,
   originalCode: string,
   expectedFinalCode: string,
 ): void {
-  const printedCode = parseModifyPrint(originalCode, (ps) => ps, true)
+  return testParseModifyPrint(filename, originalCode, expectedFinalCode, (ps) => ps)
+}
+
+export function testParseThenPrintWithoutUids(
+  filename: string,
+  originalCode: string,
+  expectedFinalCode: string,
+): void {
+  const printedCode = parseModifyPrint(filename, originalCode, (ps) => ps, true)
   expect(printedCode).toEqual(expectedFinalCode)
 }
 
 export function testParseModifyPrint(
+  filename: string,
   originalCode: string,
   expectedFinalCode: string,
   transform: (parseSuccess: ParseSuccess) => ParseSuccess,
   stripUids?: boolean,
 ): void {
-  const printedCode = parseModifyPrint(originalCode, transform, stripUids)
+  const printedCode = parseModifyPrint(filename, originalCode, transform, stripUids)
   expect(printedCode).toEqual(expectedFinalCode)
 }
 
 function parseModifyPrint(
+  filename: string,
   originalCode: string,
   transform: (parseSuccess: ParseSuccess) => ParseSuccess,
   stripUids?: boolean,
@@ -240,6 +247,7 @@ function parseModifyPrint(
     (initialParseSuccess) => {
       const transformed = transform(initialParseSuccess)
       const printedCode = printCode(
+        filename,
         printCodeOptions(false, true, true, stripUids),
         transformed.imports,
         transformed.topLevelElements,

--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -134,6 +134,8 @@ import { WorkerCodeUpdate, WorkerParsedUpdate } from '../../../components/editor
 import { fixParseSuccessUIDs } from './uid-fix'
 import { applyPrettier } from 'utopia-vscode-common'
 import { BakedInStoryboardVariableName } from '../../model/scene-utils'
+import { stripExtension } from '../../../components/custom-code/custom-code-utils'
+import { absolutePathFromRelativePath } from '../../../utils/path-utils'
 
 function buildPropertyCallingFunction(
   functionName: string,
@@ -772,6 +774,7 @@ function printTopLevelElements(
 }
 
 function printCodeImpl(
+  filePath: string,
   printOptions: PrintCodeOptions,
   imports: Imports,
   topLevelElements: Array<TopLevelElement>,
@@ -788,9 +791,19 @@ function printCodeImpl(
 
   fastForEach(importOrigins, (importOrigin) => {
     const importForClause = imports[importOrigin]
-    const matchingTopLevelElements: ImportStatement[] = topLevelElements.filter(
-      (e) => isImportStatement(e) && e.module === importOrigin,
-    ) as ImportStatement[]
+    const absoluteImportOrigin = stripExtension(
+      absolutePathFromRelativePath(filePath, false, importOrigin),
+    )
+    const matchingTopLevelElements: ImportStatement[] = topLevelElements.filter((e) => {
+      if (isImportStatement(e)) {
+        const absoluteImportModule = stripExtension(
+          absolutePathFromRelativePath(filePath, false, e.module),
+        )
+        return absoluteImportOrigin === absoluteImportModule
+      } else {
+        return false
+      }
+    }) as ImportStatement[]
     const { importedWithName, importedFromWithin, importedAs } = importForClause
 
     const hasImportWithName = matchingTopLevelElements.some((e) => e.importWithName)

--- a/editor/src/core/workers/ts/ts-worker.ts
+++ b/editor/src/core/workers/ts/ts-worker.ts
@@ -221,7 +221,7 @@ type DetailedTypeInfo = {
 }
 
 // FIXME This needs extracting, but getCodeFileContents relies on the parse printer for printing
-function getProjectFileContentsAsString(file: ProjectFile): string | null {
+function getProjectFileContentsAsString(filepath: string, file: ProjectFile): string | null {
   switch (file.type) {
     case 'ASSET_FILE':
       return ''
@@ -230,7 +230,7 @@ function getProjectFileContentsAsString(file: ProjectFile): string | null {
     case 'IMAGE_FILE':
       return file.base64 ?? ''
     case 'TEXT_FILE':
-      return getTextFileContents(file, false, true)
+      return getTextFileContents(filepath, file, false, true)
     default:
       const _exhaustiveCheck: never = file
       throw new Error(`Unhandled file type ${JSON.stringify(file)}`)
@@ -264,7 +264,7 @@ export function handleMessage(
         if (typeof workerMessage.content === 'string') {
           content = workerMessage.content
         } else {
-          content = getProjectFileContentsAsString(workerMessage.content)
+          content = getProjectFileContentsAsString(workerMessage.filename, workerMessage.content)
         }
 
         if (content != null) {
@@ -344,7 +344,7 @@ export function initBrowserFS(
   })
 
   walkContentsTree(projectContents, (filename, file) => {
-    const fileContents = getProjectFileContentsAsString(file)
+    const fileContents = getProjectFileContentsAsString(filename, file)
     if (fileContents != null) {
       writeFile(fs, filename, fileContents)
     }

--- a/editor/src/scripts/parse-print-analysis.ts
+++ b/editor/src/scripts/parse-print-analysis.ts
@@ -32,6 +32,7 @@ async function processFile(
     (_) => initialPrettifiedContents,
     (success) => {
       return printCode(
+        javascriptFilePath,
         printCodeOptions(false, true, false, true),
         success.imports,
         success.topLevelElements,


### PR DESCRIPTION
Fixes #1773

**Problem:**
When reproducing the code from the parsed model, the printing logic wasn't correctly handling there case where multiple import statements refer to the same file but with differing paths.

**Fix:**
Consolidate paths for imports by converting them into their absolute path.

**Commit Details:**
- Fixes #1773.
- Changed `mergeImports` to cater for multiple imports for the same
  absolute path with differing paths. Imports are now merged against
  the existing value if there is one for the import keyed against
  `existingKeyToUse`.
- `printCodeImpl` now checks the absolute path when finding import
  statements that match the given import origin.
- Added the file path as a parameter to functions that call
  `printCodeImpl` as it now requires the path of the code being printed.
