### PR TITLE
fix(inspector) color popup should toggle only when it's interactive

### DIFF
--- a/editor/src/components/inspector/controls/color-control.tsx
+++ b/editor/src/components/inspector/controls/color-control.tsx
@@ -130,7 +130,9 @@ export const ColorControl = betterReactMemo('ColorControl', (props: ColorControl
           }}
           onMouseDown={(e) => {
             e.stopPropagation()
-            setPopupOpen((value) => !value)
+            if (props.controlStyles.interactive) {
+              setPopupOpen((value) => !value)
+            }
           }}
         >
           <div

--- a/editor/src/uuiui/inputs/string-input.tsx
+++ b/editor/src/uuiui/inputs/string-input.tsx
@@ -53,8 +53,8 @@ export const StringInput = betterReactMemo(
         }
       }, [focusOnMount, ref])
 
-      const disabled = controlStatus === 'disabled'
       const controlStyles: ControlStyles = getControlStyles(controlStatus)
+      const disabled = !controlStyles.interactive
 
       const inputPropsKeyDown = inputProps.onKeyDown
 


### PR DESCRIPTION
**Problem:**
Some of the inspector controls are interactive with the 'unoverwritable' control status.
The inspector color control can be opened and users can type into the string input.

**Fix:**
Fix the color control toggle button callback. The string control used the 'disabled' status instead of the 'interactive' from controlStyles.

**Commit Details:**
- fix color-control
- fix string-input
