### PR TITLE
Re-enable and fix the target selector add button.

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -403,7 +403,7 @@ export const SingleInspectorEntryPoint: React.FunctionComponent<{
             }
           }
           let defaults = [...DefaultStyleTargets]
-          defaults.reverse().map((defaultTarget) => {
+          defaults.reverse().forEach((defaultTarget) => {
             const styleObject = getSimpleAttributeAtPath(
               right(localJSXElement.props),
               PP.create(defaultTarget.path),


### PR DESCRIPTION
Fixes #1991

**Problem:**
There were two issues:
- When adding a new selector, it was always added as a top level property, which would not get included in the selector list.
- When adding a selector with a name like `&:hover` it would cause the parser to fail on the nonsense JSX that would result in because it was added at the top level.

**Fix:**
The two fixes for the above issues respectively were:
- Fix the logic to always insert new selectors under an existing selector, this required both stopping it from always inserting to index `0` and preventing that index from being shifted by `-1`.
- The previous fix resolved this issue as those selectors are valid under the top level.

**Commit Details:**
- Fixes #1991.
- Removed some object field remapping for clarity.
- `TargetListHeader` now takes `targetIndex` as a property so that
  on triggering insertion it can be passed to `setAddingIndex` instead
  of zero.
- Re-added the `SquareButton` to the action sheet.
- `AddingRow` now doesn't shift `addingIndex` by `-1` when invoking
  `onInsert`.
- Changed a `map` to a `forEach` in `SingleInspectorEntryPoint`.
