### PR TITLE
improve the styling for object control

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -46,7 +46,6 @@ import {
   Subdued,
   VerySubdued,
   FlexRow,
-  InspectorSubsectionHeader,
 } from '../../../../uuiui'
 import { getControlStyles } from '../../../../uuiui-deps'
 import { InfoBox } from '../../../common/notices'

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -377,10 +377,7 @@ const RowForObjectControl = betterReactMemo(
     return (
       <div
         style={{
-          paddingTop: 8,
-          paddingBottom: 8,
-          paddingLeft: 0,
-          paddingRight: 0,
+          padding: '8px 0',
         }}
       >
         <div>

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -46,6 +46,7 @@ import {
   Subdued,
   VerySubdued,
   FlexRow,
+  InspectorSubsectionHeader,
 } from '../../../../uuiui'
 import { getControlStyles } from '../../../../uuiui-deps'
 import { InfoBox } from '../../../common/notices'
@@ -374,29 +375,39 @@ const RowForObjectControl = betterReactMemo(
     const title = titleForControl(propPath, controlDescription)
 
     return (
-      <>
-        <InspectorSectionHeader>
+      <div
+        style={{
+          paddingTop: 8,
+          paddingBottom: 8,
+          paddingLeft: 0,
+          paddingRight: 0,
+        }}
+      >
+        <div>
           <SimpleFlexRow style={{ flexGrow: 1 }}>
             <PropertyLabel target={[propPath]} style={{ textTransform: 'capitalize' }}>
               {title}
             </PropertyLabel>
           </SimpleFlexRow>
-        </InspectorSectionHeader>
+        </div>
         {mapToArray((innerControl: ControlDescription, prop: string) => {
           const innerPropPath = PP.appendPropertyPathElems(propPath, [prop])
           return (
-            <>
-              {innerControl.type}
+            <FlexRow
+              style={{
+                margin: '-8px 0 0 8px',
+              }}
+            >
               <RowForControl
                 key={`object-control-row-${PP.toString(innerPropPath)}`}
                 controlDescription={innerControl}
                 isScene={isScene}
                 propPath={innerPropPath}
               />
-            </>
+            </FlexRow>
           )
         }, controlDescription.object)}
-      </>
+      </div>
     )
   },
 )


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/2226774/136220819-297caba9-37e1-4b3a-b812-16150aca5b48.png)

**Problem:**
The object control looks like a subsection. it starts with a big header text and hairline. but then it ends with no extra padding, which makes everything below it look like part of the object control.

**Fix:**
* De-emphasize the object control's title. 
* Remove the extra rows that were announcing the control type.
* Add negative margin to rows belonging together
* Add extra margin before and after the object control

after:
<img width="276" alt="image" src="https://user-images.githubusercontent.com/2226774/136220541-aa0f4656-b333-4be0-a99c-41678309ee9a.png">
