### PR TITLE
Ensure (forked) is added to end of project name

### DIFF
--- a/editor/src/components/editor/persistence/generic/persistence-machine.ts
+++ b/editor/src/components/editor/persistence/generic/persistence-machine.ts
@@ -735,7 +735,12 @@ export function createPersistenceMachine<ModelType, FileType>(
                     DOWNLOAD_ASSETS_COMPLETE: {
                       target: CreatingProjectId,
                       actions: assign({
-                        project: (_, event) => event.downloadAssetsResult.projectModel,
+                        project: (_, event) => {
+                          return {
+                            name: `${event.downloadAssetsResult.projectModel.name} (forked)`,
+                            content: event.downloadAssetsResult.projectModel.content,
+                          }
+                        },
                       }),
                     },
                   },

--- a/editor/src/components/editor/persistence/persistence.ts
+++ b/editor/src/components/editor/persistence/persistence.ts
@@ -103,7 +103,7 @@ export class PersistenceMachine {
           case 'DOWNLOAD_ASSETS_COMPLETE': {
             if (state.matches({ core: { [Forking]: CreatingProjectId } })) {
               this.queuedActions.push(setForkedFromProjectID(state.context.projectId!))
-              this.queuedActions.push(setProjectName(`${state.context.project!.name} (forked)`))
+              this.queuedActions.push(setProjectName(state.context.project!.name))
               this.queuedActions.push(showToast(notice('Project successfully forked!')))
             }
 


### PR DESCRIPTION
**Problem:**
Updating the URL when forking was using the old project's name because it uses the stored in the state machine's context, which hadn't been updated.

**Fix:**
Ensure that the project's name is updated in the machine's context
