### PR TITLE
Remove body from issue closed discord messages

### DIFF
--- a/.github/workflows/discord-issue-closed.yml
+++ b/.github/workflows/discord-issue-closed.yml
@@ -20,7 +20,6 @@ jobs:
               "title": $title,
               "color": 13313073,
               "url": $html_url,
-              "description": $description,
               "footer": {
                 "text": $repo_full_name
               }
@@ -30,12 +29,11 @@ jobs:
           AUTHOR_HTML_URL: ${{ github.event.sender.html_url }}
           TITLE: 'Closed #${{ github.event.issue.number }} ${{ github.event.issue.title }}'
           HTML_URL: ${{ github.event.issue.html_url }}
-          DESCRIPTION: ${{ github.event.issue.body }}
           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
         run: |
           # This provides the env variable used by the next step
           # We have to do it like this to prevent any of the values screwing up the json
-          echo "DISCORD_EMBEDS=$(jq -nc --arg author_name "$AUTHOR" --arg author_icon_url "$AUTHOR_ICON_URL" --arg author_html_url "$AUTHOR_HTML_URL" --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" "$TEMPLATE")" >> $GITHUB_ENV
+          echo "DISCORD_EMBEDS=$(jq -nc --arg author_name "$AUTHOR" --arg author_icon_url "$AUTHOR_ICON_URL" --arg author_html_url "$AUTHOR_HTML_URL" --arg title "$TITLE" --arg html_url "$HTML_URL" --arg repo_full_name "$REPO_FULL_NAME" "$TEMPLATE")" >> $GITHUB_ENV
       - name: Send Notification
         uses: Ilshidur/action-discord@0.3.2
         env:

--- a/.github/workflows/discord-pr-comments.yml
+++ b/.github/workflows/discord-pr-comments.yml
@@ -11,12 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request || github.event.issue.pull_request }}
     steps:
-      - name: Capture Body With Diff
-        if: ${{ github.event.comment.diff_hunk }}
-        env:
-          BASE_DIFF_HUNK: ${{ github.event.comment.diff_hunk }}
-          BODY: ${{ github.event.comment.body }}
-        run: echo "BODY=\`\`\`$BASE_DIFF_HUNK\`\`\`\n$BODY" >> $GITHUB_ENV
       - name: Build PR Review Comment Args
         if: ${{ github.event.pull_request }}
         env:
@@ -51,6 +45,7 @@ jobs:
           AUTHOR: ${{ github.event.sender.login }}
           AUTHOR_ICON_URL: ${{ github.event.sender.avatar_url }}
           AUTHOR_HTML_URL: ${{ github.event.sender.html_url }}
+          BODY: ${{ github.event.comment.body }}
           HTML_URL: ${{ github.event.comment.html_url }}
           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
         run: |


### PR DESCRIPTION
Fixes #1851

**Problem:**
Issue closed messages in Discord don't need a body, much like PR closed messages also don't.

**Fix:**
Remove the description field.

I'm pretty sure some of these things don't appear in the regular integration's messages:

`<div>Hi</div>`

```
<div>Hey!</div>
```