### PR TITLE
fix(insertion) for parsed components use registerComponent element and imports when available

### DIFF
--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -333,16 +333,6 @@ export function getComponentGroups(
             },
             parsedControls,
           )
-          let attributes: JSXAttributes = []
-          for (const key of Object.keys(defaultProps)) {
-            attributes.push(
-              jsxAttributesEntry(
-                key,
-                jsxAttributeValue(defaultProps[key], emptyComments),
-                emptyComments,
-              ),
-            )
-          }
 
           const propertyControlsForDependency =
             propertyControlsInfo[fullPath] ?? propertyControlsInfo[pathWithoutExtension]
@@ -359,6 +349,16 @@ export function getComponentGroups(
               stylePropOptions,
             )
           } else {
+            let attributes: JSXAttributes = []
+            for (const key of Object.keys(defaultProps)) {
+              attributes.push(
+                jsxAttributesEntry(
+                  key,
+                  jsxAttributeValue(defaultProps[key], emptyComments),
+                  emptyComments,
+                ),
+              )
+            }
             return insertableComponent(
               exportedComponent.importsToAdd,
               jsxElementWithoutUID(exportedComponent.listingName, attributes, []),

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -343,12 +343,29 @@ export function getComponentGroups(
               ),
             )
           }
-          return insertableComponent(
-            exportedComponent.importsToAdd,
-            jsxElementWithoutUID(exportedComponent.listingName, attributes, []),
-            exportedComponent.listingName,
-            stylePropOptions,
-          )
+
+          const propertyControlsForDependency =
+            propertyControlsInfo[fullPath] ?? propertyControlsInfo[pathWithoutExtension]
+          if (
+            propertyControlsForDependency != null &&
+            propertyControlsForDependency[exportedComponent.listingName] != null
+          ) {
+            const descriptor = propertyControlsForDependency[exportedComponent.listingName]
+
+            return insertableComponent(
+              descriptor.componentInfo.importsToAdd,
+              descriptor.componentInfo.elementToInsert,
+              exportedComponent.listingName,
+              stylePropOptions,
+            )
+          } else {
+            return insertableComponent(
+              exportedComponent.importsToAdd,
+              jsxElementWithoutUID(exportedComponent.listingName, attributes, []),
+              exportedComponent.listingName,
+              stylePropOptions,
+            )
+          }
         })
         result.push(
           insertableComponentGroup(


### PR DESCRIPTION
**Problem:**
When using the `registerComponent` for internal components the `requiredImports` and `insert` fields are ignored.

**Fix:**
This was missing from the insert menu support, originally it was prepared to work on registering third party components.

**Commit Details:**
- when creating the component insert menu entries it now checks for existing component descriptor
