### PR TITLE
Maintain the cursor when scrubbing a value in the inspector.

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -332,7 +332,7 @@ export const EditorComponentInner = betterReactMemo(
         </SimpleFlexColumn>
         <ModalComponent />
         <ToastRenderer />
-        <CanvasCursorComponent />
+        <EditorCursorComponent />
         {props.propertyControlsInfoSupported && props.vscodeBridgeReady ? (
           <PropertyControlsInfoComponent />
         ) : null}
@@ -364,23 +364,29 @@ export function EditorComponent(props: EditorProps) {
   )
 }
 
-const CanvasCursorComponent = betterReactMemo('CanvasCursorComponent', () => {
+const EditorCursorComponent = betterReactMemo('EditorCursorComponent', () => {
   const cursor = useEditorState((store) => {
     return Utils.defaultIfNull(store.editor.canvas.cursor, getCursorFromDragState(store.editor))
-  }, 'CanvasCursorComponent')
-  return cursor == null ? null : (
-    <div
-      key='cursor-area'
-      style={{
-        position: 'fixed',
-        left: 0,
-        top: 0,
-        width: '100vw',
-        height: '100vh',
-        cursor: cursor,
-      }}
-    />
-  )
+  }, 'EditorCursorComponent cursor')
+
+  const styleProps = React.useMemo(() => {
+    let workingStyleProps: React.CSSProperties = {
+      position: 'fixed',
+      left: 0,
+      top: 0,
+      width: '100vw',
+      height: '100vh',
+      pointerEvents: 'none',
+      zIndex: 9999999,
+    }
+    if (cursor != null) {
+      workingStyleProps.cursor = cursor
+      workingStyleProps.pointerEvents = 'all'
+    }
+    return workingStyleProps
+  }, [cursor])
+
+  return <div key='cursor-area' id='cursor-overlay' style={styleProps} />
 })
 
 const ToastRenderer = betterReactMemo('ToastRenderer', () => {

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -47,11 +47,12 @@ import {
   VerySubdued,
   FlexRow,
 } from '../../../../uuiui'
-import { getControlStyles } from '../../../../uuiui-deps'
+import { CSSCursor, getControlStyles } from '../../../../uuiui-deps'
 import { InfoBox } from '../../../common/notices'
 import { InspectorContextMenuWrapper } from '../../../context-menu-wrapper'
 import {
   openCodeEditorFile,
+  setCursorOverlay,
   setFocusedElement,
   showContextMenu,
 } from '../../../editor/actions/action-creators'
@@ -217,6 +218,7 @@ const RowForInvalidControl = betterReactMemo(
 interface AbstractRowForControlProps {
   propPath: PropertyPath
   isScene: boolean
+  setGlobalCursor: (cursor: CSSCursor | null) => void
 }
 
 function titleForControl(propPath: PropertyPath, control: ControlDescription): string {
@@ -262,6 +264,7 @@ const RowForBaseControl = betterReactMemo('RowForBaseControl', (props: RowForBas
           propName={propName}
           controlDescription={controlDescription}
           propMetadata={propMetadata}
+          setGlobalCursor={props.setGlobalCursor}
         />
       </UIGridRow>
     </InspectorContextMenuWrapper>
@@ -346,6 +349,7 @@ const RowForArrayControl = betterReactMemo(
                   controlDescription={controlDescription.propertyControl}
                   isScene={isScene}
                   propPath={PP.appendPropertyPathElems(propPath, [index])}
+                  setGlobalCursor={props.setGlobalCursor}
                 />
               </animated.div>
             )
@@ -356,6 +360,7 @@ const RowForArrayControl = betterReactMemo(
             controlDescription={controlDescription.propertyControl}
             isScene={isScene}
             propPath={PP.appendPropertyPathElems(propPath, [springs.length])}
+            setGlobalCursor={props.setGlobalCursor}
           />
         ) : null}
       </>
@@ -399,6 +404,7 @@ const RowForObjectControl = betterReactMemo(
                 controlDescription={innerControl}
                 isScene={isScene}
                 propPath={innerPropPath}
+                setGlobalCursor={props.setGlobalCursor}
               />
             </FlexRow>
           )
@@ -537,6 +543,13 @@ export const ComponentSectionInner = betterReactMemo(
       useUsedPropsWithoutControls(propsGivenToElement),
     )
     const dispatch = useEditorState((state) => state.dispatch, 'ComponentSectionInner')
+
+    const setGlobalCursor = React.useCallback(
+      (cursor: CSSCursor | null) => {
+        dispatch([setCursorOverlay(cursor)], 'everyone')
+      },
+      [dispatch],
+    )
 
     const selectedViews = useEditorState(
       (store) => store.editor.selectedViews,
@@ -715,6 +728,7 @@ export const ComponentSectionInner = betterReactMemo(
                                 propPath={PP.create([propName])}
                                 controlDescription={controlDescription}
                                 isScene={props.isScene}
+                                setGlobalCursor={setGlobalCursor}
                               />
                             </UIGridRow>
                           )

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -1,6 +1,6 @@
 import fastDeepEquals from 'fast-deep-equal'
 import React from 'react'
-import { betterReactMemo, SliderControl } from '../../../../uuiui-deps'
+import { betterReactMemo, CSSCursor, SliderControl } from '../../../../uuiui-deps'
 import {
   BaseControlDescription,
   BooleanControlDescription,
@@ -57,6 +57,7 @@ export interface ControlForPropProps<T extends BaseControlDescription> {
   propName: string
   controlDescription: T
   propMetadata: InspectorInfo<any>
+  setGlobalCursor: (cursor: CSSCursor | null) => void
 }
 
 export const ControlForBooleanProp = betterReactMemo(
@@ -480,7 +481,7 @@ export const ControlForStringProp = betterReactMemo(
 export const ControlForVectorProp = betterReactMemo(
   'ControlForVectorProp',
   (props: ControlForPropProps<Vector2ControlDescription | Vector3ControlDescription>) => {
-    const { propPath, propMetadata, controlDescription } = props
+    const { propPath, propMetadata, controlDescription, setGlobalCursor } = props
 
     const vectorValue =
       (propMetadata.propertyStatus.set ? propMetadata.value : controlDescription.defaultValue) ?? []
@@ -520,6 +521,12 @@ export const ControlForVectorProp = betterReactMemo(
       },
     )
 
-    return <ChainedNumberInput idPrefix={'vector'} propsArray={propsArray} />
+    return (
+      <ChainedNumberInput
+        idPrefix={'vector'}
+        propsArray={propsArray}
+        setGlobalCursor={setGlobalCursor}
+      />
+    )
   },
 )

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -146,6 +146,7 @@ export interface NumberInputProps extends AbstractNumberInputProps<CSSNumber> {
   onSubmitValue?: OnSubmitValueOrUnknownOrEmpty<CSSNumber>
   onTransientSubmitValue?: OnSubmitValueOrUnknownOrEmpty<CSSNumber>
   onForcedSubmitValue?: OnSubmitValueOrUnknownOrEmpty<CSSNumber>
+  setGlobalCursor?: (cursor: CSSCursor | null) => void
 }
 
 const ScrubThreshold = 3
@@ -175,6 +176,7 @@ export const NumberInput = betterReactMemo<NumberInputProps>(
     focusOnMount = false,
     numberType,
     defaultUnitToHide,
+    setGlobalCursor,
   }) => {
     const ref = React.useRef<HTMLInputElement>(null)
     const controlStyles = getControlStyles(controlStatus)
@@ -403,8 +405,9 @@ export const NumberInput = betterReactMemo<NumberInputProps>(
           )
         })
         setScrubThresholdPassed(false)
+        setGlobalCursor?.(null)
       },
-      [scrubOnMouseMove, setScrubValue, parsedStateValueUnit, ref],
+      [scrubOnMouseMove, setScrubValue, parsedStateValueUnit, ref, setGlobalCursor],
     )
 
     const rc = roundCorners == null ? 'all' : roundCorners
@@ -571,10 +574,11 @@ export const NumberInput = betterReactMemo<NumberInputProps>(
             setValueAtDragOrigin(propsValue.value)
             setDragOriginX(e.screenX)
             setDragOriginY(e.screenY)
+            setGlobalCursor?.(CSSCursor.ResizeEW)
           }
         }
       },
-      [propsValue, scrubOnMouseMove, scrubOnMouseUp],
+      [propsValue, scrubOnMouseMove, scrubOnMouseUp, setGlobalCursor],
     )
 
     let placeholder: string = ''
@@ -803,6 +807,7 @@ interface SimpleNumberInputProps extends Omit<AbstractNumberInputProps<number>, 
   onSubmitValue: OnSubmitValueOrEmpty<number>
   onTransientSubmitValue: OnSubmitValueOrEmpty<number>
   onForcedSubmitValue: OnSubmitValueOrEmpty<number>
+  setGlobalCursor?: (cursor: CSSCursor | null) => void
 }
 
 function wrappedSimpleOnSubmitValue(
@@ -877,11 +882,12 @@ interface ChainedNumberControlProps {
   propsArray: Array<Omit<NumberInputProps, 'chained' | 'id'>>
   idPrefix: string
   style?: React.CSSProperties
+  setGlobalCursor?: (cursor: CSSCursor | null) => void
 }
 
 export const ChainedNumberInput: React.FunctionComponent<ChainedNumberControlProps> = betterReactMemo(
   'ChainedNumberInput',
-  ({ propsArray, idPrefix, style }) => {
+  ({ propsArray, idPrefix, style, setGlobalCursor }) => {
     return (
       <FlexRow style={style}>
         {propsArray.map((props, i) => {
@@ -894,6 +900,7 @@ export const ChainedNumberInput: React.FunctionComponent<ChainedNumberControlPro
                   {...props}
                   chained='first'
                   roundCorners='left'
+                  setGlobalCursor={setGlobalCursor}
                 />
               )
             }
@@ -905,6 +912,7 @@ export const ChainedNumberInput: React.FunctionComponent<ChainedNumberControlPro
                   {...props}
                   chained='last'
                   roundCorners='right'
+                  setGlobalCursor={setGlobalCursor}
                 />
               )
             }
@@ -916,6 +924,7 @@ export const ChainedNumberInput: React.FunctionComponent<ChainedNumberControlPro
                   {...props}
                   chained='middle'
                   roundCorners='none'
+                  setGlobalCursor={setGlobalCursor}
                 />
               )
             }


### PR DESCRIPTION
Fixes #1892

**Problem:**
When scrubbing the values in a vector component, the cursor reverts to the pointer.

**Fix:**
This utilises the existing `SET_CURSOR_OVERLAY` action, triggering it from the mouse down/up on the labels used for scrubbing maintain the cursor regardless of position.

**Commit Details:**
- Fixes #1892.
- Renamed `CanvasCursorComponent` to `EditorCursorComponent`, because it covers
  the entire editor and always has.
- Changed `EditorCursorComponent` to always exist, toggling the cursor on when necessary.
- `ComponentSectionInner` creates a `setGlobalCursor` function from the `dispatch`
  function and now passes it down into `RowForControl`.
- Added `setGlobalCursor` to the props of a few inspector components so that it can
  reach the `ControlForVectorProp`, where it is passed into `ChainedNumberInput`.
- `NumberInput` now takes the optional `setGlobalCursor` and applies it when
  triggering the mouse down/up on the label.
