### PR TITLE
fix(components) show property controls for elements imported with import as

### DIFF
--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -154,8 +154,10 @@ export function getPropertyControlsForTarget(
           ? absolutePath.replace(/\.(js|jsx|ts|tsx)$/, '')
           : absolutePath
 
-        const nameLastPart = getJSXElementNameAsString(element.name)
-        return propertyControlsInfo[trimmedPath]?.[nameLastPart]?.propertyControls
+        const originalName =
+          importedFrom?.type === 'IMPORTED_ORIGIN' ? importedFrom.exportedName : null
+        const nameAsString = originalName ?? getJSXElementNameAsString(element.name)
+        return propertyControlsInfo[trimmedPath]?.[nameAsString]?.propertyControls
       }
     },
   )


### PR DESCRIPTION
**Problem:**
Components using named imports, like `import {Card as MyCard} from "..."`, are not showing the property controls in the inspector.

**Fix:**
The issue is that component section is relying on the jsx element name to find the matching property controls. The fix is to use the `importedFrom` result to find the original exported name for elements imported from other files.

**Commit Details:**
- imported elements use `importedFrom.exportedName` as a name, fallback is the jsx element name
