### PR TITLE
fix(inspector) Trim a few of the property control parser errors.

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -2184,7 +2184,7 @@ export function parseColor(color: unknown): Either<string, CSSColor> {
     return left('No color value provided.')
   }
   if (typeof color !== 'string') {
-    return left('Invalid value for color provided.')
+    return left('Value not valid.')
   }
   const trimmed = color.trim()
 
@@ -2271,7 +2271,7 @@ export function parseAlphaFromCSSColor(color: CSSColor): number {
       return color.a
     default:
       const _exhaustiveCheck: never = color
-      throw new Error('Unknown color, cannot parse alpha channel')
+      throw new Error('No valid alpha.')
   }
 }
 
@@ -2319,7 +2319,7 @@ export function giveCSSColorNewAlpha(newAlpha: number, color: CSSColor): CSSColo
       } as CSSColorRGB
     default:
       const _exhaustiveCheck: never = color
-      throw new Error('Unknown color, cannot parse alpha channel')
+      throw new Error('No valid alpha.')
   }
 }
 

--- a/editor/src/core/property-controls/property-controls-parser.spec.ts
+++ b/editor/src/core/property-controls/property-controls-parser.spec.ts
@@ -62,7 +62,7 @@ function runBaseTestSuite<T>(
       title: true,
     }
     expect(parseFn(value)).toEqual(
-      left(objectFieldParseError('title', descriptionParseError('Value is not a string.'))),
+      left(objectFieldParseError('title', descriptionParseError('Not a string.'))),
     )
   })
   it('fails on an invalid type', () => {
@@ -71,9 +71,7 @@ function runBaseTestSuite<T>(
       type: 'ham sandwich',
     }
     expect(parseFn(value)).toEqual(
-      left(
-        objectFieldParseError('type', descriptionParseError('Value is not a member of an enum.')),
-      ),
+      left(objectFieldParseError('type', descriptionParseError('Not a member of an enum.'))),
     )
   })
 
@@ -103,7 +101,7 @@ const validBooleanControlDescriptionValue: BooleanControlDescription = {
   title: 'Boolean Control',
   type: 'boolean',
   defaultValue: true,
-  disabledTitle: 'Value is not set.',
+  disabledTitle: 'Not set.',
   enabledTitle: 'Value is set',
 }
 
@@ -262,7 +260,7 @@ describe('parseOptionsControlDescription', () => {
       left(
         objectFieldParseError(
           'options',
-          arrayIndexParseError(0, descriptionParseError('Value is not an object.')),
+          arrayIndexParseError(0, descriptionParseError('Not an object.')),
         ),
       ),
     )
@@ -297,7 +295,7 @@ describe('parsePopUpListControlDescription', () => {
       left(
         objectFieldParseError(
           'options',
-          arrayIndexParseError(0, descriptionParseError('Value is not an object.')),
+          arrayIndexParseError(0, descriptionParseError('Not an object.')),
         ),
       ),
     )
@@ -410,9 +408,7 @@ describe('parseControlDescription', () => {
     )
   })
   it('fails on a value that is not an object', () => {
-    expect(parseControlDescription('hat')).toEqual(
-      left(descriptionParseError('Value is not an object.')),
-    )
+    expect(parseControlDescription('hat')).toEqual(left(descriptionParseError('Not an object.')))
   })
   it('fails on a value that is an invalid case of one of the descriptions', () => {
     const value = {
@@ -420,7 +416,7 @@ describe('parseControlDescription', () => {
       title: true,
     }
     expect(parseControlDescription(value)).toEqual(
-      left(objectFieldParseError('title', descriptionParseError('Value is not a string.'))),
+      left(objectFieldParseError('title', descriptionParseError('Not a string.'))),
     )
   })
 })
@@ -447,16 +443,14 @@ describe('parsePropertyControls', () => {
     }
     const expectedResult: ParseResult<ParsedPropertyControls> = right({
       width: right(validNumberControlDescriptionValue),
-      height: left(
-        objectFieldParseError('defaultValue', descriptionParseError('Value is not a number.')),
-      ),
+      height: left(objectFieldParseError('defaultValue', descriptionParseError('Not a number.'))),
     })
     expect(parsePropertyControls(propertyControlsValue)).toEqual(expectedResult)
   })
   it('gives an error if the entire value is invalid', () => {
     const propertyControlsValue = 5
     const expectedResult: ParseResult<ParsedPropertyControls> = left(
-      descriptionParseError('Property controls are not an object.'),
+      descriptionParseError('Not an object.'),
     )
     expect(parsePropertyControls(propertyControlsValue)).toEqual(expectedResult)
   })

--- a/editor/src/core/property-controls/property-controls-parser.ts
+++ b/editor/src/core/property-controls/property-controls-parser.ts
@@ -92,7 +92,7 @@ type OptionTitles<P> = Array<string> | ((props: P | null) => Array<string>)
 
 const parseOptionTitles: Parser<OptionTitles<any>> = parseAlternative<OptionTitles<any>>(
   [parseArray(parseString), parseFunction],
-  'Value is not an array of strings or a function.',
+  'Not a string array or a function.',
 )
 
 export function parseEnumControlDescription(value: unknown): ParseResult<EnumControlDescription> {
@@ -323,7 +323,7 @@ export function parseOptionsControlDescription(
 }
 
 const invalidColorStringResult: ParseResult<string> = left(
-  descriptionParseError('Value is not a valid color string.'),
+  descriptionParseError('Not a valid color string.'),
 )
 
 // We want to parse the string, but check that it can be parsed as a color.
@@ -584,7 +584,7 @@ export function parseControlDescription(value: unknown): ParseResult<ControlDesc
         )
     }
   } else {
-    return left(descriptionParseError('Value is not an object.'))
+    return left(descriptionParseError('Not an object.'))
   }
 }
 
@@ -597,7 +597,7 @@ export function parsePropertyControls(value: unknown): ParseResult<ParsedPropert
   if (typeof value === 'object' && !Array.isArray(value) && value != null) {
     return right(objectMap(parseControlDescription, value as any))
   } else {
-    return left(descriptionParseError('Property controls are not an object.'))
+    return left(descriptionParseError('Not an object.'))
   }
 }
 

--- a/editor/src/utils/value-parser-utils.spec.ts
+++ b/editor/src/utils/value-parser-utils.spec.ts
@@ -3,12 +3,12 @@ import { left, right } from '../core/shared/either'
 
 describe('parseBoolean', () => {
   it('returns a left for something which is not a boolean', () => {
-    expect(parseBoolean(9)).toEqual(left(descriptionParseError('Value is not a boolean.')))
-    expect(parseBoolean('hat')).toEqual(left(descriptionParseError('Value is not a boolean.')))
-    expect(parseBoolean({})).toEqual(left(descriptionParseError('Value is not a boolean.')))
-    expect(parseBoolean([])).toEqual(left(descriptionParseError('Value is not a boolean.')))
-    expect(parseBoolean(null)).toEqual(left(descriptionParseError('Value is not a boolean.')))
-    expect(parseBoolean(undefined)).toEqual(left(descriptionParseError('Value is not a boolean.')))
+    expect(parseBoolean(9)).toEqual(left(descriptionParseError('Not a boolean.')))
+    expect(parseBoolean('hat')).toEqual(left(descriptionParseError('Not a boolean.')))
+    expect(parseBoolean({})).toEqual(left(descriptionParseError('Not a boolean.')))
+    expect(parseBoolean([])).toEqual(left(descriptionParseError('Not a boolean.')))
+    expect(parseBoolean(null)).toEqual(left(descriptionParseError('Not a boolean.')))
+    expect(parseBoolean(undefined)).toEqual(left(descriptionParseError('Not a boolean.')))
   })
   it('returns a right for something which is a boolean', () => {
     expect(parseBoolean(true)).toEqual(right(true))
@@ -18,12 +18,12 @@ describe('parseBoolean', () => {
 
 describe('parseNumber', () => {
   it('returns a left for something which is not a number', () => {
-    expect(parseNumber('hat')).toEqual(left(descriptionParseError('Value is not a number.')))
-    expect(parseNumber(true)).toEqual(left(descriptionParseError('Value is not a number.')))
-    expect(parseNumber({})).toEqual(left(descriptionParseError('Value is not a number.')))
-    expect(parseNumber([])).toEqual(left(descriptionParseError('Value is not a number.')))
-    expect(parseNumber(null)).toEqual(left(descriptionParseError('Value is not a number.')))
-    expect(parseNumber(undefined)).toEqual(left(descriptionParseError('Value is not a number.')))
+    expect(parseNumber('hat')).toEqual(left(descriptionParseError('Not a number.')))
+    expect(parseNumber(true)).toEqual(left(descriptionParseError('Not a number.')))
+    expect(parseNumber({})).toEqual(left(descriptionParseError('Not a number.')))
+    expect(parseNumber([])).toEqual(left(descriptionParseError('Not a number.')))
+    expect(parseNumber(null)).toEqual(left(descriptionParseError('Not a number.')))
+    expect(parseNumber(undefined)).toEqual(left(descriptionParseError('Not a number.')))
   })
   it('returns a right for something which is a number', () => {
     expect(parseNumber(1)).toEqual(right(1))
@@ -36,12 +36,12 @@ describe('parseNumber', () => {
 
 describe('parseString', () => {
   it('returns a left for something which is not a string', () => {
-    expect(parseString(9)).toEqual(left(descriptionParseError('Value is not a string.')))
-    expect(parseString(true)).toEqual(left(descriptionParseError('Value is not a string.')))
-    expect(parseString({})).toEqual(left(descriptionParseError('Value is not a string.')))
-    expect(parseString([])).toEqual(left(descriptionParseError('Value is not a string.')))
-    expect(parseString(null)).toEqual(left(descriptionParseError('Value is not a string.')))
-    expect(parseString(undefined)).toEqual(left(descriptionParseError('Value is not a string.')))
+    expect(parseString(9)).toEqual(left(descriptionParseError('Not a string.')))
+    expect(parseString(true)).toEqual(left(descriptionParseError('Not a string.')))
+    expect(parseString({})).toEqual(left(descriptionParseError('Not a string.')))
+    expect(parseString([])).toEqual(left(descriptionParseError('Not a string.')))
+    expect(parseString(null)).toEqual(left(descriptionParseError('Not a string.')))
+    expect(parseString(undefined)).toEqual(left(descriptionParseError('Not a string.')))
   })
   it('returns a right for something which is a string', () => {
     expect(parseString('')).toEqual(right(''))

--- a/editor/src/utils/value-parser-utils.ts
+++ b/editor/src/utils/value-parser-utils.ts
@@ -159,7 +159,7 @@ export function objectKeyParser<V>(
         return left(objectFieldNotPresentParseError(key))
       }
     } else {
-      return left(descriptionParseError('Value is not an object.'))
+      return left(descriptionParseError('Not an object.'))
     }
   }
 }
@@ -180,7 +180,7 @@ export function optionalObjectKeyParser<V>(
         return right(undefined)
       }
     } else {
-      return left(descriptionParseError('Value is not an object.'))
+      return left(descriptionParseError('Not an object.'))
     }
   }
 }
@@ -205,7 +205,7 @@ export function parseObject<V>(
         Object.keys(valueAsObject),
       )
     } else {
-      return left(descriptionParseError('Value is not an object.'))
+      return left(descriptionParseError('Not an object.'))
     }
   }
 }
@@ -231,7 +231,7 @@ export function parseArray<V>(
       const withErrorParser = arrayValueParserWithError(arrayValueParser)
       return traverseEither(withErrorParser, valueAsArray)
     } else {
-      return left(descriptionParseError('Value is not an array.'))
+      return left(descriptionParseError('Not an array.'))
     }
   }
 }
@@ -240,7 +240,7 @@ export function parseBoolean(value: unknown): ParseResult<boolean> {
   if (typeof value === 'boolean') {
     return right(value)
   } else {
-    return left(descriptionParseError('Value is not a boolean.'))
+    return left(descriptionParseError('Not a boolean.'))
   }
 }
 
@@ -248,7 +248,7 @@ export function parseNumber(value: unknown): ParseResult<number> {
   if (typeof value === 'number') {
     return right(value)
   } else {
-    return left(descriptionParseError('Value is not a number.'))
+    return left(descriptionParseError('Not a number.'))
   }
 }
 
@@ -256,7 +256,7 @@ export function parseString(value: unknown): ParseResult<string> {
   if (typeof value === 'string') {
     return right(value)
   } else {
-    return left(descriptionParseError('Value is not a string.'))
+    return left(descriptionParseError('Not a string.'))
   }
 }
 
@@ -267,7 +267,7 @@ export function parseEnum<E extends string | number>(possibleValues: Array<E>): 
         return right(possibleValue)
       }
     }
-    return left(descriptionParseError('Value is not a member of an enum.'))
+    return left(descriptionParseError('Not a member of an enum.'))
   }
 }
 
@@ -301,7 +301,7 @@ export function parseFunction<T>(value: unknown): ParseResult<T> {
   if (typeof value === 'function') {
     return right(value as any)
   } else {
-    return left(descriptionParseError('Value is not a function.'))
+    return left(descriptionParseError('Not a function.'))
   }
 }
 


### PR DESCRIPTION
**Problem:**
Some of the error messages for property controls don't fit on a single line.

**Fix:**
Trimmed a bunch of the failure messages as much as possible while retaining their meaning.

**Commit Details:**
- For various parsers in `property-controls-parser.ts`, `css-utils.ts`
  and `value-parser-utils.ts` trim the length of their failure messages.
