### PR TITLE
Add in crossorigin attribute for some preloads.

### DIFF
--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -179,7 +179,7 @@ projectDetailsToPossibleMetadata (ProjectDetailsMetadata metadata) = Just metada
 dependencyPreload :: Text -> ProjectDependency -> TagSoupTags
 dependencyPreload cdnRoot ProjectDependency{..} =
   let dependencyURL = cdnRoot <> "/" <> packagerLink dependencyName dependencyVersion
-      linkOpen = TagOpen "link" [("href", dependencyURL), ("rel", "preload"), ("as", "fetch")]
+      linkOpen = TagOpen "link" [("href", dependencyURL), ("rel", "preload"), ("as", "fetch"), ("crossorigin", "anonymous")]
    in [linkOpen, TagClose "link", TagText "\n    "]
 
 dependenciesHtmlFromProject :: Text -> Maybe DB.DecodedProject -> TagSoupTags
@@ -245,7 +245,7 @@ partitionOutScriptDefer True _ = []
 preloadsForScripts :: [Text] -> TagSoupTags
 preloadsForScripts (srcURL : remainder) =
   let forRemainder = preloadsForScripts remainder
-      openTag = TagOpen "link" [("href", srcURL), ("rel", "preload"), ("as", "script")]
+      openTag = TagOpen "link" [("href", srcURL), ("rel", "preload"), ("as", "script"), ("crossorigin", "anonymous")]
       closeTag = TagClose "link"
       textTag = TagText "\n    "
    in openTag : closeTag : textTag : forRemainder


### PR DESCRIPTION
**Problem:**
We've been getting some warnings in Chrome about the preloads.

**Fix:**
By adding the crossorigin attribute for some of the preloads, the error about a preload not being used because the credentials do not match should be corrected.

**Notes:**
The error `The resource <URL> was preloaded using link preload but not used within a few seconds from the window's load event.` appears to be unavoidable if they're not used almost instantly.

**Commit Details:**
- Add in crossorigin attribute for some preloads.
