### PR TITLE
Show code snippet for failing third party components.

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -192,7 +192,7 @@ export class CanvasErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
-    const fancyError = processErrorWithSourceMap(error, true)
+    const fancyError = processErrorWithSourceMap(null, this.props.filePath, error, true)
     this.props.reportError(this.props.filePath, asErrorObject(fancyError), errorInfo)
   }
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -111,6 +111,7 @@ export function createComponentRendererComponent(params: {
     const appliedProps = optionalMap(
       (param) =>
         applyPropsParamToPassedProps(
+          params.filePath,
           mutableContext.rootScope,
           mutableContext.requireResult,
           realPassedProps,
@@ -167,6 +168,7 @@ export function createComponentRendererComponent(params: {
       )
 
       runBlockUpdatingScope(
+        params.filePath,
         mutableContext.requireResult,
         utopiaJsxComponent.arbitraryJSBlock,
         scope,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -205,7 +205,12 @@ export function renderCoreElement(
           }
         : inScope
 
-      const assembledProps = jsxAttributesToProps(blockScope, element.props, requireResult)
+      const assembledProps = jsxAttributesToProps(
+        filePath,
+        blockScope,
+        element.props,
+        requireResult,
+      )
 
       const passthroughProps = monkeyUidProp(uid, assembledProps)
 
@@ -262,7 +267,7 @@ export function renderCoreElement(
           innerRender,
         ),
       }
-      return runJSXArbitraryBlock(requireResult, element, blockScope)
+      return runJSXArbitraryBlock(filePath, requireResult, element, blockScope)
     }
     case 'JSX_FRAGMENT': {
       let renderedChildren: Array<React.ReactChild> = []
@@ -467,11 +472,12 @@ export function utopiaCanvasJSXLookup(
 }
 
 function runJSXArbitraryBlock(
+  filePath: string,
   requireResult: MapLike<any>,
   block: JSXArbitraryBlock,
   currentScope: MapLike<any>,
 ): any {
-  return resolveParamsAndRunJsCode(block, requireResult, currentScope)
+  return resolveParamsAndRunJsCode(filePath, block, requireResult, currentScope)
 }
 
 function getElementFromScope(jsxElementToLookup: JSXElement, scope: MapLike<any> | null): any {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.tsx
@@ -156,7 +156,7 @@ export function createExecutionScope(
       lookupRenderer,
     )
 
-    runBlockUpdatingScope(requireResult, combinedTopLevelArbitraryBlock, executionScope)
+    runBlockUpdatingScope(filePath, requireResult, combinedTopLevelArbitraryBlock, executionScope)
   }
   // WARNING: mutating the mutableContextRef
   updateMutableUtopiaCtxRefWithNewProps(mutableContextRef, {

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-props-utils.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-props-utils.ts
@@ -10,6 +10,7 @@ import {
 import { AnyMap, jsxAttributeToValue } from '../../../core/shared/jsx-attributes'
 
 export function applyPropsParamToPassedProps(
+  filePath: string,
   inScope: MapLike<any>,
   requireResult: MapLike<any>,
   passedProps: MapLike<unknown>,
@@ -22,7 +23,7 @@ export function applyPropsParamToPassedProps(
     defaultExpression: JSXAttributeOtherJavaScript | null,
   ): unknown {
     if (value === undefined && defaultExpression != null) {
-      return jsxAttributeToValue(inScope, requireResult, defaultExpression)
+      return jsxAttributeToValue(filePath, inScope, requireResult, defaultExpression)
     } else {
       return value
     }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-scope-utils.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-scope-utils.ts
@@ -4,11 +4,12 @@ import { resolveParamsAndRunJsCode } from '../../../core/shared/javascript-cache
 import { fastForEach } from '../../../core/shared/utils'
 
 export function runBlockUpdatingScope(
+  filePath: string,
   requireResult: MapLike<any>,
   block: ArbitraryJSBlock,
   currentScope: MapLike<any>,
 ): void {
-  const result = resolveParamsAndRunJsCode(block, requireResult, currentScope)
+  const result = resolveParamsAndRunJsCode(filePath, block, requireResult, currentScope)
   fastForEach(block.definedWithin, (within) => {
     currentScope[within] = result[within]
   })

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -278,7 +278,7 @@ export function renderCanvasReturnResultAndError(
     errorsReportedSpyEnabled = errorsReported
   } catch (e) {
     // TODO instead of relying on this hack here, we should create a new test function that runs the real react render instead of ReactDOMServer.renderToStaticMarkup
-    processErrorWithSourceMap(e, true)
+    processErrorWithSourceMap(UiFilePath, uiFileCode, e, true)
     errorsReportedSpyEnabled = [e]
   }
   errorsReported = []
@@ -298,7 +298,7 @@ export function renderCanvasReturnResultAndError(
     errorsReportedSpyDisabled = errorsReported
   } catch (e) {
     // TODO instead of relying on this hack here, we should create a new test function that runs the real react render instead of ReactDOMServer.renderToStaticMarkup
-    processErrorWithSourceMap(e, true)
+    processErrorWithSourceMap(UiFilePath, uiFileCode, e, true)
     errorsReportedSpyDisabled = [e]
   }
 

--- a/editor/src/components/expression-graph.spec.ts
+++ b/editor/src/components/expression-graph.spec.ts
@@ -74,9 +74,17 @@ describe('evaluateExpressions', function () {
         context[dependencyVarName] = dependency.value
       }
       const fixedExpression = replaceAll(expression, '@', '')
-      return Utils.SafeFunction(false, context, 'return ' + fixedExpression, null, [], (e) => {
-        throw e
-      })(null)
+      return Utils.SafeFunction(
+        false,
+        context,
+        'test.js',
+        'return ' + fixedExpression,
+        null,
+        [],
+        (e) => {
+          throw e
+        },
+      )(null)
     }
     const expectedResult: EvaluateExpressionsResult<string> = {
       type: 'circularreference',
@@ -185,9 +193,17 @@ describe('evaluateExpressions', function () {
         context[dependencyVarName] = dependency.value
       }
       const fixedExpression = replaceAll(expression, '@', '')
-      return Utils.SafeFunction(false, context, 'return ' + fixedExpression, null, [], (e) => {
-        throw e
-      })(null)
+      return Utils.SafeFunction(
+        false,
+        context,
+        'test.js',
+        'return ' + fixedExpression,
+        null,
+        [],
+        (e) => {
+          throw e
+        },
+      )(null)
     }
     const expectedResult: EvaluateExpressionsResult<string> = {
       type: 'success',
@@ -276,9 +292,17 @@ describe('evaluateExpressions', function () {
         context[dependencyVarName] = dependency.value
       }
       const fixedExpression = replaceAll(expression, '@', '')
-      return Utils.SafeFunction(false, context, 'return ' + fixedExpression, null, [], (e) => {
-        throw e
-      })(null)
+      return Utils.SafeFunction(
+        false,
+        context,
+        'test.js',
+        'return ' + fixedExpression,
+        null,
+        [],
+        (e) => {
+          throw e
+        },
+      )(null)
     }
     const expectedResult: EvaluateExpressionsResult<string> = {
       type: 'success',
@@ -361,9 +385,17 @@ describe('evaluateExpressions', function () {
         context[dependencyVarName] = dependency.value
       }
       const fixedExpression = replaceAll(expression, '@', '')
-      return Utils.SafeFunction(false, context, 'return ' + fixedExpression, null, [], (e) => {
-        throw e
-      })(null)
+      return Utils.SafeFunction(
+        false,
+        context,
+        'test.js',
+        'return ' + fixedExpression,
+        null,
+        [],
+        (e) => {
+          throw e
+        },
+      )(null)
     }
     const expectedResult: EvaluateExpressionsResult<string> = {
       type: 'success',
@@ -422,9 +454,17 @@ describe('evaluateExpressions', function () {
         context[dependencyVarName] = dependency.value
       }
       const fixedExpression = replaceAll(expression, '@', '')
-      return Utils.SafeFunction(false, context, 'return ' + fixedExpression, null, [], (e) => {
-        throw e
-      })(null)
+      return Utils.SafeFunction(
+        false,
+        context,
+        'test.js',
+        'return ' + fixedExpression,
+        null,
+        [],
+        (e) => {
+          throw e
+        },
+      )(null)
     }
     const expectedResult: EvaluateExpressionsResult<string> = {
       type: 'success',

--- a/editor/src/core/es-modules/evaluator/evaluator.ts
+++ b/editor/src/core/es-modules/evaluator/evaluator.ts
@@ -86,6 +86,7 @@ function evaluateJs(
     SafeFunction(
       false,
       { require: requireFn, exports: exports, module: module, process: process },
+      filePath,
       code,
       sourceMap,
       [],

--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -173,7 +173,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue(55, emptyComments),
       ),
     )
-    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    const compiledProps = jsxAttributesToProps(
+      'test.js',
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+    )
     expect(compiledProps.top).toEqual(55)
   })
 
@@ -196,7 +201,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('hello', emptyComments),
       ),
     )
-    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    const compiledProps = jsxAttributesToProps(
+      'test.js',
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+    )
     expect(compiledProps.my.property.path).toEqual('hello')
   })
 
@@ -208,7 +218,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue(2000, emptyComments),
       ),
     )
-    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    const compiledProps = jsxAttributesToProps(
+      'test.js',
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+    )
     expect(compiledProps.layout.left).toEqual(2000)
   })
 
@@ -220,7 +235,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('easy!', emptyComments),
       ),
     )
-    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    const compiledProps = jsxAttributesToProps(
+      'test.js',
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+    )
     expect(compiledProps.layout.deep.path).toEqual('easy!')
   })
 
@@ -232,7 +252,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('wee', emptyComments),
       ),
     )
-    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    const compiledProps = jsxAttributesToProps(
+      'test.js',
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+    )
     expect(compiledProps.objectWithArray.array).toEqual([0, 1, 'wee'])
   })
 
@@ -244,7 +269,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('wee', emptyComments),
       ),
     )
-    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    const compiledProps = jsxAttributesToProps(
+      'test.js',
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+    )
     expect(compiledProps.objectWithNestedArray.array).toEqual([0, 1, 'wee'])
   })
 
@@ -256,7 +286,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('wee', emptyComments),
       ),
     )
-    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    const compiledProps = jsxAttributesToProps(
+      'test.js',
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+    )
     expect(compiledProps.objectWithNestedArray.array).toEqual([0, 1, 'wee'])
   })
 
@@ -268,7 +303,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('wee', emptyComments),
       ),
     )
-    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    const compiledProps = jsxAttributesToProps(
+      'test.js',
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+    )
     expect(compiledProps.objectWithNestedArray.array).toEqual({ 0: 0, 1: 1, 2: 2, wee: 'wee' })
   })
 
@@ -282,6 +322,7 @@ describe('setJSXValueAtPath', () => {
         ),
       )
       const compiledProps = jsxAttributesToProps(
+        'test.js',
         { props: sampleParentProps },
         updatedAttributes,
         {},
@@ -297,7 +338,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('wee', emptyComments),
       ),
     )
-    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    const compiledProps = jsxAttributesToProps(
+      'test.js',
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+    )
     expect(compiledProps.style.backgroundColor).toEqual('wee')
   })
 
@@ -316,7 +362,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('hola', emptyComments),
       ),
     )
-    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes2, {})
+    const compiledProps = jsxAttributesToProps(
+      'test.js',
+      { props: sampleParentProps },
+      updatedAttributes2,
+      {},
+    )
     expect(compiledProps.my.property.path).toEqual('hello')
     expect(compiledProps.my.property.other.path).toEqual('hola')
   })
@@ -329,7 +380,12 @@ describe('setJSXValueAtPath', () => {
         jsxAttributeValue('blue', emptyComments),
       ),
     )
-    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    const compiledProps = jsxAttributesToProps(
+      'test.js',
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+    )
     expect(compiledProps.style.backgroundColor).toEqual('blue')
   })
 
@@ -455,7 +511,12 @@ describe('setJSXValueAtPath', () => {
     const updatedAttributes = forceRight(
       setJSXValueAtPath([], PP.create(['top', 0]), jsxAttributeValue(55, emptyComments)),
     )
-    const compiledProps = jsxAttributesToProps({ props: sampleParentProps }, updatedAttributes, {})
+    const compiledProps = jsxAttributesToProps(
+      'test.js',
+      { props: sampleParentProps },
+      updatedAttributes,
+      {},
+    )
     expect(compiledProps).toEqual({ top: [55] })
   })
 })
@@ -463,6 +524,7 @@ describe('setJSXValueAtPath', () => {
 describe('jsxAttributesToProps', () => {
   it('works', () => {
     const compiledProps = jsxAttributesToProps(
+      'test.js',
       { props: sampleParentProps },
       sampleJsxAttributes(),
       {},
@@ -486,7 +548,7 @@ describe('jsxAttributesToProps', () => {
         emptyComments,
       ),
     })
-    const compiledProps = jsxAttributesToProps({}, attributes, {})
+    const compiledProps = jsxAttributesToProps('test.js', {}, attributes, {})
 
     expect(compiledProps).toEqual({ style: { paddingLeft: 23, padding: 5 } })
     expect(Object.entries(compiledProps.style)).toEqual([
@@ -528,7 +590,7 @@ describe('jsxAttributesToProps', () => {
       ),
     })
 
-    const compiledProps = jsxAttributesToProps({}, attributes, {})
+    const compiledProps = jsxAttributesToProps('test.js', {}, attributes, {})
 
     expect(compiledProps).toEqual({ style: { paddingLeft: 23, padding: 5 } })
     expect(Object.entries(compiledProps.style)).toEqual([

--- a/editor/src/core/shared/javascript-cache.ts
+++ b/editor/src/core/shared/javascript-cache.ts
@@ -19,6 +19,7 @@ export function resetFunctionCache(): void {
 }
 
 export function resolveParamsAndRunJsCode(
+  filePath: string,
   javascriptBlock: JavaScriptContainer,
   requireResult: MapLike<any>,
   currentScope: MapLike<any>,
@@ -38,13 +39,14 @@ export function resolveParamsAndRunJsCode(
   //
   // The reason for us filtering the `definedElsewhere` here is so that we can throw a ReferenceError when
   // actually executing the JS code, rather than an error that would confuse the user
-  const result = getOrUpdateFunctionCache(updatedBlock, requireResult, (e) => {
+  const result = getOrUpdateFunctionCache(filePath, updatedBlock, requireResult, (e) => {
     throw e
   })(currentScope['callerThis'], ...Object.values(definedElsewhereInfo))
   return result
 }
 
 function getOrUpdateFunctionCache(
+  filePath: string,
   javascript: JavaScriptContainer,
   requireResult: MapLike<any>,
   handleError: (error: Error) => void,
@@ -54,6 +56,7 @@ function getOrUpdateFunctionCache(
     const newCachedFunction = SafeFunctionCurriedErrorHandler(
       false,
       requireResult,
+      filePath,
       javascript.transpiledJavascript,
       javascript.sourceMap,
       javascript.definedElsewhere,

--- a/editor/src/core/shared/jsx-attributes.ts
+++ b/editor/src/core/shared/jsx-attributes.ts
@@ -166,6 +166,7 @@ export function jsxFunctionAttributeToRawValue(
 }
 
 export function jsxAttributeToValue(
+  filePath: string,
   inScope: MapLike<any>,
   requireResult: MapLike<any>,
   attribute: JSXAttribute,
@@ -176,7 +177,7 @@ export function jsxAttributeToValue(
     case 'ATTRIBUTE_NESTED_ARRAY':
       let returnArray: Array<any> = []
       for (const elem of attribute.content) {
-        const value = jsxAttributeToValue(inScope, requireResult, elem.value)
+        const value = jsxAttributeToValue(filePath, inScope, requireResult, elem.value)
 
         // We don't need to explicitly handle spreads because `concat` will take care of it for us
         returnArray = returnArray.concat(value)
@@ -186,7 +187,7 @@ export function jsxAttributeToValue(
     case 'ATTRIBUTE_NESTED_OBJECT':
       let returnObject: { [key: string]: any } = {}
       fastForEach(attribute.content, (prop) => {
-        const value = jsxAttributeToValue(inScope, requireResult, prop.value)
+        const value = jsxAttributeToValue(filePath, inScope, requireResult, prop.value)
 
         switch (prop.type) {
           case 'PROPERTY_ASSIGNMENT':
@@ -206,13 +207,13 @@ export function jsxAttributeToValue(
       const foundFunction = (UtopiaUtils as any)[attribute.functionName]
       if (foundFunction != null) {
         const resolvedParameters = attribute.parameters.map((param) =>
-          jsxAttributeToValue(inScope, requireResult, param),
+          jsxAttributeToValue(filePath, inScope, requireResult, param),
         )
         return foundFunction(...resolvedParameters)
       }
       throw new Error(`Couldn't find helper function with name ${attribute.functionName}`)
     case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-      return resolveParamsAndRunJsCode(attribute, requireResult, inScope)
+      return resolveParamsAndRunJsCode(filePath, attribute, requireResult, inScope)
     default:
       const _exhaustiveCheck: never = attribute
       throw new Error(`Unhandled attribute ${JSON.stringify(attribute)}`)
@@ -220,6 +221,7 @@ export function jsxAttributeToValue(
 }
 
 export function jsxAttributesToProps(
+  filePath: string,
   inScope: MapLike<any>,
   attributes: JSXAttributes,
   requireResult: MapLike<any>,
@@ -228,12 +230,12 @@ export function jsxAttributesToProps(
   for (const entry of attributes) {
     switch (entry.type) {
       case 'JSX_ATTRIBUTES_ENTRY':
-        result[entry.key] = jsxAttributeToValue(inScope, requireResult, entry.value)
+        result[entry.key] = jsxAttributeToValue(filePath, inScope, requireResult, entry.value)
         break
       case 'JSX_ATTRIBUTES_SPREAD':
         result = {
           ...result,
-          ...jsxAttributeToValue(inScope, requireResult, entry.spreadValue),
+          ...jsxAttributeToValue(filePath, inScope, requireResult, entry.spreadValue),
         }
         break
       default:

--- a/editor/src/third-party/react-error-overlay/utils/isInternalFile.ts
+++ b/editor/src/third-party/react-error-overlay/utils/isInternalFile.ts
@@ -11,7 +11,6 @@ function isInternalFile(sourceFileName: string | null, fileName: string | null) 
     sourceFileName == null ||
     sourceFileName === '' ||
     sourceFileName.indexOf('/~/') !== -1 ||
-    sourceFileName.indexOf('/node_modules/') !== -1 ||
     sourceFileName.trim().indexOf(' ') !== -1 ||
     fileName == null ||
     fileName === ''

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -277,7 +277,7 @@ function createFakeMetadataForJSXElement(
       ),
       ...parentScope,
     }
-    const props = jsxAttributesToProps(inScope, element.props, Utils.NO_OP)
+    const props = jsxAttributesToProps('test.js', inScope, element.props, Utils.NO_OP)
     const children = element.children.flatMap((child) =>
       createFakeMetadataForJSXElement(
         child,


### PR DESCRIPTION
Fixes #1734

**Problem:**
If a third party component fails with an exception when imported the user doesn't get much information about what went wrong.

**Fix:**
When executing the 3rd party module, the stack frames are enhanced with the code executed if there's no source map for it (which there will always be in that case). A slight tweak to some of the overlay logic results in that code snippet showing up correctly.

**Commit Details:**
- Fixes #1734.
- `enhanceStackFrames` now takes some fallback code and a file path
  to respectively supply code when we're just evaluating a block of
  code with no source map and supply a filename for the file being
  evaluated.
- Changed `parseSourceCodeFromRawSourceMap` to return `null` if no
  source map is found so that it's possible to distinguish that case.
- A lot of small changes chaining out the need to supply the fallback
  code and file path for `enhanceStackFrames`.
- Removed the `node_modules` check from `isInternalFile` so that third
  party components get shown in the overlay.
