### PR TITLE
Improve server build flow.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -283,6 +283,7 @@ let
       set -e
       rebuild-cabal
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/server
+      pkill utopia-web || true
       ${cabal}/bin/cabal new-run -j --disable-optimization --disable-profiling --disable-documentation --disable-library-coverage --disable-benchmarks utopia-web -- +RTS -N -c
     '')
     (pkgs.writeScriptBin "run-server" ''
@@ -296,7 +297,7 @@ let
       set -e
       cabal-update
       cd $(${pkgs.git}/bin/git rev-parse --show-toplevel)/server
-      ${pkgs.nodePackages.nodemon}/bin/nodemon -e hs,yaml --watch src --watch package.yaml --exec run-server-inner
+      ${pkgs.nodePackages.nodemon}/bin/nodemon --delay 200ms -e hs,yaml --watch src --watch package.yaml --exec run-server-inner
     '')
   ];
 
@@ -344,6 +345,7 @@ let
       #!/usr/bin/env bash
       # Kill nodemon because it just seems to keep running.
       pkill nodemon
+      pkill utopia-web
       stop-postgres
       tmux kill-session -t utopia-dev
     '')


### PR DESCRIPTION
**Problem:**
Sometimes nodemon does manage to properly stop the server or in some cases manages to spawn multiple builds that all run over the top of each other.

**Fix:**
One part of this makes sure to stop the server process whenever possible, along with adding a delay option for `nodemon` that should help debounce the server build, where it was spawning multiple builds at a time.

**Commit Details:**
- Have `run-server-inner` kill the `utopia-web` process before attempting to build and
  run a new one.
- Add a little delay in for nodemon to prevent it from dogpiling
  a bunch of builds all over the top of each other.
- `stop-dev` script also attempts to kill the `utopia-web` process,
  in case nodemon wasn't able to for whatever reason.
