### PR TITLE
Ensure the evaluationCache is cleared on transitive dependencies

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-code-execution.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-code-execution.spec.browser2.tsx
@@ -1,0 +1,113 @@
+import {
+  isParseSuccess,
+  ParsedTextFile,
+  RevisionsState,
+  textFile,
+  textFileContents,
+} from '../../../core/shared/project-file-types'
+import { emptySet } from '../../../core/shared/set-utils'
+import { lintAndParse } from '../../../core/workers/parser-printer/parser-printer'
+import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
+import { updateFile } from '../../editor/actions/action-creators'
+import { StoryboardFilePath } from '../../editor/store/editor-state'
+import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
+
+const indirectFilePath = '/src/indirect.js'
+const indirectDependencyValueBefore = 'Initial indirect dependency value'
+const indirectFileContent = `export const IndirectDependencyValue = '${indirectDependencyValueBefore}'`
+
+const directFilePath = '/src/direct.js'
+const directFileContent = `
+import { IndirectDependencyValue } from '${indirectFilePath}'
+
+export const DirectDependencyValue = 'IndirectDependencyValue: ' + IndirectDependencyValue
+`
+
+const appFilePath = '/src/app.js'
+const appFileContent = `
+import * as React from 'react'
+import { DirectDependencyValue } from '${directFilePath}'
+export var App = (props) => {
+  return (
+    <div
+      data-testid='app-root-div'
+      data-uid='app-root'
+      style={{
+        position: 'relative',
+        left: 0,
+        top: 0,
+        width: '100%',
+        height: '100%'
+      }}
+    >
+      { DirectDependencyValue }
+    </div>
+  )
+}
+`
+
+const storyboardFileContent = `
+import * as React from 'react';
+import { Scene, Storyboard } from 'utopia-api';
+import { App } from '${appFilePath}';
+
+export var storyboard = (
+  <Storyboard data-uid='storyboard'>
+    <Scene
+      data-uid='scene'
+      style={{ position: 'absolute', left: 400, top: 0, width: 375, height: 812 }}
+    >
+      <App data-uid='app' />
+    </Scene>
+  </Storyboard>
+);
+`
+
+async function createAndRenderProject() {
+  const project = createModifiedProject({
+    [StoryboardFilePath]: storyboardFileContent,
+    [appFilePath]: appFileContent,
+    [directFilePath]: directFileContent,
+    [indirectFilePath]: indirectFileContent,
+  })
+  return renderTestEditorWithModel(project, 'await-first-dom-report')
+}
+
+describe('Updating a transitive dependency', () => {
+  it('Updates the rendered result', async () => {
+    const { dispatch, renderedDOM } = await createAndRenderProject()
+
+    const appRootDivBefore = renderedDOM.getByTestId('app-root-div')
+    expect(appRootDivBefore.innerText).toEqual(
+      `IndirectDependencyValue: ${indirectDependencyValueBefore}`,
+    )
+
+    const indirectDependencyValueAfter = 'Updated indirect dependency value'
+    const updatedIndirectFileContent = `export const IndirectDependencyValue = '${indirectDependencyValueAfter}'`
+
+    const updatedIndirectFileParsedTextFile = lintAndParse(
+      indirectFilePath,
+      updatedIndirectFileContent,
+      null,
+      emptySet(),
+    ) as ParsedTextFile
+
+    const updatedIndirectFile = textFile(
+      textFileContents(
+        updatedIndirectFileContent,
+        updatedIndirectFileParsedTextFile,
+        RevisionsState.BothMatch,
+      ),
+      null,
+      isParseSuccess(updatedIndirectFileParsedTextFile) ? updatedIndirectFileParsedTextFile : null,
+      Date.now(),
+    )
+
+    await dispatch([updateFile(indirectFilePath, updatedIndirectFile, false)], true)
+
+    const appRootDivAfter = renderedDOM.getByTestId('app-root-div')
+    expect(appRootDivAfter.innerText).toEqual(
+      `IndirectDependencyValue: ${indirectDependencyValueAfter}`,
+    )
+  })
+})

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -87,13 +87,13 @@ import {
   getUnsavedCodeFromTextFile,
 } from '../../../core/model/project-file-utils'
 import {
-  AccumulatedVSCodeChanges,
-  emptyAccumulatedVSCodeChanges,
-  combineAccumulatedVSCodeChanges,
-  getVSCodeChanges,
+  ProjectChanges,
+  emptyProjectChanges,
+  combineProjectChanges,
+  getProjectChanges,
   sendVSCodeChanges,
   WriteProjectFileChange,
-  ProjectChange,
+  ProjectFileChange,
 } from './vscode-changes'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { isJsOrTsFile, isCssFile } from '../../../core/shared/file-utils'
@@ -353,7 +353,7 @@ function maybeRequestModelUpdateOnEditor(
   }
 }
 
-let currentVSCodeChanges: AccumulatedVSCodeChanges = emptyAccumulatedVSCodeChanges
+let accumulatedProjectChanges: ProjectChanges = emptyProjectChanges
 let applyProjectChangesCoordinator: Promise<void> = Promise.resolve()
 
 export function editorDispatch(
@@ -509,8 +509,8 @@ export function editorDispatch(
     )
   }
 
-  const newVSCodeChanges = getVSCodeChanges(storedState.editor, frozenEditorState)
-  applyProjectChanges(frozenEditorState, newVSCodeChanges, updatedFromVSCode)
+  const projectChanges = getProjectChanges(storedState.editor, frozenEditorState)
+  applyProjectChanges(frozenEditorState, projectChanges, updatedFromVSCode)
 
   const shouldUpdatePreview =
     anySendPreviewModel || frozenEditorState.projectContents !== storedState.editor.projectContents
@@ -527,28 +527,28 @@ export function editorDispatch(
 
 function applyProjectChanges(
   frozenEditorState: EditorState,
-  accumulatedChanges: AccumulatedVSCodeChanges,
+  projectChanges: ProjectChanges,
   updatedFromVSCode: boolean,
 ) {
-  triggerPropertyControlsIframeIfNeeded(frozenEditorState, accumulatedChanges.fileChanges)
+  triggerPropertyControlsIframeIfNeeded(frozenEditorState, projectChanges.fileChanges)
 
-  currentVSCodeChanges = combineAccumulatedVSCodeChanges(
-    currentVSCodeChanges,
-    updatedFromVSCode ? { ...accumulatedChanges, fileChanges: [] } : accumulatedChanges,
+  accumulatedProjectChanges = combineProjectChanges(
+    accumulatedProjectChanges,
+    updatedFromVSCode ? { ...projectChanges, fileChanges: [] } : projectChanges,
   )
 
   if (frozenEditorState.vscodeReady) {
     // Chain off of the previous one to ensure the ordering is maintained.
     applyProjectChangesCoordinator = applyProjectChangesCoordinator.then(async () => {
-      const changesToSend = currentVSCodeChanges
-      currentVSCodeChanges = emptyAccumulatedVSCodeChanges
+      const changesToSend = accumulatedProjectChanges
+      accumulatedProjectChanges = emptyProjectChanges
       return sendVSCodeChanges(changesToSend).catch((error) => {
         console.error('Error sending updates to VS Code', error)
       })
     })
   }
 
-  const updatedFileNames = accumulatedChanges.fileChanges.map((fileChange) => fileChange.fullPath)
+  const updatedFileNames = projectChanges.fileChanges.map((fileChange) => fileChange.fullPath)
   const updatedAndReverseDepFilenames = getTransitiveReverseDependencies(
     frozenEditorState.projectContents,
     frozenEditorState.nodeModules.files,
@@ -746,7 +746,7 @@ function elementPathStillExists(
 
 function triggerPropertyControlsIframeIfNeeded(
   newEditor: EditorState,
-  fileChanges: Array<ProjectChange>,
+  fileChanges: Array<ProjectFileChange>,
 ) {
   const updatedProjectCodeFilePaths: Array<string> = mapDropNulls((change) => {
     if (change.type === 'WRITE_PROJECT_FILE') {

--- a/editor/src/components/editor/store/vscode-changes.spec.ts
+++ b/editor/src/components/editor/store/vscode-changes.spec.ts
@@ -1,5 +1,5 @@
 import {
-  combineAccumulatedVSCodeChanges,
+  combineProjectChanges,
   deletePathChange,
   ensureDirectoryExistsChange,
   writeProjectFileChange,
@@ -28,7 +28,7 @@ describe('combineAccumulatedVSCodeChanges', () => {
       selectedChanged: null,
     }
 
-    const result = combineAccumulatedVSCodeChanges(first, second)
+    const result = combineProjectChanges(first, second)
     expect(result).toEqual({
       fileChanges: [
         ensureDirectoryExists1,

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -62,7 +62,7 @@ import {
   getHighlightBoundsForElementPath,
   getOpenTextFileKey,
 } from '../../components/editor/store/editor-state'
-import { ProjectChange } from '../../components/editor/store/vscode-changes'
+import { ProjectFileChange } from '../../components/editor/store/vscode-changes'
 
 const Scheme = 'utopia'
 const RootDir = `/${Scheme}`
@@ -244,7 +244,7 @@ export async function sendGetUtopiaVSCodeConfigMessage(): Promise<void> {
   return sendMessage(getUtopiaVSCodeConfig())
 }
 
-export async function applyProjectChanges(changes: Array<ProjectChange>): Promise<void> {
+export async function applyProjectChanges(changes: Array<ProjectFileChange>): Promise<void> {
   for (const change of changes) {
     switch (change.type) {
       case 'DELETE_PATH':


### PR DESCRIPTION
Fixes #1969 

**Problem:**
When making changes to a file, the bundler worker was previously relied upon to clear all cached evaluations of transitive dependencies of that file. When we removed the bundler worker from the main editor, we regressed and lost that functionality.

**Fix:**
Restore the cache clearing, this time incorporating it into the `editorDispatch` via a newly added `applyProjectChanges` function. This function uses the `AccumulatedVSCodeChanges` (which includes an array of all changes made to files as part of this action dispatch handling), allowing us to call any side-effecting (yuck, evil!) code that should result from those project content changes.

**TODO**

- [ ] Add tests