### PR TITLE
snip the BundlerWorker / ts-worker from the main editor

### DIFF
--- a/editor/src/components/canvas/dom-walker.spec.browser.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser.tsx
@@ -12,7 +12,6 @@ import {
   ElementInstanceMetadataMap,
 } from '../../core/shared/element-template'
 import {
-  FakeBundlerWorker,
   FakeLinterWorker,
   FakeParserPrinterWorker,
   FakeWatchdogWorker,
@@ -66,7 +65,6 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
       shortcutConfig: {},
     },
     workers: new UtopiaTsWorkersImplementation(
-      new FakeBundlerWorker(),
       new FakeParserPrinterWorker(),
       new FakeLinterWorker(),
       new FakeWatchdogWorker(),

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -102,6 +102,7 @@ const FailJestOnCanvasError = () => {
   const stableCallback = React.useCallback((newRuntimeErrors: Array<RuntimeErrorInfo>) => {
     // we have new runtime errors, let's take the tests down
     if (newRuntimeErrors.length > 0) {
+      console.error('Canvas Error!!!!!', newRuntimeErrors[0]?.error)
       fail(newRuntimeErrors[0]?.error)
       expect(newRuntimeErrors[0]?.error ?? null).toEqual(null)
     }

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -102,6 +102,7 @@ const FailJestOnCanvasError = () => {
   const stableCallback = React.useCallback((newRuntimeErrors: Array<RuntimeErrorInfo>) => {
     // we have new runtime errors, let's take the tests down
     if (newRuntimeErrors.length > 0) {
+      fail(newRuntimeErrors[0]?.error)
       expect(newRuntimeErrors[0]?.error ?? null).toEqual(null)
     }
   }, [])

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -46,7 +46,6 @@ import {
 } from '../../core/shared/project-file-types'
 import { PrettierConfig } from 'utopia-vscode-common'
 import {
-  FakeBundlerWorker,
   FakeLinterWorker,
   FakeParserPrinterWorker,
   FakeWatchdogWorker,
@@ -195,7 +194,6 @@ export async function renderTestEditorWithModel(
       shortcutConfig: {},
     },
     workers: new UtopiaTsWorkersImplementation(
-      new FakeBundlerWorker(),
       new FakeParserPrinterWorker(),
       new FakeLinterWorker(),
       new FakeWatchdogWorker(),

--- a/editor/src/core/es-modules/evaluator/evaluator.ts
+++ b/editor/src/core/es-modules/evaluator/evaluator.ts
@@ -17,7 +17,9 @@ function isEsModuleError(error: Error) {
     // I cannot test for a more explicit string because Node.js (Jest) and Chrome has slightly different error messages,
     // and it made me feel like I shouldn't codify the string matching to today's version of Chrome, so
     // I went with this more generic solution.
-    (error.message.indexOf('export') > -1 || error.message.indexOf('import') > -1)
+    (error.message.indexOf('export') > -1 ||
+      error.message.indexOf('import') > -1 ||
+      error.message.indexOf('*') > -1)
   )
 }
 

--- a/editor/src/core/workers/common/worker-types.ts
+++ b/editor/src/core/workers/common/worker-types.ts
@@ -264,15 +264,8 @@ export function createInitTSWorkerMessage(
 }
 
 export interface UtopiaTsWorkers {
-  sendInitMessage: (
-    typeDefinitions: TypeDefinitions,
-    projectContent: ProjectContentTreeRoot,
-  ) => void
-  sendUpdateFileMessage: (filename: string, content: FileContent, emitBuild: boolean) => void
   sendParsePrintMessage: (files: Array<ParseOrPrint>) => void
   sendLinterRequestMessage: (filename: string, content: string) => void
-  addBundleResultEventListener: (handler: (e: MessageEvent) => void) => void
-  removeBundleResultEventListener: (handler: (e: MessageEvent) => void) => void
   addParserPrinterEventListener: (handler: (e: MessageEvent) => void) => void
   removeParserPrinterEventListener: (handler: (e: MessageEvent) => void) => void
   addLinterResultEventListener: (handler: (e: MessageEvent) => void) => void

--- a/editor/src/core/workers/test-workers.ts
+++ b/editor/src/core/workers/test-workers.ts
@@ -13,28 +13,6 @@ import {
   ParsePrintResultMessage,
 } from './common/worker-types'
 
-export class FakeBundlerWorker implements BundlerWorker {
-  messageListeners: Array<(ev: MessageEvent) => any> = []
-
-  addMessageListener = (listener: (ev: MessageEvent) => any): void => {
-    this.messageListeners.push(listener)
-  }
-
-  removeMessageListener = (listener: (ev: MessageEvent) => any): void => {
-    this.messageListeners = this.messageListeners.filter((l) => l !== listener)
-  }
-
-  receiveMessage = (data: any) => {
-    this.messageListeners.forEach((l) => {
-      l(new MessageEvent('message', { data: data }))
-    })
-  }
-
-  postMessage = (message: any): void => {
-    handleTSWorkerMessage(message, this.receiveMessage)
-  }
-}
-
 export class FakeParserPrinterWorker implements ParserPrinterWorker {
   messageListeners: Array<(ev: MessageEvent) => any> = []
 

--- a/editor/src/core/workers/workers.ts
+++ b/editor/src/core/workers/workers.ts
@@ -1,6 +1,5 @@
 import { TypeDefinitions } from '../shared/npm-dependency-types'
 import { createLinterRequestMessage } from './linter/linter-worker'
-import { NewBundlerWorker, BundlerWorker } from './bundler-bridge'
 import { createLinterWorker, createParserPrinterWorker, createWatchdogWorker } from './utils'
 import {
   createWatchdogInitMessage,
@@ -18,34 +17,14 @@ import {
 import { ProjectContentTreeRoot } from '../../components/assets'
 
 export class UtopiaTsWorkersImplementation implements UtopiaTsWorkers {
-  private bundlerWorker: NewBundlerWorker
-
   constructor(
-    bundlerWorker: BundlerWorker,
     private parserPrinterWorker: ParserPrinterWorker,
     private linterWorker: LinterWorker,
     private watchdogWorker: WatchdogWorker,
-  ) {
-    this.bundlerWorker = new NewBundlerWorker(bundlerWorker)
-  }
-  sendInitMessage(typeDefinitions: TypeDefinitions, projectContents: ProjectContentTreeRoot): void {
-    this.bundlerWorker.sendInitMessage(typeDefinitions, projectContents, null)
-  }
-
-  sendUpdateFileMessage(filename: string, content: FileContent): void {
-    this.bundlerWorker.sendUpdateFileMessage(filename, content)
-  }
+  ) {}
 
   sendLinterRequestMessage(filename: string, content: string): void {
     this.linterWorker.sendLinterRequestMessage(filename, content)
-  }
-
-  addBundleResultEventListener(handler: (e: MessageEvent) => void): void {
-    this.bundlerWorker.addBundleResultEventListener(handler)
-  }
-
-  removeBundleResultEventListener(handler: (e: MessageEvent) => void): void {
-    this.bundlerWorker.removeBundleResultEventListener(handler)
   }
 
   sendParsePrintMessage(files: Array<ParseOrPrint>): void {

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -137,7 +137,6 @@ export class Editor {
       history: history,
       userState: defaultUserState,
       workers: new UtopiaTsWorkersImplementation(
-        new RealBundlerWorker(),
         new RealParserPrinterWorker(),
         new RealLinterWorker(),
         watchdogWorker,
@@ -153,39 +152,6 @@ export class Editor {
     this.utopiaStoreApi = storeHook
 
     reduxDevtoolsSendInitialState(this.storedState)
-
-    const handleWorkerMessage = (msg: OutgoingWorkerMessage) => {
-      switch (msg.type) {
-        case 'build': {
-          // FIXME: In theory, we could get back an error from an old build here, which would no longer be
-          // applicable, but since we now clear those on code changes, and failed builds are extremely fast,
-          // this is near impossible to reproduce *right now*. However, it could still become a very real
-          // issue in the future, so it still needs addressing
-          let actions: Array<EditorAction> = []
-          if (!this.storedState.editor.safeMode) {
-            const codeResultCache = generateCodeResultCache(
-              this.storedState.editor.projectContents,
-              this.storedState.editor.codeResultCache.projectModules,
-              msg.buildResult,
-              msg.exportsInfo,
-              this.storedState.editor.nodeModules.files,
-              this.boundDispatch,
-              this.storedState.editor.codeResultCache.evaluationCache,
-              msg.buildType,
-              true,
-            )
-
-            if (codeResultCache != null) {
-              actions.push(EditorActions.updateCodeResultCache(codeResultCache, msg.buildType))
-            }
-          }
-          const errors = getAllErrorsFromBuildResult(msg.buildResult)
-          actions.push(EditorActions.setCodeEditorBuildErrors(errors))
-          this.storedState.dispatch(actions, 'everyone')
-          break
-        }
-      }
-    }
 
     const handleLinterMessage = (msg: LinterResultMessage) => {
       switch (msg.type) {
@@ -211,7 +177,6 @@ export class Editor {
       }
     }
 
-    this.storedState.workers.addBundleResultEventListener((e) => handleWorkerMessage(e.data))
     this.storedState.workers.addLinterResultEventListener((e) => handleLinterMessage(e.data))
     this.storedState.workers.addHeartbeatRequestEventListener((e) =>
       handleHeartbeatRequestMessage(e.data),


### PR DESCRIPTION
During my digging through wtf the editor is doing when loading a project, I noticed that the BundlerWorker (also called `ts-worker` to make things confusing) is not producing useful output for the main editor thread. I am simply removing it and no one will notice. It doesn't bring significant loading time benefit, but at least we are using significantly less resources this way!

The property-controls-iframe and the preview.html are still using the ts-worker on their own. I'm not touching that, it's good and fine.