### PR TITLE
remove react-spring from the default package list

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -206,11 +206,6 @@ export const DefaultPackagesList: Array<DependencyPackageDetails> = [
     version: '0.4.1',
     status: 'default-package',
   },
-  {
-    name: 'react-spring',
-    version: '8.0.27',
-    status: 'default-package',
-  },
 ]
 
 export const StoryboardFilePath: string = '/utopia/storyboard.js'


### PR DESCRIPTION
**Problem:**
`react-spring` was on the list of default dependencies for a fresh project. but it is not pre-bundled with the editor. it means that a fresh project would _always_ need to reach out to the packager server to download react-spring. 

**Fix:**
Don't include react-spring as a default dependency. It is very easy to install it on-demand.
