### PR TITLE
feature(components) add code snippet for easier insertion

### DIFF
--- a/utopia-vscode-extension/package.json
+++ b/utopia-vscode-extension/package.json
@@ -38,6 +38,12 @@
           }
         }
       }
+    ],
+    "snippets": [
+      {
+        "language": "javascript",
+        "path": "./snippets.json"
+      }
     ]
   },
   "dependencies": {

--- a/utopia-vscode-extension/snippets.json
+++ b/utopia-vscode-extension/snippets.json
@@ -5,9 +5,14 @@
       "registerComponent({",
       "  name: ${1}, // name is what appears in the insertion list",
       "  moduleName: ${2}, // name of module, or relative file path",
-      "  controls: ${3}, // property controls",
-      "  insert: ${4}, ",
-      "  requiredImports: ${5}",
+      "  controls: {",
+      "    replaceMe: {",
+      "      control: 'string-input',",
+      "      label: 'placeholder control'",
+      "    },",
+      "  }, // property controls",
+      "  insert: ${4}, // `<Button label='Click Me!' />`",
+      "  requiredImports: ${5} // `import { Button } from 'my-app';` ",
       "})"
     ],
     "description": "Register Component"

--- a/utopia-vscode-extension/snippets.json
+++ b/utopia-vscode-extension/snippets.json
@@ -1,0 +1,15 @@
+{
+  "registerComponent": {
+    "prefix": "registerComponent",
+    "body": [
+      "registerComponent({",
+      "  name: ${1}, // name is what appears in the insertion list",
+      "  moduleName: ${2}, // name of module, or relative file path",
+      "  controls: ${3}, // property controls",
+      "  insert: ${4}, ",
+      "  requiredImports: ${5}",
+      "})"
+    ],
+    "description": "Register Component"
+  }
+}

--- a/utopia-vscode-extension/snippets.json
+++ b/utopia-vscode-extension/snippets.json
@@ -3,16 +3,16 @@
     "prefix": "registerComponent",
     "body": [
       "registerComponent({",
-      "  name: ${1}, // name is what appears in the insertion list",
-      "  moduleName: ${2}, // name of module, or relative file path",
+      "  name: '${1}', // name is what appears in the insertion list",
+      "  moduleName: '${2}', // name of module, or relative file path",
       "  controls: {",
       "    replaceMe: {",
       "      control: 'string-input',",
       "      label: 'placeholder control'",
       "    },",
       "  }, // property controls",
-      "  insert: ${4}, // `<Button label='Click Me!' />`",
-      "  requiredImports: ${5} // `import { Button } from 'my-app';` ",
+      "  insert: '<${1} />', // `<Button label='Click Me!' />`",
+      "  requiredImports: `import { ${1} } from '${2}';` // `import { Button } from 'my-app';` ",
       "})"
     ],
     "description": "Register Component"


### PR DESCRIPTION
**Problem:**
The new register component helper function is difficult to use.

**Fix:**
Add a custom code snippet that inserts the function when starting to type the 'registerComponent'

**Commit Details:**
- created a simple snippet
- added snippet to extension package.json

Should be merged after https://github.com/concrete-utopia/utopia/pull/2003
