### PR TITLE
fix(canvas) fix components using props.style

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -521,7 +521,7 @@ export function renderComponentUsingJsxFactoryFunction(
 }
 
 function fixStyleObjectRemoveCommentOnlyValues(props: Readonly<unknown>): any {
-  if (typeof props === 'object' && 'style' in props) {
+  if (typeof props === 'object' && 'style' in props && (props as any)['style'] != null) {
     const propsAsAny = props as any
     const style = propsAsAny.style
     const fixedStyle: any = objectMap((styleProp) => {


### PR DESCRIPTION
Fixes https://github.com/concrete-utopia/utopia/issues/1790

**Problem:**
The canvas throws an error when inserting a component with `style={props.style}`. It also shows the same error when you have the same component inserted already but don't pass any style prop to the element. Or when you pass `style={undefined}` to an element.

**Fix:**
The result when creating the props from jsx attributes contains `style: undefined` in this case, but we only check if style is in props.

**Commit Details:**
- checking if style is not null in props
