### PR TITLE
Handle rapidly fired requests to getParseResult.

### DIFF
--- a/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
+++ b/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
@@ -1,12 +1,5 @@
 export const utopiaApiTypings = `declare module 'utopia-api/helpers/helper-functions' {
   import { PropertyControls } from 'utopia-api/property-controls/property-controls';
-  export function registerComponent(paramsObj: {
-      name: string;
-      moduleName: string;
-      controls: PropertyControls;
-      insert: string;
-      requiredImports: string;
-  }): void;
   export interface ComponentInsertOption {
       codeToInsert: string;
       additionalRequiredImports?: string;

--- a/editor/src/core/workers/parser-printer/parser-printer-worker.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-worker.ts
@@ -59,9 +59,9 @@ export function handleMessage(
               throw new Error(`Unhandled file type ${JSON.stringify(file)}`)
           }
         })
-        sendMessage(createParsePrintFilesResult(results))
+        sendMessage(createParsePrintFilesResult(results, workerMessage.messageID))
       } catch (e) {
-        sendMessage(createParsePrintFailedMessage())
+        sendMessage(createParsePrintFailedMessage(workerMessage.messageID))
         throw e
       }
       break

--- a/editor/src/core/workers/test-workers.ts
+++ b/editor/src/core/workers/test-workers.ts
@@ -10,6 +10,7 @@ import { BundlerWorker } from './bundler-bridge'
 import {
   createParsePrintFilesRequest,
   ParseOrPrint,
+  ParsePrintFilesRequest,
   ParsePrintResultMessage,
 } from './common/worker-types'
 
@@ -30,8 +31,8 @@ export class FakeParserPrinterWorker implements ParserPrinterWorker {
     })
   }
 
-  sendParsePrintMessage = (files: Array<ParseOrPrint>): void => {
-    handleParserPrinterMessage(createParsePrintFilesRequest(files), this.receiveMessage)
+  sendParsePrintMessage = (request: ParsePrintFilesRequest): void => {
+    handleParserPrinterMessage(request, this.receiveMessage)
   }
 }
 

--- a/editor/src/core/workers/workers.ts
+++ b/editor/src/core/workers/workers.ts
@@ -13,6 +13,7 @@ import {
   FileContent,
   createParsePrintFilesRequest,
   ParseOrPrint,
+  ParsePrintFilesRequest,
 } from './common/worker-types'
 import { ProjectContentTreeRoot } from '../../components/assets'
 
@@ -27,8 +28,8 @@ export class UtopiaTsWorkersImplementation implements UtopiaTsWorkers {
     this.linterWorker.sendLinterRequestMessage(filename, content)
   }
 
-  sendParsePrintMessage(files: Array<ParseOrPrint>): void {
-    this.parserPrinterWorker.sendParsePrintMessage(files)
+  sendParsePrintMessage(request: ParsePrintFilesRequest): void {
+    this.parserPrinterWorker.sendParsePrintMessage(request)
   }
 
   addParserPrinterEventListener(handler: (e: MessageEvent) => void): void {
@@ -61,7 +62,7 @@ export class UtopiaTsWorkersImplementation implements UtopiaTsWorkers {
 }
 
 export interface ParserPrinterWorker {
-  sendParsePrintMessage: (files: Array<ParseOrPrint>) => void
+  sendParsePrintMessage: (request: ParsePrintFilesRequest) => void
 
   addParseFileResultEventListener(handler: (e: MessageEvent) => void): void
 
@@ -74,8 +75,8 @@ export class RealParserPrinterWorker implements ParserPrinterWorker {
     this.worker = createParserPrinterWorker()
   }
 
-  sendParsePrintMessage(files: Array<ParseOrPrint>): void {
-    this.worker.postMessage(createParsePrintFilesRequest(files))
+  sendParsePrintMessage(request: ParsePrintFilesRequest): void {
+    this.worker.postMessage(request)
   }
 
   addParseFileResultEventListener(handler: (e: MessageEvent) => void): void {
@@ -193,7 +194,7 @@ export class MockUtopiaTsWorkers implements UtopiaTsWorkers {
     // empty
   }
 
-  sendParsePrintMessage(files: Array<ParseOrPrint>): void {
+  sendParsePrintMessage(request: ParsePrintFilesRequest): void {
     // empty
   }
 


### PR DESCRIPTION
**Problem:**
When multiple insert options are added via `registerModule`, often the first one is used for all of them when inserting.

The underlying issue was that `getParseResult` didn't discriminate between the results coming back from the worker, so would accept any that arrived.

**Fix:**
Each message going to the parser printer worker now gets a unique ID attached to it which is returned as part of the result, so that the handler function can ensure it is only handling results that match the request sent.

**Commit Details:**
- Created a base interface for the various parse-print message types
  called `ParsePrintBase` which holds the `messageID` value used
  to coordinate the requests and responses.
- `getParseResult` now uses a global of `PARSE_PRINT_MESSAGE_COUNTER`
  to create unique ids for each request so that the handler function
  only handles the messages with that id.
- Parser printer worker now sends back the id given in the request
  as part of the response.
- A few minor tweaks to various interfaces in the workers around using
  `ParsePrintFilesRequest` instead of an array of `ParseOrPrint`.
