### PR TITLE
Make browser spec tests await the first DOM report

### DIFF
--- a/editor/src/components/canvas/canvas-actions.spec.tsx
+++ b/editor/src/components/canvas/canvas-actions.spec.tsx
@@ -30,6 +30,7 @@ describe('createDragState', () => {
         </div>
       </div>
       `),
+      'dont-await-first-dom-report',
     )
 
     const selectedViews = [EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])]

--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser.tsx
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser.tsx
@@ -29,6 +29,7 @@ describe('moving a scene/rootview on the canvas', () => {
           />
         </View>
       `),
+      'await-first-dom-report',
     )
 
     await renderResult.dispatch(
@@ -157,7 +158,7 @@ describe('moving a scene/rootview on the canvas', () => {
         }`,
       PrettierConfig,
     )
-    const renderResult = await renderTestEditorWithCode(testCode)
+    const renderResult = await renderTestEditorWithCode(testCode, 'await-first-dom-report')
 
     const targetPath = EP.elementPath([[BakedInStoryboardUID, TestSceneUID]])
     await renderResult.dispatch([selectComponents([targetPath], false)], false)
@@ -307,7 +308,7 @@ describe('resizing a scene/rootview on the canvas', () => {
         }`,
       PrettierConfig,
     )
-    const renderResult = await renderTestEditorWithCode(testCode)
+    const renderResult = await renderTestEditorWithCode(testCode, 'await-first-dom-report')
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa'])
     await renderResult.dispatch([selectComponents([targetPath], false)], false)
@@ -435,7 +436,7 @@ describe('resizing a scene/rootview on the canvas', () => {
       }`,
       PrettierConfig,
     )
-    const renderResult = await renderTestEditorWithCode(testCode)
+    const renderResult = await renderTestEditorWithCode(testCode, 'await-first-dom-report')
 
     const targetPath = EP.elementPath([[BakedInStoryboardUID, TestSceneUID]])
     await renderResult.dispatch([selectComponents([targetPath], false)], false)

--- a/editor/src/components/canvas/canvas-utils.spec.browser.tsx
+++ b/editor/src/components/canvas/canvas-utils.spec.browser.tsx
@@ -28,6 +28,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const pinChange = pinFrameChange(
@@ -59,6 +60,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const pinChange = pinFrameChange(
@@ -90,6 +92,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const pinChange = pinFrameChange(
@@ -121,6 +124,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const pinChange = pinFrameChange(
@@ -152,6 +156,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const pinChange = pinFrameChange(
@@ -215,6 +220,7 @@ describe('updateFramesOfScenesAndComponents - pinFrameChange -', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const pinChange = pinFrameChange(
@@ -436,6 +442,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const pinChange = pinMoveChange(EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']), {
@@ -467,6 +474,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const pinChange = pinMoveChange(EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']), {
@@ -567,6 +575,7 @@ describe('updateFramesOfScenesAndComponents - pinMoveChange -', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const pinChange = pinMoveChange(EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb']), {
@@ -748,6 +757,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const pinChange = singleResizeChange(
@@ -779,6 +789,7 @@ describe('updateFramesOfScenesAndComponents - singleResizeChange -', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const pinChange = singleResizeChange(

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser.tsx
@@ -84,6 +84,7 @@ describe('Select Mode Selection', () => {
             </div>
           </div>
       `),
+      'await-first-dom-report',
     )
 
     const areaControl = renderResult.renderedDOM.getByTestId('targetdiv')
@@ -178,7 +179,10 @@ describe('Select Mode Advanced Cases', () => {
   beforeAll(setElectronWindow)
 
   it('Can cmd-click to select Button on a Card Scene Root', async () => {
-    const renderResult = await renderTestEditorWithCode(TestProjectAlpineClimb)
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectAlpineClimb,
+      'await-first-dom-report',
+    )
 
     const cardSceneRoot = renderResult.renderedDOM.getByTestId('card-scene')
     const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
@@ -211,7 +215,10 @@ describe('Select Mode Advanced Cases', () => {
   })
 
   it('Five double clicks to select Button on a Card Scene Root', async () => {
-    const renderResult = await renderTestEditorWithCode(TestProjectAlpineClimb)
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectAlpineClimb,
+      'await-first-dom-report',
+    )
 
     const cardSceneRoot = renderResult.renderedDOM.getByTestId('card-scene')
     const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
@@ -264,7 +271,10 @@ describe('Select Mode Advanced Cases', () => {
   })
 
   it('Keep double clicking to select Button inside a focused generated Card', async () => {
-    const renderResult = await renderTestEditorWithCode(TestProjectAlpineClimb)
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectAlpineClimb,
+      'await-first-dom-report',
+    )
 
     const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
 

--- a/editor/src/components/canvas/dom-walker-caching.spec.browser.tsx
+++ b/editor/src/components/canvas/dom-walker-caching.spec.browser.tsx
@@ -14,7 +14,10 @@ describe('Dom-walker Caching', () => {
     const projectContents = createComplexDefaultProjectContents()
     const projectContentsTreeRoot = contentsToTree(projectContents)
 
-    const renderResult = await renderTestEditorWithProjectContent(projectContentsTreeRoot)
+    const renderResult = await renderTestEditorWithProjectContent(
+      projectContentsTreeRoot,
+      'await-first-dom-report',
+    )
     // unfortunately we have to dispatch a non-action to allow the dom-walker to run for a second time.
     // It needs to run for a second time to "settle".
     await renderResult.dispatch([CanvasActions.scrollCanvas(canvasPoint({ x: 0, y: 0 }))], true)

--- a/editor/src/components/canvas/move-template.spec.browser.tsx
+++ b/editor/src/components/canvas/move-template.spec.browser.tsx
@@ -55,6 +55,7 @@ describe('moveTemplate', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const targets = [EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])]
@@ -88,6 +89,7 @@ describe('moveTemplate', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const targets = [EP.appendNewElementPath(TestScenePath, ['aaa'])]
@@ -121,6 +123,7 @@ describe('moveTemplate', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const targets = [EP.appendNewElementPath(TestScenePath, ['aaa'])]
@@ -178,6 +181,7 @@ describe('moveTemplate', () => {
         <View data-uid='hhh'/>
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const targets = [
@@ -235,6 +239,7 @@ describe('moveTemplate', () => {
         <View data-uid='eee'/>
       </View>
       `),
+      'await-first-dom-report',
     )
 
     const targets = [
@@ -310,7 +315,10 @@ describe('moveTemplate', () => {
   }`,
       ),
     }
-    const renderResult = await renderTestEditorWithProjectContent(contentsToTree(projectContents))
+    const renderResult = await renderTestEditorWithProjectContent(
+      contentsToTree(projectContents),
+      'await-first-dom-report',
+    )
     const targetPath = EP.appendNewElementPath(TestScenePath, ['app-outer-div', 'app-inner-div'])
 
     ;(generateUidWithExistingComponents as any) = jest.fn().mockReturnValue(NewUID)
@@ -391,7 +399,10 @@ describe('moveTemplate', () => {
   }`,
       ),
     }
-    const renderResult = await renderTestEditorWithProjectContent(contentsToTree(projectContents))
+    const renderResult = await renderTestEditorWithProjectContent(
+      contentsToTree(projectContents),
+      'await-first-dom-report',
+    )
     const targetPath = EP.appendNewElementPath(TestScenePath, ['app-outer-div', 'app-wrapper-view'])
     const selectionAfterUnwrap = EP.appendNewElementPath(TestScenePath, [
       'app-outer-div',
@@ -443,6 +454,7 @@ describe('moveTemplate', () => {
           <View data-uid='hhh'/>
         </View>
       `),
+      'await-first-dom-report',
     )
 
     const targets = [
@@ -491,6 +503,7 @@ describe('moveTemplate', () => {
           <View data-uid='eee'/>
         </View>
       `),
+      'await-first-dom-report',
     )
 
     const targets = [
@@ -535,6 +548,7 @@ describe('moveTemplate', () => {
           <View data-uid='eee'/>
         </View>
       `),
+      'await-first-dom-report',
     )
 
     const targets = [
@@ -578,6 +592,7 @@ describe('moveTemplate', () => {
           <View data-uid='eee' style={{ position: 'absolute', left: 50, top: 175, width: 80, height: 80 }}/>
         </View>
       `),
+      'await-first-dom-report',
     )
 
     await renderResult.dispatch(
@@ -626,6 +641,7 @@ describe('moveTemplate', () => {
           <View data-testid='eee' data-uid='eee' style={{ position: 'relative', backgroundColor: '#00ff00', left: 150, top: 250, width: 80, height: 80 }}/>
         </View>
       `),
+      'await-first-dom-report',
     )
 
     await renderResult.dispatch(
@@ -758,6 +774,7 @@ describe('moveTemplate', () => {
       }`,
         PrettierConfig,
       ),
+      'await-first-dom-report',
     )
 
     await renderResult.dispatch(
@@ -918,6 +935,7 @@ describe('moveTemplate', () => {
       }`,
         PrettierConfig,
       ),
+      'await-first-dom-report',
     )
 
     await renderResult.dispatch(
@@ -1050,6 +1068,7 @@ describe('moveTemplate', () => {
           </div>
         </div>
       `),
+      'await-first-dom-report',
     )
     ;(generateUidWithExistingComponents as any) = jest.fn().mockReturnValue(NewUID)
     await renderResult.dispatch(
@@ -1175,6 +1194,7 @@ describe('moveTemplate', () => {
       }`,
         PrettierConfig,
       ),
+      'await-first-dom-report',
     )
     ;(generateUidWithExistingComponents as any) = jest.fn().mockReturnValue(NewUID)
 
@@ -1301,6 +1321,7 @@ describe('moveTemplate', () => {
           <View data-testid='eee' data-uid='eee' style={{ backgroundColor: '#00ff00', position: 'absolute', left: 150, top: 250, width: 80, height: 80 }}/>
         </View>
       `),
+      'await-first-dom-report',
     )
 
     await renderResult.dispatch(
@@ -1416,6 +1437,7 @@ describe('moveTemplate', () => {
           />
         </View>
       `),
+      'await-first-dom-report',
     )
     ;(generateUidWithExistingComponents as any) = jest.fn().mockReturnValue(NewUID)
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper-third-party.spec.browser.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper-third-party.spec.browser.tsx
@@ -137,7 +137,7 @@ function createTestProject() {
       projectContents: updatedProjectContents,
     }
   }, baseModel)
-  return renderTestEditorWithModel(updatedProject)
+  return renderTestEditorWithModel(updatedProject, 'await-first-dom-report')
 }
 
 xdescribe('Spy Wrapper Tests For React Three Fiber', () => {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.spec.browser.tsx
@@ -114,7 +114,7 @@ function createModifiedProject(modifiedFiles: { [filename: string]: string }) {
       projectContents: updatedProjectContents,
     }
   }, baseModel)
-  return renderTestEditorWithModel(updatedProject)
+  return renderTestEditorWithModel(updatedProject, 'await-first-dom-report')
 }
 
 function createExampleProject() {

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -114,15 +114,25 @@ const FailJestOnCanvasError = () => {
   return null
 }
 
-export async function renderTestEditorWithCode(appUiJsFileCode: string) {
-  return renderTestEditorWithModel(createTestProjectWithCode(appUiJsFileCode))
+export async function renderTestEditorWithCode(
+  appUiJsFileCode: string,
+  awaitFirstDomReport: 'await-first-dom-report' | 'dont-await-first-dom-report',
+) {
+  return renderTestEditorWithModel(createTestProjectWithCode(appUiJsFileCode), awaitFirstDomReport)
 }
-export async function renderTestEditorWithProjectContent(projectContent: ProjectContentTreeRoot) {
-  return renderTestEditorWithModel(persistentModelForProjectContents(projectContent))
+export async function renderTestEditorWithProjectContent(
+  projectContent: ProjectContentTreeRoot,
+  awaitFirstDomReport: 'await-first-dom-report' | 'dont-await-first-dom-report',
+) {
+  return renderTestEditorWithModel(
+    persistentModelForProjectContents(projectContent),
+    awaitFirstDomReport,
+  )
 }
 
 export async function renderTestEditorWithModel(
   model: PersistentModel,
+  awaitFirstDomReport: 'await-first-dom-report' | 'dont-await-first-dom-report',
 ): Promise<{
   dispatch: (actions: ReadonlyArray<EditorAction>, waitForDOMReport: boolean) => Promise<void>
   getDomReportDispatched: () => Promise<void>
@@ -254,6 +264,10 @@ export async function renderTestEditorWithModel(
   await act(async () => {
     await asyncTestDispatch([switchEditorMode(EditorModes.selectMode())], undefined, true, false)
   })
+
+  if (awaitFirstDomReport === 'await-first-dom-report') {
+    await domReportDispatched
+  }
 
   return {
     dispatch: async (actions: ReadonlyArray<EditorAction>, waitForDOMReport: boolean) => {

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -568,7 +568,10 @@ describe('action DELETE_SELECTED', () => {
   }`,
       ),
     }
-    const renderResult = await renderTestEditorWithProjectContent(contentsToTree(projectContents))
+    const renderResult = await renderTestEditorWithProjectContent(
+      contentsToTree(projectContents),
+      'dont-await-first-dom-report',
+    )
     const targetPath = EP.appendNewElementPath(TestScenePath, [
       'app-outer-div',
       'app-inner-div-to-delete',

--- a/editor/src/components/inspector/common/css-utils.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/css-utils.spec.browser2.tsx
@@ -20,6 +20,7 @@ describe('toggle style prop', () => {
           />
         </View>
       `),
+      'await-first-dom-report',
     )
 
     await renderResult.dispatch(
@@ -54,6 +55,7 @@ describe('toggle style prop', () => {
           />
         </View>
       `),
+      'await-first-dom-report',
     )
 
     await renderResult.dispatch(
@@ -87,6 +89,7 @@ describe('toggle style prop', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     await renderResult.dispatch(
@@ -128,6 +131,7 @@ describe('toggle style prop', () => {
           />
         </View>
       `),
+      'await-first-dom-report',
     )
 
     await renderResult.dispatch(
@@ -161,6 +165,7 @@ describe('toggle style prop', () => {
           />
         </View>
       `),
+      'await-first-dom-report',
     )
 
     await renderResult.dispatch(

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser.tsx
@@ -54,6 +54,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -109,6 +110,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -196,6 +198,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -283,6 +286,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -370,6 +374,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     await act(async () => {
@@ -437,6 +442,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -520,6 +526,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -639,6 +646,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     await act(async () => {
@@ -732,6 +740,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     await act(async () => {
@@ -825,6 +834,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     await act(async () => {
@@ -918,6 +928,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     await act(async () => {
@@ -1042,6 +1053,7 @@ describe('inspector tests with real metadata', () => {
       }`,
         PrettierConfig,
       ),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -1144,6 +1156,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -1233,6 +1246,7 @@ describe('inspector tests with real metadata', () => {
           ></div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     await act(async () => {
@@ -1351,6 +1365,7 @@ describe('inspector tests with real metadata', () => {
       }`,
         PrettierConfig,
       ),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -1460,6 +1475,7 @@ describe('inspector tests with real metadata', () => {
       }`,
         PrettierConfig,
       ),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -1565,6 +1581,7 @@ describe('inspector tests with real metadata', () => {
       }`,
         PrettierConfig,
       ),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -1648,6 +1665,7 @@ describe('inspector tests with real metadata', () => {
           <div data-uid={'bbb'}>hello</div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -1684,6 +1702,7 @@ describe('inspector tests with real metadata', () => {
           <div data-uid={'bbb'} style={{flex: '1 0 15px'}}>hello</div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -1743,6 +1762,7 @@ describe('inspector tests with real metadata', () => {
           >hello</div>
         </div>
       `),
+      'await-first-dom-report',
     )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['aaa', 'bbb'])
@@ -1827,7 +1847,10 @@ describe('inspector tests with real metadata', () => {
       ),
     }
 
-    const renderResult = await renderTestEditorWithProjectContent(contentsToTree(projectContents))
+    const renderResult = await renderTestEditorWithProjectContent(
+      contentsToTree(projectContents),
+      'await-first-dom-report',
+    )
 
     const targetPath = EP.appendNewElementPath(TestScenePath, ['app-outer-div', 'app-inner-div'])
 

--- a/editor/src/components/inspector/common/inspector-update-tests.spec.browser.tsx
+++ b/editor/src/components/inspector/common/inspector-update-tests.spec.browser.tsx
@@ -29,6 +29,7 @@ describe('updating style properties keeps the original order', () => {
         />
       </div>
       `),
+      'await-first-dom-report',
     )
 
     const changePinProps = setProp_UNSAFE(

--- a/editor/src/core/layout/layout-utils.spec.browser.tsx
+++ b/editor/src/core/layout/layout-utils.spec.browser.tsx
@@ -45,6 +45,7 @@ describe('maybeSwitchLayoutProps', () => {
         />
       </View>
       `),
+      'await-first-dom-report',
     )
 
     await renderResult.dispatch(

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -25,6 +25,7 @@ describe('React Render Count Tests - ', () => {
         />
       </View>
       `),
+      'dont-await-first-dom-report',
     )
     await renderResult.dispatch(
       [selectComponents([EP.appendNewElementPath(TestScenePath, ['aaa'])], false)],
@@ -80,6 +81,7 @@ describe('React Render Count Tests - ', () => {
         </View>
       )
       `),
+      'dont-await-first-dom-report',
     )
     await renderResult.dispatch(
       [selectComponents([EP.appendNewElementPath(TestScenePath, ['aaa'])], false)],
@@ -139,6 +141,7 @@ describe('React Render Count Tests - ', () => {
         />
       </View>
       `),
+      'dont-await-first-dom-report',
     )
     await renderResult.dispatch(
       [selectComponents([EP.appendNewElementPath(TestScenePath, ['aaa'])], false)],
@@ -197,6 +200,7 @@ describe('React Render Count Tests - ', () => {
         </View>
       )
       `),
+      'dont-await-first-dom-report',
     )
     await renderResult.dispatch(
       [selectComponents([EP.appendNewElementPath(TestScenePath, ['aaa'])], false)],

--- a/editor/src/core/workers/parser-printer/parser-printer-uids.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-uids.spec.tsx
@@ -208,7 +208,10 @@ describe('parseCode', () => {
         } `,
       ),
     }
-    const renderResult = await renderTestEditorWithProjectContent(contentsToTree(projectContents))
+    const renderResult = await renderTestEditorWithProjectContent(
+      contentsToTree(projectContents),
+      'dont-await-first-dom-report',
+    )
 
     const uniqueIDs = getAllUniqueUids(
       renderResult.getEditorState().editor.projectContents,

--- a/editor/src/utils/clipboard.spec.tsx
+++ b/editor/src/utils/clipboard.spec.tsx
@@ -64,7 +64,10 @@ export var App = (props) => {
 }`,
       ),
     }
-    const renderResult = await renderTestEditorWithProjectContent(contentsToTree(projectContents))
+    const renderResult = await renderTestEditorWithProjectContent(
+      contentsToTree(projectContents),
+      'dont-await-first-dom-report',
+    )
     const targetPath1 = EP.appendNewElementPath(TestScenePath, [
       'app-outer-div',
       'app-inner-div-to-copy',


### PR DESCRIPTION
Fixes #1766 (I think)

**Problem:**
I believe the issue at play here is that we don't await the first DOM report before attempting to update the model in our `.spec.browser` tests, implying that we're not awaiting the correct metadata or (I believe) a complete rendered canvas.

This is just a theory because I'm not entirely sure how to verify it, but I have verified that in tests that select a component and then call e.g. `const areaControl = renderResult.renderedDOM.getByTestId('ccc')`, those tests will still pass even if the initial selection is removed, leading me to believe that the presence of that test ID does not necessarily mean the component has been rendered or is selected.

**Fix:**
Update the function `renderTestEditorWithModel` to take a second param `awaitFirstDomReport: 'await-first-dom-report' | 'dont-await-first-dom-report'`, which determines whether or not the function blocks until the first DOM report is received. Then, for all `spec.browser` tests that call this we block on that first report, and for all non-browser tests we don't.
