### PR TITLE
Chore/relative ci integration

### DIFF
--- a/.github/workflows/master-pushes.yml
+++ b/.github/workflows/master-pushes.yml
@@ -176,3 +176,48 @@ jobs:
           token: ${{ secrets.DEPLOY_REPO_ACCESS_TOKEN }}
           repository: concrete-utopia/utopia-deploy
           event-type: trigger-deploy
+
+  build-staging-baseline:
+    name: Build Staging Editor for Relative CI Baseline
+    runs-on: ubuntu-latest
+    env:
+      UTOPIA_SHA: ${{ github.sha }}
+      AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
+      AUTH0_ENDPOINT: enter.utopia.app
+      AUTH0_REDIRECT_URI: https://utopia.app/authenticate
+    steps:
+      # Gets the branch that this PR is targeting and replaces forward slashes in the name with hyphens.
+      # So that later steps can produce a bundle incorporating that into the name and upload it.
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Cache editor modules
+        uses: actions/cache@v2
+        with:
+          path: editor/node_modules
+          key: ${{ runner.os }}-node-editor-PRs-${{ hashFiles('editor/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-editor-PRs-
+      - name: Cache utopia-api modules
+        uses: actions/cache@v2
+        with:
+          path: utopia-api/node_modules
+          key: ${{ runner.os }}-node-utopia-api-PRs-${{ hashFiles('utopia-api/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-utopia-api-PRs-
+      - name: Cache utopia-vscode-common modules
+        uses: actions/cache@v2
+        with:
+          path: utopia-vscode-common/node_modules
+          key: ${{ runner.os }}-utopia-vscode-common-PRs-node-modules-${{ hashFiles('utopia-vscode-common/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-utopia-vscode-common-PRs-node-modules-
+      - name: Install nix
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-20.09
+      - name: Build Editor
+        if: steps.cache-editor-tests.outputs.cache-hit != 'true'
+        env:
+          RELATIVE_CI_KEY: ${{ secrets.RELATIVE_CI_KEY }}
+        run: |
+          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run build-editor-staging-ci

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -147,6 +147,8 @@ jobs:
           nix_path: nixpkgs=channel:nixos-20.09
       - name: Build Editor
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
+        env:
+          RELATIVE_CI_KEY: ${{ secrets.RELATIVE_CI_KEY }}
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run build-editor-staging-ci
       - name: Create Editor Bundle

--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -1326,6 +1326,21 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@bundle-stats/plugin-webpack-filter": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@bundle-stats/plugin-webpack-filter/-/plugin-webpack-filter-3.1.3.tgz",
+      "integrity": "sha512-KluPrsSm05jgFxAHO1sqU9ghoDO7XitLZ0pGiRvfU3+KAP+XxNh6I9AfaPJWTtb7vjCF+b46WynAmrOXc9AyFw==",
+      "dev": true
+    },
+    "@bundle-stats/plugin-webpack-validate": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@bundle-stats/plugin-webpack-validate/-/plugin-webpack-validate-3.1.3.tgz",
+      "integrity": "sha512-8YPquB0+eoUoOtQGitVJGzPi6nhNBkar/IZH24UQflQWXjPlvwT3XJ9HNDDGWjdfUXWCWGOrEqMpoLtxYUxWpQ==",
+      "dev": true,
+      "requires": {
+        "superstruct": "^0.8.3"
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -4367,6 +4382,135 @@
           "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.5.10.tgz",
           "integrity": "sha512-upluvSRWrlCiExu2UbkuMIPJ9AigyjRFoO7O9eUossIj7rPPq7pcJ0NKk6t2P7KF80tg/UdPX6/pNKOSbs9DEg==",
           "dev": true
+        }
+      }
+    },
+    "@relative-ci/agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@relative-ci/agent/-/agent-2.1.0.tgz",
+      "integrity": "sha512-XhLSuCa4mDQIhm0Lpe5Tzx6+5UojkPaEYSTImgf/xwZGC3ikT84mf6wDxX0J6UNRkoObegQrpr5MDkgOPSo6oQ==",
+      "dev": true,
+      "requires": {
+        "@bundle-stats/plugin-webpack-filter": "^3.1.3",
+        "@bundle-stats/plugin-webpack-validate": "^3.1.3",
+        "@relative-ci/env-ci": "^5.3.1",
+        "core-js": "^3.6.4",
+        "cosmiconfig": "^7.0.0",
+        "debug": "^4.1.1",
+        "dotenv": "^10.0.0",
+        "fs-extra": "^10.0.0",
+        "isomorphic-fetch": "^3.0.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.18.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.0.tgz",
+          "integrity": "sha512-WJeQqq6jOYgVgg4NrXKL0KLQhi0CT4ZOCvFL+3CQ5o7I6J8HkT5wd53EadMfqTDp1so/MT1J+w2ujhWcCJtN7w==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
+        "fs-extra": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "isomorphic-fetch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+          "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+          "dev": true,
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "whatwg-fetch": "^3.4.1"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
+    },
+    "@relative-ci/env-ci": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@relative-ci/env-ci/-/env-ci-5.3.1.tgz",
+      "integrity": "sha512-FychihgwUb2n28hACPROIb7LDrIQPGrIPXOZ7OsIFZw8o2rJzI1Xz0l6EJd79ePB+30rgmMJBFCnTmsH+t5ZvQ==",
+      "dev": true,
+      "requires": {
+        "execa": "^4.0.0",
+        "java-properties": "^1.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
         }
       }
     },
@@ -10198,6 +10342,12 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -14555,6 +14705,12 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/jStat/-/jStat-1.5.3.tgz",
       "integrity": "sha1-Rw7cQfm6k/mfjftOZl195tfkdiM=",
+      "dev": true
+    },
+    "java-properties": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+      "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
       "dev": true
     },
     "jest": {
@@ -26832,6 +26988,16 @@
         }
       }
     },
+    "superstruct": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.8.4.tgz",
+      "integrity": "sha512-48Ors8IVWZm/tMr8r0Si6+mJiB7mkD7jqvIzktjJ4+EnP5tBp0qOpiM1J8sCUorKx+TXWrfb3i1UcjdD1YK/wA==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2",
+        "tiny-invariant": "^1.0.6"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -27421,6 +27587,12 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "optional": true
+    },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==",
+      "dev": true
     },
     "tiny-lr-fork": {
       "version": "0.0.5",

--- a/editor/package.json
+++ b/editor/package.json
@@ -208,6 +208,7 @@
     "@hot-loader/react-dom": "16.13.0",
     "@jest-runner/electron": "3.0.0",
     "@react-three/fiber": "7.0.1",
+    "@relative-ci/agent": "^2.1.0",
     "@testing-library/react": "9.1.4",
     "@testing-library/react-hooks": "5.1.2",
     "@types/chai": "3.5.1",

--- a/editor/webpack.config.js
+++ b/editor/webpack.config.js
@@ -8,6 +8,7 @@ const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin')
 const TerserPlugin = require('terser-webpack-plugin')
 const path = require('path')
 const webpack = require('webpack')
+const { RelativeCiAgentWebpackPlugin } = require('@relative-ci/agent')
 
 const Production = 'production'
 const Staging = 'staging'
@@ -195,6 +196,8 @@ const config = {
     }),
 
     new webpack.ProvidePlugin({ BrowserFS: 'browserfs' }), // weirdly, the browserfs/dist/shims/fs shim assumes a global BrowserFS being available
+
+    new RelativeCiAgentWebpackPlugin(),
   ],
 
   resolve: {


### PR DESCRIPTION
This PR adds integration for relative-ci

**Commit Details:**
- new secret in github secrets
- new webpack plugin that only runs on CI
- **Note:** I added a "build staging editor" step to our master workflow. relative-ci uses these as the baseline so that the PRs have something to compare themselves against. It adds a bit of load on our CI, but because this is the staging build, and not the terser build, it's only 1-2 minutes of extra work.
- **Note 2:** I'm running relative-ci for the "staging" webpack build. this means that the numbers are showing the uncompressed JS bundle sizes. the bundle size (below shown as 42.9 MB will first go through a minifier (the TerserPlugin) and then also become compressed on the server (as far as I understand)). But the terser is so _damn_ slow, running it for every PR would add 15-25 extra minutes to the Ci job. it's  better to use the fast uncompressed numbers to compare against each other. I think it's safe to assume that the size changes in the uncompressed JS bundle are a good indicator of size change of the final compressed JS.