### PR TITLE
Fix for number input up and down increment buttons.

### DIFF
--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -252,6 +252,7 @@ export const NumberInput = betterReactMemo<NumberInputProps>(
     const maximum = scaleFactor * unscaledMaximum
     const stepSize = unscaledStepSize == null ? 1 : unscaledStepSize * scaleFactor
 
+    const repeatedValueRef = React.useRef(nonNullPropsValue)
     const incrementBy = React.useCallback(
       (
         currentValue: CSSNumber,
@@ -276,6 +277,7 @@ export const NumberInput = betterReactMemo<NumberInputProps>(
           }
         }
         updateStateValue(newValue)
+        repeatedValueRef.current = newValue
         return newValue
       },
       [
@@ -288,7 +290,6 @@ export const NumberInput = betterReactMemo<NumberInputProps>(
       ],
     )
 
-    const repeatedValueRef = React.useRef(nonNullPropsValue)
     const repeatIncrement = React.useCallback(
       (
         currentValue: CSSNumber,
@@ -297,7 +298,6 @@ export const NumberInput = betterReactMemo<NumberInputProps>(
         transient: boolean,
       ) => {
         const newValue = incrementBy(currentValue, incrementStepSize, shiftKey, transient)
-        repeatedValueRef.current = newValue
         incrementAnimationFrame = window.requestAnimationFrame(() =>
           repeatIncrement(newValue, incrementStepSize, shiftKey, transient),
         )


### PR DESCRIPTION
Fixes #1933

**Problem:**
When the `on(In|De)crementMouseDown` callback fires it gets a new value by invoking `incrementBy` and sets that property, but when the paired `on(In|De)crementMouseUp` callback fires it retrieves the value from the `repeatedValueRef` and sets the property with that value, thereby reverting the original change.

**Fix:**
In `incrementBy`, update the value in `repeatedValueRef`.

**Commit Details:**
- Fixes #1933.
- Moved `repeatedValueRef` to slightly earlier in the file.
- The `incrementBy` callback now updates `repeatedValueRef.current`.
