### PR TITLE
Fix/canvas resize absolute element

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2994,7 +2994,7 @@ export function getResizeOptions(
             case 'before':
               return ['PinnedTop', 'Height', 'marginTop', 'minHeight', 'maxHeight']
             case 'after':
-              return ['Height', 'PinnedBottom', 'marginBottom', 'minHeight', 'maxHeight']
+              return ['PinnedBottom', 'Height', 'marginBottom', 'minHeight', 'maxHeight']
             default:
               const _exhaustiveCheck: never = edge
               throw new Error(`Unhandled control edge ${JSON.stringify(edge)}`)
@@ -3004,7 +3004,7 @@ export function getResizeOptions(
             case 'before':
               return ['PinnedLeft', 'Width', 'marginLeft', 'minWidth', 'maxWidth']
             case 'after':
-              return ['Width', 'PinnedRight', 'marginRight', 'minWidth', 'maxWidth']
+              return ['PinnedRight', 'Width', 'marginRight', 'minWidth', 'maxWidth']
             default:
               const _exhaustiveCheck: never = edge
               throw new Error(`Unhandled control edge ${JSON.stringify(edge)}`)

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2994,7 +2994,7 @@ export function getResizeOptions(
             case 'before':
               return ['PinnedTop', 'Height', 'marginTop', 'minHeight', 'maxHeight']
             case 'after':
-              return ['PinnedBottom', 'Height', 'marginBottom', 'minHeight', 'maxHeight']
+              return ['Height', 'PinnedBottom', 'marginBottom', 'minHeight', 'maxHeight']
             default:
               const _exhaustiveCheck: never = edge
               throw new Error(`Unhandled control edge ${JSON.stringify(edge)}`)
@@ -3004,7 +3004,7 @@ export function getResizeOptions(
             case 'before':
               return ['PinnedLeft', 'Width', 'marginLeft', 'minWidth', 'maxWidth']
             case 'after':
-              return ['PinnedRight', 'Width', 'marginRight', 'minWidth', 'maxWidth']
+              return ['Width', 'PinnedRight', 'marginRight', 'minWidth', 'maxWidth']
             default:
               const _exhaustiveCheck: never = edge
               throw new Error(`Unhandled control edge ${JSON.stringify(edge)}`)

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -49,6 +49,7 @@ import {
 } from '../canvas-utils'
 import { safeIndex } from '../../../core/shared/array-utils'
 import { CSSPosition } from '../../inspector/common/css-utils'
+import * as EP from '../../../core/shared/element-path'
 
 interface ResizeControlProps extends ResizeRectangleProps {
   cursor: CSSCursor
@@ -139,7 +140,10 @@ class ResizeControl extends React.Component<ResizeControlProps> {
         [
           CanvasActions.createDragState(newDragState),
           setCanvasAnimationsEnabled(false),
-          setResizeOptionsTargetOptions(propertyTargetOptions),
+          setResizeOptionsTargetOptions(
+            propertyTargetOptions,
+            this.props.propertyTargetSelectedIndex,
+          ),
         ],
         'canvas',
       )
@@ -285,6 +289,11 @@ class ResizeEdge extends React.Component<ResizeEdgeProps, ResizeEdgeState> {
             left={left + shiftPropertyTargetSelectorAxis('vertical', this.props.direction, edge)}
             options={getResizeOptions(layoutSystem, this.props.direction, edge)}
             targetComponentMetadata={this.props.targetComponentMetadata}
+            key={
+              this.props.targetComponentMetadata != null
+                ? EP.toString(this.props.targetComponentMetadata.elementPath)
+                : `${this.props.direction}-${this.props.position.x}-${this.props.position.y}`
+            }
           />,
         )}
       </React.Fragment>
@@ -374,6 +383,11 @@ const ResizeLines = betterReactMemo('ResizeLines', (props: ResizeLinesProps) => 
           left={left + shiftPropertyTargetSelectorAxis('vertical', props.direction, edge)}
           options={getResizeOptions(layoutSystem, props.direction, edge)}
           targetComponentMetadata={props.targetComponentMetadata}
+          key={
+            props.targetComponentMetadata != null
+              ? EP.toString(props.targetComponentMetadata.elementPath)
+              : `${props.direction}-${props.position.x}-${props.position.y}`
+          }
         />,
       )}
       {mouseCatcher}

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -914,6 +914,7 @@ export interface IncrementResizeOptionsSelectedIndex {
 export interface SetResizeOptionsTargetOptions {
   action: 'SET_RESIZE_OPTIONS_TARGET_OPTIONS'
   propertyTargetOptions: Array<LayoutTargetableProp>
+  index: number | null
 }
 
 export interface HideVSCodeLoadingScreen {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1465,10 +1465,12 @@ export function incrementResizeOptionsSelectedIndex(): IncrementResizeOptionsSel
 
 export function setResizeOptionsTargetOptions(
   propertyTargetOptions: Array<LayoutTargetableProp>,
+  index: number | null,
 ): SetResizeOptionsTargetOptions {
   return {
     action: 'SET_RESIZE_OPTIONS_TARGET_OPTIONS',
     propertyTargetOptions: propertyTargetOptions,
+    index: index,
   }
 }
 export function hideVSCodeLoadingScreen(): HideVSCodeLoadingScreen {

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4902,7 +4902,7 @@ export const UPDATE_FNS = {
         ...editor.canvas,
         resizeOptions: {
           propertyTargetOptions: action.propertyTargetOptions,
-          propertyTargetSelectedIndex: 0,
+          propertyTargetSelectedIndex: action.index ?? 0,
         },
       },
     }


### PR DESCRIPTION
Fixes #1836 

**Problem:**
Resizing an absolute element with `top, left, width, height` properties set on the right edge will change the `right` style property by default. Because the property-target list always selects the first item.

**Fix:**
Selecting the first property target with a real value. When no values are set it selects the first item in the list.

**Commit Details:**
- extended `setResizeOptionsTargetOptions` action to include the selected index
- always render a new property-target-selector for new selection
