### PR TITLE
feature(component-section) focus new rows for unused props

### DIFF
--- a/editor/src/components/inspector/controls/boolean-control.tsx
+++ b/editor/src/components/inspector/controls/boolean-control.tsx
@@ -6,6 +6,7 @@ import { CheckboxInput } from '../../../uuiui'
 
 export interface BooleanControlProps extends DEPRECATEDControlProps<boolean> {
   onMouseDown?: (e: React.MouseEvent<HTMLInputElement>) => void
+  focusOnMount?: boolean
 }
 
 export const BooleanControl: React.FunctionComponent<BooleanControlProps> = ({
@@ -27,6 +28,7 @@ export const BooleanControl: React.FunctionComponent<BooleanControlProps> = ({
       id={props.id}
       onChange={onSubmitValue}
       onMouseDown={props.onMouseDown}
+      focusOnMount={props.focusOnMount}
     />
   )
 }

--- a/editor/src/components/inspector/controls/string-control.tsx
+++ b/editor/src/components/inspector/controls/string-control.tsx
@@ -68,6 +68,7 @@ export const StringControl = betterReactMemo(
           className={inputClassName}
           placeholder={mixed ? 'mixed' : undefined}
           onFocus={props.onFocus}
+          focusOnMount={props.focus}
           onBlur={inputOnBlur}
           onChange={inputOnChange}
           value={getDisplayValue()}

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -198,6 +198,7 @@ interface AbstractRowForControlProps {
   isScene: boolean
   setGlobalCursor: (cursor: CSSCursor | null) => void
   indentationLevel: number
+  focusOnMount: boolean
 }
 
 function titleForControl(propPath: PropertyPath, control: RegularControlDescription): string {
@@ -273,6 +274,7 @@ const RowForBaseControl = betterReactMemo('RowForBaseControl', (props: RowForBas
           controlDescription={controlDescription}
           propMetadata={propMetadata}
           setGlobalCursor={props.setGlobalCursor}
+          focusOnMount={props.focusOnMount}
         />
       </UIGridRow>
     </InspectorContextMenuWrapper>
@@ -359,6 +361,7 @@ const RowForArrayControl = betterReactMemo(
                   propPath={PP.appendPropertyPathElems(propPath, [index])}
                   setGlobalCursor={props.setGlobalCursor}
                   indentationLevel={1}
+                  focusOnMount={props.focusOnMount && index === 0}
                 />
               </animated.div>
             )
@@ -371,6 +374,7 @@ const RowForArrayControl = betterReactMemo(
             propPath={PP.appendPropertyPathElems(propPath, [springs.length])}
             setGlobalCursor={props.setGlobalCursor}
             indentationLevel={1}
+            focusOnMount={false}
           />
         ) : null}
       </React.Fragment>
@@ -453,7 +457,7 @@ const RowForObjectControl = betterReactMemo(
           </div>
           {when(
             open,
-            mapToArray((innerControl: RegularControlDescription, prop: string) => {
+            mapToArray((innerControl: RegularControlDescription, prop: string, index: number) => {
               const innerPropPath = PP.appendPropertyPathElems(propPath, [prop])
               return (
                 <RowForControl
@@ -463,6 +467,7 @@ const RowForObjectControl = betterReactMemo(
                   propPath={innerPropPath}
                   setGlobalCursor={props.setGlobalCursor}
                   indentationLevel={props.indentationLevel + 1}
+                  focusOnMount={props.focusOnMount && index === 0}
                 />
               )
             }, controlDescription.object),
@@ -531,13 +536,18 @@ const RowForUnionControl = betterReactMemo(
       return null
     } else if (isBaseControlDescription(controlToUse)) {
       return (
-        <RowForBaseControl {...props} label={labelAsRenderProp} controlDescription={controlToUse} />
+        <RowForBaseControl
+          {...props}
+          label={labelAsRenderProp}
+          controlDescription={controlToUse}
+          focusOnMount={false}
+        />
       )
     } else {
       return (
         <React.Fragment>
           {label}
-          <RowForControl {...props} controlDescription={controlToUse} />
+          <RowForControl {...props} controlDescription={controlToUse} focusOnMount={false} />
         </React.Fragment>
       )
     }

--- a/editor/src/components/inspector/sections/component-section/folder-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/folder-section.tsx
@@ -79,7 +79,7 @@ export const FolderSection = betterReactMemo('FolderSection', (props: FolderSect
     [props.isRoot, colorTheme],
   )
 
-  const createRowForControl = (propName: string) => {
+  const createRowForControl = (propName: string, focusOnMount: boolean) => {
     const controlDescription = props.parsedPropertyControls[propName]
     return foldEither(
       (propertyError) => {
@@ -104,6 +104,7 @@ export const FolderSection = betterReactMemo('FolderSection', (props: FolderSect
             visibleEmptyControls={props.visibleEmptyControls}
             unsetPropNames={props.unsetPropNames}
             showHiddenControl={props.showHiddenControl}
+            focusOnMount={focusOnMount}
           />
         )
       },
@@ -122,7 +123,10 @@ export const FolderSection = betterReactMemo('FolderSection', (props: FolderSect
           title={props.title ?? ''}
         />,
       )}
-      {when(open, controlsWithValue.map(createRowForControl))}
+      {when(
+        open,
+        controlsWithValue.map((control) => createRowForControl(control, false)),
+      )}
       {when(
         props.isRoot,
         Object.keys(props.detectedPropsAndValuesWithoutControls).map((propName) => {
@@ -139,11 +143,15 @@ export const FolderSection = betterReactMemo('FolderSection', (props: FolderSect
               isScene={false}
               setGlobalCursor={props.setGlobalCursor}
               indentationLevel={props.indentationLevel + 1}
+              focusOnMount={false}
             />
           )
         }),
       )}
-      {when(open, emptyControls.map(createRowForControl))}
+      {when(
+        open,
+        emptyControls.map((control) => createRowForControl(control, true)),
+      )}
       {when(
         open,
         <HiddenControls

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -69,6 +69,7 @@ export interface ControlForPropProps<T extends BaseControlDescription> {
   controlDescription: T
   propMetadata: InspectorInfo<any>
   setGlobalCursor: (cursor: CSSCursor | null) => void
+  focusOnMount: boolean
 }
 
 export const ControlForBooleanProp = betterReactMemo(
@@ -90,6 +91,7 @@ export const ControlForBooleanProp = betterReactMemo(
         onSubmitValue={propMetadata.onSubmitValue}
         controlStatus={propMetadata.controlStatus}
         controlStyles={propMetadata.controlStyles}
+        focusOnMount={props.focusOnMount}
       />
     )
   },
@@ -173,6 +175,7 @@ export const ControlForRawJSProp = betterReactMemo(
         onSubmitValue={submitValue}
         controlStatus={propMetadata.controlStatus}
         controlStyles={controlStyles}
+        focus={props.focusOnMount}
       />
     )
   },
@@ -213,6 +216,7 @@ export const ControlForEnumProp = betterReactMemo(
         onSubmitValue={submitValue}
         options={options}
         containerMode={'default'}
+        autoFocus={props.focusOnMount}
       />
     )
   },
@@ -289,6 +293,7 @@ export const ControlForExpressionEnumProp = betterReactMemo(
         onSubmitValue={submitValue}
         options={options}
         containerMode={'default'}
+        autoFocus={props.focusOnMount}
       />
     )
   },
@@ -319,6 +324,7 @@ export const ControlForImageProp = betterReactMemo(
         }
         controlStatus={propMetadata.controlStatus}
         controlStyles={controlStyles}
+        focus={props.focusOnMount}
       />
     )
   },
@@ -366,6 +372,7 @@ export const ControlForNumberProp = betterReactMemo(
           maximum={controlDescription.max}
           labelInner={controlDescription.unit}
           defaultUnitToHide={'px'}
+          focusOnMount={props.focusOnMount}
         />
       )
     }
@@ -420,6 +427,7 @@ export const ControlForPopupListProp = betterReactMemo(
         onSubmitValue={submitValue}
         options={controlDescription.options}
         containerMode={'default'}
+        autoFocus={props.focusOnMount}
       />
     )
   },
@@ -466,6 +474,7 @@ export const NumberWithSliderControl = betterReactMemo(
           minimum={controlDescription.min}
           maximum={controlDescription.max}
           defaultUnitToHide={'px'}
+          focusOnMount={props.focusOnMount}
         />
       </UIGridRow>
     )
@@ -491,6 +500,7 @@ export const ControlForStringProp = betterReactMemo(
         onSubmitValue={propMetadata.onSubmitValue}
         controlStatus={propMetadata.controlStatus}
         controlStyles={propMetadata.controlStyles}
+        focus={props.focusOnMount}
       />
     )
   },

--- a/editor/src/components/inspector/sections/component-section/row-or-folder-wrapper.tsx
+++ b/editor/src/components/inspector/sections/component-section/row-or-folder-wrapper.tsx
@@ -20,6 +20,7 @@ type RowOrFolderWrapperProps = {
   visibleEmptyControls: string[]
   unsetPropNames: string[]
   showHiddenControl: (path: string) => void
+  focusOnMount?: boolean
 }
 
 export const RowOrFolderWrapper = betterReactMemo(
@@ -57,6 +58,7 @@ export const RowOrFolderWrapper = betterReactMemo(
               isScene={props.isScene}
               setGlobalCursor={props.setGlobalCursor}
               indentationLevel={props.indentationLevel}
+              focusOnMount={props.focusOnMount ?? false}
             />
           </UIGridRow>
         )

--- a/editor/src/core/shared/object-utils.ts
+++ b/editor/src/core/shared/object-utils.ts
@@ -152,14 +152,14 @@ export function forEachValue<T>(fn: (val: ValueOf<T>, key: keyof T) => void, obj
 }
 
 export function mapToArray<T, U>(
-  fn: (val: T, key: string) => U,
+  fn: (val: T, key: string, index: number) => U,
   obj: { [key: string]: T },
 ): Array<U> {
   const keys = Object.keys(obj)
   let result: Array<U> = []
-  fastForEach(keys, (key) => {
+  fastForEach(keys, (key, index) => {
     const value = obj[key]
-    result.push(fn(value, key))
+    result.push(fn(value, key, index))
   })
 
   return result

--- a/editor/src/uuiui/inputs/checkbox-input.tsx
+++ b/editor/src/uuiui/inputs/checkbox-input.tsx
@@ -30,6 +30,12 @@ export const CheckboxInput = betterReactMemo(
         }
       })
 
+      React.useEffect(() => {
+        if (focusOnMount && ref.current != null) {
+          ref.current.focus()
+        }
+      }, [focusOnMount, ref])
+
       const colorTheme = useColorTheme()
       const checked =
         props.checked != null && (controlStyles.interactive || controlStyles.showContent)


### PR DESCRIPTION
**Problem:**
In the component section clicking on a list element from the empty props list creates a new control to allow editing. It should be focused automatically.

**Fix:**
Adding 'focusOnMount' to string, number, boolean and popuplist controls in the component-section. For array and object controls it is focusing the first item. Inside the `FolderSection` the visible empty controls are passing the focusOnMount prop to the controls.

**Commit Details:**
- updated checkbox-input to use focus on mount
- string, number and popuplist controls already have this prop
