### PR TITLE
Maintain selection while editing arbitrary elements.

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -441,7 +441,6 @@ import {
   addSceneToJSXComponents,
   UserState,
   UserConfiguration,
-  getHighlightBoundsForUids,
   getElementPathsInBounds,
   StoryboardFilePath,
   modifyUnderlyingTarget,

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -46,7 +46,6 @@ import {
   getAllBuildErrors,
   getAllErrorsFromFiles,
   getAllLintErrors,
-  getHighlightBoundsForUids,
   persistentModelFromEditorModel,
   reconstructJSXMetadata,
   storedEditorStateFromEditorState,
@@ -694,49 +693,5 @@ function filterEditorForFiles(editor: EditorState) {
       buildErrors: pick(allFiles, editor.codeEditorErrors.buildErrors),
       lintErrors: pick(allFiles, editor.codeEditorErrors.lintErrors),
     },
-  }
-}
-
-function removeNonExistingViewReferencesFromState(editorState: EditorState): EditorState {
-  const rootComponents = editorState.jsxMetadata
-  const updatedSelectedViews = ElementPathArrayKeepDeepEquality(
-    editorState.selectedViews,
-    mapDropNulls(
-      (selectedView) => elementPathStillExists(rootComponents, selectedView),
-      editorState.selectedViews,
-    ),
-  ).value
-  const updatedHighlightedViews = ElementPathArrayKeepDeepEquality(
-    editorState.highlightedViews,
-    mapDropNulls(
-      (highlightedView) => elementPathStillExists(rootComponents, highlightedView),
-      editorState.highlightedViews,
-    ),
-  ).value
-  const updatedHiddenInstances = ElementPathArrayKeepDeepEquality(
-    editorState.hiddenInstances,
-    mapDropNulls(
-      (hiddenInstance) => elementPathStillExists(rootComponents, hiddenInstance),
-      editorState.hiddenInstances,
-    ),
-  ).value
-  return {
-    ...editorState,
-    selectedViews: updatedSelectedViews,
-    highlightedViews: updatedHighlightedViews,
-    hiddenInstances: updatedHiddenInstances,
-  }
-}
-
-function elementPathStillExists(
-  newComponents: ElementInstanceMetadataMap,
-  pathToUpdate: ElementPath,
-): ElementPath | null {
-  const pathStillExists =
-    MetadataUtils.findElementByElementPath(newComponents, pathToUpdate) != null
-  if (pathStillExists) {
-    return pathToUpdate
-  } else {
-    return null
   }
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1880,22 +1880,18 @@ export function getStoryboardElementPathFromEditorState(
   )
 }
 
-export function getHighlightBoundsForUids(editorState: EditorState): HighlightBoundsForUids | null {
-  const selectedFile = getOpenFile(editorState)
-  if (isTextFile(selectedFile)) {
-    return getHighlightBoundsFromParseResult(selectedFile.fileContents.parsed)
-  }
-
-  return null
-}
-
 export function getHighlightBoundsForFile(
   editorState: EditorState,
   fullPath: string,
 ): HighlightBoundsForUids | null {
   const file = getContentsTreeFileFromString(editorState.projectContents, fullPath)
-  if (isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
-    return getHighlightBoundsFromParseResult(file.fileContents.parsed)
+  if (isTextFile(file)) {
+    if (isParseSuccess(file.fileContents.parsed)) {
+      return getHighlightBoundsFromParseResult(file.fileContents.parsed)
+    }
+    if (file.lastParseSuccess != null) {
+      return getHighlightBoundsFromParseResult(file.lastParseSuccess)
+    }
   }
   return null
 }

--- a/editor/src/components/editor/store/vscode-changes.ts
+++ b/editor/src/components/editor/store/vscode-changes.ts
@@ -28,7 +28,6 @@ import {
 import {
   EditorState,
   getHighlightBoundsForElementPaths,
-  getHighlightBoundsForUids,
   getUnderlyingVSCodeBridgeID,
 } from './editor-state'
 import { shallowEqual } from '../../../core/shared/equality-utils'

--- a/editor/src/core/workers/parser-printer/uid-fix.spec.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.spec.ts
@@ -172,6 +172,17 @@ describe('fixParseSuccessUIDs', () => {
     )
     expect(getUidTree(firstResult)).toEqual(getUidTree(secondResult))
   })
+
+  it('handles elements within arbitrary blocks', () => {
+    const firstResult = lintAndParse('test.js', fileWithArbitraryBlockInside, null, emptySet())
+    const secondResult = lintAndParse(
+      'test.js',
+      fileWithSlightlyDifferentArbitraryBlockInside,
+      asParseSuccessOrNull(firstResult),
+      emptySet(),
+    )
+    expect(getUidTree(firstResult)).toEqual(getUidTree(secondResult))
+  })
 })
 
 const baseFileContents = createFileText(`
@@ -392,6 +403,42 @@ export var SameFileApp = (props) => {
         }}
       />
     </>
+  )
+}
+`)
+
+const fileWithArbitraryBlockInside = createFileText(`
+export var SameFileApp = (props) => {
+  return (
+    <div
+      style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
+    >
+      {[1, 2, 3].map((index) => {
+      <View
+        style={{
+          width: 191 + index,
+        }}
+      />
+      })}
+    </div>
+  )
+}
+`)
+
+const fileWithSlightlyDifferentArbitraryBlockInside = createFileText(`
+export var SameFileApp = (props) => {
+  return (
+    <div
+      style={{ position: 'relative', width: '100%', height: '100%', backgroundColor: '#FFFFFF' }}
+    >
+      {[1, 2, 3].map((index) => {
+      <View
+        style={{
+          width: 161 + index,
+        }}
+      />
+      })}
+    </div>
   )
 }
 `)

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -394,7 +394,7 @@ function initMessaging(context: vscode.ExtensionContext, workspaceRootUri: vscod
       updateDecorations(currentDecorations)
     }),
     vscode.window.onDidChangeTextEditorSelection((event) => {
-      if (event.kind !== undefined && event.kind !== vscode.TextEditorSelectionChangeKind.Command) {
+      if (event.kind !== vscode.TextEditorSelectionChangeKind.Command) {
         cursorPositionChanged(event)
       }
     }),
@@ -463,10 +463,14 @@ async function openFile(fileUri: vscode.Uri, retries: number = 5): Promise<boole
 }
 
 function cursorPositionChanged(event: vscode.TextEditorSelectionChangeEvent): void {
-  const editor = event.textEditor
-  const filename = editor.document.uri.path
-  const position = editor.selection.active
-  sendMessage(editorCursorPositionChanged(filename, position.line, position.character))
+  try {
+    const editor = event.textEditor
+    const filename = editor.document.uri.path
+    const position = editor.selection.active
+    sendMessage(editorCursorPositionChanged(filename, position.line, position.character))
+  } catch (error) {
+    console.error('cursorPositionChanged failure.', error)
+  }
 }
 
 function rangesIntersectLinesOnly(first: vscode.Range, second: vscode.Range): boolean {


### PR DESCRIPTION
Fixes #1986

**Problem:**
The UID fixing logic that attempts to keep `data-uid` values consistent between parse passes on a file did not peer inside arbitrary blocks, which meant that any edit would result in slight edits changing the path to address them.

**Fix:**
The logic within `fixParseSuccessUIDs` now includes the case of drilling into `JSXArbitraryBlock` instances. Also `getHighlightBoundsForFile` includes a fallback case so that if the parse fails while mid-typing the old highlights are used, which should prevent the selection flickering off and back on again.

A previous fix to try and ensure that backspaces in VS Code were handled correctly has been resurrected as well, with an additional catch around the handler for that logic to protect against shenanigans.

**Commit Details:**
- Fixes #1986.
- Remove the check for `event.kind` in `initMessaging` so that backspaces
  definitely get included.
- Add a catch inside `cursorPositionChanged` as a safety measure against
  failures in there.
- Added `walkElementsWithin` to handle `ElementsWithin` for an arbitrary
  block similarly to `walkElementChildren`.
- Factored out `compareAndWalkElements` from `walkElementChildren` so that
  it could be used in `walkElementsWithin`, adding an additional clause for
  `JSXArbitraryBlock` instances.
- `getHighlightBoundsForFile` now includes a fallback case to the previous parse result.
- Removed `getHighlightBoundsForUids` as it's unused.
- Removed `removeNonExistingViewReferencesFromState` and `elementPathStillExists`
  as they are unused.
