### PR TITLE
Updated output stats for staging and production

### DIFF
--- a/editor/webpack.config.js
+++ b/editor/webpack.config.js
@@ -352,6 +352,16 @@ const config = {
 
   // Use default source maps in dev mode, or attach a source map if in prod
   devtool: isProd ? 'source-map' : 'eval',
+
+  stats: isProdOrStaging
+    ? {
+        assetsSpace: 1000,
+        chunkGroupMaxAssets: 1000,
+        groupAssetsByEmitStatus: false,
+        groupAssetsByChunk: false,
+        colors: true,
+      }
+    : {},
 }
 
 if (verbose) {


### PR DESCRIPTION
**Problem:**
Since updating to webpack v5 we lost some of the useful stats output when building

**Fix:**
Tweaked the stats output so that we can now see the sizes of all of the chunks, as well as which entrypoints use those chunks. Unfortunately this doesn't show which workers use which modules though.

**Sample output now:** (from a staging build, hence the sizes)
![Screenshot_20210916_125132](https://user-images.githubusercontent.com/1044774/133607995-3ecb8032-5a89-46fc-9954-542d0c771d90.png)
