### PR TITLE
hotfix for the inspector target selector

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -492,8 +492,8 @@ export const SingleInspectorEntryPoint: React.FunctionComponent<{
   )
 
   const onStyleSelectorInsert = React.useCallback(
-    (parent: CSSTarget, label: string) => {
-      const newPath = [...parent.path, label]
+    (parent: CSSTarget | undefined, label: string) => {
+      const newPath = [...(parent?.path ?? []), label]
       const newPropertyPath = PP.create(newPath)
       const actions: Array<EditorAction> = refElementsToTargetForUpdates.current.map((elem) =>
         EditorActions.setProp_UNSAFE(elem, newPropertyPath, jsxAttributeValue({}, emptyComments)),

--- a/editor/src/components/inspector/sections/header-section/target-selector.tsx
+++ b/editor/src/components/inspector/sections/header-section/target-selector.tsx
@@ -418,9 +418,10 @@ const TargetListHeader = betterReactMemo('TargetListHeader', (props: TargetListH
         {selectedItem}
       </H1>
       <SectionActionSheet className='actionsheet'>
-        <SquareButton highlight disabled={isAdding} onClick={startAdding}>
+        {/* Plus button is disabled until the root insertion issue is fixed https://github.com/concrete-utopia/utopia/issues/1991 */}
+        {/* <SquareButton highlight disabled={isAdding} onClick={startAdding}>
           <FunctionIcons.Add />
-        </SquareButton>
+        </SquareButton> */}
         <SquareButton highlight onClick={togglePathPanel}>
           <ExpandableIndicator
             testId='target-selector'


### PR DESCRIPTION
Fixes #1961

**Problem:**
The root level + button in the target selector took down the App. It turns out it was an unchecked property access on a possibly undefined object.

**Fix:**
Add a `?.` optional chaining.

**Note:**
I also noticed that the top level + button's behavior is broken: https://github.com/concrete-utopia/utopia/issues/1991
I am disabling the top level + button until it's fixed. 
To add sub-targets (ie `css={'&:hover': {...`) you need to use the context menu's Add Nested Selector button:
<img width="267" alt="image" src="https://user-images.githubusercontent.com/2226774/140928081-1d9f9bf8-a005-4d21-b27a-871398820222.png">
