### PR TITLE
Error tooltips on the file browser warning icon

### DIFF
--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -63,16 +63,19 @@ export interface FileBrowserItemInfo {
   typeInformation?: string | null
   originatingPath: string
   modified: boolean
-  hasErrorMessages: boolean
+  errorMessages: ErrorMessage[]
   exportedFunction: boolean
   isUploadedAssetFile: boolean
 }
 
-export function fileHasErrorMessages(path: string, errorMessages: ErrorMessage[] | null): boolean {
+export function filterErrorMessages(
+  path: string,
+  errorMessages: ErrorMessage[] | null,
+): ErrorMessage[] {
   if (errorMessages == null) {
-    return false
+    return []
   } else {
-    return errorMessages.some((m) => m.fileName === path)
+    return errorMessages.filter((m) => m.fileName === path)
   }
 }
 
@@ -86,15 +89,13 @@ function collectFileBrowserItems(
   walkContentsTree(projectContents, (fullPath, element) => {
     const originatingPath = fullPath
 
-    const hasErrorMessages = fileHasErrorMessages(fullPath, errorMessages)
-
     if (collapsedPaths.every((collapsed) => !fullPath.startsWith(collapsed + '/'))) {
       fileBrowserItems.push({
         path: fullPath,
         type: 'file',
         fileType: element.type,
         originatingPath: originatingPath,
-        hasErrorMessages: hasErrorMessages,
+        errorMessages: filterErrorMessages(fullPath, errorMessages),
         modified: isModifiedFile(element),
         exportedFunction: false,
         isUploadedAssetFile:
@@ -117,7 +118,7 @@ function collectFileBrowserItems(
                 fileType: null,
                 typeInformation: typeInformation,
                 originatingPath: originatingPath,
-                hasErrorMessages: false,
+                errorMessages: [],
                 modified: false,
                 exportedFunction: typeInformation.includes('=>'),
                 isUploadedAssetFile: false,
@@ -304,7 +305,7 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
             expand={Expand}
             setSelected={setSelected}
             collapsed={element.type === 'file' && collapsedPaths.indexOf(element.path) > -1}
-            hasErrorMessages={fileHasErrorMessages(element.path, errorMessages)}
+            errorMessages={filterErrorMessages(element.path, errorMessages)}
             dropTarget={dropTarget}
           />
         </div>

--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -291,7 +291,7 @@ class FileBrowserItemInner extends React.PureComponent<
           this.props.collapsed,
           this.props.exportedFunction,
         )}
-        color={this.props.hasErrorMessages ? 'error' : undefined}
+        color={this.props.errorMessages.length > 0 ? 'error' : undefined}
         width={18}
         height={18}
         onDoubleClick={this.toggleCollapse}
@@ -366,7 +366,7 @@ class FileBrowserItemInner extends React.PureComponent<
       )
     } else {
       let labelColor: string = colorTheme.neutralForeground.value
-      if (this.props.hasErrorMessages) {
+      if (this.props.errorMessages.length > 0) {
         labelColor = colorTheme.errorForeground.value
       } else if (this.props.fileType === 'ASSET_FILE') {
         labelColor = colorTheme.primary.value
@@ -717,9 +717,17 @@ class FileBrowserItemInner extends React.PureComponent<
                 </Button>
               ) : null}
 
-              {this.props.hasErrorMessages ? (
+              {this.props.errorMessages.length > 0 ? (
                 <span style={{ margin: '0px 4px' }}>
-                  <WarningIcon color='error' />
+                  <WarningIcon
+                    color='error'
+                    tooltipText={this.props.errorMessages
+                      .map(
+                        (errorMessage) =>
+                          `${errorMessage.startLine}:${errorMessage.startColumn} - ${errorMessage.source}: ${errorMessage.message}`,
+                      )
+                      .join(`,\n`)}
+                  />
                 </span>
               ) : null}
             </SimpleFlexRow>


### PR DESCRIPTION

<img width="757" alt="image" src="https://user-images.githubusercontent.com/2226774/137175019-781244dd-41f5-428c-82bf-4f3cfdad6024.png">

**Problem:**
We'd show a Warning Triangle in the file navigator, but hovering on it does not tell us what's the problem

**Fix:**
Give a tooltip to the Warning Triangle that says what is the error

