### PR TITLE
fix(editor) Carry over the branch_name parameter into iframe URLs.

### DIFF
--- a/editor/src/components/code-editor/code-editor-container.tsx
+++ b/editor/src/components/code-editor/code-editor-container.tsx
@@ -16,6 +16,10 @@ const VSCodeIframeContainer = betterReactMemo(
     const url = new URL(baseIframeSrc)
     url.searchParams.append('project_id', projectID)
 
+    const branchName = url.searchParams.get('branch_name')
+    if (branchName != null) {
+      url.searchParams.append('branch_name', branchName)
+    }
     return (
       <iframe
         key={'vscode-editor'}

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -434,13 +434,19 @@ const ToastRenderer = betterReactMemo('ToastRenderer', () => {
 const PropertyControlsInfoComponent = betterReactMemo('PropertyControlsInfoComponent', () => {
   const iframeSrc = createIframeUrl(PROPERTY_CONTROLS_INFO_BASE_URL, 'property-controls-info.html')
 
+  const urlParams = new URLSearchParams(window.location.search)
+  const branchName = urlParams.get('branch_name')
+  const url = new URL(iframeSrc)
+  if (branchName != null) {
+    url.searchParams.append('branch_name', branchName)
+  }
   return (
     <iframe
       key={PropertyControlsInfoIFrameID}
       id={PropertyControlsInfoIFrameID}
       width='0px'
       height='0px'
-      src={iframeSrc}
+      src={url.toString()}
       allow='autoplay'
       style={{
         backgroundColor: 'transparent',

--- a/editor/src/components/preview/preview-pane.tsx
+++ b/editor/src/components/preview/preview-pane.tsx
@@ -215,18 +215,34 @@ class PreviewColumnContent extends React.Component<PreviewColumnProps, PreviewCo
       </FlexRow>
     )
 
-    const floatingPreviewURL =
+    const urlParams = new URLSearchParams(window.location.search)
+    function addInBranchNames(url: string): string {
+      if (url === '') {
+        return url
+      } else {
+        const branchName = urlParams.get('branch_name')
+        const parsedURL = new URL(url)
+        if (branchName != null) {
+          parsedURL.searchParams.append('branch_name', branchName)
+        }
+        return parsedURL.toString()
+      }
+    }
+    let floatingPreviewURL =
       this.props.id == null
         ? ''
         : shareURLForProject(FLOATING_PREVIEW_BASE_URL, this.props.id, this.props.projectName)
-    const iframePreviewURL =
+    floatingPreviewURL = addInBranchNames(floatingPreviewURL)
+    let iframePreviewURL =
       this.props.id == null
         ? ''
         : `${floatingPreviewURL}?embedded=true&refreshCount=${this.state.refreshCount}`
-    const popoutPreviewURL =
+    iframePreviewURL = addInBranchNames(iframePreviewURL)
+    let popoutPreviewURL =
       this.props.id == null
         ? ''
         : shareURLForProject(BASE_URL, this.props.id, this.props.projectName)
+    popoutPreviewURL = addInBranchNames(popoutPreviewURL)
 
     const iFrame = (
       <iframe

--- a/editor/src/templates/vscode-editor-outer-iframe.tsx
+++ b/editor/src/templates/vscode-editor-outer-iframe.tsx
@@ -10,6 +10,10 @@ function VSCodeOuterIframe(): React.ReactElement {
   const baseIframeSrc = createIframeUrl(VSCODE_EDITOR_IFRAME_BASE_URL, 'vscode-editor-inner-iframe')
   const url = new URL(baseIframeSrc)
   url.searchParams.append('project_id', projectID)
+  const branchName = urlParams.get('branch_name')
+  if (branchName != null) {
+    url.searchParams.append('branch_name', branchName)
+  }
   return (
     <iframe
       id={'vscode-outer'}


### PR DESCRIPTION
**Problem:**
Currently the iframes used in our editor do not honour the `branch_name` query parameter.

**Fix:**
Carry the `branch_name` parameter over wherever we can.

**Commit Details:**
- Makes sure that our iframes also carry over the `branch_name`
  parameter into their URLs.
