### PR TITLE
fix: do not include lib in the uploaded editor bundle path

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -115,11 +115,11 @@ jobs:
       - name: Create Editor Bundle
         working-directory: editor/lib/
         run: |
-          tar -czvf ./${{ steps.extract_branch.outputs.branch }}.tar.gz *
+          tar -czvf ../${{ steps.extract_branch.outputs.branch }}.tar.gz *
       - name: Upload Editor Bundle
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
-          args: --acl private --exclude '*' --include 'editor/lib/${{ steps.extract_branch.outputs.branch }}.tar.gz'
+          args: --acl private --exclude '*' --include 'editor/${{ steps.extract_branch.outputs.branch }}.tar.gz'
         env:
           AWS_S3_BUCKET: ${{ secrets.STAGING_BUNDLE_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_BUNDLE_ACCESS_KEY }}


### PR DESCRIPTION
**Problem:**
In #1856 I did not realize that in the S3 upload step if we upload a file from editor/lib/X it's S3 path will also be editor/lib/X. This broke the pull request staging deploy.

**Fix:**
move the editor bundle file back to editor/ isntead of editor/lib/
