### PR TITLE
fix(component-section) add contextmenu to object property label

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -450,6 +450,11 @@ const RowForObjectControl = betterReactMemo(
     const title = labelForControl(propPath, controlDescription)
     const indentation = props.indentationLevel * 8
 
+    const propMetadata = useComponentPropsInspectorInfo(propPath, isScene, controlDescription)
+    const contextMenuItems = Utils.stripNulls([
+      addOnUnsetValues([PP.lastPart(propPath)], propMetadata.onUnsetValues),
+    ])
+
     return (
       <div
         css={{
@@ -465,8 +470,12 @@ const RowForObjectControl = betterReactMemo(
           },
         }}
       >
-        <div>
-          <div onClick={handleOnClick}>
+        <div onClick={handleOnClick}>
+          <InspectorContextMenuWrapper
+            id={`context-menu-for-${PP.toString(propPath)}`}
+            items={contextMenuItems}
+            data={null}
+          >
             <SimpleFlexRow style={{ flexGrow: 1 }}>
               <PropertyLabel
                 target={[propPath]}
@@ -485,25 +494,25 @@ const RowForObjectControl = betterReactMemo(
                 <ObjectIndicator open={open} />
               </PropertyLabel>
             </SimpleFlexRow>
-          </div>
-          {when(
-            open,
-            mapToArray((innerControl: RegularControlDescription, prop: string, index: number) => {
-              const innerPropPath = PP.appendPropertyPathElems(propPath, [prop])
-              return (
-                <RowForControl
-                  key={`object-control-row-${PP.toString(innerPropPath)}`}
-                  controlDescription={innerControl}
-                  isScene={isScene}
-                  propPath={innerPropPath}
-                  setGlobalCursor={props.setGlobalCursor}
-                  indentationLevel={props.indentationLevel + 1}
-                  focusOnMount={props.focusOnMount && index === 0}
-                />
-              )
-            }, controlDescription.object),
-          )}
+          </InspectorContextMenuWrapper>
         </div>
+        {when(
+          open,
+          mapToArray((innerControl: RegularControlDescription, prop: string, index: number) => {
+            const innerPropPath = PP.appendPropertyPathElems(propPath, [prop])
+            return (
+              <RowForControl
+                key={`object-control-row-${PP.toString(innerPropPath)}`}
+                controlDescription={innerControl}
+                isScene={isScene}
+                propPath={innerPropPath}
+                setGlobalCursor={props.setGlobalCursor}
+                indentationLevel={props.indentationLevel + 1}
+                focusOnMount={props.focusOnMount && index === 0}
+              />
+            )
+          }, controlDescription.object),
+        )}
       </div>
     )
   },


### PR DESCRIPTION
**Problem:**
The context-menu to unset a property is missing from the component inspector for object controls.

**Fix:**
Adding the context-menu wrapper. 

**Commit Details:**
- removed an empty wrapper div
- added the context menu wrapper with unset menuitem

<img width="257" alt="Screenshot 2021-11-03 at 17 01 52" src="https://user-images.githubusercontent.com/4403069/140097075-0fb8e0af-39b3-4684-aff9-33cddd31ada8.png">

