### PR TITLE
Use Yarn instead of NPM for the packager.

### DIFF
--- a/server/src/Utopia/Web/Packager/NPM.hs
+++ b/server/src/Utopia/Web/Packager/NPM.hs
@@ -118,14 +118,14 @@ withInstalledProject logger NPMMetrics{..} semaphore versionedPackageName withIn
   let deleteDir = ignoringIOErrors . removeDirectoryRecursive
   bracketP createDir deleteDir $ \tempDir -> do
     -- Run `npm install "packageName@packageVersion"`.
-    let baseProc = proc "npm" ["install", "--silent", "--ignore-scripts", "--omit", "peer", toS versionedPackageName]
+    let baseProc = proc "yarn" ["add", "--silent", "--ignore-scripts", toS versionedPackageName]
     let procWithCwd = baseProc { cwd = Just tempDir, env = Just [("NODE_OPTIONS", "--max_old_space_size=256")] }
     liftIO $ withSemaphore semaphore $ do
-      loggerLn logger ("Starting NPM Install: " <> toLogStr versionedPackageName)
+      loggerLn logger ("Starting Yarn Add: " <> toLogStr versionedPackageName)
       _ <- invokeAndMeasure npmInstallMetric $
           addInvocationDescription npmInstallMetric ("NPM install for " <> versionedPackageName) $
           readCreateProcess procWithCwd ""
-      loggerLn logger ("NPM Install Finished: " <> toLogStr versionedPackageName)
+      loggerLn logger ("Yarn Add Finished: " <> toLogStr versionedPackageName)
     -- Invoke action against path.
     withInstalledPath tempDir
 

--- a/server/test/Test/Utopia/Web/Packager/NPM.hs
+++ b/server/test/Test/Utopia/Web/Packager/NPM.hs
@@ -53,7 +53,7 @@ npmSpec = do
     describe "withInstalledProject" $ do
       it "should have the various dependencies in node_modules for react" $ \(logger, _, _, npmMetrics, semaphore) -> do
         result <- runResourceT $ sourceToList $ withInstalledProject logger npmMetrics semaphore "react@16.13.1" getNodeModulesSubDirectories
-        (sort result) `shouldBe` [".bin", ".package-lock.json", "js-tokens", "loose-envify", "object-assign", "prop-types", "react", "react-is"]
+        (sort result) `shouldBe` [".bin", ".yarn-integrity", "js-tokens", "loose-envify", "object-assign", "prop-types", "react", "react-is"]
       it "should fail for a non-existent project" $ \(logger, _, _, npmMetrics, semaphore) -> do
         (runResourceT $ sourceToList $ withInstalledProject logger npmMetrics semaphore "non-existent-project-that-will-never-exist@9.9.9.9.9.9" getNodeModulesSubDirectories) `shouldThrow` anyIOException
     describe "getModuleAndDependenciesFiles" $ do


### PR DESCRIPTION
Fixes #2009

**Problem:**
Some packages don't want to be installed by npm for varying reasons.

**Fix:**
Switch to using yarn when pulling down a particular dependency in the package server.

**Commit Details:**
- Fixes #2009.
- Switched to using `yarn add` instead of `npm install` in `withInstalledProject`.
