### PR TITLE
Preload project dependencies.

### DIFF
--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -45,6 +45,8 @@ function builtInDependency(
   }
 }
 
+// Ensure this is kept up to date with:
+// server/src/Utopia/Web/Packager/NPM.hs
 export const BuiltInDependencies: Array<BuiltInDependency> = [
   builtInDependency('utopia-api', UtopiaAPI, utopiaAPIPackageJSON.version),
   builtInDependency('uuiui', UUIUI, editorPackageJSON.version),

--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -29,6 +29,7 @@
       crossorigin="anonymous"
     ></script>
 
+    <!-- preloadProjectDependencies -->
     <style>
       body {
         margin: 0;

--- a/editor/src/templates/preview.html
+++ b/editor/src/templates/preview.html
@@ -8,6 +8,7 @@
       href="/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
       as="image"
     />
+    <!-- preloadProjectDependencies -->
     <style>
       @keyframes animation-keyframes {
         from {

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -273,6 +273,10 @@ innerServerExecutor (GetSiteRoot action) = do
   portOfServer <- fmap _serverPort ask
   let siteRoot = "http://localhost:" <> show portOfServer
   return $ action siteRoot
+innerServerExecutor (GetCDNRoot action) = do
+  portOfServer <- fmap _serverPort ask
+  let siteRoot = "http://localhost:" <> show portOfServer
+  return $ action siteRoot
 innerServerExecutor (GetPathToServe defaultPathToServe possibleBranchName action) = do
   possibleDownloads <- fmap _branchDownloads ask
   pathToServe <- case (defaultPathToServe, possibleBranchName, possibleDownloads) of

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -61,7 +61,8 @@ data ProductionServerResources = ProductionServerResources
                                , _locksRef                :: PackageVersionLocksRef
                                , _siteHost                :: Text
                                , _branchDownloads         :: Maybe BranchDownloads
-                                , _matchingVersionsCache  :: MatchingVersionsCache
+                               , _matchingVersionsCache   :: MatchingVersionsCache
+                               , _cdnHost                 :: Text
                                }
 
 $(makeFieldsNoPrefix ''ProductionServerResources)
@@ -207,6 +208,10 @@ innerServerExecutor (GetSiteRoot action) = do
   hostOfServer <- fmap _siteHost ask
   let siteRoot = "https://" <> hostOfServer
   return $ action siteRoot
+innerServerExecutor (GetCDNRoot action) = do
+  hostOfCDN <- fmap _cdnHost ask
+  let cdnRoot = "https://" <> hostOfCDN
+  return $ action cdnRoot
 innerServerExecutor (GetPathToServe defaultPathToServe possibleBranchName action) = do
   possibleDownloads <- fmap _branchDownloads ask
   pathToServe <- case (defaultPathToServe, possibleBranchName, possibleDownloads) of
@@ -275,6 +280,7 @@ initialiseResources = do
   _assetsCaches <- emptyAssetsCaches assetPathsAndBuilders
   _nodeSemaphore <- newQSem 1
   _siteHost <- fmap toS $ getEnv "SITE_HOST"
+  _cdnHost <- fmap toS $ getEnv "CDN_HOST"
   _branchDownloads <- createBranchDownloads
   _locksRef <- newIORef mempty
   _matchingVersionsCache <- newMatchingVersionsCache

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -121,6 +121,7 @@ data ServiceCallsF a = NotFound
                      | GetPackagePackagerContent Text ((ConduitT () ByteString (ResourceT IO) (), UTCTime) -> a)
                      | AccessControlAllowOrigin (Maybe Text) (Maybe Text -> a)
                      | GetSiteRoot (Text -> a)
+                     | GetCDNRoot (Text -> a)
                      | GetPathToServe FilePath (Maybe Text) (FilePath -> a)
                      | GetVSCodeAssetRoot (FilePath -> a)
                      | GetUserConfiguration Text (Maybe DecodedUserConfiguration -> a)

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -23,6 +23,7 @@ import qualified Text.Blaze.Html5        as H
 import           Utopia.Web.JSON
 import           Utopia.Web.Servant
 import           Utopia.Web.ServiceTypes
+import           Web.HttpApiData
 
 {-
   'deriveJSON' as used here creates 'Data.Aeson.FromJSON' and 'Data.Aeson.ToJSON' instances
@@ -201,3 +202,12 @@ type API = (AuthCookie :> Protected)
 
 apiProxy :: Proxy API
 apiProxy = Proxy
+
+packagerAPI :: Proxy PackagePackagerAPI
+packagerAPI = Proxy
+
+packagerLink :: Text -> Text -> Text
+packagerLink packageName packageVersion =
+  let versionedName = packageName <> "@" <> packageVersion
+   in toUrlPiece $ safeLink apiProxy packagerAPI versionedName
+


### PR DESCRIPTION
Fixes #1808

**Problem:**
Project dependencies are downloaded once the editor has downloaded, been executed and the project contents loaded. This means the potentially comparatively slow downloads can delay the appearance of the canvas.

**Fix:**
When the project page (and preview too) is loaded, the project contents are parsed and preload requests are added in for each of the project dependencies.

**Commit Details:**
- Fixes #1808.
- Added a marker in `index.html` and `preview.html`
  to be replaced with the preload `link` elements.
- Added `GetCDNRoot` service call, implemented similarly
  to the `GetSiteRoot` service call, which in production
  looks for the `CDN_ROOT` environment variable.
- Implemented `packagerLink` to create the URLs for the
  packager endpoint.
- Added `ProjectDependency` record to hold the pairing
  of dependency name and version.
- Added `providedDependencies` to match up with the entries
  in `built-in-dependencies-list.ts`, with comments to
  help ensure the two are kept in sync.
- Implemented `getProjectDependenciesFromPackageJSON` to
  take the project, drill into the project contents and
  then pull out the dependencies from the `package.json`
  file within.
- Implemented `dependenciesHtmlFromProject` to construct
  the appropriate HTML for a given project to preload the
  dependency packages.
- `renderPageWithMetadata` now invokes
  `dependenciesHtmlFromProject` so that it can include the
  output in the project index and preview pages.
