### PR TITLE
fix(code-editor) open storyboard file on load

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -1553,7 +1553,10 @@ export const UPDATE_FNS = {
         )
       },
     )
-    initVSCodeBridge(action.projectId, parsedProjectFiles, dispatch)
+    const storyboardFile = getContentsTreeFileFromString(parsedProjectFiles, StoryboardFilePath)
+    const openFilePath = storyboardFile != null ? StoryboardFilePath : null
+    initVSCodeBridge(action.projectId, parsedProjectFiles, dispatch, openFilePath)
+
     const parsedModel = {
       ...migratedModel,
       projectContents: parsedProjectFiles,
@@ -3418,7 +3421,12 @@ export const UPDATE_FNS = {
     if (vscodeBridgeId.type === 'VSCODE_BRIDGE_ID_DEFAULT') {
       vscodeBridgeId = vsCodeBridgeIdProjectId(action.id)
       // Side effect.
-      initVSCodeBridge(action.id, editor.projectContents, dispatch)
+      initVSCodeBridge(
+        action.id,
+        editor.projectContents,
+        dispatch,
+        editor.canvas.openFile?.filename ?? null,
+      )
     }
     return {
       ...editor,

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -162,6 +162,7 @@ export async function initVSCodeBridge(
   projectID: string,
   projectContents: ProjectContentTreeRoot,
   dispatch: EditorDispatch,
+  openFilePath: string | null,
 ): Promise<void> {
   async function innerInit(): Promise<void> {
     dispatch([markVSCodeBridgeReady(false)], 'everyone')
@@ -192,6 +193,9 @@ export async function initVSCodeBridge(
       })
       sendGetUtopiaVSCodeConfigMessage()
       watchForChanges(dispatch)
+      if (openFilePath != null) {
+        sendOpenFileMessage(openFilePath)
+      }
     }
     dispatch([markVSCodeBridgeReady(true)], 'everyone')
   }


### PR DESCRIPTION
**Problem:**
After the editor loads the code editor looks empty.

**Fix:**
Opening the Storyboard file when the code editor initializes.

**Commit Details:**
- find storyboard file when loading a project
- open file at init
