### PR TITLE
Update the project URL again with name updates.

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -52,9 +52,17 @@ import {
   FlexColumn,
 } from '../../uuiui'
 import { betterReactMemo } from '../../uuiui-deps'
-import { createIframeUrl } from '../../core/shared/utils'
+import { createIframeUrl, projectURLForProject } from '../../core/shared/utils'
 import { setBranchNameFromURL } from '../../utils/branches'
 import { FatalIndexedDBErrorComponent } from './fatal-indexeddb-error-component'
+
+function pushProjectURLToBrowserHistory(projectId: string, projectName: string): void {
+  // Make sure we don't replace the query params
+  const queryParams = window.top.location.search
+  const projectURL = projectURLForProject(projectId, projectName)
+  const title = `Utopia ${projectName}`
+  window.top.history.pushState({}, title, `${projectURL}${queryParams}`)
+}
 
 interface NumberSize {
   width: number
@@ -172,6 +180,7 @@ export const EditorComponentInner = betterReactMemo(
       (store) => store.editor.projectName,
       'EditorComponentInner projectName',
     )
+    const projectId = useEditorState((store) => store.editor.id, 'EditorComponentInner projectId')
     const previewVisible = useEditorState(
       (store) => store.editor.preview.visible,
       'EditorComponentInner previewVisible',
@@ -186,6 +195,12 @@ export const EditorComponentInner = betterReactMemo(
     React.useEffect(() => {
       document.title = projectName + ' - Utopia'
     }, [projectName])
+
+    React.useEffect(() => {
+      if (projectId) {
+        pushProjectURLToBrowserHistory(projectId, projectName)
+      }
+    }, [projectName, projectId])
 
     const onClosePreview = React.useCallback(
       () => dispatch([EditorActions.setPanelVisibility('preview', false)]),

--- a/editor/src/components/editor/persistence/persistence.ts
+++ b/editor/src/components/editor/persistence/persistence.ts
@@ -44,14 +44,6 @@ import {
   ProjectWithFileChanges,
 } from './generic/persistence-types'
 
-export function pushProjectURLToBrowserHistory(projectId: string, projectName: string): void {
-  // Make sure we don't replace the query params
-  const queryParams = window.top.location.search
-  const projectURL = projectURLForProject(projectId, projectName)
-  const title = `Utopia ${projectName}`
-  window.top.history.pushState({}, title, `${projectURL}${queryParams}`)
-}
-
 export class PersistenceMachine {
   private interpreter: Interpreter<
     PersistenceContext<PersistentModel>,
@@ -136,13 +128,6 @@ export class PersistenceMachine {
 
           if (this.queuedActions.length > 0) {
             const actionsToDispatch = this.queuedActions
-            const projectIdOrNameChanged = actionsToDispatch.some(
-              (action) =>
-                action.action === 'SET_PROJECT_ID' || action.action === 'SET_PROJECT_NAME',
-            )
-            if (projectIdOrNameChanged) {
-              pushProjectURLToBrowserHistory(state.context.projectId!, state.context.project!.name)
-            }
             this.queuedActions = []
             dispatch(actionsToDispatch)
           }

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -242,7 +242,7 @@ export class Editor {
               }
             })
           } else {
-            this.storedState.persistence.createNew(createNewProjectName(), defaultProject())
+            this.storedState.persistence.createNew(emptyEditorState.projectName, defaultProject())
           }
         } else {
           this.storedState.persistence.load(projectId)


### PR DESCRIPTION
Fixes #1902

**Problem:**
When renaming a project, the URL wasn't updated at the same time.

**Fix:**
The logic for updating the URL was in a conditional that didn't get triggered after the rename.

The browser URL is now updated similarly to how the window title gets updated via a `useEffect` clause, albeit with both project ID and project name being used.

Fixing this exposed an issue where the name would change a second time when creating a new project, that was fixed by using the same name generated as the editor starts up when triggering the creation of a new project in the state machine.

**Commit Details:**
- Fixes #1902.
- Moved `pushProjectURLToBrowserHistory` to `editor-component.tsx` as it
  doesn't make any sense for it to live with the persistence layer.
- `EditorComponentInner`, similar to what happens with `document.title`,
  will push an URL update onto the browser history (which to the user
  looks like the URL changing without reloading) based on project ID
  and/or project name updates.
- Removed the logic from the state machine for updating the URL.
- When creating a new project, the name previously generated is used
  so that it doesn't cycle names in the URL bar.
