### PR TITLE
Fixed up the husky install

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -42,7 +42,6 @@
     "fetch-tailwind-classes": "npx -s sh ts-node --pretty --require ignore-styles --transpile-only ./src/scripts/fetch-and-parse-tailwind-classes.ts && npx prettier --write ./src/core/third-party/tailwind-defaults.ts",
     "lint-editor": "lint-staged"
   },
-  "prepare": "cd .. && husky install editor/.husky",
   "jest": {
     "testEnvironment": "jest-environment-jsdom-global",
     "preset": "ts-jest",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "devDependencies": {
     "husky": "^7.0.2"
   },
-  "scripts": {},
+  "scripts": {
+    "prepare": "husky install"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/concrete-utopia/utopia.git"


### PR DESCRIPTION
**Problem:**
#1846 Ensured that linting (and prettier) are applied in all projects as part of the commit hook, but was missing a required `prepare` script to actually install the commit hook.

**Fix:**
Add the `prepare` script to the root `package.json` and remove the old (incorrectly placed and now referring to a file that no longer exists) one from `editor/package.json`