### PR TITLE
Add a logger to the server.

### DIFF
--- a/server/package.yaml
+++ b/server/package.yaml
@@ -28,6 +28,7 @@ dependencies:
   - ekg-core
   - ekg-json
   - exceptions
+  - fast-logger
   - filepath
   - free
   - zlib
@@ -73,6 +74,7 @@ dependencies:
   - temporary
   - text
   - time
+  - time-manager
   - transformers
   - unix
   - unordered-containers

--- a/server/src/Utopia/Web/Executors/Common.hs
+++ b/server/src/Utopia/Web/Executors/Common.hs
@@ -38,6 +38,7 @@ import           Servant.Client                   hiding (Response)
 import           System.Directory
 import           System.Environment
 import           System.FilePath
+import           System.Log.FastLogger
 import           System.Metrics                   hiding (Value)
 import qualified Text.Blaze.Html5                 as H
 import           Utopia.Web.Assets
@@ -79,6 +80,7 @@ data EnvironmentRuntime r = EnvironmentRuntime
   , _envServerPort       :: r -> Int
   , _serverAPI           :: r -> Server API
   , _startupLogging      :: r -> Bool
+  , _getLogger           :: r -> FastLogger
   , _metricsStore        :: r -> Store
   , _cacheForAssets      :: r -> IO AssetResultCache
   , _forceSSL            :: r -> Bool

--- a/server/src/Utopia/Web/Github.hs
+++ b/server/src/Utopia/Web/Github.hs
@@ -15,7 +15,7 @@ fetchRepoArchive owner repo = do
   let options = WR.defaults & WR.header "User-Agent" .~ ["concrete-utopia/utopia"] & WR.header "Accept" .~ ["application/vnd.github.v3+json"] & WR.checkResponse .~ (Just $ \_ _ -> return ())
   let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repo <> "/zipball/"
   repoResult <- WR.getWith options (toS repoUrl)
-  let responseStatus = repoResult ^. WR.responseStatus ^. WR.statusCode
+  let responseStatus = repoResult ^. (WR.responseStatus . WR.statusCode)
   if responseStatus == 200
     then return $ Just $ repoResult ^. WR.responseBody
     else return $ Nothing

--- a/server/src/Utopia/Web/Logging.hs
+++ b/server/src/Utopia/Web/Logging.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# OPTIONS_GHC -Wno-warnings-deprecations #-}
+
+module Utopia.Web.Logging where
+
+import           Protolude
+import           System.Log.FastLogger
+
+loggerLn :: FastLogger -> LogStr -> IO ()
+loggerLn logger mainStr = logger (mainStr <> "\n")

--- a/server/src/Utopia/Web/Proxy.hs
+++ b/server/src/Utopia/Web/Proxy.hs
@@ -7,7 +7,6 @@ import           Control.Lens
 import           Control.Monad.Fail
 import           Data.Binary.Builder            (toLazyByteString)
 import qualified Data.ByteString.Lazy           as BL
-import qualified Data.Text                      as T
 import           Network.HTTP.Client            (HttpException (HttpExceptionRequest),
                                                  HttpExceptionContent (StatusCodeException),
                                                  Manager)

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 95d26c9bca5c9d192fba1affbbd166ab45f3235ec0a5be2c00823ff65dcc3ef2
+-- hash: 894d76fbba980d5a8e577a2b81bebf2dcf7366e6727bc616a75c4bf1d9f2d995
 
 name:           utopia-web
 version:        0.1.0.4
@@ -40,6 +40,7 @@ executable utopia-web
       Utopia.Web.Executors.Production
       Utopia.Web.Github
       Utopia.Web.JSON
+      Utopia.Web.Logging
       Utopia.Web.Metrics
       Utopia.Web.Packager.Locking
       Utopia.Web.Packager.NPM
@@ -79,6 +80,7 @@ executable utopia-web
     , ekg-core
     , ekg-json
     , exceptions
+    , fast-logger
     , filepath
     , free
     , generic-lens
@@ -123,6 +125,7 @@ executable utopia-web
     , temporary
     , text
     , time
+    , time-manager
     , transformers
     , unix
     , unordered-containers
@@ -163,6 +166,7 @@ test-suite utopia-web-test
       Utopia.Web.Executors.Production
       Utopia.Web.Github
       Utopia.Web.JSON
+      Utopia.Web.Logging
       Utopia.Web.Metrics
       Utopia.Web.Packager.Locking
       Utopia.Web.Packager.NPM
@@ -203,6 +207,7 @@ test-suite utopia-web-test
     , ekg-core
     , ekg-json
     , exceptions
+    , fast-logger
     , filepath
     , free
     , generic-lens
@@ -256,6 +261,7 @@ test-suite utopia-web-test
     , temporary
     , text
     , time
+    , time-manager
     , transformers
     , unix
     , unordered-containers


### PR DESCRIPTION
**Problem:**
Periodically the text `utopia-web: Thread killed by timeout manager` is logged out from the server.

**Fix:**
The above error appears to result from our websocket proxying for webpack, which doesn't run in production and it doesn't appear there's an extension point we can reach which would allow us to prevent the error. But since it doesn't occur in production it seems like far less of an issue.

However in attempting to fix this, a logger was implemented for the server, which is worth keeping.

**Commit Details:**
- Added `fast-logger` direct dependency to the server.
- Production and Development configs produce the logger.
- Use the logger for `DebugLog` and for exception handling
  in the server.
- Added check for timeouts to the server calls.
