### PR TITLE
Env/dockerized dev env 1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,34 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.205.1/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+USER node
+
+RUN sudo apt-get update && sudo apt-get install --no-install-recommends -y  locales curl xz-utils vim  ca-certificates direnv && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* \
+      && sudo mkdir -m 0755 /nix && sudo groupadd -r nixbld && sudo chown node /nix \
+      && for n in $(seq 1 10); do sudo useradd -c "Nix build user $n" -d /var/empty -g nixbld -G nixbld -M -N -r -s "$(command -v nologin)" "nixbld$n"; done
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN set -o pipefail && curl -L https://nixos.org/nix/install | bash
+
+
+# Fixes locale-related issues: https://gitlab.haskell.org/ghc/ghc/-/issues/8118
+RUN locale-gen en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends direnv curl
+
+# RUN whoami
+
+# RUN curl -L https://nixos.org/nix/install | sh
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN su node -c "npm install -g <your-package-list -here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
+	"postCreateCommand": "nix-shell --run start-postgres",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.205.1/containers/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
+		// Append -bullseye or -buster to pin to an OS version.
+		// Use -bullseye variants on local on arm64/Apple Silicon.
+		"args": { 
+			"VARIANT": "16-bullseye"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node",
+	"features": {
+		"git": "os-provided",
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+.pnpm-store
+
 node_modules
 
 ## Build generated


### PR DESCRIPTION
Active notes:

✅ install Remote - Containers vscode extension https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers

check out the branch, open `/utopia` root folder in vscode, then run "Reopen in container" command
✅ the Dockerfile will install nix and pull things from apt-get
once the container is done, VSCode will automatically execute `nix-shell --run start-postgres`

✅ nix-shell will pull down the dependencies, then load up fine
❌`start-postgres` error:
```
[nix-shell:/workspaces/utopia]$ start-postgres
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
pg_ctl: PID file "utopia-db/postmaster.pid" does not exist
Is server running?
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
pg_ctl: PID file "utopia-db/postmaster.pid" does not exist
Is server running?
waiting for server to start.... done
server started
psql: error: FATAL:  role "node" does not exist
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
createdb: error: could not connect to database template1: FATAL:  role "node" does not exist
```