### PR TITLE
wait for metadata instead of timer

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper-third-party.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper-third-party.spec.browser2.tsx
@@ -149,7 +149,7 @@ async function waitForFullMetadata(getEditorState: () => EditorStore): Promise<t
         'storyboard/scene-1/canvas-app:canvas-app-div/test-mesh/test-meshStandardMaterial'
       ] != null
     if (foundMetadata) {
-      return Promise.resolve(foundMetadata)
+      return true
     }
     if (totalWaitTime > 5000) {
       throw new Error('The React Three Fiber test timed out.')


### PR DESCRIPTION
**Problem:**

#1881 re-enabled the react-three-fiber tests. it worked around an asynchronicity issue by a simple `await wait(100)`. Apperently that wasn't good enough because sometimes the tests now fail on github CI, probably when the runner machine is very slow.

**Fix:**
Make a spin lock that periodically checks if the metadata is available, and await that.
