### PR TITLE
feature(inspector) mini target selector

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -312,9 +312,6 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
             aspectRatioLocked={aspectRatioLocked}
             toggleAspectRatioLock={toggleAspectRatioLock}
           />
-          <StyleSection />
-          <WarningSubsection />
-          <ImgSection />
           <TargetSelectorSection
             targets={props.targets}
             selectedTargetPath={props.selectedTargetPath}
@@ -323,6 +320,9 @@ export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: In
             onStyleSelectorDelete={props.onStyleSelectorDelete}
             onStyleSelectorInsert={props.onStyleSelectorInsert}
           />
+          <StyleSection />
+          <WarningSubsection />
+          <ImgSection />
           <EventHandlersSection />
         </React.Fragment>
       )

--- a/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
@@ -24,7 +24,7 @@ export const ContainerSubsection = betterReactMemo('ContainerSubsection', () => 
   const [seeMoreVisible, toggleSeeMoreVisible] = useToggle(false)
   return (
     <>
-      <InspectorSubsectionHeader>
+      <InspectorSubsectionHeader style={{ borderTop: 'none' }}>
         <FlexRow
           style={{
             flexGrow: 1,


### PR DESCRIPTION
This PR is about experimenting with the target selector.

**Commit Details:**
- moving the target selector between the layout section and style section
- introducing a mini target selector as a default view 
- the original target selector is available with opening the toggle on the right side

Test project https://utopia.pizza/p/7625888f-nasal-skirt/?branch_name=feature-inspetor-mini-target-selector

It looks something like this now: 
<img width="257" alt="Screenshot 2021-12-02 at 15 13 46" src="https://user-images.githubusercontent.com/4403069/144438742-6bde80d3-68ba-4c95-8efa-fe10315f17f0.png">

