### PR TITLE
add jest/eslint rules, fix problems that came up

### DIFF
--- a/editor/.eslintrc.js
+++ b/editor/.eslintrc.js
@@ -8,13 +8,14 @@ module.exports = {
     },
   },
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'prettier', 'react', 'react-hooks'],
+  plugins: ['@typescript-eslint', 'prettier', 'react', 'react-hooks', 'jest'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:react/recommended',
     'prettier',
     'prettier/@typescript-eslint',
+    'plugin:jest/recommended',
   ],
   rules: {
     // Built-in eslint rules
@@ -160,6 +161,9 @@ module.exports = {
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/no-shadow': ['error'],
+    'jest/no-conditional-expect': 'off',
+    'jest/no-done-callback': 'off',
+    'jest/no-test-prefixes': 'off',
   },
   overrides: [
     {

--- a/editor/package.json
+++ b/editor/package.json
@@ -272,6 +272,7 @@
     "enzyme": "3.3.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.9.0",
+    "eslint-plugin-jest": "^25.3.0",
     "eslint-plugin-prettier": "3.1.2",
     "expect": "26.1.0",
     "fast-check": "1.15.0",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -112,6 +112,7 @@ specifiers:
   eslint: 6.8.0
   eslint-config-prettier: 6.9.0
   eslint-plugin-import: 2.22.1
+  eslint-plugin-jest: ^25.3.0
   eslint-plugin-jsx-a11y: 6.4.1
   eslint-plugin-prettier: 3.1.2
   eslint-plugin-react: 7.23.2
@@ -442,6 +443,7 @@ devDependencies:
   enzyme: 3.3.0
   eslint: 6.8.0
   eslint-config-prettier: 6.9.0_eslint@6.8.0
+  eslint-plugin-jest: 25.3.0_8fd0a5697fab765342df5a2a3599194b
   eslint-plugin-prettier: 3.1.2_eslint@6.8.0+prettier@2.0.5
   expect: 26.1.0
   fast-check: 1.15.0
@@ -3343,6 +3345,24 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/experimental-utils/5.5.0_eslint@6.8.0+typescript@4.1.3:
+    resolution: {integrity: sha512-kjWeeVU+4lQ1SLYErRKV5yDXbWDPkpbzTUUlfAUifPYvpX0qZlrcCZ96/6oWxt3QxtK5WVhXz+KsnwW9cIW+3A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.9
+      '@typescript-eslint/scope-manager': 5.5.0
+      '@typescript-eslint/types': 5.5.0
+      '@typescript-eslint/typescript-estree': 5.5.0_typescript@4.1.3
+      eslint: 6.8.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@6.8.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/parser/4.24.0_eslint@6.8.0+typescript@4.1.3:
     resolution: {integrity: sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3371,9 +3391,22 @@ packages:
       '@typescript-eslint/visitor-keys': 4.24.0
     dev: true
 
+  /@typescript-eslint/scope-manager/5.5.0:
+    resolution: {integrity: sha512-0/r656RmRLo7CbN4Mdd+xZyPJ/fPCKhYdU6mnZx+8msAD8nJSP8EyCFkzbd6vNVZzZvWlMYrSNekqGrCBqFQhg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.5.0
+      '@typescript-eslint/visitor-keys': 5.5.0
+    dev: true
+
   /@typescript-eslint/types/4.24.0:
     resolution: {integrity: sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+    dev: true
+
+  /@typescript-eslint/types/5.5.0:
+    resolution: {integrity: sha512-OaYTqkW3GnuHxqsxxJ6KypIKd5Uw7bFiQJZRyNi1jbMJnK3Hc/DR4KwB6KJj6PBRkJJoaNwzMNv9vtTk87JhOg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
   /@typescript-eslint/typescript-estree/4.24.0_typescript@4.1.3:
@@ -3397,12 +3430,41 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/5.5.0_typescript@4.1.3:
+    resolution: {integrity: sha512-pVn8btYUiYrjonhMAO0yG8lm7RApzy2L4RC7Td/mC/qFkyf6vRbGyZozoA94+w6D2Y2GRqpMoCWcwx/EUOzyoQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.5.0
+      '@typescript-eslint/visitor-keys': 5.5.0
+      debug: 4.3.2
+      globby: 11.0.4
+      is-glob: 4.0.3
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.1.3
+      typescript: 4.1.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/visitor-keys/4.24.0:
     resolution: {integrity: sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     dependencies:
       '@typescript-eslint/types': 4.24.0
       eslint-visitor-keys: 2.1.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.5.0:
+    resolution: {integrity: sha512-4GzJ1kRtsWzHhdM40tv0ZKHNSbkDhF0Woi/TDwVJX6UICwJItvP7ZTXbjTkCdrors7ww0sYe0t+cIKDAJwZ7Kw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.5.0
+      eslint-visitor-keys: 3.1.0
     dev: true
 
   /@ungap/promise-all-settled/1.1.2:
@@ -6622,6 +6684,28 @@ packages:
       tsconfig-paths: 3.11.0
     dev: false
 
+  /eslint-plugin-jest/25.3.0_8fd0a5697fab765342df5a2a3599194b:
+    resolution: {integrity: sha512-79WQtuBsTN1S8Y9+7euBYwxIOia/k7ykkl9OCBHL3xuww5ecursHy/D8GCIlvzHVWv85gOkS5Kv6Sh7RxOgK1Q==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^4.0.0 || ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      jest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      jest:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 4.24.0_d722183cf3439456233a2142a3db9ede
+      '@typescript-eslint/experimental-utils': 5.5.0_eslint@6.8.0+typescript@4.1.3
+      eslint: 6.8.0
+      jest: 27.2.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /eslint-plugin-jsx-a11y/6.4.1_eslint@6.8.0:
     resolution: {integrity: sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==}
     engines: {node: '>=4.0'}
@@ -6712,6 +6796,16 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: true
 
+  /eslint-utils/3.0.0_eslint@6.8.0:
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+    dependencies:
+      eslint: 6.8.0
+      eslint-visitor-keys: 2.1.0
+    dev: true
+
   /eslint-visitor-keys/1.3.0:
     resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
     engines: {node: '>=4'}
@@ -6719,6 +6813,11 @@ packages:
   /eslint-visitor-keys/2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
     engines: {node: '>=10'}
+    dev: true
+
+  /eslint-visitor-keys/3.1.0:
+    resolution: {integrity: sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
   /eslint/6.8.0:

--- a/editor/src/bundled-dependencies/codeBundle.spec.ts
+++ b/editor/src/bundled-dependencies/codeBundle.spec.ts
@@ -26,7 +26,9 @@ function getBuildResultMessageForDefaultProject(onResult: (result: BuildResultMe
           break
         }
         default:
-          fail(`Expected a 'build' message from tsworker, received ${receivedContent.type}`)
+          throw new Error(
+            `Expected a 'build' message from tsworker, received ${receivedContent.type}`,
+          )
       }
     },
     'noid',

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -20870,7 +20870,7 @@ export var storyboard = (props) => {
 }
 `;
 
-exports[`UiJsxCanvas render multifile projects renders a canvas with App imported from a file 2`] = `
+exports[`UiJsxCanvas render multifile projects renders a canvas with App imported from a file 2 1`] = `
 Array [
   Object {
     "message": "Element hierarchy is too deep, potentially has become infinite.",

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper-third-party.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper-third-party.spec.browser2.tsx
@@ -116,7 +116,7 @@ function renderTestProject() {
       emptySet(),
     ) as ParsedTextFile
     if (!isParseSuccess(parsedFile)) {
-      fail('The test file parse failed')
+      throw new Error('The test file parse failed')
     }
 
     const updatedProjectContents = addFileToProjectContents(

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -2175,7 +2175,7 @@ describe('UiJsxCanvas render multifile projects', () => {
     `)
   })
 
-  it('renders a canvas with App imported from a file', () => {
+  it('renders a canvas with App imported from a file 2', () => {
     testCanvasErrorMultifile(
       null,
       `import * as React from 'react'

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -108,7 +108,7 @@ const FailJestOnCanvasError = () => {
     // we have new runtime errors, let's take the tests down
     if (newRuntimeErrors.length > 0) {
       console.error('Canvas Error!!!!!', newRuntimeErrors[0]?.error)
-      fail(newRuntimeErrors[0]?.error)
+      throw newRuntimeErrors[0]?.error
       expect(newRuntimeErrors[0]?.error ?? null).toEqual(null)
     }
   }, [])
@@ -308,7 +308,7 @@ export function getPrintedUiJsCode(
   if (isTextFile(file)) {
     return file.fileContents.code
   } else {
-    fail('File is not a text file.')
+    throw new Error('File is not a text file.')
   }
 }
 
@@ -324,7 +324,7 @@ export function getPrintedUiJsCodeWithoutUIDs(store: EditorStore): string {
       file.fileContents.parsed.exportsDetail,
     )
   } else {
-    fail('File is not a text file.')
+    throw new Error('File is not a text file.')
   }
 }
 

--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -488,7 +488,7 @@ describe('incorporateBuildResult', () => {
     })
     expect(Object.keys(nodeModules)).toMatchInlineSnapshot(`Array []`)
   })
-  it('should remove a value if there is no transpiled code', () => {
+  it('should remove a value if there is no transpiled code 2', () => {
     const projectContents = addFileToProjectContents(
       {},
       '/app.js',

--- a/editor/src/components/editor/actions/actions.spec.ts
+++ b/editor/src/components/editor/actions/actions.spec.ts
@@ -489,13 +489,13 @@ describe('moveTemplate', () => {
           const movedView = Utils.path(['rootElement', 'children', 0, 'children', 0], updatedRoot)
           expect(movedView).toEqual(view('ccc', [], 10, 10, 100, 100))
         } else {
-          fail('First top level element is not a component.')
+          throw new Error('First top level element is not a component.')
         }
       } else {
-        fail('File does not contain parse success.')
+        throw new Error('File does not contain parse success.')
       }
     } else {
-      fail('src/app.js is not a UI JS file.')
+      throw new Error('src/app.js is not a UI JS file.')
     }
   })
 
@@ -1234,10 +1234,10 @@ describe('INSERT_WITH_DEFAULTS', () => {
           "
         `)
       } else {
-        fail('File does not contain parse success.')
+        throw new Error('File does not contain parse success.')
       }
     } else {
-      fail('File is not a text file.')
+      throw new Error('File is not a text file.')
     }
   })
 
@@ -1337,10 +1337,10 @@ describe('INSERT_WITH_DEFAULTS', () => {
           "
         `)
       } else {
-        fail('File does not contain parse success.')
+        throw new Error('File does not contain parse success.')
       }
     } else {
-      fail('File is not a text file.')
+      throw new Error('File is not a text file.')
     }
   })
 
@@ -1429,10 +1429,10 @@ describe('INSERT_WITH_DEFAULTS', () => {
           "
         `)
       } else {
-        fail('File does not contain parse success.')
+        throw new Error('File does not contain parse success.')
       }
     } else {
-      fail('File is not a text file.')
+      throw new Error('File is not a text file.')
     }
   })
 
@@ -1521,10 +1521,10 @@ describe('INSERT_WITH_DEFAULTS', () => {
           "
         `)
       } else {
-        fail('File does not contain parse success.')
+        throw new Error('File does not contain parse success.')
       }
     } else {
-      fail('File is not a text file.')
+      throw new Error('File is not a text file.')
     }
   })
 
@@ -1605,10 +1605,10 @@ describe('INSERT_WITH_DEFAULTS', () => {
           "
         `)
       } else {
-        fail('File does not contain parse success.')
+        throw new Error('File does not contain parse success.')
       }
     } else {
-      fail('File is not a text file.')
+      throw new Error('File is not a text file.')
     }
   })
 })

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -1018,7 +1018,7 @@ describe('updating package.json', () => {
       '/package.json',
     )
     if (packageJsonFile == null || packageJsonFile.type != 'TEXT_FILE') {
-      fail('Package.json file should exist and should be a TextFile')
+      throw new Error('Package.json file should exist and should be a TextFile')
     } else {
       expect(packageJsonFile.fileContents).toMatchInlineSnapshot(`
         Object {

--- a/editor/src/components/expression-graph.spec.ts
+++ b/editor/src/components/expression-graph.spec.ts
@@ -1,3 +1,5 @@
+// disaling jest expect rules because this file uses Chai.expect
+/* eslint-disable jest/valid-expect */
 import * as Chai from 'chai'
 const expect = Chai.expect
 import Utils from '../utils/utils'

--- a/editor/src/components/inspector/common/css-utils.spec.ts
+++ b/editor/src/components/inspector/common/css-utils.spec.ts
@@ -258,7 +258,7 @@ function testRegexMatches(
       const matchGroup = stringAndMatch.matchGroups[i]
       if (matchGroup != null) {
         if (stringAndMatch.testString.match(regex)![i] !== matchGroup) {
-          fail(
+          throw new Error(
             `${stringAndMatch.testString}: ${
               stringAndMatch.testString.match(regex)![i]
             } doesn't equal ${matchGroup}`,
@@ -370,13 +370,13 @@ function testBackgroundLayers(
   for (const validString of validStrings) {
     const parsed = parseFunction(validString)
     if (isLeft(parsed)) {
-      fail(`${parsed.value}: ${validString}`)
+      throw new Error(`${parsed.value}: ${validString}`)
     }
   }
   for (const invalidString of invalidStrings) {
     const parsed = parseFunction(invalidString)
     if (isRight(parsed)) {
-      fail(`${parsed.value}: ${invalidString}`)
+      throw new Error(`${parsed.value}: ${invalidString}`)
     }
   }
 }
@@ -1640,7 +1640,7 @@ describe('cssColorToChromaColor', () => {
   })
 })
 
-describe('parseBackgroundColor', () => {
+describe('parseBackgroundColor 2', () => {
   it('parses a background color', () => {
     const validStrings = ['#fff', 'rgba(255 255 255 / 1)']
 

--- a/editor/src/components/inspector/common/property-path-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.spec.tsx
@@ -909,7 +909,7 @@ describe('Integration Test: opacity property', () => {
     expect(hookResult.controlStatus).toEqual(expectedControlStatus)
   })
 
-  xit('parses a multiselect-unoverwritable control status', () => {
+  xit('parses a multiselect-unoverwritable control status 2', () => {
     const hookResult = getOpacityHookResult(
       [`nodeValue1`, `nodeValue2`],
       [`nodeValue1`, `nodeValue2`],

--- a/editor/src/components/inspector/common/property-path-hooks.test-utils.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.test-utils.tsx
@@ -88,15 +88,15 @@ export function getPropsForStyleProp(
 
   const parseResult = testParseCode(code)
   if (!isParseSuccess(parseResult)) {
-    fail('expected parseResult to be Right')
+    throw new Error('expected parseResult to be Right')
   }
   const appComponent = parseResult.topLevelElements.find(isUtopiaJSXComponent)
 
   if (appComponent == null || !isUtopiaJSXComponent(appComponent) || appComponent.name !== `App`) {
-    fail('expected the second topLevelElement to be the App component')
+    throw new Error('expected the second topLevelElement to be the App component')
   }
   if (!isJSXElement(appComponent.rootElement)) {
-    fail(`expected the App component's root element to be a JSXElement`)
+    throw new Error(`expected the App component's root element to be a JSXElement`)
   }
 
   return appComponent.rootElement.props

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -195,7 +195,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
       createBuiltInDependenciesList(NO_OP, null, null),
     )
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
-      fail(`Expected successful nodeModules fetch`)
+      throw new Error(`Expected successful nodeModules fetch`)
     }
     const nodeModules = fetchNodeModulesResult.nodeModules
     const onRemoteModuleDownload = jest.fn()
@@ -230,7 +230,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
       createBuiltInDependenciesList(NO_OP, null, null),
     ).then((fetchNodeModulesResult) => {
       if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
-        fail(`Expected successful nodeModules fetch`)
+        throw new Error(`Expected successful nodeModules fetch`)
       }
       const nodeModules = fetchNodeModulesResult.nodeModules
 
@@ -301,7 +301,7 @@ describe('ES Dependency Manager', () => {
       createBuiltInDependenciesList(NO_OP, null, null),
     )
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
-      fail(`Expected successful nodeModules fetch`)
+      throw new Error(`Expected successful nodeModules fetch`)
     }
     const nodeModules = fetchNodeModulesResult.nodeModules
     const onRemoteModuleDownload = jest.fn()
@@ -336,7 +336,7 @@ describe('ES Dependency Manager — d.ts', () => {
       createBuiltInDependenciesList(NO_OP, null, null),
     )
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
-      fail(`Expected successful nodeModules fetch`)
+      throw new Error(`Expected successful nodeModules fetch`)
     }
     const nodeModules = fetchNodeModulesResult.nodeModules
     const typings = getDependencyTypeDefinitions(nodeModules)
@@ -371,7 +371,7 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
       createBuiltInDependenciesList(NO_OP, null, null),
     ).then((fetchNodeModulesResult) => {
       if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
-        fail(`Expected successful nodeModules fetch`)
+        throw new Error(`Expected successful nodeModules fetch`)
       }
       const nodeModules = fetchNodeModulesResult.nodeModules
 
@@ -437,7 +437,7 @@ describe('ES Dependency manager - retry behavior', () => {
       createBuiltInDependenciesList(NO_OP, null, null),
     ).then((fetchNodeModulesResult) => {
       if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
-        fail(`Expected successful nodeModule fetch`)
+        throw new Error(`Expected successful nodeModule fetch`)
       }
       expect(Object.keys(fetchNodeModulesResult.nodeModules)).toHaveLength(228)
       expect(

--- a/editor/src/core/model/element-template-utils.spec.ts
+++ b/editor/src/core/model/element-template-utils.spec.ts
@@ -81,13 +81,13 @@ describe('guaranteeUniqueUids', () => {
     const fixedElementProps = Utils.pathOr([], ['props'], fixedElement)
     const fixedElementUIDProp = getJSXAttribute(fixedElementProps, 'data-uid')
     if (fixedElementUIDProp == null) {
-      fail('Unable to find uid for element.')
+      throw new Error('Unable to find uid for element.')
     } else if (isJSXAttributeValue(fixedElementUIDProp)) {
       const fixedElementUID = (fixedElement as JSXElement).uid
       expect(fixedElementUID).toEqual(fixedElementUIDProp.value)
       expect(fixedElementUID).not.toEqual('')
     } else {
-      fail('fixedElementUIDProp is not a simple value')
+      throw new Error('fixedElementUIDProp is not a simple value')
     }
   })
 })

--- a/editor/src/core/model/jsx-attributes.spec.ts
+++ b/editor/src/core/model/jsx-attributes.spec.ts
@@ -436,7 +436,7 @@ describe('setJSXValueAtPath', () => {
       jsxAttributeValue(100, emptyComments),
     )
     if (isLeft(result)) {
-      fail(`result is LEFT`)
+      throw new Error(`result is LEFT`)
     }
 
     expect(result.value).toEqual(
@@ -491,7 +491,7 @@ describe('setJSXValueAtPath', () => {
       jsxAttributeValue(100, emptyComments),
     )
     if (isLeft(result)) {
-      fail(`result is LEFT`)
+      throw new Error(`result is LEFT`)
     }
 
     expect(result.value).toEqual(
@@ -613,7 +613,7 @@ describe('getModifiableJSXAttributeAtPath', () => {
       if (backgroundColor != null && isJSXAttributeValue(backgroundColor.value)) {
         expect(backgroundColor.value.value).toEqual('red')
       } else {
-        fail('backgroundColor is not a JSXAttributeValue')
+        throw new Error('backgroundColor is not a JSXAttributeValue')
       }
     }
   })
@@ -680,7 +680,7 @@ describe('jsxSimpleAttributeToValue', () => {
       top: 50,
       left: 100,
     }
-    expect(isRight(attributeValue))
+    expect(isRight(attributeValue)).toBeTruthy()
     expect(attributeValue.value).toEqual(expectedAttrValue)
   })
 })

--- a/editor/src/core/model/storyboard-utils.spec.ts
+++ b/editor/src/core/model/storyboard-utils.spec.ts
@@ -35,7 +35,7 @@ export var App = (props) => {
   const parsedFile = lintAndParse(StoryboardFilePath, appFile, null, emptySet()) as ParsedTextFile
 
   if (!isParseSuccess(parsedFile)) {
-    fail('The test file parse failed')
+    throw new Error('The test file parse failed')
   }
 
   const projectContentsWithoutStoryboard = removeFromProjectContents(
@@ -64,14 +64,14 @@ describe('addStoryboardFileToProject', () => {
   it('adds storyboard file to project that does not have one', () => {
     const actualResult = addStoryboardFileToProject(createTestProjectLackingStoryboardFile())
     if (actualResult == null) {
-      fail('Editor state was not updated.')
+      throw new Error('Editor state was not updated.')
     } else {
       const storyboardFile = getContentsTreeFileFromString(
         actualResult.projectContents,
         StoryboardFilePath,
       )
       if (storyboardFile == null) {
-        fail('No storyboard file was created.')
+        throw new Error('No storyboard file was created.')
       } else {
         if (isTextFile(storyboardFile)) {
           const topLevelElements = foldParsedTextFile(
@@ -84,7 +84,7 @@ describe('addStoryboardFileToProject', () => {
           )
           expect(topLevelElements).toMatchSnapshot()
         } else {
-          fail('Storyboard file is not a UI JS file.')
+          throw new Error('Storyboard file is not a UI JS file.')
         }
       }
     }

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -14,7 +14,7 @@ jest.mock('../../components/canvas/controls/outline-utils', () => ({
   isZeroSizedElement: () => false, // in test environment elements have no size
 }))
 
-describe('React Render Count Tests - ', () => {
+describe('React Render Count Tests -', () => {
   it('Clicking on opacity slider with a simple project', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`

--- a/editor/src/core/webpack-loaders/loaders.spec.ts
+++ b/editor/src/core/webpack-loaders/loaders.spec.ts
@@ -18,7 +18,7 @@ function nameForModuleLoader(moduleLoader: ModuleLoader): string {
   } else if (moduleLoader === SVGLoader) {
     return 'SVG Loader'
   } else {
-    fail('Invalid loader')
+    throw new Error('Invalid loader')
   }
 }
 

--- a/editor/src/core/workers/bundler-bridge.spec.ts
+++ b/editor/src/core/workers/bundler-bridge.spec.ts
@@ -52,7 +52,7 @@ describe('Bundler State Machine', () => {
 
     await initReadyPromise
 
-    expect(stateMachine.state.matches('worker.idle'))
+    expect(stateMachine.state.matches('worker.idle')).toBeTruthy()
   })
 
   it('starts the worker when it receives a file to update', async () => {

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
@@ -74,7 +74,9 @@ export var ${BakedInStoryboardVariableName} = (props) => {
     ).formatted
     const parseResult = testParseCode(code)
     foldParsedTextFile(
-      (failure) => fail(failure),
+      (failure) => {
+        throw new Error(JSON.stringify(failure))
+      },
       (success) => {
         const firstComponent = success.topLevelElements.find(isUtopiaJSXComponent)
         if (firstComponent != null) {
@@ -87,19 +89,22 @@ export var ${BakedInStoryboardVariableName} = (props) => {
                 firstChild.elementsWithin[Object.keys(firstChild.elementsWithin)[0]]
               expect(getJSXAttribute(elementWithin.props, 'data-uid')).not.toBeNull()
             } else {
-              fail('First child is not an arbitrary block of code.')
+              throw new Error('First child is not an arbitrary block of code.')
             }
           } else {
-            fail('Root element not a JSX element.')
+            throw new Error('Root element not a JSX element.')
           }
         } else {
-          fail('Not a component at the root.')
+          throw new Error('Not a component at the root.')
         }
       },
-      (unparsed) => fail(unparsed),
+      (unparsed) => {
+        throw new Error(JSON.stringify(unparsed))
+      },
       parseResult,
     )
   })
+  // eslint-disable-next-line jest/expect-expect
   it('should write updated arbitrary elements back into code', () => {
     const code = applyPrettier(
       `import * as React from "react";
@@ -772,7 +777,7 @@ return { arr: arr };`
     )
     expect(actualResult).toEqual(expectedResult)
   })
-  it('supports passing down the scope to children of components', () => {
+  it('supports passing down the scope to children of components 2', () => {
     const code = `import React from "react";
 import { View } from "utopia-api";
 export var whatever = (props) => {
@@ -864,7 +869,7 @@ export var whatever = (props) => {
     )
     expect(actualResult).toEqual(expectedResult)
   })
-  xit('supports nested array destructuring in a function param', () => {
+  xit('supports nested array destructuring in a function param 2', () => {
     // FIXME Nested array destructuring doesn't work
     const code = `import React from "react";
 import { View } from "utopia-api";
@@ -1210,7 +1215,7 @@ export var storyboard = (
         }
       `)
     } else {
-      fail(`Failed to parse code`)
+      throw new Error(`Failed to parse code`)
     }
   })
 

--- a/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
@@ -19,23 +19,6 @@ import { objectMap, omit } from '../../shared/object-utils'
 import { BakedInStoryboardVariableName, BakedInStoryboardUID } from '../../model/scene-utils'
 import { isParseSuccess } from '../../shared/project-file-types'
 
-export function stripUnhelpfulFields(value: any): any {
-  switch (typeof value) {
-    case 'object': {
-      if (Array.isArray(value)) {
-        return value.map(stripUnhelpfulFields)
-      } else {
-        return objectMap(
-          stripUnhelpfulFields,
-          omit(['sourceMap', 'javascript', 'uniqueID', 'code'], value),
-        )
-      }
-    }
-    default:
-      return value
-  }
-}
-
 describe('JSX parser', () => {
   it('adds in data-uid attributes for elements in arbitrary code', () => {
     const code = `import * as React from "react";
@@ -50,7 +33,7 @@ export var App = props => {
 };`
     const parsedCode = testParseCode(code)
     if (!isParseSuccess(parsedCode)) {
-      fail(parsedCode)
+      throw new Error(JSON.stringify(parsedCode))
     }
   })
   it('fails on unprettied code', () => {
@@ -78,13 +61,13 @@ export var App = props => {
           })
           expect(topComponent.rootElement.props).toEqual(expectedProps)
         } else {
-          fail('Root element not a JSX element.')
+          throw new Error('Root element not a JSX element.')
         }
       } else {
-        fail('Not a component.')
+        throw new Error('Not a component.')
       }
     } else {
-      fail(parsedPlainCode)
+      throw new Error(JSON.stringify(parsedPlainCode))
     }
   })
   it('parses elements that use props spreading - #1365', () => {

--- a/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-comments.spec.ts
@@ -117,11 +117,12 @@ describe('Parsing and printing code with comments', () => {
   forEachValue((commentText, commentKey) => {
     const testFn = notYetSupported.includes(commentKey) ? xit : it
     testFn(`should retain the comment '${commentText}'`, () => {
+      // eslint-disable-next-line jest/no-standalone-expect
       expect(parsedThenPrinted.includes(commentText)).toBeTruthy()
       const firstIndex = parsedThenPrinted.indexOf(commentText)
       const lastIndex = parsedThenPrinted.lastIndexOf(commentText)
       if (firstIndex !== lastIndex) {
-        fail(`Found more than one instance of ${commentText}`)
+        throw new Error(`Found more than one instance of ${commentText}`)
       }
     })
   }, comments)

--- a/editor/src/core/workers/parser-printer/parser-printer-dot-notation.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-dot-notation.spec.tsx
@@ -44,18 +44,20 @@ export var storyboard = (props) => {
     const parseResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
     foldParsedTextFile(
       (failure) => {
-        fail(failure)
+        throw new Error(JSON.stringify(failure))
       },
       (success) => {
         expect(success.imports).toMatchSnapshot()
         expect(success.topLevelElements).toMatchSnapshot()
       },
       (unparsed) => {
-        fail(unparsed)
+        throw new Error(JSON.stringify(unparsed))
       },
       parseResult,
     )
   })
+
+  // eslint-disable-next-line jest/expect-expect
   it('dot-notated elements cycle fully back and forth', () => {
     const originalCode = `
 import * as React from "react";

--- a/editor/src/core/workers/parser-printer/parser-printer-event-handlers.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-event-handlers.spec.tsx
@@ -93,7 +93,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
       ).formatted
       expect(printedCode).toEqual(expectedCode)
     } else {
-      fail(parseResult)
+      throw new Error(JSON.stringify(parseResult))
     }
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-exports.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-exports.spec.tsx
@@ -61,7 +61,7 @@ describe('parseCode', () => {
     if (isParseSuccess(actualResult)) {
       expect(actualResult.exportsDetail).toMatchInlineSnapshot(`Array []`)
     } else {
-      fail('Did not parse successfully.')
+      throw new Error('Did not parse successfully.')
     }
   })
 
@@ -88,7 +88,7 @@ export const { name: firstName, surname } = entireValue`
         ]
       `)
     } else {
-      fail('Did not parse successfully.')
+      throw new Error('Did not parse successfully.')
     }
   })
 
@@ -116,7 +116,7 @@ export { thing1, thing2 }`
         ]
       `)
     } else {
-      fail('Did not parse successfully.')
+      throw new Error('Did not parse successfully.')
     }
   })
 
@@ -144,7 +144,7 @@ export { thing1 as importantThing1, thing2 as importantThing2 }`
         ]
       `)
     } else {
-      fail('Did not parse successfully.')
+      throw new Error('Did not parse successfully.')
     }
   })
 
@@ -172,7 +172,7 @@ export { thing1 as default, thing2 as importantThing2 }`
         ]
       `)
     } else {
-      fail('Did not parse successfully.')
+      throw new Error('Did not parse successfully.')
     }
   })
 
@@ -212,7 +212,7 @@ export let exportedLet1, exportedLet2;
         ]
       `)
     } else {
-      fail('Did not parse successfully.')
+      throw new Error('Did not parse successfully.')
     }
   })
 
@@ -265,7 +265,7 @@ export const exportedConst1 = 'const1', exportedConst2 = 'const2';
         ]
       `)
     } else {
-      fail('Did not parse successfully.')
+      throw new Error('Did not parse successfully.')
     }
   })
 
@@ -286,28 +286,7 @@ export function App() {
         ]
       `)
     } else {
-      fail('Did not parse successfully.')
-    }
-  })
-
-  it(`parses 'export function' marked values`, () => {
-    const code = `import * as React from "react";
-export function App() {
-  return <div />
-}
-`
-    const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
-    if (isParseSuccess(actualResult)) {
-      expect(actualResult.exportsDetail).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "functionName": "App",
-            "type": "EXPORT_FUNCTION",
-          },
-        ]
-      `)
-    } else {
-      fail('Did not parse successfully.')
+      throw new Error('Did not parse successfully.')
     }
   })
 
@@ -326,7 +305,7 @@ export class App {}
         ]
       `)
     } else {
-      fail('Did not parse successfully.')
+      throw new Error('Did not parse successfully.')
     }
   })
 
@@ -345,7 +324,7 @@ export default function() { return 5 }
         ]
       `)
     } else {
-      fail('Did not parse successfully.')
+      throw new Error('Did not parse successfully.')
     }
   })
 
@@ -364,7 +343,7 @@ export default function addFive() { return 5 }
         ]
       `)
     } else {
-      fail('Did not parse successfully.')
+      throw new Error('Did not parse successfully.')
     }
   })
 
@@ -383,7 +362,7 @@ export default class App {}
         ]
       `)
     } else {
-      fail('Did not parse successfully.')
+      throw new Error('Did not parse successfully.')
     }
   })
   describe(`re-exports`, () => {
@@ -402,7 +381,7 @@ export default class App {}
           ]
         `)
       } else {
-        fail(actualResult)
+        throw new Error(JSON.stringify(actualResult))
       }
     })
     it(`parses a wildcard re-export into a named value from another module`, () => {
@@ -420,7 +399,7 @@ export default class App {}
           ]
         `)
       } else {
-        fail(actualResult)
+        throw new Error(JSON.stringify(actualResult))
       }
     })
     it(`parses a re-export of specific named values from another module`, () => {
@@ -447,10 +426,10 @@ export default class App {}
           ]
         `)
       } else {
-        fail(actualResult)
+        throw new Error(JSON.stringify(actualResult))
       }
     })
-    it(`parses a re-export of specific named values from another module`, () => {
+    it(`parses a re-export of specific named values from another module 2`, () => {
       const code = `export { import1 as thing1, import2 as thing2 } from 'othermodule'`
 
       const actualResult = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
@@ -474,7 +453,7 @@ export default class App {}
           ]
         `)
       } else {
-        fail(actualResult)
+        throw new Error(JSON.stringify(actualResult))
       }
     })
     it(`parses a re-export of the default export from another module`, () => {
@@ -497,7 +476,7 @@ export default class App {}
           ]
         `)
       } else {
-        fail(actualResult)
+        throw new Error(JSON.stringify(actualResult))
       }
     })
   })

--- a/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
@@ -108,7 +108,7 @@ describe('JSX parser', () => {
         "
       `)
     } else {
-      fail(parseResult)
+      throw new Error(JSON.stringify(parseResult))
     }
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/expect-expect */
 import {
   clearParseResultUniqueIDsAndEmptyBlocks,
   testParseCode,
@@ -856,7 +857,7 @@ describe('Parsing, printing, reparsing a function component with props', () => {
     const firstParse = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(code))
 
     if (!isParseSuccess(firstParse)) {
-      fail(firstParse)
+      throw new Error(JSON.stringify(firstParse))
     }
 
     const firstAsParseSuccess = firstParse
@@ -873,7 +874,7 @@ describe('Parsing, printing, reparsing a function component with props', () => {
     const secondParse = clearParseResultUniqueIDsAndEmptyBlocks(testParseCode(printed))
 
     if (!isParseSuccess(secondParse)) {
-      fail(secondParse)
+      throw new Error(JSON.stringify(secondParse))
     }
 
     const secondAsParseSuccess = firstParse

--- a/editor/src/core/workers/parser-printer/parser-printer-pragma.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-pragma.spec.ts
@@ -16,7 +16,7 @@ describe('Parsing JSX Pragma:', () => {
     if (isParseSuccess(parsedPlainCode)) {
       expect(parsedPlainCode.jsxFactoryFunction).toEqual(null)
     } else {
-      fail(parsedPlainCode)
+      throw new Error(JSON.stringify(parsedPlainCode))
     }
   })
 
@@ -33,7 +33,7 @@ describe('Parsing JSX Pragma:', () => {
     if (isParseSuccess(parsedPlainCode)) {
       expect(parsedPlainCode.jsxFactoryFunction).toEqual('jsx')
     } else {
-      fail(parsedPlainCode)
+      throw new Error(JSON.stringify(parsedPlainCode))
     }
   })
 
@@ -76,7 +76,7 @@ describe('Parsing JSX Pragma:', () => {
     if (isParseSuccess(parsedPlainCode)) {
       expect(parsedPlainCode.jsxFactoryFunction).toEqual('preact.h')
     } else {
-      fail(parsedPlainCode)
+      throw new Error(JSON.stringify(parsedPlainCode))
     }
   })
 
@@ -94,7 +94,7 @@ describe('Parsing JSX Pragma:', () => {
     if (isParseSuccess(parsedPlainCode)) {
       expect(parsedPlainCode.jsxFactoryFunction).toEqual('preact.h')
     } else {
-      fail(parsedPlainCode)
+      throw new Error(JSON.stringify(parsedPlainCode))
     }
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-uids.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-uids.spec.tsx
@@ -59,7 +59,9 @@ describe('parseCode', () => {
   it('produces unique IDs for every element', () => {
     const parseResult = testParseCode(MajesticBrokerTestCaseCode)
     foldParsedTextFile(
-      (_) => fail('Is a failure.'),
+      (_) => {
+        throw new Error('Is a failure.')
+      },
       (success) => {
         const projectContents = addFileToProjectContents(
           {},
@@ -74,7 +76,9 @@ describe('parseCode', () => {
         const uniqueIDs = getAllUniqueUids(projectContents, 'Unique IDs failure.')
         expect(uniq(uniqueIDs).length).toMatchInlineSnapshot(`77`)
       },
-      (_) => fail('Is unparsed.'),
+      (_) => {
+        throw new Error('Is unparsed.')
+      },
       parseResult,
     )
   })

--- a/editor/src/core/workers/parser-printer/parser-printer-utils.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-utils.spec.ts
@@ -107,11 +107,11 @@ describe('guaranteeUniqueUidsFromTopLevel', () => {
     const rootElementProps = Utils.path<JSXAttributes>(['rootElement', 'props'], fixedComponent)
     const uidProp = getJSXAttribute(rootElementProps ?? [], 'data-uid')
     if (uidProp == null) {
-      fail('uid prop does not exist')
+      throw new Error('uid prop does not exist')
     } else if (isJSXAttributeValue(uidProp)) {
       expect(rootElement?.uid).toEqual(uidProp.value)
     } else {
-      fail('uid prop should be a simple value')
+      throw new Error('uid prop should be a simple value')
     }
   })
 

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -2498,7 +2498,7 @@ export var Whatever = (props) => <View>
       expect(actualResult.topLevelElements.filter(isArbitraryJSBlock).length).toEqual(1)
       expect(actualResult.topLevelElements.filter(isUtopiaJSXComponent).length).toEqual(0)
     } else {
-      fail('Parse result is not a success.')
+      throw new Error('Parse result is not a success.')
     }
   })
 
@@ -2525,13 +2525,15 @@ export var whatever = (props) => <View data-uid='aaa'>
             const leftProp = getJSXAttributeForced(child.props, 'left')
             expect(leftProp.type).toEqual('ATTRIBUTE_OTHER_JAVASCRIPT')
           } else {
-            fail(`First child is not an element ${child}`)
+            throw new Error(`First child is not an element ${child}`)
           }
         } else {
-          fail(`Unexpected number of children returned: ${result.rootElement.children.length}`)
+          throw new Error(
+            `Unexpected number of children returned: ${result.rootElement.children.length}`,
+          )
         }
       } else {
-        fail(`Root element is not an element ${result.rootElement}`)
+        throw new Error(`Root element is not an element ${result.rootElement}`)
       }
     }
   })
@@ -2613,7 +2615,7 @@ export var whatever = (props) => <View data-uid='aaa'>
     )
     expect(actualResult).toEqual(expectedResult)
   })
-  it('parses the code when it is a var', () => {
+  it('parses the code when it is a var 2', () => {
     const code = `import * as React from "react";
 import {
   UtopiaUtils,
@@ -3055,7 +3057,7 @@ export var whatever = props => {
       )
       expect(printedCode).toEqual(code)
     } else {
-      fail('Parse result is not a success.')
+      throw new Error('Parse result is not a success.')
     }
   })
   it('parses back and forth as a function', () => {
@@ -4557,7 +4559,9 @@ export var whatever2 = (props) => <View data-uid='aaa'>
 `
     const actualResult = testParseCode(code)
     foldParsedTextFile(
-      (_) => fail('Unable to parse code.'),
+      (_) => {
+        throw new Error('Unable to parse code.')
+      },
       (success) => {
         let uids: Array<string> = []
         for (const topLevelElement of success.topLevelElements) {
@@ -4566,7 +4570,9 @@ export var whatever2 = (props) => <View data-uid='aaa'>
           }
         }
       },
-      (_) => fail('Unable to parse code.'),
+      (_) => {
+        throw new Error('Unable to parse code.')
+      },
       actualResult,
     )
   })
@@ -4614,7 +4620,9 @@ export var whatever = (props) => <View data-uid='aaa'>
 `
     const actualResult = testParseCode(code)
     foldParsedTextFile(
-      (_) => fail('Unable to parse code.'),
+      (_) => {
+        throw new Error('Unable to parse code.')
+      },
       (success) => {
         expect(elementsStructure(success.topLevelElements)).toMatchInlineSnapshot(`
           "UNPARSED_CODE
@@ -4622,7 +4630,9 @@ export var whatever = (props) => <View data-uid='aaa'>
           UNPARSED_CODE"
         `)
       },
-      (_) => fail('Unable to parse code.'),
+      (_) => {
+        throw new Error('Unable to parse code.')
+      },
       actualResult,
     )
   })
@@ -4665,7 +4675,7 @@ export var App = props => {
   it('maps a arbitraryJSBlock correctly', () => {
     const parseResult = testParseCode(code)
     if (!isParseSuccess(parseResult)) {
-      fail('expected parseResult to be Right')
+      throw new Error('expected parseResult to be Right')
     }
     const consoleLogBlock = parseResult.topLevelElements.find(isArbitraryJSBlock)!
 
@@ -4673,7 +4683,7 @@ export var App = props => {
       !isArbitraryJSBlock(consoleLogBlock) ||
       consoleLogBlock.javascript !== `console.log('hello!')`
     ) {
-      fail('expected the first topLevelElement to be the console logline')
+      throw new Error('expected the first topLevelElement to be the console logline')
     }
 
     const transpiledCharacter = 1 + consoleLogBlock.transpiledJavascript.indexOf('log')
@@ -4689,17 +4699,17 @@ export var App = props => {
   it('maps an arbitraryJSBlock inside a utopiaJSXComponent', () => {
     const parseResult = testParseCode(code)
     if (!isParseSuccess(parseResult)) {
-      fail('expected parseResult to be Right')
+      throw new Error('expected parseResult to be Right')
     }
     const appComponent = parseResult.topLevelElements.find(isUtopiaJSXComponent)!
     if (!isUtopiaJSXComponent(appComponent) || appComponent.name !== `App`) {
-      fail('expected the second topLevelElement to be the App component')
+      throw new Error('expected the second topLevelElement to be the App component')
     }
 
     const arbitraryBlock = appComponent.arbitraryJSBlock
 
     if (arbitraryBlock == null) {
-      fail(`expected the App component's arbitraryJSBlock to be defined`)
+      throw new Error(`expected the App component's arbitraryJSBlock to be defined`)
     }
 
     const transpiledCharacter = 1 + arbitraryBlock.transpiledJavascript.split('\n')[1].indexOf('b')
@@ -4715,14 +4725,14 @@ export var App = props => {
   it('maps a jsxAttributeOtherJavaScript correctly', () => {
     const parseResult = testParseCode(code)
     if (!isParseSuccess(parseResult)) {
-      fail('expected parseResult to be a success')
+      throw new Error('expected parseResult to be a success')
     }
     const appComponent = parseResult.topLevelElements.find(isUtopiaJSXComponent)!
     if (!isUtopiaJSXComponent(appComponent) || appComponent.name !== `App`) {
-      fail('expected the second topLevelElement to be the App component')
+      throw new Error('expected the second topLevelElement to be the App component')
     }
     if (!isJSXElement(appComponent.rootElement)) {
-      fail(`expected the App component's root element to be a JSXElement`)
+      throw new Error(`expected the App component's root element to be a JSXElement`)
     }
 
     const arbitraryProp = optionalMap(
@@ -4733,7 +4743,7 @@ export var App = props => {
     )
 
     if (arbitraryProp == null || !isJSXAttributeOtherJavaScript(arbitraryProp)) {
-      fail(`expected <View /> to have an arbitrary js prop called props.arbitrary`)
+      throw new Error(`expected <View /> to have an arbitrary js prop called props.arbitrary`)
     }
 
     const transpiledCharacter = 1 + arbitraryProp.transpiledJavascript.indexOf('log')

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -243,7 +243,9 @@ function parseModifyPrint(
 ): string {
   const initialParseResult = testParseCode(originalCode)
   return foldParsedTextFile(
-    (failure) => fail(failure),
+    (failure) => {
+      throw new Error(JSON.stringify(failure))
+    },
     (initialParseSuccess) => {
       const transformed = transform(initialParseSuccess)
       const printedCode = printCode(
@@ -256,7 +258,9 @@ function parseModifyPrint(
       )
       return printedCode
     },
-    (failure) => fail(failure),
+    (failure) => {
+      throw new Error(JSON.stringify(failure))
+    },
     initialParseResult,
   )
 }
@@ -931,10 +935,10 @@ export function forceParseSuccessFromFileOrFail(
     if (isParseSuccess(file.fileContents.parsed)) {
       return file.fileContents.parsed
     } else {
-      fail(`Not a parse success ${file.fileContents.parsed}`)
+      throw new Error(`Not a parse success ${file.fileContents.parsed}`)
     }
   } else {
-    fail(`Not a text file ${file}`)
+    throw new Error(`Not a text file ${file}`)
   }
 }
 

--- a/editor/src/core/workers/ts/ts-worker.spec.ts
+++ b/editor/src/core/workers/ts/ts-worker.spec.ts
@@ -17,6 +17,7 @@ describe('Typescript worker builds the project', () => {
   it('initializing a new project', (done) => {
     handleMessage(SampleInitTSWorkerMessage, (msg) => {
       if (msg.type === 'build') {
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(msg).toMatchSnapshot()
         done()
       }
@@ -43,7 +44,7 @@ describe('Typescript worker applies the loaders', () => {
         // Ensure no errors
         for (const builtFile in msg.buildResult) {
           if (msg.buildResult[builtFile].errors.length > 0) {
-            fail(`Build errors found in built file ${builtFile}`)
+            done.fail(`Build errors found in built file ${builtFile}`)
           }
         }
 

--- a/editor/src/printer-parsers/css/css-parser-utils.spec.ts
+++ b/editor/src/printer-parsers/css/css-parser-utils.spec.ts
@@ -45,7 +45,7 @@ describe('cssValueOnlyContainsComments', () => {
     expect(cssValueOnlyContainsComments(testStringWithValue)).toBeFalsy()
   })
 
-  it('identifies one comment and one real value', () => {
+  it('identifies one comment and one real value 2', () => {
     const testStringWithValue = '/*red*/ green'
     expect(cssValueOnlyContainsComments(testStringWithValue)).toBeFalsy()
   })

--- a/editor/src/sample-projects/sample-project-utils.test-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.test-utils.ts
@@ -72,7 +72,7 @@ export function createTestProjectWithCode(appUiJsFile: string): PersistentModel 
   ) as ParsedTextFile
 
   if (!isParseSuccess(parsedFile)) {
-    fail('The test file parse failed')
+    throw new Error('The test file parse failed')
   }
 
   return {

--- a/editor/src/utils/react-performance.spec.ts
+++ b/editor/src/utils/react-performance.spec.ts
@@ -46,12 +46,12 @@ describe('keepDeepReferenceEqualityIfPossible', () => {
     expect(a[1] === r[1]).toBeTruthy()
   })
 
-  it('keeps reference equality for matching parts of arrays even if they are different in length', () => {
+  it('keeps reference equality for matching parts of arrays even if they are different in length 2', () => {
     const a = deepFreeze([{ a: 5 }, { b: { c: { d: 6 } } }]) as any[]
     const b = deepFreeze([{ a: 5 }]) as any[]
     const r = keepDeepReferenceEqualityIfPossible(a, b)
     expect(fastDeepEquals(b, r)).toBeTruthy()
-    expect(r.length === 1).toBeTruthy
+    expect(r.length === 1).toBeTruthy()
     expect(a === r).toBeFalsy()
     expect(a[0] === r[0]).toBeTruthy()
   })
@@ -126,7 +126,7 @@ describe('keepDeepReferenceEqualityIfPossible', () => {
     expect(a.b === r.b).toBeTruthy()
   })
 
-  it('keeps reference equality for parts of objects even if they have different keys', () => {
+  it('keeps reference equality for parts of objects even if they have different keys 2', () => {
     const a = deepFreeze({
       a: ['this is', 'an array'],
       b: { c: { d: 6 } },

--- a/editor/src/utils/utils.spec.ts
+++ b/editor/src/utils/utils.spec.ts
@@ -3,6 +3,9 @@ import Utils from './utils'
 import { CanvasRectangle, LocalPoint, LocalRectangle } from '../core/shared/math-utils'
 import { longestCommonArray } from '../core/shared/utils'
 import fastDeepEquals from 'fast-deep-equal'
+
+// disabling jest/valid-expect because this file uses Chai.expect
+/* eslint-disable jest/valid-expect */
 const expect = Chai.expect
 
 describe('longestCommonArray', () => {

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -394,7 +394,7 @@ export function simplifiedMetadataMap(metadata: ElementInstanceMetadataMap): Sim
   const sanitizedSpyData = objectMap((elementMetadata, key) => {
     const elementPathAsReportedBySpy = EP.toString(elementMetadata.elementPath)
     if (elementPathAsReportedBySpy !== key) {
-      fail(`The reported template path should match what was used as key`)
+      throw new Error(`The reported template path should match what was used as key`)
     }
 
     return simplifiedMetadata(elementMetadata)


### PR DESCRIPTION
**Problem:**
We want to avoid accidentally committing and merging `describe.only` and `it.only` tests to the repository, as those "focus" the test runner and disable other tests.

**Fix:**
ESLint has a [Jest Plugin](https://github.com/jest-community/eslint-plugin-jest) which will throw us an Error when encountering a `describe.only`

I enabled most of the recommended rules, and fixed the issues that came up.

Most importantly, I deleted all uses of `fail()` and instead throw an error.

We also had a few tests with matching names so I appended ` 2` to some of those test names 