### PR TITLE
only initiate react-hot-loader if we are in hot mode

### DIFF
--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -12,7 +12,7 @@ import {
   FakeWatchdogWorker,
 } from '../../core/workers/test-workers'
 import { UtopiaTsWorkersImplementation } from '../../core/workers/workers'
-import { HotRoot } from '../../templates/editor'
+import { EditorRoot } from '../../templates/editor'
 import { left } from '../../core/shared/either'
 import { EditorDispatch } from '../editor/action-types'
 import { load } from '../editor/actions/actions'
@@ -77,7 +77,7 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
   const storeHook = create<EditorStore>((set) => initialEditorStore)
 
   render(
-    <HotRoot
+    <EditorRoot
       api={storeHook}
       useStore={storeHook}
       spyCollector={spyCollector}

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -51,7 +51,7 @@ import {
   FakeWatchdogWorker,
 } from '../../core/workers/test-workers'
 import { UtopiaTsWorkersImplementation } from '../../core/workers/workers'
-import { HotRoot } from '../../templates/editor'
+import { EditorRoot } from '../../templates/editor'
 import Utils from '../../utils/utils'
 import { DispatchPriority, EditorAction, notLoggedIn } from '../editor/action-types'
 import { load } from '../editor/actions/actions'
@@ -222,7 +222,7 @@ export async function renderTestEditorWithModel(
       }}
     >
       <FailJestOnCanvasError />
-      <HotRoot
+      <EditorRoot
         api={storeHook}
         useStore={storeHook}
         spyCollector={spyCollector}

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -316,13 +316,13 @@ export class Editor {
   }
 }
 
-export const HotRoot: React.FunctionComponent<{
+export const EditorRoot: React.FunctionComponent<{
   api: UtopiaStoreAPI
   useStore: UtopiaStoreHook
   spyCollector: UiJsxCanvasContextData
   propertyControlsInfoSupported: boolean
   vscodeBridgeReady: boolean
-}> = hot(({ api, useStore, spyCollector, propertyControlsInfoSupported, vscodeBridgeReady }) => {
+}> = ({ api, useStore, spyCollector, propertyControlsInfoSupported, vscodeBridgeReady }) => {
   return (
     <EditorStateContext.Provider value={{ api, useStore }}>
       <UiJsxCanvasCtxAtom.Provider value={spyCollector}>
@@ -333,8 +333,28 @@ export const HotRoot: React.FunctionComponent<{
       </UiJsxCanvasCtxAtom.Provider>
     </EditorStateContext.Provider>
   )
+}
+
+EditorRoot.displayName = 'Utopia Editor Root'
+
+export const HotRoot: React.FunctionComponent<{
+  api: UtopiaStoreAPI
+  useStore: UtopiaStoreHook
+  spyCollector: UiJsxCanvasContextData
+  propertyControlsInfoSupported: boolean
+  vscodeBridgeReady: boolean
+}> = hot(({ api, useStore, spyCollector, propertyControlsInfoSupported, vscodeBridgeReady }) => {
+  return (
+    <EditorRoot
+      api={api}
+      useStore={useStore}
+      spyCollector={spyCollector}
+      propertyControlsInfoSupported={propertyControlsInfoSupported}
+      vscodeBridgeReady={vscodeBridgeReady}
+    />
+  )
 })
-HotRoot.displayName = 'Utopia Editor Root'
+HotRoot.displayName = 'Utopia Editor Hot Root'
 
 async function renderRootComponent(
   useStore: UtopiaStoreHook,
@@ -348,16 +368,29 @@ async function renderRootComponent(
     // as subsequent updates will be fed through Zustand
     const rootElement = document.getElementById(EditorID)
     if (rootElement != null) {
-      ReactDOM.render(
-        <HotRoot
-          api={api}
-          useStore={useStore}
-          spyCollector={spyCollector}
-          propertyControlsInfoSupported={propertyControlsInfoSupported}
-          vscodeBridgeReady={vscodeBridgeReady}
-        />,
-        rootElement,
-      )
+      if (process.env.HOT_MODE) {
+        ReactDOM.render(
+          <HotRoot
+            api={api}
+            useStore={useStore}
+            spyCollector={spyCollector}
+            propertyControlsInfoSupported={propertyControlsInfoSupported}
+            vscodeBridgeReady={vscodeBridgeReady}
+          />,
+          rootElement,
+        )
+      } else {
+        ReactDOM.render(
+          <EditorRoot
+            api={api}
+            useStore={useStore}
+            spyCollector={spyCollector}
+            propertyControlsInfoSupported={propertyControlsInfoSupported}
+            vscodeBridgeReady={vscodeBridgeReady}
+          />,
+          rootElement,
+        )
+      }
     }
   })
 }

--- a/editor/webpack.config.js
+++ b/editor/webpack.config.js
@@ -180,6 +180,7 @@ const config = {
       'process.platform': 'undefined',
       'process.env.BABEL_TYPES_8_BREAKING': 'undefined',
       'process.env.JEST_WORKER_ID': 'undefined',
+      'process.env.HOT_MODE': hot,
     }),
 
     // setting up the various process.env.VARIABLE replacements


### PR DESCRIPTION
**Problem:**
The editor would complain that react-hot-loader is misconfigured. NOT ANYMORE!

**Fix:**
Create a non-hot editor root. Use that if not in hot mode. Also use the non-hot editor root in tests, to avoid printing 500x warnings for each test run.
