### PR TITLE
Always render DesignPanelRoot

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -36,10 +36,6 @@ import { usePubSubAtom } from '../../core/shared/atom-with-pub-sub'
 import CanvasActions from './canvas-actions'
 import { canvasPoint } from '../../core/shared/math-utils'
 
-interface DesignPanelRootProps {
-  isUiJsFileOpen: boolean
-}
-
 interface NumberSize {
   width: number
   height: number
@@ -117,7 +113,7 @@ const NothingOpenCard = betterReactMemo('NothingOpen', () => {
   )
 })
 
-export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: DesignPanelRootProps) => {
+export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', () => {
   const dispatch = useEditorState((store) => store.dispatch, 'DesignPanelRoot dispatch')
   const interfaceDesigner = useEditorState(
     (store) => store.editor.interfaceDesigner,
@@ -169,12 +165,9 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
       elementRef: HTMLElement,
       delta: NumberSize,
     ) => {
-      if (props.isUiJsFileOpen) {
-        updateDeltaWidth(delta.width)
-      }
-      setCodeEditorResizingWidth(null)
+      updateDeltaWidth(delta.width)
     },
-    [updateDeltaWidth, props.isUiJsFileOpen],
+    [updateDeltaWidth],
   )
 
   const onResize = React.useCallback(
@@ -184,11 +177,11 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
       elementRef: HTMLElement,
       delta: NumberSize,
     ) => {
-      if (props.isUiJsFileOpen && navigatorVisible) {
+      if (navigatorVisible) {
         setCodeEditorResizingWidth(interfaceDesigner.codePaneWidth + delta.width)
       }
     },
-    [interfaceDesigner, navigatorVisible, props.isUiJsFileOpen],
+    [interfaceDesigner, navigatorVisible],
   )
 
   const [navigatorWidth, setNavigatorWidth] = usePubSubAtom(NavigatorWidthAtom)
@@ -264,7 +257,7 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
             className='resizableFlexColumnCanvasCode'
             style={{
               ...UtopiaStyles.flexColumn,
-              display: !props.isUiJsFileOpen || interfaceDesigner.codePaneVisible ? 'flex' : 'none',
+              display: interfaceDesigner.codePaneVisible ? 'flex' : 'none',
               width: isCanvasVisible ? undefined : interfaceDesigner.codePaneWidth,
               height: '100%',
               position: 'relative',
@@ -279,7 +272,7 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
           </Resizable>
         </SimpleFlexColumn>
 
-        {props.isUiJsFileOpen && isCanvasVisible ? (
+        {isCanvasVisible ? (
           <SimpleFlexColumn
             style={{
               flexGrow: 1,
@@ -301,7 +294,7 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
               <TopMenu />
             </SimpleFlexRow>
 
-            {isCanvasVisible && props.isUiJsFileOpen && navigatorVisible ? (
+            {isCanvasVisible && navigatorVisible ? (
               <div
                 style={{
                   height: `calc(100% - ${TopMenuHeight}px)`,
@@ -339,13 +332,13 @@ export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', (props: Design
                 </ResizableFlexColumn>
               </div>
             ) : null}
-            <CanvasWrapperComponent {...props} />
+            <CanvasWrapperComponent />
             <FloatingInsertMenu />
           </SimpleFlexColumn>
         ) : null}
       </SimpleFlexRow>
 
-      {isCanvasVisible && props.isUiJsFileOpen ? (
+      {isCanvasVisible ? (
         <>
           {isRightMenuExpanded ? (
             <SimpleFlexRow

--- a/editor/src/components/canvas/dom-walker.spec.browser.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser.tsx
@@ -77,7 +77,7 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
 
   const storeHook = create<EditorStore>((set) => initialEditorStore)
 
-  const result = render(
+  render(
     <HotRoot
       api={storeHook}
       useStore={storeHook}
@@ -86,8 +86,6 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
       vscodeBridgeReady={false}
     />,
   )
-  const noFileOpenText = result.getByText('No file open')
-  expect(noFileOpenText).toBeDefined()
 
   await act(async () => {
     await load(dispatch, createTestProjectWithCode(appUiJsFileCode), 'Test', '0', false)

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -232,9 +232,6 @@ export async function renderTestEditorWithModel(
     </React.Profiler>,
   )
 
-  const noFileOpenText = result.getByText('No file open')
-  expect(noFileOpenText).toBeDefined()
-
   await act(async () => {
     await new Promise<void>((resolve, reject) => {
       load(

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -293,7 +293,7 @@ export const EditorComponentInner = betterReactMemo(
                   overflowX: 'hidden',
                 }}
               >
-                <OpenFileEditor />
+                <DesignPanelRoot />
               </SimpleFlexRow>
               {/* insert more columns here */}
 
@@ -363,26 +363,6 @@ export function EditorComponent(props: EditorProps) {
     </DndProvider>
   )
 }
-
-const OpenFileEditor = betterReactMemo('OpenFileEditor', () => {
-  const { isUiJsFileOpen } = useEditorState((store) => {
-    const selectedFile = getOpenFile(store.editor)
-    const selectedFileName = getOpenTextFileKey(store.editor)
-    const isAppDotJS = selectedFileName?.endsWith('app.js') ?? false
-    const isStoryboardFile = selectedFileName?.endsWith(StoryboardFilePath) ?? false
-    const isCanvasFile = isAppDotJS || isStoryboardFile // FIXME This is not how we should determine whether or not to open the canvas
-    return {
-      isUiJsFileOpen: selectedFile != null && isCanvasFile,
-    }
-  }, 'OpenFileEditor')
-
-  if (isUiJsFileOpen) {
-    return <DesignPanelRoot isUiJsFileOpen={isUiJsFileOpen} />
-  } else {
-    return <Subdued>No file open</Subdued>
-  }
-})
-OpenFileEditor.displayName = 'OpenFileEditor'
 
 const CanvasCursorComponent = betterReactMemo('CanvasCursorComponent', () => {
   const cursor = useEditorState((store) => {


### PR DESCRIPTION
**Problem:**
We are unnecessarily hiding the `DesignPanelRoot` if no file is open due to previous (now non-existent) constraints.

**Fix:**
Remove the `isUiJsFileOpen` and all uses of it in and around `DesignPanelRoot`. The "changes" to `canvas-wrapper-component.tsx` are just the removal of an empty props object and type, which triggered a prettier reformat, so check the "hide whitespace" option on this PR or just ignore that file completely.