### PR TITLE
use preventDefault on string-input's form

### DIFF
--- a/editor/src/components/inspector/common/inspector-utils.tsx
+++ b/editor/src/components/inspector/common/inspector-utils.tsx
@@ -147,6 +147,10 @@ export const stopPropagation = (e: React.MouseEvent) => {
   e.stopPropagation()
 }
 
+export const preventDefault = (e: React.SyntheticEvent) => {
+  e.preventDefault()
+}
+
 export const useHandleCloseOnESCOrEnter = (closePopup: (key: 'Escape' | 'Enter') => void): void => {
   const handleCloseOnESCOrEnter = React.useCallback(
     (e: KeyboardEvent) => {

--- a/editor/src/uuiui/inputs/string-input.tsx
+++ b/editor/src/uuiui/inputs/string-input.tsx
@@ -8,7 +8,7 @@ import {
   ControlStyles,
   getControlStyles,
 } from '../../components/inspector/common/control-status'
-import { stopPropagation } from '../../components/inspector/common/inspector-utils'
+import { preventDefault, stopPropagation } from '../../components/inspector/common/inspector-utils'
 import { betterReactMemo } from '../../uuiui-deps'
 import { useColorTheme, UtopiaTheme } from '../styles/theme'
 import { InspectorInput, InspectorInputEmotionStyle } from './base-input'
@@ -84,7 +84,12 @@ export const StringInput = betterReactMemo(
       }
 
       return (
-        <form autoComplete='off' style={style} onMouseDown={stopPropagation}>
+        <form
+          autoComplete='off'
+          style={style}
+          onMouseDown={stopPropagation}
+          onSubmit={preventDefault}
+        >
           <div
             className='string-input-container'
             css={{


### PR DESCRIPTION
**Problem:**
`StringInput` wraps its <input /> in a <form>. While there's a preventDefault() line in some of the input's callbacks, it's called _after_ the onSubmit handler, which means if the onSubmit callback throws an error, preventDefault() will never run, leading the form to submit, making the editor reload. Yikes! 

**Fix:**
Instead of fixing up inside the input callbacks, I put a generic `onSubmit={preventDefault}` on the form itself.