### PR TITLE
Improve running of npm and constrain it a little.

### DIFF
--- a/server/package.yaml
+++ b/server/package.yaml
@@ -25,8 +25,6 @@ dependencies:
   - cryptohash-sha256
   - data-default
   - directory
-  - ekg-core
-  - ekg-json
   - exceptions
   - fast-logger
   - filepath
@@ -79,6 +77,7 @@ dependencies:
   - unix
   - unordered-containers
   - uuid
+  - vector
   - wai
   - wai-app-static
   - wai-extra ==3.0.29.1

--- a/server/src/Utopia/Web/Database.hs
+++ b/server/src/Utopia/Web/Database.hs
@@ -31,10 +31,9 @@ import           Opaleye
 import           Opaleye.Trans
 import           Protolude                       hiding (get)
 import           System.Environment
-import           System.Metrics                  hiding (Value)
 import           System.Posix.User
 import           Utopia.Web.Database.Types
-import           Utopia.Web.Metrics
+import           Utopia.Web.Metrics              hiding (count)
 
 data DatabaseMetrics = DatabaseMetrics
                      { _generateUniqueIDMetrics         :: InvocationMetric

--- a/server/src/Utopia/Web/Metrics.hs
+++ b/server/src/Utopia/Web/Metrics.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE KindSignatures      #-}
@@ -6,25 +7,173 @@
 {-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData          #-}
 {-# LANGUAGE TypeOperators       #-}
+
 module Utopia.Web.Metrics where
 
 import           Control.Exception.Lifted
 import           Control.Monad.Trans.Control
-import           Data.Text                   (Text)
+import           Data.Aeson
+import qualified Data.HashMap.Strict         as M
+import           Data.IORef
+import qualified Data.Text                   as T
 import           Data.Time.Clock.POSIX
-import           Protolude                   hiding (finally, onException)
-import           System.Metrics
-import qualified System.Metrics.Counter      as Counter
-import qualified System.Metrics.Distribution as Distribution
-import qualified System.Metrics.Gauge        as Gauge
+import           Data.Vector                 hiding (foldr', maximum, minimum,
+                                              sum)
+import           GHC.Generics
+import           Protolude                   hiding (drop, finally, length,
+                                              maximum, minimum, onException,
+                                              sum)
+
+newtype Counter = Counter { underlyingCounter :: IORef Word64 }
+                  deriving (Eq, Generic)
+
+incrementCounter :: Counter -> IO ()
+incrementCounter Counter{..} = atomicModifyIORef' underlyingCounter (\n -> (n + 1, ()))
+
+newtype Gauge = Gauge { underlyingGauge :: IORef Word64 }
+                deriving (Eq, Generic)
+
+incrementGauge :: Gauge -> IO ()
+incrementGauge Gauge{..} = atomicModifyIORef' underlyingGauge (\n -> (n + 1, ()))
+
+decrementGauge :: Gauge -> IO ()
+decrementGauge Gauge{..} = atomicModifyIORef' underlyingGauge (\n -> (n - 1, ()))
+
+data DistributionValues = DistributionValues
+                        { count   :: Word64
+                        , sum     :: Double
+                        , minimum :: Double
+                        , maximum :: Double
+                        }
+                        deriving (Eq, Show, Generic)
+
+newtype Distribution = Distribution { underlyingValues :: IORef DistributionValues }
+                       deriving (Eq, Generic)
+
+updateDistributionValues :: DistributionValues -> Double -> DistributionValues
+updateDistributionValues DistributionValues{..} value =
+  let newCount = count + 1
+      newSum = sum + value
+      newMinimum = if count == 0 then value else min minimum value
+      newMaximum = if count == 0 then value else max maximum value
+   in DistributionValues
+      { count = newCount
+      , sum = newSum
+      , minimum = newMinimum
+      , maximum = newMaximum
+      }
+
+addToDistribution :: Distribution -> Double -> IO ()
+addToDistribution Distribution{..} value = atomicModifyIORef' underlyingValues (\v -> (updateDistributionValues v value, ()))
+
+newtype RecentDescriptions = RecentDescriptions { descriptions :: IORef (Vector Text) }
+                             deriving (Eq, Generic)
+
+maximumNumberOfDescriptions :: Int
+maximumNumberOfDescriptions = 20
+
+addToRecentDescriptions :: RecentDescriptions -> Text -> IO ()
+addToRecentDescriptions RecentDescriptions{..} descriptionText = do
+  time <- getCurrentTime
+  let textToAdd = show time <> " - " <> descriptionText
+  let updateVector vec =
+        let withNew = snoc vec textToAdd
+            newLength = length withNew
+            toDrop = max 0 (newLength - maximumNumberOfDescriptions)
+         in drop toDrop withNew
+  atomicModifyIORef' descriptions (\v -> (updateVector v, ()))
+
+data StoreEntry = CounterStoreEntry Counter
+                | GaugeStoreEntry Gauge
+                | DistributionStoreEntry Distribution
+                | RecentDescriptionsEntry RecentDescriptions
+                deriving (Eq, Generic)
+
+newtype Store = Store { storeEntries :: IORef (M.HashMap Text StoreEntry) }
+                      deriving (Eq, Generic)
+
+createCounter :: Text -> Store -> IO Counter
+createCounter counterName Store{..} = do
+  ref <- newIORef 0
+  let newCounter = Counter ref
+  let newCounterEntry = CounterStoreEntry newCounter
+  atomicModifyIORef' storeEntries (\entries -> (M.insert counterName newCounterEntry entries, ()))
+  pure newCounter
+
+createGauge :: Text -> Store -> IO Gauge
+createGauge gaugeName Store{..} = do
+  ref <- newIORef 0
+  let newGauge = Gauge ref
+  let newGaugeEntry = GaugeStoreEntry newGauge
+  atomicModifyIORef' storeEntries (\entries -> (M.insert gaugeName newGaugeEntry entries, ()))
+  pure newGauge
+
+createDistribution :: Text -> Store -> IO Distribution
+createDistribution distributionName Store{..} = do
+  ref <- newIORef $ DistributionValues 0 0 0 0
+  let newDistribution = Distribution ref
+  let newDistributionEntry = DistributionStoreEntry newDistribution
+  atomicModifyIORef' storeEntries (\entries -> (M.insert distributionName newDistributionEntry entries, ()))
+  pure newDistribution
+
+createRecentDescriptions :: Text -> Store -> IO RecentDescriptions
+createRecentDescriptions descriptionsName Store{..} = do
+  ref <- newIORef mempty
+  let newRecentDescriptions = RecentDescriptions ref
+  let newRecentDescriptionsEntry = RecentDescriptionsEntry newRecentDescriptions
+  atomicModifyIORef' storeEntries (\entries -> (M.insert descriptionsName newRecentDescriptionsEntry entries, ()))
+  pure newRecentDescriptions
+
+newStore :: IO Store
+newStore = do
+  entriesRef <- newIORef mempty
+  pure $ Store entriesRef
+
+data SampleEntry = SampleEntryJSON Value
+                 | SampleEntryMap (M.HashMap Text SampleEntry)
+                 deriving (Eq, Show)
+
+asEntry :: ToJSON a => a -> SampleEntry
+asEntry value = SampleEntryJSON $ toJSON value
+
+storeEntryAsSampleEntry :: StoreEntry -> IO SampleEntry
+storeEntryAsSampleEntry (CounterStoreEntry Counter{..}) = fmap (SampleEntryJSON . toJSON) (readIORef underlyingCounter)
+storeEntryAsSampleEntry (GaugeStoreEntry Gauge{..}) = fmap (SampleEntryJSON . toJSON) (readIORef underlyingGauge)
+storeEntryAsSampleEntry (DistributionStoreEntry Distribution{..}) = do
+  DistributionValues{..} <- readIORef underlyingValues
+  let mean = if count == 0 then 0.0 else sum / realToFrac count
+  pure $ SampleEntryMap $ M.fromList [("count", asEntry count), ("sum", asEntry sum), ("mean", asEntry mean), ("min", asEntry minimum), ("max", asEntry maximum)]
+storeEntryAsSampleEntry (RecentDescriptionsEntry RecentDescriptions{..}) = fmap (SampleEntryJSON . toJSON) (readIORef descriptions)
+
+instance ToJSON SampleEntry where
+  toJSON (SampleEntryJSON value)   = value
+  toJSON (SampleEntryMap entryMap) = toJSON entryMap
+
+instance Semigroup SampleEntry where
+  (SampleEntryMap firstMap) <> (SampleEntryMap secondMap) = SampleEntryMap (M.unionWith mappend firstMap secondMap)
+  firstSample@(SampleEntryMap _) <> (SampleEntryJSON _) = firstSample
+  (SampleEntryJSON _) <> secondSample@(SampleEntryMap _) = secondSample
+  (SampleEntryJSON _) <> secondSample@(SampleEntryJSON _) = secondSample
+
+instance Monoid SampleEntry where
+  mempty = SampleEntryJSON Null
+
+sampleAsJSON :: Store -> IO Value
+sampleAsJSON Store{..} = do
+  storeMap <- readIORef storeEntries
+  let entryFold key metric = foldr' (\pathPart -> \working -> fmap (\e -> SampleEntryMap $ M.singleton pathPart e) working) (storeEntryAsSampleEntry metric) $ T.splitOn "." key
+  asSampleEntry <- M.foldMapWithKey entryFold storeMap
+  pure $ toJSON asSampleEntry
 
 data InvocationMetric = InvocationMetric
-                      { _successes :: Counter.Counter
-                      , _failures  :: Counter.Counter
-                      , _total     :: Counter.Counter
-                      , _timing    :: Distribution.Distribution
-                      , _inflight  :: Gauge.Gauge
+                      { _successes    :: Counter
+                      , _failures     :: Counter
+                      , _total        :: Counter
+                      , _timing       :: Distribution
+                      , _inflight     :: Gauge
+                      , _descriptions :: RecentDescriptions
                       }
 
 createInvocationMetric :: Text -> Store -> IO InvocationMetric
@@ -34,12 +183,14 @@ createInvocationMetric basePath store = do
   totalCounter <- createCounter (basePath <> ".total") store
   timingDistribution <- createDistribution (basePath <> ".time") store
   inflightGauge <- createGauge (basePath <> ".inflight") store
+  recentDescriptions <- createRecentDescriptions (basePath <> ".descriptions") store
   return $ InvocationMetric
          { _successes = successCounter
          , _failures = failureCounter
          , _total = totalCounter
          , _timing = timingDistribution
          , _inflight = inflightGauge
+         , _descriptions = recentDescriptions
          }
 
 {-|
@@ -47,15 +198,20 @@ createInvocationMetric basePath store = do
 -}
 invokeAndMeasure :: (MonadBaseControl IO m, MonadIO m) => InvocationMetric -> m a -> m a
 invokeAndMeasure InvocationMetric{..} action = do
-  startTime <- liftIO $ getPOSIXTime
-  liftIO $ Gauge.inc _inflight
+  startTime <- liftIO getPOSIXTime
+  liftIO $ incrementGauge _inflight
   let finallyClause = liftIO $ do
         endTime <- getPOSIXTime
         let diffTime = round ((endTime - startTime) * 1000000)
-        Distribution.add _timing (fromInteger diffTime / 1000)
-        Gauge.dec _inflight
-  let exceptionClause = liftIO $ Counter.inc _failures
-  liftIO $ Counter.inc _total
+        addToDistribution _timing (fromInteger diffTime / 1000)
+        decrementGauge _inflight
+  let exceptionClause = liftIO $ incrementCounter _failures
+  liftIO $ incrementCounter _total
   result <- finally (onException action exceptionClause) finallyClause
-  liftIO $ Counter.inc _successes
+  liftIO $ incrementCounter _successes
   return result
+
+addInvocationDescription :: (MonadIO m) => InvocationMetric -> Text -> m a -> m a
+addInvocationDescription InvocationMetric{..} description action = do
+  liftIO $ addToRecentDescriptions _descriptions description
+  action

--- a/server/src/Utopia/Web/Server.hs
+++ b/server/src/Utopia/Web/Server.hs
@@ -20,9 +20,9 @@ import           Servant
 import           Servant.Conduit                 ()
 import           System.Log.FastLogger
 import           System.TimeManager
-import           Utopia.Web.Ekg
 import           Utopia.Web.Executors.Common
 import           Utopia.Web.Logging
+import           Utopia.Web.ServantMonitoring
 import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files
 

--- a/server/test/Test/Utopia/Web/Packager/NPM.hs
+++ b/server/test/Test/Utopia/Web/Packager/NPM.hs
@@ -10,6 +10,8 @@ import           Protolude
 import           System.FilePath
 import           Test.Hspec
 import           Utopia.Web.Packager.NPM
+import           System.Log.FastLogger
+import           Utopia.Web.Metrics
 
 expectedFilenames :: [Text]
 expectedFilenames = [
@@ -29,20 +31,34 @@ getNodeModulesSubDirectories projectFolder =
   let targetDir = projectFolder </> "node_modules"
    in mapOutput (\path -> fromMaybe path $ stripPrefix (targetDir <> "/") path) $ sourceDirectory targetDir
 
+type Prerequisites = (FastLogger, IO (), Store, NPMMetrics, QSem)
+
+createPrerequisites :: IO Prerequisites
+createPrerequisites = do
+  (logger, loggerShutdown) <- newFastLogger LogNone
+  semaphore <- newQSem 1
+  store <- newStore
+  npmMetrics <- createNPMMetrics store
+  pure (logger, loggerShutdown, store, npmMetrics, semaphore)
+
+cleanupPrerequisites :: Prerequisites -> IO ()
+cleanupPrerequisites (_, loggerShutdown, _, _, _) = loggerShutdown
+
+withPrerequisites :: (Prerequisites -> IO ()) -> IO ()
+withPrerequisites = bracket createPrerequisites cleanupPrerequisites
+
 npmSpec :: Spec
 npmSpec = do
-  describe "withInstalledProject" $ do
-    it "should have the various dependencies in node_modules for react" $ do
-      semaphore <- newQSem 1
-      result <- runResourceT $ sourceToList $ withInstalledProject semaphore "react@16.13.1" getNodeModulesSubDirectories
-      (sort result) `shouldBe` [".bin", ".package-lock.json", "js-tokens", "loose-envify", "object-assign", "prop-types", "react", "react-is"]
-    it "should fail for a non-existent project" $ do
-      semaphore <- newQSem 1
-      (runResourceT $ sourceToList $ withInstalledProject semaphore "non-existent-project-that-will-never-exist@9.9.9.9.9.9" getNodeModulesSubDirectories) `shouldThrow` anyIOException
-  describe "getModuleAndDependenciesFiles" $ do
-    it "should get a bunch of .cjs, .js, .mjs and package.json files" $ do
-      semaphore <- newQSem 1
-      result <- runResourceT $ sourceToList $ withInstalledProject semaphore "fflate@0.7.1" getModuleAndDependenciesFiles
-      let filteredResult = filter (\(_, v) -> v /= encodedPlaceholder) result
-      let sortedFilenames = sort $ fmap pack $ toListOf (traverse . _1) filteredResult
-      sortedFilenames `shouldBe` expectedFilenames
+  around withPrerequisites $ do
+    describe "withInstalledProject" $ do
+      it "should have the various dependencies in node_modules for react" $ \(logger, _, _, npmMetrics, semaphore) -> do
+        result <- runResourceT $ sourceToList $ withInstalledProject logger npmMetrics semaphore "react@16.13.1" getNodeModulesSubDirectories
+        (sort result) `shouldBe` [".bin", ".package-lock.json", "js-tokens", "loose-envify", "object-assign", "prop-types", "react", "react-is"]
+      it "should fail for a non-existent project" $ \(logger, _, _, npmMetrics, semaphore) -> do
+        (runResourceT $ sourceToList $ withInstalledProject logger npmMetrics semaphore "non-existent-project-that-will-never-exist@9.9.9.9.9.9" getNodeModulesSubDirectories) `shouldThrow` anyIOException
+    describe "getModuleAndDependenciesFiles" $ do
+      it "should get a bunch of .cjs, .js, .mjs and package.json files" $ \(logger, _, _, npmMetrics, semaphore) -> do
+        result <- runResourceT $ sourceToList $ withInstalledProject logger npmMetrics semaphore "fflate@0.7.1" getModuleAndDependenciesFiles
+        let filteredResult = filter (\(_, v) -> v /= encodedPlaceholder) result
+        let sortedFilenames = sort $ fmap pack $ toListOf (traverse . _1) filteredResult
+        sortedFilenames `shouldBe` expectedFilenames

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 894d76fbba980d5a8e577a2b81bebf2dcf7366e6727bc616a75c4bf1d9f2d995
+-- hash: c9c7076c3b2eb98f67cf0b65b55f118971dfbea085bfee40202accb5ebd99bb8
 
 name:           utopia-web
 version:        0.1.0.4
@@ -32,7 +32,6 @@ executable utopia-web
       Utopia.Web.Database.Migrations
       Utopia.Web.Database.Types
       Utopia.Web.Editor.Branches
-      Utopia.Web.Ekg
       Utopia.Web.Endpoints
       Utopia.Web.Exceptions
       Utopia.Web.Executors.Common
@@ -46,6 +45,7 @@ executable utopia-web
       Utopia.Web.Packager.NPM
       Utopia.Web.Proxy
       Utopia.Web.Servant
+      Utopia.Web.ServantMonitoring
       Utopia.Web.Server
       Utopia.Web.ServiceTypes
       Utopia.Web.Types
@@ -77,8 +77,6 @@ executable utopia-web
     , cryptohash-sha256
     , data-default
     , directory
-    , ekg-core
-    , ekg-json
     , exceptions
     , fast-logger
     , filepath
@@ -130,6 +128,7 @@ executable utopia-web
     , unix
     , unordered-containers
     , uuid
+    , vector
     , wai
     , wai-app-static
     , wai-extra ==3.0.29.1
@@ -158,7 +157,6 @@ test-suite utopia-web-test
       Utopia.Web.Database.Migrations
       Utopia.Web.Database.Types
       Utopia.Web.Editor.Branches
-      Utopia.Web.Ekg
       Utopia.Web.Endpoints
       Utopia.Web.Exceptions
       Utopia.Web.Executors.Common
@@ -172,6 +170,7 @@ test-suite utopia-web-test
       Utopia.Web.Packager.NPM
       Utopia.Web.Proxy
       Utopia.Web.Servant
+      Utopia.Web.ServantMonitoring
       Utopia.Web.Server
       Utopia.Web.ServiceTypes
       Utopia.Web.Types
@@ -204,8 +203,6 @@ test-suite utopia-web-test
     , cryptohash-sha256
     , data-default
     , directory
-    , ekg-core
-    , ekg-json
     , exceptions
     , fast-logger
     , filepath
@@ -266,6 +263,7 @@ test-suite utopia-web-test
     , unix
     , unordered-containers
     , uuid
+    , vector
     , wai
     , wai-app-static
     , wai-extra ==3.0.29.1


### PR DESCRIPTION
**Problem:**
We keep seeing errors about exceeding the memory limit on Heroku. 

**Fix:**
This adds some improved logging specifically around the npm actions themselves, so we can see if those are taking especially long.

The times when npm calls are made are logged into the metrics, so it should be possible to tally host monitoring against those.

The heap space of npm when doing `npm install` has been constrained to see if that alleviates the memory issues.

**Commit Details:**
- Removed `ekg-*` libraries as they weren't that great.
- Recreate implementations of `Counter`, `Gauge` and `Distribution`
  from scratch in `Utopia.Web.Metrics` module.
- Add new `RecentDescriptions` metric, to hold a kind of recent log
  of events.
- Shift everything over to the new metrics.
- Get `Utopia.Web.Packager.NPM` module to use `fast-logger`.
- Add new metrics for `Utopia.Web.Packager.NPM` module in `NPMMetrics`.
- Used `RecentDescriptions` metric in `findMatchingVersions` and
  `withInstalledProject`.
- Reworked `Test.Utopia.Web.Packager.NPM` module to use `around` from
  `hspec`, which cleans up the handling of pre-requisites massively.
- Added limited heap space option when invoking `npm install`.
