### PR TITLE
Preload VS Code content.

### DIFF
--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- ogTags -->
+    <!--ogTags-->
+
     <link
       rel="icon"
       type="image/png"
@@ -13,8 +14,10 @@
       href="/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
       as="image"
     />
+
+    <!--editorScript-->
+
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="use-credentials" />
-    <!-- dom-to-image -->
     <script
       defer
       src="https://cdn.jsdelivr.net/gh/mcklayin/dom-to-image-improved@v2.8.0/dist/dom-to-image-more.min.js"
@@ -22,7 +25,10 @@
       crossorigin="anonymous"
     ></script>
 
-    <!-- preloadProjectDependencies -->
+    <!--preloadVSCode-->
+
+    <!--preloadProjectDependencies-->
+
     <style>
       body {
         margin: 0;
@@ -52,7 +58,7 @@
     </style>
   </head>
   <body>
-    <!-- projectIDScript -->
+    <!--projectIDScript-->
     <div id="portal-target"></div>
     <div id="canvas-contextmenu-portal-target"></div>
     <div id="text-field-placeholder"></div>

--- a/editor/src/templates/preview.html
+++ b/editor/src/templates/preview.html
@@ -1,14 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- ogTags -->
+    <!--ogTags-->
+
     <link
       rel="preload"
       type="image/png"
       href="/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
       as="image"
     />
-    <!-- preloadProjectDependencies -->
+
+    <!--editorScript-->
+
+    <!--preloadProjectDependencies-->
+
     <style>
       @keyframes animation-keyframes {
         from {
@@ -28,7 +33,7 @@
     </style>
   </head>
   <body>
-    <!-- projectIDScript -->
+    <!--projectIDScript-->
     <div id="preview">
       <!-- loading content-->
       <div

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -5,7 +5,7 @@ description: Utopia Web
 github: concrete-utopia/utopia
 category: Development
 license: MIT
-ghc-options: -threaded -rtsopts
+ghc-options: -Wall -threaded -rtsopts
 dependencies:
   - aeson
   - aeson-pretty

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -248,8 +248,8 @@ innerServerExecutor (GetPackageJSON javascriptPackageName maybeJavascriptPackage
   return $ action packageMetadata
 innerServerExecutor (GetPackageVersionJSON javascriptPackageName maybeJavascriptPackageVersion action) = do
   semaphore <- fmap _nodeSemaphore ask
-  matchingVersionsCache <- fmap _matchingVersionsCache ask
-  packageMetadata <- liftIO $ findMatchingVersions semaphore matchingVersionsCache javascriptPackageName maybeJavascriptPackageVersion
+  versionsCache <- fmap _matchingVersionsCache ask
+  packageMetadata <- liftIO $ findMatchingVersions semaphore versionsCache javascriptPackageName maybeJavascriptPackageVersion
   return $ action packageMetadata
 innerServerExecutor (GetCommitHash action) = do
   hashToUse <- fmap _commitHash ask
@@ -266,8 +266,8 @@ innerServerExecutor (GetHashedAssetPaths action) = do
   return $ action _editorMappings
 innerServerExecutor (GetPackagePackagerContent versionedPackageName action) = do
   semaphore <- fmap _nodeSemaphore ask
-  locksRef <- fmap _locksRef ask
-  packagerContent <- liftIO $ getPackagerContent semaphore locksRef versionedPackageName
+  packagerLocksRef <- fmap _locksRef ask
+  packagerContent <- liftIO $ getPackagerContent semaphore packagerLocksRef versionedPackageName
   return $ action packagerContent
 innerServerExecutor (AccessControlAllowOrigin _ action) = do
   return $ action $ Just "*"

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -183,8 +183,8 @@ innerServerExecutor (GetPackageJSON javascriptPackageName maybeJavascriptPackage
   return $ action packageMetadata
 innerServerExecutor (GetPackageVersionJSON javascriptPackageName maybeJavascriptPackageVersion action) = do
   semaphore <- fmap _nodeSemaphore ask
-  matchingVersionsCache <- fmap _matchingVersionsCache ask
-  packageMetadata <- liftIO $ findMatchingVersions semaphore matchingVersionsCache javascriptPackageName maybeJavascriptPackageVersion
+  versionsCache <- fmap _matchingVersionsCache ask
+  packageMetadata <- liftIO $ findMatchingVersions semaphore versionsCache javascriptPackageName maybeJavascriptPackageVersion
   return $ action packageMetadata
 innerServerExecutor (GetCommitHash action) = do
   hashToUse <- fmap _commitHash ask
@@ -199,8 +199,8 @@ innerServerExecutor (GetHashedAssetPaths action) = do
   return $ action _editorMappings
 innerServerExecutor (GetPackagePackagerContent versionedPackageName action) = do
   semaphore <- fmap _nodeSemaphore ask
-  locksRef <- fmap _locksRef ask
-  packagerContent <- liftIO $ getPackagerContent semaphore locksRef versionedPackageName
+  packagerLocksRef <- fmap _locksRef ask
+  packagerContent <- liftIO $ getPackagerContent semaphore packagerLocksRef versionedPackageName
   return $ action packagerContent
 innerServerExecutor (AccessControlAllowOrigin _ action) = do
   return $ action $ Just "*"

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e83d456103edba455f137157039a03c0c8ffec40f6796a1389ac1cacf963ee6f
+-- hash: adf78f12b8a13baf00c23769be7544868d8b3259901648968bebebc54b9941d1
 
 name:           utopia-web
 version:        0.1.0.4
@@ -52,7 +52,7 @@ executable utopia-web
   hs-source-dirs:
       src
   default-extensions: NoImplicitPrelude
-  ghc-options: -threaded -rtsopts
+  ghc-options: -Wall -threaded -rtsopts
   extra-libraries:
       z
   build-depends:
@@ -171,7 +171,7 @@ test-suite utopia-web-test
       test
       src
   default-extensions: NoImplicitPrelude
-  ghc-options: -threaded -rtsopts
+  ghc-options: -Wall -threaded -rtsopts
   extra-libraries:
       z
   build-depends:


### PR DESCRIPTION
**Problem:**
VS Code loads comparatively late in the entire editor loading process and has some large-ish downloads.

**Fix:**
This ended up with two overall changes, the first being to preload some of the VS Code content early.

In doing so, it was observed that `preload`s are superceding `defer`s, causing the editor code download (and therefore editor load) to be delayed behind all of the `preload`s. As a result, now all of the editor code has a `preload` `link` added for it ahead of any others like those created for VS Code and project dependencies.

**Commit Details:**
- Added `preloadVSCode` comment tag and trimmed out the spaces
  from the other tags.
- Preloads for VS Code added with the other preloads in
  `renderPageWithMetadata`.
- Added placeholder for webpack introduced content.
- Reintroduced `-Wall` to server build.
- Refactored the OpenGraph, project metadata, project
  ID script and dependency preload functions now refactored
  to use tagsoup types, including them in the content
  via `injectIntoPage`.
- Introduced VS Code preloads into `renderPageWithMetadata`.
- Some minor tweaks to naming to avoid shadowing.
