### PR TITLE
Handle nonexistent array property control values.

### DIFF
--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -450,6 +450,14 @@ describe('setJSXValueAtPath', () => {
       }),
     )
   })
+
+  it('creates an array if the property path part is a number', () => {
+    const updatedAttributes = forceRight(
+      setJSXValueAtPath([], PP.create(['top', 0]), jsxAttributeValue(55, emptyComments)),
+    )
+    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    expect(compiledProps).toEqual({ top: [55] })
+  })
 })
 
 describe('jsxAttributesToProps', () => {
@@ -968,7 +976,7 @@ describe('getAllPathsFromAttributes', () => {
     expect(result).toEqual([
       PP.create(['cica']),
       PP.create(['cica', 'deep']),
-      PP.create(['cica', 'deep', '0']),
+      PP.create(['cica', 'deep', 0]),
     ])
   })
 

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -30,6 +30,7 @@ import {
   ElementsWithin,
   isJSXAttributeOtherJavaScript,
   emptyComments,
+  jsxAttributeNestedArraySimple,
 } from './element-template'
 import { resolveParamsAndRunJsCode } from './javascript-cache'
 import { PropertyPath } from './project-file-types'
@@ -409,10 +410,16 @@ export function getJSXAttributeAtPathInner(
 export function deeplyCreatedValue(path: PropertyPath, value: JSXAttribute): JSXAttribute {
   const elements = PP.getElements(path)
   return elements.reduceRight((acc: JSXAttribute, propName) => {
-    return jsxAttributeNestedObject(
-      [jsxPropertyAssignment(`${propName}`, acc, emptyComments, emptyComments)],
-      emptyComments,
-    )
+    if (typeof propName === 'number') {
+      let newArray: Array<JSXAttribute> = []
+      newArray[propName] = acc
+      return jsxAttributeNestedArraySimple(newArray)
+    } else {
+      return jsxAttributeNestedObject(
+        [jsxPropertyAssignment(propName, acc, emptyComments, emptyComments)],
+        emptyComments,
+      )
+    }
   }, value)
 }
 

--- a/editor/src/core/shared/property-path.spec.ts
+++ b/editor/src/core/shared/property-path.spec.ts
@@ -1,0 +1,14 @@
+import { create } from './property-path'
+
+describe('create', () => {
+  it('distinguishes between paths containing strings and numbers', () => {
+    const firstEndsWithString = create(['path', '0'])
+    const firstEndsWithNumber = create(['path', 0])
+    const secondEndsWithString = create(['path', '0'])
+    const secondEndsWithNumber = create(['path', 0])
+    expect(firstEndsWithString).toStrictEqual({ propertyElements: ['path', '0'] })
+    expect(firstEndsWithNumber).toStrictEqual({ propertyElements: ['path', 0] })
+    expect(secondEndsWithString).toStrictEqual({ propertyElements: ['path', '0'] })
+    expect(secondEndsWithNumber).toStrictEqual({ propertyElements: ['path', 0] })
+  })
+})

--- a/editor/src/core/shared/property-path.ts
+++ b/editor/src/core/shared/property-path.ts
@@ -38,12 +38,15 @@ export function clearPropertyPathCache() {
 function getPathCache(elements: Array<PropertyPathPart>): PropertyPathCache {
   let workingPathCache: PropertyPathCache = globalPathCache
   fastForEach(elements, (pathPart) => {
-    if (workingPathCache.childCaches[pathPart] == null) {
+    // Create a distinction between keys of `0` and `'0'`,
+    // as indexing into an object coerces the key to a string.
+    const childCacheKey = `${typeof pathPart}-${pathPart}`
+    if (workingPathCache.childCaches[childCacheKey] == null) {
       const newCache = emptyPathCache()
-      workingPathCache.childCaches[pathPart] = newCache
+      workingPathCache.childCaches[childCacheKey] = newCache
       workingPathCache = newCache
     } else {
-      workingPathCache = workingPathCache.childCaches[pathPart]
+      workingPathCache = workingPathCache.childCaches[childCacheKey]
     }
   })
   return workingPathCache


### PR DESCRIPTION
Fixes #1936

**Problem:**
When a value does not exist, `deeplyCreatedValue` was creating a nested object when the path part was of type `number`.

**Fix:**
For path parts of type `number`, instead create a nested array, so that a path of `['defaultOpenKeys', 0]` in an `array` property control when set and a value does not exist in `defaultOpenKeys` will result in an array instead of an object.

There is a bonus fix relating to distinguishing numbers and strings in property path parts. As JavaScript coerces the index value of an object to a string indexing with `0` and `'0'` to `'0'`, `getPathCache` pulls the two together so that the first one created becomes the value used for both. As a result an earlier call could cause the `deeplyCreatedValue` function to still create a nested object as a result.

**Commit Details:**
- Fixes #1936.
- Modified `deeplyCreatedValue` to check the type of the path parts
  to create a nested array if the part is a number.
- Fixed an issue where `getPathCache` was indexing into the `childCaches`
  object using the path parts, which get coerced to a string. Now
  the key distinguishes between those path parts being a string or number.
