### PR TITLE
Minor property control tweaks.

### DIFF
--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -489,7 +489,7 @@ export function getPropertyControlsForTarget(
           ? absolutePath.replace(/\.(js|jsx|ts|tsx)$/, '')
           : absolutePath
 
-        const nameLastPart = getJSXElementNameLastPart(element.name)
+        const nameLastPart = getJSXElementNameAsString(element.name)
         if (
           propertyControlsInfo[trimmedPath] != null &&
           propertyControlsInfo[trimmedPath][nameLastPart] != null

--- a/editor/src/core/property-controls/third-party-property-controls/antd-controls.ts
+++ b/editor/src/core/property-controls/third-party-property-controls/antd-controls.ts
@@ -6,7 +6,7 @@ const Button: PropertyControls = {
     title: 'href',
   },
   onClick: {
-    type: 'ignore',
+    type: 'eventhandler',
     title: 'onClick',
   },
   disabled: {
@@ -230,7 +230,10 @@ const Text: PropertyControls = {
 
 const Menu: PropertyControls = {
   defaultOpenKeys: {
-    type: 'ignore',
+    type: 'array',
+    propertyControl: {
+      type: 'string',
+    },
     title: 'defaultOpenKeys',
   },
   defaultSelectedKeys: {


### PR DESCRIPTION
**Problem:**
The sub components of the `antd` `Menu` would not get their property controls populated as a result of them being defined as `Menu.Item`, but the lookup would only look for `Item`.

**Fix:**
Slight tweak to the handling of the lookup call to provide the full name not just the last part of the element name.

Some slight tweaks have been made to the antd property controls as well.

**Commit Details:**
- Fixes an issue in `getPropertyControlsForTarget` where it
  wouldn't be able to identify property controls for `Menu.Item`.
- Updated the definitions for the antd property controls of
  `Button.onClick` and `Menu.defaultOpenKeys`.