### PR TITLE
Filter out empty component groups.

### DIFF
--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -10,7 +10,6 @@ import { JSXElementName, jsxElementNameEquals } from '../../../core/shared/eleme
 import { getElementsToTarget } from '../../inspector/common/inspector-utils'
 import { Imports } from '../../../core/shared/project-file-types'
 import {
-  getComponentGroups,
   getComponentGroupsAsSelectOptions,
   InsertableComponent,
 } from '../../../components/shared/project-components'

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -22,8 +22,8 @@ import {
 } from '../../../uuiui'
 import { usePossiblyResolvedPackageDependencies } from '../../editor/npm-dependency/npm-dependency'
 import {
-  getComponentGroups,
   getInsertableGroupLabel,
+  getNonEmptyComponentGroups,
   InsertableComponent,
   InsertableComponentGroup,
   InsertableComponentGroupType,
@@ -119,7 +119,7 @@ function useGetInsertableComponents(): InsertableComponentFlatList {
       return []
     } else {
       return convertInsertableComponentsToFlatList(
-        getComponentGroups(
+        getNonEmptyComponentGroups(
           packageStatus,
           propertyControlsInfo,
           projectContents,

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -69,10 +69,10 @@ import {
 } from '../../uuiui'
 import { betterReactMemo } from '../../uuiui-deps'
 import {
-  getComponentGroups,
   getDependencyStatus,
   getInsertableGroupLabel,
   getInsertableGroupPackageStatus,
+  getNonEmptyComponentGroups,
 } from '../shared/project-components'
 import { ProjectContentTreeRoot } from '../assets'
 import { generateUidWithExistingComponents } from '../../core/model/element-template-utils'
@@ -282,7 +282,7 @@ class InsertMenuInner extends React.Component<InsertMenuProps> {
     const insertableGroups =
       this.props.currentlyOpenFilename == null
         ? []
-        : getComponentGroups(
+        : getNonEmptyComponentGroups(
             this.props.packageStatus,
             this.props.propertyControlsInfo,
             this.props.projectContents,

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -285,6 +285,25 @@ export function stylePropOptionsForPropertyControls(
   }
 }
 
+export function getNonEmptyComponentGroups(
+  packageStatus: PackageStatusMap,
+  propertyControlsInfo: PropertyControlsInfo,
+  projectContents: ProjectContentTreeRoot,
+  dependencies: Array<PossiblyUnversionedNpmDependency>,
+  originatingPath: string,
+): Array<InsertableComponentGroup> {
+  const groups = getComponentGroups(
+    packageStatus,
+    propertyControlsInfo,
+    projectContents,
+    dependencies,
+    originatingPath,
+  )
+  return groups.filter((group) => {
+    return group.insertableComponents.length > 0
+  })
+}
+
 export function getComponentGroups(
   packageStatus: PackageStatusMap,
   propertyControlsInfo: PropertyControlsInfo,


### PR DESCRIPTION
**Problem:**
We don't want the inspector to show files which have no exported components.

**Fix:**
Filter out the component groups which do not have exported components in a little utility function.

**Commit Details:**
- Created `getNonEmptyComponentGroups` to filter out the empty
  groups for presentation.
- Used `getNonEmptyComponentGroups` in the various locations that
  `getComponentGroups` was originally used in.
