### PR TITLE
Add a ready indicator for VS Code to the editor state.

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -1070,6 +1070,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     safeMode: currentEditor.safeMode,
     saveError: currentEditor.saveError,
     vscodeBridgeReady: currentEditor.vscodeBridgeReady,
+    vscodeReady: currentEditor.vscodeReady,
     focusedElementPath: currentEditor.focusedElementPath,
     config: defaultConfig(),
     theme: currentEditor.theme,
@@ -4457,7 +4458,10 @@ export const UPDATE_FNS = {
     // Side effects.
     sendCodeEditorDecorations(editor)
     sendSelectedElement(editor)
-    return editor
+    return {
+      ...editor,
+      vscodeReady: true,
+    }
   },
   SET_FOCUSED_ELEMENT: (action: SetFocusedElement, editor: EditorModel): EditorModel => {
     let shouldApplyChange: boolean = false

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -473,18 +473,20 @@ export function editorDispatch(
     )
   }
 
-  // Chain off of the previous one to ensure the ordering is maintained.
-  currentVSCodeChanges = combineAccumulatedVSCodeChanges(
-    currentVSCodeChanges,
-    getVSCodeChanges(storedState.editor, frozenEditorState, updatedFromVSCode),
-  )
-  applyProjectChangesCoordinator = applyProjectChangesCoordinator.then(async () => {
-    const changesToSend = currentVSCodeChanges
-    currentVSCodeChanges = emptyAccumulatedVSCodeChanges
-    return sendVSCodeChanges(changesToSend).catch((error) => {
-      console.error('Error sending updates to VS Code', error)
+  if (frozenEditorState.vscodeReady) {
+    // Chain off of the previous one to ensure the ordering is maintained.
+    currentVSCodeChanges = combineAccumulatedVSCodeChanges(
+      currentVSCodeChanges,
+      getVSCodeChanges(storedState.editor, frozenEditorState, updatedFromVSCode),
+    )
+    applyProjectChangesCoordinator = applyProjectChangesCoordinator.then(async () => {
+      const changesToSend = currentVSCodeChanges
+      currentVSCodeChanges = emptyAccumulatedVSCodeChanges
+      return sendVSCodeChanges(changesToSend).catch((error) => {
+        console.error('Error sending updates to VS Code', error)
+      })
     })
-  })
+  }
 
   const shouldUpdatePreview =
     anySendPreviewModel || frozenEditorState.projectContents !== storedState.editor.projectContents

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -501,6 +501,7 @@ export interface EditorState {
   safeMode: boolean
   saveError: boolean
   vscodeBridgeReady: boolean
+  vscodeReady: boolean
   focusedElementPath: ElementPath | null
   config: UtopiaVSCodeConfig
   theme: Theme
@@ -1271,6 +1272,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     safeMode: false,
     saveError: false,
     vscodeBridgeReady: false,
+    vscodeReady: false,
     focusedElementPath: null,
     config: defaultConfig(),
     theme: 'light',
@@ -1520,6 +1522,7 @@ export function editorModelFromPersistentModel(
     },
     codeEditorErrors: persistentModel.codeEditorErrors,
     vscodeBridgeReady: false,
+    vscodeReady: false,
     focusedElementPath: null,
     config: defaultConfig(),
     theme: 'light',

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -327,6 +327,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.INCREMENT_RESIZE_OPTIONS_SELECTED_INDEX(state)
     case 'SET_RESIZE_OPTIONS_TARGET_OPTIONS':
       return UPDATE_FNS.SET_RESIZE_OPTIONS_TARGET_OPTIONS(action, state)
+    case 'SEND_CODE_EDITOR_INITIALISATION':
+      return UPDATE_FNS.SEND_CODE_EDITOR_INITIALISATION(action, state)
     default:
       return state
   }


### PR DESCRIPTION
Fixes #1821

**Problem:**
Updates to the project contents were being sent to VS Code before it had been fully initialised, resulting in errors on creating a new project.

**Fix:**
Added a flag to indicate VS Code has fully initialised so that the editor knows it can send those changes.

**Commit Details:**
- Fixes #1821.
- Added `vscodeReady` to `EditorState`.
- In `editorDispatch`, don't send any changes to VS Code unless
  `vscodeReady` is set to `true`.
- Have the `SEND_CODE_EDITOR_INITIALISATION` action mark VS Code
  as ready.
- Wire in the `SEND_CODE_EDITOR_INITIALISATION` action, as it
  wasn't ever previously being fired...
