### PR TITLE
Fixed a regression around exporting a default identifier

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -26254,7 +26254,7 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
   <div
     id=\\"canvas-container\\"
     style=\\"position: absolute;\\"
-    data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:b93 utopia-storyboard-uid/scene-aaa/app-entity:b93/2f0 utopia-storyboard-uid/scene-aaa/app-entity:b93/59c utopia-storyboard-uid/scene-aaa/app-entity:b93/54b utopia-storyboard-uid/scene-aaa/app-entity:b93/d18 utopia-storyboard-uid/scene-aaa/app-entity:b93/995 utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf utopia-storyboard-uid/scene-aaa/app-entity:b93/d00 utopia-storyboard-uid/scene-aaa/app-entity:b93/7d0 utopia-storyboard-uid/scene-aaa/app-entity:b93/4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f utopia-storyboard-uid/scene-aaa/app-entity:b93/315 utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9 utopia-storyboard-uid/scene-aaa/app-entity:b93/301 utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce utopia-storyboard-uid/scene-aaa/app-entity:b93/f77 utopia-storyboard-uid/scene-aaa/app-entity:b93/218 utopia-storyboard-uid/scene-aaa/app-entity:b93/a17 utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa\\"
+    data-utopia-valid-paths=\\"utopia-storyboard-uid utopia-storyboard-uid/scene-aaa utopia-storyboard-uid/scene-aaa/app-entity utopia-storyboard-uid/scene-aaa/app-entity:b93 utopia-storyboard-uid/scene-aaa/app-entity:b93/2f0 utopia-storyboard-uid/scene-aaa/app-entity:b93/59c utopia-storyboard-uid/scene-aaa/app-entity:b93/54b utopia-storyboard-uid/scene-aaa/app-entity:b93/d18 utopia-storyboard-uid/scene-aaa/app-entity:b93/995 utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf utopia-storyboard-uid/scene-aaa/app-entity:b93/d00 utopia-storyboard-uid/scene-aaa/app-entity:b93/7d0 utopia-storyboard-uid/scene-aaa/app-entity:b93/4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f utopia-storyboard-uid/scene-aaa/app-entity:b93/315 utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9 utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1 utopia-storyboard-uid/scene-aaa/app-entity:b93/301 utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce utopia-storyboard-uid/scene-aaa/app-entity:b93/f77 utopia-storyboard-uid/scene-aaa/app-entity:b93/218 utopia-storyboard-uid/scene-aaa/app-entity:b93/a17 utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa\\"
     data-utopia-root-element-path=\\"utopia-storyboard-uid\\"
   >
     <div
@@ -26346,6 +26346,12 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
           data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9\\"
         >
           Default Named Function
+        </div>
+        <div
+          data-uid=\\"4cf 1a1\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1\\"
+        >
+          Defined Then Default Exported
         </div>
         <div
           data-uid=\\"4cf 301\\"
@@ -26979,6 +26985,7 @@ import DefaultExpression from '/defaultexpression'
 import DefaultFunction from '/defaultfunction'
 import DefaultClass from '/defaultclass'
 import DefaultNamedFunction from '/defaultnamedfunction'
+import DefinedThenDefaultExported from '/definedthendefaultexported'
 import NamedAsDefault from '/namedasdefault'
 import * as ReexportWildcard from '/reexportwildcard'
 import { assigned } from '/reexportmoduleintonamedexport'
@@ -27001,6 +27008,7 @@ export var App = (props) => {
       <DefaultFunction />
       <DefaultClass />
       <DefaultNamedFunction />
+      <DefinedThenDefaultExported />
       <NamedAsDefault />
       <ReexportWildcard.OriginallyAssigned1 />
       <assigned.OriginallyAssigned1 />
@@ -27131,6 +27139,35 @@ export var App = (props) => {
             ],
             "type": "JSX_ELEMENT",
             "uid": "5b9",
+          },
+          Object {
+            "children": Array [],
+            "name": Object {
+              "baseVariable": "DefinedThenDefaultExported",
+              "propertyPath": Object {
+                "propertyElements": Array [],
+              },
+            },
+            "props": Array [
+              Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "key": "data-uid",
+                "type": "JSX_ATTRIBUTES_ENTRY",
+                "value": Object {
+                  "comments": Object {
+                    "leadingComments": Array [],
+                    "trailingComments": Array [],
+                  },
+                  "type": "ATTRIBUTE_VALUE",
+                  "value": "1a1",
+                },
+              },
+            ],
+            "type": "JSX_ELEMENT",
+            "uid": "1a1",
           },
           Object {
             "children": Array [],
@@ -27476,6 +27513,123 @@ export var App = (props) => {
           Array [
             "b93",
             "0cf",
+          ],
+        ],
+        "type": "elementpath",
+      },
+      "skipDeepFreeze": true,
+    },
+    "specialSizeMeasurements": Object {
+      "clientHeight": 0,
+      "clientWidth": 0,
+      "coordinateSystemBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "display": "initial",
+      "flexDirection": null,
+      "htmlElementName": "div",
+      "immediateParentBounds": Object {
+        "height": 0,
+        "width": 0,
+        "x": 0,
+        "y": 0,
+      },
+      "immediateParentProvidesLayout": true,
+      "layoutSystemForChildren": "flow",
+      "margin": Object {},
+      "naturalHeight": null,
+      "naturalWidth": null,
+      "offset": Object {
+        "x": 0,
+        "y": 0,
+      },
+      "padding": Object {},
+      "parentFlexDirection": null,
+      "parentLayoutSystem": "flow",
+      "position": "static",
+      "providesBoundsForChildren": false,
+      "renderedChildrenCount": 0,
+      "usesParentBounds": false,
+    },
+  },
+  "utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1": Object {
+    "attributeMetadatada": Object {},
+    "componentInstance": false,
+    "computedStyle": Object {},
+    "element": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "children": Array [],
+        "name": Object {
+          "baseVariable": "DefinedThenDefaultExported",
+          "propertyPath": Object {
+            "propertyElements": Array [],
+          },
+        },
+        "props": Array [
+          Object {
+            "comments": Object {
+              "leadingComments": Array [],
+              "trailingComments": Array [],
+            },
+            "key": "data-uid",
+            "type": "JSX_ATTRIBUTES_ENTRY",
+            "value": Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "type": "ATTRIBUTE_VALUE",
+              "value": "1a1",
+            },
+          },
+        ],
+        "type": "JSX_ELEMENT",
+        "uid": "1a1",
+      },
+    },
+    "elementPath": Object {
+      "parts": Array [
+        Array [
+          "utopia-storyboard-uid",
+          "scene-aaa",
+          "app-entity",
+        ],
+        Array [
+          "b93",
+          "1a1",
+        ],
+      ],
+      "type": "elementpath",
+    },
+    "globalFrame": null,
+    "importInfo": Object {
+      "type": "RIGHT",
+      "value": Object {
+        "originalName": null,
+        "path": "/definedthendefaultexported",
+        "variableName": "DefinedThenDefaultExported",
+      },
+    },
+    "isEmotionOrStyledComponent": false,
+    "label": null,
+    "localFrame": null,
+    "props": Object {
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1",
+      "data-uid": "1a1",
+      "data-utopia-instance-path": Object {
+        "parts": Array [
+          Array [
+            "utopia-storyboard-uid",
+            "scene-aaa",
+            "app-entity",
+          ],
+          Array [
+            "b93",
+            "1a1",
           ],
         ],
         "type": "elementpath",
@@ -27999,6 +28153,7 @@ import DefaultExpression from '/defaultexpression'
 import DefaultFunction from '/defaultfunction'
 import DefaultClass from '/defaultclass'
 import DefaultNamedFunction from '/defaultnamedfunction'
+import DefinedThenDefaultExported from '/definedthendefaultexported'
 import NamedAsDefault from '/namedasdefault'
 import * as ReexportWildcard from '/reexportwildcard'
 import { assigned } from '/reexportmoduleintonamedexport'
@@ -28021,6 +28176,7 @@ export var App = (props) => {
       <DefaultFunction />
       <DefaultClass />
       <DefaultNamedFunction />
+      <DefinedThenDefaultExported />
       <NamedAsDefault />
       <ReexportWildcard.OriginallyAssigned1 />
       <assigned.OriginallyAssigned1 />

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -44,6 +44,7 @@ import DefaultExpression from '/defaultexpression'
 import DefaultFunction from '/defaultfunction'
 import DefaultClass from '/defaultclass'
 import DefaultNamedFunction from '/defaultnamedfunction'
+import DefinedThenDefaultExported from '/definedthendefaultexported'
 import NamedAsDefault from '/namedasdefault'
 import * as ReexportWildcard from '/reexportwildcard'
 import { assigned } from '/reexportmoduleintonamedexport'
@@ -66,6 +67,7 @@ export var App = (props) => {
       <DefaultFunction />
       <DefaultClass />
       <DefaultNamedFunction />
+      <DefinedThenDefaultExported />
       <NamedAsDefault />
       <ReexportWildcard.OriginallyAssigned1 />
       <assigned.OriginallyAssigned1 />
@@ -99,6 +101,9 @@ export default function() { return <div>Default Function</div> }`,
 export default class DefaultClass extends React.Component { render() { return <div>Export Default Class</div> } }`,
         '/defaultnamedfunction.js': `import * as React from 'react'
 export default function DefaultNamedFunction() { return <div>Default Named Function</div> }`,
+        '/definedthendefaultexported.js': `import * as React from 'react'
+        const DefinedThenDefaultExported = () => <div>Defined Then Default Exported</div>
+        export default DefinedThenDefaultExported`,
         '/namedasdefault.js': `import * as React from 'react'
 const ToBeDefaultExported = () => <div>Named As Default</div>
 export { ToBeDefaultExported as default }`,

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -562,8 +562,8 @@ function attemptToResolveParsedComponents(
                 addToFilteredScope('default', exportDetail.name)
               }
               break
-            case 'EXPORT_EXPRESSION':
-              addToFilteredScope('default', 'default')
+            case 'EXPORT_IDENTIFIER':
+              addToFilteredScope('default', exportDetail.name)
               break
             case 'EXPORT_CLASS':
               addToFilteredScope(exportDetail.className, exportDetail.className)

--- a/editor/src/components/editor/export-utils.ts
+++ b/editor/src/components/editor/export-utils.ts
@@ -108,7 +108,12 @@ export function getExportedComponentImports(
               )
             }
             break
-          case 'EXPORT_EXPRESSION':
+          case 'EXPORT_IDENTIFIER':
+            addToResult(
+              exportDetail.name,
+              exportDetail.name,
+              importDetails(null, [importAlias(exportDetail.name)], null),
+            )
             break
           case 'REEXPORT_WILDCARD':
             break

--- a/editor/src/core/model/storyboard-utils.ts
+++ b/editor/src/core/model/storyboard-utils.ts
@@ -230,7 +230,15 @@ export function addStoryboardFileToProject(editorModel: EditorModel): EditorMode
                   }
                 }
                 break
-              case 'EXPORT_EXPRESSION':
+              case 'EXPORT_IDENTIFIER':
+                {
+                  const possibleMainComponentName = PossiblyMainComponentNames.includes(
+                    exportDetail.name,
+                  )
+                  updateCandidate(
+                    namedComponentToImport(fullPath, possibleMainComponentName, exportDetail.name),
+                  )
+                }
                 break
               case 'REEXPORT_WILDCARD':
                 break

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -242,14 +242,17 @@ export function exportDefaultFunctionOrClass(name: string | null): ExportDefault
   }
 }
 
-// export default expression;
-export interface ExportExpression {
-  type: 'EXPORT_EXPRESSION'
+// const App = (…) { … }
+// export default App;
+export interface ExportIdentifier {
+  type: 'EXPORT_IDENTIFIER'
+  name: string
 }
 
-export function exportExpression(): ExportExpression {
+export function exportIdentifier(name: string): ExportIdentifier {
   return {
-    type: 'EXPORT_EXPRESSION',
+    type: 'EXPORT_IDENTIFIER',
+    name: name,
   }
 }
 
@@ -299,7 +302,7 @@ export type ExportDetail =
   | ExportVariables
   | ExportDestructuredAssignment
   | ExportDefaultFunctionOrClass
-  | ExportExpression
+  | ExportIdentifier
   | ReexportWildcard
   | ReexportVariables
 


### PR DESCRIPTION
Fixes #1879

**Problem:**
`export default App` was being treated as arbitrary code, but without the associated `definedElsewhere` scope captured. This was because of a change in the way we were capturing export details which handles anonymous functions but not literals.

**Fix:**
Revert to using `pushUnparsedCode` in the case where the export default is an identifier, as well as capturing the identifier's name in the recently introduced export type, so that we can handle that when importing in the canvas.