### PR TITLE
Handle the removal of registerModule calls.

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -49,6 +49,7 @@ export const CanvasComponentEntry = betterReactMemo(
       return pickUiJsxCanvasProps(
         store.editor,
         store.derived,
+        store.dispatch,
         true,
         onDomReport,
         clearConsoleLogs,

--- a/editor/src/components/canvas/canvas-globals.spec.ts
+++ b/editor/src/components/canvas/canvas-globals.spec.ts
@@ -1,0 +1,457 @@
+import { right } from '../../core/shared/either'
+import {
+  emptyComments,
+  jsxAttributesEntry,
+  jsxAttributeValue,
+  jsxElementWithoutUID,
+} from '../../core/shared/element-template'
+import { importAlias, importDetails } from '../../core/shared/project-file-types'
+import { DispatchPriority, EditorAction, EditorDispatch } from '../editor/action-types'
+import {
+  addControlsToCheck,
+  ControlsToCheck,
+  resetControlsToCheck,
+  validateControlsToCheck,
+} from './canvas-globals'
+import {
+  ComponentDescriptor,
+  ComponentDescriptorWithName,
+  PropertyControlsInfo,
+} from '../custom-code/code-file'
+
+const cardComponentDescriptor: ComponentDescriptor = {
+  propertyControls: right({
+    title: right({
+      control: 'string-input',
+      label: 'Title',
+    }),
+  }),
+  insertOptions: [
+    {
+      insertMenuLabel: 'Card Default',
+      elementToInsert: jsxElementWithoutUID(
+        'Card',
+        [jsxAttributesEntry('title', jsxAttributeValue('Default', emptyComments), emptyComments)],
+        [],
+      ),
+      importsToAdd: {
+        ['/src/card']: importDetails(null, [importAlias('Card')], null),
+      },
+    },
+  ],
+}
+
+const cardComponentDescriptorWithName: ComponentDescriptorWithName = {
+  ...cardComponentDescriptor,
+  componentName: 'Card',
+}
+
+const cardControlsToCheck: ControlsToCheck = Promise.resolve(
+  right([cardComponentDescriptorWithName]),
+)
+
+const cardPropertyControlsInfo: PropertyControlsInfo = {
+  ['/src/card']: {
+    Card: cardComponentDescriptor,
+  },
+}
+
+const modifiedCardComponentDescriptor: ComponentDescriptor = {
+  propertyControls: right({
+    title: right({
+      control: 'string-input',
+      label: 'Title',
+    }),
+    border: right({
+      control: 'string-input',
+      label: 'Border',
+    }),
+  }),
+  insertOptions: [
+    {
+      insertMenuLabel: 'Card Default',
+      elementToInsert: jsxElementWithoutUID(
+        'Card',
+        [
+          jsxAttributesEntry('title', jsxAttributeValue('Default', emptyComments), emptyComments),
+          jsxAttributesEntry('border', jsxAttributeValue('shiny', emptyComments), emptyComments),
+        ],
+        [],
+      ),
+      importsToAdd: {
+        ['/src/card']: importDetails(null, [importAlias('Card')], null),
+      },
+    },
+  ],
+}
+
+const modifiedCardComponentDescriptorWithName: ComponentDescriptorWithName = {
+  ...modifiedCardComponentDescriptor,
+  componentName: 'Card',
+}
+
+const modifiedCardControlsToCheck: ControlsToCheck = Promise.resolve(
+  right([modifiedCardComponentDescriptorWithName]),
+)
+
+const selectorComponentDescriptor: ComponentDescriptor = {
+  propertyControls: right({
+    value: right({
+      control: 'popuplist',
+      label: 'Value',
+      options: ['True', 'False', 'FileNotFound'],
+    }),
+  }),
+  insertOptions: [
+    {
+      insertMenuLabel: 'True False Selector',
+      elementToInsert: jsxElementWithoutUID(
+        'Selector',
+        [
+          jsxAttributesEntry(
+            'value',
+            jsxAttributeValue(`'FileNotFound'`, emptyComments),
+            emptyComments,
+          ),
+        ],
+        [],
+      ),
+      importsToAdd: {
+        ['/src/selector']: importDetails(null, [importAlias('Selector')], null),
+      },
+    },
+  ],
+}
+
+const selectorComponentDescriptorWithName: ComponentDescriptorWithName = {
+  ...selectorComponentDescriptor,
+  componentName: 'Selector',
+}
+
+const selectorControlsToCheck: ControlsToCheck = Promise.resolve(
+  right([selectorComponentDescriptorWithName]),
+)
+
+const selectorPropertyControlsInfo: PropertyControlsInfo = {
+  ['/src/selector']: {
+    Selector: selectorComponentDescriptor,
+  },
+}
+
+describe('validateControlsToCheck', () => {
+  beforeEach(() => {
+    // Twice because the first will leave some data in `previousModuleNamesOrPaths`.
+    resetControlsToCheck()
+    resetControlsToCheck()
+  })
+  it('does nothing if no controls are added', async () => {
+    let actionsDispatched: Array<EditorAction> = []
+    const dispatch: EditorDispatch = (
+      actions: ReadonlyArray<EditorAction>,
+      priority?: DispatchPriority,
+    ) => {
+      actionsDispatched.push(...actions)
+    }
+    await validateControlsToCheck(dispatch, {})
+    expect(actionsDispatched).toMatchInlineSnapshot(`Array []`)
+  })
+  it('includes some controls added', async () => {
+    let actionsDispatched: Array<EditorAction> = []
+    const dispatch: EditorDispatch = (
+      actions: ReadonlyArray<EditorAction>,
+      priority?: DispatchPriority,
+    ) => {
+      actionsDispatched.push(...actions)
+    }
+    addControlsToCheck('/src/card', cardControlsToCheck)
+    await validateControlsToCheck(dispatch, {})
+    expect(actionsDispatched).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "UPDATE_PROPERTY_CONTROLS_INFO",
+          "moduleNamesOrPathsToDelete": Array [],
+          "propertyControlsInfo": Object {
+            "/src/card": Object {
+              "Card": Object {
+                "insertOptions": Array [
+                  Object {
+                    "elementToInsert": Object {
+                      "children": Array [],
+                      "name": Object {
+                        "baseVariable": "Card",
+                        "propertyPath": Object {
+                          "propertyElements": Array [],
+                        },
+                      },
+                      "props": Array [
+                        Object {
+                          "comments": Object {
+                            "leadingComments": Array [],
+                            "trailingComments": Array [],
+                          },
+                          "key": "title",
+                          "type": "JSX_ATTRIBUTES_ENTRY",
+                          "value": Object {
+                            "comments": Object {
+                              "leadingComments": Array [],
+                              "trailingComments": Array [],
+                            },
+                            "type": "ATTRIBUTE_VALUE",
+                            "value": "Default",
+                          },
+                        },
+                      ],
+                    },
+                    "importsToAdd": Object {
+                      "/src/card": Object {
+                        "importedAs": null,
+                        "importedFromWithin": Array [
+                          Object {
+                            "alias": "Card",
+                            "name": "Card",
+                          },
+                        ],
+                        "importedWithName": null,
+                      },
+                    },
+                    "insertMenuLabel": "Card Default",
+                  },
+                ],
+                "propertyControls": Object {
+                  "type": "RIGHT",
+                  "value": Object {
+                    "title": Object {
+                      "type": "RIGHT",
+                      "value": Object {
+                        "control": "string-input",
+                        "label": "Title",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ]
+    `)
+  })
+  it('deletes the controls removed', async () => {
+    let actionsDispatched: Array<EditorAction> = []
+    const dispatch: EditorDispatch = (
+      actions: ReadonlyArray<EditorAction>,
+      priority?: DispatchPriority,
+    ) => {
+      actionsDispatched.push(...actions)
+    }
+    addControlsToCheck('/src/card', cardControlsToCheck)
+    resetControlsToCheck()
+    await validateControlsToCheck(dispatch, cardPropertyControlsInfo)
+    expect(actionsDispatched).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "UPDATE_PROPERTY_CONTROLS_INFO",
+          "moduleNamesOrPathsToDelete": Array [
+            "/src/card",
+          ],
+          "propertyControlsInfo": Object {},
+        },
+      ]
+    `)
+  })
+  it('includes newly added controls', async () => {
+    let actionsDispatched: Array<EditorAction> = []
+    const dispatch: EditorDispatch = (
+      actions: ReadonlyArray<EditorAction>,
+      priority?: DispatchPriority,
+    ) => {
+      actionsDispatched.push(...actions)
+    }
+    addControlsToCheck('/src/card', cardControlsToCheck)
+    addControlsToCheck('/src/selector', selectorControlsToCheck)
+    await validateControlsToCheck(dispatch, cardPropertyControlsInfo)
+    expect(actionsDispatched).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "UPDATE_PROPERTY_CONTROLS_INFO",
+          "moduleNamesOrPathsToDelete": Array [],
+          "propertyControlsInfo": Object {
+            "/src/selector": Object {
+              "Selector": Object {
+                "insertOptions": Array [
+                  Object {
+                    "elementToInsert": Object {
+                      "children": Array [],
+                      "name": Object {
+                        "baseVariable": "Selector",
+                        "propertyPath": Object {
+                          "propertyElements": Array [],
+                        },
+                      },
+                      "props": Array [
+                        Object {
+                          "comments": Object {
+                            "leadingComments": Array [],
+                            "trailingComments": Array [],
+                          },
+                          "key": "value",
+                          "type": "JSX_ATTRIBUTES_ENTRY",
+                          "value": Object {
+                            "comments": Object {
+                              "leadingComments": Array [],
+                              "trailingComments": Array [],
+                            },
+                            "type": "ATTRIBUTE_VALUE",
+                            "value": "'FileNotFound'",
+                          },
+                        },
+                      ],
+                    },
+                    "importsToAdd": Object {
+                      "/src/selector": Object {
+                        "importedAs": null,
+                        "importedFromWithin": Array [
+                          Object {
+                            "alias": "Selector",
+                            "name": "Selector",
+                          },
+                        ],
+                        "importedWithName": null,
+                      },
+                    },
+                    "insertMenuLabel": "True False Selector",
+                  },
+                ],
+                "propertyControls": Object {
+                  "type": "RIGHT",
+                  "value": Object {
+                    "value": Object {
+                      "type": "RIGHT",
+                      "value": Object {
+                        "control": "popuplist",
+                        "label": "Value",
+                        "options": Array [
+                          "True",
+                          "False",
+                          "FileNotFound",
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ]
+    `)
+  })
+  it('includes modified controls', async () => {
+    let actionsDispatched: Array<EditorAction> = []
+    const dispatch: EditorDispatch = (
+      actions: ReadonlyArray<EditorAction>,
+      priority?: DispatchPriority,
+    ) => {
+      actionsDispatched.push(...actions)
+    }
+    addControlsToCheck('/src/card', modifiedCardControlsToCheck)
+    addControlsToCheck('/src/selector', selectorControlsToCheck)
+    await validateControlsToCheck(dispatch, {
+      ...cardPropertyControlsInfo,
+      ...selectorPropertyControlsInfo,
+    })
+    expect(actionsDispatched).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "UPDATE_PROPERTY_CONTROLS_INFO",
+          "moduleNamesOrPathsToDelete": Array [],
+          "propertyControlsInfo": Object {
+            "/src/card": Object {
+              "Card": Object {
+                "insertOptions": Array [
+                  Object {
+                    "elementToInsert": Object {
+                      "children": Array [],
+                      "name": Object {
+                        "baseVariable": "Card",
+                        "propertyPath": Object {
+                          "propertyElements": Array [],
+                        },
+                      },
+                      "props": Array [
+                        Object {
+                          "comments": Object {
+                            "leadingComments": Array [],
+                            "trailingComments": Array [],
+                          },
+                          "key": "title",
+                          "type": "JSX_ATTRIBUTES_ENTRY",
+                          "value": Object {
+                            "comments": Object {
+                              "leadingComments": Array [],
+                              "trailingComments": Array [],
+                            },
+                            "type": "ATTRIBUTE_VALUE",
+                            "value": "Default",
+                          },
+                        },
+                        Object {
+                          "comments": Object {
+                            "leadingComments": Array [],
+                            "trailingComments": Array [],
+                          },
+                          "key": "border",
+                          "type": "JSX_ATTRIBUTES_ENTRY",
+                          "value": Object {
+                            "comments": Object {
+                              "leadingComments": Array [],
+                              "trailingComments": Array [],
+                            },
+                            "type": "ATTRIBUTE_VALUE",
+                            "value": "shiny",
+                          },
+                        },
+                      ],
+                    },
+                    "importsToAdd": Object {
+                      "/src/card": Object {
+                        "importedAs": null,
+                        "importedFromWithin": Array [
+                          Object {
+                            "alias": "Card",
+                            "name": "Card",
+                          },
+                        ],
+                        "importedWithName": null,
+                      },
+                    },
+                    "insertMenuLabel": "Card Default",
+                  },
+                ],
+                "propertyControls": Object {
+                  "type": "RIGHT",
+                  "value": Object {
+                    "border": Object {
+                      "type": "RIGHT",
+                      "value": Object {
+                        "control": "string-input",
+                        "label": "Border",
+                      },
+                    },
+                    "title": Object {
+                      "type": "RIGHT",
+                      "value": Object {
+                        "control": "string-input",
+                        "label": "Title",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ]
+    `)
+  })
+})

--- a/editor/src/components/canvas/canvas-globals.ts
+++ b/editor/src/components/canvas/canvas-globals.ts
@@ -1,0 +1,94 @@
+import {
+  ComponentDescriptorsForFile,
+  ComponentDescriptorWithName,
+  PropertyControlsInfo,
+} from '../custom-code/code-file'
+import { EditorState } from '../editor/store/editor-state'
+import deepEqual from 'fast-deep-equal'
+import { EditorDispatch } from '../editor/action-types'
+import { updatePropertyControlsInfo } from '../editor/actions/action-creators'
+import { emptySet } from '../../core/shared/set-utils'
+import { Either, forEachLeft, forEachRight } from '../../core/shared/either'
+import { mapArrayToDictionary } from '../../core/shared/array-utils'
+
+export type ControlsToCheck = Promise<Either<string, Array<ComponentDescriptorWithName>>>
+
+export interface PropertyControlsInfoToCheck {
+  moduleNameOrPath: string
+  newDescriptorsForFile: ControlsToCheck
+}
+
+let previousModuleNamesOrPaths: Set<string> = emptySet()
+let controlsToCheck: Array<PropertyControlsInfoToCheck> = []
+
+export function addControlsToCheck(
+  moduleNameOrPath: string,
+  newDescriptorsForFile: ControlsToCheck,
+): void {
+  controlsToCheck.push({
+    moduleNameOrPath: moduleNameOrPath,
+    newDescriptorsForFile: newDescriptorsForFile,
+  })
+}
+
+export function resetControlsToCheck(): void {
+  previousModuleNamesOrPaths.clear()
+  controlsToCheck.forEach((control) => {
+    previousModuleNamesOrPaths.add(control.moduleNameOrPath)
+  })
+  controlsToCheck = []
+}
+
+export async function validateControlsToCheck(
+  dispatch: EditorDispatch,
+  propertyControlsInfo: PropertyControlsInfo,
+): Promise<void> {
+  let shouldDispatch: boolean = false
+  let updatedPropertyControlsInfo: PropertyControlsInfo = {}
+  // This should capture new or updated property controls.
+  for (const toCheck of controlsToCheck) {
+    const currentDescriptorsForFile = propertyControlsInfo[toCheck.moduleNameOrPath] ?? {}
+    const newDescriptorsForFileEither = await toCheck.newDescriptorsForFile
+    // The descriptors check out.
+    forEachRight(newDescriptorsForFileEither, (newDescriptorsForFileArray) => {
+      // FIXME At what point should we be caching / memoising this?
+      const newDescriptorsForFile: ComponentDescriptorsForFile = mapArrayToDictionary(
+        newDescriptorsForFileArray,
+        (descriptorWithName) => descriptorWithName.componentName,
+        (descriptorWithName) => {
+          return {
+            propertyControls: descriptorWithName.propertyControls,
+            insertOptions: descriptorWithName.insertOptions,
+          }
+        },
+      )
+      const descriptorsChanged = !deepEqual(currentDescriptorsForFile, newDescriptorsForFile)
+      if (descriptorsChanged) {
+        shouldDispatch = true
+        updatedPropertyControlsInfo[toCheck.moduleNameOrPath] = newDescriptorsForFile
+      }
+    })
+    // There was some kind of an error with the descriptors.
+    forEachLeft(newDescriptorsForFileEither, (error) => {
+      console.error(
+        `There was a problem with 'registerModule' ${toCheck.moduleNameOrPath}: ${error}`,
+      )
+    })
+  }
+  // Capture those that have been deleted.
+  let moduleNamesOrPathsToDelete: Array<string> = []
+  for (const previousModuleNameOrPath of previousModuleNamesOrPaths) {
+    const foundIt = controlsToCheck.some(
+      (control) => control.moduleNameOrPath === previousModuleNameOrPath,
+    )
+    if (!foundIt) {
+      shouldDispatch = true
+      moduleNamesOrPathsToDelete.push(previousModuleNameOrPath)
+    }
+  }
+
+  // Only send if there's something to send.
+  if (shouldDispatch) {
+    dispatch([updatePropertyControlsInfo(updatedPropertyControlsInfo, moduleNamesOrPathsToDelete)])
+  }
+}

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -73,7 +73,7 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
     persistence: DummyPersistenceMachine,
     dispatch: dispatch,
     alreadySaved: false,
-    builtInDependencies: createBuiltInDependenciesList(dispatch, () => emptyEditorState, null),
+    builtInDependencies: createBuiltInDependenciesList(null),
   }
 
   const storeHook = create<EditorStore>((set) => initialEditorStore)

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper-third-party.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper-third-party.spec.browser2.tsx
@@ -26,7 +26,7 @@ import { matchInlineSnapshotBrowser } from '../../../../test/karma-snapshots'
 import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { NO_OP } from '../../../core/shared/utils'
 
-const builtInDependencies = createBuiltInDependenciesList(NO_OP, null, null)
+const builtInDependencies = createBuiltInDependenciesList(null)
 builtInDependencies.push({
   moduleName: '@react-three/fiber',
   nodeModule: {

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -226,6 +226,8 @@ export function renderCanvasReturnResultAndError(
       projectContents: storeHookForTest.api.getState().editor.projectContents,
       transientFilesState: storeHookForTest.api.getState().derived.canvas.transientState.filesState,
       scrollAnimation: false,
+      propertyControlsInfo: {},
+      dispatch: NO_OP,
     }
   } else {
     canvasProps = {
@@ -248,6 +250,8 @@ export function renderCanvasReturnResultAndError(
       projectContents: storeHookForTest.api.getState().editor.projectContents,
       transientFilesState: storeHookForTest.api.getState().derived.canvas.transientState.filesState,
       scrollAnimation: false,
+      propertyControlsInfo: {},
+      dispatch: NO_OP,
     }
   }
 

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -212,7 +212,7 @@ export async function renderTestEditorWithModel(
   const builtInDependencies =
     mockBuiltInDependencies != null
       ? mockBuiltInDependencies
-      : createBuiltInDependenciesList(asyncTestDispatch, () => emptyEditorState, workers)
+      : createBuiltInDependenciesList(workers)
   const initialEditorStore: EditorStore = {
     editor: emptyEditorState,
     derived: derivedState,

--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -362,7 +362,7 @@ describe('Generating codeResultCache', () => {
       {},
       'incremental',
       false,
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
 
     expect(codeResultCache).toMatchSnapshot()
@@ -379,7 +379,7 @@ describe('Generating codeResultCache', () => {
       {},
       'incremental',
       false,
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
 
     expect(codeResultCache).toMatchSnapshot()
@@ -395,7 +395,7 @@ describe('Generating codeResultCache', () => {
       {},
       'incremental',
       false,
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
 
     expect(codeResultCache).toMatchSnapshot()
@@ -414,7 +414,7 @@ describe('Creating require function', () => {
       {},
       'incremental',
       false,
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
 
     expect(codeResultCache.curriedRequireFn({})('/', './app', false)).toMatchSnapshot()
@@ -430,7 +430,7 @@ describe('Creating require function', () => {
       {},
       'incremental',
       false,
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
 
     expect(codeResultCache.curriedRequireFn({})('/', './app', false)).toMatchSnapshot()
@@ -447,7 +447,7 @@ describe('Creating require function', () => {
       {},
       'incremental',
       false,
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
 
     expect(() =>
@@ -465,7 +465,7 @@ describe('Creating require function', () => {
       {},
       'incremental',
       false,
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
 
     expect(() =>

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -784,6 +784,7 @@ export interface SetShortcut {
 export interface UpdatePropertyControlsInfo {
   action: 'UPDATE_PROPERTY_CONTROLS_INFO'
   propertyControlsInfo: PropertyControlsInfo
+  moduleNamesOrPathsToDelete: Array<string>
 }
 
 export interface AddStoryboardFile {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1269,10 +1269,12 @@ export function setShortcut(shortcutName: string, newKey: Key): SetShortcut {
 
 export function updatePropertyControlsInfo(
   propertyControlsInfo: PropertyControlsInfo,
+  moduleNamesOrPathsToDelete: Array<string>,
 ): UpdatePropertyControlsInfo {
   return {
     action: 'UPDATE_PROPERTY_CONTROLS_INFO',
     propertyControlsInfo: propertyControlsInfo,
+    moduleNamesOrPathsToDelete: moduleNamesOrPathsToDelete,
   }
 }
 

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -4381,12 +4381,16 @@ export const UPDATE_FNS = {
     action: UpdatePropertyControlsInfo,
     editor: EditorState,
   ): EditorState => {
+    let updatedPropertyControlsInfo: PropertyControlsInfo = {
+      ...editor.propertyControlsInfo,
+      ...action.propertyControlsInfo,
+    }
+    for (const moduleNameOrPathToDelete of action.moduleNamesOrPathsToDelete) {
+      delete updatedPropertyControlsInfo[moduleNameOrPathToDelete]
+    }
     return {
       ...editor,
-      propertyControlsInfo: {
-        ...editor.propertyControlsInfo,
-        ...action.propertyControlsInfo,
-      },
+      propertyControlsInfo: updatedPropertyControlsInfo,
     }
   },
   ADD_STORYBOARD_FILE: (_action: AddStoryboardFile, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -100,7 +100,7 @@ const workers = new MockUtopiaTsWorkers()
 
 const testScenePath = ScenePath1ForTestUiJsFile
 const testElementPath = EP.appendNewElementPath(ScenePath1ForTestUiJsFile, ['pancake'])
-const builtInDependencies: BuiltInDependencies = createBuiltInDependenciesList(NO_OP, null, null)
+const builtInDependencies: BuiltInDependencies = createBuiltInDependenciesList(null)
 
 describe('action SELECT_VIEWS', () => {
   it('updates selectedview in editor', () => {

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -21,7 +21,7 @@ function createEmptyEditorStoreHook() {
     persistence: null as any,
     dispatch: null as any,
     alreadySaved: false,
-    builtInDependencies: createBuiltInDependenciesList(NO_OP, () => emptyEditorState, null),
+    builtInDependencies: createBuiltInDependenciesList(null),
   }
 
   const storeHook = create<EditorStore>((set) => initialEditorStore)

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -57,7 +57,7 @@ export function getStoreHook(
     persistence: null as any,
     dispatch: mockDispatch,
     alreadySaved: false,
-    builtInDependencies: createBuiltInDependenciesList(NO_OP, null, null),
+    builtInDependencies: createBuiltInDependenciesList(null),
   }
 
   const storeHook = create<EditorStore & UpdateFunctionHelpers>((set) => ({

--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -52,13 +52,11 @@ function builtInDependency(
 }
 
 export function createBuiltInDependenciesList(
-  dispatch: EditorDispatch,
-  getEditorState: (() => EditorState) | null,
   workers: UtopiaTsWorkers | null,
 ): BuiltInDependencies {
   const UtopiaAPISpecial: typeof UtopiaAPI = {
     ...UtopiaAPI,
-    registerModule: createRegisterModuleFunction(dispatch, getEditorState, workers),
+    registerModule: createRegisterModuleFunction(workers),
   }
 
   // Ensure this is kept up to date with:

--- a/editor/src/core/es-modules/package-manager/package-manager.spec.ts
+++ b/editor/src/core/es-modules/package-manager/package-manager.spec.ts
@@ -67,7 +67,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse(fileNoImports as PackagerServerResponse),
       {},
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
     const requireResult = reqFn('/src/index.js', 'mypackage')
     expect(requireResult).toHaveProperty('hello')
@@ -80,7 +80,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse(fileWithImports),
       {},
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
     const requireResult = reqFn('/src/index.js', 'mypackage')
     expect(requireResult).toHaveProperty('hello')
@@ -93,7 +93,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse(fileWithLocalImport),
       {},
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
     const requireResult = reqFn('/src/index.js', 'mypackage')
     expect(requireResult).toHaveProperty('hello')
@@ -106,7 +106,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse(fileWithImports),
       {},
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
     reqFn('/src/index.js', 'mypackage/simple.css')
 
@@ -120,7 +120,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse(fileWithImports),
       {},
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
     reqFn('/src/index.js', 'mypackage/simple.css')
 
@@ -136,7 +136,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse(fileWithImports),
       {},
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
 
     const requireResult = reqFn('/src/index.js', 'mypackage/simple.svg')
@@ -153,7 +153,7 @@ describe('ES Dependency Package Manager', () => {
       {},
       extractNodeModulesFromPackageResponse(fileWithImports),
       {},
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
     const test = () => reqFn('/src/index.js', 'mypackage2')
     expect(test).toThrowError(`Could not find dependency: 'mypackage2' relative to '/src/index.js`)
@@ -168,7 +168,7 @@ describe('ES Dependency Manager — Cycles', () => {
       {},
       extractNodeModulesFromPackageResponse(fileWithImports),
       {},
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
       spyEvaluator,
     )
     const requireResult = reqFn('/src/index.js', 'mypackage/moduleA')
@@ -192,7 +192,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
     )
     const fetchNodeModulesResult = await fetchNodeModules(
       [requestedNpmDependency('react-spring', '8.0.27')],
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
       throw new Error(`Expected successful nodeModules fetch`)
@@ -204,7 +204,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
       {},
       nodeModules,
       {},
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
     const reactSpring = req('/src/index.js', 'react-spring')
     expect(Object.keys(reactSpring)).not.toHaveLength(0)
@@ -227,7 +227,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
     )
     fetchNodeModules(
       [requestedNpmDependency('antd', '4.2.5')],
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     ).then((fetchNodeModulesResult) => {
       if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
         throw new Error(`Expected successful nodeModules fetch`)
@@ -243,7 +243,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
           {},
           updatedNodeModules,
           {},
-          createBuiltInDependenciesList(NO_OP, null, null),
+          createBuiltInDependenciesList(null),
           spyEvaluator,
         )
 
@@ -264,7 +264,7 @@ describe('ES Dependency Manager — Real-life packages', () => {
         {},
         nodeModules,
         {},
-        createBuiltInDependenciesList(NO_OP, null, null),
+        createBuiltInDependenciesList(null),
         spyEvaluator,
       )
       const antd = req('/src/index.js', 'antd')
@@ -298,7 +298,7 @@ describe('ES Dependency Manager', () => {
     )
     const fetchNodeModulesResult = await fetchNodeModules(
       [requestedNpmDependency('broken', '1.0.0')],
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
       throw new Error(`Expected successful nodeModules fetch`)
@@ -310,7 +310,7 @@ describe('ES Dependency Manager', () => {
       {},
       nodeModules,
       {},
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
     expect(() => req('/src/index.js', 'broken')).toThrowErrorMatchingInlineSnapshot(
       `"Fail on import."`,
@@ -333,7 +333,7 @@ describe('ES Dependency Manager — d.ts', () => {
 
     const fetchNodeModulesResult = await fetchNodeModules(
       [requestedNpmDependency('react-spring', '8.0.27')],
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     )
     if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
       throw new Error(`Expected successful nodeModules fetch`)
@@ -368,7 +368,7 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
     )
     fetchNodeModules(
       [requestedNpmDependency('mypackage', '0.0.1')],
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     ).then((fetchNodeModulesResult) => {
       if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
         throw new Error(`Expected successful nodeModules fetch`)
@@ -384,7 +384,7 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
           {},
           updatedNodeModules,
           {},
-          createBuiltInDependenciesList(NO_OP, null, null),
+          createBuiltInDependenciesList(null),
         )
 
         // this is like calling `import 'mypackage/dist/style.css';`, we only care about the side effect
@@ -405,7 +405,7 @@ describe('ES Dependency Manager — Downloads extra files as-needed', () => {
         {},
         nodeModules,
         {},
-        createBuiltInDependenciesList(NO_OP, null, null),
+        createBuiltInDependenciesList(null),
       )
       expect(() => req('/src/index.js', 'mypackage/dist/style.css')).toThrow(
         createResolvingRemoteDependencyError('mypackage/dist/style.css'),
@@ -434,7 +434,7 @@ describe('ES Dependency manager - retry behavior', () => {
 
     fetchNodeModules(
       [requestedNpmDependency('react-spring', '8.0.27')],
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     ).then((fetchNodeModulesResult) => {
       if (fetchNodeModulesResult.dependenciesWithError.length > 0) {
         throw new Error(`Expected successful nodeModule fetch`)
@@ -456,7 +456,7 @@ describe('ES Dependency manager - retry behavior', () => {
 
     fetchNodeModules(
       [requestedNpmDependency('react-spring', '8.0.27')],
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
     ).then((fetchNodeModulesResult) => {
       expect(fetchNodeModulesResult.dependenciesWithError).toHaveLength(1)
       expect(fetchNodeModulesResult.dependenciesWithError[0].name).toBe('react-spring')
@@ -484,7 +484,7 @@ describe('ES Dependency manager - retry behavior', () => {
 
     fetchNodeModules(
       [requestedNpmDependency('react-spring', '8.0.27')],
-      createBuiltInDependenciesList(NO_OP, null, null),
+      createBuiltInDependenciesList(null),
       false,
     ).then((fetchNodeModulesResult) => {
       expect(fetchNodeModulesResult.dependenciesWithError).toHaveLength(1)
@@ -501,7 +501,7 @@ describe('ES Dependency manager - browser field substitutions', () => {
     {},
     createNodeModules(moduleResolutionExamples.contents),
     {},
-    createBuiltInDependenciesList(NO_OP, null, null),
+    createBuiltInDependenciesList(null),
   )
 
   it('returns the replaced module', () => {

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -127,12 +127,7 @@ export class Editor {
       watchdogWorker,
     )
 
-    const getEditorState = () => this.storedState.editor
-    const builtInDependencies = createBuiltInDependenciesList(
-      this.boundDispatch,
-      getEditorState,
-      workers,
-    )
+    const builtInDependencies = createBuiltInDependenciesList(workers)
     const onCreatedOrLoadedProject = (
       projectId: string,
       projectName: string,

--- a/editor/src/templates/preview.tsx
+++ b/editor/src/templates/preview.tsx
@@ -133,7 +133,7 @@ const initPreview = () => {
   queuedModel = null
   cachedDependencies = {}
   const bundlerWorker = new NewBundlerWorker(new RealBundlerWorker())
-  const builtInDependencies = createBuiltInDependenciesList(NO_OP, null, null)
+  const builtInDependencies = createBuiltInDependenciesList(null)
 
   const startPollingFromServer = (appID: string | null) => {
     if (appID != null) {


### PR DESCRIPTION
**Problem:**
`registerModule` calls add or update to the property controls info, but if a call is removed, those values remain there.

**Fix:**
To fix the above issue, something like this flow was implemented:
- Just before rendering the canvas, checkpoint what was previously added via `registerModule` calls.
- Render the canvas which includes invoking the various `registerModule` calls.
- On a `useEffect` call after the canvas has rendered take the value previously stored in the checkpoint and those entries added via `registerModule` calls and see what needs to be added or removed from the property controls.

**Commit Details:**
- Created `canvas-globals.ts` to hold the property controls values
  pushed from `registerModule` so that it can be accessed from the
  two paths of the `registerModule` function and the root of the
  canvas itself.
- `validateControlsToCheck` subsumes a lot of the logic from
  `registerModuleInternal` including the awaiting of the promises.
- `UPDATE_PROPERTY_CONTROLS_INFO` action now includes
  `moduleNamesOrPathsToDelete` which should be removed from the
  `EditorState.propertyControlsInfo` value.
- At the start of `UiJsxCanvas` `resetControlsToCheck` is invoked
  to setup the globals so that the paired call of
  `validateControlsToCheck` wrapped in a `useEffect` callback can
  detect those calls which have not been made on a subsequent render.
