### PR TITLE
Prevent npm from including peer dependencies on the server

### DIFF
--- a/server/src/Utopia/Web/Packager/NPM.hs
+++ b/server/src/Utopia/Web/Packager/NPM.hs
@@ -118,7 +118,7 @@ withInstalledProject logger NPMMetrics{..} semaphore versionedPackageName withIn
   let deleteDir = ignoringIOErrors . removeDirectoryRecursive
   bracketP createDir deleteDir $ \tempDir -> do
     -- Run `npm install "packageName@packageVersion"`.
-    let baseProc = proc "npm" ["install", "--silent", "--ignore-scripts", toS versionedPackageName]
+    let baseProc = proc "npm" ["install", "--silent", "--ignore-scripts", "--omit", "peer", toS versionedPackageName]
     let procWithCwd = baseProc { cwd = Just tempDir, env = Just [("NODE_OPTIONS", "--max_old_space_size=256")] }
     liftIO $ withSemaphore semaphore $ do
       loggerLn logger ("Starting NPM Install: " <> toLogStr versionedPackageName)


### PR DESCRIPTION
**Problem:**
`@react-three/drei` was causing issues in Utopia, because the peer dependencies for `react` and `react-dom` were resulting in multiple versions of react, which in turn was causing an R3F hooks error. This was previously not a problem, but an npm update changed the handling of peer dependencies such that they are now installed by default.

**Fix:**
Include the argument `--omit peer` when calling `npm install` on the server.