### PR TITLE
Use the CDN for the pyramid image used in loading screens

### DIFF
--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -6,12 +6,12 @@
     <link
       rel="icon"
       type="image/png"
-      href="/editor/icons/favicons/favicon-192.png?hash=%UTOPIA_SHA%"
+      href="%UTOPIA_DOMAIN%/editor/icons/favicons/favicon-192.png?hash=%UTOPIA_SHA%"
     />
     <link
       rel="preload"
       type="image/png"
-      href="/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
+      href="%UTOPIA_DOMAIN%/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
       as="image"
     />
 
@@ -95,8 +95,8 @@
             border: 1px solid beige;
           "
         >
-          <img src='/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%'' height='128px' alt='Utopia
-          Logo '/>
+          <img src='%UTOPIA_DOMAIN%/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%''
+          height='128px' alt='Utopia Logo '/>
 
           <div
             class="progress-bar-shell"

--- a/editor/src/templates/preview.html
+++ b/editor/src/templates/preview.html
@@ -6,7 +6,7 @@
     <link
       rel="preload"
       type="image/png"
-      href="/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
+      href="%UTOPIA_DOMAIN%/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
       as="image"
     />
 
@@ -50,7 +50,7 @@
         "
       >
         <img
-          src="/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
+          src="%UTOPIA_DOMAIN%/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
           height="128px"
           alt="Utopia
         Logo "

--- a/editor/src/templates/project-not-found.html
+++ b/editor/src/templates/project-not-found.html
@@ -4,7 +4,7 @@
     <link
       rel="icon"
       type="image/png"
-      href="/editor/icons/favicons/favicon-192.png?hash=%UTOPIA_SHA%"
+      href="%UTOPIA_DOMAIN%/editor/icons/favicons/favicon-192.png?hash=%UTOPIA_SHA%"
     />
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="use-credentials" />
     <link


### PR DESCRIPTION
**Problem:**
The pyramid image used in loading screens is being loaded directly from the server rather than via the CDN

**Fix:**
Prefix with `%UTOPIA_DOMAIN%` so that the CDN endpoints will be used to serve it