### PR TITLE
worker chunking

### DIFF
--- a/editor/jest-setup-beforeall.js
+++ b/editor/jest-setup-beforeall.js
@@ -1,0 +1,2 @@
+// Mocking core/workers/utils.ts because the original contains `import.meta` statements which break in a Node (Jest) environment
+jest.mock('./src/core/workers/utils')

--- a/editor/jest.config.js
+++ b/editor/jest.config.js
@@ -109,6 +109,7 @@ module.exports = {
       },
       roots: ['src', 'node_modules', '<rootDir>/node_modules'],
       transformIgnorePatterns: ['/node_modules/(?!utopia-api)'], // this lets ts-jest work on `/node_modules/utopia-api` which is a simlink to `../utopia-api`.
+      setupFiles: ['./jest-setup-beforeall.js'],
     },
     {
       testEnvironment: '@jest-runner/electron/environment',
@@ -129,6 +130,7 @@ module.exports = {
         },
       },
       roots: ['src', 'node_modules', '<rootDir>/node_modules'],
+      setupFiles: ['./jest-setup-beforeall.js'],
     },
   ],
 }

--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -7,8 +7,8 @@ import * as ReactDOM from 'react-dom'
 import * as EmotionReact from '@emotion/react'
 import * as EmotionStyled from '@emotion/styled'
 
-import * as editorPackageJSON from '../../../../package.json'
-import * as utopiaAPIPackageJSON from '../../../../../utopia-api/package.json'
+import editorPackageJSON from '../../../../package.json'
+import utopiaAPIPackageJSON from '../../../../../utopia-api/package.json'
 import { applyUIDMonkeyPatch } from '../../../utils/canvas-react-utils'
 
 applyUIDMonkeyPatch()

--- a/editor/src/core/workers/__mocks__/utils.ts
+++ b/editor/src/core/workers/__mocks__/utils.ts
@@ -1,0 +1,15 @@
+export function createTsWorker() {
+  return null
+}
+
+export function createParserPrinterWorker() {
+  return null
+}
+
+export function createLinterWorker() {
+  return null
+}
+
+export function createWatchdogWorker() {
+  return null
+}

--- a/editor/src/core/workers/__mocks__/utils.ts
+++ b/editor/src/core/workers/__mocks__/utils.ts
@@ -1,3 +1,7 @@
+/**
+ * We are mocking core/workers/utils.ts because they use es6 stuff `import.meta.url` for webpack. That is not compatible with Node.js (Jest).
+ */
+
 export function createTsWorker() {
   return null
 }

--- a/editor/src/core/workers/bundler-bridge.ts
+++ b/editor/src/core/workers/bundler-bridge.ts
@@ -11,7 +11,7 @@ import {
   UpdateProcessedMessage,
 } from './ts/ts-worker'
 import utils from '../../utils/utils'
-import { workerForFile } from './utils'
+import { createTsWorker } from './utils'
 import { ProjectContentTreeRoot } from '../../components/assets'
 
 export interface BundlerContext {
@@ -326,7 +326,7 @@ export interface BundlerWorker {
 }
 
 export class RealBundlerWorker implements BundlerWorker {
-  worker = workerForFile('editor/tsWorker.js')
+  worker = createTsWorker()
 
   addMessageListener = (listener: (ev: MessageEvent) => any): void => {
     this.worker.addEventListener('message', listener)

--- a/editor/src/core/workers/utils.ts
+++ b/editor/src/core/workers/utils.ts
@@ -22,7 +22,6 @@ export function createTsWorker(): Worker {
 export function createParserPrinterWorker(): Worker {
   const oldPublicPath = __webpack_public_path__
   __webpack_public_path__ = BASE_URL
-  console.info('createParserPrinterWorker', import.meta.url, oldPublicPath, __webpack_public_path__)
   const worker = new Worker(new URL('./parser-printer/parser-printer.worker.ts', import.meta.url))
   __webpack_public_path__ = oldPublicPath
   return worker

--- a/editor/src/core/workers/utils.ts
+++ b/editor/src/core/workers/utils.ts
@@ -13,7 +13,6 @@ import { BASE_URL } from '../../common/env-vars'
 export function createTsWorker(): Worker {
   const oldPublicPath = __webpack_public_path__
   __webpack_public_path__ = BASE_URL
-  console.info('create ts worker', import.meta.url, oldPublicPath, __webpack_public_path__)
   const worker = new Worker(new URL('./ts/ts.worker.ts', import.meta.url))
   __webpack_public_path__ = oldPublicPath
   return worker

--- a/editor/src/core/workers/utils.ts
+++ b/editor/src/core/workers/utils.ts
@@ -1,10 +1,45 @@
-import { BASE_URL, URL_HASH } from '../../common/env-vars'
-import { setBranchNameFromURL } from '../../utils/branches'
+import { BASE_URL } from '../../common/env-vars'
 
-export function workerForFile(fileName: string): Worker {
-  let workerURL = new URL(`${BASE_URL}${fileName}`)
-  let workerQueryParams = workerURL.searchParams
-  workerQueryParams.set('hash', URL_HASH)
-  setBranchNameFromURL(workerQueryParams)
-  return new Worker(workerURL.href)
+/**
+ * Webpack 5 only supports a single public path for assets and feeding the Worker url via `import.meta.url`
+ * This causes problems when using a CDN, because of same origin restrictions, you are not allowed to load workers from cdns.
+ *
+ * The solution is to use the webpack-supported global __webpack_public_path__ variable, which updates the value returned by import.meta.url
+ *
+ * in all of these cases, oldPublicPath is the asset url (the CDN url in deployed editors). we temporarily change it to BASE_URL (which is the url the editor is loaded from)
+ * and then after loading the worker, restore it to the CDN url.
+ */
+
+export function createTsWorker(): Worker {
+  const oldPublicPath = __webpack_public_path__
+  __webpack_public_path__ = BASE_URL
+  console.info('create ts worker', import.meta.url, oldPublicPath, __webpack_public_path__)
+  const worker = new Worker(new URL('./ts/ts.worker.ts', import.meta.url))
+  __webpack_public_path__ = oldPublicPath
+  return worker
+}
+
+export function createParserPrinterWorker(): Worker {
+  const oldPublicPath = __webpack_public_path__
+  __webpack_public_path__ = BASE_URL
+  console.info('createParserPrinterWorker', import.meta.url, oldPublicPath, __webpack_public_path__)
+  const worker = new Worker(new URL('./parser-printer/parser-printer.worker.ts', import.meta.url))
+  __webpack_public_path__ = oldPublicPath
+  return worker
+}
+
+export function createLinterWorker(): Worker {
+  const oldPublicPath = __webpack_public_path__
+  __webpack_public_path__ = BASE_URL
+  const worker = new Worker(new URL('./linter/linter.worker.ts', import.meta.url))
+  __webpack_public_path__ = oldPublicPath
+  return worker
+}
+
+export function createWatchdogWorker(): Worker {
+  const oldPublicPath = __webpack_public_path__
+  __webpack_public_path__ = BASE_URL
+  const worker = new Worker(new URL('./watchdog.worker.ts', import.meta.url))
+  __webpack_public_path__ = oldPublicPath
+  return worker
 }

--- a/editor/src/core/workers/workers.ts
+++ b/editor/src/core/workers/workers.ts
@@ -2,7 +2,7 @@ import { TypeDefinitions } from '../shared/npm-dependency-types'
 import { createParsePrintFilesRequest, ParseOrPrint } from './parser-printer/parser-printer-worker'
 import { createLinterRequestMessage } from './linter/linter-worker'
 import { NewBundlerWorker, BundlerWorker } from './bundler-bridge'
-import { workerForFile } from './utils'
+import { createLinterWorker, createParserPrinterWorker, createWatchdogWorker } from './utils'
 import {
   createWatchdogInitMessage,
   createHeartbeatResponseMessage,
@@ -88,7 +88,7 @@ export interface ParserPrinterWorker {
 export class RealParserPrinterWorker implements ParserPrinterWorker {
   private worker: Worker
   constructor() {
-    this.worker = workerForFile('editor/parserPrinterWorker.js')
+    this.worker = createParserPrinterWorker()
   }
 
   sendParsePrintMessage(files: Array<ParseOrPrint>): void {
@@ -115,7 +115,7 @@ export interface LinterWorker {
 export class RealLinterWorker implements LinterWorker {
   private worker: Worker
   constructor() {
-    this.worker = workerForFile('editor/linterWorker.js')
+    this.worker = createLinterWorker()
   }
 
   sendLinterRequestMessage(filename: string, content: string): void {
@@ -143,7 +143,7 @@ export class RealWatchdogWorker implements WatchdogWorker {
   private setIntervalId: NodeJS.Timer | null = null
 
   constructor() {
-    this.worker = workerForFile('editor/watchdogWorker.js')
+    this.worker = createWatchdogWorker()
   }
 
   initWatchdogWorker(projectId: string): void {

--- a/editor/src/missing-types/index.d.ts
+++ b/editor/src/missing-types/index.d.ts
@@ -93,3 +93,8 @@ declare module '@svgr/plugin-jsx'
 declare module '@root/encoding/base64'
 
 declare module 'react/jsx-runtime'
+
+/**
+ * the __webpack_public_path__ is a global variable supported by Webpack that can be used to dynamically change the value of import.meta.url
+ */
+declare var __webpack_public_path__: string

--- a/editor/tsconfig.json
+++ b/editor/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "outDir": "./lib",
     "target": "es2019",
-    "module": "commonjs",
+    "module": "ESNext",
+    "moduleResolution": "Node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,

--- a/editor/webpack.config.js
+++ b/editor/webpack.config.js
@@ -62,22 +62,12 @@ const config = {
     vsCodeEditorOuterIframe: hot
       ? ['react-hot-loader/patch', './src/templates/vscode-editor-outer-iframe.tsx']
       : './src/templates/vscode-editor-outer-iframe.tsx',
-    tsWorker: './src/core/workers/ts/ts.worker.ts',
-    parserPrinterWorker: './src/core/workers/parser-printer/parser-printer.worker.ts',
-    linterWorker: './src/core/workers/linter/linter.worker.ts',
-    watchdogWorker: './src/core/workers/watchdog.worker.ts',
   },
 
   output: {
     crossOriginLoading: 'anonymous',
     filename: (chunkData) => {
-      const name = chunkData.chunk.name
-      const nameOnly =
-        name === 'tsWorker' ||
-        name === 'parserPrinterWorker' ||
-        name === 'linterWorker' ||
-        name === 'watchdogWorker'
-      return nameOnly ? '[name].js' : `[name].${hashPattern}.js`
+      return `[name].${hashPattern}.js`
     },
     chunkFilename: `[id].${hashPattern}.js`,
     path: __dirname + '/lib',
@@ -203,6 +193,8 @@ const config = {
     new webpack.EnvironmentPlugin({
       GOOGLE_WEB_FONTS_KEY: '', // providing an empty default for GOOGLE_WEB_FONTS_KEY for now
     }),
+
+    new webpack.ProvidePlugin({ BrowserFS: 'browserfs' }), // weirdly, the browserfs/dist/shims/fs shim assumes a global BrowserFS being available
   ],
 
   resolve: {
@@ -346,18 +338,7 @@ const config = {
       : [],
     moduleIds: 'hashed', // "Short hashes as ids for better long term caching."
     splitChunks: {
-      chunks(chunk) {
-        // exclude workers until we figure out a way to chunk those
-        return (
-          chunk.name !== 'tsWorker' &&
-          chunk.name !== 'parserPrinterWorker' &&
-          chunk.name !== 'linterWorker' &&
-          chunk.name !== 'watchdogWorker'
-        )
-      },
-      minSize: 10000, // Minimum size before chunking
-      maxAsyncRequests: isProdOrStaging ? 6 : Infinity,
-      maxInitialRequests: isProdOrStaging ? 6 : Infinity,
+      chunks: 'all',
     },
   },
 


### PR DESCRIPTION
**Problem:**
We have 3 large workers – tsWorker, parserPrinterWorker, and linterWorker. They are very heavy because they have dependencies like standalone Babel and Typescript. The three workers actually share a majority of dependencies, but in our current setup each worker is compiled into an isolated js bundle without chunking, they cannot reuse the same dependencies.  This means that when fully loading the utopia editor, we download the same typescript and babel about 4 times.

**Fix:**
With webpack v5, if you load a worker using a specific syntax that webpack can statically analyze (`return new Worker(new URL('./parser-printer/parser-printer.worker.ts', import.meta.url))`) Webpack automatically creates proper reusable chunks!

**Commit Details:**
- Use webpack-friendly worker loading syntax
- There was an issue with the webpack publicPath pointing to the CDN (workers are not allowed to load from cdn because of same-origin policies). The workaround for the issue is to dynamically change `__webpack_public_path__` when loading the workers and then reset it to the CDN URL. It's not nice, but it works
- had to fix Jest tests because they don't support `import.meta.url`

Here's master from a few days ago:
<img width="2115" alt="old" src="https://user-images.githubusercontent.com/2226774/132655884-6da96ccc-3cd2-4a40-82fa-23d58a09292e.png">
Notice that there's multiple typescript.js'es, among other things.

Here's how the new bundles look like:
<img width="1893" alt="new" src="https://user-images.githubusercontent.com/2226774/132655482-f35e8faa-c98b-4358-a4de-465c321ab4ba.png">
Note that @enidemi 's #1801 is not merged yet, so these two PRs combined should make for an even nicer reduction!
You can see that there's only a single typescript.js (instead of three!) There's only one remaining mystery, there's still two babel.js's, but I don't want to investigate until Eni's PR is on master.
