### PR TITLE
Handle hook use count errors gracefully in the canvas.

### DIFF
--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -123,8 +123,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(520) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(530)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(525) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(535)
   })
 
   it('Changing the selected view with a simple project', async () => {

--- a/editor/src/core/shared/runtime-report-logs.tsx
+++ b/editor/src/core/shared/runtime-report-logs.tsx
@@ -31,7 +31,7 @@ export function useReadOnlyRuntimeErrors(): Array<RuntimeErrorInfo> {
 }
 
 export function useWriteOnlyRuntimeErrors(): {
-  onRuntimeError: (editedFile: string, error: FancyError, errorInfo?: React.ErrorInfo) => void
+  addToRuntimeErrors: (editedFile: string, error: FancyError, errorInfo?: React.ErrorInfo) => void
   clearRuntimeErrors: () => void
 } {
   const updateRuntimeErrors = usePubSubAtomWriteOnly(runtimeErrorsAtom)
@@ -67,7 +67,7 @@ export function useWriteOnlyRuntimeErrors(): {
   }, [updateRuntimeErrors])
 
   return {
-    onRuntimeError: onRuntimeError,
+    addToRuntimeErrors: onRuntimeError,
     clearRuntimeErrors: clearRuntimeErrors,
   }
 }

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -316,3 +316,11 @@ function patchedCreateReactElement(type: any, props: any, ...children: any): any
     return realCreateElement(type, updatedProps, ...children)
   }
 }
+
+export function isHooksErrorMessage(message: string): boolean {
+  return (
+    message === 'Rendered more hooks than during the previous render.' ||
+    message ===
+      'Rendered fewer hooks than expected. This may be caused by an accidental early return statement.'
+  )
+}

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -321,6 +321,7 @@ export function isHooksErrorMessage(message: string): boolean {
   return (
     message === 'Rendered more hooks than during the previous render.' ||
     message ===
-      'Rendered fewer hooks than expected. This may be caused by an accidental early return statement.'
+      'Rendered fewer hooks than expected. This may be caused by an accidental early return statement.' ||
+    message === 'Should have a queue. This is likely a bug in React. Please file an issue.'
   )
 }


### PR DESCRIPTION
**Problem:**
Editing code can result in hook use count errors in the canvas, which is sort of correct given how the canvas works, but is not correct for a user's code in isolation.

**Fix:**
Attempt to detect these hook use count errors and have the canvas reset.

**Commit Details:**
- Renamed `onRuntimeError` to `addToRuntimeErrors` in `useWriteOnlyRuntimeErrors`.
- `CanvasComponentEntry` attempts to detect hook use count errors by
  checking the error message for a given exception, triggering a canvas
  reset should one occur.
- Added `isHooksErrorMessage` to capture the specific error messages used
  by hook use count errors.
