### PR TITLE
layout(shadow subsection) - fix row height to not clip the section

### DIFF
--- a/editor/src/components/inspector/sections/style-section/shadow-subsection/shadow-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/shadow-subsection/shadow-subsection.tsx
@@ -143,7 +143,7 @@ interface ShadowItemProps {
   contextMenuItems: Array<ContextMenuItem<null>>
 }
 
-const rowHeight = UtopiaTheme.layout.rowHeight.normal
+const rowHeight = UtopiaTheme.layout.rowHeight.max
 
 const ShadowItem = betterReactMemo<ShadowItemProps>('ShadowItem', (props) => {
   const [enabledSubmitValueToggle] = props.useSubmitValueFactory(


### PR DESCRIPTION
**Problem:**
The shadow subsection rows were cut off unnecessarily, because they contained a row of labels

**Fix:**
Changed this, so that the rows use the maximum height
