### PR TITLE
Post the performance test results direct to Discord

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -189,6 +189,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v1
         if: ${{ success() || failure() }}
         with:
+          token: ${{ secrets.UTOPIA_ACCESS_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             [Link to test editor](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -240,7 +240,7 @@ jobs:
           MASTER_MESSAGE: ${{ steps.run-performance-test.outputs.perf-message-master }}
           MASTER_CHART: ${{ steps.run-performance-test.outputs.perf-chart-master }}
         run: |
-          echo "DISCORD_EMBEDS=$(jq -nc --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" --arg staging_message "STAGING_MESSAGE" --arg master_message "MASTER_MESSAGE" --arg staging_chart "STAGING_CHART" --arg master_chart "MASTER_CHART" "$TEMPLATE")" >> $GITHUB_ENV
+          echo "DISCORD_EMBEDS=$(jq -nc --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" --arg staging_message "$STAGING_MESSAGE" --arg master_message "$MASTER_MESSAGE" --arg staging_chart "$STAGING_CHART" --arg master_chart "$MASTER_CHART" "$TEMPLATE")" >> $GITHUB_ENV
       - name: Send Discord Notification
         uses: Ilshidur/action-discord@0.3.2
         env:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -205,12 +205,12 @@ jobs:
                 "fields": [
                   {
                     "name": "This PR:",
-                    "value": $staging_message,
+                    "value": $staging_message
                   },
                   {
                     "name": "Current Staging:",
-                    "value": $master_message,
-                  },
+                    "value": $master_message
+                  }
                 ],
                 "footer": {
                   "text": $repo_full_name

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -189,8 +189,64 @@ jobs:
         uses: peter-evans/create-or-update-comment@v1
         if: ${{ success() || failure() }}
         with:
-          token: ${{ secrets.UTOPIA_ACCESS_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             [Link to test editor](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})
             ${{ steps.run-performance-test.outputs.perf-result }}
+      - name: Build Discord Message
+        env:
+          TEMPLATE: >-
+            [
+              {
+                "title": $title,
+                "url": $html_url,
+                "color": 2369839,
+                "description": $description,
+                "fields": [
+                  {
+                    "name": "This PR:",
+                    "value": $staging_message,
+                  },
+                  {
+                    "name": "Current Staging:",
+                    "value": $master_message,
+                  },
+                ],
+                "footer": {
+                  "text": $repo_full_name
+                }
+              },
+              {
+                "title": "This PR:",
+                "color": 2369839,
+                "image": {
+                  "url": $staging_chart
+                }
+              },
+              {
+                "title": "Current Staging:",
+                "color": 14540253,
+                "image": {
+                  "url": $master_chart
+                }
+              }
+            ]
+          TITLE: 'Performance Results for #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'
+          HTML_URL: ${{ github.event.pull_request.html_url }}
+          DESCRIPTION: 'Link to test editor: https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }}'
+          REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+          STAGING_MESSAGE: ${{ steps.run-performance-test.outputs.perf-message-staging }}
+          STAGING_CHART: ${{ steps.run-performance-test.outputs.perf-chart-staging }}
+          MASTER_MESSAGE: ${{ steps.run-performance-test.outputs.perf-message-master }}
+          MASTER_CHART: ${{ steps.run-performance-test.outputs.perf-chart-master }}
+        run: |
+          echo "DISCORD_EMBEDS=$(jq -nc --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" --arg staging_message "STAGING_MESSAGE" --arg master_message "MASTER_MESSAGE" --arg staging_chart "STAGING_CHART" --arg master_chart "MASTER_CHART" "$TEMPLATE")" >> $GITHUB_ENV
+      - name: Send Discord Notification
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_PRS_WEBHOOK }}
+          DISCORD_USERNAME: 'Puppeteer'
+          DISCORD_AVATAR: https://octodex.github.com/images/puppeteer.png
+          MESSAGE: 'Performance results for #${{ github.event.pull_request.number }}'
+        with:
+          args: ${{ env.MESSAGE }}

--- a/performance-test/src/index.ts
+++ b/performance-test/src/index.ts
@@ -2,8 +2,13 @@ import { testPerformance } from './puppeteer-test'
 
 // Execute the one (and only so far) performance test we have.
 testPerformance().catch((e) => {
-  console.info(
-    `::set-output name=perf-result::"There was an error with Puppeteer: ${e.name} – ${e.message}"`,
-  )
+  const errorMessage = `"There was an error with Puppeteer: ${e.name} – ${e.message}"`
+  console.info(`::set-output name=perf-result::${errorMessage}`)
+
+  // Output the individual parts for building a discord message
+  console.info(`::set-output name=perf-message-staging:: ${errorMessage}`)
+  console.info(`::set-output name=perf-chart-staging:: ""`)
+  console.info(`::set-output name=perf-message-master:: ""`)
+  console.info(`::set-output name=perf-chart-master:: ""`)
   return
 })


### PR DESCRIPTION
Fixes #1858 

**Problem:**
By default, workflows cannot trigger more workflows. This means that our workflow that comments on a PR with the performance chart will not trigger the workflow required to then post that comment to Discord. On top of that, the message format isn't well suited to Discord.

**Fix:**
Add the individual parts making up the message to the performance test output, and then use those to craft and directly post a message to Discord.