### PR TITLE
Fallback to branch downloads

### DIFF
--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -15,10 +15,8 @@ import           Control.Lens                     hiding ((.=), (<.>))
 import           Control.Monad.Catch              hiding (Handler, catch)
 import           Control.Monad.RWS.Strict
 import           Data.Aeson
-import           Data.Binary.Builder
 import qualified Data.ByteString.Lazy             as BL
 import           Data.Conduit.Combinators         hiding (foldMap)
-import qualified Data.HashMap.Strict              as M
 import           Data.IORef
 import           Data.Pool
 import           Data.String                      (String)

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -300,6 +300,10 @@ innerServerExecutor (ClearBranchCache branchName action) = do
   possibleDownloads <- fmap _branchDownloads ask
   liftIO $ traverse_ (\d -> deleteBranchCache d branchName) possibleDownloads
   return action
+innerServerExecutor (GetDownloadBranchFolders action) = do
+  downloads <- fmap _branchDownloads ask
+  folders <- liftIO $ maybe (pure []) getDownloadedLocalFolders downloads
+  pure $ action folders
 
 {-|
   Invokes a service call using the supplied resources.

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -233,6 +233,10 @@ innerServerExecutor (ClearBranchCache branchName action) = do
   possibleDownloads <- fmap _branchDownloads ask
   liftIO $ traverse_ (\d -> deleteBranchCache d branchName) possibleDownloads
   return action
+innerServerExecutor (GetDownloadBranchFolders action) = do
+  downloads <- fmap _branchDownloads ask
+  folders <- liftIO $ maybe (pure []) getDownloadedLocalFolders downloads
+  pure $ action folders
 
 readEditorContentFromDisk :: Maybe BranchDownloads -> Maybe Text -> Text -> IO Text
 readEditorContentFromDisk (Just downloads) (Just branchName) fileName = do

--- a/server/src/Utopia/Web/ServiceTypes.hs
+++ b/server/src/Utopia/Web/ServiceTypes.hs
@@ -127,6 +127,7 @@ data ServiceCallsF a = NotFound
                      | GetUserConfiguration Text (Maybe DecodedUserConfiguration -> a)
                      | SaveUserConfiguration Text (Maybe Value) a
                      | ClearBranchCache Text a
+                     | GetDownloadBranchFolders ([FilePath] -> a)
                      deriving Functor
 
 {-


### PR DESCRIPTION
Fixes #1816

**Problem:**
Webpack 5 doesn't appear to be able to handle query parameters for workers, which we use for branch name based downloads of staging bundles.

**Fix:**
On a regular 404 of an editor asset, attempt to get that asset from the branch download folders instead of straight returning that 404 to the client. There's a certain amount of this intended to work by coincidence given that the branch downloads will block on the download flow and then when that attempts to load the worker code it should already be downloaded then it will already be there. As well as the files having "unique" hash based filenames, so the old versions shouldn't be loaded triggering this flow.

**Commit Details:**
- Fixes #1816.
- Removed underscores from the fields in `Branches.hs`
  to make them more amenable to use in lenses.
- Implemented `getDownloadedLocalFolders` to pull all the
  folders for branches which are fully downloaded staging
  bundles.
- Replaced `return` with `pure` in a few places.
- Applied some formatting to the server code.
- Fixed an issue with `isEditorJSSrcAttribute` which would
  fail to handle paths with query parameters on the end,
  affecting branch downloads.
- Integrated fallbacks in `editorAssetsEndpoint` by invoking
  `fallbackOn404` against the standard `servePath` and one
  for each branch folder.
- Added service type `GetDownloadBranchFolders` as the integration
  point between `getDownloadedLocalFolders` with the endpoint.
