### PR TITLE
feat(editor) Create a rawjs property control

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section-utils.spec.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section-utils.spec.tsx
@@ -105,13 +105,18 @@ describe('inferControlTypeBasedOnValue', () => {
   })
 
   it('Ignores the style prop', () => {
-    const styleObjectResult = inferControlTypeBasedOnValue({}, 'style')
-    expect(styleObjectResult.type).toEqual('ignore')
+    const result = inferControlTypeBasedOnValue({}, 'style')
+    expect(result.type).toEqual('ignore')
   })
 
-  it('ignores a React element', () => {
-    const reactComponentResult = inferControlTypeBasedOnValue(<div />)
-    expect(reactComponentResult.type).toEqual('ignore')
+  it('Treats a React element as rawjs', () => {
+    const result = inferControlTypeBasedOnValue(<div />)
+    expect(result.type).toEqual('rawjs')
+  })
+
+  it('treats a function as rawjs', () => {
+    const result = inferControlTypeBasedOnValue(() => {})
+    expect(result.type).toEqual('rawjs')
   })
 
   it('Correctly infers nested array / object horror show controls', () => {

--- a/editor/src/components/inspector/sections/component-section/component-section-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/component-section-utils.ts
@@ -40,10 +40,27 @@ function inferControlTypeBasedOnValueInner(
         title: propName,
       }
     }
+    case 'function': {
+      return {
+        type: 'rawjs',
+        title: propName,
+      }
+    }
     case 'object': {
-      if (propValue == null || React.isValidElement(propValue) || propName === 'style') {
+      if (propValue == null || propName === 'style') {
         return {
           type: 'ignore',
+        }
+      } else if (React.isValidElement(propValue)) {
+        if (propName === 'children') {
+          return {
+            type: 'ignore',
+          }
+        } else {
+          return {
+            type: 'rawjs',
+            title: propName,
+          }
         }
       } else if (Array.isArray(propValue)) {
         if (propValue.length === 2 && isNumberArray(propValue)) {

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -68,10 +68,8 @@ import { PropertyRow } from '../../widgets/property-row'
 import {
   ControlForBooleanProp,
   ControlForColorProp,
-  ControlForComponentInstanceProp,
   ControlForEnumProp,
   ControlForEulerProp,
-  ControlForEventHandlerProp,
   ControlForExpressionEnumProp,
   ControlForImageProp,
   ControlForMatrix3Prop,
@@ -81,6 +79,7 @@ import {
   ControlForPopupListProp,
   ControlForPropProps,
   ControlForQuaternionProp,
+  ControlForRawJSProp,
   ControlForStringProp,
   ControlForVectorProp,
 } from './property-control-controls'
@@ -124,16 +123,10 @@ const ControlForProp = betterReactMemo(
           return <ControlForBooleanProp {...props} controlDescription={controlDescription} />
         case 'color':
           return <ControlForColorProp {...props} controlDescription={controlDescription} />
-        case 'componentinstance':
-          return (
-            <ControlForComponentInstanceProp {...props} controlDescription={controlDescription} />
-          )
         case 'enum':
           return <ControlForEnumProp {...props} controlDescription={controlDescription} />
         case 'euler':
           return <ControlForEulerProp {...props} controlDescription={controlDescription} />
-        case 'eventhandler':
-          return <ControlForEventHandlerProp {...props} controlDescription={controlDescription} />
         case 'expression-enum':
           return <ControlForExpressionEnumProp {...props} controlDescription={controlDescription} />
         case 'ignore':
@@ -152,6 +145,8 @@ const ControlForProp = betterReactMemo(
           return <ControlForPopupListProp {...props} controlDescription={controlDescription} />
         case 'quaternion':
           return <ControlForQuaternionProp {...props} controlDescription={controlDescription} />
+        case 'rawjs':
+          return <ControlForRawJSProp {...props} controlDescription={controlDescription} />
         case 'string':
           return <ControlForStringProp {...props} controlDescription={controlDescription} />
         case 'vector2':

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -5,10 +5,8 @@ import {
   BaseControlDescription,
   BooleanControlDescription,
   ColorControlDescription,
-  ComponentInstanceDescription,
   EnumControlDescription,
   EulerControlDescription,
-  EventHandlerControlDescription,
   ExpressionEnumControlDescription,
   ImageControlDescription,
   Matrix3ControlDescription,
@@ -17,6 +15,7 @@ import {
   OptionsControlDescription,
   PopUpListControlDescription,
   QuaternionControlDescription,
+  RawJSControlDescription,
   StringControlDescription,
   Vector2ControlDescription,
   Vector3ControlDescription,
@@ -123,14 +122,11 @@ export const ControlForColorProp = betterReactMemo(
   },
 )
 
-export const ControlForComponentInstanceProp = betterReactMemo(
-  'ControlForComponentInstanceProp',
-  (props: ControlForPropProps<ComponentInstanceDescription>) => {
+export const ControlForRawJSProp = betterReactMemo(
+  'ControlForRawJSProp',
+  (props: ControlForPropProps<RawJSControlDescription>) => {
     const { propName, propMetadata, controlDescription } = props
-    const dispatch = useEditorState(
-      (store) => store.dispatch,
-      'ControlForComponentInstanceProp dispatch',
-    )
+    const dispatch = useEditorState((store) => store.dispatch, 'ControlForRawJSProp dispatch')
 
     const targetFilePaths = useEditorState((store) => {
       const currentFilePath = forceNotNull(
@@ -146,9 +142,9 @@ export const ControlForComponentInstanceProp = betterReactMemo(
         )
         return normalisePathSuccessOrThrowError(normalisedPath).filePath
       })
-    }, 'ControlForComponentInstanceProp targetFilePaths')
+    }, 'ControlForRawJSProp targetFilePaths')
 
-    const controlId = `${propName}-componentinstance-property-control`
+    const controlId = `${propName}-rawjs-property-control`
     const value = propMetadata.propertyStatus.set
       ? propMetadata.value
       : controlDescription.defaultValue
@@ -295,19 +291,6 @@ export const ControlForExpressionEnumProp = betterReactMemo(
         containerMode={'default'}
       />
     )
-  },
-)
-
-export const ControlForEventHandlerProp = betterReactMemo(
-  'ControlForEventHandlerProp',
-  (props: ControlForPropProps<EventHandlerControlDescription>) => {
-    const { propName, propMetadata, controlDescription } = props
-
-    const value = propMetadata.propertyStatus.set
-      ? propMetadata.value
-      : controlDescription.defaultValue
-
-    return <EventHandlerControl handlerName={propName} value={value ?? ''} />
   },
 )
 

--- a/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
+++ b/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
@@ -346,7 +346,7 @@ declare module 'utopia-api/primitives/view' {
 }
 declare module 'utopia-api/property-controls/property-controls' {
   import type { CSSProperties } from 'react';
-  export type BaseControlType = 'boolean' | 'color' | 'componentinstance' | 'enum' | 'expression-enum' | 'euler' | 'eventhandler' | 'ignore' | 'image' | 'matrix3' | 'matrix4' | 'number' | 'options' | 'popuplist' | 'quaternion' | 'string' | 'styleobject' | 'vector2' | 'vector3' | 'vector4';
+  export type BaseControlType = 'boolean' | 'color' | 'enum' | 'expression-enum' | 'euler' | 'ignore' | 'image' | 'matrix3' | 'matrix4' | 'number' | 'options' | 'popuplist' | 'quaternion' | 'rawjs' | 'string' | 'styleobject' | 'vector2' | 'vector3' | 'vector4';
   interface AbstractControlDescription<T extends ControlType> {
       title?: string;
       type: T;
@@ -361,9 +361,6 @@ declare module 'utopia-api/property-controls/property-controls' {
   }
   export interface ColorControlDescription extends AbstractBaseControlDescription<'color'> {
       defaultValue?: string;
-  }
-  export interface ComponentInstanceDescription extends AbstractBaseControlDescription<'componentinstance'> {
-      defaultValue?: never;
   }
   export type AllowedEnumType = string | boolean | number | undefined | null;
   export interface EnumControlDescription extends AbstractBaseControlDescription<'enum'> {
@@ -389,9 +386,6 @@ declare module 'utopia-api/property-controls/property-controls' {
   }
   export interface EulerControlDescription extends AbstractBaseControlDescription<'euler'> {
       defaultValue?: [number, number, number, string];
-  }
-  export interface EventHandlerControlDescription extends AbstractBaseControlDescription<'eventhandler'> {
-      defaultValue?: never;
   }
   export interface IgnoreControlDescription extends AbstractBaseControlDescription<'ignore'> {
       defaultValue?: never;
@@ -447,6 +441,9 @@ declare module 'utopia-api/property-controls/property-controls' {
   export interface QuaternionControlDescription extends AbstractBaseControlDescription<'quaternion'> {
       defaultValue?: [number, number, number, number];
   }
+  export interface RawJSControlDescription extends AbstractBaseControlDescription<'rawjs'> {
+      defaultValue?: unknown;
+  }
   export interface StringControlDescription extends AbstractBaseControlDescription<'string'> {
       defaultValue?: string;
       placeholder?: string;
@@ -465,7 +462,7 @@ declare module 'utopia-api/property-controls/property-controls' {
   export interface Vector4ControlDescription extends AbstractBaseControlDescription<'vector4'> {
       defaultValue?: [number, number, number, number];
   }
-  export type BaseControlDescription = BooleanControlDescription | ColorControlDescription | ComponentInstanceDescription | EnumControlDescription | ExpressionEnumControlDescription | EulerControlDescription | EventHandlerControlDescription | IgnoreControlDescription | ImageControlDescription | Matrix3ControlDescription | Matrix4ControlDescription | NumberControlDescription | OptionsControlDescription | PopUpListControlDescription | QuaternionControlDescription | StringControlDescription | StyleObjectControlDescription | Vector2ControlDescription | Vector3ControlDescription | Vector4ControlDescription;
+  export type BaseControlDescription = BooleanControlDescription | ColorControlDescription | EnumControlDescription | ExpressionEnumControlDescription | EulerControlDescription | IgnoreControlDescription | ImageControlDescription | Matrix3ControlDescription | Matrix4ControlDescription | NumberControlDescription | OptionsControlDescription | PopUpListControlDescription | QuaternionControlDescription | RawJSControlDescription | StringControlDescription | StyleObjectControlDescription | Vector2ControlDescription | Vector3ControlDescription | Vector4ControlDescription;
   export type HigherLevelControlType = 'array' | 'object' | 'union';
   export type ControlType = BaseControlType | HigherLevelControlType | 'folder';
   interface AbstractHigherLevelControlDescription<T extends HigherLevelControlType> extends AbstractControlDescription<T> {
@@ -501,7 +498,7 @@ declare module 'utopia-api/property-controls/property-controls' {
   export function getDefaultProps(propertyControls: PropertyControls): {
       [prop: string]: unknown;
   };
-  export function expression(value: AllowedEnumType, expressionString: string, toImport: ImportType): ExpressionEnum;
+  export function expression(value: AllowedEnumType, expressionString: string, toImport?: ImportType): ExpressionEnum;
   export function importStar(source: string, name: string): ImportType;
   export function importDefault(source: string, name: string): ImportType;
   export function importNamed(source: string, name: string): ImportType;

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -123,8 +123,8 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(460) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(470)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(530) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(540)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -241,7 +241,7 @@ describe('React Render Count Tests - ', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(2520) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(2530)
+    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(2680) // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toBeLessThan(2690)
   })
 })

--- a/editor/src/core/property-controls/property-control-values.spec.ts
+++ b/editor/src/core/property-controls/property-control-values.spec.ts
@@ -2,9 +2,7 @@ import {
   ControlDescription,
   BooleanControlDescription,
   ColorControlDescription,
-  ComponentInstanceDescription,
   EnumControlDescription,
-  EventHandlerControlDescription,
   IgnoreControlDescription,
   NumberControlDescription,
   OptionsControlDescription,
@@ -13,9 +11,8 @@ import {
   ArrayControlDescription,
   ObjectControlDescription,
   UnionControlDescription,
-  BaseControlDescription,
-  HigherLevelControlDescription,
   RegularControlDescription,
+  RawJSControlDescription,
 } from 'utopia-api'
 import {
   JSXAttribute,
@@ -113,15 +110,15 @@ describe('ColorControlDescription', () => {
   )
 })
 
-describe('ComponentInstanceControlDescription', () => {
-  const componentInstanceControlDescriptionValue: ComponentInstanceDescription = {
-    type: 'componentinstance',
+describe('RawJSControlDescription', () => {
+  const rawJSControlDescriptionValue: RawJSControlDescription = {
+    type: 'rawjs',
   }
 
   const validValue = 'Cake'
   const wrappedValidValue = jsxAttributeOtherJavaScript(validValue, ``, [], null, {})
 
-  runBaseTestSuite(validValue, wrappedValidValue, [], componentInstanceControlDescriptionValue)
+  runBaseTestSuite(validValue, wrappedValidValue, [], rawJSControlDescriptionValue)
 })
 
 describe('EnumControlDescription', () => {
@@ -139,17 +136,6 @@ describe('EnumControlDescription', () => {
   ]
 
   runBaseTestSuite(validValue, wrappedValidValue, wrappedInvalidValues, enumControlDescriptionValue)
-})
-
-describe('EventHandlerControlDescription', () => {
-  const eventHandlerControlDescriptionValue: EventHandlerControlDescription = {
-    type: 'eventhandler',
-  }
-
-  const validValue = 'Cake'
-  const wrappedValidValue = jsxAttributeOtherJavaScript(validValue, ``, [], null, {})
-
-  runBaseTestSuite(validValue, wrappedValidValue, [], eventHandlerControlDescriptionValue)
 })
 
 describe('IgnoreControlDescription', () => {

--- a/editor/src/core/property-controls/property-control-values.ts
+++ b/editor/src/core/property-controls/property-control-values.ts
@@ -243,16 +243,12 @@ export function unwrapperAndParserForBaseControl(
       return defaultUnwrapFirst(parseBoolean)
     case 'color':
       return defaultUnwrapFirst(parseColorValue)
-    case 'componentinstance':
-      return jsUnwrapFirst(parseAny)
     case 'enum':
       return defaultUnwrapFirst(parseAllowedEnum(control.options))
     case 'expression-enum':
       return defaultUnwrapFirst(parseAny)
     case 'euler':
       return defaultUnwrapFirst(parseArray(parseAny))
-    case 'eventhandler':
-      return jsUnwrapFirst(parseAny)
     case 'ignore':
       return defaultUnwrapFirst(parseAny)
     case 'image':
@@ -268,6 +264,8 @@ export function unwrapperAndParserForBaseControl(
       return defaultUnwrapFirst(parseAny)
     case 'quaternion':
       return defaultUnwrapFirst(parseArray(parseNumber))
+    case 'rawjs':
+      return jsUnwrapFirst(parseAny)
     case 'string':
       return defaultUnwrapFirst(parseString)
     case 'styleobject':
@@ -288,11 +286,9 @@ export function unwrapperAndParserForPropertyControl(
   switch (control.type) {
     case 'boolean':
     case 'color':
-    case 'componentinstance':
     case 'enum':
     case 'expression-enum':
     case 'euler':
-    case 'eventhandler':
     case 'ignore':
     case 'image':
     case 'matrix3':
@@ -301,6 +297,7 @@ export function unwrapperAndParserForPropertyControl(
     case 'options':
     case 'popuplist':
     case 'quaternion':
+    case 'rawjs':
     case 'string':
     case 'styleobject':
     case 'vector2':
@@ -409,16 +406,12 @@ export function printerForBasePropertyControl(control: BaseControlDescription): 
       return printSimple
     case 'color':
       return printColor
-    case 'componentinstance':
-      return printJS
     case 'enum':
       return printSimple
     case 'expression-enum':
       return printSimple
     case 'euler':
       return printSimple
-    case 'eventhandler':
-      return printJS
     case 'ignore':
       return printSimple
     case 'image':
@@ -434,6 +427,8 @@ export function printerForBasePropertyControl(control: BaseControlDescription): 
       return printSimple
     case 'quaternion':
       return printSimple
+    case 'rawjs':
+      return printJS
     case 'string':
       return printSimple
     case 'styleobject':
@@ -491,11 +486,9 @@ export function printerForPropertyControl(control: RegularControlDescription): P
   switch (control.type) {
     case 'boolean':
     case 'color':
-    case 'componentinstance':
     case 'enum':
     case 'expression-enum':
     case 'euler':
-    case 'eventhandler':
     case 'ignore':
     case 'image':
     case 'matrix3':
@@ -504,6 +497,7 @@ export function printerForPropertyControl(control: RegularControlDescription): P
     case 'options':
     case 'popuplist':
     case 'quaternion':
+    case 'rawjs':
     case 'string':
     case 'styleobject':
     case 'vector2':

--- a/editor/src/core/property-controls/property-controls-parser.spec.ts
+++ b/editor/src/core/property-controls/property-controls-parser.spec.ts
@@ -6,12 +6,11 @@ import {
   PopUpListControlDescription,
   OptionsControlDescription,
   ColorControlDescription,
-  ComponentInstanceDescription,
   IgnoreControlDescription,
-  EventHandlerControlDescription,
   ImageControlDescription,
   StyleObjectControlDescription,
   FolderControlDescription,
+  RawJSControlDescription,
 } from 'utopia-api'
 import {
   parseNumberControlDescription,
@@ -21,15 +20,14 @@ import {
   parsePopUpListControlDescription,
   parseOptionsControlDescription,
   parseColorControlDescription,
-  parseComponentInstanceControlDescription,
   ParsedPropertyControls,
   parsePropertyControls,
   parseIgnoreControlDescription,
-  parseEventHandlerControlDescription,
   parseImageControlDescription,
   parseStyleObjectControlDescription,
   parseFolderControlDescription,
   parseControlDescription,
+  parseRawJSControlDescription,
 } from './property-controls-parser'
 import { right, left, isLeft } from '../shared/either'
 import {
@@ -131,18 +129,18 @@ describe('parseColorControlDescription', () => {
   )
 })
 
-const validComponentInstanceControlDescriptionValue: ComponentInstanceDescription = {
-  title: 'Component Instance Control',
-  type: 'componentinstance',
+const validRawJSControlDescriptionValue: RawJSControlDescription = {
+  title: 'Raw JS Control',
+  type: 'rawjs',
 }
 
-describe('parseComponentInstanceControlDescription', () => {
+describe('parseRawJSControlDescription', () => {
   runBaseTestSuite(
-    validComponentInstanceControlDescriptionValue,
+    validRawJSControlDescriptionValue,
     ['type'],
     [],
     false,
-    parseComponentInstanceControlDescription,
+    parseRawJSControlDescription,
   )
 })
 
@@ -162,21 +160,6 @@ describe('parseEnumControlDescription', () => {
     [['hat']],
     true,
     parseEnumControlDescription,
-  )
-})
-
-const validEventHandlerControlDescriptionValue: EventHandlerControlDescription = {
-  title: 'Event Handler Control',
-  type: 'eventhandler',
-}
-
-describe('parseEventHandlerControlDescription', () => {
-  runBaseTestSuite(
-    validEventHandlerControlDescriptionValue,
-    ['type'],
-    [],
-    false,
-    parseEventHandlerControlDescription,
   )
 })
 
@@ -381,9 +364,9 @@ describe('parseControlDescription', () => {
       right(validColorControlDescriptionValue),
     )
   })
-  it('parses a component instance description correctly', () => {
-    expect(parseControlDescription(validComponentInstanceControlDescriptionValue)).toEqual(
-      right(validComponentInstanceControlDescriptionValue),
+  it('parses a raw js control description correctly', () => {
+    expect(parseControlDescription(validRawJSControlDescriptionValue)).toEqual(
+      right(validRawJSControlDescriptionValue),
     )
   })
   it('parses an ignore description correctly', () => {

--- a/editor/src/core/property-controls/property-controls-parser.ts
+++ b/editor/src/core/property-controls/property-controls-parser.ts
@@ -1,7 +1,6 @@
 import {
   BooleanControlDescription,
   ColorControlDescription,
-  ComponentInstanceDescription,
   ControlDescription,
   EnumControlDescription,
   NumberControlDescription,
@@ -11,7 +10,6 @@ import {
   IgnoreControlDescription,
   UnionControlDescription,
   ImageControlDescription,
-  EventHandlerControlDescription,
   ArrayControlDescription,
   ObjectControlDescription,
   StyleObjectControlDescription,
@@ -20,11 +18,10 @@ import {
   ExpressionEnumControlDescription,
   ExpressionEnum,
   ImportType,
-  BaseControlDescription,
-  HigherLevelControlDescription,
   FolderControlDescription,
   PropertyControls,
   RegularControlDescription,
+  RawJSControlDescription,
 } from 'utopia-api'
 import { parseColor } from '../../components/inspector/common/css-utils'
 import {
@@ -187,23 +184,6 @@ export function parseExpressionEnum(value: unknown): ParseResult<ExpressionEnum>
   )
 }
 
-export function parseEventHandlerControlDescription(
-  value: unknown,
-): ParseResult<EventHandlerControlDescription> {
-  return applicative2Either(
-    (title, type) => {
-      let eventHandlerControlDescription: EventHandlerControlDescription = {
-        type: type,
-      }
-      setOptionalProp(eventHandlerControlDescription, 'title', title)
-
-      return eventHandlerControlDescription
-    },
-    optionalObjectKeyParser(parseString, 'title')(value),
-    objectKeyParser(parseEnum(['eventhandler']), 'type')(value),
-  )
-}
-
 export function parseBooleanControlDescription(
   value: unknown,
 ): ParseResult<BooleanControlDescription> {
@@ -350,20 +330,18 @@ export function parseColorControlDescription(value: unknown): ParseResult<ColorC
   )
 }
 
-export function parseComponentInstanceControlDescription(
-  value: unknown,
-): ParseResult<ComponentInstanceDescription> {
+export function parseRawJSControlDescription(value: unknown): ParseResult<RawJSControlDescription> {
   return applicative2Either(
     (title, type) => {
-      let componentInstanceDescription: ComponentInstanceDescription = {
+      let rawJSControlDescription: RawJSControlDescription = {
         type: type,
       }
-      setOptionalProp(componentInstanceDescription, 'title', title)
+      setOptionalProp(rawJSControlDescription, 'title', title)
 
-      return componentInstanceDescription
+      return rawJSControlDescription
     },
     optionalObjectKeyParser(parseString, 'title')(value),
-    objectKeyParser(parseEnum(['componentinstance']), 'type')(value),
+    objectKeyParser(parseEnum(['rawjs']), 'type')(value),
   )
 }
 
@@ -562,14 +540,10 @@ export function parseRegularControlDescription(
         return parseBooleanControlDescription(value)
       case 'color':
         return parseColorControlDescription(value)
-      case 'componentinstance':
-        return parseComponentInstanceControlDescription(value)
       case 'enum':
         return parseEnumControlDescription(value)
       case 'expression-enum':
         return parseExpressionEnumControlDescription(value)
-      case 'eventhandler':
-        return parseEventHandlerControlDescription(value)
       case 'ignore':
         return parseIgnoreControlDescription(value)
       case 'image':
@@ -580,6 +554,8 @@ export function parseRegularControlDescription(
         return parseOptionsControlDescription(value)
       case 'popuplist':
         return parsePopUpListControlDescription(value)
+      case 'rawjs':
+        return parseRawJSControlDescription(value)
       case 'string':
         return parseStringControlDescription(value)
       case 'styleobject':

--- a/editor/src/core/property-controls/third-party-property-controls/antd-controls.ts
+++ b/editor/src/core/property-controls/third-party-property-controls/antd-controls.ts
@@ -6,7 +6,7 @@ const Button: PropertyControls = {
     title: 'href',
   },
   onClick: {
-    type: 'eventhandler',
+    type: 'rawjs',
     title: 'onClick',
   },
   disabled: {
@@ -32,7 +32,7 @@ const Button: PropertyControls = {
     defaultValue: 'default',
   },
   icon: {
-    type: 'componentinstance',
+    type: 'rawjs',
     title: 'icon',
   },
   ghost: {
@@ -316,7 +316,7 @@ const Menu: PropertyControls = {
     title: 'onClick',
   },
   overflowedIndicator: {
-    type: 'componentinstance',
+    type: 'rawjs',
     title: 'overflowedIndicator',
   },
 }
@@ -336,7 +336,7 @@ const MenuItem: PropertyControls = {
     title: 'title',
   },
   icon: {
-    type: 'componentinstance',
+    type: 'rawjs',
     title: 'icon',
   },
   danger: {
@@ -365,7 +365,7 @@ const MenuSubMenu: PropertyControls = {
     title: 'title',
   },
   icon: {
-    type: 'componentinstance',
+    type: 'rawjs',
     title: 'icon',
   },
   onTitleClick: {

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -6,11 +6,9 @@ import { fastForEach } from '../utils'
 export type BaseControlType =
   | 'boolean'
   | 'color'
-  | 'componentinstance'
   | 'enum'
   | 'expression-enum'
   | 'euler'
-  | 'eventhandler'
   | 'ignore'
   | 'image'
   | 'matrix3'
@@ -19,6 +17,7 @@ export type BaseControlType =
   | 'options'
   | 'popuplist'
   | 'quaternion'
+  | 'rawjs'
   | 'string'
   | 'styleobject'
   | 'vector2'
@@ -42,11 +41,6 @@ export interface BooleanControlDescription extends AbstractBaseControlDescriptio
 
 export interface ColorControlDescription extends AbstractBaseControlDescription<'color'> {
   defaultValue?: string
-}
-
-export interface ComponentInstanceDescription
-  extends AbstractBaseControlDescription<'componentinstance'> {
-  defaultValue?: never
 }
 
 export type AllowedEnumType = string | boolean | number | undefined | null
@@ -79,11 +73,6 @@ export interface ExpressionEnumControlDescription
 
 export interface EulerControlDescription extends AbstractBaseControlDescription<'euler'> {
   defaultValue?: [number, number, number, string]
-}
-
-export interface EventHandlerControlDescription
-  extends AbstractBaseControlDescription<'eventhandler'> {
-  defaultValue?: never
 }
 
 export interface IgnoreControlDescription extends AbstractBaseControlDescription<'ignore'> {
@@ -148,6 +137,10 @@ export interface QuaternionControlDescription extends AbstractBaseControlDescrip
   defaultValue?: [number, number, number, number]
 }
 
+export interface RawJSControlDescription extends AbstractBaseControlDescription<'rawjs'> {
+  defaultValue?: unknown
+}
+
 export interface StringControlDescription extends AbstractBaseControlDescription<'string'> {
   defaultValue?: string
   placeholder?: string
@@ -174,11 +167,9 @@ export interface Vector4ControlDescription extends AbstractBaseControlDescriptio
 export type BaseControlDescription =
   | BooleanControlDescription
   | ColorControlDescription
-  | ComponentInstanceDescription
   | EnumControlDescription
   | ExpressionEnumControlDescription
   | EulerControlDescription
-  | EventHandlerControlDescription
   | IgnoreControlDescription
   | ImageControlDescription
   | Matrix3ControlDescription
@@ -187,6 +178,7 @@ export type BaseControlDescription =
   | OptionsControlDescription
   | PopUpListControlDescription
   | QuaternionControlDescription
+  | RawJSControlDescription
   | StringControlDescription
   | StyleObjectControlDescription
   | Vector2ControlDescription
@@ -240,11 +232,9 @@ export function isBaseControlDescription(
   switch (control.type) {
     case 'boolean':
     case 'color':
-    case 'componentinstance':
     case 'enum':
     case 'expression-enum':
     case 'euler':
-    case 'eventhandler':
     case 'ignore':
     case 'image':
     case 'matrix3':
@@ -253,6 +243,7 @@ export function isBaseControlDescription(
     case 'options':
     case 'popuplist':
     case 'quaternion':
+    case 'rawjs':
     case 'string':
     case 'styleobject':
     case 'vector2':


### PR DESCRIPTION
**Problem:**
We have 2 control types for dealing with raw JS: `'componentinstance'` and `'eventhandler'`

**Fix:**
Take the work from #1940 and use that as a `'rawjs'` control type, then replace the other two existing types with this. This also includes inference of React elements (excluding the `children` prop), and js functions as part of the property control inference.