### PR TITLE
Render editor root as soon as possible

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -36,10 +36,6 @@ import { usePubSubAtom } from '../../core/shared/atom-with-pub-sub'
 import CanvasActions from './canvas-actions'
 import { canvasPoint } from '../../core/shared/math-utils'
 
-interface DesignPanelRootProps {
-  isUiJsFileOpen: boolean
-}
-
 interface NumberSize {
   width: number
   height: number
@@ -117,7 +113,7 @@ const NothingOpenCard = betterReactMemo('NothingOpen', () => {
   )
 })
 
-export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: DesignPanelRootProps) => {
+export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', () => {
   const dispatch = useEditorState((store) => store.dispatch, 'DesignPanelRoot dispatch')
   const interfaceDesigner = useEditorState(
     (store) => store.editor.interfaceDesigner,
@@ -169,12 +165,9 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
       elementRef: HTMLElement,
       delta: NumberSize,
     ) => {
-      if (props.isUiJsFileOpen) {
-        updateDeltaWidth(delta.width)
-      }
-      setCodeEditorResizingWidth(null)
+      updateDeltaWidth(delta.width)
     },
-    [updateDeltaWidth, props.isUiJsFileOpen],
+    [updateDeltaWidth],
   )
 
   const onResize = React.useCallback(
@@ -184,11 +177,11 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
       elementRef: HTMLElement,
       delta: NumberSize,
     ) => {
-      if (props.isUiJsFileOpen && navigatorVisible) {
+      if (navigatorVisible) {
         setCodeEditorResizingWidth(interfaceDesigner.codePaneWidth + delta.width)
       }
     },
-    [interfaceDesigner, navigatorVisible, props.isUiJsFileOpen],
+    [interfaceDesigner, navigatorVisible],
   )
 
   const [navigatorWidth, setNavigatorWidth] = usePubSubAtom(NavigatorWidthAtom)
@@ -264,7 +257,7 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
             className='resizableFlexColumnCanvasCode'
             style={{
               ...UtopiaStyles.flexColumn,
-              display: !props.isUiJsFileOpen || interfaceDesigner.codePaneVisible ? 'flex' : 'none',
+              display: interfaceDesigner.codePaneVisible ? 'flex' : 'none',
               width: isCanvasVisible ? undefined : interfaceDesigner.codePaneWidth,
               height: '100%',
               position: 'relative',
@@ -279,7 +272,7 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
           </Resizable>
         </SimpleFlexColumn>
 
-        {props.isUiJsFileOpen && isCanvasVisible ? (
+        {isCanvasVisible ? (
           <SimpleFlexColumn
             style={{
               flexGrow: 1,
@@ -301,7 +294,7 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
               <TopMenu />
             </SimpleFlexRow>
 
-            {isCanvasVisible && props.isUiJsFileOpen && navigatorVisible ? (
+            {isCanvasVisible && navigatorVisible ? (
               <div
                 style={{
                   height: `calc(100% - ${TopMenuHeight}px)`,
@@ -339,13 +332,13 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
                 </ResizableFlexColumn>
               </div>
             ) : null}
-            <CanvasWrapperComponent {...props} />
+            <CanvasWrapperComponent />
             <FloatingInsertMenu />
           </SimpleFlexColumn>
         ) : null}
       </SimpleFlexRow>
 
-      {isCanvasVisible && props.isUiJsFileOpen ? (
+      {isCanvasVisible ? (
         <>
           {isRightMenuExpanded ? (
             <SimpleFlexRow

--- a/editor/src/components/canvas/dom-walker.spec.browser.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser.tsx
@@ -77,7 +77,7 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
 
   const storeHook = create<EditorStore>((set) => initialEditorStore)
 
-  const result = render(
+  render(
     <HotRoot
       api={storeHook}
       useStore={storeHook}
@@ -86,8 +86,6 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
       vscodeBridgeReady={false}
     />,
   )
-  const noFileOpenText = result.getByText('No file open')
-  expect(noFileOpenText).toBeDefined()
 
   await act(async () => {
     await load(dispatch, createTestProjectWithCode(appUiJsFileCode), 'Test', '0', false)

--- a/editor/src/components/canvas/dom-walker.spec.browser.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser.tsx
@@ -90,15 +90,7 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
   expect(noFileOpenText).toBeDefined()
 
   await act(async () => {
-    await load(
-      dispatch,
-      createTestProjectWithCode(appUiJsFileCode),
-      'Test',
-      '0',
-      initialEditorStore.workers,
-      Utils.NO_OP,
-      false,
-    )
+    await load(dispatch, createTestProjectWithCode(appUiJsFileCode), 'Test', '0', false)
   })
   const sanitizedMetadata = sanitizeJsxMetadata(storeHook.getState().editor.jsxMetadata)
   expect(sanitizedMetadata).toMatchSnapshot()

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -232,9 +232,6 @@ export async function renderTestEditorWithModel(
     </React.Profiler>,
   )
 
-  const noFileOpenText = result.getByText('No file open')
-  expect(noFileOpenText).toBeDefined()
-
   await act(async () => {
     await new Promise<void>((resolve, reject) => {
       load(

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -249,8 +249,6 @@ export async function renderTestEditorWithModel(
         model,
         'Test',
         '0',
-        initialEditorStore.workers,
-        Utils.NO_OP,
         false,
       )
     })

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -5091,55 +5091,11 @@ function setCanvasFramesInnerNew(
   return updateFramesOfScenesAndComponents(editor, framesAndTargets, optionalParentFrame)
 }
 
-export async function newProject(
-  dispatch: EditorDispatch,
-  renderEditorRoot: () => void,
-): Promise<void> {
-  const defaultPersistentModel = defaultProject()
-  const npmDependencies = dependenciesWithEditorRequirements(defaultPersistentModel.projectContents)
-  const fetchNodeModulesResult = await fetchNodeModules(npmDependencies)
-
-  const nodeModules: NodeModules = fetchNodeModulesResult.nodeModules
-  const packageResult: PackageStatusMap = createLoadedPackageStatusMapFromDependencies(
-    npmDependencies,
-    fetchNodeModulesResult.dependenciesWithError,
-    fetchNodeModulesResult.dependenciesNotFound,
-  )
-
-  const codeResultCache = generateCodeResultCache(
-    defaultPersistentModel.projectContents,
-    {},
-    SampleFileBuildResult,
-    SampleFileBundledExportsInfo,
-    nodeModules,
-    dispatch,
-    {},
-    'full-build',
-    false,
-  )
-
-  renderEditorRoot()
-  dispatch(
-    [
-      {
-        action: 'NEW',
-        nodeModules: nodeModules,
-        persistentModel: defaultPersistentModel,
-        codeResultCache: codeResultCache,
-        packageResult: packageResult,
-      },
-    ],
-    'everyone',
-  )
-}
-
 export async function load(
   dispatch: EditorDispatch,
   model: PersistentModel,
   title: string,
   projectId: string,
-  workers: UtopiaTsWorkers,
-  renderEditorRoot: () => void,
   retryFetchNodeModules: boolean = true,
 ): Promise<void> {
   // this action is now async!
@@ -5170,8 +5126,6 @@ export async function load(
   const storedState = await loadStoredState(projectId)
 
   const safeMode = await localforage.getItem<boolean>(getProjectLockedKey(projectId))
-
-  renderEditorRoot()
 
   dispatch(
     [

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -293,7 +293,7 @@ export const EditorComponentInner = betterReactMemo(
                   overflowX: 'hidden',
                 }}
               >
-                <OpenFileEditor />
+                <DesignPanelRoot />
               </SimpleFlexRow>
               {/* insert more columns here */}
 
@@ -363,26 +363,6 @@ export function EditorComponent(props: EditorProps) {
     </DndProvider>
   )
 }
-
-const OpenFileEditor = betterReactMemo('OpenFileEditor', () => {
-  const { isUiJsFileOpen } = useEditorState((store) => {
-    const selectedFile = getOpenFile(store.editor)
-    const selectedFileName = getOpenTextFileKey(store.editor)
-    const isAppDotJS = selectedFileName?.endsWith('app.js') ?? false
-    const isStoryboardFile = selectedFileName?.endsWith(StoryboardFilePath) ?? false
-    const isCanvasFile = isAppDotJS || isStoryboardFile // FIXME This is not how we should determine whether or not to open the canvas
-    return {
-      isUiJsFileOpen: selectedFile != null && isCanvasFile,
-    }
-  }, 'OpenFileEditor')
-
-  if (isUiJsFileOpen) {
-    return <DesignPanelRoot isUiJsFileOpen={isUiJsFileOpen} />
-  } else {
-    return <Subdued>No file open</Subdued>
-  }
-})
-OpenFileEditor.displayName = 'OpenFileEditor'
 
 const CanvasCursorComponent = betterReactMemo('CanvasCursorComponent', () => {
   const cursor = useEditorState((store) => {

--- a/editor/src/components/editor/notification-bar.tsx
+++ b/editor/src/components/editor/notification-bar.tsx
@@ -39,6 +39,8 @@ export const LoginStatusBar = betterReactMemo('LoginStatusBar', () => {
   }
 
   switch (loginState.type) {
+    case 'LOGIN_NOT_YET_KNOWN':
+      return null
     case 'LOGGED_IN':
       return null
     case 'OFFLINE_STATE':

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -316,6 +316,7 @@ export async function getUserConfiguration(loginState: LoginState): Promise<User
         // FIXME Client should show an error if server requests fail
         throw new Error(`server responded with ${response.status} ${response.statusText}`)
       }
+    case 'LOGIN_NOT_YET_KNOWN':
     case 'NOT_LOGGED_IN':
     case 'LOGIN_LOST':
     case 'OFFLINE_STATE':

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -134,7 +134,7 @@ import { emptyComplexMap, ComplexMap, addToComplexMap } from '../../../utils/map
 import * as friendlyWords from 'friendly-words'
 import { fastForEach } from '../../../core/shared/utils'
 import { ShortcutConfiguration } from '../shortcut-definitions'
-import { notLoggedIn } from '../../../common/user'
+import { loginNotYetKnown, notLoggedIn } from '../../../common/user'
 import { immediatelyResolvableDependenciesWithEditorRequirements } from '../npm-dependency/npm-dependency'
 import { getControlsForExternalDependencies } from '../../../core/property-controls/property-controls-utils'
 import {
@@ -235,7 +235,7 @@ export interface UserState extends UserConfiguration {
 }
 
 export const defaultUserState: UserState = {
-  loginState: notLoggedIn,
+  loginState: loginNotYetKnown,
   shortcutConfig: {},
 }
 

--- a/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
+++ b/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
@@ -124,8 +124,6 @@ export const SettingsPanel = betterReactMemo('SettingsPanel', () => {
           persistentModel,
           entireStateRef.current.editor.projectName,
           entireStateRef.current.editor.id!,
-          entireStateRef.current.workers,
-          NO_OP,
         )
       }
     },

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -269,6 +269,8 @@ export class Editor {
           this.storedState.persistence.load(projectId)
         }
       })
+
+      renderRootEditor()
     })
   }
 

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -144,15 +144,7 @@ export class Editor {
       projectId: string,
       projectName: string,
       project: PersistentModel,
-    ) =>
-      load(
-        this.storedState.dispatch,
-        project,
-        projectName,
-        projectId,
-        this.storedState.workers,
-        renderRootEditor,
-      )
+    ) => load(this.storedState.dispatch, project, projectName, projectId)
 
     this.storedState = {
       editor: emptyEditorState,
@@ -213,6 +205,7 @@ export class Editor {
 
     getLoginState('cache').then((loginState: LoginState) => {
       startPollingLoginState(this.boundDispatch, loginState)
+      renderRootEditor()
       this.storedState.userState.loginState = loginState
       getUserConfiguration(loginState).then((shortcutConfiguration) => {
         this.storedState.userState = {
@@ -269,8 +262,6 @@ export class Editor {
           this.storedState.persistence.load(projectId)
         }
       })
-
-      renderRootEditor()
     })
   }
 

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -172,6 +172,8 @@ export class Editor {
     this.updateStore = storeHook.setState
     this.utopiaStoreApi = storeHook
 
+    renderRootEditor()
+
     reduxDevtoolsSendInitialState(this.storedState)
 
     const handleLinterMessage = (msg: LinterResultMessage) => {
@@ -205,7 +207,6 @@ export class Editor {
 
     getLoginState('cache').then((loginState: LoginState) => {
       startPollingLoginState(this.boundDispatch, loginState)
-      renderRootEditor()
       this.storedState.userState.loginState = loginState
       getUserConfiguration(loginState).then((shortcutConfiguration) => {
         this.storedState.userState = {

--- a/website-next/components/common/user.ts
+++ b/website-next/components/common/user.ts
@@ -5,6 +5,10 @@ export interface UserDetails {
   picture?: string
 }
 
+interface LoginNotYetKnown {
+  type: 'LOGIN_NOT_YET_KNOWN'
+}
+
 interface LoggedInUser {
   type: 'LOGGED_IN'
   user: UserDetails
@@ -27,6 +31,7 @@ interface CookiesOrLocalForageUnavailable {
 }
 
 export type LoginState =
+  | LoginNotYetKnown
   | LoggedInUser
   | NotLoggedIn
   | LoginLost
@@ -38,6 +43,14 @@ export function loggedInUser(user: UserDetails): LoggedInUser {
     type: 'LOGGED_IN',
     user: user,
   }
+}
+
+export const loginNotYetKnown: LoginNotYetKnown = {
+  type: 'LOGIN_NOT_YET_KNOWN',
+}
+
+export function isLoginNotYetKnown(loginState: unknown): loginState is LoginNotYetKnown {
+  return (loginState as Partial<LoginState>)?.type === 'LOGIN_NOT_YET_KNOWN'
 }
 
 export const notLoggedIn: NotLoggedIn = {


### PR DESCRIPTION
**Problem:**
We were waiting until a project was loaded or created before actually rendering the editor, but we no longer need to.

**Fix:**
Render the editor root as soon as possible. To prevent a login bar briefly appearing for logged in users, I've added a new login state to capture the case when it's not yet known if the user is logged in or not.