### PR TITLE
Fixed the loading screen CSS

### DIFF
--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -95,8 +95,11 @@
             border: 1px solid beige;
           "
         >
-          <img src='%UTOPIA_DOMAIN%/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%''
-          height='128px' alt='Utopia Logo '/>
+          <img
+            src="%UTOPIA_DOMAIN%/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
+            height="128px"
+            alt="Utopia Logo"
+          />
 
           <div
             class="progress-bar-shell"
@@ -107,6 +110,7 @@
               border: 1px solid black;
               border-radius: 8px;
               overflow: hidden;
+              box-sizing: border-box !important;
             "
           >
             <div

--- a/editor/src/templates/preview.html
+++ b/editor/src/templates/preview.html
@@ -47,13 +47,13 @@
           flex-direction: column;
           align-items: center;
           justify-content: center;
+          border: 1px solid beige;
         "
       >
         <img
           src="%UTOPIA_DOMAIN%/editor/pyramid_fullsize@2x.jpg?hash=%UTOPIA_SHA%"
           height="128px"
-          alt="Utopia
-        Logo "
+          alt="Utopia Logo"
         />
 
         <div


### PR DESCRIPTION
**Problem:**
The loading screen bar was implicitly relying on `initial-load.css`, meaning the bar itself wasn't correctly filled.

**Fix:**
This had already been resolved in the preview, so I've brought both uses in line with each other.

**Before:**
![Screenshot_20210917_155507](https://user-images.githubusercontent.com/1044774/133804162-50a77e82-e44d-4d54-a764-875e596a6ba6.png)

**After:**
![Screenshot_20210917_155542](https://user-images.githubusercontent.com/1044774/133804183-32406e82-4cda-4c53-a277-4b543b9797f3.png)

