### PR TITLE
Make the registerComponent snippet use a bit clearer for the sake of imports

### DIFF
--- a/utopia-vscode-extension/snippets.json
+++ b/utopia-vscode-extension/snippets.json
@@ -4,8 +4,8 @@
     "body": ["registerComponent"],
     "description": "Register Component Import"
   },
-  "registerComponent({})": {
-    "prefix": "registerComponent({})",
+  "registerComponent({...})": {
+    "prefix": "registerComponent({...})",
     "body": [
       "registerComponent({",
       "  name: '${1}', // name is what appears in the insertion list",

--- a/utopia-vscode-extension/snippets.json
+++ b/utopia-vscode-extension/snippets.json
@@ -1,6 +1,11 @@
 {
   "registerComponent": {
     "prefix": "registerComponent",
+    "body": ["registerComponent"],
+    "description": "Register Component Import"
+  },
+  "registerComponent({})": {
+    "prefix": "registerComponent({})",
     "body": [
       "registerComponent({",
       "  name: '${1}', // name is what appears in the insertion list",
@@ -15,6 +20,6 @@
       "  requiredImports: `import { ${1} } from '${2}';` // `import { Button } from 'my-app';` ",
       "})"
     ],
-    "description": "Register Component"
+    "description": "Register Component Function Body"
   }
 }


### PR DESCRIPTION
**Problem:**
The `registerComponent` snippet is suggested when typing "registerComponent" in an import.

**Fix:**
Create two separate snippets in an attempt to make it clearer which one will insert the text "registerComponent" and which will insert a function body.

**Screenshot:**
![Screenshot_20211123_112306](https://user-images.githubusercontent.com/1044774/143015815-ea67ecd2-7b1f-4c6a-b799-342621f40620.png)

The way snippets work is the the `prefix` is the text that is shown on the left, and the key is what is shown on the right. In this case we are using the same values for both.


