### PR TITLE
sendPropertyControlsInfoRequest if the project files changed

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -92,9 +92,11 @@ import {
   combineAccumulatedVSCodeChanges,
   getVSCodeChanges,
   sendVSCodeChanges,
+  WriteProjectFileChange,
 } from './vscode-changes'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { isJsOrTsFile, isCssFile } from '../../../core/shared/file-utils'
+import { sendPropertyControlsInfoRequest } from '../../../core/property-controls/property-controls-utils'
 
 export interface DispatchResult extends EditorStore {
   nothingChanged: boolean
@@ -518,6 +520,8 @@ export function editorDispatch(
     })
   }
 
+  triggerPropertyControlsIframeIfNeeded(storedState.editor, frozenEditorState)
+
   const shouldUpdatePreview =
     anySendPreviewModel || frozenEditorState.projectContents !== storedState.editor.projectContents
   if (shouldUpdatePreview) {
@@ -710,5 +714,30 @@ function elementPathStillExists(
     return pathToUpdate
   } else {
     return null
+  }
+}
+
+function triggerPropertyControlsIframeIfNeeded(oldEditor: EditorState, newEditor: EditorState) {
+  const newVSCodeChanges = getVSCodeChanges(oldEditor, newEditor, false)
+  const updatedProjectCodeFilePaths: Array<string> = mapDropNulls((change) => {
+    if (change.type === 'WRITE_PROJECT_FILE') {
+      return change.fullPath
+    } else {
+      return null
+    }
+  }, newVSCodeChanges.fileChanges)
+
+  if (updatedProjectCodeFilePaths.length > 0) {
+    const updatedAndReverseDepFilenames = getTransitiveReverseDependencies(
+      newEditor.projectContents,
+      newEditor.nodeModules.files,
+      updatedProjectCodeFilePaths,
+    )
+    sendPropertyControlsInfoRequest(
+      newEditor.nodeModules.files,
+      newEditor.projectContents,
+      true,
+      updatedAndReverseDepFilenames,
+    )
   }
 }

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -93,6 +93,7 @@ import {
   getVSCodeChanges,
   sendVSCodeChanges,
   WriteProjectFileChange,
+  ProjectChange,
 } from './vscode-changes'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { isJsOrTsFile, isCssFile } from '../../../core/shared/file-utils'
@@ -505,22 +506,21 @@ export function editorDispatch(
     )
   }
 
+  const newVSCodeChanges = getVSCodeChanges(storedState.editor, frozenEditorState)
+  currentVSCodeChanges = combineAccumulatedVSCodeChanges(currentVSCodeChanges, newVSCodeChanges)
+
   if (frozenEditorState.vscodeReady) {
     // Chain off of the previous one to ensure the ordering is maintained.
-    currentVSCodeChanges = combineAccumulatedVSCodeChanges(
-      currentVSCodeChanges,
-      getVSCodeChanges(storedState.editor, frozenEditorState, updatedFromVSCode),
-    )
     applyProjectChangesCoordinator = applyProjectChangesCoordinator.then(async () => {
       const changesToSend = currentVSCodeChanges
       currentVSCodeChanges = emptyAccumulatedVSCodeChanges
-      return sendVSCodeChanges(changesToSend).catch((error) => {
+      return sendVSCodeChanges(changesToSend, updatedFromVSCode).catch((error) => {
         console.error('Error sending updates to VS Code', error)
       })
     })
   }
 
-  triggerPropertyControlsIframeIfNeeded(storedState.editor, frozenEditorState)
+  triggerPropertyControlsIframeIfNeeded(frozenEditorState, newVSCodeChanges.fileChanges)
 
   const shouldUpdatePreview =
     anySendPreviewModel || frozenEditorState.projectContents !== storedState.editor.projectContents
@@ -717,15 +717,17 @@ function elementPathStillExists(
   }
 }
 
-function triggerPropertyControlsIframeIfNeeded(oldEditor: EditorState, newEditor: EditorState) {
-  const newVSCodeChanges = getVSCodeChanges(oldEditor, newEditor, false)
+function triggerPropertyControlsIframeIfNeeded(
+  newEditor: EditorState,
+  fileChanges: ProjectChange[],
+) {
   const updatedProjectCodeFilePaths: Array<string> = mapDropNulls((change) => {
     if (change.type === 'WRITE_PROJECT_FILE') {
       return change.fullPath
     } else {
       return null
     }
-  }, newVSCodeChanges.fileChanges)
+  }, fileChanges)
 
   if (updatedProjectCodeFilePaths.length > 0) {
     const updatedAndReverseDepFilenames = getTransitiveReverseDependencies(

--- a/editor/src/components/editor/store/vscode-changes.ts
+++ b/editor/src/components/editor/store/vscode-changes.ts
@@ -212,9 +212,8 @@ export function shouldIncludeSelectedElementChanges(
 export function getProjectContentsChanges(
   oldEditorState: EditorState,
   newEditorState: EditorState,
-  updateCameFromVSCode: boolean,
 ): Array<ProjectChange> {
-  if (oldEditorState.vscodeBridgeId != null && !updateCameFromVSCode) {
+  if (oldEditorState.vscodeBridgeId != null) {
     return collateProjectChanges(
       getUnderlyingVSCodeBridgeID(oldEditorState.vscodeBridgeId),
       oldEditorState.projectContents,
@@ -288,10 +287,9 @@ export function localAccumulatedToVSCodeAccumulated(
 export function getVSCodeChanges(
   oldEditorState: EditorState,
   newEditorState: EditorState,
-  updateCameFromVSCode: boolean,
 ): AccumulatedVSCodeChanges {
   return {
-    fileChanges: getProjectContentsChanges(oldEditorState, newEditorState, updateCameFromVSCode),
+    fileChanges: getProjectContentsChanges(oldEditorState, newEditorState),
     updateDecorations: shouldIncludeVSCodeDecorations(oldEditorState, newEditorState)
       ? getCodeEditorDecorations(newEditorState)
       : null,


### PR DESCRIPTION
**Problem:**
The property controls iframe "worker" would only run at project load.

Turns out it is because no one called `sendPropertyControlsInfoRequest`, only `generateCodeResultCache` which is only called when node_modules changes or at project load.

**Fix:**
Add a new `triggerPropertyControlsIframeIfNeeded()` and call it at the end of `dispatch`.

**Commit Details:**
- New "dispatch middleware" function `triggerPropertyControlsIframeIfNeeded`
- It internally uses `getVSCodeChanges`. Unfortunately it needs to call `getVSCodeChanges` itself  and cannot reuse the other `getVSCodeChanges` from the `sendVSCodeChanges` code in dispatch.tsx
