### PR TITLE
feature(components) component with registerControls is added to the insert menu list

### DIFF
--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -1,6 +1,6 @@
 import Utils from '../../utils/utils'
 import { EmitFileResult } from '../../core/workers/ts/ts-worker'
-import { PropertyControls } from 'utopia-api'
+import { ImportType, PropertyControls } from 'utopia-api'
 import { RawSourceMap } from '../../core/workers/ts/ts-typings/RawSourceMap'
 import {
   getControlsForExternalDependencies,
@@ -81,7 +81,12 @@ export type UtopiaRequireFn = (
 export type CurriedUtopiaRequireFn = (projectContents: ProjectContentTreeRoot) => UtopiaRequireFn
 
 export type PropertyControlsInfo = {
-  [filenameNoExtension: string]: { [componentName: string]: PropertyControls }
+  [filenameNoExtension: string]: {
+    [componentName: string]: {
+      propertyControls: PropertyControls
+      componentInfo: { requiredImports?: Array<ImportType> }
+    }
+  }
 }
 
 export type ResolveFn = (importOrigin: string, toImport: string) => Either<string, string>

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -157,8 +157,8 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
     propertyControlsInfo: {
       ...initialEditorState.propertyControlsInfo,
       '/utopia/storyboard': {
-        App: propertyControlsForApp,
-        OtherComponent: propertyControlsForOtherComponent,
+        App: { propertyControls: propertyControlsForApp, componentInfo: {} },
+        OtherComponent: { propertyControls: propertyControlsForOtherComponent, componentInfo: {} },
       },
     },
     jsxMetadata: metadata,

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -50,7 +50,11 @@ import { EventHandlerControl } from '../event-handlers-section/event-handlers-se
 import { OptionChainControl } from '../../controls/option-chain-control'
 import { useKeepReferenceEqualityIfPossible } from '../../../../utils/react-performance'
 import { UIGridRow } from '../../widgets/ui-grid-row'
-import { importDetails, Imports, PropertyPath } from '../../../../core/shared/project-file-types'
+import {
+  importDetailsFromImportOption,
+  Imports,
+  PropertyPath,
+} from '../../../../core/shared/project-file-types'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { addImports, forceParseFile, setProp_UNSAFE } from '../../../editor/actions/action-creators'
 import { jsxAttributeOtherJavaScript } from '../../../../core/shared/element-template'
@@ -307,13 +311,7 @@ export const ExpressionPopUpListPropertyControl = betterReactMemo(
         if (expressionOption != null && expressionOption.requiredImport != null) {
           const importOption = expressionOption.requiredImport
           const importToAdd: Imports = {
-            [importOption.source]: importDetails(
-              importOption.type === 'default' ? importOption.name : null,
-              importOption.type == null
-                ? [{ name: importOption.name, alias: importOption.name }]
-                : [],
-              importOption.type === 'star' ? importOption.name : null,
-            ),
+            [importOption.source]: importDetailsFromImportOption(importOption),
           }
           actions.push(addImports(importToAdd, target))
         }

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -414,7 +414,7 @@ Array [
             "importedWithName": null,
           },
         },
-        "name": "Date Picker",
+        "name": "DatePicker",
         "stylePropOptions": Array [
           "do-not-add",
           "add-size",
@@ -611,7 +611,7 @@ Array [
             "importedWithName": null,
           },
         },
-        "name": "Number Input",
+        "name": "InputNumber",
         "stylePropOptions": Array [
           "do-not-add",
           "add-size",
@@ -1236,7 +1236,7 @@ Array [
             "importedWithName": null,
           },
         },
-        "name": "Menu Item",
+        "name": "Menu.Item",
         "stylePropOptions": Array [
           "do-not-add",
           "add-size",
@@ -1289,7 +1289,7 @@ Array [
             "importedWithName": null,
           },
         },
-        "name": "Menu SubMenu",
+        "name": "Menu.SubMenu",
         "stylePropOptions": Array [
           "do-not-add",
           "add-size",
@@ -1325,7 +1325,7 @@ Array [
             "importedWithName": null,
           },
         },
-        "name": "Menu ItemGroup",
+        "name": "Menu.ItemGroup",
         "stylePropOptions": Array [
           "do-not-add",
           "add-size",
@@ -1522,7 +1522,7 @@ Array [
             "importedWithName": null,
           },
         },
-        "name": "Typography Text",
+        "name": "Typography.Text",
         "stylePropOptions": Array [
           "do-not-add",
           "add-size",

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -1,6 +1,7 @@
 import { PropertyControls } from 'utopia-api'
 import { URL_HASH } from '../../common/env-vars'
 import { defaultPropertiesForComponentInFile } from '../../core/property-controls/property-controls-utils'
+import { mapArrayToDictionary } from '../../core/shared/array-utils'
 import { flatMapEither, foldEither, right } from '../../core/shared/either'
 import {
   emptyComments,
@@ -19,6 +20,7 @@ import {
   PossiblyUnversionedNpmDependency,
 } from '../../core/shared/npm-dependency-types'
 import {
+  importDetailsFromImportOption,
   Imports,
   isParsedTextFile,
   isParseSuccess,
@@ -410,9 +412,13 @@ export function getComponentGroups(
           const defaultAttributes = getDefaultPropsAsAttributes(
             propertyControlsForDependency[name].propertyControls,
           )
-          const importsToAdd = propertyControlsForDependency[name].componentInfo.requiredImports
+          const importsToAdd: Imports = mapArrayToDictionary(
+            propertyControlsForDependency[name].componentInfo.requiredImports ?? [],
+            (importInfo) => importInfo.source,
+            (importInfo) => importDetailsFromImportOption(importInfo),
+          )
           return componentDescriptor(
-            {},
+            importsToAdd,
             jsxElementWithoutUID(elementName, defaultAttributes, []),
             name,
             propertyControlsForDependency[name].propertyControls,

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -407,12 +407,15 @@ export function getComponentGroups(
             elementNameAsArray.length > 0
               ? jsxElementName(elementNameAsArray.shift()!, elementNameAsArray)
               : name
-          const defaultAttributes = getDefaultPropsAsAttributes(propertyControlsForDependency[name])
+          const defaultAttributes = getDefaultPropsAsAttributes(
+            propertyControlsForDependency[name].propertyControls,
+          )
+          const importsToAdd = propertyControlsForDependency[name].componentInfo.requiredImports
           return componentDescriptor(
             {},
             jsxElementWithoutUID(elementName, defaultAttributes, []),
             name,
-            propertyControlsForDependency[name],
+            propertyControlsForDependency[name].propertyControls,
           )
         })
 

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -216,7 +216,7 @@ function makeHTMLDescriptor(
   }
   addDefaultProps(propertyControls)
   return componentDescriptor(
-    addImport('', 'react', null, [], 'React', emptyImportsValue),
+    [{ source: 'react', name: 'React', type: 'star' }],
     jsxElementWithoutUID(tag, defaultProps, []),
     tag,
     propertyControls,
@@ -380,7 +380,11 @@ export function getComponentGroups(
         }
       }
       return insertableComponent(
-        component.importsToAdd,
+        mapArrayToDictionary(
+          component.importsToAdd,
+          (importOption) => importOption.source,
+          (importOption) => importDetailsFromImportOption(importOption),
+        ),
         component.element,
         component.name,
         stylePropOptions,
@@ -412,13 +416,10 @@ export function getComponentGroups(
           const defaultAttributes = getDefaultPropsAsAttributes(
             propertyControlsForDependency[name].propertyControls,
           )
-          const importsToAdd: Imports = mapArrayToDictionary(
-            propertyControlsForDependency[name].componentInfo.requiredImports ?? [],
-            (importInfo) => importInfo.source,
-            (importInfo) => importDetailsFromImportOption(importInfo),
-          )
+          const requiredImports =
+            propertyControlsForDependency[name].componentInfo.requiredImports ?? []
           return componentDescriptor(
-            importsToAdd,
+            requiredImports,
             jsxElementWithoutUID(elementName, defaultAttributes, []),
             name,
             propertyControlsForDependency[name].propertyControls,

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -408,11 +408,8 @@ export function getComponentGroups(
       const propertyControlsForDependency = propertyControlsInfo[dependency.name]
       if (propertyControlsForDependency != null) {
         const components = Object.keys(propertyControlsForDependency).map((name) => {
-          const elementNameAsArray = name.split('.')
-          const elementName =
-            elementNameAsArray.length > 0
-              ? jsxElementName(elementNameAsArray.shift()!, elementNameAsArray)
-              : name
+          const [baseVariable, ...propertyPathParts] = name.split('.')
+          const elementName = jsxElementName(baseVariable, propertyPathParts)
           const defaultAttributes = getDefaultPropsAsAttributes(
             propertyControlsForDependency[name].propertyControls,
           )

--- a/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
+++ b/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
@@ -1,6 +1,6 @@
 export const utopiaApiTypings = `declare module 'utopia-api/helpers/helper-functions' {
-  import { PropertyControls } from 'utopia-api/property-controls/property-controls';
-  export function registerControls(componentName: string, packageName: string, propertyControls: PropertyControls): void;
+  import { PropertyControls, ImportType } from 'utopia-api/property-controls/property-controls';
+  export function registerControls(componentName: string, packageName: string, propertyControls: PropertyControls, requiredImports?: Array<ImportType>): void;
   export type RawSingleBorderWidth = number | string;
   export type RawSplitBorderWidth = [
       RawSingleBorderWidth,

--- a/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
+++ b/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
@@ -377,7 +377,7 @@ declare module 'utopia-api/property-controls/property-controls' {
   }
   export interface ImportType {
       source: string;
-      name: string;
+      name: string | null;
       type: 'star' | 'default' | null;
   }
   export interface ExpressionControlOption<T> {

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -54,15 +54,20 @@ describe('registered property controls', () => {
     expect(editorState.propertyControlsInfo[storyboardPath]).toMatchInlineSnapshot(`
       Object {
         "App": Object {
-          "background": Object {
-            "control": "color",
+          "componentInfo": Object {
+            "requiredImports": undefined,
           },
-          "label": Object {
-            "control": "string-input",
-          },
-          "visible": Object {
-            "control": "checkbox",
-            "defaultValue": true,
+          "propertyControls": Object {
+            "background": Object {
+              "control": "color",
+            },
+            "label": Object {
+              "control": "string-input",
+            },
+            "visible": Object {
+              "control": "checkbox",
+              "defaultValue": true,
+            },
           },
         },
       }

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -1,4 +1,4 @@
-import { PropertyControls, registerControls } from 'utopia-api'
+import { ImportType, PropertyControls, registerControls } from 'utopia-api'
 import deepEqual from 'fast-deep-equal'
 
 import { ProjectContentTreeRoot } from '../../components/assets'
@@ -16,7 +16,12 @@ export function createRegisterControlsFunction(
   getEditorState: (() => EditorState) | null,
 ): typeof registerControls {
   // create a function with a signature that matches utopia-api/registerControls
-  return (componentName: string, packageName: string, propertyControls: PropertyControls): void => {
+  return (
+    componentName: string,
+    packageName: string,
+    propertyControls: PropertyControls,
+    requiredImports?: Array<ImportType>,
+  ): void => {
     if (componentName == null || packageName == null || typeof propertyControls !== 'object') {
       console.warn(
         'registerControls has 3 parameters: component name, package name, property controls object',
@@ -33,7 +38,7 @@ export function createRegisterControlsFunction(
             ...currentPropertyControlsInfo[packageName],
             [componentName]: {
               propertyControls: propertyControls,
-              componentInfo: {}, // TODO requiredimport
+              componentInfo: { requiredImports: requiredImports },
             },
           },
         }

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -31,7 +31,10 @@ export function createRegisterControlsFunction(
         const updatedControls: PropertyControlsInfo = {
           [packageName]: {
             ...currentPropertyControlsInfo[packageName],
-            [componentName]: propertyControls,
+            [componentName]: {
+              propertyControls: propertyControls,
+              componentInfo: {}, // TODO requiredimport
+            },
           },
         }
         if (!currentControlsAreTheSame) {
@@ -57,7 +60,7 @@ export function getThirdPartyControlsIntrinsic(
     )
   })
   if (foundPackageWithElement != null) {
-    return propertyControlsInfo[foundPackageWithElement][elementName]
+    return propertyControlsInfo[foundPackageWithElement][elementName].propertyControls
   }
   return null
 }

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -262,7 +262,10 @@ export function getThirdPartyPropertyControls(
         const jsxElementName = getJSXElementNameAsString(descriptor.element.name)
         propertyControlsInfo[packageName] = {
           ...propertyControlsInfo[packageName],
-          [jsxElementName]: descriptor.propertyControls,
+          [jsxElementName]: {
+            propertyControls: descriptor.propertyControls,
+            componentInfo: {}, // TODO requiredImports
+          },
         }
       }
     })
@@ -370,7 +373,8 @@ export function getPropertyControlsForTarget(
           propertyControlsInfo[trimmedPath] != null &&
           propertyControlsInfo[trimmedPath][nameLastPart] != null
         ) {
-          return propertyControlsInfo[trimmedPath][nameLastPart] as PropertyControls
+          return propertyControlsInfo[trimmedPath][nameLastPart]
+            .propertyControls as PropertyControls
         } else {
           return null
         }

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -1,6 +1,6 @@
 import { PropertyControlsInfo } from '../../components/custom-code/code-file'
 import { ParsedPropertyControls, parsePropertyControls } from './property-controls-parser'
-import { PropertyControls, getDefaultProps } from 'utopia-api'
+import { PropertyControls, getDefaultProps, ImportType } from 'utopia-api'
 import { isRight, foldEither, left } from '../shared/either'
 import { forEachValue } from '../shared/object-utils'
 import { descriptionParseError, ParseResult } from '../../utils/value-parser-utils'
@@ -264,7 +264,7 @@ export function getThirdPartyPropertyControls(
           ...propertyControlsInfo[packageName],
           [jsxElementName]: {
             propertyControls: descriptor.propertyControls,
-            componentInfo: {}, // TODO requiredImports
+            componentInfo: { requiredImports: descriptor.importsToAdd },
           },
         }
       }

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -147,11 +147,13 @@ export function importsEquals(first: Imports, second: Imports): boolean {
 }
 
 export function importDetailsFromImportOption(importOption: ImportType): ImportDetails {
-  return importDetails(
-    importOption.type === 'default' ? importOption.name : null,
-    importOption.type == null ? [{ name: importOption.name, alias: importOption.name }] : [],
-    importOption.type === 'star' ? importOption.name : null,
-  )
+  const importedWithName = importOption.type === 'default' ? importOption.name : null
+  const importedAs = importOption.type === 'star' ? importOption.name : null
+  const importedFromWithin =
+    importOption.type == null && importOption.name != null
+      ? [{ name: importOption.name, alias: importOption.name }]
+      : []
+  return importDetails(importedWithName, importedFromWithin, importedAs)
 }
 
 // export let name1, name2, …, nameN; // also var, const

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -1,4 +1,4 @@
-import { NormalisedFrame } from 'utopia-api'
+import { ImportType, NormalisedFrame } from 'utopia-api'
 import {
   ArbitraryJSBlock,
   ImportStatement,
@@ -144,6 +144,14 @@ export type Imports = { [importSource: string]: ImportDetails }
 
 export function importsEquals(first: Imports, second: Imports): boolean {
   return objectEquals(first, second, importDetailsEquals)
+}
+
+export function importDetailsFromImportOption(importOption: ImportType): ImportDetails {
+  return importDetails(
+    importOption.type === 'default' ? importOption.name : null,
+    importOption.type == null ? [{ name: importOption.name, alias: importOption.name }] : [],
+    importOption.type === 'star' ? importOption.name : null,
+  )
 }
 
 // export let name1, name2, …, nameN; // also var, const

--- a/editor/src/core/third-party/antd-components.ts
+++ b/editor/src/core/third-party/antd-components.ts
@@ -23,10 +23,14 @@ function createBasicComponent(
 ): ComponentDescriptor {
   const defaultAttributes = getDefaultPropsAsAttributes(propertyControls)
   return componentDescriptor(
-    {
-      antd: importDetails(null, [importAlias(baseVariable)], null),
-      'antd/dist/antd.css': importDetails(null, [], null),
-    },
+    [
+      {
+        source: 'antd',
+        name: baseVariable,
+        type: null,
+      },
+      { source: 'antd/dist/antd.css', name: null, type: null },
+    ],
     jsxElementWithoutUID(jsxElementName(baseVariable, propertyPathParts), defaultAttributes, []),
     name,
     { ...StyleObjectProps, ...propertyControls },

--- a/editor/src/core/third-party/react-three-fiber-components.ts
+++ b/editor/src/core/third-party/react-three-fiber-components.ts
@@ -13,7 +13,7 @@ function createBasicComponent(
   propertyControls: PropertyControls | null,
 ): ComponentDescriptor {
   return componentDescriptor(
-    {},
+    [],
     jsxElementWithoutUID(
       jsxElementName(baseVariable, []),
       [], // Note: we don't have default props for react-three-fiber insertion

--- a/editor/src/core/third-party/third-party-types.ts
+++ b/editor/src/core/third-party/third-party-types.ts
@@ -1,16 +1,16 @@
 import { JSXElementWithoutUID } from '../shared/element-template'
 import { Imports } from '../shared/project-file-types'
-import { PropertyControls } from 'utopia-api'
+import { ImportType, PropertyControls } from 'utopia-api'
 
 export interface ComponentDescriptor {
-  importsToAdd: Imports
+  importsToAdd: Array<ImportType>
   element: JSXElementWithoutUID
   name: string
   propertyControls: PropertyControls | null
 }
 
 export function componentDescriptor(
-  importsToAdd: Imports,
+  importsToAdd: Array<ImportType>,
   element: JSXElementWithoutUID,
   name: string,
   propertyControls: PropertyControls | null,

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -21,9 +21,7 @@ function createBasicUtopiaComponent(
 ): ComponentDescriptor {
   const defaultAttributes = getDefaultPropsAsAttributes(propertyControls)
   return componentDescriptor(
-    {
-      'utopia-api': importDetails(null, [importAlias(baseVariable)], null),
-    },
+    [{ source: 'utopia-api', type: null, name: baseVariable }],
     jsxElementWithoutUID(jsxElementName(baseVariable, []), defaultAttributes, children),
     name,
     propertyControls,

--- a/utopia-api/src/helpers/helper-functions.tsx
+++ b/utopia-api/src/helpers/helper-functions.tsx
@@ -1,10 +1,11 @@
-import { PropertyControls } from '../property-controls/property-controls'
+import { PropertyControls, ImportType } from '../property-controls/property-controls'
 import { testImage } from './test-assets'
 
 export function registerControls(
   componentName: string,
   packageName: string,
   propertyControls: PropertyControls,
+  requiredImports?: Array<ImportType>,
 ): void {
   // Function is deliberately empty. If called inside the Utopia Editor, it has effect to the running environment
 }

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -56,7 +56,7 @@ export interface PopUpListControlDescription extends AbstractBaseControlDescript
 
 export interface ImportType {
   source: string // importSource
-  name: string
+  name: string | null
   type: 'star' | 'default' | null
 }
 


### PR DESCRIPTION
**Problem:**
Components using registerControls should appear as insertable elements.

**Fix:**
Using the propertyControlsInfo from the editorState to create insert items. Previously it was using built-in component descriptions with import details but this was missing from the propertyControlsInfo. It is changed to contain an optional info object with import details.

**Commit Details:**
- updated `getComponentGroups` used by the insert menus (sidebar, popup) to use property controls info to create insertion groups.
- changed `registerControls` with optional `requiredImports` parameter
- `ComponentDescriptor` is changed to have utopia-api ImportType instead of ImportDetails to avoid double conversion.
