### PR TITLE
Protect against infinite depth content.

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -20870,6 +20870,16 @@ export var storyboard = (props) => {
 }
 `;
 
+exports[`UiJsxCanvas render multifile projects renders a canvas with App imported from a file 2`] = `
+Array [
+  Object {
+    "message": "Element hierarchy is too deep, potentially has become infinite.",
+    "name": "Error",
+    "stackFrames": Array [],
+  },
+]
+`;
+
 exports[`UiJsxCanvas render props can be accessed inside the arbitrary js block inside a text range 1`] = `
 "<div style=\\"all: initial;\\">
   <div

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -128,6 +128,13 @@ export function createComponentRendererComponent(params: {
 
     const instancePath: ElementPath | null = tryToGetInstancePath(instancePathAny, pathsString)
 
+    // Protect against infinite recursion by taking the view that anything
+    // beyond a particular depth is going infinite or is likely
+    // to be out of control otherwise.
+    if (instancePath != null && EP.depth(instancePath) > 100) {
+      throw new Error(`Element hierarchy is too deep, potentially has become infinite.`)
+    }
+
     const rootElementPath = optionalMap(
       (path) => EP.appendNewElementPath(path, getUtopiaID(utopiaJsxComponent.rootElement)),
       instancePath,

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -5,6 +5,7 @@ import {
   testCanvasRenderInline,
   testCanvasRenderMultifile,
   testCanvasRenderInlineMultifile,
+  testCanvasErrorMultifile,
 } from './ui-jsx-canvas.test-utils'
 import { TestAppUID, TestSceneUID } from './ui-jsx.test-utils'
 
@@ -2167,5 +2168,50 @@ describe('UiJsxCanvas render multifile projects', () => {
       </div>
       "
     `)
+  })
+
+  it('renders a canvas with App imported from a file', () => {
+    testCanvasErrorMultifile(
+      null,
+      `import * as React from 'react'
+      import { Storyboard, Scene } from 'utopia-api'
+      import { App } from '/app'
+
+      export var ${BakedInStoryboardVariableName} = (props) => {
+        return (
+          <Storyboard data-uid={'${BakedInStoryboardUID}'}>
+            <Scene
+              style={{ position: 'absolute', height: 200, left: 59, width: 200, top: 79 }}
+              data-uid={'${TestSceneUID}'}
+            >
+              <App
+                data-uid='${TestAppUID}'
+                style={{ position: 'absolute', height: '100%', width: '100%' }}
+                title={'Hi there!'}
+              />
+            </Scene>
+          </Storyboard>
+        )
+      }
+      `,
+      {
+        '/app.js': `
+        import * as React from 'react'
+        import { App2 } from '/app2'
+        export var App = (props) => {
+          return <div data-uid='app-outer-div'>
+            <App2 />
+          </div>
+        }`,
+        '/app2.js': `
+        import * as React from 'react'
+        import { App } from '/app'
+        export var App2 = (props) => {
+          return <div data-uid='app-outer-div'>
+            <App />
+          </div>
+        }`,
+      },
+    )
   })
 })

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -3,7 +3,25 @@
 exports[`getComponentGroups returns all the various default groups 1`] = `
 Array [
   Object {
-    "insertableComponents": Array [],
+    "insertableComponents": Array [
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "App",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+        },
+        "importsToAdd": Object {},
+        "name": "App",
+        "stylePropOptions": Array [
+          "do-not-add",
+        ],
+      },
+    ],
     "source": Object {
       "path": "/src/app.js",
       "type": "PROJECT_COMPONENT_GROUP",

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -294,10 +294,7 @@ export function getComponentGroups(
         file.fileContents.parsed,
       )
       if (possibleExportedComponents != null) {
-        const componentsWithoutApp_KILLME = possibleExportedComponents.filter(
-          (c) => c.listingName !== 'App', // TODO make this filtering smarter. Filter out the component(s) that we are currently inserting into instead of this
-        )
-        const insertableComponents = componentsWithoutApp_KILLME.map((exportedComponent) => {
+        const insertableComponents = possibleExportedComponents.map((exportedComponent) => {
           const pathWithoutExtension = dropFileExtension(fullPath)
           const { defaultProps, parsedControls } = defaultPropertiesForComponentInFile(
             exportedComponent.listingName,


### PR DESCRIPTION
Fixes #1590

**Problem:**
Previously we prevented insertion of an element called `App` as a heuristic to avoid having an infinite render loop in the canvas if that component ever ended up inside itself. But that only works if it matches that name, which is highly unlikely and a complex project could easily have many components which could induce infinite recursion.

**Fix:**
The original intent of the bug was to improve the filtering, but that becomes an increasingly complicated nest of checks especially once an element in the hierarchy has any kind of conditional rendering or if it gets passed in a prop, which may hide it from introspection.

Instead this thresholds the depth of rendering in the canvas, so that an exception will be thrown to prevent it from running forever or crashing the whole editor, with a message indicating that it was because of an excessive render depth.

**Commit Details:**
- Fixes #1590.
- Add a condition to `createComponentRendererComponent` to protect against
  an excessive depth of calls.
- Removed the filtering of `App` from the insertable components.
