### PR TITLE
ux(components) - improve array row height and add reorder indicators

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -345,7 +345,7 @@ const RowForArrayControl = betterReactMemo(
             return (
               <animated.div
                 {...bind(index)}
-                key={index}
+                key={index} //FIXME this causes the row drag handle to jump after finishing the re-order
                 style={{
                   ...springStyle,
                   width: '100%',


### PR DESCRIPTION
**Problem:**
- Our array control for components is too tall for each row
- It was reorderable, but doesn't indicate this

**Fix:**
- Change  height to `normal`
- Show a reorder indicator on hover

![image](https://user-images.githubusercontent.com/2945037/139083636-f26b92af-78f5-4d48-bb5d-b6c0f256c5b8.png)

NB there's a bit of flicker after the re-order