### PR TITLE
Handle sub-dependencies in the property controls correctly.

### DIFF
--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -1,5 +1,400 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getComponentGroups handles a sub-dependency correctly 1`] = `
+Array [
+  Object {
+    "insertableComponents": Array [
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "App",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+        },
+        "importsToAdd": Object {},
+        "name": "App",
+        "stylePropOptions": Array [
+          "do-not-add",
+        ],
+      },
+    ],
+    "source": Object {
+      "path": "/src/app.js",
+      "type": "PROJECT_COMPONENT_GROUP",
+    },
+  },
+  Object {
+    "insertableComponents": Array [],
+    "source": Object {
+      "path": "/src/index.js",
+      "type": "PROJECT_COMPONENT_GROUP",
+    },
+  },
+  Object {
+    "insertableComponents": Array [],
+    "source": Object {
+      "path": "/utopia/storyboard.js",
+      "type": "PROJECT_COMPONENT_GROUP",
+    },
+  },
+  Object {
+    "insertableComponents": Array [
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "div",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "div",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "span",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "span",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "h1",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "h1",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "h2",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "h2",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "p",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "p",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "button",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "button",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "input",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [],
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "input",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "video",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "style",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": Object {
+                  "height": "120px",
+                  "width": "250px",
+                },
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "controls",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": true,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "autoPlay",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": true,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "loop",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": true,
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "src",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "https://dl8.webmfiles.org/big-buck-bunny_trailer.webm",
+              },
+            },
+          ],
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "video",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+      Object {
+        "element": Object {
+          "children": Array [],
+          "name": Object {
+            "baseVariable": "img",
+            "propertyPath": Object {
+              "propertyElements": Array [],
+            },
+          },
+          "props": Array [
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "style",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": Object {
+                  "height": "64px",
+                  "width": "64px",
+                },
+              },
+            },
+            Object {
+              "comments": Object {
+                "leadingComments": Array [],
+                "trailingComments": Array [],
+              },
+              "key": "src",
+              "type": "JSX_ATTRIBUTES_ENTRY",
+              "value": Object {
+                "comments": Object {
+                  "leadingComments": Array [],
+                  "trailingComments": Array [],
+                },
+                "type": "ATTRIBUTE_VALUE",
+                "value": "/editor/icons/favicons/favicon-128.png?hash=nocommit",
+              },
+            },
+          ],
+        },
+        "importsToAdd": Object {
+          "react": Object {
+            "importedAs": "React",
+            "importedFromWithin": Array [],
+            "importedWithName": null,
+          },
+        },
+        "name": "img",
+        "stylePropOptions": Array [
+          "do-not-add",
+          "add-size",
+        ],
+      },
+    ],
+    "source": Object {
+      "type": "HTML_GROUP",
+    },
+  },
+  Object {
+    "insertableComponents": Array [],
+    "source": Object {
+      "dependencyName": "@heroicons/react",
+      "dependencyStatus": "loaded",
+      "type": "PROJECT_DEPENDENCY_GROUP",
+    },
+  },
+]
+`;
+
 exports[`getComponentGroups returns all the various default groups 1`] = `
 Array [
   Object {

--- a/editor/src/components/shared/project-components.spec.ts
+++ b/editor/src/components/shared/project-components.spec.ts
@@ -1,3 +1,4 @@
+import { right } from '../../core/shared/either'
 import {
   PackageStatusMap,
   PossiblyUnversionedNpmDependency,
@@ -6,7 +7,7 @@ import {
 import { DefaultThirdPartyControlDefinitions } from '../../core/third-party/third-party-controls'
 import { simpleDefaultProjectPreParsed } from '../../sample-projects/sample-project-utils.test-utils'
 import { PropertyControlsInfo } from '../custom-code/code-file'
-import { getComponentGroups } from './project-components'
+import { getComponentGroups, getDependencyStatus } from './project-components'
 
 describe('getComponentGroups', () => {
   it('returns all the various default groups', () => {
@@ -29,5 +30,56 @@ describe('getComponentGroups', () => {
     )
 
     expect(actualResult).toMatchSnapshot()
+  })
+  it('handles a sub-dependency correctly', () => {
+    const packageStatus: PackageStatusMap = {
+      '@heroicons/react': { status: 'loaded' },
+    }
+    const dependencies: Array<PossiblyUnversionedNpmDependency> = [
+      resolvedNpmDependency('@heroicons/react', '1.0.5'),
+    ]
+
+    const propertyControlsInfo: PropertyControlsInfo = {
+      '@heroicons/react/solid': {
+        BeakerIcon: {
+          propertyControls: right({}),
+          insertOptions: [],
+        },
+      },
+    }
+    const actualResult = getComponentGroups(
+      packageStatus,
+      propertyControlsInfo,
+      simpleDefaultProjectPreParsed().projectContents,
+      dependencies,
+      '/src/app.js',
+    )
+
+    expect(actualResult).toMatchSnapshot()
+  })
+})
+
+describe('getDependencyStatus', () => {
+  it('shows the dependency as loaded when property controls exist for a sub-dependency', () => {
+    const propertyControlsInfo: PropertyControlsInfo = {
+      '@heroicons/react/solid': {
+        BeakerIcon: {
+          propertyControls: right({}),
+          insertOptions: [],
+        },
+      },
+    }
+    const packageStatus: PackageStatusMap = {
+      '@heroicons/react': {
+        status: 'loaded',
+      },
+    }
+    const result = getDependencyStatus(
+      packageStatus,
+      propertyControlsInfo,
+      '@heroicons/react',
+      'version-lookup',
+    )
+    expect(result).toEqual('loaded')
   })
 })

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -177,11 +177,12 @@ export function getDependencyStatus(
     case null:
       return defaultStatus
     case 'loaded':
-      if (dependencyName in propertyControlsInfo) {
-        return 'loaded'
-      } else {
-        return 'loading'
+      for (const infoKey of Object.keys(propertyControlsInfo)) {
+        if (infoKey.startsWith(dependencyName)) {
+          return 'loaded'
+        }
       }
+      return 'loading'
     default:
       return regularStatus
   }
@@ -450,13 +451,15 @@ export function getComponentGroups(
         dependency.name,
         'loaded',
       )
-      const propertyControlsForDependency = propertyControlsInfo[dependency.name]
-      if (propertyControlsForDependency != null) {
-        addDependencyDescriptor(
-          dependency.name,
-          insertableComponentGroupProjectDependency(dependency.name, dependencyStatus),
-          propertyControlsForDependency,
-        )
+      for (const infoKey of Object.keys(propertyControlsInfo)) {
+        if (infoKey.startsWith(dependency.name)) {
+          const propertyControlsForDependency = propertyControlsInfo[infoKey]
+          addDependencyDescriptor(
+            dependency.name,
+            insertableComponentGroupProjectDependency(dependency.name, dependencyStatus),
+            propertyControlsForDependency,
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
**Problem:**
An import in some code (and therefore the definition in `registerModule`) may be a sub-path of the dependency defined in `package.json`, which means they do not line up when compared with equality in the property controls handling.

**Fix:**
Effectively replace places where equality is used with `startsWith`.

**Commit Details:**
- `getDependencyStatus` uses `startWith` to compare values in
  `propertyControlsInfo` so that sub-dependencies can be picked up.
- `getComponentGroups` uses `startWith` to compare values in
  `propertyControlsInfo` so that sub-dependencies can be picked up.
