### PR TITLE
Handle files restored in the VS Code session.

### DIFF
--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -199,10 +199,10 @@ export async function initVSCodeBridge(
             throw new Error(`Unhandled message type${JSON.stringify(message)}`)
         }
       })
-      sendGetUtopiaVSCodeConfigMessage()
+      await sendGetUtopiaVSCodeConfigMessage()
       watchForChanges(dispatch)
       if (openFilePath != null) {
-        sendOpenFileMessage(openFilePath)
+        await sendOpenFileMessage(openFilePath)
       } else {
         loadingScreenHidden = true
         dispatch([hideVSCodeLoadingScreen()], 'everyone')

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -268,6 +268,16 @@ function watchForChangesFromVSCode(context: vscode.ExtensionContext, projectID: 
     return document.uri.scheme === projectID
   }
 
+  // Capture files that are _already_ open, so that the bridge
+  // becomes aware that they have been opened from something like
+  // a session restore.
+  for (const document of vscode.workspace.textDocuments) {
+    if (isUtopiaDocument(document)) {
+      const path = fromUtopiaURI(document.uri)
+      pendingWork.push(didOpen(path))
+    }
+  }
+
   context.subscriptions.push(
     vscode.workspace.onDidChangeTextDocument((event) => {
       if (isUtopiaDocument(event.document)) {


### PR DESCRIPTION
**Problem:**
If the storyboard was loaded from the VS Code session restore, then the editor would never dismiss the loading screen for VS Code, leaving the user effectively stuck staring at it forever.

**Fix:**
Firing the `DID_OPEN` message for any files open when the extension initialises, so that the bridge receives that making the loading screen go away.

**Commit Details:**
- At the top of `watchForChangesFromVSCode`, loop over the files
  already open and send the `DID_OPEN` message for them so that
  the main editor will hide the loading screen.
- Add some `await`s to `initVSCodeBridge` because there didn't
  appear to be any downside to doing so.