### PR TITLE
Website Footer: add links to privacy policy and T&C

### DIFF
--- a/website-next/components/contact-us.js
+++ b/website-next/components/contact-us.js
@@ -4,6 +4,8 @@ const navigation = [
   { name: 'Play with Utopia', href: 'https://utopia.app/p/36ae27be-welcome-to-utopia' },
   { name: 'Join our Discord', href: 'https://discord.gg/NEEnPKCgzC' },
   { name: 'Check us on Github', href: 'https://github.com/concrete-utopia/utopia' },
+  { name: 'Privacy Policy', href: '/policies#privacy-policy' },
+  { name: 'Terms and Conditions', href: '/policies' },
 ]
 
 export const ContactUs = (props) => (
@@ -42,7 +44,7 @@ export const ContactUs = (props) => (
         <a
           key={item.name}
           href={item.href}
-          className='block px-6 py-2 rounded-md text-body hover:text-gray-900 hover:bg-gray-50'
+          className='block px-6 py-2 rounded-md text-body hover:text-gray-900 hover:bg-gray-50 text-center'
           onMouseDown={() =>
             gtag('event', 'navigate', { category: 'links', label: item.href, value: 1 })
           }

--- a/website-next/pages/blog/introducing-utopia.jsx
+++ b/website-next/pages/blog/introducing-utopia.jsx
@@ -151,7 +151,7 @@ export default function Blog() {
           Team Utopia
         </Paragraph>
       </div>
-      <div className='max-w-3xl mx-auto pt-12 pb-28'>
+      <div className='max-w-5xl mx-auto pt-12 pb-28'>
         <ContactUs />
       </div>
       <CookieConsentBar />

--- a/website-next/pages/policies.js
+++ b/website-next/pages/policies.js
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 export default function Policies() {
   return (
-    <div>
+    <div className='max-w-3xl mx-auto'>
       <h1>Momentumworks Inc / Utopia's Terms of Service, Privacy Policy, and GDPR policy</h1>
       <p>
         Hi and welcome! You're reading Utopia’s Terms of Service, which include an agreement between
@@ -502,7 +502,7 @@ export default function Policies() {
         telephone at (916) 445-1254 or (800) 952-5210. Hearing impaired users can reach the
         Complaint Assistance Unit at TDD (800) 326-2297 or TDD (916) 322-1700.
       </p>
-      <h2>Privacy Policy</h2>
+      <h2 id='privacy-policy'>Privacy Policy</h2>
       <h3>Last Modified: 2017-03-12</h3>
       <p>
         Momentumworks Inc takes the private nature of your personal information very seriously. We


### PR DESCRIPTION
This PR adds links to our Privacy Policy and Terms and Conditions to the footer of the website.

<img width="1292" alt="image" src="https://user-images.githubusercontent.com/2226774/133997318-9a812ce2-abc5-448f-b822-e6f670e474ae.png">


**Commit Details:**
- Added max width and margin auto to the policies page
- Made the footer slightly wider to accomodate two new buttons

