### PR TITLE
fix(vscode) fix when there is no selectedview

### DIFF
--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -297,6 +297,9 @@ export function getSelectedElementChangedMessage(
   newEditorState: EditorState,
 ): SelectedElementChanged | null {
   const selectedView = newEditorState.selectedViews[0]
+  if (selectedView == null) {
+    return null
+  }
   const highlightBounds = getHighlightBoundsForElementPath(selectedView, newEditorState)
   if (highlightBounds == null) {
     return null


### PR DESCRIPTION
**Problem:**
Fixing an error coming from #1825 and #1830

**Fix:**
Check if there are any selectedviews when trying to send it in the action handler `SEND_CODE_EDITOR_INITIALISATION`

**Commit Details:**
- update `getSelectedElementChangedMessage`
