### PR TITLE
Fix/inspector target selector after layout section

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -312,9 +312,6 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
             aspectRatioLocked={aspectRatioLocked}
             toggleAspectRatioLock={toggleAspectRatioLock}
           />
-          <StyleSection />
-          <WarningSubsection />
-          <ImgSection />
           <TargetSelectorSection
             targets={props.targets}
             selectedTargetPath={props.selectedTargetPath}
@@ -323,6 +320,9 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
             onStyleSelectorDelete={props.onStyleSelectorDelete}
             onStyleSelectorInsert={props.onStyleSelectorInsert}
           />
+          <StyleSection />
+          <WarningSubsection />
+          <ImgSection />
           <EventHandlersSection />
         </React.Fragment>
       )

--- a/editor/src/components/inspector/sections/header-section/target-selector.tsx
+++ b/editor/src/components/inspector/sections/header-section/target-selector.tsx
@@ -70,7 +70,7 @@ export const TargetSelectorPanel = betterReactMemo(
       [targets, onStyleSelectorRename],
     )
 
-    const [isOpen, setIsOpen] = React.useState<boolean>(false)
+    const [isOpen, setIsOpen] = React.useState<boolean>(true)
 
     const onDeleteByIndex = React.useCallback(
       (index: number) => onStyleSelectorDelete(targets[index]),


### PR DESCRIPTION
**Problem:**
The target selector is hidden in the bottom of the inspector, a more exposed position would make it useable.

**Fix:**
Moving the target selector between the Layout and Style section. Changing the initial state for the target selector section to open.


