### PR TITLE
layout(pin control) - makes the pin control less stretchy

### DIFF
--- a/editor/src/components/inspector/controls/pin-control.tsx
+++ b/editor/src/components/inspector/controls/pin-control.tsx
@@ -76,7 +76,7 @@ export const PinControl = (props: PinControlProps) => {
   return (
     <div id='pin-control' className={props.className} style={props.style}>
       <svg
-        width={`${Width}`}
+        width={Width}
         viewBox={`0 0 ${Width} ${Height}`}
         version='1.1'
         xmlns='http://www.w3.org/2000/svg'


### PR DESCRIPTION
**Problem:**
- The pin control would expand to fill available space _and preserve its aspect ratio_ - which isn't compatible with a variable width inspector. 
- It also didn't align well with the input fields

**Fix:**
- Make the pin control not take 100% of its available width
- Adjust height / padding / stroke to align More Perfectly with the inputs