### PR TITLE
Exclude style and children in certain places.

### DIFF
--- a/editor/src/components/inspector/sections/component-section/folder-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/folder-section.tsx
@@ -16,6 +16,7 @@ import { RowOrFolderWrapper } from './row-or-folder-wrapper'
 import { RowForControl, RowForInvalidControl } from './component-section'
 import { InspectorWidthAtom } from '../../common/inspector-atoms'
 import { useAtom } from 'jotai'
+import { specialPropertiesToIgnore } from '../../../../core/property-controls/property-controls-utils'
 
 interface FolderSectionProps {
   isRoot: boolean
@@ -139,22 +140,26 @@ export const FolderSection = betterReactMemo('FolderSection', (props: FolderSect
       {when(
         props.isRoot,
         Object.keys(props.detectedPropsAndValuesWithoutControls).map((propName) => {
-          const propValue = props.detectedPropsAndValuesWithoutControls[propName]
-          const controlDescription: ControlDescription = inferControlTypeBasedOnValue(
-            propValue,
-            propName,
-          )
-          return (
-            <RowForControl
-              key={propName}
-              propPath={PP.create([propName])}
-              controlDescription={controlDescription}
-              isScene={false}
-              setGlobalCursor={props.setGlobalCursor}
-              indentationLevel={props.indentationLevel + 1}
-              focusOnMount={false}
-            />
-          )
+          if (specialPropertiesToIgnore.includes(propName)) {
+            return null
+          } else {
+            const propValue = props.detectedPropsAndValuesWithoutControls[propName]
+            const controlDescription: ControlDescription = inferControlTypeBasedOnValue(
+              propValue,
+              propName,
+            )
+            return (
+              <RowForControl
+                key={propName}
+                propPath={PP.create([propName])}
+                controlDescription={controlDescription}
+                isScene={false}
+                setGlobalCursor={props.setGlobalCursor}
+                indentationLevel={props.indentationLevel + 1}
+                focusOnMount={false}
+              />
+            )
+          }
         }),
       )}
       {when(

--- a/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
@@ -19,6 +19,7 @@ import { FolderSection } from './folder-section'
 import { CSSCursor } from '../../../canvas/canvas-types'
 import { UIGridRow } from '../../widgets/ui-grid-row'
 import { VerySubdued } from '../../../../uuiui'
+import { specialPropertiesToIgnore } from '../../../../core/property-controls/property-controls-utils'
 
 function useFilterPropsContext(paths: ElementPath[]): InspectorPropsContextData {
   const currentContext = useContext(InspectorPropsContext)
@@ -63,6 +64,13 @@ export const PropertyControlsSection = betterReactMemo(
       propsWithControlsButNoValue,
     } = props
 
+    // Filter out these because we don't want to include them in the unused props.
+    const filteredDetectedPropsWithNoValue = useKeepReferenceEqualityIfPossible(
+      detectedPropsWithNoValue.filter((detectedPropWithNoValue) => {
+        return !specialPropertiesToIgnore.includes(detectedPropWithNoValue)
+      }),
+    )
+
     const dispatch = useEditorState((state) => state.dispatch, 'ComponentSectionInner')
     const setGlobalCursor = React.useCallback(
       (cursor: CSSCursor | null) => {
@@ -99,10 +107,12 @@ export const PropertyControlsSection = betterReactMemo(
       <InspectorPropsContext.Provider value={updatedContext}>
         {rootFolder}
         {/** props set on the component instance and props used inside the component code */}
-        {detectedPropsWithNoValue.length > 0 ? (
+        {filteredDetectedPropsWithNoValue.length > 0 ? (
           <UIGridRow padded tall={false} variant={'<-------------1fr------------->'}>
             <div>
-              <VerySubdued>{`Unused props: ${detectedPropsWithNoValue.join(', ')}.`}</VerySubdued>
+              <VerySubdued>{`Unused props: ${filteredDetectedPropsWithNoValue.join(
+                ', ',
+              )}.`}</VerySubdued>
             </div>
           </UIGridRow>
         ) : null}

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -63,8 +63,8 @@ describe('React Render Count Tests -', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(485) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(495)
+    // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`483`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -123,8 +123,8 @@ describe('React Render Count Tests -', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThan(525) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(535)
+    // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`521`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -177,8 +177,8 @@ describe('React Render Count Tests -', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(2350) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(2360)
+    // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2344`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -241,7 +241,7 @@ describe('React Render Count Tests -', () => {
     )
 
     const renderCountAfter = renderResult.getNumberOfRenders()
-    expect(renderCountAfter - renderCountBefore).toBeGreaterThanOrEqual(2505) // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toBeLessThan(2515)
+    // if this breaks, GREAT NEWS but update the test please :)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2498`)
   })
 })

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -181,3 +181,5 @@ export function hasStyleControls(propertyControls: ParseResult<ParsedPropertyCon
     propertyControls,
   )
 }
+
+export const specialPropertiesToIgnore: Array<string> = ['style', 'children']


### PR DESCRIPTION
**Problem:**
The `style` and `children` properties turn up in places we don't want them in the inspector.

**Fix:**
In the unused props and in the regular property controls listing, ensure these properties are not listed.

**Commit Details:**
- Exclude `style` and `children` from being listed as part of the
  properties detected that lack controls.
- Exclude `style` and `children` from being listed as part of the
  unused props.
