### PR TITLE
Mark intrinsic elements from libraries also as imported.

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-info-box.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-info-box.tsx
@@ -15,6 +15,7 @@ import { openCodeEditorFile, setFocusedElement } from '../../../editor/actions/a
 import { useEditorState } from '../../../editor/store/store-hook'
 import { UIGridRow } from '../../widgets/ui-grid-row'
 import * as EP from '../../../../core/shared/element-path'
+import { when } from '../../../../utils/react-conditionals'
 
 function useComponentType(path: ElementPath): string | null {
   return useEditorState((store) => {
@@ -120,7 +121,13 @@ export const ComponentInfoBox = () => {
           </span>
           <p>
             {`This ${componentType} is imported from `}
-            <InlineLink href={componentPackageMgrLink}>{`${componentPackageName}`}</InlineLink> via
+            {when(
+              componentPackageName != null,
+              <>
+                <InlineLink href={componentPackageMgrLink}>{`${componentPackageName}`}</InlineLink>{' '}
+                via
+              </>,
+            )}
             NPM.
           </p>
         </UIGridRow>

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -42,6 +42,10 @@ import {
   createImportedFrom,
   createNotImported,
   ElementInstanceMetadata,
+  isIntrinsicElement,
+  isIntrinsicElementFromString,
+  isIntrinsicHTMLElement,
+  isIntrinsicHTMLElementString,
 } from '../shared/element-template'
 import {
   sceneMetadata as _sceneMetadata,
@@ -84,10 +88,10 @@ export function isUtopiaAPIComponentFromMetadata(
   elementInstanceMetadata: ElementInstanceMetadata,
 ): boolean {
   const foundImportInfo = maybeEitherToMaybe(elementInstanceMetadata.importInfo)
-  if (foundImportInfo != null) {
-    return foundImportInfo.path === 'utopia-api'
-  } else {
+  if (foundImportInfo == null) {
     return false
+  } else {
+    return foundImportInfo.path === 'utopia-api'
   }
 }
 
@@ -274,13 +278,48 @@ export function isImportedComponent(
   }
 }
 
+export function isIntrinsicElementMetadata(
+  elementInstanceMetadata: ElementInstanceMetadata,
+): boolean {
+  return foldEither(
+    isIntrinsicElementFromString,
+    (child) => {
+      if (isJSXElement(child)) {
+        return isIntrinsicElement(child.name)
+      } else {
+        return false
+      }
+    },
+    elementInstanceMetadata.element,
+  )
+}
+
+export function isIntrinsicHTMLElementMetadata(
+  elementInstanceMetadata: ElementInstanceMetadata,
+): boolean {
+  return foldEither(
+    isIntrinsicHTMLElementString,
+    (child) => {
+      if (isJSXElement(child)) {
+        return isIntrinsicHTMLElement(child.name)
+      } else {
+        return false
+      }
+    },
+    elementInstanceMetadata.element,
+  )
+}
+
 export function isImportedComponentNPM(
   elementInstanceMetadata: ElementInstanceMetadata | null,
 ): boolean {
   return (
-    isImportedComponent(elementInstanceMetadata) &&
-    elementInstanceMetadata != null &&
-    !isUtopiaAPIComponentFromMetadata(elementInstanceMetadata)
+    (elementInstanceMetadata != null &&
+      isIntrinsicElementMetadata(elementInstanceMetadata) &&
+      !isIntrinsicHTMLElementMetadata(elementInstanceMetadata)) ||
+    (isImportedComponent(elementInstanceMetadata) &&
+      elementInstanceMetadata != null &&
+      !isUtopiaAPIComponentFromMetadata(elementInstanceMetadata))
   )
 }
 


### PR DESCRIPTION
**Problem:**
React Three Fiber elements were not marked as being components coming from NPM, which is as a result of them not having associated imports, because React intrinsics.

**Fix:**
For intrinsics that are not regular HTML intrinsics, the inspector now treats them as being components that came from NPM.

**Limitations:**
As the R3F elements are intrinsics with no matching import, we cannot identify _which_ library they originate from.

**Commit Details:**
- Added `isIntrinsicElementMetadata` and `isIntrinsicHTMLElementMetadata`,
  which just invoke the aready existing similarly named functions but
  against an instance of `ElementInstanceMetadata`.
- Modified `isImportedComponentNPM` to also include intrinsic elements
  which are not regular HTML intrinsics.
- Slightly tweaked `ComponentInfoBox` to handle the case for intrinsics
  from dependencies which wont have a value for `componentPackageName`.