### PR TITLE
Load VS Code earlier.

### DIFF
--- a/editor/src/components/canvas/dom-walker.spec.browser.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser.tsx
@@ -83,6 +83,7 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
       useStore={storeHook}
       spyCollector={spyCollector}
       propertyControlsInfoSupported={false}
+      vscodeBridgeReady={false}
     />,
   )
   const noFileOpenText = result.getByText('No file open')

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -218,6 +218,7 @@ export async function renderTestEditorWithModel(
         useStore={storeHook}
         spyCollector={spyCollector}
         propertyControlsInfoSupported={false}
+        vscodeBridgeReady={false}
       />
     </React.Profiler>,
   )

--- a/editor/src/components/code-editor/code-editor-container.tsx
+++ b/editor/src/components/code-editor/code-editor-container.tsx
@@ -3,6 +3,7 @@ import { betterReactMemo } from '../../uuiui-deps'
 import { useEditorState } from '../editor/store/store-hook'
 import { MONACO_EDITOR_IFRAME_BASE_URL } from '../../common/env-vars'
 import { createIframeUrl } from '../../core/shared/utils'
+import { getUnderlyingVSCodeBridgeID } from '../editor/store/editor-state'
 
 const VSCodeIframeContainer = betterReactMemo(
   'VSCodeIframeContainer',
@@ -34,7 +35,7 @@ const VSCodeIframeContainer = betterReactMemo(
 export const CodeEditorWrapper = betterReactMemo('CodeEditorWrapper', () => {
   const selectedProps = useEditorState((store) => {
     return {
-      vscodeBridgeId: store.editor.vscodeBridgeId,
+      vscodeBridgeId: getUnderlyingVSCodeBridgeID(store.editor.vscodeBridgeId),
     }
   }, 'CodeEditorWrapper')
 

--- a/editor/src/components/code-editor/code-editor-container.tsx
+++ b/editor/src/components/code-editor/code-editor-container.tsx
@@ -3,8 +3,6 @@ import { betterReactMemo } from '../../uuiui-deps'
 import { useEditorState } from '../editor/store/store-hook'
 import { MONACO_EDITOR_IFRAME_BASE_URL } from '../../common/env-vars'
 import { createIframeUrl } from '../../core/shared/utils'
-import { forceNotNull } from '../../core/shared/optional-utils'
-import { reduxDevtoolsLogMessage } from '../../core/shared/redux-devtools'
 
 const VSCodeIframeContainer = betterReactMemo(
   'VSCodeIframeContainer',
@@ -37,20 +35,8 @@ export const CodeEditorWrapper = betterReactMemo('CodeEditorWrapper', () => {
   const selectedProps = useEditorState((store) => {
     return {
       vscodeBridgeId: store.editor.vscodeBridgeId,
-      vscodeBridgeReady: store.editor.vscodeBridgeReady,
     }
   }, 'CodeEditorWrapper')
 
-  if (selectedProps.vscodeBridgeReady) {
-    return (
-      <VSCodeIframeContainer
-        projectID={forceNotNull(
-          'VSCode Bridge ID must be set when launching the code editor',
-          selectedProps.vscodeBridgeId,
-        )}
-      />
-    )
-  } else {
-    return <div style={{ flex: 1 }}>Loading...</div>
-  }
+  return <VSCodeIframeContainer projectID={selectedProps.vscodeBridgeId} />
 })

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -461,6 +461,7 @@ import {
   getPackageJsonFromEditorState,
   transformElementAtPath,
   getNewSceneName,
+  vsCodeBridgeIdProjectId,
 } from '../store/editor-state'
 import { loadStoredState } from '../stored-state'
 import { applyMigrations } from './migrations/migrations'
@@ -1576,7 +1577,7 @@ export const UPDATE_FNS = {
       ...editorModelFromPersistentModel(parsedModel, dispatch),
       projectName: action.title,
       id: action.projectId,
-      vscodeBridgeId: action.projectId, // we assign a first value when loading a project. SET_PROJECT_ID will not change this, saving us from having to reload VSCode
+      vscodeBridgeId: vsCodeBridgeIdProjectId(action.projectId), // we assign a first value when loading a project. SET_PROJECT_ID will not change this, saving us from having to reload VSCode
       nodeModules: {
         skipDeepFreeze: true,
         files: action.nodeModules,
@@ -3428,12 +3429,16 @@ export const UPDATE_FNS = {
     editor: EditorModel,
     dispatch: EditorDispatch,
   ): EditorModel => {
-    // Side effect.
-    initVSCodeBridge(action.id, editor.projectContents, dispatch)
+    let vscodeBridgeId = editor.vscodeBridgeId
+    if (vscodeBridgeId.type === 'VSCODE_BRIDGE_ID_DEFAULT') {
+      vscodeBridgeId = vsCodeBridgeIdProjectId(action.id)
+      // Side effect.
+      initVSCodeBridge(action.id, editor.projectContents, dispatch)
+    }
     return {
       ...editor,
       id: action.id,
-      vscodeBridgeId: action.id,
+      vscodeBridgeId: vscodeBridgeId,
     }
   },
   UPDATE_CODE_RESULT_CACHE: (action: UpdateCodeResultCache, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -3428,16 +3428,12 @@ export const UPDATE_FNS = {
     editor: EditorModel,
     dispatch: EditorDispatch,
   ): EditorModel => {
-    let newVscodeBridgeId = editor.vscodeBridgeId
-    if (editor.vscodeBridgeId == null) {
-      // ONLY update vscodeBridgeId if it was null
-      newVscodeBridgeId = action.id
-      initVSCodeBridge(action.id, editor.projectContents, dispatch)
-    }
+    // Side effect.
+    initVSCodeBridge(action.id, editor.projectContents, dispatch)
     return {
       ...editor,
       id: action.id,
-      vscodeBridgeId: newVscodeBridgeId,
+      vscodeBridgeId: action.id,
     }
   },
   UPDATE_CODE_RESULT_CACHE: (action: UpdateCodeResultCache, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -61,6 +61,7 @@ interface NumberSize {
 
 export interface EditorProps {
   propertyControlsInfoSupported: boolean
+  vscodeBridgeReady: boolean
 }
 
 function useDelayedValueHook(inputValue: boolean, delayMs: number): boolean {
@@ -331,7 +332,9 @@ export const EditorComponentInner = betterReactMemo(
         <ModalComponent />
         <ToastRenderer />
         <CanvasCursorComponent />
-        {props.propertyControlsInfoSupported ? <PropertyControlsInfoComponent /> : null}
+        {props.propertyControlsInfoSupported && props.vscodeBridgeReady ? (
+          <PropertyControlsInfoComponent />
+        ) : null}
       </SimpleFlexRow>
     )
   },

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -149,6 +149,9 @@ import { MapLike } from 'typescript'
 import { pick } from '../../../core/shared/object-utils'
 import { LayoutTargetableProp, StyleLayoutProp } from '../../../core/layout/layout-helpers-new'
 import { atomWithPubSub } from '../../../core/shared/atom-with-pub-sub'
+
+import { v4 as UUID } from 'uuid'
+
 const ObjectPathImmutable: any = OPI
 
 export enum LeftMenuTab {
@@ -332,7 +335,7 @@ export interface ResizeOptions {
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
   id: string | null
-  vscodeBridgeId: string | null
+  vscodeBridgeId: string
   forkedFromProjectId: string | null
   appID: string | null
   projectName: string
@@ -1090,7 +1093,7 @@ export const BaseCanvasOffsetLeftPane = {
 export function createEditorState(dispatch: EditorDispatch): EditorState {
   return {
     id: null,
-    vscodeBridgeId: null,
+    vscodeBridgeId: UUID(),
     forkedFromProjectId: null,
     appID: null,
     projectName: createNewProjectName(),
@@ -1336,7 +1339,7 @@ export function editorModelFromPersistentModel(
   )
   const editor: EditorState = {
     id: null,
-    vscodeBridgeId: null,
+    vscodeBridgeId: UUID(),
     forkedFromProjectId: persistentModel.forkedFromProjectId,
     appID: persistentModel.appID ?? null,
     projectName: createNewProjectName(),

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -332,10 +332,48 @@ export interface ResizeOptions {
   propertyTargetSelectedIndex: number
 }
 
+export interface VSCodeBridgeIdDefault {
+  type: 'VSCODE_BRIDGE_ID_DEFAULT'
+  defaultID: string
+}
+
+export function vsCodeBridgeIdDefault(defaultID: string): VSCodeBridgeIdDefault {
+  return {
+    type: 'VSCODE_BRIDGE_ID_DEFAULT',
+    defaultID: defaultID,
+  }
+}
+
+export interface VSCodeBridgeIdProjectId {
+  type: 'VSCODE_BRIDGE_ID_PROJECT_ID'
+  projectID: string
+}
+
+export function vsCodeBridgeIdProjectId(projectID: string): VSCodeBridgeIdProjectId {
+  return {
+    type: 'VSCODE_BRIDGE_ID_PROJECT_ID',
+    projectID: projectID,
+  }
+}
+
+export type VSCodeBridgeId = VSCodeBridgeIdDefault | VSCodeBridgeIdProjectId
+
+export function getUnderlyingVSCodeBridgeID(bridgeId: VSCodeBridgeId): string {
+  switch (bridgeId.type) {
+    case 'VSCODE_BRIDGE_ID_DEFAULT':
+      return bridgeId.defaultID
+    case 'VSCODE_BRIDGE_ID_PROJECT_ID':
+      return bridgeId.projectID
+    default:
+      const _exhaustiveCheck: never = bridgeId
+      throw new Error(`Unhandled type ${JSON.stringify(bridgeId)}`)
+  }
+}
+
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
   id: string | null
-  vscodeBridgeId: string
+  vscodeBridgeId: VSCodeBridgeId
   forkedFromProjectId: string | null
   appID: string | null
   projectName: string
@@ -1093,7 +1131,7 @@ export const BaseCanvasOffsetLeftPane = {
 export function createEditorState(dispatch: EditorDispatch): EditorState {
   return {
     id: null,
-    vscodeBridgeId: UUID(),
+    vscodeBridgeId: vsCodeBridgeIdDefault(UUID()),
     forkedFromProjectId: null,
     appID: null,
     projectName: createNewProjectName(),
@@ -1339,7 +1377,7 @@ export function editorModelFromPersistentModel(
   )
   const editor: EditorState = {
     id: null,
-    vscodeBridgeId: UUID(),
+    vscodeBridgeId: vsCodeBridgeIdDefault(UUID()),
     forkedFromProjectId: persistentModel.forkedFromProjectId,
     appID: persistentModel.appID ?? null,
     projectName: createNewProjectName(),

--- a/editor/src/components/editor/store/vscode-changes.ts
+++ b/editor/src/components/editor/store/vscode-changes.ts
@@ -29,6 +29,7 @@ import {
   EditorState,
   getHighlightBoundsForElementPaths,
   getHighlightBoundsForUids,
+  getUnderlyingVSCodeBridgeID,
 } from './editor-state'
 import { shallowEqual } from '../../../core/shared/equality-utils'
 
@@ -215,7 +216,7 @@ export function getProjectContentsChanges(
 ): Array<ProjectChange> {
   if (oldEditorState.vscodeBridgeId != null && !updateCameFromVSCode) {
     return collateProjectChanges(
-      oldEditorState.vscodeBridgeId,
+      getUnderlyingVSCodeBridgeID(oldEditorState.vscodeBridgeId),
       oldEditorState.projectContents,
       newEditorState.projectContents,
     )

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -242,6 +242,7 @@ export class Editor {
                 this.utopiaStoreApi,
                 this.spyCollector,
                 true,
+                this.storedState.editor.vscodeBridgeReady,
               ),
             )
           } else if (isLoggedIn(loginState) && githubOwner != null && githubRepo != null) {
@@ -270,6 +271,7 @@ export class Editor {
                             this.utopiaStoreApi,
                             this.spyCollector,
                             true,
+                            this.storedState.editor.vscodeBridgeReady,
                           ),
                       )
                     } else {
@@ -290,12 +292,19 @@ export class Editor {
                 this.utopiaStoreApi,
                 this.spyCollector,
                 true,
+                this.storedState.editor.vscodeBridgeReady,
               ),
             )
           }
         } else if (isCookiesOrLocalForageUnavailable(loginState)) {
           createNewProject(this.boundDispatch, () =>
-            renderRootComponent(this.utopiaStoreHook, this.utopiaStoreApi, this.spyCollector, true),
+            renderRootComponent(
+              this.utopiaStoreHook,
+              this.utopiaStoreApi,
+              this.spyCollector,
+              true,
+              this.storedState.editor.vscodeBridgeReady,
+            ),
           )
         } else if (isSampleProject(projectId)) {
           createNewProjectFromSampleProject(
@@ -308,6 +317,7 @@ export class Editor {
                 this.utopiaStoreApi,
                 this.spyCollector,
                 true,
+                this.storedState.editor.vscodeBridgeReady,
               ),
           )
         } else {
@@ -324,6 +334,7 @@ export class Editor {
                     this.utopiaStoreApi,
                     this.spyCollector,
                     true,
+                    this.storedState.editor.vscodeBridgeReady,
                   ),
               )
             } else {
@@ -337,6 +348,7 @@ export class Editor {
                     this.utopiaStoreApi,
                     this.spyCollector,
                     true,
+                    this.storedState.editor.vscodeBridgeReady,
                   )
                 },
                 () => {
@@ -414,11 +426,15 @@ export const HotRoot: React.FunctionComponent<{
   useStore: UtopiaStoreHook
   spyCollector: UiJsxCanvasContextData
   propertyControlsInfoSupported: boolean
-}> = hot(({ api, useStore, spyCollector, propertyControlsInfoSupported }) => {
+  vscodeBridgeReady: boolean
+}> = hot(({ api, useStore, spyCollector, propertyControlsInfoSupported, vscodeBridgeReady }) => {
   return (
     <EditorStateContext.Provider value={{ api, useStore }}>
       <UiJsxCanvasCtxAtom.Provider value={spyCollector}>
-        <EditorComponent propertyControlsInfoSupported={propertyControlsInfoSupported} />
+        <EditorComponent
+          propertyControlsInfoSupported={propertyControlsInfoSupported}
+          vscodeBridgeReady={vscodeBridgeReady}
+        />
       </UiJsxCanvasCtxAtom.Provider>
     </EditorStateContext.Provider>
   )
@@ -430,6 +446,7 @@ async function renderRootComponent(
   api: UtopiaStoreAPI,
   spyCollector: UiJsxCanvasContextData,
   propertyControlsInfoSupported: boolean,
+  vscodeBridgeReady: boolean,
 ): Promise<void> {
   return triggerHashedAssetsUpdate().then(() => {
     // NOTE: we only need to call this function once,
@@ -442,6 +459,7 @@ async function renderRootComponent(
           useStore={useStore}
           spyCollector={spyCollector}
           propertyControlsInfoSupported={propertyControlsInfoSupported}
+          vscodeBridgeReady={vscodeBridgeReady}
         />,
         rootElement,
       )


### PR DESCRIPTION
Fixes #1793

**Problem:**
Currently the VS Code iframe loads quite late, but makes about 1/3 of the requests during the startup of the editor including a few sizeable downloads.

**Fix:**
The iframe is now loaded effectively immediately as a value for `vscodeBridgeId` will now be available immediately and cannot be null.

An additional fix was made which potentially only helps locally as it delays the property controls component from starting up until the VS Code bridge is ready. As it was blocking execution on the main thread which delayed the VS Code iframe from opening.

**Commit Details:**
- Fixes #1793.
- `EditorState.vscodeBridgeId` is now not nullable and a value is
  always supplied to it during startup.
- The `CodeEditorWrapper` now does not wait for the bridge to be
  marked as ready.
- The `PropertyControlsInfoComponent` holds off from starting up
  until the VS Code bridge is ready.
