### PR TITLE
layout(inspector) - make it scrollable again

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -400,10 +400,11 @@ const ResizableInspectorPane = betterReactMemo<ResizableInspectorPaneProps>(
             alignItems: 'stretch',
             flexDirection: 'column',
             width: '100%',
+            height: '100%',
+            overflowY: 'scroll',
             backgroundColor: colorTheme.inspectorBackground.value,
             flexGrow: 0,
             flexShrink: 0,
-            overflowY: 'scroll',
             paddingBottom: 100,
           }}
         >


### PR DESCRIPTION
Fixes #1962 

**Problem:**
Recent changes made the inspector scroll the entire editor, because the scrollable container (`overflow-y`) was expanding vertically to fit its contents, therefore never triggering scrolling behaviour.

**Fix:**
Give the container an explicit height of 100%.