### PR TITLE
Fix/react memo

### DIFF
--- a/editor/src/components/canvas/canvas-loading-screen.tsx
+++ b/editor/src/components/canvas/canvas-loading-screen.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import { Global, css } from '@emotion/react'
-import { betterReactMemo } from '../../uuiui-deps'
 import { BaseCanvasOffsetLeftPane } from '../editor/store/editor-state'
 import { useColorTheme } from '../../uuiui'
 
-export const CanvasLoadingScreen = betterReactMemo('CanvasLoadingScreen', () => {
+export const CanvasLoadingScreen = React.memo(() => {
   const colorTheme = useColorTheme()
   return (
     <React.Fragment>

--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -23,7 +23,6 @@ import { fastForEach, NO_OP } from '../../core/shared/utils'
 import Footer from '../../third-party/react-error-overlay/components/Footer'
 import Header from '../../third-party/react-error-overlay/components/Header'
 import { FlexColumn, Button, UtopiaTheme, FlexRow } from '../../uuiui'
-import { betterReactMemo } from '../../uuiui-deps'
 import { useReadOnlyRuntimeErrors } from '../../core/shared/runtime-report-logs'
 import StackFrame from '../../third-party/react-error-overlay/utils/stack-frame'
 import { ModeSelectButtons } from './mode-select-buttons'
@@ -55,7 +54,7 @@ export function filterOldPasses(errorMessages: Array<ErrorMessage>): Array<Error
   })
 }
 
-export const CanvasWrapperComponent = betterReactMemo('CanvasWrapperComponent', () => {
+export const CanvasWrapperComponent = React.memo(() => {
   const { dispatch, editorState, derivedState } = useEditorState(
     (store) => ({
       dispatch: store.dispatch,
@@ -131,81 +130,78 @@ export const CanvasWrapperComponent = betterReactMemo('CanvasWrapperComponent', 
 
 interface ErrorOverlayComponentProps {}
 
-const ErrorOverlayComponent = betterReactMemo(
-  'ErrorOverlayComponent',
-  (props: ErrorOverlayComponentProps) => {
-    const dispatch = useEditorState((store) => store.dispatch, 'ErrorOverlayComponent dispatch')
-    const utopiaParserErrors = useEditorState((store) => {
-      return parseFailureAsErrorMessages(
-        getOpenUIJSFileKey(store.editor),
-        getOpenUIJSFile(store.editor),
-      )
-    }, 'ErrorOverlayComponent utopiaParserErrors')
-    const fatalCodeEditorErrors = useEditorState((store) => {
-      return getAllCodeEditorErrors(store.editor, 'error', true)
-    }, 'ErrorOverlayComponent fatalCodeEditorErrors')
-
-    const runtimeErrors = useReadOnlyRuntimeErrors()
-
-    const overlayErrors = React.useMemo(() => {
-      return runtimeErrors.map((runtimeError) => {
-        const stackFrames =
-          runtimeError.error.stackFrames != null
-            ? runtimeError.error.stackFrames
-            : [
-                new StackFrame(
-                  'WARNING: This error has no Stack Frames, it might be coming from Utopia itself!',
-                ),
-              ]
-        return {
-          error: runtimeError.error,
-          unhandledRejection: false,
-          contextSize: 3, // magic number from react-error-overlay
-          stackFrames: stackFrames,
-        }
-      })
-    }, [runtimeErrors])
-
-    const lintErrors = fatalCodeEditorErrors.filter((e) => e.source === 'eslint')
-    // we start with the lint errors, since those show up the fastest. any subsequent error will go below in the error screen
-    const errorRecords = filterOldPasses([...lintErrors, ...utopiaParserErrors])
-
-    const onOpenFile = React.useCallback(
-      (path: string) => {
-        dispatch([openCodeEditorFile(path, true), setFocus('codeEditor')])
-      },
-      [dispatch],
+const ErrorOverlayComponent = React.memo((props: ErrorOverlayComponentProps) => {
+  const dispatch = useEditorState((store) => store.dispatch, 'ErrorOverlayComponent dispatch')
+  const utopiaParserErrors = useEditorState((store) => {
+    return parseFailureAsErrorMessages(
+      getOpenUIJSFileKey(store.editor),
+      getOpenUIJSFile(store.editor),
     )
+  }, 'ErrorOverlayComponent utopiaParserErrors')
+  const fatalCodeEditorErrors = useEditorState((store) => {
+    return getAllCodeEditorErrors(store.editor, 'error', true)
+  }, 'ErrorOverlayComponent fatalCodeEditorErrors')
 
-    const overlay = React.useMemo(
-      () => (
-        <ReactErrorOverlay
-          currentBuildErrorRecords={errorRecords}
-          currentRuntimeErrorRecords={overlayErrors}
-          onOpenFile={onOpenFile}
-          overlayOffset={0}
-        />
-      ),
-      [errorRecords, overlayErrors, onOpenFile],
-    )
+  const runtimeErrors = useReadOnlyRuntimeErrors()
 
-    React.useEffect(() => {
-      if (overlay != null) {
-        // If this is showing, we need to clear any canvas drag state and apply the changes it would have resulted in,
-        // since that might have been the cause of the error being thrown, as well as switching back to select mode
-        dispatch([
-          CanvasActions.clearDragState(true),
-          switchEditorMode(EditorModes.selectMode()),
-          clearHighlightedViews(),
-        ])
+  const overlayErrors = React.useMemo(() => {
+    return runtimeErrors.map((runtimeError) => {
+      const stackFrames =
+        runtimeError.error.stackFrames != null
+          ? runtimeError.error.stackFrames
+          : [
+              new StackFrame(
+                'WARNING: This error has no Stack Frames, it might be coming from Utopia itself!',
+              ),
+            ]
+      return {
+        error: runtimeError.error,
+        unhandledRejection: false,
+        contextSize: 3, // magic number from react-error-overlay
+        stackFrames: stackFrames,
       }
-    }, [dispatch, overlay])
+    })
+  }, [runtimeErrors])
 
-    return overlay
-  },
-)
+  const lintErrors = fatalCodeEditorErrors.filter((e) => e.source === 'eslint')
+  // we start with the lint errors, since those show up the fastest. any subsequent error will go below in the error screen
+  const errorRecords = filterOldPasses([...lintErrors, ...utopiaParserErrors])
 
-export const SafeModeErrorOverlay = betterReactMemo('SafeModeErrorOverlay', () => {
+  const onOpenFile = React.useCallback(
+    (path: string) => {
+      dispatch([openCodeEditorFile(path, true), setFocus('codeEditor')])
+    },
+    [dispatch],
+  )
+
+  const overlay = React.useMemo(
+    () => (
+      <ReactErrorOverlay
+        currentBuildErrorRecords={errorRecords}
+        currentRuntimeErrorRecords={overlayErrors}
+        onOpenFile={onOpenFile}
+        overlayOffset={0}
+      />
+    ),
+    [errorRecords, overlayErrors, onOpenFile],
+  )
+
+  React.useEffect(() => {
+    if (overlay != null) {
+      // If this is showing, we need to clear any canvas drag state and apply the changes it would have resulted in,
+      // since that might have been the cause of the error being thrown, as well as switching back to select mode
+      dispatch([
+        CanvasActions.clearDragState(true),
+        switchEditorMode(EditorModes.selectMode()),
+        clearHighlightedViews(),
+      ])
+    }
+  }, [dispatch, overlay])
+
+  return overlay
+})
+
+export const SafeModeErrorOverlay = React.memo(() => {
   const dispatch = useEditorState((store) => store.dispatch, 'SafeModeErrorOverlay dispatch')
   const onTryAgain = React.useCallback(() => {
     dispatch([setSafeMode(false)], 'everyone')

--- a/editor/src/components/canvas/controls/breadcrumb-trail.tsx
+++ b/editor/src/components/canvas/controls/breadcrumb-trail.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import { useEditorState } from '../../../components/editor/store/store-hook'
-import {
-  betterReactMemo,
-  useKeepReferenceEqualityIfPossible,
-} from '../../../utils/react-performance'
+import { useKeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
 import { Utils } from '../../../uuiui-deps'
 import * as EP from '../../../core/shared/element-path'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
@@ -16,7 +13,7 @@ interface ElementPathElement {
   path: ElementPath
 }
 
-export const BreadcrumbTrail = betterReactMemo('BreadcrumbTrail', () => {
+export const BreadcrumbTrail = React.memo(() => {
   const { dispatch, jsxMetadata, selectedViews } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,

--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -28,25 +28,19 @@ import {
   useGetSelectedClasses,
 } from '../../../core/tailwind/tailwind-options'
 import { colorTheme, FlexColumn, FlexRow, useColorTheme, UtopiaTheme } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import * as EditorActions from '../../editor/actions/action-creators'
 import { useEditorState } from '../../editor/store/store-hook'
 
-const DropdownIndicator = betterReactMemo(
-  'DropdownIndicator',
-  (props: IndicatorProps<TailWindOption, true>) => (
-    <components.DropdownIndicator {...props}>
-      <span style={{ lineHeight: '20px', opacity: props.isDisabled ? 0 : 1 }}> ↓ </span>
-    </components.DropdownIndicator>
-  ),
-)
+const DropdownIndicator = React.memo((props: IndicatorProps<TailWindOption, true>) => (
+  <components.DropdownIndicator {...props}>
+    <span style={{ lineHeight: '20px', opacity: props.isDisabled ? 0 : 1 }}> ↓ </span>
+  </components.DropdownIndicator>
+))
 
 const ClearIndicator = () => null
 const IndicatorSeparator = () => null
 
-const NoOptionsMessage = betterReactMemo('NoOptionsMessage', (props: any) => (
-  <span {...props}>No results found</span>
-))
+const NoOptionsMessage = React.memo((props: any) => <span {...props}>No results found</span>)
 
 const getOptionColors = (
   theme: typeof colorTheme,
@@ -93,7 +87,7 @@ function formatOptionLabel(
   )
 }
 
-const Menu = betterReactMemo('Menu', (props: MenuProps<TailWindOption, true>) => {
+const Menu = React.memo((props: MenuProps<TailWindOption, true>) => {
   const theme = useColorTheme()
   const focusedOption = usePubSubAtomReadOnly(focusedOptionAtom)
   const showFooter = props.options.length > 0
@@ -134,16 +128,13 @@ const Menu = betterReactMemo('Menu', (props: MenuProps<TailWindOption, true>) =>
   )
 })
 
-const ValueContainer = betterReactMemo(
-  'ValueContainer',
-  (props: ValueContainerProps<TailWindOption, true>) => {
-    return (
-      <div style={{ overflowX: 'scroll', flex: 1 }}>
-        <components.ValueContainer {...props} />
-      </div>
-    )
-  },
-)
+const ValueContainer = React.memo((props: ValueContainerProps<TailWindOption, true>) => {
+  return (
+    <div style={{ overflowX: 'scroll', flex: 1 }}>
+      <components.ValueContainer {...props} />
+    </div>
+  )
+})
 
 const filterOption = () => true
 const MaxResults = 500
@@ -155,8 +146,7 @@ const Input = (props: InputProps) => {
 }
 let queuedDispatchTimeout: number | undefined = undefined
 
-export const ClassNameSelect = betterReactMemo(
-  'ClassNameSelect',
+export const ClassNameSelect = React.memo(
   React.forwardRef<HTMLInputElement>((_, ref) => {
     const theme = useColorTheme()
     const targets = useEditorState((store) => store.editor.selectedViews, 'ClassNameSelect targets')

--- a/editor/src/components/canvas/controls/formula-bar.tsx
+++ b/editor/src/components/canvas/controls/formula-bar.tsx
@@ -2,7 +2,6 @@
 import React from 'react'
 import { jsx } from '@emotion/react'
 import * as EditorActions from '../../editor/actions/action-creators'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { useColorTheme, SimpleFlexRow, UtopiaTheme, HeadlessStringInput } from '../../../uuiui'
 import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
@@ -23,7 +22,11 @@ import {
 } from '../../editor/shortcut-definitions'
 import { useInputFocusOnCountIncrease } from '../../editor/hook-utils'
 
-export const FormulaBar = betterReactMemo('FormulaBar', () => {
+interface FormulaBarProps {
+  style: React.CSSProperties
+}
+
+export const FormulaBar = React.memo<FormulaBarProps>((props) => {
   const saveTimerRef = React.useRef<any>(null)
   const dispatch = useEditorState((store) => store.dispatch, 'FormulaBar dispatch')
 

--- a/editor/src/components/canvas/controls/highlight-control.tsx
+++ b/editor/src/components/canvas/controls/highlight-control.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { CanvasRectangle, CanvasPoint } from '../../../core/shared/math-utils'
 import { useColorTheme } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { isZeroSizedElement, ZeroControlSize } from './outline-utils'
 import { ZeroSizeHighlightControl } from './zero-sized-element-controls'
 
@@ -12,38 +11,35 @@ interface HighlightControlProps {
   color?: string
 }
 
-export const HighlightControl = betterReactMemo(
-  'HighlightControl',
-  (props: HighlightControlProps) => {
-    const colorTheme = useColorTheme()
-    const outlineWidth = 1.5 / props.scale
-    const outlineColor =
-      props.color === null ? colorTheme.canvasSelectionPrimaryOutline.value : props.color
+export const HighlightControl = React.memo((props: HighlightControlProps) => {
+  const colorTheme = useColorTheme()
+  const outlineWidth = 1.5 / props.scale
+  const outlineColor =
+    props.color === null ? colorTheme.canvasSelectionPrimaryOutline.value : props.color
 
-    if (isZeroSizedElement(props.frame)) {
-      return (
-        <ZeroSizeHighlightControl
-          frame={props.frame}
-          canvasOffset={props.canvasOffset}
-          scale={props.scale}
-          color={outlineColor}
-        />
-      )
-    } else {
-      return (
-        <div
-          className='role-component-highlight-outline'
-          style={{
-            position: 'absolute',
-            left: props.canvasOffset.x + props.frame.x,
-            top: props.canvasOffset.y + props.frame.y,
-            width: props.frame.width,
-            height: props.frame.height,
-            boxShadow: `0px 0px 0px ${outlineWidth}px ${outlineColor}`,
-            pointerEvents: 'none',
-          }}
-        />
-      )
-    }
-  },
-)
+  if (isZeroSizedElement(props.frame)) {
+    return (
+      <ZeroSizeHighlightControl
+        frame={props.frame}
+        canvasOffset={props.canvasOffset}
+        scale={props.scale}
+        color={outlineColor}
+      />
+    )
+  } else {
+    return (
+      <div
+        className='role-component-highlight-outline'
+        style={{
+          position: 'absolute',
+          left: props.canvasOffset.x + props.frame.x,
+          top: props.canvasOffset.y + props.frame.y,
+          width: props.frame.width,
+          height: props.frame.height,
+          boxShadow: `0px 0px 0px ${outlineWidth}px ${outlineColor}`,
+          pointerEvents: 'none',
+        }}
+      />
+    )
+  }
+})

--- a/editor/src/components/canvas/controls/insertion-control.tsx
+++ b/editor/src/components/canvas/controls/insertion-control.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { CanvasVector, CanvasRectangle } from '../../../core/shared/math-utils'
 import { useColorTheme } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { Outline } from './outline'
 
 export interface InsertionControlProps {
@@ -10,18 +9,15 @@ export interface InsertionControlProps {
   scale: number
 }
 
-export const InsertionControls = betterReactMemo(
-  'InsertionControls',
-  (props: InsertionControlProps) => {
-    const colorTheme = useColorTheme()
-    // TODO Show transparent image overlay when inserting an image
-    return (
-      <Outline
-        rect={props.frame}
-        offset={props.canvasOffset}
-        scale={props.scale}
-        color={colorTheme.canvasSelectionSecondaryOutline.value}
-      />
-    )
-  },
-)
+export const InsertionControls = React.memo((props: InsertionControlProps) => {
+  const colorTheme = useColorTheme()
+  // TODO Show transparent image overlay when inserting an image
+  return (
+    <Outline
+      rect={props.frame}
+      offset={props.canvasOffset}
+      scale={props.scale}
+      color={colorTheme.canvasSelectionSecondaryOutline.value}
+    />
+  )
+})

--- a/editor/src/components/canvas/controls/insertion-plus-button.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.tsx
@@ -7,7 +7,6 @@ import { IndexPosition } from '../../../utils/utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import * as EP from '../../../core/shared/element-path'
 import { openFloatingInsertMenu } from '../../editor/actions/action-creators'
-import { betterReactMemo } from '../../../utils/react-performance'
 import { useColorTheme } from '../../../uuiui/styles/theme'
 
 const InsertionButtonOffset = 10
@@ -24,8 +23,7 @@ interface ButtonControlProps {
   indexPosition: IndexPosition
 }
 
-export const InsertionControls: React.FunctionComponent<ControlProps> = betterReactMemo(
-  'InsertionControls',
+export const InsertionControls: React.FunctionComponent<ControlProps> = React.memo(
   (props: ControlProps): React.ReactElement | null => {
     if (props.selectedViews.length !== 1) {
       return null
@@ -196,39 +194,36 @@ export const InsertionControls: React.FunctionComponent<ControlProps> = betterRe
   },
 )
 
-const InsertionButtonContainer = betterReactMemo(
-  'InsertionButtonContainer',
-  (props: ButtonControlProps) => {
-    const [plusVisible, setPlusVisible] = React.useState(false)
+const InsertionButtonContainer = React.memo((props: ButtonControlProps) => {
+  const [plusVisible, setPlusVisible] = React.useState(false)
 
-    const onMouseEnter = () => setPlusVisible(true)
-    const onMouseLeave = () => setPlusVisible(false)
+  const onMouseEnter = () => setPlusVisible(true)
+  const onMouseLeave = () => setPlusVisible(false)
 
-    return (
-      <div
-        key={props.key}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        style={{
-          position: 'absolute',
-          left: props.positionX,
-          top: props.positionY,
-        }}
-      >
-        {plusVisible ? (
-          <>
-            <Line {...props} />
-            <PlusButton {...props} />
-          </>
-        ) : (
-          <BlueDot {...props} />
-        )}
-      </div>
-    )
-  },
-)
+  return (
+    <div
+      key={props.key}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={{
+        position: 'absolute',
+        left: props.positionX,
+        top: props.positionY,
+      }}
+    >
+      {plusVisible ? (
+        <>
+          <Line {...props} />
+          <PlusButton {...props} />
+        </>
+      ) : (
+        <BlueDot {...props} />
+      )}
+    </div>
+  )
+})
 
-const BlueDot = betterReactMemo('BlueDot', (props: ButtonControlProps) => {
+const BlueDot = React.memo((props: ButtonControlProps) => {
   const colorTheme = useColorTheme()
   const BlueDotSize = 7 / props.scale
   return (
@@ -257,7 +252,7 @@ const BlueDot = betterReactMemo('BlueDot', (props: ButtonControlProps) => {
   )
 })
 
-const PlusButton = betterReactMemo('PlusButton', (props: ButtonControlProps) => {
+const PlusButton = React.memo((props: ButtonControlProps) => {
   const dispatch = useEditorState((store) => store.dispatch, 'PlusButton dispatch')
   const colorTheme = useColorTheme()
   const { parentPath, indexPosition } = props
@@ -323,7 +318,7 @@ const PlusButton = betterReactMemo('PlusButton', (props: ButtonControlProps) => 
   )
 })
 
-const Line = betterReactMemo('Line', (props: ButtonControlProps) => {
+const Line = React.memo((props: ButtonControlProps) => {
   const colorTheme = useColorTheme()
 
   const LineWidth = 1 / props.scale

--- a/editor/src/components/canvas/controls/layout-parent-control.tsx
+++ b/editor/src/components/canvas/controls/layout-parent-control.tsx
@@ -6,7 +6,7 @@ import * as EP from '../../../core/shared/element-path'
 import { emptyComments, jsxAttributeValue } from '../../../core/shared/element-template'
 import { when } from '../../../utils/react-conditionals'
 import { Icn, IcnProps, PopupList, useColorTheme } from '../../../uuiui'
-import { betterReactMemo, SelectOption } from '../../../uuiui-deps'
+import { SelectOption } from '../../../uuiui-deps'
 import { InlineLink } from '../../../uuiui/inline-button'
 import { setProp_UNSAFE } from '../../editor/actions/action-creators'
 import { useEditorState } from '../../editor/store/store-hook'
@@ -28,178 +28,172 @@ const getFlexDirectionIcon = (
   )
 }
 
-export const LayoutParentControl = betterReactMemo(
-  'LayoutParentControl',
-  (): JSX.Element | null => {
-    const colorTheme = useColorTheme()
+export const LayoutParentControl = React.memo((): JSX.Element | null => {
+  const colorTheme = useColorTheme()
 
-    const dispatch = useEditorState((store) => store.dispatch, 'LayoutParentControl dispatch')
+  const dispatch = useEditorState((store) => store.dispatch, 'LayoutParentControl dispatch')
 
-    const { canvasOffset, scale } = useEditorState((store) => {
-      return {
-        canvasOffset: store.editor.canvas.roundedCanvasOffset,
-        scale: store.editor.canvas.scale,
-      }
-    }, 'LayoutParentControl canvas')
-    const {
-      parentTarget,
-      parentLayout,
-      parentFrame,
-      flexWrap,
-      flexDirection,
-      alignItems,
-    } = useEditorState((store) => {
-      if (store.editor.selectedViews.length !== 1) {
-        return {
-          parentTarget: null,
-          parentLayout: null,
-          parentFrame: null,
-          flexWrap: null,
-          flexDirection: null,
-          alignItems: null,
-        }
-      }
-      const element = MetadataUtils.getParent(
-        store.editor.jsxMetadata,
-        store.editor.selectedViews[0],
-      )
-      return {
-        parentTarget: element?.elementPath,
-        parentLayout: element?.specialSizeMeasurements.layoutSystemForChildren,
-        parentFrame: element?.globalFrame,
-        flexWrap: element?.props?.style?.flexWrap ?? 'nowrap',
-        flexDirection: element?.props?.style?.flexDirection ?? 'row',
-        alignItems: element?.props?.style?.alignItems ?? 'flex-start',
-      }
-    }, 'LayoutParentControl')
-
-    const {
-      justifyFlexStart,
-      justifyFlexEnd,
-      alignDirection,
-      alignItemsFlexStart,
-      alignItemsFlexEnd,
-      alignContentFlexStart,
-      alignContentFlexEnd,
-    } = getDirectionAwareLabels(flexWrap, flexDirection)
-    const allAlignmentOptions = alignItemsOptions(
-      alignDirection,
-      alignItemsFlexStart,
-      alignItemsFlexEnd,
-    )
-    const selectedAlignment = allAlignmentOptions.find((option) => option.value === alignItems)
-
-    const flexDirectionIcon = getFlexDirectionIcon(flexWrap, flexDirection)
-    const flexDirectionClicked = React.useCallback(
-      (event: React.MouseEvent<HTMLDivElement>) => {
-        if (parentTarget != null) {
-          const newValue = flexDirection === 'row' ? 'column' : 'row'
-          dispatch(
-            [
-              setProp_UNSAFE(
-                parentTarget,
-                createLayoutPropertyPath('flexDirection'),
-                jsxAttributeValue(newValue, emptyComments),
-              ),
-            ],
-            'canvas',
-          )
-        }
-      },
-      [parentTarget, flexDirection, dispatch],
-    )
-
-    const onSubmitValueAlignment = React.useCallback(
-      (option: SelectOption) => {
-        if (parentTarget != null) {
-          dispatch(
-            [
-              setProp_UNSAFE(
-                parentTarget,
-                createLayoutPropertyPath('alignItems'),
-                jsxAttributeValue(option.value, emptyComments),
-              ),
-            ],
-            'canvas',
-          )
-        }
-      },
-      [parentTarget, dispatch],
-    )
-
-    const onControlMouseDown = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-      event.nativeEvent.stopPropagation()
-      event.nativeEvent.stopImmediatePropagation()
-      event.stopPropagation()
-    }, [])
-
-    if (parentFrame == null) {
-      return null
+  const { canvasOffset, scale } = useEditorState((store) => {
+    return {
+      canvasOffset: store.editor.canvas.roundedCanvasOffset,
+      scale: store.editor.canvas.scale,
     }
+  }, 'LayoutParentControl canvas')
+  const {
+    parentTarget,
+    parentLayout,
+    parentFrame,
+    flexWrap,
+    flexDirection,
+    alignItems,
+  } = useEditorState((store) => {
+    if (store.editor.selectedViews.length !== 1) {
+      return {
+        parentTarget: null,
+        parentLayout: null,
+        parentFrame: null,
+        flexWrap: null,
+        flexDirection: null,
+        alignItems: null,
+      }
+    }
+    const element = MetadataUtils.getParent(store.editor.jsxMetadata, store.editor.selectedViews[0])
+    return {
+      parentTarget: element?.elementPath,
+      parentLayout: element?.specialSizeMeasurements.layoutSystemForChildren,
+      parentFrame: element?.globalFrame,
+      flexWrap: element?.props?.style?.flexWrap ?? 'nowrap',
+      flexDirection: element?.props?.style?.flexDirection ?? 'row',
+      alignItems: element?.props?.style?.alignItems ?? 'flex-start',
+    }
+  }, 'LayoutParentControl')
 
-    return (
+  const {
+    justifyFlexStart,
+    justifyFlexEnd,
+    alignDirection,
+    alignItemsFlexStart,
+    alignItemsFlexEnd,
+    alignContentFlexStart,
+    alignContentFlexEnd,
+  } = getDirectionAwareLabels(flexWrap, flexDirection)
+  const allAlignmentOptions = alignItemsOptions(
+    alignDirection,
+    alignItemsFlexStart,
+    alignItemsFlexEnd,
+  )
+  const selectedAlignment = allAlignmentOptions.find((option) => option.value === alignItems)
+
+  const flexDirectionIcon = getFlexDirectionIcon(flexWrap, flexDirection)
+  const flexDirectionClicked = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (parentTarget != null) {
+        const newValue = flexDirection === 'row' ? 'column' : 'row'
+        dispatch(
+          [
+            setProp_UNSAFE(
+              parentTarget,
+              createLayoutPropertyPath('flexDirection'),
+              jsxAttributeValue(newValue, emptyComments),
+            ),
+          ],
+          'canvas',
+        )
+      }
+    },
+    [parentTarget, flexDirection, dispatch],
+  )
+
+  const onSubmitValueAlignment = React.useCallback(
+    (option: SelectOption) => {
+      if (parentTarget != null) {
+        dispatch(
+          [
+            setProp_UNSAFE(
+              parentTarget,
+              createLayoutPropertyPath('alignItems'),
+              jsxAttributeValue(option.value, emptyComments),
+            ),
+          ],
+          'canvas',
+        )
+      }
+    },
+    [parentTarget, dispatch],
+  )
+
+  const onControlMouseDown = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    event.nativeEvent.stopPropagation()
+    event.nativeEvent.stopImmediatePropagation()
+    event.stopPropagation()
+  }, [])
+
+  if (parentFrame == null) {
+    return null
+  }
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: parentFrame.x + canvasOffset.x,
+        top: parentFrame.y + canvasOffset.y - 16 / scale,
+        transform: `${scale < 1 ? `scale(${1 / scale})` : ''}`,
+      }}
+    >
       <div
         style={{
+          right: 42,
+          zoom: scale >= 1 ? 1 / scale : 1,
           position: 'absolute',
-          left: parentFrame.x + canvasOffset.x,
-          top: parentFrame.y + canvasOffset.y - 16 / scale,
-          transform: `${scale < 1 ? `scale(${1 / scale})` : ''}`,
+          borderRadius: 2,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'stretch',
+          justifyContent: 'flex-start',
+          boxShadow: `${colorTheme.canvasControlsSizeBoxShadowColor.o(20).value} 0px 0px 1px, ${
+            colorTheme.canvasControlsSizeBoxShadowColor.o(21).value
+          } 0px 1px 2px 1px`,
+          backgroundColor: colorTheme.inspectorBackground.value,
+          textTransform: 'capitalize',
         }}
+        onMouseDown={onControlMouseDown}
       >
-        <div
-          style={{
-            right: 42,
-            zoom: scale >= 1 ? 1 / scale : 1,
-            position: 'absolute',
-            borderRadius: 2,
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'stretch',
-            justifyContent: 'flex-start',
-            boxShadow: `${colorTheme.canvasControlsSizeBoxShadowColor.o(20).value} 0px 0px 1px, ${
-              colorTheme.canvasControlsSizeBoxShadowColor.o(21).value
-            } 0px 1px 2px 1px`,
-            backgroundColor: colorTheme.inspectorBackground.value,
-            textTransform: 'capitalize',
-          }}
-          onMouseDown={onControlMouseDown}
+        <svg
+          style={{ position: 'absolute', left: 'calc(100% + 8px)', top: 2 }}
+          width='30px'
+          height='11px'
+          viewBox='0 0 30 11'
         >
-          <svg
-            style={{ position: 'absolute', left: 'calc(100% + 8px)', top: 2 }}
-            width='30px'
-            height='11px'
-            viewBox='0 0 30 11'
-          >
-            <g stroke='none' strokeWidth='1' fill='none' fillRule='evenodd' strokeLinecap='round'>
-              <polyline stroke='#979797' points='0.5 0.5 15.5 0.5 30 10'></polyline>
-            </g>
-          </svg>
-          <div style={{ display: 'flex' }}>
-            <span style={{ padding: '0px 4px', fontSize: 8, color: '#007aff' }}>Parent</span>
-          </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '0px 4px' }}>
-            <span style={{ fontSize: 10, fontWeight: 500, color: colorTheme.fg4.value }}>
-              {parentLayout}
-            </span>
-            {when(
-              flexDirectionIcon != null && parentLayout === 'flex',
-              <Icn onClick={flexDirectionClicked} {...(flexDirectionIcon as IcnProps)} />,
-            )}
-            {when(
-              flexDirectionIcon != null && parentLayout === 'flex',
-              <div>
-                {selectedAlignment ? (
-                  <PopupList
-                    options={allAlignmentOptions}
-                    value={selectedAlignment}
-                    onSubmitValue={onSubmitValueAlignment}
-                  />
-                ) : null}
-              </div>,
-            )}
-          </div>
+          <g stroke='none' strokeWidth='1' fill='none' fillRule='evenodd' strokeLinecap='round'>
+            <polyline stroke='#979797' points='0.5 0.5 15.5 0.5 30 10'></polyline>
+          </g>
+        </svg>
+        <div style={{ display: 'flex' }}>
+          <span style={{ padding: '0px 4px', fontSize: 8, color: '#007aff' }}>Parent</span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '0px 4px' }}>
+          <span style={{ fontSize: 10, fontWeight: 500, color: colorTheme.fg4.value }}>
+            {parentLayout}
+          </span>
+          {when(
+            flexDirectionIcon != null && parentLayout === 'flex',
+            <Icn onClick={flexDirectionClicked} {...(flexDirectionIcon as IcnProps)} />,
+          )}
+          {when(
+            flexDirectionIcon != null && parentLayout === 'flex',
+            <div>
+              {selectedAlignment ? (
+                <PopupList
+                  options={allAlignmentOptions}
+                  value={selectedAlignment}
+                  onSubmitValue={onSubmitValueAlignment}
+                />
+              ) : null}
+            </div>,
+          )}
         </div>
       </div>
-    )
-  },
-)
+    </div>
+  )
+})

--- a/editor/src/components/canvas/controls/margin-controls.tsx
+++ b/editor/src/components/canvas/controls/margin-controls.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Sides } from 'utopia-api'
 import { CanvasRectangle, CanvasPoint } from '../../../core/shared/math-utils'
 import { useColorTheme } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 
 interface MarginControlsProps {
   margin: Partial<Sides> | null
@@ -11,7 +10,7 @@ interface MarginControlsProps {
   scale: number
 }
 
-export const MarginControls = betterReactMemo('MarginControls', (props: MarginControlsProps) => {
+export const MarginControls = React.memo((props: MarginControlsProps) => {
   const colorTheme = useColorTheme()
 
   if (props.margin == null) {

--- a/editor/src/components/canvas/controls/mode-toggle-button.tsx
+++ b/editor/src/components/canvas/controls/mode-toggle-button.tsx
@@ -4,10 +4,9 @@ import React from 'react'
 import { css, jsx } from '@emotion/react'
 import { useEditorState } from '../../editor/store/store-hook'
 import { updateFormulaBarMode } from '../../editor/actions/action-creators'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { useColorTheme } from '../../../uuiui'
 
-export const ModeToggleButton = betterReactMemo('ModeToggleButton', () => {
+export const ModeToggleButton = React.memo(() => {
   const colorTheme = useColorTheme()
   const selectedMode = useEditorState(
     (store) => store.editor.topmenu.formulaBarMode,

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -37,7 +37,6 @@ import { targetRespectsLayout } from '../../../core/layout/layout-helpers'
 import { createSelector } from 'reselect'
 import { PropertyControlsInfo, ResolveFn } from '../../custom-code/code-file'
 import { useColorTheme } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import {
   isDragging,
   isResizing,
@@ -116,107 +115,104 @@ interface NewCanvasControlsProps {
   cursor: CSSCursor
 }
 
-export const NewCanvasControls = betterReactMemo(
-  'NewCanvasControls',
-  (props: NewCanvasControlsProps) => {
-    const canvasControlProps = useEditorState(
-      (store) => ({
-        dispatch: store.dispatch,
-        editor: store.editor,
-        derived: store.derived,
-        canvasOffset: store.editor.canvas.roundedCanvasOffset,
-        animationEnabled:
-          (store.editor.canvas.dragState == null ||
-            getDragStateStart(store.editor.canvas.dragState, store.editor.canvas.resizeOptions) ==
-              null) &&
-          store.editor.canvas.animationsEnabled,
+export const NewCanvasControls = React.memo((props: NewCanvasControlsProps) => {
+  const canvasControlProps = useEditorState(
+    (store) => ({
+      dispatch: store.dispatch,
+      editor: store.editor,
+      derived: store.derived,
+      canvasOffset: store.editor.canvas.roundedCanvasOffset,
+      animationEnabled:
+        (store.editor.canvas.dragState == null ||
+          getDragStateStart(store.editor.canvas.dragState, store.editor.canvas.resizeOptions) ==
+            null) &&
+        store.editor.canvas.animationsEnabled,
 
-        controls: store.derived.canvas.controls,
-        scale: store.editor.canvas.scale,
-        focusedPanel: store.editor.focusedPanel,
-        transientCanvasState: store.derived.canvas.transientState,
-      }),
-      'NewCanvasControls',
-    )
+      controls: store.derived.canvas.controls,
+      scale: store.editor.canvas.scale,
+      focusedPanel: store.editor.focusedPanel,
+      transientCanvasState: store.derived.canvas.transientState,
+    }),
+    'NewCanvasControls',
+  )
 
-    const {
-      localSelectedViews,
-      localHighlightedViews,
-      setSelectedViewsLocally,
-    } = useLocalSelectedHighlightedViews(canvasControlProps.transientCanvasState)
+  const {
+    localSelectedViews,
+    localHighlightedViews,
+    setSelectedViewsLocally,
+  } = useLocalSelectedHighlightedViews(canvasControlProps.transientCanvasState)
 
-    const canvasScrollAnimation = useEditorState(
-      (store) => store.editor.canvas.scrollAnimation,
-      'NewCanvasControls scrollAnimation',
-    )
+  const canvasScrollAnimation = useEditorState(
+    (store) => store.editor.canvas.scrollAnimation,
+    'NewCanvasControls scrollAnimation',
+  )
 
-    // Somehow this being setup and hooked into the div makes the `onDrop` call
-    // work properly in `editor-canvas.ts`. I blame React DnD for this.
-    const dropSpec: DropTargetHookSpec<FileBrowserItemProps, 'CANVAS', unknown> = {
-      accept: 'filebrowser',
-      canDrop: () => true,
-    }
+  // Somehow this being setup and hooked into the div makes the `onDrop` call
+  // work properly in `editor-canvas.ts`. I blame React DnD for this.
+  const dropSpec: DropTargetHookSpec<FileBrowserItemProps, 'CANVAS', unknown> = {
+    accept: 'filebrowser',
+    canDrop: () => true,
+  }
 
-    const [_, drop] = useDrop(dropSpec)
+  const [_, drop] = useDrop(dropSpec)
 
-    const forwardedRef = React.useCallback(
-      (node: ConnectableElement) => {
-        return drop(node)
-      },
-      [drop],
-    )
+  const forwardedRef = React.useCallback(
+    (node: ConnectableElement) => {
+      return drop(node)
+    },
+    [drop],
+  )
 
-    if (isLiveMode(canvasControlProps.editor.mode) && !canvasControlProps.editor.keysPressed.cmd) {
-      return null
-    } else {
-      return (
+  if (isLiveMode(canvasControlProps.editor.mode) && !canvasControlProps.editor.keysPressed.cmd) {
+    return null
+  } else {
+    return (
+      <div
+        key='canvas-controls'
+        ref={forwardedRef}
+        className={
+          canvasControlProps.focusedPanel === 'canvas'
+            ? '  canvas-controls focused '
+            : ' canvas-controls '
+        }
+        id='canvas-controls'
+        style={{
+          pointerEvents: 'initial',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          transform: 'translate3d(0, 0, 0)',
+          width: `100%`,
+          height: `100%`,
+          zoom: canvasControlProps.scale >= 1 ? `${canvasControlProps.scale * 100}%` : 1,
+          cursor: props.cursor,
+          visibility: canvasScrollAnimation ? 'hidden' : 'initial',
+        }}
+      >
         <div
-          key='canvas-controls'
-          ref={forwardedRef}
-          className={
-            canvasControlProps.focusedPanel === 'canvas'
-              ? '  canvas-controls focused '
-              : ' canvas-controls '
-          }
-          id='canvas-controls'
           style={{
-            pointerEvents: 'initial',
             position: 'absolute',
             top: 0,
             left: 0,
-            transform: 'translate3d(0, 0, 0)',
-            width: `100%`,
-            height: `100%`,
-            zoom: canvasControlProps.scale >= 1 ? `${canvasControlProps.scale * 100}%` : 1,
-            cursor: props.cursor,
-            visibility: canvasScrollAnimation ? 'hidden' : 'initial',
+            width: `${canvasControlProps.scale < 1 ? 100 / canvasControlProps.scale : 100}%`,
+            height: `${canvasControlProps.scale < 1 ? 100 / canvasControlProps.scale : 100}%`,
+            transformOrigin: 'top left',
+            transform: canvasControlProps.scale < 1 ? `scale(${canvasControlProps.scale}) ` : '',
           }}
         >
-          <div
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: `${canvasControlProps.scale < 1 ? 100 / canvasControlProps.scale : 100}%`,
-              height: `${canvasControlProps.scale < 1 ? 100 / canvasControlProps.scale : 100}%`,
-              transformOrigin: 'top left',
-              transform: canvasControlProps.scale < 1 ? `scale(${canvasControlProps.scale}) ` : '',
-            }}
-          >
-            <NewCanvasControlsInner
-              windowToCanvasPosition={props.windowToCanvasPosition}
-              localSelectedViews={localSelectedViews}
-              localHighlightedViews={localHighlightedViews}
-              setLocalSelectedViews={setSelectedViewsLocally}
-              {...canvasControlProps}
-            />
-          </div>
-          <ElementContextMenu contextMenuInstance='context-menu-canvas' />
+          <NewCanvasControlsInner
+            windowToCanvasPosition={props.windowToCanvasPosition}
+            localSelectedViews={localSelectedViews}
+            localHighlightedViews={localHighlightedViews}
+            setLocalSelectedViews={setSelectedViewsLocally}
+            {...canvasControlProps}
+          />
         </div>
-      )
-    }
-  },
-)
+        <ElementContextMenu contextMenuInstance='context-menu-canvas' />
+      </div>
+    )
+  }
+})
 NewCanvasControls.displayName = 'NewCanvasControls'
 
 interface NewCanvasControlsInnerProps {

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -19,8 +19,6 @@ import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { useColorTheme } from '../../../uuiui'
 import { useEditorState } from '../../editor/store/store-hook'
 import { KeysPressed } from '../../../utils/keyboard'
-
-import { betterReactMemo } from '../../../uuiui-deps'
 import { PositionOutline } from './position-outline'
 import { stripNulls, uniqBy } from '../../../core/shared/array-utils'
 
@@ -66,44 +64,41 @@ interface CenteredCrossSVGProps {
   centerY: number
 }
 
-const CenteredCrossSVG = betterReactMemo(
-  'centeredCross',
-  ({ id, centerX, centerY, scale }: CenteredCrossSVGProps) => {
-    const colorTheme = useColorTheme()
-    return (
-      <svg
-        id={id}
-        style={{
-          left: centerX,
-          top: centerY,
-          position: 'absolute',
-          width: 6,
-          height: 6,
-          transformOrigin: 'center center',
-          transform: `translateX(-50%) translateY(-50%) scale(${1 / scale})`,
-        }}
-        width='4px'
-        height='4px'
-        viewBox='0 0 4 4'
-        version='1.1'
+const CenteredCrossSVG = React.memo(({ id, centerX, centerY, scale }: CenteredCrossSVGProps) => {
+  const colorTheme = useColorTheme()
+  return (
+    <svg
+      id={id}
+      style={{
+        left: centerX,
+        top: centerY,
+        position: 'absolute',
+        width: 6,
+        height: 6,
+        transformOrigin: 'center center',
+        transform: `translateX(-50%) translateY(-50%) scale(${1 / scale})`,
+      }}
+      width='4px'
+      height='4px'
+      viewBox='0 0 4 4'
+      version='1.1'
+    >
+      <g
+        stroke='none'
+        strokeWidth='1'
+        fill='none'
+        fillRule='evenodd'
+        strokeLinecap='round'
+        strokeLinejoin='round'
       >
-        <g
-          stroke='none'
-          strokeWidth='1'
-          fill='none'
-          fillRule='evenodd'
-          strokeLinecap='round'
-          strokeLinejoin='round'
-        >
-          <g id='cross_svg' stroke={colorTheme.primary.value}>
-            <line x1='0.5' y1='0.5' x2='3.5' y2='3.5'></line>
-            <line x1='0.5' y1='3.5' x2='3.5' y2='0.5'></line>
-          </g>
+        <g id='cross_svg' stroke={colorTheme.primary.value}>
+          <line x1='0.5' y1='0.5' x2='3.5' y2='3.5'></line>
+          <line x1='0.5' y1='3.5' x2='3.5' y2='0.5'></line>
         </g>
-      </svg>
-    )
-  },
-)
+      </g>
+    </svg>
+  )
+})
 
 export const OutlineControls = (props: OutlineControlsProps) => {
   const colorTheme = useColorTheme()

--- a/editor/src/components/canvas/controls/padding-controls.tsx
+++ b/editor/src/components/canvas/controls/padding-controls.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Sides } from 'utopia-api'
 import { CanvasRectangle, CanvasPoint } from '../../../core/shared/math-utils'
 import { useColorTheme } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 
 interface PaddingControlsProps {
   padding: Partial<Sides> | null
@@ -11,7 +10,7 @@ interface PaddingControlsProps {
   scale: number
 }
 
-export const PaddingControls = betterReactMemo('PaddingControls', (props: PaddingControlsProps) => {
+export const PaddingControls = React.memo((props: PaddingControlsProps) => {
   const colorTheme = useColorTheme()
   if (props.padding == null) {
     return null

--- a/editor/src/components/canvas/controls/position-outline.tsx
+++ b/editor/src/components/canvas/controls/position-outline.tsx
@@ -7,7 +7,6 @@ import { isJSXElement } from '../../../core/shared/element-template'
 import { CanvasPoint, CanvasRectangle } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { useColorTheme } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { useEditorState } from '../../editor/store/store-hook'
 
 interface PositionOutlineProps {
@@ -17,7 +16,7 @@ interface PositionOutlineProps {
   scale: number
 }
 
-export const PositionOutline = betterReactMemo('PositionOutline', (props: PositionOutlineProps) => {
+export const PositionOutline = React.memo((props: PositionOutlineProps) => {
   const containingFrame = useContainingFrameForElement(props.path)
   const attributes = usePropsOrJSXAttributes(props.path)
   if (containingFrame != null) {
@@ -126,8 +125,7 @@ interface PinOutlineProps {
   scale: number
 }
 
-const PinOutline = betterReactMemo(
-  'PinOutline',
+const PinOutline = React.memo(
   (props: PinOutlineProps): JSX.Element => {
     const colorTheme = useColorTheme()
     const width = props.isHorizontalLine ? props.size : 0

--- a/editor/src/components/canvas/controls/property-target-selector.tsx
+++ b/editor/src/components/canvas/controls/property-target-selector.tsx
@@ -8,7 +8,6 @@ import { getSimpleAttributeAtPath } from '../../../core/model/element-metadata-u
 import { eitherToMaybe, left } from '../../../core/shared/either'
 import { ElementInstanceMetadata } from '../../../core/shared/element-template'
 import { LayoutTargetablePropArrayKeepDeepEquality } from '../../../utils/deep-equality-instances'
-import { betterReactMemo } from '../../../utils/react-performance'
 import { useColorTheme } from '../../../uuiui'
 import {
   decrementResizeOptionsSelectedIndex,
@@ -44,8 +43,7 @@ function labelForOption(option: LayoutTargetableProp): string {
   }
 }
 
-export const PropertyTargetSelector = betterReactMemo(
-  'PropertyTargetSelector',
+export const PropertyTargetSelector = React.memo(
   (props: PropertyTargetSelectorProps): JSX.Element => {
     const colorTheme = useColorTheme()
     const { resizeOptions, dispatch } = useEditorState((editorState) => {

--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 import { usePropControlledRef_DANGEROUS } from '../../inspector/common/inspector-utils'
-import { betterReactMemo, getControlStyles, SelectOption, Utils } from '../../../uuiui-deps'
+import { getControlStyles, SelectOption, Utils } from '../../../uuiui-deps'
 import * as EP from '../../../core/shared/element-path'
 import * as EditorActions from '../../editor/actions/action-creators'
 import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
@@ -16,7 +16,7 @@ import {
 import { usePossiblyResolvedPackageDependencies } from '../../../components/editor/npm-dependency/npm-dependency'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 
-export const RenderAsRow = betterReactMemo('RenderAsRow', () => {
+export const RenderAsRow = React.memo(() => {
   const dispatch = useEditorState((store) => {
     return store.dispatch
   }, 'RenderAsRow dispatch')

--- a/editor/src/components/canvas/controls/repositionable-control.tsx
+++ b/editor/src/components/canvas/controls/repositionable-control.tsx
@@ -4,50 +4,46 @@ import Utils from '../../../utils/utils'
 import * as EP from '../../../core/shared/element-path'
 import { ControlProps } from './new-canvas-controls'
 import { getSelectionColor } from './outline-control'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { useColorTheme } from '../../../uuiui'
 
 const Size = 6
 
-export const RepositionableControl = betterReactMemo(
-  'RepositionableControl',
-  (props: ControlProps) => {
-    const colorTheme = useColorTheme()
+export const RepositionableControl = React.memo((props: ControlProps) => {
+  const colorTheme = useColorTheme()
 
-    const outlineOffset = 0.5 / props.scale
+  const outlineOffset = 0.5 / props.scale
 
-    let indicators: JSX.Element[] = []
-    Utils.fastForEach(props.selectedViews, (selectedView) => {
-      const frame = MetadataUtils.getFrameInCanvasCoords(selectedView, props.componentMetadata)
-      if (frame == null) {
-        return
-      }
+  let indicators: JSX.Element[] = []
+  Utils.fastForEach(props.selectedViews, (selectedView) => {
+    const frame = MetadataUtils.getFrameInCanvasCoords(selectedView, props.componentMetadata)
+    if (frame == null) {
+      return
+    }
 
-      const selectionColor = getSelectionColor(
-        selectedView,
-        props.componentMetadata,
-        props.focusedElementPath,
-        colorTheme,
-      )
+    const selectionColor = getSelectionColor(
+      selectedView,
+      props.componentMetadata,
+      props.focusedElementPath,
+      colorTheme,
+    )
 
-      indicators.push(
-        <div
-          key={EP.toComponentId(selectedView)}
-          className='role-outline'
-          style={{
-            position: 'absolute',
-            left: props.canvasOffset.x + frame.x - Size / 2 + outlineOffset,
-            top: props.canvasOffset.y + frame.y - Size / 2 + outlineOffset,
-            borderRadius: '50%',
-            width: Size,
-            height: Size,
-            backgroundColor: selectionColor,
-            pointerEvents: 'none',
-          }}
-        />,
-      )
-    })
+    indicators.push(
+      <div
+        key={EP.toComponentId(selectedView)}
+        className='role-outline'
+        style={{
+          position: 'absolute',
+          left: props.canvasOffset.x + frame.x - Size / 2 + outlineOffset,
+          top: props.canvasOffset.y + frame.y - Size / 2 + outlineOffset,
+          borderRadius: '50%',
+          width: Size,
+          height: Size,
+          backgroundColor: selectionColor,
+          pointerEvents: 'none',
+        }}
+      />,
+    )
+  })
 
-    return <>{indicators}</>
-  },
-)
+  return <>{indicators}</>
+})

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -38,7 +38,6 @@ import { colorTheme as fixmeColorTheme, useColorTheme } from '../../../uuiui'
 import { LayoutTargetableProp } from '../../../core/layout/layout-helpers-new'
 import { PropertyTargetSelector } from './property-target-selector'
 import { unless, when } from '../../../utils/react-conditionals'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { isZeroSizedElement } from './outline-utils'
 import { ZeroSizeResizeControl } from './zero-sized-element-controls'
 import {
@@ -316,7 +315,7 @@ interface ResizeLinesProps {
 }
 
 const LineOffset = 6
-const ResizeLines = betterReactMemo('ResizeLines', (props: ResizeLinesProps) => {
+const ResizeLines = React.memo((props: ResizeLinesProps) => {
   const reference = React.createRef<HTMLDivElement>()
   const LineSVGComponent =
     props.position.y === 0.5 ? DimensionableControlVertical : DimensionableControlHorizontal

--- a/editor/src/components/canvas/controls/yoga-control.tsx
+++ b/editor/src/components/canvas/controls/yoga-control.tsx
@@ -19,7 +19,6 @@ import { getOriginalFrames } from '../canvas-utils'
 import { ControlProps } from './new-canvas-controls'
 import { getSelectionColor } from './outline-control'
 import { ResizeRectangle } from './size-box'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { useColorTheme } from '../../../uuiui'
 import { withUnderlyingTarget } from '../../editor/store/editor-state'
 
@@ -126,7 +125,7 @@ export interface YogaControlsProps extends ControlProps {
   dragState: ResizeDragState | null
 }
 
-export const YogaControls = betterReactMemo('YogaControls', (props: YogaControlsProps) => {
+export const YogaControls = React.memo((props: YogaControlsProps) => {
   const colorTheme = useColorTheme()
   const targets = props.selectedViews
   const everyThingIsYogaLayouted = targets.every((selectedView) => {

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -10,7 +10,6 @@ import {
   emptyComments,
   jsxAttributeValue,
 } from '../../../core/shared/element-template'
-import { betterReactMemo } from '../../../uuiui-deps'
 import {
   clearHighlightedViews,
   selectComponents,
@@ -24,43 +23,40 @@ import { createLayoutPropertyPath } from '../../../core/layout/layout-helpers-ne
 import { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
 
 const EmptyChildren: ElementInstanceMetadata[] = []
-export const ZeroSizedElementControls = betterReactMemo(
-  'ZeroSizedElementControls',
-  (props: ControlProps) => {
-    let zeroSizeChildren = EmptyChildren
-    if (props.cmdKeyPressed) {
-      zeroSizeChildren = props.selectedViews.flatMap((view) => {
-        const children = MetadataUtils.getChildren(props.componentMetadata, view)
-        return children.filter((child) => {
-          if (child.globalFrame == null) {
-            return false
-          } else {
-            return isZeroSizedElement(child.globalFrame)
-          }
-        })
+export const ZeroSizedElementControls = React.memo((props: ControlProps) => {
+  let zeroSizeChildren = EmptyChildren
+  if (props.cmdKeyPressed) {
+    zeroSizeChildren = props.selectedViews.flatMap((view) => {
+      const children = MetadataUtils.getChildren(props.componentMetadata, view)
+      return children.filter((child) => {
+        if (child.globalFrame == null) {
+          return false
+        } else {
+          return isZeroSizedElement(child.globalFrame)
+        }
       })
-    }
+    })
+  }
 
-    return (
-      <React.Fragment>
-        {zeroSizeChildren.map((element) => {
-          let isHighlighted =
-            props.highlightedViews.find((view) => EP.pathsEqual(element.elementPath, view)) != null
-          return (
-            <ZeroSizeSelectControl
-              key={`zero-size-element-${EP.toString(element.elementPath)}`}
-              element={element}
-              dispatch={props.dispatch}
-              canvasOffset={props.canvasOffset}
-              scale={props.scale}
-              isHighlighted={isHighlighted}
-            />
-          )
-        })}
-      </React.Fragment>
-    )
-  },
-)
+  return (
+    <React.Fragment>
+      {zeroSizeChildren.map((element) => {
+        let isHighlighted =
+          props.highlightedViews.find((view) => EP.pathsEqual(element.elementPath, view)) != null
+        return (
+          <ZeroSizeSelectControl
+            key={`zero-size-element-${EP.toString(element.elementPath)}`}
+            element={element}
+            dispatch={props.dispatch}
+            canvasOffset={props.canvasOffset}
+            scale={props.scale}
+            isHighlighted={isHighlighted}
+          />
+        )
+      })}
+    </React.Fragment>
+  )
+})
 
 interface ZeroSizeSelectControlProps {
   element: ElementInstanceMetadata
@@ -70,66 +66,63 @@ interface ZeroSizeSelectControlProps {
   isHighlighted: boolean
 }
 
-const ZeroSizeSelectControl = betterReactMemo(
-  'ZeroSizeSelectControl',
-  (props: ZeroSizeSelectControlProps) => {
-    const colorTheme = useColorTheme()
-    const { dispatch, element, canvasOffset, scale } = props
-    const controlSize = 1 / scale
-    const onControlMouseDown = React.useCallback(
-      (event: React.MouseEvent<HTMLDivElement>) => {
-        event.stopPropagation()
-        dispatch([selectComponents([element.elementPath], false)], 'everyone')
-      },
-      [dispatch, element.elementPath],
-    )
+const ZeroSizeSelectControl = React.memo((props: ZeroSizeSelectControlProps) => {
+  const colorTheme = useColorTheme()
+  const { dispatch, element, canvasOffset, scale } = props
+  const controlSize = 1 / scale
+  const onControlMouseDown = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation()
+      dispatch([selectComponents([element.elementPath], false)], 'everyone')
+    },
+    [dispatch, element.elementPath],
+  )
 
-    const onControlMouseOver = React.useCallback(
-      (event: React.MouseEvent<HTMLDivElement>) => {
-        if (!props.isHighlighted) {
-          dispatch([setHighlightedView(element.elementPath)], 'everyone')
-        }
-      },
-      [dispatch, element.elementPath, props.isHighlighted],
-    )
+  const onControlMouseOver = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!props.isHighlighted) {
+        dispatch([setHighlightedView(element.elementPath)], 'everyone')
+      }
+    },
+    [dispatch, element.elementPath, props.isHighlighted],
+  )
 
-    const onControlMouseOut = React.useCallback(
-      (event: React.MouseEvent<HTMLDivElement>) => {
-        if (props.isHighlighted) {
-          dispatch([clearHighlightedViews()], 'everyone')
-        }
-      },
-      [dispatch, props.isHighlighted],
-    )
+  const onControlMouseOut = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (props.isHighlighted) {
+        dispatch([clearHighlightedViews()], 'everyone')
+      }
+    },
+    [dispatch, props.isHighlighted],
+  )
 
-    if (element.globalFrame == null) {
-      return null
-    } else {
-      const frame = element.globalFrame
-      return (
-        <div
-          onMouseDown={onControlMouseDown}
-          onMouseOver={onControlMouseOver}
-          onMouseOut={onControlMouseOut}
-          style={{
-            position: 'absolute',
-            left: frame.x + canvasOffset.x - ZeroControlSize / 2,
-            top: frame.y + canvasOffset.y - ZeroControlSize / 2,
-            width: frame.width + ZeroControlSize,
-            height: frame.height + ZeroControlSize,
-            borderRadius: ZeroControlSize / 2,
-          }}
-          css={{
-            boxShadow: `0px 0px 0px ${controlSize}px ${colorTheme.primary.value}`,
-            '&:hover': {
-              boxShadow: `0px 0px 0px ${controlSize * 2}px ${colorTheme.primary.value}`,
-            },
-          }}
-        />
-      )
-    }
-  },
-)
+  if (element.globalFrame == null) {
+    return null
+  } else {
+    const frame = element.globalFrame
+    return (
+      <div
+        onMouseDown={onControlMouseDown}
+        onMouseOver={onControlMouseOver}
+        onMouseOut={onControlMouseOut}
+        style={{
+          position: 'absolute',
+          left: frame.x + canvasOffset.x - ZeroControlSize / 2,
+          top: frame.y + canvasOffset.y - ZeroControlSize / 2,
+          width: frame.width + ZeroControlSize,
+          height: frame.height + ZeroControlSize,
+          borderRadius: ZeroControlSize / 2,
+        }}
+        css={{
+          boxShadow: `0px 0px 0px ${controlSize}px ${colorTheme.primary.value}`,
+          '&:hover': {
+            boxShadow: `0px 0px 0px ${controlSize * 2}px ${colorTheme.primary.value}`,
+          },
+        }}
+      />
+    )
+  }
+})
 
 export interface ZeroSizeControlProps {
   frame: CanvasRectangle
@@ -138,49 +131,43 @@ export interface ZeroSizeControlProps {
   color: string | null | undefined
 }
 
-export const ZeroSizeHighlightControl = betterReactMemo(
-  'ZeroSizeHighlightControl',
-  (props: ZeroSizeControlProps) => {
-    const controlSize = (1 / props.scale) * 2
-    return (
-      <div
-        className='role-component-highlight-outline-no-size'
-        style={{
-          position: 'absolute',
-          left: props.frame.x + props.canvasOffset.x - ZeroControlSize / 2,
-          top: props.frame.y + props.canvasOffset.y - ZeroControlSize / 2,
-          width: props.frame.width + ZeroControlSize,
-          height: props.frame.height + ZeroControlSize,
-          borderRadius: ZeroControlSize / 2,
-          boxShadow: `0px 0px 0px ${controlSize}px ${props.color}`,
-        }}
-      />
-    )
-  },
-)
+export const ZeroSizeHighlightControl = React.memo((props: ZeroSizeControlProps) => {
+  const controlSize = (1 / props.scale) * 2
+  return (
+    <div
+      className='role-component-highlight-outline-no-size'
+      style={{
+        position: 'absolute',
+        left: props.frame.x + props.canvasOffset.x - ZeroControlSize / 2,
+        top: props.frame.y + props.canvasOffset.y - ZeroControlSize / 2,
+        width: props.frame.width + ZeroControlSize,
+        height: props.frame.height + ZeroControlSize,
+        borderRadius: ZeroControlSize / 2,
+        boxShadow: `0px 0px 0px ${controlSize}px ${props.color}`,
+      }}
+    />
+  )
+})
 
-export const ZeroSizeOutlineControl = betterReactMemo(
-  'ZeroSizeOutlineControl',
-  (props: ZeroSizeControlProps) => {
-    const colorTheme = useColorTheme()
-    const controlSize = 1 / props.scale
+export const ZeroSizeOutlineControl = React.memo((props: ZeroSizeControlProps) => {
+  const colorTheme = useColorTheme()
+  const controlSize = 1 / props.scale
 
-    return (
-      <div
-        className='role-outline-no-size'
-        style={{
-          position: 'absolute',
-          left: props.frame.x + props.canvasOffset.x - ZeroControlSize / 2,
-          top: props.frame.y + props.canvasOffset.y - ZeroControlSize / 2,
-          width: props.frame.width + ZeroControlSize,
-          height: props.frame.height + ZeroControlSize,
-          borderRadius: ZeroControlSize / 2,
-          boxShadow: `0px 0px 0px ${controlSize}px ${colorTheme.primary.value}, inset 0px 0px 0px ${controlSize}px ${colorTheme.primary.value}`,
-        }}
-      />
-    )
-  },
-)
+  return (
+    <div
+      className='role-outline-no-size'
+      style={{
+        position: 'absolute',
+        left: props.frame.x + props.canvasOffset.x - ZeroControlSize / 2,
+        top: props.frame.y + props.canvasOffset.y - ZeroControlSize / 2,
+        width: props.frame.width + ZeroControlSize,
+        height: props.frame.height + ZeroControlSize,
+        borderRadius: ZeroControlSize / 2,
+        boxShadow: `0px 0px 0px ${controlSize}px ${colorTheme.primary.value}, inset 0px 0px 0px ${controlSize}px ${colorTheme.primary.value}`,
+      }}
+    />
+  )
+})
 
 interface ZeroSizeResizeControlProps extends ZeroSizeControlProps {
   element: ElementInstanceMetadata | null
@@ -188,95 +175,89 @@ interface ZeroSizeResizeControlProps extends ZeroSizeControlProps {
   maybeClearHighlightsOnHoverEnd: () => void
 }
 
-export const ZeroSizeResizeControl = betterReactMemo(
-  'ZeroSizeResizeControl',
-  (props: ZeroSizeResizeControlProps) => {
-    const { dispatch, element, maybeClearHighlightsOnHoverEnd } = props
+export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlProps) => {
+  const { dispatch, element, maybeClearHighlightsOnHoverEnd } = props
 
-    const onControlStopPropagation = React.useCallback(
-      (event: React.MouseEvent<HTMLDivElement>) => {
-        event.stopPropagation()
-      },
-      [],
-    )
+  const onControlStopPropagation = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation()
+  }, [])
 
-    const onControlMouseMove = React.useCallback(
-      (event: React.MouseEvent<HTMLDivElement>) => {
-        event.stopPropagation()
-        maybeClearHighlightsOnHoverEnd()
-      },
-      [maybeClearHighlightsOnHoverEnd],
-    )
+  const onControlMouseMove = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation()
+      maybeClearHighlightsOnHoverEnd()
+    },
+    [maybeClearHighlightsOnHoverEnd],
+  )
 
-    const onControlDoubleClick = React.useCallback(() => {
-      let propsToSet: Array<{ path: PropertyPath; value: any }> = []
-      if (element != null) {
-        const isFlexParent = element.specialSizeMeasurements.parentLayoutSystem === 'flex'
-        if (props.frame.width === 0 || element.specialSizeMeasurements.display === 'inline') {
-          if (
-            isFlexParent &&
-            (element.specialSizeMeasurements.parentFlexDirection === 'row' ||
-              element.specialSizeMeasurements.parentFlexDirection === 'row-reverse')
-          ) {
-            propsToSet.push({
-              path: createLayoutPropertyPath('flexBasis'),
-              value: 100,
-            })
-          } else {
-            propsToSet.push({
-              path: createLayoutPropertyPath('Width'),
-              value: 100,
-            })
-          }
-        }
-        if (props.frame.height === 0 || element.specialSizeMeasurements.display === 'inline') {
-          if (
-            isFlexParent &&
-            (element.specialSizeMeasurements.parentFlexDirection === 'column' ||
-              element.specialSizeMeasurements.parentFlexDirection === 'column-reverse')
-          ) {
-            propsToSet.push({
-              path: createLayoutPropertyPath('flexBasis'),
-              value: 100,
-            })
-          } else {
-            propsToSet.push({
-              path: createLayoutPropertyPath('Height'),
-              value: 100,
-            })
-          }
-        }
-        if (!isFlexParent && element.specialSizeMeasurements.display === 'inline') {
+  const onControlDoubleClick = React.useCallback(() => {
+    let propsToSet: Array<{ path: PropertyPath; value: any }> = []
+    if (element != null) {
+      const isFlexParent = element.specialSizeMeasurements.parentLayoutSystem === 'flex'
+      if (props.frame.width === 0 || element.specialSizeMeasurements.display === 'inline') {
+        if (
+          isFlexParent &&
+          (element.specialSizeMeasurements.parentFlexDirection === 'row' ||
+            element.specialSizeMeasurements.parentFlexDirection === 'row-reverse')
+        ) {
           propsToSet.push({
-            path: createLayoutPropertyPath('position'),
-            value: 'absolute',
+            path: createLayoutPropertyPath('flexBasis'),
+            value: 100,
+          })
+        } else {
+          propsToSet.push({
+            path: createLayoutPropertyPath('Width'),
+            value: 100,
           })
         }
-        const setPropActions = propsToSet.map((prop) => {
-          return setProp_UNSAFE(
-            element.elementPath,
-            prop.path,
-            jsxAttributeValue(prop.value, emptyComments),
-          )
-        })
-        dispatch(setPropActions, 'everyone')
       }
-    }, [dispatch, element, props.frame])
+      if (props.frame.height === 0 || element.specialSizeMeasurements.display === 'inline') {
+        if (
+          isFlexParent &&
+          (element.specialSizeMeasurements.parentFlexDirection === 'column' ||
+            element.specialSizeMeasurements.parentFlexDirection === 'column-reverse')
+        ) {
+          propsToSet.push({
+            path: createLayoutPropertyPath('flexBasis'),
+            value: 100,
+          })
+        } else {
+          propsToSet.push({
+            path: createLayoutPropertyPath('Height'),
+            value: 100,
+          })
+        }
+      }
+      if (!isFlexParent && element.specialSizeMeasurements.display === 'inline') {
+        propsToSet.push({
+          path: createLayoutPropertyPath('position'),
+          value: 'absolute',
+        })
+      }
+      const setPropActions = propsToSet.map((prop) => {
+        return setProp_UNSAFE(
+          element.elementPath,
+          prop.path,
+          jsxAttributeValue(prop.value, emptyComments),
+        )
+      })
+      dispatch(setPropActions, 'everyone')
+    }
+  }, [dispatch, element, props.frame])
 
-    return (
-      <div
-        onMouseMove={onControlMouseMove}
-        onMouseDown={onControlStopPropagation}
-        onDoubleClick={onControlDoubleClick}
-        className='role-resize-no-size'
-        style={{
-          position: 'absolute',
-          left: props.frame.x + props.canvasOffset.x - ZeroControlSize / 2,
-          top: props.frame.y + props.canvasOffset.y - ZeroControlSize / 2,
-          width: props.frame.width + ZeroControlSize,
-          height: props.frame.height + ZeroControlSize,
-        }}
-      />
-    )
-  },
-)
+  return (
+    <div
+      onMouseMove={onControlMouseMove}
+      onMouseDown={onControlStopPropagation}
+      onDoubleClick={onControlDoubleClick}
+      className='role-resize-no-size'
+      style={{
+        position: 'absolute',
+        left: props.frame.x + props.canvasOffset.x - ZeroControlSize / 2,
+        top: props.frame.y + props.canvasOffset.y - ZeroControlSize / 2,
+        width: props.frame.width + ZeroControlSize,
+        height: props.frame.height + ZeroControlSize,
+      }}
+    />
+  )
+})

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -28,7 +28,6 @@ import {
   LargerIcons,
   ResizableFlexColumn,
 } from '../../uuiui'
-import { betterReactMemo } from '../../uuiui-deps'
 import { TopMenu } from '../editor/top-menu'
 import { ConsoleAndErrorsPane } from '../code-editor/console-and-errors-pane'
 import { FloatingInsertMenu } from './ui/floating-insert-menu'
@@ -47,7 +46,7 @@ const TopMenuHeight = 35
 // height so that the bottom border on the top menu aligns
 // with the top border of the first inspector section
 
-const NothingOpenCard = betterReactMemo('NothingOpen', () => {
+const NothingOpenCard = React.memo(() => {
   const colorTheme = useColorTheme()
   const dispatch = useEditorState((store) => store.dispatch, 'NothingOpenCard dispatch')
   const handleOpenCanvasClick = React.useCallback(() => {
@@ -117,7 +116,7 @@ const NothingOpenCard = betterReactMemo('NothingOpen', () => {
   )
 })
 
-export const DesignPanelRoot = betterReactMemo('DesignPanelRoot', () => {
+export const DesignPanelRoot = React.memo(() => {
   const dispatch = useEditorState((store) => store.dispatch, 'DesignPanelRoot dispatch')
   const interfaceDesigner = useEditorState(
     (store) => store.editor.interfaceDesigner,
@@ -357,60 +356,57 @@ DesignPanelRoot.displayName = 'DesignPanelRoot'
 interface ResizableInspectorPaneProps {
   isInsertMenuSelected: boolean
 }
-const ResizableInspectorPane = betterReactMemo<ResizableInspectorPaneProps>(
-  'ResizableInspectorPane',
-  (props) => {
-    const colorTheme = useColorTheme()
-    const [, updateInspectorWidth] = useAtom(InspectorWidthAtom)
+const ResizableInspectorPane = React.memo<ResizableInspectorPaneProps>((props) => {
+  const colorTheme = useColorTheme()
+  const [, updateInspectorWidth] = useAtom(InspectorWidthAtom)
 
-    const resizableRef = React.useRef<Resizable>(null)
-    const [width, setWidth] = React.useState<number>(UtopiaTheme.layout.inspectorSmallWidth)
+  const resizableRef = React.useRef<Resizable>(null)
+  const [width, setWidth] = React.useState<number>(UtopiaTheme.layout.inspectorSmallWidth)
 
-    const onResize = React.useCallback(() => {
-      const newWidth = resizableRef.current?.size.width
-      if (newWidth != null) {
-        // we have to use the instance ref to directly access the get size() getter, because re-resize's API only wants to tell us deltas, but we need the snapped width
-        setWidth(newWidth)
-        updateInspectorWidth(newWidth > UtopiaTheme.layout.inspectorSmallWidth ? 'wide' : 'regular')
-      }
-    }, [updateInspectorWidth])
+  const onResize = React.useCallback(() => {
+    const newWidth = resizableRef.current?.size.width
+    if (newWidth != null) {
+      // we have to use the instance ref to directly access the get size() getter, because re-resize's API only wants to tell us deltas, but we need the snapped width
+      setWidth(newWidth)
+      updateInspectorWidth(newWidth > UtopiaTheme.layout.inspectorSmallWidth ? 'wide' : 'regular')
+    }
+  }, [updateInspectorWidth])
 
-    return (
-      <Resizable
-        ref={resizableRef}
-        defaultSize={{
-          width: UtopiaTheme.layout.inspectorSmallWidth,
+  return (
+    <Resizable
+      ref={resizableRef}
+      defaultSize={{
+        width: UtopiaTheme.layout.inspectorSmallWidth,
+        height: '100%',
+      }}
+      size={{
+        width: width,
+        height: '100%',
+      }}
+      style={{ transition: 'width 100ms ease-in-out' }}
+      snap={{
+        x: [UtopiaTheme.layout.inspectorSmallWidth, UtopiaTheme.layout.inspectorLargeWidth],
+      }}
+      onResizeStart={onResize}
+      onResize={onResize}
+      onResizeStop={onResize}
+    >
+      <SimpleFlexRow
+        className='Inspector-entrypoint'
+        style={{
+          alignItems: 'stretch',
+          flexDirection: 'column',
+          width: '100%',
           height: '100%',
+          overflowY: 'scroll',
+          backgroundColor: colorTheme.inspectorBackground.value,
+          flexGrow: 0,
+          flexShrink: 0,
+          paddingBottom: 100,
         }}
-        size={{
-          width: width,
-          height: '100%',
-        }}
-        style={{ transition: 'width 100ms ease-in-out' }}
-        snap={{
-          x: [UtopiaTheme.layout.inspectorSmallWidth, UtopiaTheme.layout.inspectorLargeWidth],
-        }}
-        onResizeStart={onResize}
-        onResize={onResize}
-        onResizeStop={onResize}
       >
-        <SimpleFlexRow
-          className='Inspector-entrypoint'
-          style={{
-            alignItems: 'stretch',
-            flexDirection: 'column',
-            width: '100%',
-            height: '100%',
-            overflowY: 'scroll',
-            backgroundColor: colorTheme.inspectorBackground.value,
-            flexGrow: 0,
-            flexShrink: 0,
-            paddingBottom: 100,
-          }}
-        >
-          {props.isInsertMenuSelected ? <InsertMenuPane /> : <InspectorEntryPoint />}
-        </SimpleFlexRow>
-      </Resizable>
-    )
-  },
-)
+        {props.isInsertMenuSelected ? <InsertMenuPane /> : <InspectorEntryPoint />}
+      </SimpleFlexRow>
+    </Resizable>
+  )
+})

--- a/editor/src/components/canvas/mode-select-buttons.tsx
+++ b/editor/src/components/canvas/mode-select-buttons.tsx
@@ -3,7 +3,6 @@
 import { jsx } from '@emotion/react'
 import React from 'react'
 import { useColorTheme, FlexRow, UtopiaStyles } from '../../uuiui'
-import { betterReactMemo } from '../../uuiui-deps'
 import { switchEditorMode } from '../editor/actions/action-creators'
 import { EditorModes, isLiveMode, isSelectLiteMode, isSelectMode } from '../editor/editor-modes'
 import { useEditorState } from '../editor/store/store-hook'
@@ -14,7 +13,7 @@ interface ModeSelectButtonProps {
   onMouseDown: () => void
 }
 
-const ModeSelectButton = betterReactMemo('ModeSelectButton', (props: ModeSelectButtonProps) => {
+const ModeSelectButton = React.memo((props: ModeSelectButtonProps) => {
   const colorTheme = useColorTheme()
   return props.selected ? (
     <div
@@ -52,7 +51,7 @@ const ModeSelectButton = betterReactMemo('ModeSelectButton', (props: ModeSelectB
   )
 })
 
-export const ModeSelectButtons = betterReactMemo('ModeSelectButtons', () => {
+export const ModeSelectButtons = React.memo(() => {
   const colorTheme = useColorTheme()
   const currentMode = useEditorState((store) => store.editor.mode, 'ModeSelectButtons editor.mode')
   const dispatch = useEditorState((store) => store.dispatch, 'ModeSelectButtons dispatch')

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
@@ -3,7 +3,6 @@ import fastDeepEquals from 'fast-deep-equal'
 import { useContextSelector } from 'use-context-selector'
 import { Scene, SceneProps } from 'utopia-api'
 import { useColorTheme, UtopiaStyles } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { RerenderUtopiaCtxAtom } from './ui-jsx-canvas-contexts'
 import { DomWalkerInvalidateScenesCtxAtom, UiJsxCanvasCtxAtom } from '../ui-jsx-canvas'
 import { UTOPIA_SCENE_ID_KEY } from '../../../core/model/utopia-constants'
@@ -11,8 +10,7 @@ import { usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
 
 type ExtendedSceneProps = SceneProps & { [UTOPIA_SCENE_ID_KEY]: string }
 
-export const SceneComponent = betterReactMemo(
-  'Scene',
+export const SceneComponent = React.memo(
   (props: React.PropsWithChildren<ExtendedSceneProps>) => {
     const colorTheme = useColorTheme()
     const canvasIsLive = usePubSubAtomReadOnly(RerenderUtopiaCtxAtom).canvasIsLive

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -70,7 +70,6 @@ import {
 import { runBlockUpdatingScope } from './ui-jsx-canvas-renderer/ui-jsx-canvas-scope-utils'
 import { CanvasContainerID } from './canvas-types'
 import {
-  betterReactMemo,
   useKeepReferenceEqualityIfPossible,
   useKeepShallowReferenceEquality,
 } from '../../utils/react-performance'
@@ -290,8 +289,7 @@ function clearSpyCollectorInvalidPaths(
   })
 }
 
-export const UiJsxCanvas = betterReactMemo(
-  'UiJsxCanvas',
+export const UiJsxCanvas = React.memo(
   React.forwardRef<HTMLDivElement, UiJsxCanvasPropsWithErrorCallback>((props, ref) => {
     const {
       offset,

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -9,7 +9,7 @@ import WindowedSelect, {
   ValueType,
 } from 'react-windowed-select'
 
-import { betterReactMemo, getControlStyles } from '../../../uuiui-deps'
+import { getControlStyles } from '../../../uuiui-deps'
 import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 
 import {
@@ -316,8 +316,7 @@ interface CheckboxRowProps {
   onChange: (value: boolean) => void
 }
 
-const CheckboxRow = betterReactMemo<React.PropsWithChildren<CheckboxRowProps>>(
-  'CheckboxRow',
+const CheckboxRow = React.memo<React.PropsWithChildren<CheckboxRowProps>>(
   ({ id, checked, onChange, children }) => {
     const colorTheme = useColorTheme()
 
@@ -364,7 +363,7 @@ function getMenuTitle(insertMenuMode: 'closed' | 'insert' | 'convert' | 'wrap'):
   }
 }
 
-export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
+export var FloatingMenu = React.memo(() => {
   const colorTheme = useColorTheme()
 
   // This is a ref so that changing the highlighted element does not trigger a re-render loop
@@ -657,34 +656,31 @@ export var FloatingMenu = betterReactMemo('FloatingMenu', () => {
 
 interface FloatingInsertMenuProps {}
 
-export const FloatingInsertMenu = betterReactMemo(
-  'FloatingInsertMenu',
-  (props: FloatingInsertMenuProps) => {
-    const dispatch = useEditorState((store) => store.dispatch, 'FloatingInsertMenu dispatch')
-    const isVisible = useEditorState(
-      (store) => store.editor.floatingInsertMenu.insertMenuMode !== 'closed',
-      'FloatingInsertMenu insertMenuOpen',
-    )
-    const onClickOutside = React.useCallback(() => {
-      dispatch([closeFloatingInsertMenu()])
-    }, [dispatch])
+export const FloatingInsertMenu = React.memo((props: FloatingInsertMenuProps) => {
+  const dispatch = useEditorState((store) => store.dispatch, 'FloatingInsertMenu dispatch')
+  const isVisible = useEditorState(
+    (store) => store.editor.floatingInsertMenu.insertMenuMode !== 'closed',
+    'FloatingInsertMenu insertMenuOpen',
+  )
+  const onClickOutside = React.useCallback(() => {
+    dispatch([closeFloatingInsertMenu()])
+  }, [dispatch])
 
-    return isVisible ? (
-      <OnClickOutsideHOC onClickOutside={onClickOutside}>
-        <div
-          style={{
-            pointerEvents: 'initial',
-            position: 'absolute',
-            left: '50%',
-            top: '50%',
-            transform: 'translateX(-50%) translateY(-50%)',
-            zIndex: 30,
-            // ^ above navigator
-          }}
-        >
-          <FloatingMenu />
-        </div>
-      </OnClickOutsideHOC>
-    ) : null
-  },
-)
+  return isVisible ? (
+    <OnClickOutsideHOC onClickOutside={onClickOutside}>
+      <div
+        style={{
+          pointerEvents: 'initial',
+          position: 'absolute',
+          left: '50%',
+          top: '50%',
+          transform: 'translateX(-50%) translateY(-50%)',
+          zIndex: 30,
+          // ^ above navigator
+        }}
+      >
+        <FloatingMenu />
+      </div>
+    </OnClickOutsideHOC>
+  ) : null
+})

--- a/editor/src/components/code-editor/code-editor-container.tsx
+++ b/editor/src/components/code-editor/code-editor-container.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { betterReactMemo } from '../../uuiui-deps'
 import { useEditorState } from '../editor/store/store-hook'
 import { MONACO_EDITOR_IFRAME_BASE_URL } from '../../common/env-vars'
 import { createIframeUrl } from '../../core/shared/utils'
@@ -7,47 +6,41 @@ import { getUnderlyingVSCodeBridgeID } from '../editor/store/editor-state'
 import { VSCodeLoadingScreen } from './vscode-editor-loading-screen'
 import { getEditorBranchNameFromURL, setBranchNameFromURL } from '../../utils/branches'
 
-const VSCodeIframeContainer = betterReactMemo(
-  'VSCodeIframeContainer',
-  (props: { projectID: string }) => {
-    const projectID = props.projectID
-    const baseIframeSrc = createIframeUrl(
-      MONACO_EDITOR_IFRAME_BASE_URL,
-      'vscode-editor-outer-iframe',
-    )
-    const url = new URL(baseIframeSrc)
-    url.searchParams.append('project_id', projectID)
+const VSCodeIframeContainer = React.memo((props: { projectID: string }) => {
+  const projectID = props.projectID
+  const baseIframeSrc = createIframeUrl(MONACO_EDITOR_IFRAME_BASE_URL, 'vscode-editor-outer-iframe')
+  const url = new URL(baseIframeSrc)
+  url.searchParams.append('project_id', projectID)
 
-    setBranchNameFromURL(url.searchParams)
+  setBranchNameFromURL(url.searchParams)
 
-    return (
-      <div
-        style={{
-          flex: 1,
-        }}
-      >
-        <VSCodeLoadingScreen />
-        {/* for Karma tests, we skip creating this iframe to avoid hitting a 404 */}
-        {window.KarmaTestEnvironment ? null : (
-          <iframe
-            key={'vscode-editor'}
-            id={'vscode-editor'}
-            src={url.toString()}
-            allow='autoplay'
-            style={{
-              width: '100%',
-              height: '100%',
-              backgroundColor: 'transparent',
-              borderWidth: 0,
-            }}
-          />
-        )}
-      </div>
-    )
-  },
-)
+  return (
+    <div
+      style={{
+        flex: 1,
+      }}
+    >
+      <VSCodeLoadingScreen />
+      {/* for Karma tests, we skip creating this iframe to avoid hitting a 404 */}
+      {window.KarmaTestEnvironment ? null : (
+        <iframe
+          key={'vscode-editor'}
+          id={'vscode-editor'}
+          src={url.toString()}
+          allow='autoplay'
+          style={{
+            width: '100%',
+            height: '100%',
+            backgroundColor: 'transparent',
+            borderWidth: 0,
+          }}
+        />
+      )}
+    </div>
+  )
+})
 
-export const CodeEditorWrapper = betterReactMemo('CodeEditorWrapper', () => {
+export const CodeEditorWrapper = React.memo(() => {
   const selectedProps = useEditorState((store) => {
     return {
       vscodeBridgeId: getUnderlyingVSCodeBridgeID(store.editor.vscodeBridgeId),

--- a/editor/src/components/code-editor/code-problems.tsx
+++ b/editor/src/components/code-editor/code-problems.tsx
@@ -17,7 +17,6 @@ import { VariableSizeList as List } from 'react-window'
 import { useColorTheme, UtopiaTheme } from '../../uuiui/styles/theme'
 import { FlexRow } from '../../uuiui/widgets/layout/flex-row'
 import { NO_OP } from '../../core/shared/utils'
-import { betterReactMemo } from '../../utils/react-performance'
 import { TabComponent } from '../../uuiui/tab'
 import { Icons } from '../../uuiui/icons'
 import { SimpleFlexColumn } from '../../uuiui/widgets/layout/flex-column'
@@ -150,8 +149,7 @@ const ProblemTabBarHeight = 32
 
 type OpenCodeEditorTab = 'problems' | 'console'
 
-export const CodeEditorTabPane = betterReactMemo<CodeEditorTabPaneProps>(
-  'CodeEditorTabPane',
+export const CodeEditorTabPane = React.memo<CodeEditorTabPaneProps>(
   ({ errorMessages, onOpenFile, canvasConsoleLogs }) => {
     const colorTheme = useColorTheme()
     const defaultHeightWhenOpen =
@@ -381,20 +379,17 @@ interface ProblemsErrorRowProps {
 
 const ProblemsHeaderRowHeight = 25
 
-const ProblemsHeaderRow = betterReactMemo(
-  'Problems Header Row',
-  (props: ProblemsHeaderRowProps) => {
-    const { fileName } = props
-    return (
-      <FlexRow style={{ height: ProblemsHeaderRowHeight, padding: '4px 8px' }}>
-        <Icons.React />
-        <span style={{ marginLeft: 4 }}> {fileName}</span>
-      </FlexRow>
-    )
-  },
-)
+const ProblemsHeaderRow = React.memo((props: ProblemsHeaderRowProps) => {
+  const { fileName } = props
+  return (
+    <FlexRow style={{ height: ProblemsHeaderRowHeight, padding: '4px 8px' }}>
+      <Icons.React />
+      <span style={{ marginLeft: 4 }}> {fileName}</span>
+    </FlexRow>
+  )
+})
 
-const ProblemsErrorRow = betterReactMemo('Problems Error Row', (props: ProblemsErrorRowProps) => {
+const ProblemsErrorRow = React.memo((props: ProblemsErrorRowProps) => {
   const { errorMessage, onOpenFile } = props
   return <ErrorMessageRow errorMessage={errorMessage} onOpenFile={onOpenFile} />
 })
@@ -410,7 +405,7 @@ function getRowHeight(index: number, data: Array<ProblemRowData>): number {
   }
 }
 
-const ProblemsTab = betterReactMemo('Problems Tab', (props: ProblemsTabProps) => {
+const ProblemsTab = React.memo((props: ProblemsTabProps) => {
   const { errorMessages, height, onOpenFile } = props
 
   const rowData: Array<ProblemRowData> = React.useMemo(() => {

--- a/editor/src/components/code-editor/console-and-errors-pane.tsx
+++ b/editor/src/components/code-editor/console-and-errors-pane.tsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import { useReadOnlyConsoleLogs } from '../../core/shared/runtime-report-logs'
-import { betterReactMemo } from '../../uuiui-deps'
 import { setFocus } from '../common/actions'
 import { openCodeEditorFile } from '../editor/actions/action-creators'
 import { getAllCodeEditorErrors } from '../editor/store/editor-state'
 import { useEditorState } from '../editor/store/store-hook'
 import { CodeEditorTabPane } from './code-problems'
 
-export const ConsoleAndErrorsPane = betterReactMemo('ConsoleAndErrorsPane', () => {
+export const ConsoleAndErrorsPane = React.memo(() => {
   const dispatch = useEditorState((store) => store.dispatch, 'ConsoleAndErrorsPane dispatch')
 
   const canvasConsoleLogs = useReadOnlyConsoleLogs()

--- a/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
+++ b/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Global, css } from '@emotion/react'
 import { useEditorState } from '../editor/store/store-hook'
-import { betterReactMemo } from '../../uuiui-deps'
 
 const SampleCode = [
   {
@@ -83,199 +82,196 @@ const JSIcon = () => (
   </svg>
 )
 
-export const VSCodeLoadingScreen = betterReactMemo(
-  'VSCodeLoadingScreen',
-  (): React.ReactElement | null => {
-    const vscodeLoadingScreenVisible = useEditorState(
-      (store) => store.editor.vscodeLoadingScreenVisible,
-      'VSCodeIframeContainer',
-    )
-    if (!vscodeLoadingScreenVisible) {
-      return null
-    }
-    return (
+export const VSCodeLoadingScreen = React.memo((): React.ReactElement | null => {
+  const vscodeLoadingScreenVisible = useEditorState(
+    (store) => store.editor.vscodeLoadingScreenVisible,
+    'VSCodeIframeContainer',
+  )
+  if (!vscodeLoadingScreenVisible) {
+    return null
+  }
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        fontSize: 13,
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: '-apple-system, system-ui, sans-serif',
+      }}
+    >
+      <Global
+        styles={css`
+          @keyframes placeholderShimmer {
+            0% {
+              background-position: -468px 0;
+            }
+            100% {
+              background-position: 468px 0;
+            }
+          }
+
+          .shimmer {
+            color: transparent;
+            animation-name: placeholderShimmer;
+            animation-duration: 1.25s;
+            animation-fill-mode: forwards;
+            animation-iteration-count: infinite;
+            animation-timing-function: linear;
+            background: #f6f6f6;
+            background: linear-gradient(to right, #f6f6f6 8%, #f0f0f0 18%, #f6f6f6 33%);
+            background-size: 800px 104px;
+            position: relative;
+          }
+        `}
+      />
+      {/* tab row */}
       <div
         style={{
-          width: '100%',
-          height: '100%',
-          fontSize: 13,
           display: 'flex',
-          flexDirection: 'column',
-          fontFamily: '-apple-system, system-ui, sans-serif',
+          alignItems: 'flex-end',
+          height: 35,
+          background: '#f3f3f3',
         }}
       >
-        <Global
-          styles={css`
-            @keyframes placeholderShimmer {
-              0% {
-                background-position: -468px 0;
-              }
-              100% {
-                background-position: 468px 0;
-              }
-            }
-
-            .shimmer {
-              color: transparent;
-              animation-name: placeholderShimmer;
-              animation-duration: 1.25s;
-              animation-fill-mode: forwards;
-              animation-iteration-count: infinite;
-              animation-timing-function: linear;
-              background: #f6f6f6;
-              background: linear-gradient(to right, #f6f6f6 8%, #f0f0f0 18%, #f6f6f6 33%);
-              background-size: 800px 104px;
-              position: relative;
-            }
-          `}
-        />
-        {/* tab row */}
+        {/* single tab */}
         <div
           style={{
-            display: 'flex',
-            alignItems: 'flex-end',
+            background: '#FAFAFA',
+            color: 'rgb(51,51,51)',
+            borderRight: '1px solid rgb(243, 243, 243)',
             height: 35,
-            background: '#f3f3f3',
-          }}
-        >
-          {/* single tab */}
-          <div
-            style={{
-              background: '#FAFAFA',
-              color: 'rgb(51,51,51)',
-              borderRight: '1px solid rgb(243, 243, 243)',
-              height: 35,
-              display: 'flex',
-              alignItems: 'center',
-              paddingLeft: 12,
-              paddingRight: 12,
-              width: 140,
-            }}
-          >
-            <div style={{ color: '#b7b73b', display: 'flex' }}>
-              <JSIcon />
-            </div>
-            <span style={{}}>storyboard.js</span>
-          </div>
-        </div>
-        {/* breadcrumbs */}
-        <div
-          className='monaco-breadcrumbs'
-          style={{
-            paddingLeft: 15,
-            height: 22,
             display: 'flex',
             alignItems: 'center',
-            color: '#888',
+            paddingLeft: 12,
+            paddingRight: 12,
+            width: 140,
+          }}
+        >
+          <div style={{ color: '#b7b73b', display: 'flex' }}>
+            <JSIcon />
+          </div>
+          <span style={{}}>storyboard.js</span>
+        </div>
+      </div>
+      {/* breadcrumbs */}
+      <div
+        className='monaco-breadcrumbs'
+        style={{
+          paddingLeft: 15,
+          height: 22,
+          display: 'flex',
+          alignItems: 'center',
+          color: '#888',
+        }}
+      >
+        <div
+          className='folder monaco-breadcrumb-item'
+          role='listitem'
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
           }}
         >
           <div
-            className='folder monaco-breadcrumb-item'
-            role='listitem'
+            className='monaco-icon-label'
             style={{
+              height: 22,
+              lineHeight: '22px',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <div className='monaco-icon-label-container' title='~/utopia'>
+              <span className='monaco-icon-name-container'>
+                <a style={{ color: 'rgba(97, 97, 97, 0.8)' }} className='label-name'>
+                  utopia
+                </a>
+              </span>
+              <span className='monaco-icon-description-container'></span>
+            </div>
+          </div>
+          <div style={{ height: 16 }}>
+            <Chevron />
+          </div>
+        </div>
+        <div
+          className='file monaco-breadcrumb-item'
+          role='listitem'
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            className='monaco-icon-label file-icon storyboard.js-name-file-icon js-ext-file-icon ext-file-icon javascript-lang-file-icon'
+            style={{
+              paddingRight: 6,
+              height: 22,
+              lineHeight: '22px',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
             }}
           >
-            <div
-              className='monaco-icon-label'
-              style={{
-                height: 22,
-                lineHeight: '22px',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <div className='monaco-icon-label-container' title='~/utopia'>
-                <span className='monaco-icon-name-container'>
-                  <a style={{ color: 'rgba(97, 97, 97, 0.8)' }} className='label-name'>
-                    utopia
-                  </a>
-                </span>
-                <span className='monaco-icon-description-container'></span>
-              </div>
+            <div style={{ color: '#b7b73b', display: 'flex', paddingRight: 4 }}>
+              <JSIcon />
+            </div>
+            <div className='monaco-icon-label-container' title='~/utopia/storyboard.js'>
+              <span className='monaco-icon-name-container'>
+                <a style={{ color: 'rgba(97, 97, 97, 0.8)' }} className='label-name'>
+                  storyboard.js
+                </a>
+              </span>
+              <span className='monaco-icon-description-container'></span>
             </div>
             <div style={{ height: 16 }}>
               <Chevron />
             </div>
           </div>
-          <div
-            className='file monaco-breadcrumb-item'
-            role='listitem'
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <div
-              className='monaco-icon-label file-icon storyboard.js-name-file-icon js-ext-file-icon ext-file-icon javascript-lang-file-icon'
-              style={{
-                paddingRight: 6,
-                height: 22,
-                lineHeight: '22px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <div style={{ color: '#b7b73b', display: 'flex', paddingRight: 4 }}>
-                <JSIcon />
-              </div>
-              <div className='monaco-icon-label-container' title='~/utopia/storyboard.js'>
-                <span className='monaco-icon-name-container'>
-                  <a style={{ color: 'rgba(97, 97, 97, 0.8)' }} className='label-name'>
-                    storyboard.js
-                  </a>
-                </span>
-                <span className='monaco-icon-description-container'></span>
-              </div>
-              <div style={{ height: 16 }}>
-                <Chevron />
-              </div>
-            </div>
-          </div>
-        </div>
-        {/* code */}
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: '66px 500px',
-            gridTemplateRows: 'repeat(12, 18px)',
-            alignItems: 'center',
-            fontSize: 12,
-            color: '#6d705b',
-            fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-          }}
-        >
-          {SampleCode.map((line, rowNumber) => (
-            <React.Fragment key={rowNumber}>
-              <span
-                style={{
-                  textAlign: 'right',
-                  paddingRight: 27,
-                }}
-              >
-                {rowNumber}
-              </span>
-              <div>
-                <span
-                  className='shimmer'
-                  style={{
-                    marginLeft: line.indent * 14,
-                    wordWrap: 'normal',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                  }}
-                >
-                  {line.code}
-                </span>
-              </div>
-            </React.Fragment>
-          ))}
         </div>
       </div>
-    )
-  },
-)
+      {/* code */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '66px 500px',
+          gridTemplateRows: 'repeat(12, 18px)',
+          alignItems: 'center',
+          fontSize: 12,
+          color: '#6d705b',
+          fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+        }}
+      >
+        {SampleCode.map((line, rowNumber) => (
+          <React.Fragment key={rowNumber}>
+            <span
+              style={{
+                textAlign: 'right',
+                paddingRight: 27,
+              }}
+            >
+              {rowNumber}
+            </span>
+            <div>
+              <span
+                className='shimmer'
+                style={{
+                  marginLeft: line.indent * 14,
+                  wordWrap: 'normal',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                }}
+              >
+                {line.code}
+              </span>
+            </div>
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  )
+})

--- a/editor/src/components/common/ellipsis-spinner.tsx
+++ b/editor/src/components/common/ellipsis-spinner.tsx
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx, css, keyframes } from '@emotion/react'
 import React from 'react'
-import { betterReactMemo } from '../../uuiui-deps'
 
 const ellipsis1Anim = keyframes`{
   0% {
@@ -48,7 +47,7 @@ const Ellipsis = (props: any) => (
   />
 )
 
-export const EllipsisSpinner = betterReactMemo('Ellipsis Spinner', () => {
+export const EllipsisSpinner = React.memo(() => {
   return (
     <div
       id='spinner'

--- a/editor/src/components/documentation/getting-started.tsx
+++ b/editor/src/components/documentation/getting-started.tsx
@@ -25,7 +25,6 @@ import { stripNulls } from '../../core/shared/array-utils'
 import { projectURLForProject } from '../../core/shared/utils'
 import { EllipsisSpinner } from '../common/ellipsis-spinner'
 import { FlexRow, FlexColumn } from '../../uuiui'
-import { betterReactMemo } from '../../uuiui-deps'
 
 const codeString = `
 App.propertyControls = {
@@ -51,7 +50,7 @@ App.propertyControls = {
 
 `
 
-const ProjectCard = betterReactMemo('Project Card', (props: ProjectListing) => {
+const ProjectCard = React.memo((props: ProjectListing) => {
   const projectURL = projectURLForProject(props.id, props.title)
   const onClick = React.useCallback(() => window.open(projectURL, '_self'), [projectURL])
   return (
@@ -151,8 +150,7 @@ const FeaturedProjectIDs: ReadonlyArray<string> = [
   'f4fcb83b-react-spring-cards',
 ]
 
-const LoadedProjectsRow = betterReactMemo(
-  'Loaded Projects',
+const LoadedProjectsRow = React.memo(
   ({ projects }: { projects: ReadonlyArray<ProjectListing> }) => {
     return (
       <FlexRow
@@ -179,7 +177,7 @@ const LoadedProjectsRow = betterReactMemo(
   },
 )
 
-const FeaturedProjects = betterReactMemo('Featured Projects', () => {
+const FeaturedProjects = React.memo(() => {
   const [featuredProjectList, setFeaturedProjectList] = React.useState<ReadonlyArray<
     ProjectListing
   > | null>(null)
@@ -214,7 +212,7 @@ const FeaturedProjects = betterReactMemo('Featured Projects', () => {
   )
 })
 
-export const GettingStarted = betterReactMemo('Getting Started', () => {
+export const GettingStarted = React.memo(() => {
   return (
     <FixedWidth>
       <H1>Welcome to the Developer Preview</H1>

--- a/editor/src/components/editor/component-button.tsx
+++ b/editor/src/components/editor/component-button.tsx
@@ -13,14 +13,13 @@ import {
   UtopiaStyles,
   UtopiaTheme,
 } from '../../uuiui'
-import { betterReactMemo } from '../../uuiui-deps'
 import { RenderAsRow } from '../canvas/controls/render-as'
 import { useEditorState } from './store/store-hook'
 import * as EP from '../../core/shared/element-path'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { setFocusedElement } from './actions/action-creators'
 
-export const ComponentOrInstanceIndicator = betterReactMemo('ComponentOrInstanceIndicator', () => {
+export const ComponentOrInstanceIndicator = React.memo(() => {
   const { metadata, focusedElementPath, selectedViews } = useEditorState((store) => {
     return {
       metadata: store.editor.jsxMetadata,

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -47,7 +47,6 @@ import {
   Subdued,
   FlexColumn,
 } from '../../uuiui'
-import { betterReactMemo } from '../../uuiui-deps'
 import { createIframeUrl, projectURLForProject } from '../../core/shared/utils'
 import { setBranchNameFromURL } from '../../utils/branches'
 import { FatalIndexedDBErrorComponent } from './fatal-indexeddb-error-component'
@@ -86,256 +85,248 @@ function useDelayedValueHook(inputValue: boolean, delayMs: number): boolean {
   return returnValue
 }
 
-export const EditorComponentInner = betterReactMemo(
-  'EditorComponentInner',
-  (props: EditorProps) => {
-    const editorStoreRef = useRefEditorState((store) => store)
-    const colorTheme = useColorTheme()
-    const onWindowMouseDown = React.useCallback(
-      (event: MouseEvent) => {
-        const popupId = editorStoreRef.current.editor.openPopupId
-        if (popupId != null) {
-          const popupElement = document.getElementById(popupId)
-          const triggerElement = document.getElementById(`trigger-${popupId}`)
-          const clickOutsidePopup =
-            popupElement != null && !popupElement.contains(event.target as Node)
-          const clickOutsideTrigger =
-            triggerElement != null && !triggerElement.contains(event.target as Node)
-          if (
-            (clickOutsidePopup && triggerElement == null) ||
-            (clickOutsidePopup && clickOutsideTrigger)
-          ) {
-            editorStoreRef.current.dispatch([EditorActions.closePopup()], 'everyone')
-          }
-        }
-        const activeElement = document.activeElement
+export const EditorComponentInner = React.memo((props: EditorProps) => {
+  const editorStoreRef = useRefEditorState((store) => store)
+  const colorTheme = useColorTheme()
+  const onWindowMouseDown = React.useCallback(
+    (event: MouseEvent) => {
+      const popupId = editorStoreRef.current.editor.openPopupId
+      if (popupId != null) {
+        const popupElement = document.getElementById(popupId)
+        const triggerElement = document.getElementById(`trigger-${popupId}`)
+        const clickOutsidePopup =
+          popupElement != null && !popupElement.contains(event.target as Node)
+        const clickOutsideTrigger =
+          triggerElement != null && !triggerElement.contains(event.target as Node)
         if (
-          event.target !== activeElement &&
-          activeElement != null &&
-          activeElement.getAttribute('data-inspector-input') != null &&
-          (activeElement as any).blur != null
+          (clickOutsidePopup && triggerElement == null) ||
+          (clickOutsidePopup && clickOutsideTrigger)
         ) {
-          // OMG what a nightmare! This is the only way of keeping the Inspector fast and ensuring the blur handler for inputs
-          // is called before triggering a change that might change the selection
-          ;(activeElement as any).blur()
+          editorStoreRef.current.dispatch([EditorActions.closePopup()], 'everyone')
         }
-      },
-      [editorStoreRef],
-    )
-
-    const namesByKey = React.useMemo(() => {
-      return applyShortcutConfigurationToDefaults(editorStoreRef.current.userState.shortcutConfig)
-    }, [editorStoreRef])
-
-    const onWindowKeyDown = React.useCallback(
-      (event: KeyboardEvent) => {
-        handleKeyDown(
-          event,
-          editorStoreRef.current.editor,
-          editorStoreRef.current.derived,
-          namesByKey,
-          editorStoreRef.current.dispatch,
-        )
-      },
-      [editorStoreRef, namesByKey],
-    )
-
-    const onWindowKeyUp = React.useCallback(
-      (event) => {
-        handleKeyUp(
-          event,
-          editorStoreRef.current.editor,
-          namesByKey,
-          editorStoreRef.current.dispatch,
-        )
-      },
-      [editorStoreRef, namesByKey],
-    )
-
-    const preventDefault = React.useCallback((event: MouseEvent) => {
-      event.preventDefault()
-    }, [])
-
-    React.useEffect(() => {
-      window.addEventListener('mousedown', onWindowMouseDown, true)
-      window.addEventListener('keydown', onWindowKeyDown)
-      window.addEventListener('keyup', onWindowKeyUp)
-      window.addEventListener('contextmenu', preventDefault)
-      return function cleanup() {
-        window.removeEventListener('mousedown', onWindowMouseDown, true)
-        window.removeEventListener('keydown', onWindowKeyDown)
-        window.removeEventListener('keyup', onWindowKeyUp)
-        window.removeEventListener('contextmenu', preventDefault)
       }
-    }, [onWindowMouseDown, onWindowKeyDown, onWindowKeyUp, preventDefault])
-
-    const dispatch = useEditorState((store) => store.dispatch, 'EditorComponentInner dispatch')
-    const projectName = useEditorState(
-      (store) => store.editor.projectName,
-      'EditorComponentInner projectName',
-    )
-    const projectId = useEditorState((store) => store.editor.id, 'EditorComponentInner projectId')
-    const previewVisible = useEditorState(
-      (store) => store.editor.preview.visible,
-      'EditorComponentInner previewVisible',
-    )
-    const leftMenuExpanded = useEditorState(
-      (store) => store.editor.leftMenu.expanded,
-      'EditorComponentInner leftMenuExpanded',
-    )
-
-    const delayedLeftMenuExpanded = useDelayedValueHook(leftMenuExpanded, 200)
-
-    React.useEffect(() => {
-      document.title = projectName + ' - Utopia'
-    }, [projectName])
-
-    React.useEffect(() => {
-      if (projectId) {
-        pushProjectURLToBrowserHistory(projectId, projectName)
+      const activeElement = document.activeElement
+      if (
+        event.target !== activeElement &&
+        activeElement != null &&
+        activeElement.getAttribute('data-inspector-input') != null &&
+        (activeElement as any).blur != null
+      ) {
+        // OMG what a nightmare! This is the only way of keeping the Inspector fast and ensuring the blur handler for inputs
+        // is called before triggering a change that might change the selection
+        ;(activeElement as any).blur()
       }
-    }, [projectName, projectId])
+    },
+    [editorStoreRef],
+  )
 
-    const onClosePreview = React.useCallback(
-      () => dispatch([EditorActions.setPanelVisibility('preview', false)]),
-      [dispatch],
-    )
+  const namesByKey = React.useMemo(() => {
+    return applyShortcutConfigurationToDefaults(editorStoreRef.current.userState.shortcutConfig)
+  }, [editorStoreRef])
 
-    const startDragInsertion = React.useCallback(
-      (event: React.DragEvent<HTMLDivElement>) => {
-        const draggedTypes = event.nativeEvent?.dataTransfer?.types
-        const isDraggedFile =
-          draggedTypes != null && draggedTypes.length === 1 && draggedTypes[0] === 'Files'
-        if (isDraggedFile) {
-          const actions = [
-            EditorActions.setPanelVisibility('leftmenu', true),
-            EditorActions.setLeftMenuTab(LeftMenuTab.Contents),
-          ]
-          dispatch(actions, 'everyone')
-        }
-      },
-      [dispatch],
-    )
+  const onWindowKeyDown = React.useCallback(
+    (event: KeyboardEvent) => {
+      handleKeyDown(
+        event,
+        editorStoreRef.current.editor,
+        editorStoreRef.current.derived,
+        namesByKey,
+        editorStoreRef.current.dispatch,
+      )
+    },
+    [editorStoreRef, namesByKey],
+  )
 
-    const vscodeBridgeReady = useEditorState((store) => {
-      return store.editor.vscodeBridgeReady
-    }, 'EditorComponentInner vscodeBridgeReady')
+  const onWindowKeyUp = React.useCallback(
+    (event) => {
+      handleKeyUp(event, editorStoreRef.current.editor, namesByKey, editorStoreRef.current.dispatch)
+    },
+    [editorStoreRef, namesByKey],
+  )
 
-    return (
-      <SimpleFlexRow
-        className='editor-main-vertical-and-modals'
+  const preventDefault = React.useCallback((event: MouseEvent) => {
+    event.preventDefault()
+  }, [])
+
+  React.useEffect(() => {
+    window.addEventListener('mousedown', onWindowMouseDown, true)
+    window.addEventListener('keydown', onWindowKeyDown)
+    window.addEventListener('keyup', onWindowKeyUp)
+    window.addEventListener('contextmenu', preventDefault)
+    return function cleanup() {
+      window.removeEventListener('mousedown', onWindowMouseDown, true)
+      window.removeEventListener('keydown', onWindowKeyDown)
+      window.removeEventListener('keyup', onWindowKeyUp)
+      window.removeEventListener('contextmenu', preventDefault)
+    }
+  }, [onWindowMouseDown, onWindowKeyDown, onWindowKeyUp, preventDefault])
+
+  const dispatch = useEditorState((store) => store.dispatch, 'EditorComponentInner dispatch')
+  const projectName = useEditorState(
+    (store) => store.editor.projectName,
+    'EditorComponentInner projectName',
+  )
+  const projectId = useEditorState((store) => store.editor.id, 'EditorComponentInner projectId')
+  const previewVisible = useEditorState(
+    (store) => store.editor.preview.visible,
+    'EditorComponentInner previewVisible',
+  )
+  const leftMenuExpanded = useEditorState(
+    (store) => store.editor.leftMenu.expanded,
+    'EditorComponentInner leftMenuExpanded',
+  )
+
+  const delayedLeftMenuExpanded = useDelayedValueHook(leftMenuExpanded, 200)
+
+  React.useEffect(() => {
+    document.title = projectName + ' - Utopia'
+  }, [projectName])
+
+  React.useEffect(() => {
+    if (projectId) {
+      pushProjectURLToBrowserHistory(projectId, projectName)
+    }
+  }, [projectName, projectId])
+
+  const onClosePreview = React.useCallback(
+    () => dispatch([EditorActions.setPanelVisibility('preview', false)]),
+    [dispatch],
+  )
+
+  const startDragInsertion = React.useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      const draggedTypes = event.nativeEvent?.dataTransfer?.types
+      const isDraggedFile =
+        draggedTypes != null && draggedTypes.length === 1 && draggedTypes[0] === 'Files'
+      if (isDraggedFile) {
+        const actions = [
+          EditorActions.setPanelVisibility('leftmenu', true),
+          EditorActions.setLeftMenuTab(LeftMenuTab.Contents),
+        ]
+        dispatch(actions, 'everyone')
+      }
+    },
+    [dispatch],
+  )
+
+  const vscodeBridgeReady = useEditorState((store) => {
+    return store.editor.vscodeBridgeReady
+  }, 'EditorComponentInner vscodeBridgeReady')
+
+  return (
+    <SimpleFlexRow
+      className='editor-main-vertical-and-modals'
+      style={{
+        height: '100%',
+        width: '100%',
+        overscrollBehaviorX: 'contain',
+      }}
+      onDragEnter={startDragInsertion}
+    >
+      <SimpleFlexColumn
+        className='editor-main-vertical'
         style={{
           height: '100%',
           width: '100%',
-          overscrollBehaviorX: 'contain',
         }}
-        onDragEnter={startDragInsertion}
       >
-        <SimpleFlexColumn
-          className='editor-main-vertical'
+        {(isChrome as boolean) ? null : <BrowserInfoBar />}
+        <LoginStatusBar />
+
+        <SimpleFlexRow
+          className='editor-main-horizontal'
           style={{
-            height: '100%',
             width: '100%',
+            flexGrow: 1,
+            overflowY: 'hidden',
+            alignItems: 'stretch',
           }}
         >
-          {(isChrome as boolean) ? null : <BrowserInfoBar />}
-          <LoginStatusBar />
-
-          <SimpleFlexRow
-            className='editor-main-horizontal'
+          <SimpleFlexColumn
             style={{
-              width: '100%',
-              flexGrow: 1,
-              overflowY: 'hidden',
-              alignItems: 'stretch',
+              height: '100%',
+              width: 44,
+              backgroundColor: colorTheme.leftMenuBackground.value,
             }}
           >
-            <SimpleFlexColumn
-              style={{
-                height: '100%',
-                width: 44,
-                backgroundColor: colorTheme.leftMenuBackground.value,
-              }}
-            >
-              <Menubar />
-            </SimpleFlexColumn>
-            <div
-              className='LeftPaneShell'
-              style={{
-                height: '100%',
-                flexShrink: 0,
-                transition: 'all .1s ease-in-out',
-                width: leftMenuExpanded ? LeftPaneDefaultWidth : 0,
-                overflowX: 'scroll',
-                backgroundColor: colorTheme.leftPaneBackground.value,
-              }}
-            >
-              {delayedLeftMenuExpanded ? <LeftPaneComponent /> : null}
-            </div>
+            <Menubar />
+          </SimpleFlexColumn>
+          <div
+            className='LeftPaneShell'
+            style={{
+              height: '100%',
+              flexShrink: 0,
+              transition: 'all .1s ease-in-out',
+              width: leftMenuExpanded ? LeftPaneDefaultWidth : 0,
+              overflowX: 'scroll',
+              backgroundColor: colorTheme.leftPaneBackground.value,
+            }}
+          >
+            {delayedLeftMenuExpanded ? <LeftPaneComponent /> : null}
+          </div>
+          <SimpleFlexRow
+            className='editor-shell'
+            style={{
+              flexGrow: 1,
+              alignItems: 'stretch',
+              borderRight: `1px solid ${colorTheme.neutralBorder.value}`,
+              backgroundColor: colorTheme.neutralBackground.value,
+            }}
+          >
             <SimpleFlexRow
-              className='editor-shell'
+              className='openTabShell'
               style={{
                 flexGrow: 1,
                 alignItems: 'stretch',
-                borderRight: `1px solid ${colorTheme.neutralBorder.value}`,
-                backgroundColor: colorTheme.neutralBackground.value,
+                justifyContent: 'stretch',
+                overflowX: 'hidden',
               }}
             >
-              <SimpleFlexRow
-                className='openTabShell'
-                style={{
-                  flexGrow: 1,
-                  alignItems: 'stretch',
-                  justifyContent: 'stretch',
-                  overflowX: 'hidden',
+              <DesignPanelRoot />
+            </SimpleFlexRow>
+            {/* insert more columns here */}
+
+            {previewVisible ? (
+              <ResizableFlexColumn
+                style={{ borderLeft: `1px solid ${colorTheme.secondaryBorder.value}` }}
+                enable={{
+                  left: true,
+                  right: false,
+                }}
+                defaultSize={{
+                  width: 350,
+                  height: '100%',
                 }}
               >
-                <DesignPanelRoot />
-              </SimpleFlexRow>
-              {/* insert more columns here */}
-
-              {previewVisible ? (
-                <ResizableFlexColumn
-                  style={{ borderLeft: `1px solid ${colorTheme.secondaryBorder.value}` }}
-                  enable={{
-                    left: true,
-                    right: false,
-                  }}
-                  defaultSize={{
-                    width: 350,
-                    height: '100%',
+                <SimpleFlexRow
+                  id='PreviewTabRail'
+                  style={{
+                    height: UtopiaTheme.layout.rowHeight.smaller,
+                    borderBottom: `1px solid ${colorTheme.subduedBorder.value}`,
+                    alignItems: 'stretch',
                   }}
                 >
-                  <SimpleFlexRow
-                    id='PreviewTabRail'
-                    style={{
-                      height: UtopiaTheme.layout.rowHeight.smaller,
-                      borderBottom: `1px solid ${colorTheme.subduedBorder.value}`,
-                      alignItems: 'stretch',
-                    }}
-                  >
-                    <TabComponent
-                      label='Preview'
-                      selected
-                      icon={<LargerIcons.PreviewPane color='primary' />}
-                      onClose={onClosePreview}
-                    />
-                  </SimpleFlexRow>
-                  <PreviewColumn />
-                </ResizableFlexColumn>
-              ) : null}
-            </SimpleFlexRow>
+                  <TabComponent
+                    label='Preview'
+                    selected
+                    icon={<LargerIcons.PreviewPane color='primary' />}
+                    onClose={onClosePreview}
+                  />
+                </SimpleFlexRow>
+                <PreviewColumn />
+              </ResizableFlexColumn>
+            ) : null}
           </SimpleFlexRow>
-        </SimpleFlexColumn>
-        <ModalComponent />
-        <ToastRenderer />
-        <EditorCursorComponent />
-      </SimpleFlexRow>
-    )
-  },
-)
+        </SimpleFlexRow>
+      </SimpleFlexColumn>
+      <ModalComponent />
+      <ToastRenderer />
+      <EditorCursorComponent />
+    </SimpleFlexRow>
+  )
+})
 
-const ModalComponent = betterReactMemo('ModalComponent', (): React.ReactElement<any> | null => {
+const ModalComponent = React.memo((): React.ReactElement<any> | null => {
   const { modal, dispatch } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
@@ -365,7 +356,7 @@ export function EditorComponent(props: EditorProps) {
   )
 }
 
-const EditorCursorComponent = betterReactMemo('EditorCursorComponent', () => {
+const EditorCursorComponent = React.memo(() => {
   const cursor = useEditorState((store) => {
     return Utils.defaultIfNull(store.editor.canvas.cursor, getCursorFromDragState(store.editor))
   }, 'EditorCursorComponent cursor')
@@ -390,7 +381,7 @@ const EditorCursorComponent = betterReactMemo('EditorCursorComponent', () => {
   return <div key='cursor-area' id='cursor-overlay' style={styleProps} />
 })
 
-const ToastRenderer = betterReactMemo('ToastRenderer', () => {
+const ToastRenderer = React.memo(() => {
   const toasts = useEditorState((store) => store.editor.toasts, 'ToastRenderer')
 
   return (

--- a/editor/src/components/editor/fatal-indexeddb-error-component.tsx
+++ b/editor/src/components/editor/fatal-indexeddb-error-component.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { betterReactMemo } from '../../uuiui-deps'
 
-export const FatalIndexedDBErrorComponent = betterReactMemo('FatalIndexedDBErrorComponent', () => {
+export const FatalIndexedDBErrorComponent = React.memo(() => {
   return (
     <div
       style={{

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -67,7 +67,6 @@ import {
   UtopiaStyles,
   UIRow,
 } from '../../uuiui'
-import { betterReactMemo } from '../../uuiui-deps'
 import {
   getDependencyStatus,
   getInsertableGroupLabel,
@@ -90,7 +89,7 @@ interface InsertMenuProps {
   projectContents: ProjectContentTreeRoot
 }
 
-export const InsertMenu = betterReactMemo('InsertMenu', () => {
+export const InsertMenu = React.memo(() => {
   const props = useEditorState((store) => {
     const openFileFullPath = getOpenFilename(store.editor)
 
@@ -363,35 +362,32 @@ interface InsertGroupProps {
   dependencyVersion: string | null
 }
 
-export const InsertGroup: React.FunctionComponent<InsertGroupProps> = betterReactMemo(
-  'InsertGroup',
-  (props) => {
-    const colorTheme = useColorTheme()
-    return (
-      <div style={{ paddingBottom: 12 }}>
-        <UIRow rowHeight={'normal'}>
-          <InspectorSubsectionHeader>
-            <div style={{ color: colorTheme.emphasizedForeground.value, fontWeight: 500 }}>
-              {props.label}
-            </div>
-            {props.subLabel == null ? null : (
-              <div style={{ color: colorTheme.subduedForeground.value, paddingLeft: 10 }}>
-                {props.subLabel}
-              </div>
-            )}
-          </InspectorSubsectionHeader>
-          <div style={{ flexGrow: 1, textAlign: 'right' }}>
-            <NpmDependencyVersionAndStatusIndicator
-              status={props.dependencyStatus}
-              version={props.dependencyVersion}
-            />
+export const InsertGroup: React.FunctionComponent<InsertGroupProps> = React.memo((props) => {
+  const colorTheme = useColorTheme()
+  return (
+    <div style={{ paddingBottom: 12 }}>
+      <UIRow rowHeight={'normal'}>
+        <InspectorSubsectionHeader>
+          <div style={{ color: colorTheme.emphasizedForeground.value, fontWeight: 500 }}>
+            {props.label}
           </div>
-        </UIRow>
-        <div style={{ padding: 8 }}>{props.children}</div>
-      </div>
-    )
-  },
-)
+          {props.subLabel == null ? null : (
+            <div style={{ color: colorTheme.subduedForeground.value, paddingLeft: 10 }}>
+              {props.subLabel}
+            </div>
+          )}
+        </InspectorSubsectionHeader>
+        <div style={{ flexGrow: 1, textAlign: 'right' }}>
+          <NpmDependencyVersionAndStatusIndicator
+            status={props.dependencyStatus}
+            version={props.dependencyVersion}
+          />
+        </div>
+      </UIRow>
+      <div style={{ padding: 8 }}>{props.children}</div>
+    </div>
+  )
+})
 
 interface InsertItemProps {
   label: string

--- a/editor/src/components/editor/notification-bar.tsx
+++ b/editor/src/components/editor/notification-bar.tsx
@@ -6,15 +6,14 @@ import { useEditorState } from './store/store-hook'
 
 import { NotificationBar } from '../common/notices'
 import { NoticeLevel } from '../common/notice'
-import { betterReactMemo } from '../../uuiui-deps'
 
-export const BrowserInfoBar = betterReactMemo('EditorOfflineBar', () => {
+export const BrowserInfoBar = React.memo(() => {
   return (
     <NotificationBar level='INFO' message={`Utopia works best and fastest in Chrome right now`} />
   )
 })
 
-const EditorOfflineBar = betterReactMemo('EditorOfflineBar', () => {
+const EditorOfflineBar = React.memo(() => {
   return (
     <NotificationBar
       level='ERROR'
@@ -23,7 +22,7 @@ const EditorOfflineBar = betterReactMemo('EditorOfflineBar', () => {
   )
 })
 
-export const LoginStatusBar = betterReactMemo('LoginStatusBar', () => {
+export const LoginStatusBar = React.memo(() => {
   const loginState = useEditorState((store) => store.userState.loginState, 'LoginStatusBar')
   const saveError = useEditorState(
     (store) => store.editor.saveError,

--- a/editor/src/components/editor/top-menu.tsx
+++ b/editor/src/components/editor/top-menu.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../uuiui'
 import { useEditorState } from './store/store-hook'
 import * as EditorActions from '../editor/actions/action-creators'
-import { betterReactMemo, Utils } from '../../uuiui-deps'
+import { Utils } from '../../uuiui-deps'
 import { FormulaBar } from '../canvas/controls/formula-bar'
 import CanvasActions from '../canvas/canvas-actions'
 import { EditorAction } from './action-types'
@@ -33,7 +33,7 @@ function useShouldResetCanvas(invalidateCount: number): [boolean, (value: boolea
   return [shouldResetCanvas, setShouldResetCanvas]
 }
 
-const TopMenuLeftControls = betterReactMemo('TopMenuLeftControls', () => {
+const TopMenuLeftControls = React.memo(() => {
   const dispatch = useEditorState((store) => store.dispatch, 'TopMenuLeftControls dispatch')
   const navigatorVisible = useEditorState(
     (store) => !store.editor.navigator.minimised,
@@ -80,7 +80,7 @@ const TopMenuLeftControls = betterReactMemo('TopMenuLeftControls', () => {
   )
 })
 
-const TopMenuRightControls = betterReactMemo('TopMenuRightControls', () => {
+const TopMenuRightControls = React.memo(() => {
   const dispatch = useEditorState((store) => store.dispatch, 'TopMenuRightControls dispatch')
   const canvasContentInvalidateCount = useEditorState(
     (store) => store.editor.canvas.canvasContentInvalidateCount,
@@ -188,7 +188,7 @@ const TopMenuRightControls = betterReactMemo('TopMenuRightControls', () => {
   )
 })
 
-export const TopMenu = betterReactMemo('TopMenu', () => {
+export const TopMenu = React.memo(() => {
   return (
     <SimpleFlexRow
       style={{

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -28,7 +28,6 @@ import {
 } from './context-menu-items'
 import { MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState } from './editor/store/store-hook'
-import { betterReactMemo } from '../uuiui-deps'
 import { CanvasContextMenuPortalTargetID } from '../core/shared/utils'
 import { EditorDispatch } from './editor/action-types'
 import { selectComponents, setHighlightedView } from './editor/actions/action-creators'
@@ -172,62 +171,59 @@ const SelectableElementItem = (props: SelectableElementItemProps) => {
   )
 }
 
-export const ElementContextMenu = betterReactMemo(
-  'ElementContextMenu',
-  ({ contextMenuInstance }: ElementContextMenuProps) => {
-    const { dispatch } = useEditorState((store) => {
-      return { dispatch: store.dispatch }
-    }, 'ElementContextMenu dispatch')
+export const ElementContextMenu = React.memo(({ contextMenuInstance }: ElementContextMenuProps) => {
+  const { dispatch } = useEditorState((store) => {
+    return { dispatch: store.dispatch }
+  }, 'ElementContextMenu dispatch')
 
-    const editorSliceRef = useRefEditorState((store) => {
-      const resolveFn = store.editor.codeResultCache.curriedResolveFn(store.editor.projectContents)
-      return {
-        canvasOffset: store.editor.canvas.roundedCanvasOffset,
-        selectedViews: store.editor.selectedViews,
-        jsxMetadata: store.editor.jsxMetadata,
-        editorDispatch: store.dispatch,
-        projectContents: store.editor.projectContents,
-        nodeModules: store.editor.nodeModules.files,
-        transientFilesState: store.derived.canvas.transientState.filesState,
-        resolve: resolveFn,
-        hiddenInstances: store.editor.hiddenInstances,
-        scale: store.editor.canvas.scale,
-        focusedElementPath: store.editor.focusedElementPath,
-      }
-    })
-
-    const getData: () => CanvasData = React.useCallback(() => {
-      const currentEditor = editorSliceRef.current
-      return {
-        canvasOffset: currentEditor.canvasOffset,
-        selectedViews: currentEditor.selectedViews,
-        jsxMetadata: currentEditor.jsxMetadata,
-        projectContents: currentEditor.projectContents,
-        nodeModules: currentEditor.nodeModules,
-        transientFilesState: currentEditor.transientFilesState,
-        resolve: currentEditor.resolve,
-        hiddenInstances: currentEditor.hiddenInstances,
-        scale: currentEditor.scale,
-        focusedElementPath: currentEditor.focusedElementPath,
-      }
-    }, [editorSliceRef])
-
-    const contextMenuItems = useCanvasContextMenuItems(contextMenuInstance, dispatch)
-
-    const portalTarget = document.getElementById(CanvasContextMenuPortalTargetID)
-    if (portalTarget == null) {
-      return null
-    } else {
-      return ReactDOM.createPortal(
-        <MomentumContextMenu
-          id={contextMenuInstance}
-          key='element-context-menu'
-          items={contextMenuItems}
-          dispatch={dispatch}
-          getData={getData}
-        />,
-        portalTarget,
-      )
+  const editorSliceRef = useRefEditorState((store) => {
+    const resolveFn = store.editor.codeResultCache.curriedResolveFn(store.editor.projectContents)
+    return {
+      canvasOffset: store.editor.canvas.roundedCanvasOffset,
+      selectedViews: store.editor.selectedViews,
+      jsxMetadata: store.editor.jsxMetadata,
+      editorDispatch: store.dispatch,
+      projectContents: store.editor.projectContents,
+      nodeModules: store.editor.nodeModules.files,
+      transientFilesState: store.derived.canvas.transientState.filesState,
+      resolve: resolveFn,
+      hiddenInstances: store.editor.hiddenInstances,
+      scale: store.editor.canvas.scale,
+      focusedElementPath: store.editor.focusedElementPath,
     }
-  },
-)
+  })
+
+  const getData: () => CanvasData = React.useCallback(() => {
+    const currentEditor = editorSliceRef.current
+    return {
+      canvasOffset: currentEditor.canvasOffset,
+      selectedViews: currentEditor.selectedViews,
+      jsxMetadata: currentEditor.jsxMetadata,
+      projectContents: currentEditor.projectContents,
+      nodeModules: currentEditor.nodeModules,
+      transientFilesState: currentEditor.transientFilesState,
+      resolve: currentEditor.resolve,
+      hiddenInstances: currentEditor.hiddenInstances,
+      scale: currentEditor.scale,
+      focusedElementPath: currentEditor.focusedElementPath,
+    }
+  }, [editorSliceRef])
+
+  const contextMenuItems = useCanvasContextMenuItems(contextMenuInstance, dispatch)
+
+  const portalTarget = document.getElementById(CanvasContextMenuPortalTargetID)
+  if (portalTarget == null) {
+    return null
+  } else {
+    return ReactDOM.createPortal(
+      <MomentumContextMenu
+        id={contextMenuInstance}
+        key='element-context-menu'
+        items={contextMenuItems}
+        dispatch={dispatch}
+        getData={getData}
+      />,
+      portalTarget,
+    )
+  }
+})

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -38,7 +38,7 @@ import { useEditorState } from '../editor/store/store-hook'
 import { addingChildElement, FileBrowserItem } from './fileitem'
 import { dropFileExtension } from '../../core/shared/file-utils'
 import { objectMap } from '../../core/shared/object-utils'
-import { betterReactMemo, useKeepReferenceEqualityIfPossible } from '../../utils/react-performance'
+import { useKeepReferenceEqualityIfPossible } from '../../utils/react-performance'
 import {
   Section,
   SectionBodyArea,
@@ -131,7 +131,7 @@ function collectFileBrowserItems(
   return fileBrowserItems
 }
 
-export const FileBrowser = betterReactMemo('FileBrowser', () => {
+export const FileBrowser = React.memo(() => {
   const { dispatch, minimised, focusedPanel } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
@@ -230,7 +230,7 @@ interface FileBrowserActionSheetProps {
   setAddingFileOrFolder: (fileOrFolder: 'file' | 'folder') => void
 }
 
-const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
+const FileBrowserItems = React.memo(() => {
   const {
     dispatch,
     projectContents,
@@ -313,28 +313,25 @@ const FileBrowserItems = betterReactMemo('FileBrowserItems', () => {
   )
 })
 
-const FileBrowserActionSheet = betterReactMemo(
-  'FileBrowserActionSheet',
-  (props: FileBrowserActionSheetProps) => {
-    const { dispatch } = useEditorState(
-      (store) => ({ dispatch: store.dispatch }),
-      'FileBrowserActionSheet dispatch',
+const FileBrowserActionSheet = React.memo((props: FileBrowserActionSheetProps) => {
+  const { dispatch } = useEditorState(
+    (store) => ({ dispatch: store.dispatch }),
+    'FileBrowserActionSheet dispatch',
+  )
+  const addFolderClick = React.useCallback(() => props.setAddingFileOrFolder('folder'), [props])
+  const addTextFileClick = React.useCallback(() => props.setAddingFileOrFolder('file'), [props])
+  if (props.visible) {
+    return (
+      <ActionSheet>
+        <SquareButton highlight onClick={addFolderClick}>
+          <Icons.NewFolder tooltipText='Add New Folder' />
+        </SquareButton>
+        <SquareButton highlight onClick={addTextFileClick}>
+          <Icons.NewTextFile tooltipText='Add Code File' />
+        </SquareButton>
+      </ActionSheet>
     )
-    const addFolderClick = React.useCallback(() => props.setAddingFileOrFolder('folder'), [props])
-    const addTextFileClick = React.useCallback(() => props.setAddingFileOrFolder('file'), [props])
-    if (props.visible) {
-      return (
-        <ActionSheet>
-          <SquareButton highlight onClick={addFolderClick}>
-            <Icons.NewFolder tooltipText='Add New Folder' />
-          </SquareButton>
-          <SquareButton highlight onClick={addTextFileClick}>
-            <Icons.NewTextFile tooltipText='Add Code File' />
-          </SquareButton>
-        </ActionSheet>
-      )
-    } else {
-      return null
-    }
-  },
-)
+  } else {
+    return null
+  }
+})

--- a/editor/src/components/inspector/common/property-path-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-path-hooks.spec.tsx
@@ -49,7 +49,6 @@ import {
   useInspectorStyleInfo,
 } from './property-path-hooks'
 import { isParseSuccess, ElementPath } from '../../../core/shared/project-file-types'
-import { betterReactMemo } from '../../../utils/react-performance'
 import {
   getPropsForStyleProp,
   makeInspectorHookContextProvider,
@@ -201,7 +200,7 @@ describe('useCallbackFactory', () => {
   })
 })
 
-const WellBehavedInspectorSubsection = betterReactMemo('WellBehavedInspectorSubsection', () => {
+const WellBehavedInspectorSubsection = React.memo(() => {
   const { value, onSubmitValue } = useInspectorStyleInfo('opacity')
   onSubmitValue(cssNumber(0.9))
   return <div onClick={() => onSubmitValue(cssNumber(0.5))}>{printCSSNumber(value, null)}</div>

--- a/editor/src/components/inspector/controls/background-solid-or-gradient-thumbnail-control.tsx
+++ b/editor/src/components/inspector/controls/background-solid-or-gradient-thumbnail-control.tsx
@@ -20,7 +20,6 @@ import {
 import { BackgroundPicker } from '../sections/style-section/background-subsection/background-picker'
 import { StringControl } from './string-control'
 import { useColorTheme, UtopiaTheme } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import Utils from '../../../utils/utils'
 
 export interface BackgroundThumbnailControlProps {
@@ -83,8 +82,7 @@ export const backgroundControlContainerStyle = {
   margin: 1,
 }
 
-export const BackgroundSolidOrGradientThumbnailControl = betterReactMemo(
-  'BackgroundControl',
+export const BackgroundSolidOrGradientThumbnailControl = React.memo(
   (props: BackgroundSolidOrGradientThumbnailControlProps) => {
     const colorTheme = useColorTheme()
     const setOpenPopup = props.setOpenPopup
@@ -207,8 +205,7 @@ export const BackgroundSolidOrGradientThumbnailControl = betterReactMemo(
   },
 )
 
-export const StringBackgroundColorControl = betterReactMemo(
-  'StringBackgroundColorControl',
+export const StringBackgroundColorControl = React.memo(
   (props: BackgroundSolidOrGradientThumbnailControlProps) => {
     const value = props.value
     if (isCSSGradientBackgroundLayer(value) || props.onSubmitSolidStringValue == null) {

--- a/editor/src/components/inspector/controls/color-control.tsx
+++ b/editor/src/components/inspector/controls/color-control.tsx
@@ -10,7 +10,6 @@ import {
 import { StringControl } from './string-control'
 import { ControlStatus, ControlStyles } from '../common/control-status'
 import { useColorTheme, UtopiaTheme } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import Utils from '../../../utils/utils'
 
 export interface ColorControlProps {
@@ -43,7 +42,7 @@ export function updateStringCSSColor(newValue: string, oldValue: CSSColor) {
   }
 }
 
-export const ColorControl = betterReactMemo('ColorControl', (props: ColorControlProps) => {
+export const ColorControl = React.memo((props: ColorControlProps) => {
   const { onSubmitValue } = props
   const [popupOpen, setPopupOpen] = React.useState(false)
   const colorTheme = useColorTheme()
@@ -152,29 +151,26 @@ export const ColorControl = betterReactMemo('ColorControl', (props: ColorControl
   )
 })
 
-export const StringColorControl = betterReactMemo(
-  'StringColorControl',
-  (props: ColorControlProps) => {
-    const color = props.value
-    if (props.onSubmitSolidStringValue == null) {
-      return null
-    }
+export const StringColorControl = React.memo((props: ColorControlProps) => {
+  const color = props.value
+  if (props.onSubmitSolidStringValue == null) {
+    return null
+  }
 
-    return (
-      <StringControl
-        id={`string-${props.id}`}
-        testId={`color-picker-string-control-${props.testId}`}
-        key={'color-string'}
-        style={props.style}
-        value={cssColorToChromaColorOrDefault(color).hex('rgba').toUpperCase()}
-        readOnly={props.controlStyles.interactive}
-        onSubmitValue={props.onSubmitSolidStringValue}
-        controlStatus={props.controlStatus}
-        controlStyles={props.controlStyles}
-        DEPRECATED_controlOptions={{
-          labelBelow: 'hex',
-        }}
-      />
-    )
-  },
-)
+  return (
+    <StringControl
+      id={`string-${props.id}`}
+      testId={`color-picker-string-control-${props.testId}`}
+      key={'color-string'}
+      style={props.style}
+      value={cssColorToChromaColorOrDefault(color).hex('rgba').toUpperCase()}
+      readOnly={props.controlStyles.interactive}
+      onSubmitValue={props.onSubmitSolidStringValue}
+      controlStatus={props.controlStatus}
+      controlStyles={props.controlStyles}
+      DEPRECATED_controlOptions={{
+        labelBelow: 'hex',
+      }}
+    />
+  )
+})

--- a/editor/src/components/inspector/controls/image-thumbnail-control.tsx
+++ b/editor/src/components/inspector/controls/image-thumbnail-control.tsx
@@ -7,89 +7,85 @@ import {
 } from './background-solid-or-gradient-thumbnail-control'
 import { clampString } from '../common/inspector-utils'
 import { Tooltip, FlexRow, UtopiaTheme, useColorTheme, Icn, Icons } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 
 interface ImageThumbnailControlProps extends BackgroundThumbnailControlProps {
   value: CSSURLFunctionBackgroundLayer
 }
 
-export const ImageThumbnailControl = betterReactMemo<ImageThumbnailControlProps>(
-  'ImageThumbnailControl',
-  (props) => {
-    const colorTheme = useColorTheme()
-    const [imageNotFound, setImageNotFound] = React.useState(false)
-    const onError = React.useCallback(() => {
-      setImageNotFound(true)
-    }, [])
-    const setOpenPopup = props.setOpenPopup
-    const closePopup = React.useCallback(() => setOpenPopup(undefined), [setOpenPopup])
+export const ImageThumbnailControl = React.memo<ImageThumbnailControlProps>((props) => {
+  const colorTheme = useColorTheme()
+  const [imageNotFound, setImageNotFound] = React.useState(false)
+  const onError = React.useCallback(() => {
+    setImageNotFound(true)
+  }, [])
+  const setOpenPopup = props.setOpenPopup
+  const closePopup = React.useCallback(() => setOpenPopup(undefined), [setOpenPopup])
 
-    const backgroundIndex = props.backgroundIndex
-    const onMouseDown = React.useCallback(
-      (e) => {
-        e.stopPropagation()
-        setOpenPopup((openPopup) => {
-          if (openPopup != null) {
-            return undefined
-          } else {
-            return backgroundIndex
-          }
-        })
-      },
-      [setOpenPopup, backgroundIndex],
-    )
+  const backgroundIndex = props.backgroundIndex
+  const onMouseDown = React.useCallback(
+    (e) => {
+      e.stopPropagation()
+      setOpenPopup((openPopup) => {
+        if (openPopup != null) {
+          return undefined
+        } else {
+          return backgroundIndex
+        }
+      })
+    },
+    [setOpenPopup, backgroundIndex],
+  )
 
-    const modalOffset = props.modalOffset != null ? props.modalOffset : { x: 0, y: 0 }
+  const modalOffset = props.modalOffset != null ? props.modalOffset : { x: 0, y: 0 }
 
-    return (
-      <div>
-        {props.popupOpen ? (
-          <BackgroundPicker
-            id={props.id}
-            testId={props.testId}
-            offsetX={modalOffset.x}
-            offsetY={modalOffset.y}
-            closePopup={closePopup}
-            value={props.value}
-            useSubmitValueFactory={props.useSubmitValueFactory}
-            backgroundLayerIndex={props.backgroundIndex}
-            controlStatus={props.controlStatus}
-          />
-        ) : null}
-        {imageNotFound ? (
-          <Tooltip title={`Image URL "${clampString(props.value.url, 20)}" not found`}>
-            <FlexRow
-              onMouseDown={onMouseDown}
-              style={{
-                width: 28,
-                height: UtopiaTheme.layout.inputHeight.default,
-                borderRadius: UtopiaTheme.inputBorderRadius,
-                backgroundColor: colorTheme.warningBgTranslucent.value,
-                boxShadow: `0 0 0 1px ${colorTheme.warningForeground.value} inset`,
-                justifyContent: 'center',
-              }}
-            >
-              <Icn type='warningtriangle' color='warning' width={16} height={16} />
-            </FlexRow>
-          </Tooltip>
-        ) : (
-          <img
+  return (
+    <div>
+      {props.popupOpen ? (
+        <BackgroundPicker
+          id={props.id}
+          testId={props.testId}
+          offsetX={modalOffset.x}
+          offsetY={modalOffset.y}
+          closePopup={closePopup}
+          value={props.value}
+          useSubmitValueFactory={props.useSubmitValueFactory}
+          backgroundLayerIndex={props.backgroundIndex}
+          controlStatus={props.controlStatus}
+        />
+      ) : null}
+      {imageNotFound ? (
+        <Tooltip title={`Image URL "${clampString(props.value.url, 20)}" not found`}>
+          <FlexRow
             onMouseDown={onMouseDown}
-            id={`background-layer-gradient-${props.backgroundIndex}`}
-            alt={`background-layer-gradient-${props.backgroundIndex}`}
-            src={props.value.url}
             style={{
-              ...backgroundControlContainerStyle,
-              display: 'block',
               width: 28,
               height: UtopiaTheme.layout.inputHeight.default,
-              objectFit: 'cover',
-              boxShadow: `0 0 0 1px ${props.controlStyles.borderColor} inset`,
+              borderRadius: UtopiaTheme.inputBorderRadius,
+              backgroundColor: colorTheme.warningBgTranslucent.value,
+              boxShadow: `0 0 0 1px ${colorTheme.warningForeground.value} inset`,
+              justifyContent: 'center',
             }}
-            onError={onError}
-          />
-        )}
-      </div>
-    )
-  },
-)
+          >
+            <Icn type='warningtriangle' color='warning' width={16} height={16} />
+          </FlexRow>
+        </Tooltip>
+      ) : (
+        <img
+          onMouseDown={onMouseDown}
+          id={`background-layer-gradient-${props.backgroundIndex}`}
+          alt={`background-layer-gradient-${props.backgroundIndex}`}
+          src={props.value.url}
+          style={{
+            ...backgroundControlContainerStyle,
+            display: 'block',
+            width: 28,
+            height: UtopiaTheme.layout.inputHeight.default,
+            objectFit: 'cover',
+            boxShadow: `0 0 0 1px ${props.controlStyles.borderColor} inset`,
+          }}
+          onError={onError}
+        />
+      )}
+    </div>
+  )
+})

--- a/editor/src/components/inspector/controls/keyword-control.tsx
+++ b/editor/src/components/inspector/controls/keyword-control.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import React from 'react'
 import { Either, isRight, left, right } from '../../../core/shared/either'
 import { StringInput } from '../../../uuiui'
-import { betterReactMemo, getControlStyles } from '../../../uuiui-deps'
+import { getControlStyles } from '../../../uuiui-deps'
 import { cssKeyword, CSSKeyword, emptyInputValue, unknownInputValue } from '../common/css-utils'
 import { usePropControlledState } from '../common/inspector-utils'
 import { InspectorControlProps, OnSubmitValueOrUnknownOrEmpty } from './control'
@@ -32,8 +32,7 @@ export function parseValidKeyword(
   }
 }
 
-export const KeywordControl = betterReactMemo<KeywordControlProps>(
-  'KeywordControl',
+export const KeywordControl = React.memo<KeywordControlProps>(
   ({
     value,
     id,

--- a/editor/src/components/inspector/controls/option-chain-control.tsx
+++ b/editor/src/components/inspector/controls/option-chain-control.tsx
@@ -5,7 +5,6 @@ import { IcnProps, UtopiaTheme } from '../../../uuiui'
 import { DEPRECATEDControlProps, DEPRECATEDGenericControlOptions } from './control'
 import { OptionControl } from './option-control'
 import Utils from '../../../utils/utils'
-import { betterReactMemo } from '../../../utils/react-performance'
 
 export interface OptionChainOption<T> {
   value: T
@@ -15,86 +14,86 @@ export interface OptionChainOption<T> {
 }
 
 // TODO come up with a typed OptionChainControl types!
-export const OptionChainControl: React.FunctionComponent<DEPRECATEDControlProps<
-  any
->> = betterReactMemo('OptionChainControl', ({ style, ...props }) => {
-  const options = props.options as Array<OptionChainOption<string | number>>
-  const labelBelow = (props.DEPRECATED_controlOptions as DEPRECATEDGenericControlOptions)
-    ?.labelBelow
-  if (!Array.isArray(props.options)) {
-    throw new Error('OptionControl needs an array of `options`')
-  }
-
-  const optionCSS: Interpolation<any> = React.useMemo(() => {
-    return {
-      position: 'relative',
-      // This is the divider in between controls
-      '&:not(:first-of-type)::after': {
-        content: '""',
-        height: 10,
-        backgroundColor: props.controlStyles.borderColor,
-        position: 'absolute',
-        left: 0,
-        top: 6,
-      },
+export const OptionChainControl: React.FunctionComponent<DEPRECATEDControlProps<any>> = React.memo(
+  ({ style, ...props }) => {
+    const options = props.options as Array<OptionChainOption<string | number>>
+    const labelBelow = (props.DEPRECATED_controlOptions as DEPRECATEDGenericControlOptions)
+      ?.labelBelow
+    if (!Array.isArray(props.options)) {
+      throw new Error('OptionControl needs an array of `options`')
     }
-  }, [props.controlStyles.borderColor])
 
-  const containerCSS: Interpolation<any> = React.useMemo(() => {
-    return {
-      display: 'flex',
-      flexDirection: 'column',
-      marginBottom: 0,
-      width: '100%',
-      ...style,
-    }
-  }, [style])
+    const optionCSS: Interpolation<any> = React.useMemo(() => {
+      return {
+        position: 'relative',
+        // This is the divider in between controls
+        '&:not(:first-of-type)::after': {
+          content: '""',
+          height: 10,
+          backgroundColor: props.controlStyles.borderColor,
+          position: 'absolute',
+          left: 0,
+          top: 6,
+        },
+      }
+    }, [props.controlStyles.borderColor])
 
-  return (
-    <div id={props.id} key={props.key} css={containerCSS}>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          height: UtopiaTheme.layout.inputHeight.default,
-          width: '100%',
-        }}
-        className={`option-chain-control-container ${Utils.pathOr(
-          '',
-          ['controlClassName'],
-          props,
-        )}`}
-        onContextMenu={props.onContextMenu}
-      >
-        {options.map((option: OptionChainOption<number | string>, index) => (
-          <OptionControl
-            {...props}
-            css={optionCSS}
-            key={'option-' + index}
-            DEPRECATED_controlOptions={{
-              tooltip: option.tooltip,
-              icon: option.icon,
-              labelInner: option.label,
-            }}
-            value={props.value === option.value}
-            // eslint-disable-next-line react/jsx-no-bind
-            onSubmitValue={(value: boolean) => {
-              if (value) {
-                props.onSubmitValue(option.value)
-              }
-            }}
-          />
-        ))}
-      </div>
-      {labelBelow == null ? null : (
-        <label
-          htmlFor={props.id}
+    const containerCSS: Interpolation<any> = React.useMemo(() => {
+      return {
+        display: 'flex',
+        flexDirection: 'column',
+        marginBottom: 0,
+        width: '100%',
+        ...style,
+      }
+    }, [style])
+
+    return (
+      <div id={props.id} key={props.key} css={containerCSS}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            height: UtopiaTheme.layout.inputHeight.default,
+            width: '100%',
+          }}
+          className={`option-chain-control-container ${Utils.pathOr(
+            '',
+            ['controlClassName'],
+            props,
+          )}`}
           onContextMenu={props.onContextMenu}
-          style={{ fontSize: 10, color: props.controlStyles.mainColor, paddingTop: 2 }}
         >
-          <span className='label-container'>{labelBelow}</span>
-        </label>
-      )}
-    </div>
-  )
-})
+          {options.map((option: OptionChainOption<number | string>, index) => (
+            <OptionControl
+              {...props}
+              css={optionCSS}
+              key={'option-' + index}
+              DEPRECATED_controlOptions={{
+                tooltip: option.tooltip,
+                icon: option.icon,
+                labelInner: option.label,
+              }}
+              value={props.value === option.value}
+              // eslint-disable-next-line react/jsx-no-bind
+              onSubmitValue={(value: boolean) => {
+                if (value) {
+                  props.onSubmitValue(option.value)
+                }
+              }}
+            />
+          ))}
+        </div>
+        {labelBelow == null ? null : (
+          <label
+            htmlFor={props.id}
+            onContextMenu={props.onContextMenu}
+            style={{ fontSize: 10, color: props.controlStyles.mainColor, paddingTop: 2 }}
+          >
+            <span className='label-container'>{labelBelow}</span>
+          </label>
+        )}
+      </div>
+    )
+  },
+)

--- a/editor/src/components/inspector/controls/pin-control.tsx
+++ b/editor/src/components/inspector/controls/pin-control.tsx
@@ -5,7 +5,6 @@ import { FramePoint } from 'utopia-api'
 import { LayoutPinnedProp } from '../../../core/layout/layout-helpers-new'
 import { FramePinsInfo } from '../common/layout-property-path-hooks'
 import { UtopiaTheme, SquareButton, width } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 
 interface PinControlProps {
   handlePinMouseDown: (frameProp: LayoutPinnedProp) => void
@@ -244,7 +243,7 @@ interface PinWidthControlProps {
   toggleWidth: () => void
 }
 
-export const PinWidthControl = betterReactMemo('PinWidthControl', (props: PinWidthControlProps) => {
+export const PinWidthControl = React.memo((props: PinWidthControlProps) => {
   const controlStyles: ControlStyles = getControlStyles(props.controlStatus)
   return (
     <SquareButton onClick={props.toggleWidth} highlight={true} spotlight={true}>
@@ -289,42 +288,39 @@ interface PinHeightControlProps {
   toggleHeight: () => void
 }
 
-export const PinHeightControl = betterReactMemo(
-  'PinHeightControl',
-  (props: PinHeightControlProps) => {
-    const controlStyles: ControlStyles = getControlStyles(props.controlStatus)
-    return (
-      <SquareButton onClick={props.toggleHeight} highlight={true} spotlight={true}>
-        <svg width='20' height='20'>
-          <g
-            id='dimensioncontrols-pin-height'
-            stroke={getStrokeColor(controlStyles, props.framePins, props.mixed, FramePoint.Height)}
-          >
-            <path
-              d={`M${HorizontalDimensionButtStart},${DimensionStart} l${DimensionButt},0`}
-              id='dimensioncontrols-pin-height-EdgeEnd-t'
-              strokeLinecap='round'
-            />
-            <path
-              d={`M${HorizontalDimensionButtStart},${VerticalDimensionEnd} l${DimensionButt},0`}
-              id='dimensioncontrols-pin-height-EdgeEnd-b'
-              strokeLinecap='round'
-            />
-            <path
-              d={`M${DimensionHorizontalMid},${DimensionStart} L${DimensionHorizontalMid},${VerticalDimensionEnd}`}
-              id='dimensioncontrols-pin-height-line'
-              strokeDasharray={getStrokeDashArray(props.framePins, props.mixed, FramePoint.Height)}
-              strokeLinecap='round'
-            />
-            <path
-              d={`M 0,0 ${DimensionWidth},0 0,${DimensionHeight} ${DimensionWidth},${DimensionHeight} z`}
-              id='dimensioncontrols-pin-width-transparent'
-              stroke='transparent'
-              fill='transparent'
-            />
-          </g>
-        </svg>
-      </SquareButton>
-    )
-  },
-)
+export const PinHeightControl = React.memo((props: PinHeightControlProps) => {
+  const controlStyles: ControlStyles = getControlStyles(props.controlStatus)
+  return (
+    <SquareButton onClick={props.toggleHeight} highlight={true} spotlight={true}>
+      <svg width='20' height='20'>
+        <g
+          id='dimensioncontrols-pin-height'
+          stroke={getStrokeColor(controlStyles, props.framePins, props.mixed, FramePoint.Height)}
+        >
+          <path
+            d={`M${HorizontalDimensionButtStart},${DimensionStart} l${DimensionButt},0`}
+            id='dimensioncontrols-pin-height-EdgeEnd-t'
+            strokeLinecap='round'
+          />
+          <path
+            d={`M${HorizontalDimensionButtStart},${VerticalDimensionEnd} l${DimensionButt},0`}
+            id='dimensioncontrols-pin-height-EdgeEnd-b'
+            strokeLinecap='round'
+          />
+          <path
+            d={`M${DimensionHorizontalMid},${DimensionStart} L${DimensionHorizontalMid},${VerticalDimensionEnd}`}
+            id='dimensioncontrols-pin-height-line'
+            strokeDasharray={getStrokeDashArray(props.framePins, props.mixed, FramePoint.Height)}
+            strokeLinecap='round'
+          />
+          <path
+            d={`M 0,0 ${DimensionWidth},0 0,${DimensionHeight} ${DimensionWidth},${DimensionHeight} z`}
+            id='dimensioncontrols-pin-width-transparent'
+            stroke='transparent'
+            fill='transparent'
+          />
+        </g>
+      </svg>
+    </SquareButton>
+  )
+})

--- a/editor/src/components/inspector/controls/string-control.tsx
+++ b/editor/src/components/inspector/controls/string-control.tsx
@@ -3,7 +3,6 @@ import { jsx } from '@emotion/react'
 import classNames from 'classnames'
 import React from 'react'
 import { StringInput } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { usePropControlledState } from '../common/inspector-utils'
 import { DEPRECATEDControlProps } from './control'
 
@@ -11,8 +10,7 @@ export interface StringControlOptions {
   DEPRECATED_labelBelow?: React.ReactChild
 }
 
-export const StringControl = betterReactMemo(
-  'StringControl',
+export const StringControl = React.memo(
   React.forwardRef<HTMLInputElement, DEPRECATEDControlProps<string>>(
     ({ value: propsValue, controlStyles, onBlur, onSubmitValue, ...props }, ref) => {
       const [mixed, setMixed] = usePropControlledState<boolean>(controlStyles.mixed)

--- a/editor/src/components/inspector/controls/unknown-array-item.tsx
+++ b/editor/src/components/inspector/controls/unknown-array-item.tsx
@@ -12,30 +12,26 @@ import { ControlStatus, ControlStyles } from '../common/control-status'
 import { PropertyRow } from '../widgets/property-row'
 import { StringControl } from './string-control'
 import { CheckboxInput, FlexRow, Tooltip } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 
 interface FakeUnknownArrayItemProps {
   controlStatus: ControlStatus
 }
 
-export const FakeUnknownArrayItem = betterReactMemo<FakeUnknownArrayItemProps>(
-  'FakeUnknownArrayItem',
-  (props) => (
-    <PropertyRow
-      style={{
-        gridTemplateColumns: '12px 1fr',
-        gridColumnGap: 8,
-      }}
-    >
-      <CheckboxInput
-        disabled={true}
-        controlStatus={props.controlStatus}
-        onMouseDown={stopPropagation}
-      />
-      <FlexRow style={{ height: 22 }}>Unknown</FlexRow>
-    </PropertyRow>
-  ),
-)
+export const FakeUnknownArrayItem = React.memo<FakeUnknownArrayItemProps>((props) => (
+  <PropertyRow
+    style={{
+      gridTemplateColumns: '12px 1fr',
+      gridColumnGap: 8,
+    }}
+  >
+    <CheckboxInput
+      disabled={true}
+      controlStatus={props.controlStatus}
+      onMouseDown={stopPropagation}
+    />
+    <FlexRow style={{ height: 22 }}>Unknown</FlexRow>
+  </PropertyRow>
+))
 
 function getIndexedUpdateUnknownArrayItemValue<T>(index: number) {
   return function updateUnknownArrayItemValue(

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -62,7 +62,6 @@ import {
 import { usePropControlledRef_DANGEROUS } from './common/inspector-utils'
 import { arrayEquals } from '../../core/shared/utils'
 import {
-  betterReactMemo,
   useKeepReferenceEqualityIfPossible,
   useKeepShallowReferenceEquality,
 } from '../../utils/react-performance'
@@ -101,8 +100,7 @@ interface AlignDistributeButtonProps {
   disabled: boolean
 }
 
-const AlignDistributeButton = betterReactMemo<AlignDistributeButtonProps>(
-  'AlignDistributeButton',
+const AlignDistributeButton = React.memo<AlignDistributeButtonProps>(
   (props: AlignDistributeButtonProps) => {
     return (
       <Button disabled={props.disabled} onMouseUp={props.onMouseUp}>
@@ -119,103 +117,100 @@ const AlignDistributeButton = betterReactMemo<AlignDistributeButtonProps>(
 )
 AlignDistributeButton.displayName = 'AlignDistributeButton'
 
-const AlignmentButtons = betterReactMemo(
-  'AlignmentButtons',
-  (props: { numberOfTargets: number }) => {
-    const dispatch = useEditorState((store) => store.dispatch, 'AlignmentButtons dispatch')
-    const alignSelected = React.useCallback(
-      (alignment: Alignment) => {
-        dispatch([alignSelectedViews(alignment)], 'everyone')
-      },
-      [dispatch],
-    )
+const AlignmentButtons = React.memo((props: { numberOfTargets: number }) => {
+  const dispatch = useEditorState((store) => store.dispatch, 'AlignmentButtons dispatch')
+  const alignSelected = React.useCallback(
+    (alignment: Alignment) => {
+      dispatch([alignSelectedViews(alignment)], 'everyone')
+    },
+    [dispatch],
+  )
 
-    const distributeSelected = React.useCallback(
-      (distribution: Distribution) => {
-        dispatch([distributeSelectedViews(distribution)], 'everyone')
-      },
-      [dispatch],
-    )
-    const disableAlign = props.numberOfTargets === 0
-    const disableDistribute = props.numberOfTargets < 3
-    const multipleTargets = props.numberOfTargets > 1
+  const distributeSelected = React.useCallback(
+    (distribution: Distribution) => {
+      dispatch([distributeSelectedViews(distribution)], 'everyone')
+    },
+    [dispatch],
+  )
+  const disableAlign = props.numberOfTargets === 0
+  const disableDistribute = props.numberOfTargets < 3
+  const multipleTargets = props.numberOfTargets > 1
 
-    const alignLeft = React.useCallback(() => alignSelected('left'), [alignSelected])
-    const alignHCenter = React.useCallback(() => alignSelected('hcenter'), [alignSelected])
-    const alignRight = React.useCallback(() => alignSelected('right'), [alignSelected])
-    const alignTop = React.useCallback(() => alignSelected('top'), [alignSelected])
-    const alignVCenter = React.useCallback(() => alignSelected('vcenter'), [alignSelected])
-    const alignBottom = React.useCallback(() => alignSelected('bottom'), [alignSelected])
-    const distributeHorizontal = React.useCallback(() => distributeSelected('horizontal'), [
-      distributeSelected,
-    ])
-    const distributeVertical = React.useCallback(() => distributeSelected('vertical'), [
-      distributeSelected,
-    ])
-    const colorTheme = useColorTheme()
-    return (
-      <FlexRow
-        style={{
-          justifyContent: 'space-around',
-          height: UtopiaTheme.layout.rowHeight.normal,
-          position: 'sticky',
-          top: 0,
-          zIndex: 1,
-          background: colorTheme.inspectorBackground.value,
-        }}
-      >
-        <AlignDistributeButton
-          onMouseUp={alignLeft}
-          toolTip={`Align to left of ${multipleTargets ? 'selection' : 'parent'}`}
-          iconType='alignLeft'
-          disabled={disableAlign}
-        />
-        <AlignDistributeButton
-          onMouseUp={alignHCenter}
-          toolTip={`Align to horizontal center of ${multipleTargets ? 'selection' : 'parent'}`}
-          iconType='alignHorizontalCenter'
-          disabled={disableAlign}
-        />
-        <AlignDistributeButton
-          onMouseUp={alignRight}
-          toolTip={`Align to right of ${multipleTargets ? 'selection' : 'parent'}`}
-          iconType='alignRight'
-          disabled={disableAlign}
-        />
-        <AlignDistributeButton
-          onMouseUp={alignTop}
-          toolTip={`Align to top of ${multipleTargets ? 'selection' : 'parent'}`}
-          iconType='alignTop'
-          disabled={disableAlign}
-        />
-        <AlignDistributeButton
-          onMouseUp={alignVCenter}
-          toolTip={`Align to vertical center of ${multipleTargets ? 'selection' : 'parent'}`}
-          iconType='alignVerticalCenter'
-          disabled={disableAlign}
-        />
-        <AlignDistributeButton
-          onMouseUp={alignBottom}
-          toolTip={`Align to bottom of ${multipleTargets ? 'selection' : 'parent'}`}
-          iconType='alignBottom'
-          disabled={disableAlign}
-        />
-        <AlignDistributeButton
-          onMouseUp={distributeHorizontal}
-          toolTip={`Distribute horizontally ↔`}
-          iconType='distributeHorizontal'
-          disabled={disableDistribute}
-        />
-        <AlignDistributeButton
-          onMouseUp={distributeVertical}
-          toolTip={`Distribute vertically ↕️`}
-          iconType='distributeVertical'
-          disabled={disableDistribute}
-        />
-      </FlexRow>
-    )
-  },
-)
+  const alignLeft = React.useCallback(() => alignSelected('left'), [alignSelected])
+  const alignHCenter = React.useCallback(() => alignSelected('hcenter'), [alignSelected])
+  const alignRight = React.useCallback(() => alignSelected('right'), [alignSelected])
+  const alignTop = React.useCallback(() => alignSelected('top'), [alignSelected])
+  const alignVCenter = React.useCallback(() => alignSelected('vcenter'), [alignSelected])
+  const alignBottom = React.useCallback(() => alignSelected('bottom'), [alignSelected])
+  const distributeHorizontal = React.useCallback(() => distributeSelected('horizontal'), [
+    distributeSelected,
+  ])
+  const distributeVertical = React.useCallback(() => distributeSelected('vertical'), [
+    distributeSelected,
+  ])
+  const colorTheme = useColorTheme()
+  return (
+    <FlexRow
+      style={{
+        justifyContent: 'space-around',
+        height: UtopiaTheme.layout.rowHeight.normal,
+        position: 'sticky',
+        top: 0,
+        zIndex: 1,
+        background: colorTheme.inspectorBackground.value,
+      }}
+    >
+      <AlignDistributeButton
+        onMouseUp={alignLeft}
+        toolTip={`Align to left of ${multipleTargets ? 'selection' : 'parent'}`}
+        iconType='alignLeft'
+        disabled={disableAlign}
+      />
+      <AlignDistributeButton
+        onMouseUp={alignHCenter}
+        toolTip={`Align to horizontal center of ${multipleTargets ? 'selection' : 'parent'}`}
+        iconType='alignHorizontalCenter'
+        disabled={disableAlign}
+      />
+      <AlignDistributeButton
+        onMouseUp={alignRight}
+        toolTip={`Align to right of ${multipleTargets ? 'selection' : 'parent'}`}
+        iconType='alignRight'
+        disabled={disableAlign}
+      />
+      <AlignDistributeButton
+        onMouseUp={alignTop}
+        toolTip={`Align to top of ${multipleTargets ? 'selection' : 'parent'}`}
+        iconType='alignTop'
+        disabled={disableAlign}
+      />
+      <AlignDistributeButton
+        onMouseUp={alignVCenter}
+        toolTip={`Align to vertical center of ${multipleTargets ? 'selection' : 'parent'}`}
+        iconType='alignVerticalCenter'
+        disabled={disableAlign}
+      />
+      <AlignDistributeButton
+        onMouseUp={alignBottom}
+        toolTip={`Align to bottom of ${multipleTargets ? 'selection' : 'parent'}`}
+        iconType='alignBottom'
+        disabled={disableAlign}
+      />
+      <AlignDistributeButton
+        onMouseUp={distributeHorizontal}
+        toolTip={`Distribute horizontally ↔`}
+        iconType='distributeHorizontal'
+        disabled={disableDistribute}
+      />
+      <AlignDistributeButton
+        onMouseUp={distributeVertical}
+        toolTip={`Distribute vertically ↕️`}
+        iconType='distributeVertical'
+        disabled={disableDistribute}
+      />
+    </FlexRow>
+  )
+})
 AlignmentButtons.displayName = 'AlignmentButtons'
 
 const nonDefaultPositionPaths: Array<PropertyPath> = [
@@ -223,7 +218,7 @@ const nonDefaultPositionPaths: Array<PropertyPath> = [
   createLayoutPropertyPath('PinnedBottom'),
 ]
 
-export const Inspector = betterReactMemo<InspectorProps>('Inspector', (props: InspectorProps) => {
+export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
   const colorTheme = useColorTheme()
   const { selectedViews } = props
   const {
@@ -347,26 +342,23 @@ Inspector.displayName = 'Inspector'
 
 const DefaultStyleTargets: Array<CSSTarget> = [cssTarget(['style'], 0), cssTarget(['css'], 0)]
 
-export const InspectorEntryPoint: React.FunctionComponent = betterReactMemo(
-  'InspectorEntryPoint',
-  () => {
-    const selectedViews = useEditorState(
-      (store) => store.editor.selectedViews,
-      'InspectorEntryPoint selectedViews',
-    )
+export const InspectorEntryPoint: React.FunctionComponent = React.memo(() => {
+  const selectedViews = useEditorState(
+    (store) => store.editor.selectedViews,
+    'InspectorEntryPoint selectedViews',
+  )
 
-    return (
-      <SingleInspectorEntryPoint
-        key={'inspector-entry-selected-views'}
-        selectedViews={selectedViews}
-      />
-    )
-  },
-)
+  return (
+    <SingleInspectorEntryPoint
+      key={'inspector-entry-selected-views'}
+      selectedViews={selectedViews}
+    />
+  )
+})
 
 export const SingleInspectorEntryPoint: React.FunctionComponent<{
   selectedViews: Array<ElementPath>
-}> = betterReactMemo('SingleInspectorEntryPoint', (props) => {
+}> = React.memo((props) => {
   const { selectedViews } = props
   const { dispatch, jsxMetadata, isUIJSFile } = useEditorState((store) => {
     return {
@@ -532,11 +524,11 @@ const rootComponentsSelector = createSelector(
   },
 )
 
-export const InspectorContextProvider = betterReactMemo<{
+export const InspectorContextProvider = React.memo<{
   selectedViews: Array<ElementPath>
   targetPath: Array<string>
   children: React.ReactNode
-}>('InspectorContextProvider', (props) => {
+}>((props) => {
   const { selectedViews } = props
   const { dispatch, jsxMetadata } = useEditorState((store) => {
     return {

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -21,10 +21,7 @@ import { mapToArray } from '../../../../core/shared/object-utils'
 import { ElementPath, PropertyPath } from '../../../../core/shared/project-file-types'
 import * as PP from '../../../../core/shared/property-path'
 import * as EP from '../../../../core/shared/element-path'
-import {
-  betterReactMemo,
-  useKeepReferenceEqualityIfPossible,
-} from '../../../../utils/react-performance'
+import { useKeepReferenceEqualityIfPossible } from '../../../../utils/react-performance'
 import Utils from '../../../../utils/utils'
 import { getParseErrorDetails, ParseError, ParseResult } from '../../../../utils/value-parser-utils'
 import {
@@ -86,62 +83,54 @@ function useComponentPropsInspectorInfo(
   return useInspectorInfoForPropertyControl(propertyPath, control)
 }
 
-const ControlForProp = betterReactMemo(
-  'ControlForProp',
-  (props: ControlForPropProps<BaseControlDescription>) => {
-    const { controlDescription } = props
-    if (controlDescription == null) {
-      return null
-    } else {
-      switch (controlDescription.control) {
-        case 'checkbox':
-          return <CheckboxPropertyControl {...props} controlDescription={controlDescription} />
-        case 'color':
-          return <ColorPropertyControl {...props} controlDescription={controlDescription} />
-        case 'euler':
-          return <EulerPropertyControl {...props} controlDescription={controlDescription} />
-        case 'expression-input':
-          return (
-            <ExpressionInputPropertyControl {...props} controlDescription={controlDescription} />
-          )
-        case 'expression-popuplist':
-          return (
-            <ExpressionPopUpListPropertyControl
-              {...props}
-              controlDescription={controlDescription}
-            />
-          )
-        case 'none':
-          return null
-        case 'matrix3':
-          return <Matrix3PropertyControl {...props} controlDescription={controlDescription} />
-        case 'matrix4':
-          return <Matrix4PropertyControl {...props} controlDescription={controlDescription} />
-        case 'number-input':
-          return <NumberInputPropertyControl {...props} controlDescription={controlDescription} />
-        case 'popuplist':
-          return <PopUpListPropertyControl {...props} controlDescription={controlDescription} />
-        case 'radio':
-          return <RadioPropertyControl {...props} controlDescription={controlDescription} />
-        case 'string-input':
-          return <StringInputPropertyControl {...props} controlDescription={controlDescription} />
-        case 'style-controls':
-          return null
-        case 'vector2':
-        case 'vector3':
-        case 'vector4':
-          return <VectorPropertyControl {...props} controlDescription={controlDescription} />
-        default:
-          return null
-      }
+const ControlForProp = React.memo((props: ControlForPropProps<BaseControlDescription>) => {
+  const { controlDescription } = props
+  if (controlDescription == null) {
+    return null
+  } else {
+    switch (controlDescription.control) {
+      case 'checkbox':
+        return <CheckboxPropertyControl {...props} controlDescription={controlDescription} />
+      case 'color':
+        return <ColorPropertyControl {...props} controlDescription={controlDescription} />
+      case 'euler':
+        return <EulerPropertyControl {...props} controlDescription={controlDescription} />
+      case 'expression-input':
+        return <ExpressionInputPropertyControl {...props} controlDescription={controlDescription} />
+      case 'expression-popuplist':
+        return (
+          <ExpressionPopUpListPropertyControl {...props} controlDescription={controlDescription} />
+        )
+      case 'none':
+        return null
+      case 'matrix3':
+        return <Matrix3PropertyControl {...props} controlDescription={controlDescription} />
+      case 'matrix4':
+        return <Matrix4PropertyControl {...props} controlDescription={controlDescription} />
+      case 'number-input':
+        return <NumberInputPropertyControl {...props} controlDescription={controlDescription} />
+      case 'popuplist':
+        return <PopUpListPropertyControl {...props} controlDescription={controlDescription} />
+      case 'radio':
+        return <RadioPropertyControl {...props} controlDescription={controlDescription} />
+      case 'string-input':
+        return <StringInputPropertyControl {...props} controlDescription={controlDescription} />
+      case 'style-controls':
+        return null
+      case 'vector2':
+      case 'vector3':
+      case 'vector4':
+        return <VectorPropertyControl {...props} controlDescription={controlDescription} />
+      default:
+        return null
     }
-  },
-)
+  }
+})
 interface ParseErrorProps {
   parseError: ParseError
 }
 
-export const ParseErrorControl = betterReactMemo('ParseErrorControl', (props: ParseErrorProps) => {
+export const ParseErrorControl = React.memo((props: ParseErrorProps) => {
   const details = getParseErrorDetails(props.parseError)
   return (
     <div>
@@ -152,7 +141,7 @@ export const ParseErrorControl = betterReactMemo('ParseErrorControl', (props: Pa
   )
 })
 
-const WarningTooltip = betterReactMemo('WarningTooltip', ({ warning }: { warning: string }) => {
+const WarningTooltip = React.memo(({ warning }: { warning: string }) => {
   const colorTheme = useColorTheme()
   return (
     <Tooltip title={warning}>
@@ -176,23 +165,20 @@ interface RowForInvalidControlProps {
   warningTooltip?: string
 }
 
-export const RowForInvalidControl = betterReactMemo(
-  'RowForInvalidControl',
-  (props: RowForInvalidControlProps) => {
-    const propPath = [PP.create([props.propName])]
-    const warning =
-      props.warningTooltip == null ? null : <WarningTooltip warning={props.warningTooltip} />
-    return (
-      <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
-        <PropertyLabel target={propPath}>
-          {warning}
-          {props.title}
-        </PropertyLabel>
-        <ParseErrorControl parseError={props.propertyError} />
-      </UIGridRow>
-    )
-  },
-)
+export const RowForInvalidControl = React.memo((props: RowForInvalidControlProps) => {
+  const propPath = [PP.create([props.propName])]
+  const warning =
+    props.warningTooltip == null ? null : <WarningTooltip warning={props.warningTooltip} />
+  return (
+    <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
+      <PropertyLabel target={propPath}>
+        {warning}
+        {props.title}
+      </PropertyLabel>
+      <ParseErrorControl parseError={props.propertyError} />
+    </UIGridRow>
+  )
+})
 
 interface AbstractRowForControlProps {
   propPath: PropertyPath
@@ -226,7 +212,7 @@ interface RowForBaseControlProps extends AbstractRowForControlProps {
   controlDescription: BaseControlDescription
 }
 
-const RowForBaseControl = betterReactMemo('RowForBaseControl', (props: RowForBaseControlProps) => {
+const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
   const { propPath, controlDescription, isScene } = props
   const title = labelForControl(propPath, controlDescription)
   const propName = `${PP.lastPart(propPath)}`
@@ -302,91 +288,83 @@ interface RowForArrayControlProps extends AbstractRowForControlProps {
   controlDescription: ArrayControlDescription
 }
 
-const RowForArrayControl = betterReactMemo(
-  'RowForArrayControl',
-  (props: RowForArrayControlProps) => {
-    const { propPath, controlDescription, isScene } = props
-    const title = labelForControl(propPath, controlDescription)
-    const { value, onSubmitValue, propertyStatus } = useComponentPropsInspectorInfo(
-      propPath,
-      isScene,
-      controlDescription,
-    )
+const RowForArrayControl = React.memo((props: RowForArrayControlProps) => {
+  const { propPath, controlDescription, isScene } = props
+  const title = labelForControl(propPath, controlDescription)
+  const { value, onSubmitValue, propertyStatus } = useComponentPropsInspectorInfo(
+    propPath,
+    isScene,
+    controlDescription,
+  )
 
-    const rowHeight = UtopiaTheme.layout.rowHeight.normal
-    const transformedValue = Array.isArray(value) ? value : [value]
-    const { springs, bind } = useArraySuperControl(
-      transformedValue,
-      onSubmitValue,
-      rowHeight,
-      false,
-    )
-    const [insertingRow, setInsertingRow] = React.useState(false)
-    const toggleInsertRow = React.useCallback(() => setInsertingRow((current) => !current), [])
+  const rowHeight = UtopiaTheme.layout.rowHeight.normal
+  const transformedValue = Array.isArray(value) ? value : [value]
+  const { springs, bind } = useArraySuperControl(transformedValue, onSubmitValue, rowHeight, false)
+  const [insertingRow, setInsertingRow] = React.useState(false)
+  const toggleInsertRow = React.useCallback(() => setInsertingRow((current) => !current), [])
 
-    React.useEffect(() => setInsertingRow(false), [springs.length])
+  React.useEffect(() => setInsertingRow(false), [springs.length])
 
-    return (
-      <React.Fragment>
-        <InspectorSectionHeader>
-          <SimpleFlexRow style={{ flexGrow: 1 }}>
-            <PropertyLabel target={[propPath]} style={{ textTransform: 'capitalize' }}>
-              {title}
-            </PropertyLabel>
-            {propertyStatus.overwritable ? (
-              <SquareButton highlight onMouseDown={toggleInsertRow}>
-                {insertingRow ? (
-                  <Icons.Minus
-                    style={{ paddingTop: 1 }}
-                    color={propertyStatus.controlled ? 'primary' : 'secondary'}
-                    width={16}
-                    height={16}
-                  />
-                ) : (
-                  <Icons.Plus
-                    style={{ paddingTop: 1 }}
-                    color={propertyStatus.controlled ? 'primary' : 'secondary'}
-                    width={16}
-                    height={16}
-                  />
-                )}
-              </SquareButton>
-            ) : null}
-          </SimpleFlexRow>
-        </InspectorSectionHeader>
-        <div
-          style={{
-            height: rowHeight * springs.length,
-          }}
-        >
-          {springs.map((springStyle, index) => (
-            <ArrayControlItem
-              springStyle={springStyle}
-              bind={bind}
-              key={index} //FIXME this causes the row drag handle to jump after finishing the re-order
-              index={index}
-              propPath={propPath}
-              isScene={props.isScene}
-              controlDescription={controlDescription}
-              focusOnMount={props.focusOnMount}
-              setGlobalCursor={props.setGlobalCursor}
-            />
-          ))}
-        </div>
-        {insertingRow ? (
-          <RowForControl
-            controlDescription={controlDescription.propertyControl}
-            isScene={isScene}
-            propPath={PP.appendPropertyPathElems(propPath, [springs.length])}
+  return (
+    <React.Fragment>
+      <InspectorSectionHeader>
+        <SimpleFlexRow style={{ flexGrow: 1 }}>
+          <PropertyLabel target={[propPath]} style={{ textTransform: 'capitalize' }}>
+            {title}
+          </PropertyLabel>
+          {propertyStatus.overwritable ? (
+            <SquareButton highlight onMouseDown={toggleInsertRow}>
+              {insertingRow ? (
+                <Icons.Minus
+                  style={{ paddingTop: 1 }}
+                  color={propertyStatus.controlled ? 'primary' : 'secondary'}
+                  width={16}
+                  height={16}
+                />
+              ) : (
+                <Icons.Plus
+                  style={{ paddingTop: 1 }}
+                  color={propertyStatus.controlled ? 'primary' : 'secondary'}
+                  width={16}
+                  height={16}
+                />
+              )}
+            </SquareButton>
+          ) : null}
+        </SimpleFlexRow>
+      </InspectorSectionHeader>
+      <div
+        style={{
+          height: rowHeight * springs.length,
+        }}
+      >
+        {springs.map((springStyle, index) => (
+          <ArrayControlItem
+            springStyle={springStyle}
+            bind={bind}
+            key={index} //FIXME this causes the row drag handle to jump after finishing the re-order
+            index={index}
+            propPath={propPath}
+            isScene={props.isScene}
+            controlDescription={controlDescription}
+            focusOnMount={props.focusOnMount}
             setGlobalCursor={props.setGlobalCursor}
-            indentationLevel={1}
-            focusOnMount={false}
           />
-        ) : null}
-      </React.Fragment>
-    )
-  },
-)
+        ))}
+      </div>
+      {insertingRow ? (
+        <RowForControl
+          controlDescription={controlDescription.propertyControl}
+          isScene={isScene}
+          propPath={PP.appendPropertyPathElems(propPath, [springs.length])}
+          setGlobalCursor={props.setGlobalCursor}
+          indentationLevel={1}
+          focusOnMount={false}
+        />
+      ) : null}
+    </React.Fragment>
+  )
+})
 interface ArrayControlItemProps {
   springStyle: { [x: string]: any; [x: number]: any }
   bind: (...args: any[]) => ReactEventHandlers
@@ -398,7 +376,7 @@ interface ArrayControlItemProps {
   setGlobalCursor: (cursor: CSSCursor | null) => void
 }
 
-const ArrayControlItem = betterReactMemo('ArrayControlItem', (props: ArrayControlItemProps) => {
+const ArrayControlItem = React.memo((props: ArrayControlItemProps) => {
   const colorTheme = useColorTheme()
   const { bind, propPath, index, isScene, springStyle, controlDescription } = props
   const propPathWithIndex = PP.appendPropertyPathElems(propPath, [index])
@@ -474,53 +452,50 @@ interface RowForTupleControlProps extends AbstractRowForControlProps {
   controlDescription: TupleControlDescription
 }
 
-const RowForTupleControl = betterReactMemo(
-  'RowForTupleControl',
-  (props: RowForTupleControlProps) => {
-    const { propPath, controlDescription, isScene } = props
-    const title = labelForControl(propPath, controlDescription)
-    const { value, onSubmitValue, propertyStatus } = useComponentPropsInspectorInfo(
-      propPath,
-      isScene,
-      controlDescription,
-    )
+const RowForTupleControl = React.memo((props: RowForTupleControlProps) => {
+  const { propPath, controlDescription, isScene } = props
+  const title = labelForControl(propPath, controlDescription)
+  const { value, onSubmitValue, propertyStatus } = useComponentPropsInspectorInfo(
+    propPath,
+    isScene,
+    controlDescription,
+  )
 
-    const rowHeight = UtopiaTheme.layout.rowHeight.normal
-    const transformedValue = Array.isArray(value) ? value : [value]
-    const boundedTransformedValue = transformedValue.slice(
-      0,
-      controlDescription.propertyControls.length,
-    )
+  const rowHeight = UtopiaTheme.layout.rowHeight.normal
+  const transformedValue = Array.isArray(value) ? value : [value]
+  const boundedTransformedValue = transformedValue.slice(
+    0,
+    controlDescription.propertyControls.length,
+  )
 
-    return (
-      <React.Fragment>
-        <InspectorSectionHeader>
-          <SimpleFlexRow style={{ flexGrow: 1 }}>
-            <PropertyLabel target={[propPath]} style={{ textTransform: 'capitalize' }}>
-              {title}
-            </PropertyLabel>
-          </SimpleFlexRow>
-        </InspectorSectionHeader>
-        <div
-          style={{
-            height: rowHeight * boundedTransformedValue.length,
-          }}
-        >
-          {boundedTransformedValue.map((_, index) => (
-            <TupleControlItem
-              key={index}
-              index={index}
-              propPath={propPath}
-              isScene={props.isScene}
-              controlDescription={controlDescription}
-              setGlobalCursor={props.setGlobalCursor}
-            />
-          ))}
-        </div>
-      </React.Fragment>
-    )
-  },
-)
+  return (
+    <React.Fragment>
+      <InspectorSectionHeader>
+        <SimpleFlexRow style={{ flexGrow: 1 }}>
+          <PropertyLabel target={[propPath]} style={{ textTransform: 'capitalize' }}>
+            {title}
+          </PropertyLabel>
+        </SimpleFlexRow>
+      </InspectorSectionHeader>
+      <div
+        style={{
+          height: rowHeight * boundedTransformedValue.length,
+        }}
+      >
+        {boundedTransformedValue.map((_, index) => (
+          <TupleControlItem
+            key={index}
+            index={index}
+            propPath={propPath}
+            isScene={props.isScene}
+            controlDescription={controlDescription}
+            setGlobalCursor={props.setGlobalCursor}
+          />
+        ))}
+      </div>
+    </React.Fragment>
+  )
+})
 
 interface TupleControlItemProps {
   propPath: PropertyPath
@@ -530,7 +505,7 @@ interface TupleControlItemProps {
   setGlobalCursor: (cursor: CSSCursor | null) => void
 }
 
-const TupleControlItem = betterReactMemo('TupleControlItem', (props: TupleControlItemProps) => {
+const TupleControlItem = React.memo((props: TupleControlItemProps) => {
   const { propPath, index, isScene, controlDescription } = props
   const propPathWithIndex = PP.appendPropertyPathElems(propPath, [index])
   const propMetadata = useComponentPropsInspectorInfo(
@@ -587,164 +562,158 @@ interface RowForObjectControlProps extends AbstractRowForControlProps {
   controlDescription: ObjectControlDescription
 }
 
-const RowForObjectControl = betterReactMemo(
-  'RowForObjectControl',
-  (props: RowForObjectControlProps) => {
-    const [open, setOpen] = React.useState(true)
-    const handleOnClick = React.useCallback(() => setOpen(!open), [setOpen, open])
-    const { propPath, controlDescription, isScene } = props
-    const title = labelForControl(propPath, controlDescription)
-    const indentation = props.indentationLevel * 8
+const RowForObjectControl = React.memo((props: RowForObjectControlProps) => {
+  const [open, setOpen] = React.useState(true)
+  const handleOnClick = React.useCallback(() => setOpen(!open), [setOpen, open])
+  const { propPath, controlDescription, isScene } = props
+  const title = labelForControl(propPath, controlDescription)
+  const indentation = props.indentationLevel * 8
 
-    const propMetadata = useComponentPropsInspectorInfo(propPath, isScene, controlDescription)
-    const contextMenuItems = Utils.stripNulls([
-      addOnUnsetValues([PP.lastPart(propPath)], propMetadata.onUnsetValues),
-    ])
+  const propMetadata = useComponentPropsInspectorInfo(propPath, isScene, controlDescription)
+  const contextMenuItems = Utils.stripNulls([
+    addOnUnsetValues([PP.lastPart(propPath)], propMetadata.onUnsetValues),
+  ])
 
-    return (
-      <div
-        css={{
-          marginTop: 8,
-          marginBottom: 8,
-          '&:hover': {
-            boxShadow: 'inset 1px 0px 0px 0px hsla(0,0%,0%,20%)',
-            background: 'hsl(0,0%,0%,1%)',
-          },
-          '&:focus-within': {
-            boxShadow: 'inset 1px 0px 0px 0px hsla(0,0%,0%,20%)',
-            background: 'hsl(0,0%,0%,1%)',
-          },
-        }}
-      >
-        <div onClick={handleOnClick}>
-          <InspectorContextMenuWrapper
-            id={`context-menu-for-${PP.toString(propPath)}`}
-            items={contextMenuItems}
-            data={null}
-          >
-            <SimpleFlexRow style={{ flexGrow: 1, paddingRight: 8 }}>
-              <PropertyLabel
-                target={[propPath]}
-                style={{
-                  textTransform: 'capitalize',
-                  paddingLeft: indentation,
-                  display: 'flex',
-                  alignItems: 'center',
-                  height: 34,
-                  fontWeight: 500,
-                  gap: 4,
-                  cursor: 'pointer',
-                }}
-              >
-                {title}
-                <ObjectIndicator open={open} />
-              </PropertyLabel>
-            </SimpleFlexRow>
-          </InspectorContextMenuWrapper>
-        </div>
-        {when(
-          open,
-          mapToArray((innerControl: RegularControlDescription, prop: string, index: number) => {
-            const innerPropPath = PP.appendPropertyPathElems(propPath, [prop])
-            return (
-              <RowForControl
-                key={`object-control-row-${PP.toString(innerPropPath)}`}
-                controlDescription={innerControl}
-                isScene={isScene}
-                propPath={innerPropPath}
-                setGlobalCursor={props.setGlobalCursor}
-                indentationLevel={props.indentationLevel + 1}
-                focusOnMount={props.focusOnMount && index === 0}
-              />
-            )
-          }, controlDescription.object),
-        )}
+  return (
+    <div
+      css={{
+        marginTop: 8,
+        marginBottom: 8,
+        '&:hover': {
+          boxShadow: 'inset 1px 0px 0px 0px hsla(0,0%,0%,20%)',
+          background: 'hsl(0,0%,0%,1%)',
+        },
+        '&:focus-within': {
+          boxShadow: 'inset 1px 0px 0px 0px hsla(0,0%,0%,20%)',
+          background: 'hsl(0,0%,0%,1%)',
+        },
+      }}
+    >
+      <div onClick={handleOnClick}>
+        <InspectorContextMenuWrapper
+          id={`context-menu-for-${PP.toString(propPath)}`}
+          items={contextMenuItems}
+          data={null}
+        >
+          <SimpleFlexRow style={{ flexGrow: 1, paddingRight: 8 }}>
+            <PropertyLabel
+              target={[propPath]}
+              style={{
+                textTransform: 'capitalize',
+                paddingLeft: indentation,
+                display: 'flex',
+                alignItems: 'center',
+                height: 34,
+                fontWeight: 500,
+                gap: 4,
+                cursor: 'pointer',
+              }}
+            >
+              {title}
+              <ObjectIndicator open={open} />
+            </PropertyLabel>
+          </SimpleFlexRow>
+        </InspectorContextMenuWrapper>
       </div>
-    )
-  },
-)
+      {when(
+        open,
+        mapToArray((innerControl: RegularControlDescription, prop: string, index: number) => {
+          const innerPropPath = PP.appendPropertyPathElems(propPath, [prop])
+          return (
+            <RowForControl
+              key={`object-control-row-${PP.toString(innerPropPath)}`}
+              controlDescription={innerControl}
+              isScene={isScene}
+              propPath={innerPropPath}
+              setGlobalCursor={props.setGlobalCursor}
+              indentationLevel={props.indentationLevel + 1}
+              focusOnMount={props.focusOnMount && index === 0}
+            />
+          )
+        }, controlDescription.object),
+      )}
+    </div>
+  )
+})
 
 interface RowForUnionControlProps extends AbstractRowForControlProps {
   controlDescription: UnionControlDescription
 }
 
-const RowForUnionControl = betterReactMemo(
-  'RowForUnionControl',
-  (props: RowForUnionControlProps) => {
-    const { propPath, controlDescription } = props
-    const title = labelForControl(propPath, controlDescription)
+const RowForUnionControl = React.memo((props: RowForUnionControlProps) => {
+  const { propPath, controlDescription } = props
+  const title = labelForControl(propPath, controlDescription)
 
-    const suitableControl = useControlForUnionControl(propPath, controlDescription)
-    const [controlToUse, setControlToUse] = React.useState(suitableControl)
+  const suitableControl = useControlForUnionControl(propPath, controlDescription)
+  const [controlToUse, setControlToUse] = React.useState(suitableControl)
 
-    const labelOptions: OptionsType<SelectOption> = controlDescription.controls.map((control) => {
-      const label = control.label ?? control.control
-      return {
-        value: control,
-        label: label,
-      }
-    })
-
-    const onLabelChangeValue = React.useCallback(
-      (option: SelectOption) => {
-        if (option.value !== controlToUse) {
-          setControlToUse(option.value)
-        }
-      },
-      [controlToUse, setControlToUse],
-    )
-
-    const simpleControlStyles = getControlStyles('simple')
-
-    const label = React.useMemo(
-      () => (
-        <PopupList
-          value={{
-            value: controlToUse,
-            label: title,
-          }}
-          options={labelOptions}
-          onSubmitValue={onLabelChangeValue}
-          containerMode='showBorderOnHover'
-          controlStyles={simpleControlStyles}
-          style={{
-            maxWidth: '100%',
-            overflow: 'hidden',
-          }}
-        />
-      ),
-      [controlToUse, labelOptions, onLabelChangeValue, simpleControlStyles, title],
-    )
-
-    const labelAsRenderProp = React.useCallback(() => label, [label])
-
-    if (controlToUse == null) {
-      return null
-    } else if (isBaseControlDescription(controlToUse)) {
-      return (
-        <RowForBaseControl
-          {...props}
-          label={labelAsRenderProp}
-          controlDescription={controlToUse}
-          focusOnMount={false}
-        />
-      )
-    } else {
-      return (
-        <React.Fragment>
-          {label}
-          <RowForControl {...props} controlDescription={controlToUse} focusOnMount={false} />
-        </React.Fragment>
-      )
+  const labelOptions: OptionsType<SelectOption> = controlDescription.controls.map((control) => {
+    const label = control.label ?? control.control
+    return {
+      value: control,
+      label: label,
     }
-  },
-)
+  })
+
+  const onLabelChangeValue = React.useCallback(
+    (option: SelectOption) => {
+      if (option.value !== controlToUse) {
+        setControlToUse(option.value)
+      }
+    },
+    [controlToUse, setControlToUse],
+  )
+
+  const simpleControlStyles = getControlStyles('simple')
+
+  const label = React.useMemo(
+    () => (
+      <PopupList
+        value={{
+          value: controlToUse,
+          label: title,
+        }}
+        options={labelOptions}
+        onSubmitValue={onLabelChangeValue}
+        containerMode='showBorderOnHover'
+        controlStyles={simpleControlStyles}
+        style={{
+          maxWidth: '100%',
+          overflow: 'hidden',
+        }}
+      />
+    ),
+    [controlToUse, labelOptions, onLabelChangeValue, simpleControlStyles, title],
+  )
+
+  const labelAsRenderProp = React.useCallback(() => label, [label])
+
+  if (controlToUse == null) {
+    return null
+  } else if (isBaseControlDescription(controlToUse)) {
+    return (
+      <RowForBaseControl
+        {...props}
+        label={labelAsRenderProp}
+        controlDescription={controlToUse}
+        focusOnMount={false}
+      />
+    )
+  } else {
+    return (
+      <React.Fragment>
+        {label}
+        <RowForControl {...props} controlDescription={controlToUse} focusOnMount={false} />
+      </React.Fragment>
+    )
+  }
+})
 
 interface RowForControlProps extends AbstractRowForControlProps {
   controlDescription: RegularControlDescription
 }
 
-export const RowForControl = betterReactMemo('RowForControl', (props: RowForControlProps) => {
+export const RowForControl = React.memo((props: RowForControlProps) => {
   const { controlDescription } = props
   if (isBaseControlDescription(controlDescription)) {
     return <RowForBaseControl {...props} controlDescription={controlDescription} />
@@ -769,61 +738,58 @@ export interface ComponentSectionProps {
   isScene: boolean
 }
 
-export const ComponentSectionInner = betterReactMemo(
-  'ComponentSectionInner',
-  (props: ComponentSectionProps) => {
-    const colorTheme = useColorTheme()
+export const ComponentSectionInner = React.memo((props: ComponentSectionProps) => {
+  const colorTheme = useColorTheme()
 
-    const propertyControlsAndTargets = useKeepReferenceEqualityIfPossible(
-      useGetPropertyControlsForSelectedComponents(),
-    )
+  const propertyControlsAndTargets = useKeepReferenceEqualityIfPossible(
+    useGetPropertyControlsForSelectedComponents(),
+  )
 
-    const [sectionExpanded, setSectionExpanded] = React.useState(true)
-    const toggleSection = React.useCallback(() => {
-      setSectionExpanded((currentlyExpanded) => !currentlyExpanded)
-    }, [setSectionExpanded])
+  const [sectionExpanded, setSectionExpanded] = React.useState(true)
+  const toggleSection = React.useCallback(() => {
+    setSectionExpanded((currentlyExpanded) => !currentlyExpanded)
+  }, [setSectionExpanded])
 
-    return (
-      <React.Fragment>
-        <InspectorSectionHeader>
-          <FlexRow style={{ flexGrow: 1, color: colorTheme.primary.value, gap: 8 }}>
-            <Icons.Component color='primary' />
-            <span>Component </span>
-          </FlexRow>
-          <SquareButton highlight onClick={toggleSection}>
-            <ExpandableIndicator
-              testId='component-section-expand'
-              visible
-              collapsed={!sectionExpanded}
-              selected={false}
+  return (
+    <React.Fragment>
+      <InspectorSectionHeader>
+        <FlexRow style={{ flexGrow: 1, color: colorTheme.primary.value, gap: 8 }}>
+          <Icons.Component color='primary' />
+          <span>Component </span>
+        </FlexRow>
+        <SquareButton highlight onClick={toggleSection}>
+          <ExpandableIndicator
+            testId='component-section-expand'
+            visible
+            collapsed={!sectionExpanded}
+            selected={false}
+          />
+        </SquareButton>
+      </InspectorSectionHeader>
+      {when(
+        sectionExpanded,
+        <React.Fragment>
+          {/* Information about the component as a whole */}
+          <ComponentInfoBox />
+          {/* List of component props with controls */}
+          {propertyControlsAndTargets.map((controlsAndTargets) => (
+            <PropertyControlsSection
+              key={EP.toString(controlsAndTargets.targets[0])}
+              propertyControls={controlsAndTargets.controls}
+              targets={controlsAndTargets.targets}
+              isScene={props.isScene}
+              detectedPropsAndValuesWithoutControls={
+                controlsAndTargets.detectedPropsAndValuesWithoutControls
+              }
+              detectedPropsWithNoValue={controlsAndTargets.detectedPropsWithNoValue}
+              propsWithControlsButNoValue={controlsAndTargets.propsWithControlsButNoValue}
             />
-          </SquareButton>
-        </InspectorSectionHeader>
-        {when(
-          sectionExpanded,
-          <React.Fragment>
-            {/* Information about the component as a whole */}
-            <ComponentInfoBox />
-            {/* List of component props with controls */}
-            {propertyControlsAndTargets.map((controlsAndTargets) => (
-              <PropertyControlsSection
-                key={EP.toString(controlsAndTargets.targets[0])}
-                propertyControls={controlsAndTargets.controls}
-                targets={controlsAndTargets.targets}
-                isScene={props.isScene}
-                detectedPropsAndValuesWithoutControls={
-                  controlsAndTargets.detectedPropsAndValuesWithoutControls
-                }
-                detectedPropsWithNoValue={controlsAndTargets.detectedPropsWithNoValue}
-                propsWithControlsButNoValue={controlsAndTargets.propsWithControlsButNoValue}
-              />
-            ))}
-          </React.Fragment>,
-        )}
-      </React.Fragment>
-    )
-  },
-)
+          ))}
+        </React.Fragment>,
+      )}
+    </React.Fragment>
+  )
+})
 
 export interface ComponentSectionState {
   errorOccurred: boolean

--- a/editor/src/components/inspector/sections/component-section/folder-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/folder-section.tsx
@@ -4,7 +4,6 @@ import { css, jsx } from '@emotion/react'
 import { ParsedPropertyControls } from '../../../../core/property-controls/property-controls-parser'
 import { eitherToMaybe, foldEither } from '../../../../core/shared/either'
 import { unless, when } from '../../../../utils/react-conditionals'
-import { betterReactMemo } from '../../../../uuiui-deps'
 import { CSSCursor } from '../../../canvas/canvas-types'
 import { ControlDescription } from 'utopia-api'
 import { inferControlTypeBasedOnValue } from './component-section-utils'
@@ -30,7 +29,7 @@ interface FolderSectionProps {
   title?: string
 }
 
-export const FolderSection = betterReactMemo('FolderSection', (props: FolderSectionProps) => {
+export const FolderSection = React.memo((props: FolderSectionProps) => {
   const showIndentation = useAtom(InspectorWidthAtom)[0] === 'wide'
   const [open, setOpen] = React.useState(true)
   const colorTheme = useColorTheme()
@@ -186,7 +185,7 @@ interface FolderLabelProps {
   showIndentation: boolean
 }
 
-const FolderLabel = betterReactMemo('FolderLabel', (props: FolderLabelProps) => {
+const FolderLabel = React.memo((props: FolderLabelProps) => {
   const { toggleOpen } = props
   const indentation = props.showIndentation ? props.indentationLevel * 8 : 0
   const handleOnClick = React.useCallback(() => toggleOpen(), [toggleOpen])
@@ -219,7 +218,7 @@ interface ExpansionArrowSVGProps {
   style: React.CSSProperties
 }
 
-const ExpansionArrowSVG = betterReactMemo('ExpansionArrowSVG', (props: ExpansionArrowSVGProps) => {
+const ExpansionArrowSVG = React.memo((props: ExpansionArrowSVGProps) => {
   const colorTheme = useColorTheme()
   return (
     <svg width='7px' height='5px' viewBox='0 0 7 5' version='1.1' style={props.style}>

--- a/editor/src/components/inspector/sections/component-section/hidden-controls-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/hidden-controls-section.tsx
@@ -2,7 +2,6 @@
 import React from 'react'
 import { css, jsx } from '@emotion/react'
 import { Subdued, useColorTheme, UtopiaTheme } from '../../../../uuiui'
-import { betterReactMemo } from '../../../../uuiui-deps'
 import { ControlStatus } from '../../common/control-status'
 
 interface HiddenControlsProps {
@@ -37,42 +36,39 @@ export function filterUnsetControls(
   return pathNames.filter((name) => isControlUnset(propertyControlsStatus[name]))
 }
 
-export const HiddenControls = betterReactMemo(
-  'HiddenControls',
-  (props: HiddenControlsProps): JSX.Element | null => {
-    const indentation = props.indentationLevel * 8
-    if (props.hiddenPropNames.length > 0) {
-      return (
-        <div
-          style={{
-            padding: '0px 8px',
-            paddingLeft: indentation,
-            minHeight: UtopiaTheme.layout.rowHeight.normal,
-            display: 'flex',
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            gap: '0px 2px',
-            alignItems: 'center',
-          }}
-        >
-          <Subdued>Available: </Subdued>
-          {props.hiddenPropNames.map((name, index) => {
-            return (
-              <HiddenControlLabel
-                key={name}
-                propName={name}
-                showHiddenControl={props.showHiddenControl}
-                isLast={props.hiddenPropNames.length - 1 === index}
-              />
-            )
-          })}
-        </div>
-      )
-    } else {
-      return null
-    }
-  },
-)
+export const HiddenControls = React.memo((props: HiddenControlsProps): JSX.Element | null => {
+  const indentation = props.indentationLevel * 8
+  if (props.hiddenPropNames.length > 0) {
+    return (
+      <div
+        style={{
+          padding: '0px 8px',
+          paddingLeft: indentation,
+          minHeight: UtopiaTheme.layout.rowHeight.normal,
+          display: 'flex',
+          flexDirection: 'row',
+          flexWrap: 'wrap',
+          gap: '0px 2px',
+          alignItems: 'center',
+        }}
+      >
+        <Subdued>Available: </Subdued>
+        {props.hiddenPropNames.map((name, index) => {
+          return (
+            <HiddenControlLabel
+              key={name}
+              propName={name}
+              showHiddenControl={props.showHiddenControl}
+              isLast={props.hiddenPropNames.length - 1 === index}
+            />
+          )
+        })}
+      </div>
+    )
+  } else {
+    return null
+  }
+})
 
 interface HiddenControlLabelProps {
   propName: string
@@ -80,28 +76,25 @@ interface HiddenControlLabelProps {
   isLast: boolean
 }
 
-const HiddenControlLabel = betterReactMemo(
-  'HiddenControlLabel',
-  (props: HiddenControlLabelProps): JSX.Element | null => {
-    const colorTheme = useColorTheme()
-    const { propName, showHiddenControl } = props
-    const labelOnClick = React.useCallback(() => showHiddenControl(propName), [
-      propName,
-      showHiddenControl,
-    ])
-    return (
-      <Subdued
-        css={{
-          ':hover': {
-            color: colorTheme.primary.value,
-          },
-        }}
-        style={{ cursor: 'pointer' }}
-        onClick={labelOnClick}
-      >
-        {propName}
-        {props.isLast ? '' : ', '}
-      </Subdued>
-    )
-  },
-)
+const HiddenControlLabel = React.memo((props: HiddenControlLabelProps): JSX.Element | null => {
+  const colorTheme = useColorTheme()
+  const { propName, showHiddenControl } = props
+  const labelOnClick = React.useCallback(() => showHiddenControl(propName), [
+    propName,
+    showHiddenControl,
+  ])
+  return (
+    <Subdued
+      css={{
+        ':hover': {
+          color: colorTheme.primary.value,
+        },
+      }}
+      style={{ cursor: 'pointer' }}
+      onClick={labelOnClick}
+    >
+      {propName}
+      {props.isLast ? '' : ', '}
+    </Subdued>
+  )
+})

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -1,6 +1,6 @@
 import fastDeepEquals from 'fast-deep-equal'
 import React from 'react'
-import { betterReactMemo, CSSCursor, SliderControl } from '../../../../uuiui-deps'
+import { CSSCursor, SliderControl } from '../../../../uuiui-deps'
 import {
   AllowedEnumType,
   BaseControlDescription,
@@ -66,8 +66,7 @@ export interface ControlForPropProps<T extends BaseControlDescription> {
   focusOnMount: boolean
 }
 
-export const CheckboxPropertyControl = betterReactMemo(
-  'CheckboxPropertyControl',
+export const CheckboxPropertyControl = React.memo(
   (props: ControlForPropProps<CheckboxControlDescription>) => {
     const { propName, propMetadata, controlDescription } = props
 
@@ -89,8 +88,7 @@ export const CheckboxPropertyControl = betterReactMemo(
   },
 )
 
-export const ColorPropertyControl = betterReactMemo(
-  'ColorPropertyControl',
+export const ColorPropertyControl = React.memo(
   (props: ControlForPropProps<ColorControlDescription>) => {
     const { propName, propMetadata, controlDescription } = props
 
@@ -115,8 +113,7 @@ export const ColorPropertyControl = betterReactMemo(
   },
 )
 
-export const ExpressionInputPropertyControl = betterReactMemo(
-  'ExpressionInputPropertyControl',
+export const ExpressionInputPropertyControl = React.memo(
   (props: ControlForPropProps<ExpressionInputControlDescription>) => {
     const { propName, propMetadata, controlDescription } = props
     const dispatch = useEditorState(
@@ -191,8 +188,7 @@ function labelForIndividualOption(option: IndividualOption): string {
   }
 }
 
-export const PopUpListPropertyControl = betterReactMemo(
-  'PopUpListPropertyControl',
+export const PopUpListPropertyControl = React.memo(
   (props: ControlForPropProps<PopUpListControlDescription>) => {
     const { propMetadata, controlDescription } = props
     const value = propMetadata.propertyStatus.set ? propMetadata.value : undefined
@@ -229,8 +225,7 @@ export const PopUpListPropertyControl = betterReactMemo(
   },
 )
 
-export const ExpressionPopUpListPropertyControl = betterReactMemo(
-  'ExpressionPopUpListPropertyControl',
+export const ExpressionPopUpListPropertyControl = React.memo(
   (props: ControlForPropProps<ExpressionPopUpListControlDescription>) => {
     const dispatch = useEditorState(
       (store) => store.dispatch,
@@ -314,8 +309,7 @@ export const ExpressionPopUpListPropertyControl = betterReactMemo(
   },
 )
 
-export const NumberInputPropertyControl = betterReactMemo(
-  'NumberInputPropertyControl',
+export const NumberInputPropertyControl = React.memo(
   (props: ControlForPropProps<NumberInputControlDescription>) => {
     const { propName, propMetadata, controlDescription } = props
 
@@ -330,14 +324,18 @@ export const NumberInputPropertyControl = betterReactMemo(
 
     const controlId = `${propName}-number-input-property-control`
     const value = propMetadata.propertyStatus.set ? propMetadata.value : undefined
-
-    if (controlDescription.min != null && controlDescription.max != null) {
-      const controlOptions: DEPRECATEDSliderControlOptions = useKeepReferenceEqualityIfPossible({
-        minimum: controlDescription.min,
-        maximum: controlDescription.max,
-        stepSize: controlDescription.step,
-      })
-      return <NumberWithSliderControl {...props} controlOptions={controlOptions} />
+    const controlOptions = useKeepReferenceEqualityIfPossible({
+      minimum: controlDescription.min,
+      maximum: controlDescription.max,
+      stepSize: controlDescription.step,
+    })
+    if (controlOptions.minimum != null && controlOptions.maximum != null) {
+      return (
+        <NumberWithSliderControl
+          {...props}
+          controlOptions={controlOptions as DEPRECATEDSliderControlOptions}
+        />
+      )
     } else {
       return (
         <SimpleNumberInput
@@ -361,8 +359,7 @@ export const NumberInputPropertyControl = betterReactMemo(
   },
 )
 
-export const RadioPropertyControl = betterReactMemo(
-  'RadioPropertyControl',
+export const RadioPropertyControl = React.memo(
   (props: ControlForPropProps<RadioControlDescription>) => {
     const { propName, propMetadata, controlDescription } = props
 
@@ -403,8 +400,7 @@ export const RadioPropertyControl = betterReactMemo(
   },
 )
 
-const NumberWithSliderControl = betterReactMemo(
-  'NumberWithSliderControl',
+const NumberWithSliderControl = React.memo(
   (
     props: ControlForPropProps<NumberInputControlDescription> & {
       controlOptions: DEPRECATEDSliderControlOptions
@@ -449,8 +445,7 @@ const NumberWithSliderControl = betterReactMemo(
   },
 )
 
-export const StringInputPropertyControl = betterReactMemo(
-  'StringInputPropertyControl',
+export const StringInputPropertyControl = React.memo(
   (props: ControlForPropProps<StringInputControlDescription>) => {
     const { propName, propMetadata, controlDescription } = props
 
@@ -521,8 +516,7 @@ function propsArrayForCSSNumberArray(
   })
 }
 
-export const VectorPropertyControl = betterReactMemo(
-  'VectorPropertyControl',
+export const VectorPropertyControl = React.memo(
   (
     props: ControlForPropProps<
       Vector2ControlDescription | Vector3ControlDescription | Vector4ControlDescription
@@ -549,8 +543,7 @@ export const VectorPropertyControl = betterReactMemo(
   },
 )
 
-export const EulerPropertyControl = betterReactMemo(
-  'EulerPropertyControl',
+export const EulerPropertyControl = React.memo(
   (props: ControlForPropProps<EulerControlDescription>) => {
     const { propPath, propMetadata, controlDescription, setGlobalCursor } = props
 
@@ -598,8 +591,7 @@ export const EulerPropertyControl = betterReactMemo(
   },
 )
 
-export const Matrix3PropertyControl = betterReactMemo(
-  'Matrix3PropertyControl',
+export const Matrix3PropertyControl = React.memo(
   (props: ControlForPropProps<Matrix3ControlDescription>) => {
     const { propPath, propMetadata, controlDescription, setGlobalCursor } = props
 
@@ -643,8 +635,7 @@ export const Matrix3PropertyControl = betterReactMemo(
   },
 )
 
-export const Matrix4PropertyControl = betterReactMemo(
-  'Matrix4PropertyControl',
+export const Matrix4PropertyControl = React.memo(
   (props: ControlForPropProps<Matrix4ControlDescription>) => {
     const { propPath, propMetadata, controlDescription, setGlobalCursor } = props
 

--- a/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
@@ -9,7 +9,6 @@ import { InspectorPropsContext, InspectorPropsContextData } from '../../common/p
 import * as EP from '../../../../core/shared/element-path'
 import { ParseResult } from '../../../../utils/value-parser-utils'
 import { ParsedPropertyControls } from '../../../../core/property-controls/property-controls-parser'
-import { betterReactMemo } from '../../../../uuiui-deps'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { setCursorOverlay } from '../../../editor/actions/action-creators'
 import { useKeepReferenceEqualityIfPossible } from '../../../../utils/react-performance'
@@ -53,70 +52,67 @@ interface PropertyControlsSectionProps {
   isScene: boolean
 }
 
-export const PropertyControlsSection = betterReactMemo(
-  'PropertyControlsSection',
-  (props: PropertyControlsSectionProps) => {
-    const {
-      targets,
-      propertyControls,
-      detectedPropsWithNoValue,
-      detectedPropsAndValuesWithoutControls,
-      propsWithControlsButNoValue,
-    } = props
+export const PropertyControlsSection = React.memo((props: PropertyControlsSectionProps) => {
+  const {
+    targets,
+    propertyControls,
+    detectedPropsWithNoValue,
+    detectedPropsAndValuesWithoutControls,
+    propsWithControlsButNoValue,
+  } = props
 
-    // Filter out these because we don't want to include them in the unused props.
-    const filteredDetectedPropsWithNoValue = useKeepReferenceEqualityIfPossible(
-      detectedPropsWithNoValue.filter((detectedPropWithNoValue) => {
-        return !specialPropertiesToIgnore.includes(detectedPropWithNoValue)
-      }),
-    )
+  // Filter out these because we don't want to include them in the unused props.
+  const filteredDetectedPropsWithNoValue = useKeepReferenceEqualityIfPossible(
+    detectedPropsWithNoValue.filter((detectedPropWithNoValue) => {
+      return !specialPropertiesToIgnore.includes(detectedPropWithNoValue)
+    }),
+  )
 
-    const dispatch = useEditorState((state) => state.dispatch, 'ComponentSectionInner')
-    const setGlobalCursor = React.useCallback(
-      (cursor: CSSCursor | null) => {
-        dispatch([setCursorOverlay(cursor)], 'everyone')
-      },
-      [dispatch],
-    )
+  const dispatch = useEditorState((state) => state.dispatch, 'ComponentSectionInner')
+  const setGlobalCursor = React.useCallback(
+    (cursor: CSSCursor | null) => {
+      dispatch([setCursorOverlay(cursor)], 'everyone')
+    },
+    [dispatch],
+  )
 
-    const updatedContext = useKeepReferenceEqualityIfPossible(useFilterPropsContext(targets))
-    const [visibleEmptyControls, showHiddenControl] = useHiddenElements()
+  const updatedContext = useKeepReferenceEqualityIfPossible(useFilterPropsContext(targets))
+  const [visibleEmptyControls, showHiddenControl] = useHiddenElements()
 
-    const rootFolder = foldEither(
-      (rootParseError) => {
-        return <ParseErrorControl parseError={rootParseError} />
-      },
-      (rootParseSuccess) => {
-        return (
-          <FolderSection
-            isRoot={true}
-            indentationLevel={0}
-            parsedPropertyControls={rootParseSuccess}
-            setGlobalCursor={setGlobalCursor}
-            visibleEmptyControls={visibleEmptyControls}
-            unsetPropNames={propsWithControlsButNoValue}
-            showHiddenControl={showHiddenControl}
-            detectedPropsAndValuesWithoutControls={detectedPropsAndValuesWithoutControls}
-          />
-        )
-      },
-      propertyControls,
-    )
+  const rootFolder = foldEither(
+    (rootParseError) => {
+      return <ParseErrorControl parseError={rootParseError} />
+    },
+    (rootParseSuccess) => {
+      return (
+        <FolderSection
+          isRoot={true}
+          indentationLevel={0}
+          parsedPropertyControls={rootParseSuccess}
+          setGlobalCursor={setGlobalCursor}
+          visibleEmptyControls={visibleEmptyControls}
+          unsetPropNames={propsWithControlsButNoValue}
+          showHiddenControl={showHiddenControl}
+          detectedPropsAndValuesWithoutControls={detectedPropsAndValuesWithoutControls}
+        />
+      )
+    },
+    propertyControls,
+  )
 
-    return (
-      <InspectorPropsContext.Provider value={updatedContext}>
-        {rootFolder}
-        {/** props set on the component instance and props used inside the component code */}
-        {filteredDetectedPropsWithNoValue.length > 0 ? (
-          <UIGridRow padded tall={false} variant={'<-------------1fr------------->'}>
-            <div>
-              <VerySubdued>{`Unused props: ${filteredDetectedPropsWithNoValue.join(
-                ', ',
-              )}.`}</VerySubdued>
-            </div>
-          </UIGridRow>
-        ) : null}
-      </InspectorPropsContext.Provider>
-    )
-  },
-)
+  return (
+    <InspectorPropsContext.Provider value={updatedContext}>
+      {rootFolder}
+      {/** props set on the component instance and props used inside the component code */}
+      {filteredDetectedPropsWithNoValue.length > 0 ? (
+        <UIGridRow padded tall={false} variant={'<-------------1fr------------->'}>
+          <div>
+            <VerySubdued>{`Unused props: ${filteredDetectedPropsWithNoValue.join(
+              ', ',
+            )}.`}</VerySubdued>
+          </div>
+        </UIGridRow>
+      ) : null}
+    </InspectorPropsContext.Provider>
+  )
+})

--- a/editor/src/components/inspector/sections/component-section/row-or-folder-wrapper.tsx
+++ b/editor/src/components/inspector/sections/component-section/row-or-folder-wrapper.tsx
@@ -4,7 +4,6 @@ import { right } from '../../../../core/shared/either'
 import { objectMap } from '../../../../core/shared/object-utils'
 import { PropertyPath } from '../../../../core/shared/project-file-types'
 import { ParseResult } from '../../../../utils/value-parser-utils'
-import { betterReactMemo } from '../../../../uuiui-deps'
 import { CSSCursor } from '../../../canvas/canvas-types'
 import { UIGridRow } from '../../widgets/ui-grid-row'
 import { FolderSection } from './folder-section'
@@ -23,45 +22,42 @@ type RowOrFolderWrapperProps = {
   focusOnMount?: boolean
 }
 
-export const RowOrFolderWrapper = betterReactMemo(
-  'RowOrFolderWrapper',
-  (props: RowOrFolderWrapperProps) => {
-    switch (props.controlDescription.control) {
-      case 'folder':
-        return (
-          <FolderSection
-            isRoot={false}
-            indentationLevel={props.indentationLevel}
-            parsedPropertyControls={objectMap(
-              (c): ParseResult<ControlDescription> => right(c), // this is not the nicest, but the Either type inference is a bit limited
-              props.controlDescription.controls,
-            )}
+export const RowOrFolderWrapper = React.memo((props: RowOrFolderWrapperProps) => {
+  switch (props.controlDescription.control) {
+    case 'folder':
+      return (
+        <FolderSection
+          isRoot={false}
+          indentationLevel={props.indentationLevel}
+          parsedPropertyControls={objectMap(
+            (c): ParseResult<ControlDescription> => right(c), // this is not the nicest, but the Either type inference is a bit limited
+            props.controlDescription.controls,
+          )}
+          setGlobalCursor={props.setGlobalCursor}
+          title={props.controlDescription.label ?? PP.toString(props.propPath)}
+          visibleEmptyControls={props.visibleEmptyControls}
+          unsetPropNames={props.unsetPropNames}
+          showHiddenControl={props.showHiddenControl}
+          detectedPropsAndValuesWithoutControls={{}}
+        />
+      )
+    default:
+      return (
+        <UIGridRow
+          padded
+          tall={false}
+          style={{ paddingLeft: 0 }}
+          variant='<-------------1fr------------->'
+        >
+          <RowForControl
+            propPath={props.propPath}
+            controlDescription={props.controlDescription}
+            isScene={props.isScene}
             setGlobalCursor={props.setGlobalCursor}
-            title={props.controlDescription.label ?? PP.toString(props.propPath)}
-            visibleEmptyControls={props.visibleEmptyControls}
-            unsetPropNames={props.unsetPropNames}
-            showHiddenControl={props.showHiddenControl}
-            detectedPropsAndValuesWithoutControls={{}}
+            indentationLevel={props.indentationLevel}
+            focusOnMount={props.focusOnMount ?? false}
           />
-        )
-      default:
-        return (
-          <UIGridRow
-            padded
-            tall={false}
-            style={{ paddingLeft: 0 }}
-            variant='<-------------1fr------------->'
-          >
-            <RowForControl
-              propPath={props.propPath}
-              controlDescription={props.controlDescription}
-              isScene={props.isScene}
-              setGlobalCursor={props.setGlobalCursor}
-              indentationLevel={props.indentationLevel}
-              focusOnMount={props.focusOnMount ?? false}
-            />
-          </UIGridRow>
-        )
-    }
-  },
-)
+        </UIGridRow>
+      )
+  }
+})

--- a/editor/src/components/inspector/sections/event-handlers-section/event-handlers-section.tsx
+++ b/editor/src/components/inspector/sections/event-handlers-section/event-handlers-section.tsx
@@ -3,10 +3,7 @@ import { forEachRight, isRight } from '../../../../core/shared/either'
 import { isJSXAttributeOtherJavaScript } from '../../../../core/shared/element-template'
 import { forEachValue } from '../../../../core/shared/object-utils'
 import * as PP from '../../../../core/shared/property-path'
-import {
-  betterReactMemo,
-  useKeepReferenceEqualityIfPossible,
-} from '../../../../utils/react-performance'
+import { useKeepReferenceEqualityIfPossible } from '../../../../utils/react-performance'
 import utils from '../../../../utils/utils'
 import { InspectorSectionHeader, StringInput } from '../../../../uuiui'
 import { InspectorContextMenuWrapper } from '../../../../uuiui-deps'
@@ -25,23 +22,20 @@ interface EventHandlerControlProps {
   value: string
 }
 
-export const EventHandlerControl = betterReactMemo(
-  'EventHandlerControl',
-  (props: EventHandlerControlProps) => {
-    const { handlerName, value } = props
-    const target = useKeepReferenceEqualityIfPossible([PP.create([handlerName])])
-    return (
-      <>
-        <PropertyLabel target={target}>{handlerName}</PropertyLabel>
-        <StringInput
-          value={value}
-          controlStatus='disabled'
-          testId={`event-handler-control-${handlerName}`}
-        />
-      </>
-    )
-  },
-)
+export const EventHandlerControl = React.memo((props: EventHandlerControlProps) => {
+  const { handlerName, value } = props
+  const target = useKeepReferenceEqualityIfPossible([PP.create([handlerName])])
+  return (
+    <>
+      <PropertyLabel target={target}>{handlerName}</PropertyLabel>
+      <StringInput
+        value={value}
+        controlStatus='disabled'
+        testId={`event-handler-control-${handlerName}`}
+      />
+    </>
+  )
+})
 
 type RawJavaScript = string
 type EventHandlerValues = { [eventHandlerName: string]: RawJavaScript }
@@ -64,38 +58,35 @@ function useGetEventHandlerInfo(): EventHandlerValues {
   return useKeepReferenceEqualityIfPossible(result)
 }
 
-const EventHandlerSectionRow = betterReactMemo(
-  'EventHandlersSectionRow',
-  (props: { eventHandlerName: string; value: string }) => {
-    const { eventHandlerName, value } = props
+const EventHandlerSectionRow = React.memo((props: { eventHandlerName: string; value: string }) => {
+  const { eventHandlerName, value } = props
 
-    const { onContextUnsetValue } = useInspectorContext()
-    const onUnsetValue = React.useCallback(
-      () => onContextUnsetValue([ppCreate(eventHandlerName)], false),
-      [eventHandlerName, onContextUnsetValue],
-    )
+  const { onContextUnsetValue } = useInspectorContext()
+  const onUnsetValue = React.useCallback(
+    () => onContextUnsetValue([ppCreate(eventHandlerName)], false),
+    [eventHandlerName, onContextUnsetValue],
+  )
 
-    const eventHandlersContextMenuItems = React.useMemo(
-      () => utils.stripNulls([addOnUnsetValues([eventHandlerName], onUnsetValue)]),
-      [eventHandlerName, onUnsetValue],
-    )
+  const eventHandlersContextMenuItems = React.useMemo(
+    () => utils.stripNulls([addOnUnsetValues([eventHandlerName], onUnsetValue)]),
+    [eventHandlerName, onUnsetValue],
+  )
 
-    return (
-      <InspectorContextMenuWrapper
-        id={`event-handlers-section-context-menu-${eventHandlerName}`}
-        items={eventHandlersContextMenuItems}
-        style={{ gridColumn: '1 / span 4' }}
-        data={null}
-      >
-        <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
-          <EventHandlerControl handlerName={eventHandlerName} value={value} />
-        </UIGridRow>
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
+  return (
+    <InspectorContextMenuWrapper
+      id={`event-handlers-section-context-menu-${eventHandlerName}`}
+      items={eventHandlersContextMenuItems}
+      style={{ gridColumn: '1 / span 4' }}
+      data={null}
+    >
+      <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
+        <EventHandlerControl handlerName={eventHandlerName} value={value} />
+      </UIGridRow>
+    </InspectorContextMenuWrapper>
+  )
+})
 
-export const EventHandlersSection = betterReactMemo('EventHandlersSection', () => {
+export const EventHandlersSection = React.memo(() => {
   const values = useGetEventHandlerInfo()
   const valueKeys = Object.keys(values)
 

--- a/editor/src/components/inspector/sections/header-section/target-selector.tsx
+++ b/editor/src/components/inspector/sections/header-section/target-selector.tsx
@@ -16,7 +16,7 @@ import {
   OnClickOutsideHOC,
   UIRow,
 } from '../../../../uuiui'
-import { betterReactMemo, ContextMenuWrapper } from '../../../../uuiui-deps'
+import { ContextMenuWrapper } from '../../../../uuiui-deps'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { ExpandableIndicator } from '../../../navigator/navigator-item/expandable-indicator'
 
@@ -44,133 +44,127 @@ interface TargetSelectorPanelProps {
   onStyleSelectorInsert: (parent: CSSTarget, label: string) => void
 }
 
-export const TargetSelectorPanel = betterReactMemo(
-  'TargetSelectorPanel',
-  (props: TargetSelectorPanelProps) => {
-    const colorTheme = useColorTheme()
-    const {
-      targets,
-      onSelect,
-      selectedTargetPath,
-      onStyleSelectorRename,
-      onStyleSelectorDelete,
-      onStyleSelectorInsert,
-    } = props
-    const [addingIndex, setAddingIndex] = React.useState<number | null>(null)
-    const [addingIndentLevel, setAddingIndentLevel] = React.useState<number | null>(null)
-    const exitAdding = React.useCallback(() => {
-      setAddingIndex(null)
-      setAddingIndentLevel(null)
-    }, [])
+export const TargetSelectorPanel = React.memo((props: TargetSelectorPanelProps) => {
+  const colorTheme = useColorTheme()
+  const {
+    targets,
+    onSelect,
+    selectedTargetPath,
+    onStyleSelectorRename,
+    onStyleSelectorDelete,
+    onStyleSelectorInsert,
+  } = props
+  const [addingIndex, setAddingIndex] = React.useState<number | null>(null)
+  const [addingIndentLevel, setAddingIndentLevel] = React.useState<number | null>(null)
+  const exitAdding = React.useCallback(() => {
+    setAddingIndex(null)
+    setAddingIndentLevel(null)
+  }, [])
 
-    const onRenameByIndex = React.useCallback(
-      (index: number, label: string) => {
-        onStyleSelectorRename(targets[index], label)
-      },
-      [targets, onStyleSelectorRename],
-    )
+  const onRenameByIndex = React.useCallback(
+    (index: number, label: string) => {
+      onStyleSelectorRename(targets[index], label)
+    },
+    [targets, onStyleSelectorRename],
+  )
 
-    const [isOpen, setIsOpen] = React.useState<boolean>(false)
+  const [isOpen, setIsOpen] = React.useState<boolean>(false)
 
-    const onDeleteByIndex = React.useCallback(
-      (index: number) => onStyleSelectorDelete(targets[index]),
-      [targets, onStyleSelectorDelete],
-    )
-    const onSelectByIndex = React.useCallback((index: number) => onSelect(targets[index].path), [
-      targets,
-      onSelect,
-    ])
-    const onInsertByIndex = React.useCallback(
-      (index: number, label: string) => {
-        onStyleSelectorInsert(targets[index], label)
-      },
-      [targets, onStyleSelectorInsert],
-    )
-    const targetIndex = getCSSTargetIndex(selectedTargetPath, targets)
+  const onDeleteByIndex = React.useCallback(
+    (index: number) => onStyleSelectorDelete(targets[index]),
+    [targets, onStyleSelectorDelete],
+  )
+  const onSelectByIndex = React.useCallback((index: number) => onSelect(targets[index].path), [
+    targets,
+    onSelect,
+  ])
+  const onInsertByIndex = React.useCallback(
+    (index: number, label: string) => {
+      onStyleSelectorInsert(targets[index], label)
+    },
+    [targets, onStyleSelectorInsert],
+  )
+  const targetIndex = getCSSTargetIndex(selectedTargetPath, targets)
 
-    const slicedTargetsAdding = React.useMemo(() => targets.slice(0, addingIndex ?? undefined), [
-      addingIndex,
-      targets,
-    ])
+  const slicedTargetsAdding = React.useMemo(() => targets.slice(0, addingIndex ?? undefined), [
+    addingIndex,
+    targets,
+  ])
 
-    const slicedTargets = React.useMemo(
-      () => (addingIndex != null ? targets.slice(addingIndex, targets.length) : targets),
-      [targets, addingIndex],
-    )
+  const slicedTargets = React.useMemo(
+    () => (addingIndex != null ? targets.slice(addingIndex, targets.length) : targets),
+    [targets, addingIndex],
+  )
 
-    return (
-      <FlexColumn
-        style={{
-          position: 'relative',
-          paddingTop: '8px',
-          userSelect: 'none',
-          WebkitUserSelect: 'none',
-        }}
-      >
-        <TargetListHeader
-          isOpen={isOpen}
-          setIsOpen={setIsOpen}
-          setAddingIndex={setAddingIndex}
-          selectedTargetPath={selectedTargetPath}
-          isAdding={addingIndex != null}
-          targetIndex={targetIndex}
-        />
-        {/* outer flexColumn takes a fixed height (or can grow to fill space, this way addable row can
+  return (
+    <FlexColumn
+      style={{
+        position: 'relative',
+        paddingTop: '8px',
+        userSelect: 'none',
+        WebkitUserSelect: 'none',
+      }}
+    >
+      <TargetListHeader
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        setAddingIndex={setAddingIndex}
+        selectedTargetPath={selectedTargetPath}
+        isAdding={addingIndex != null}
+        targetIndex={targetIndex}
+      />
+      {/* outer flexColumn takes a fixed height (or can grow to fill space, this way addable row can
       be at the top without being included in scrollable list */}
-        {isOpen ? (
+      {isOpen ? (
+        <FlexColumn className='label-fixedHeightList' style={{ height: 100, overflowY: 'scroll' }}>
           <FlexColumn
-            className='label-fixedHeightList'
-            style={{ height: 100, overflowY: 'scroll' }}
+            className='label-scrollableList'
+            style={{
+              borderTop: `1px solid ${colorTheme.secondaryBorder.value}`,
+              borderBottom: `1px solid ${colorTheme.secondaryBorder.value}`,
+              paddingTop: 5,
+              paddingBottom: 8,
+              backgroundColor: colorTheme.emphasizedBackground.value,
+              flexGrow: 1,
+              overflowY: 'scroll',
+            }}
           >
-            <FlexColumn
-              className='label-scrollableList'
-              style={{
-                borderTop: `1px solid ${colorTheme.secondaryBorder.value}`,
-                borderBottom: `1px solid ${colorTheme.secondaryBorder.value}`,
-                paddingTop: 5,
-                paddingBottom: 8,
-                backgroundColor: colorTheme.emphasizedBackground.value,
-                flexGrow: 1,
-                overflowY: 'scroll',
-              }}
-            >
-              {addingIndex != null ? (
-                <React.Fragment>
-                  <TargetList
-                    targets={slicedTargetsAdding}
-                    selectionOffset={0}
-                    selectedItemIndex={targetIndex}
-                    setAddingIndex={setAddingIndex}
-                    setAddingIndentLevel={setAddingIndentLevel}
-                    onSelect={onSelectByIndex}
-                    onRenameByIndex={onRenameByIndex}
-                    onDeleteByIndex={onDeleteByIndex}
-                  />
-                  <AddingRow
-                    onInsert={onInsertByIndex}
-                    addingIndex={addingIndex}
-                    addingIndentLevel={addingIndentLevel}
-                    finishAdding={exitAdding}
-                  />
-                </React.Fragment>
-              ) : null}
-              <TargetList
-                targets={slicedTargets}
-                selectionOffset={addingIndex != null ? addingIndex : 0}
-                selectedItemIndex={targetIndex}
-                setAddingIndex={setAddingIndex}
-                setAddingIndentLevel={setAddingIndentLevel}
-                onSelect={onSelectByIndex}
-                onRenameByIndex={onRenameByIndex}
-                onDeleteByIndex={onDeleteByIndex}
-              />
-            </FlexColumn>
+            {addingIndex != null ? (
+              <React.Fragment>
+                <TargetList
+                  targets={slicedTargetsAdding}
+                  selectionOffset={0}
+                  selectedItemIndex={targetIndex}
+                  setAddingIndex={setAddingIndex}
+                  setAddingIndentLevel={setAddingIndentLevel}
+                  onSelect={onSelectByIndex}
+                  onRenameByIndex={onRenameByIndex}
+                  onDeleteByIndex={onDeleteByIndex}
+                />
+                <AddingRow
+                  onInsert={onInsertByIndex}
+                  addingIndex={addingIndex}
+                  addingIndentLevel={addingIndentLevel}
+                  finishAdding={exitAdding}
+                />
+              </React.Fragment>
+            ) : null}
+            <TargetList
+              targets={slicedTargets}
+              selectionOffset={addingIndex != null ? addingIndex : 0}
+              selectedItemIndex={targetIndex}
+              setAddingIndex={setAddingIndex}
+              setAddingIndentLevel={setAddingIndentLevel}
+              onSelect={onSelectByIndex}
+              onRenameByIndex={onRenameByIndex}
+              onDeleteByIndex={onDeleteByIndex}
+            />
           </FlexColumn>
-        ) : null}
-      </FlexColumn>
-    )
-  },
-)
+        </FlexColumn>
+      ) : null}
+    </FlexColumn>
+  )
+})
 
 interface TargetListProps {
   targets: Array<CSSTarget>
@@ -183,7 +177,7 @@ interface TargetListProps {
   onDeleteByIndex: (index: number) => void
 }
 
-const TargetList = betterReactMemo('TargetList', (props: TargetListProps) => {
+const TargetList = React.memo((props: TargetListProps) => {
   const {
     targets,
     selectionOffset,
@@ -230,7 +224,7 @@ interface TargetListItemProps {
 }
 TargetList.displayName = 'TargetList'
 
-const TargetListItem = betterReactMemo('TargetListItem', (props: TargetListItemProps) => {
+const TargetListItem = React.memo((props: TargetListItemProps) => {
   const colorTheme = useColorTheme()
   const {
     itemIndex,
@@ -393,7 +387,7 @@ interface TargetListHeaderProps {
   targetIndex: number
 }
 
-const TargetListHeader = betterReactMemo('TargetListHeader', (props: TargetListHeaderProps) => {
+const TargetListHeader = React.memo((props: TargetListHeaderProps) => {
   const colorTheme = useColorTheme()
   const { isOpen, setIsOpen, setAddingIndex, selectedTargetPath, isAdding, targetIndex } = props
 
@@ -446,7 +440,7 @@ interface AddingRowProps {
   finishAdding: () => void
 }
 
-const AddingRow = betterReactMemo('AddingRow', (props: AddingRowProps) => {
+const AddingRow = React.memo((props: AddingRowProps) => {
   const { addingIndex, finishAdding, addingIndentLevel, onInsert } = props
   const [value, setValue] = React.useState<string>('')
 

--- a/editor/src/components/inspector/sections/image-section/image-density-control.tsx
+++ b/editor/src/components/inspector/sections/image-section/image-density-control.tsx
@@ -4,7 +4,6 @@ import { EditorAction, EditorDispatch } from '../../../editor/action-types'
 import { showToast, updateFrameDimensions } from '../../../editor/actions/action-creators'
 import { OptionChainControl } from '../../controls/option-chain-control'
 import { getControlStyles } from '../../common/control-status'
-import { betterReactMemo } from '../../../../uuiui-deps'
 import { notice } from '../../../common/notice'
 
 interface ImageDensityControl {
@@ -16,8 +15,7 @@ interface ImageDensityControl {
   clientHeight: number
 }
 
-export const ImageDensityControl = betterReactMemo(
-  'ImageDensityControl',
+export const ImageDensityControl = React.memo(
   ({
     naturalWidth,
     clientWidth,

--- a/editor/src/components/inspector/sections/image-section/image-section.tsx
+++ b/editor/src/components/inspector/sections/image-section/image-section.tsx
@@ -22,12 +22,11 @@ import {
   FunctionIcons,
   InspectorSectionIcons,
 } from '../../../../uuiui'
-import { betterReactMemo } from '../../../../uuiui-deps'
 
 const imgSrcProp = [PP.create(['src'])]
 const imgAltProp = [PP.create(['alt'])]
 
-export const ImgSection = betterReactMemo('ImgSection', () => {
+export const ImgSection = React.memo(() => {
   const colorTheme = useColorTheme()
   const selectedViews = useSelectedViews()
 

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -21,7 +21,6 @@ import {
   useWrappedEmptyOrUnknownOnSubmitValue,
   SimpleNumberInput,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import { OnSubmitValueOrEmpty } from '../../../controls/control'
 import { PropertyPath } from '../../../../../core/shared/project-file-types'
 
@@ -73,36 +72,33 @@ interface FlexDirectionControlProps extends FlexFieldControlProps<FlexDirection>
   flexWrap: FlexWrap
 }
 
-export const FlexDirectionControl = betterReactMemo(
-  'FlexDirectionControl',
-  (props: FlexDirectionControlProps) => {
-    return (
-      <InspectorContextMenuWrapper
-        id={`flexDirection-context-menu`}
-        items={[unsetPropertyMenuItem('Flex Direction', props.onUnset)]}
-        data={{}}
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
+export const FlexDirectionControl = React.memo((props: FlexDirectionControlProps) => {
+  return (
+    <InspectorContextMenuWrapper
+      id={`flexDirection-context-menu`}
+      items={[unsetPropertyMenuItem('Flex Direction', props.onUnset)]}
+      data={{}}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <OptionChainControl
+        id='flex.container.flexDirection'
+        key='flex.container.flexDirection'
+        testId='flex.container.flexDirection'
+        value={props.value}
+        DEPRECATED_controlOptions={{
+          labelBelow: 'Direction',
         }}
-      >
-        <OptionChainControl
-          id='flex.container.flexDirection'
-          key='flex.container.flexDirection'
-          testId='flex.container.flexDirection'
-          value={props.value}
-          DEPRECATED_controlOptions={{
-            labelBelow: 'Direction',
-          }}
-          controlStatus={props.controlStatus}
-          controlStyles={props.controlStyles}
-          options={flexDirectionOptions(props.flexWrap)}
-          onSubmitValue={props.onSubmitValue}
-        />
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
+        controlStatus={props.controlStatus}
+        controlStyles={props.controlStyles}
+        options={flexDirectionOptions(props.flexWrap)}
+        onSubmitValue={props.onSubmitValue}
+      />
+    </InspectorContextMenuWrapper>
+  )
+})
 
 interface FlexAlignItemsControlProps extends FlexFieldControlProps<FlexAlignment> {
   alignDirection: uglyLabel
@@ -112,44 +108,41 @@ interface FlexAlignItemsControlProps extends FlexFieldControlProps<FlexAlignment
 
 const alignItemsProp = [createLayoutPropertyPath('alignItems')]
 
-export const FlexAlignItemsControl = betterReactMemo(
-  'FlexAlignItemsControl',
-  (props: FlexAlignItemsControlProps) => {
-    return (
-      <InspectorContextMenuWrapper
-        id={`alignItems-context-menu`}
-        items={[unsetPropertyMenuItem('Align Items', props.onUnset)]}
-        data={{}}
-      >
-        <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
-          <PropertyLabel target={alignItemsProp}>Align</PropertyLabel>
-          <div
-            style={{
-              textAlign: 'center',
-              display: 'flex',
-              flexDirection: 'row',
-            }}
-          >
-            <OptionChainControl
-              id='flex.container.alignItems'
-              key='flex.container.alignItems'
-              testId='flex.container.alignItems'
-              value={props.value}
-              controlStatus={props.controlStatus}
-              controlStyles={props.controlStyles}
-              options={alignItemsOptions(
-                props.alignDirection,
-                props.alignItemsFlexStart,
-                props.alignItemsFlexEnd,
-              )}
-              onSubmitValue={props.onSubmitValue}
-            />
-          </div>
-        </UIGridRow>
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
+export const FlexAlignItemsControl = React.memo((props: FlexAlignItemsControlProps) => {
+  return (
+    <InspectorContextMenuWrapper
+      id={`alignItems-context-menu`}
+      items={[unsetPropertyMenuItem('Align Items', props.onUnset)]}
+      data={{}}
+    >
+      <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
+        <PropertyLabel target={alignItemsProp}>Align</PropertyLabel>
+        <div
+          style={{
+            textAlign: 'center',
+            display: 'flex',
+            flexDirection: 'row',
+          }}
+        >
+          <OptionChainControl
+            id='flex.container.alignItems'
+            key='flex.container.alignItems'
+            testId='flex.container.alignItems'
+            value={props.value}
+            controlStatus={props.controlStatus}
+            controlStyles={props.controlStyles}
+            options={alignItemsOptions(
+              props.alignDirection,
+              props.alignItemsFlexStart,
+              props.alignItemsFlexEnd,
+            )}
+            onSubmitValue={props.onSubmitValue}
+          />
+        </div>
+      </UIGridRow>
+    </InspectorContextMenuWrapper>
+  )
+})
 
 interface FlexWrapControlProps extends FlexFieldControlProps<FlexWrap> {}
 
@@ -168,7 +161,7 @@ const FlexWrapOptions: OptionsType<SelectOption> = [
   },
 ]
 
-export const FlexWrapControl = betterReactMemo('FlexWrapControl', (props: FlexWrapControlProps) => {
+export const FlexWrapControl = React.memo((props: FlexWrapControlProps) => {
   const { onSubmitValue: onSubmit } = props
   const onSubmitValue = React.useCallback(
     (newValue: SelectOption) => {
@@ -206,40 +199,37 @@ interface FlexJustifyContentControlProps extends FlexFieldControlProps<FlexJusti
   justifyFlexEnd: uglyLabel
 }
 
-export const FlexJustifyContentControl = betterReactMemo(
-  'FlexJustifyContentControl',
-  (props: FlexJustifyContentControlProps) => {
-    return (
-      <InspectorContextMenuWrapper
-        id={`justifyContent-context-menu`}
-        items={[unsetPropertyMenuItem('Justify Content', props.onUnset)]}
-        data={{}}
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
+export const FlexJustifyContentControl = React.memo((props: FlexJustifyContentControlProps) => {
+  return (
+    <InspectorContextMenuWrapper
+      id={`justifyContent-context-menu`}
+      items={[unsetPropertyMenuItem('Justify Content', props.onUnset)]}
+      data={{}}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <OptionChainControl
+        id='flex.container.justifyContent'
+        key='flex.container.justifyContent'
+        testId='flex.container.justifyContent'
+        value={props.value}
+        DEPRECATED_controlOptions={{
+          labelBelow: 'Justify',
         }}
-      >
-        <OptionChainControl
-          id='flex.container.justifyContent'
-          key='flex.container.justifyContent'
-          testId='flex.container.justifyContent'
-          value={props.value}
-          DEPRECATED_controlOptions={{
-            labelBelow: 'Justify',
-          }}
-          options={justifyContentOptions(
-            props.flexDirection,
-            props.justifyFlexStart,
-            props.justifyFlexEnd,
-          )}
-          onSubmitValue={props.onSubmitValue}
-          controlStatus={props.controlStatus}
-          controlStyles={props.controlStyles}
-        />
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
+        options={justifyContentOptions(
+          props.flexDirection,
+          props.justifyFlexStart,
+          props.justifyFlexEnd,
+        )}
+        onSubmitValue={props.onSubmitValue}
+        controlStatus={props.controlStatus}
+        controlStyles={props.controlStyles}
+      />
+    </InspectorContextMenuWrapper>
+  )
+})
 
 interface FlexGapControlProps extends FlexFieldControlProps<number> {
   onSubmitValue: OnSubmitValueOrEmpty<number>
@@ -248,7 +238,7 @@ interface FlexGapControlProps extends FlexFieldControlProps<number> {
 
 const flexGapProp = [createLayoutPropertyPath('FlexGap')]
 
-export const FlexGapControl = betterReactMemo('FlexGapControl', (props: FlexGapControlProps) => {
+export const FlexGapControl = React.memo((props: FlexGapControlProps) => {
   const menuItems = [unsetPropertyMenuItem('Flex Gap', props.onUnset)]
   const wrappedOnSubmit = useWrappedEmptyOrUnknownOnSubmitValue(props.onSubmitValue, props.onUnset)
   const wrappedOnTransientSubmit = useWrappedEmptyOrUnknownOnSubmitValue(
@@ -305,38 +295,35 @@ interface FlexAlignContentControlProps extends FlexFieldControlProps<FlexAlignme
   alignContentFlexEnd: uglyLabel
 }
 
-export const FlexAlignContentControl = betterReactMemo(
-  'FlexAlignContentControl',
-  (props: FlexAlignContentControlProps) => {
-    return (
-      <InspectorContextMenuWrapper
-        id={`alignContent-context-menu`}
-        items={[unsetPropertyMenuItem('Align Content', props.onUnset)]}
-        data={{}}
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          textAlign: 'center',
-        }}
-      >
-        <OptionChainControl
-          id='flex.container.alignContent'
-          key='flex.container.alignContent'
-          testId='flex.container.alignContent'
-          value={props.value}
-          options={alignContentOptions(
-            props.alignDirection,
-            props.alignContentFlexStart,
-            props.alignContentFlexEnd,
-          )}
-          onSubmitValue={props.onSubmitValue}
-          controlStatus={props.controlStatus}
-          controlStyles={props.controlStyles}
-        />
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
+export const FlexAlignContentControl = React.memo((props: FlexAlignContentControlProps) => {
+  return (
+    <InspectorContextMenuWrapper
+      id={`alignContent-context-menu`}
+      items={[unsetPropertyMenuItem('Align Content', props.onUnset)]}
+      data={{}}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        textAlign: 'center',
+      }}
+    >
+      <OptionChainControl
+        id='flex.container.alignContent'
+        key='flex.container.alignContent'
+        testId='flex.container.alignContent'
+        value={props.value}
+        options={alignContentOptions(
+          props.alignDirection,
+          props.alignContentFlexStart,
+          props.alignContentFlexEnd,
+        )}
+        onSubmitValue={props.onSubmitValue}
+        controlStatus={props.controlStatus}
+        controlStyles={props.controlStyles}
+      />
+    </InspectorContextMenuWrapper>
+  )
+})
 
 const alignContentOptions = (
   alignDirection: string,

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
@@ -15,103 +15,99 @@ import {
 import { PropertyLabel } from '../../../widgets/property-label'
 import { createLayoutPropertyPath } from '../../../../../core/layout/layout-helpers-new'
 import { useWrappedEmptyOrUnknownOnSubmitValue } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 
-export const FlexContainerControls = betterReactMemo<{ seeMoreVisible: boolean }>(
-  'FlexContainerControls',
-  (props) => {
-    // Right now flex layout isn't supported on groups, so just don't show the controls if a group is selected
-    const flexWrap = useInspectorLayoutInfo('flexWrap')
-    const flexDirection = useInspectorLayoutInfo('flexDirection')
-    const alignItems = useInspectorLayoutInfo('alignItems')
-    const alignContent = useInspectorLayoutInfo('alignContent')
-    const justifyContent = useInspectorLayoutInfo('justifyContent')
-    const flexGap = useInspectorLayoutInfo('FlexGap')
+export const FlexContainerControls = React.memo<{ seeMoreVisible: boolean }>((props) => {
+  // Right now flex layout isn't supported on groups, so just don't show the controls if a group is selected
+  const flexWrap = useInspectorLayoutInfo('flexWrap')
+  const flexDirection = useInspectorLayoutInfo('flexDirection')
+  const alignItems = useInspectorLayoutInfo('alignItems')
+  const alignContent = useInspectorLayoutInfo('alignContent')
+  const justifyContent = useInspectorLayoutInfo('justifyContent')
+  const flexGap = useInspectorLayoutInfo('FlexGap')
 
-    const {
-      justifyFlexStart,
-      justifyFlexEnd,
-      alignDirection,
-      alignItemsFlexStart,
-      alignItemsFlexEnd,
-      alignContentFlexStart,
-      alignContentFlexEnd,
-    } = getDirectionAwareLabels(flexWrap.value, flexDirection.value)
+  const {
+    justifyFlexStart,
+    justifyFlexEnd,
+    alignDirection,
+    alignItemsFlexStart,
+    alignItemsFlexEnd,
+    alignContentFlexStart,
+    alignContentFlexEnd,
+  } = getDirectionAwareLabels(flexWrap.value, flexDirection.value)
 
-    const alignItemsControlStatus: ControlStatus =
-      flexWrap.value === FlexWrap.NoWrap ? 'disabled' : alignItems.controlStatus
-    const alignItemsControlStyles: ControlStyles =
-      flexWrap.value === FlexWrap.NoWrap ? getControlStyles('disabled') : alignItems.controlStyles
+  const alignItemsControlStatus: ControlStatus =
+    flexWrap.value === FlexWrap.NoWrap ? 'disabled' : alignItems.controlStatus
+  const alignItemsControlStyles: ControlStyles =
+    flexWrap.value === FlexWrap.NoWrap ? getControlStyles('disabled') : alignItems.controlStyles
 
-    const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      flexGap.onSubmitValue,
-      flexGap.onUnsetValues,
-    )
-    const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      flexGap.onSubmitValue,
-      flexGap.onUnsetValues,
-    )
+  const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+    flexGap.onSubmitValue,
+    flexGap.onUnsetValues,
+  )
+  const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+    flexGap.onSubmitValue,
+    flexGap.onUnsetValues,
+  )
 
-    return (
-      <>
-        <UIGridRow tall padded={true} variant='<---1fr--->|------172px-------|'>
-          <FlexDirectionControl
-            value={flexDirection.value}
-            controlStatus={flexDirection.controlStatus}
-            controlStyles={flexDirection.controlStyles}
-            onSubmitValue={flexDirection.onSubmitValue}
-            onUnset={flexDirection.onUnsetValues}
-            flexWrap={flexWrap.value}
-          />
-          <FlexJustifyContentControl
-            value={justifyContent.value}
-            onSubmitValue={justifyContent.onSubmitValue}
-            onUnset={justifyContent.onUnsetValues}
-            controlStatus={justifyContent.controlStatus}
-            controlStyles={justifyContent.controlStyles}
-            flexDirection={flexDirection.value}
-            justifyFlexStart={justifyFlexStart}
-            justifyFlexEnd={justifyFlexEnd}
-          />
-        </UIGridRow>
-        <FlexGapControl
-          value={flexGap.value}
-          onSubmitValue={wrappedOnSubmitValue}
-          onTransientSubmitValue={wrappedOnTransientSubmitValue}
-          onUnset={flexGap.onUnsetValues}
-          controlStatus={flexGap.controlStatus}
-          controlStyles={flexGap.controlStyles}
+  return (
+    <>
+      <UIGridRow tall padded={true} variant='<---1fr--->|------172px-------|'>
+        <FlexDirectionControl
+          value={flexDirection.value}
+          controlStatus={flexDirection.controlStatus}
+          controlStyles={flexDirection.controlStyles}
+          onSubmitValue={flexDirection.onSubmitValue}
+          onUnset={flexDirection.onUnsetValues}
+          flexWrap={flexWrap.value}
         />
-        <FlexAlignItemsControl
-          value={alignItems.value}
-          controlStatus={alignItems.controlStatus}
-          controlStyles={alignItems.controlStyles}
-          onSubmitValue={alignItems.onSubmitValue}
-          onUnset={alignItems.onUnsetValues}
+        <FlexJustifyContentControl
+          value={justifyContent.value}
+          onSubmitValue={justifyContent.onSubmitValue}
+          onUnset={justifyContent.onUnsetValues}
+          controlStatus={justifyContent.controlStatus}
+          controlStyles={justifyContent.controlStyles}
+          flexDirection={flexDirection.value}
+          justifyFlexStart={justifyFlexStart}
+          justifyFlexEnd={justifyFlexEnd}
+        />
+      </UIGridRow>
+      <FlexGapControl
+        value={flexGap.value}
+        onSubmitValue={wrappedOnSubmitValue}
+        onTransientSubmitValue={wrappedOnTransientSubmitValue}
+        onUnset={flexGap.onUnsetValues}
+        controlStatus={flexGap.controlStatus}
+        controlStyles={flexGap.controlStyles}
+      />
+      <FlexAlignItemsControl
+        value={alignItems.value}
+        controlStatus={alignItems.controlStatus}
+        controlStyles={alignItems.controlStyles}
+        onSubmitValue={alignItems.onSubmitValue}
+        onUnset={alignItems.onUnsetValues}
+        alignDirection={alignDirection}
+        alignItemsFlexStart={alignItemsFlexStart}
+        alignItemsFlexEnd={alignItemsFlexEnd}
+      />
+      <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
+        <FlexWrapControl
+          value={flexWrap.value}
+          onSubmitValue={flexWrap.onSubmitValue}
+          onUnset={flexWrap.onUnsetValues}
+          controlStatus={flexWrap.controlStatus}
+          controlStyles={flexWrap.controlStyles}
+        />
+        <FlexAlignContentControl
+          value={alignContent.value}
+          onSubmitValue={alignContent.onSubmitValue}
+          onUnset={alignContent.onUnsetValues}
+          controlStatus={alignItemsControlStatus}
+          controlStyles={alignItemsControlStyles}
           alignDirection={alignDirection}
-          alignItemsFlexStart={alignItemsFlexStart}
-          alignItemsFlexEnd={alignItemsFlexEnd}
+          alignContentFlexStart={alignContentFlexStart}
+          alignContentFlexEnd={alignContentFlexEnd}
         />
-        <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
-          <FlexWrapControl
-            value={flexWrap.value}
-            onSubmitValue={flexWrap.onSubmitValue}
-            onUnset={flexWrap.onUnsetValues}
-            controlStatus={flexWrap.controlStatus}
-            controlStyles={flexWrap.controlStyles}
-          />
-          <FlexAlignContentControl
-            value={alignContent.value}
-            onSubmitValue={alignContent.onSubmitValue}
-            onUnset={alignContent.onUnsetValues}
-            controlStatus={alignItemsControlStatus}
-            controlStyles={alignItemsControlStyles}
-            alignDirection={alignDirection}
-            alignContentFlexStart={alignContentFlexStart}
-            alignContentFlexEnd={alignContentFlexEnd}
-          />
-        </UIGridRow>
-      </>
-    )
-  },
-)
+      </UIGridRow>
+    </>
+  )
+})

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-controls.tsx
@@ -6,13 +6,12 @@ import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { addSetProperty, unsetPropertyMenuItem } from '../../../common/context-menu-items'
 import { stylePropPathMappingFn, useInspectorLayoutInfo } from '../../../common/property-path-hooks'
 import { useWrappedEmptyOrUnknownOnSubmitValue, ChainedNumberInput } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
 import { GridRowProps, UIGridRow } from '../../../widgets/ui-grid-row'
 import { PropertyLabel } from '../../../widgets/property-label'
 import { createLayoutPropertyPath } from '../../../../../core/layout/layout-helpers-new'
 
-export const PositionControl = betterReactMemo('PositionControl', () => {
+export const PositionControl = React.memo(() => {
   const position = useInspectorLayoutInfo('position')
 
   return (
@@ -69,59 +68,56 @@ interface AlignSelfControlProps {
   variant: GridRowProps['variant']
 }
 
-export const AlignSelfControl = betterReactMemo(
-  'AlignSelfControl',
-  (props: AlignSelfControlProps) => {
-    const alignSelf = useInspectorLayoutInfo('alignSelf')
+export const AlignSelfControl = React.memo((props: AlignSelfControlProps) => {
+  const alignSelf = useInspectorLayoutInfo('alignSelf')
 
-    return (
-      <InspectorContextMenuWrapper
-        id={`align-self-context-menu`}
-        items={[unsetPropertyMenuItem('Align Self', alignSelf.onUnsetValues)]}
-        data={{}}
-      >
-        <UIGridRow padded={true} variant={props.variant}>
-          <PropertyLabel target={alignSelfProp}>Align Self</PropertyLabel>
-          <SelectControl
-            id='flex.element.alignSelf'
-            key='flex.element.alignSelf'
-            testId='flex.element.alignSelf'
-            options={
-              [
-                {
-                  value: 'auto',
-                  label: 'Auto',
-                },
-                {
-                  value: 'flex-start',
-                  label: 'Flex Start',
-                },
-                {
-                  value: 'center',
-                  label: 'Center',
-                },
-                {
-                  value: 'flex-end',
-                  label: 'Flex End',
-                },
-                {
-                  value: 'stretch',
-                  label: 'Stretch',
-                },
-              ] as Array<SelectOption>
-            }
-            value={alignSelf.value}
-            onSubmitValue={alignSelf.onSubmitValue}
-            controlStatus={alignSelf.controlStatus}
-            controlStyles={alignSelf.controlStyles}
-          />
-        </UIGridRow>
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
+  return (
+    <InspectorContextMenuWrapper
+      id={`align-self-context-menu`}
+      items={[unsetPropertyMenuItem('Align Self', alignSelf.onUnsetValues)]}
+      data={{}}
+    >
+      <UIGridRow padded={true} variant={props.variant}>
+        <PropertyLabel target={alignSelfProp}>Align Self</PropertyLabel>
+        <SelectControl
+          id='flex.element.alignSelf'
+          key='flex.element.alignSelf'
+          testId='flex.element.alignSelf'
+          options={
+            [
+              {
+                value: 'auto',
+                label: 'Auto',
+              },
+              {
+                value: 'flex-start',
+                label: 'Flex Start',
+              },
+              {
+                value: 'center',
+                label: 'Center',
+              },
+              {
+                value: 'flex-end',
+                label: 'Flex End',
+              },
+              {
+                value: 'stretch',
+                label: 'Stretch',
+              },
+            ] as Array<SelectOption>
+          }
+          value={alignSelf.value}
+          onSubmitValue={alignSelf.onSubmitValue}
+          controlStatus={alignSelf.controlStatus}
+          controlStyles={alignSelf.controlStyles}
+        />
+      </UIGridRow>
+    </InspectorContextMenuWrapper>
+  )
+})
 
-export const MarginControl = betterReactMemo('MarginControl', () => {
+export const MarginControl = React.memo(() => {
   const { marginTop, marginRight, marginBottom, marginLeft } = useInspectorInfoLonghandShorthand(
     ['marginTop', 'marginRight', 'marginBottom', 'marginLeft'],
     'margin',

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -4,7 +4,6 @@ import { UIGridRow } from '../../../widgets/ui-grid-row'
 import { PositionControl, MarginControl, AlignSelfControl } from './flex-element-controls'
 import { PropertyLabel } from '../../../widgets/property-label'
 import { createLayoutPropertyPath } from '../../../../../core/layout/layout-helpers-new'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import {
   FunctionIcons,
   Icons,
@@ -37,7 +36,7 @@ const marginProps = [
   createLayoutPropertyPath('marginBottom'),
 ]
 
-export const FlexElementSubsection = betterReactMemo('FlexElementSubsection', () => {
+export const FlexElementSubsection = React.memo(() => {
   return (
     <>
       <UIGridRow tall padded={true} variant='<---1fr--->|------172px-------|'>
@@ -59,17 +58,14 @@ interface FlexElementSubsectionProps {
   parentFlexDirection: string | null
 }
 
-export const FlexElementSubsectionExperiment = betterReactMemo(
-  'FlexElementSubsectionExperiment',
-  (props: FlexElementSubsectionProps) => {
-    return (
-      <>
-        <MainAxisControls {...props} />
-        <CrossAxisControls {...props} />
-      </>
-    )
-  },
-)
+export const FlexElementSubsectionExperiment = React.memo((props: FlexElementSubsectionProps) => {
+  return (
+    <>
+      <MainAxisControls {...props} />
+      <CrossAxisControls {...props} />
+    </>
+  )
+})
 
 export function useInitialFixedSectionState(parentFlexDirection: string | null): boolean {
   const isRowLayouted = parentFlexDirection === 'row' || parentFlexDirection === 'row-reverse'
@@ -106,66 +102,61 @@ export function useInitialSizeSectionState(): boolean {
   )
 }
 
-const MainAxisControls = betterReactMemo(
-  'MainAxisControls',
-  (props: FlexElementSubsectionProps) => {
-    const initialIsFixedSectionVisible = useInitialFixedSectionState(props.parentFlexDirection)
-    const initialIsAdvancedSectionVisible = useInitialAdvancedSectionState()
+const MainAxisControls = React.memo((props: FlexElementSubsectionProps) => {
+  const initialIsFixedSectionVisible = useInitialFixedSectionState(props.parentFlexDirection)
+  const initialIsAdvancedSectionVisible = useInitialAdvancedSectionState()
 
-    const [fixedControlsOpen, setFixedControlsOpen] = usePropControlledStateV2(
-      initialIsFixedSectionVisible,
-    )
-    const toggleFixedSection = React.useCallback(() => setFixedControlsOpen(!fixedControlsOpen), [
-      fixedControlsOpen,
-      setFixedControlsOpen,
-    ])
-    const [advancedControlsOpen, setAdvancedControlsOpen] = usePropControlledStateV2(
-      initialIsAdvancedSectionVisible,
-    )
-    const toggleAdvancedSection = React.useCallback(
-      () => setAdvancedControlsOpen(!advancedControlsOpen),
-      [advancedControlsOpen, setAdvancedControlsOpen],
-    )
-    return (
-      <>
-        <InspectorSubsectionHeader style={{ display: 'flex', justifyContent: 'space-between' }}>
-          <span>Main Axis</span>
-          <div
-            style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 4 }}
+  const [fixedControlsOpen, setFixedControlsOpen] = usePropControlledStateV2(
+    initialIsFixedSectionVisible,
+  )
+  const toggleFixedSection = React.useCallback(() => setFixedControlsOpen(!fixedControlsOpen), [
+    fixedControlsOpen,
+    setFixedControlsOpen,
+  ])
+  const [advancedControlsOpen, setAdvancedControlsOpen] = usePropControlledStateV2(
+    initialIsAdvancedSectionVisible,
+  )
+  const toggleAdvancedSection = React.useCallback(
+    () => setAdvancedControlsOpen(!advancedControlsOpen),
+    [advancedControlsOpen, setAdvancedControlsOpen],
+  )
+  return (
+    <>
+      <InspectorSubsectionHeader style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <span>Main Axis</span>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 4 }}>
+          <InlineToggleButton
+            toggleValue={fixedControlsOpen}
+            onClick={toggleFixedSection}
+            style={{
+              fontSize: 10,
+            }}
           >
-            <InlineToggleButton
-              toggleValue={fixedControlsOpen}
-              onClick={toggleFixedSection}
-              style={{
-                fontSize: 10,
-              }}
-            >
-              Fixed
-            </InlineToggleButton>
-            <InlineToggleButton
-              toggleValue={advancedControlsOpen}
-              onClick={toggleAdvancedSection}
-              style={{
-                fontSize: 10,
-              }}
-            >
-              Advanced
-            </InlineToggleButton>
-            <SquareButton highlight>
-              <Icons.Cross />
-            </SquareButton>
-          </div>
-        </InspectorSubsectionHeader>
-        <FlexGrowShrinkRow />
-        <UIGridRow padded={true} variant='<-------------1fr------------->'>
-          <FlexBasisShorthandCSSNumberControl label='B' />
-        </UIGridRow>
-        {when(fixedControlsOpen, <FixedSubsectionControls {...props} />)}
-        {when(advancedControlsOpen, <AdvancedSubsectionControls {...props} />)}
-      </>
-    )
-  },
-)
+            Fixed
+          </InlineToggleButton>
+          <InlineToggleButton
+            toggleValue={advancedControlsOpen}
+            onClick={toggleAdvancedSection}
+            style={{
+              fontSize: 10,
+            }}
+          >
+            Advanced
+          </InlineToggleButton>
+          <SquareButton highlight>
+            <Icons.Cross />
+          </SquareButton>
+        </div>
+      </InspectorSubsectionHeader>
+      <FlexGrowShrinkRow />
+      <UIGridRow padded={true} variant='<-------------1fr------------->'>
+        <FlexBasisShorthandCSSNumberControl label='B' />
+      </UIGridRow>
+      {when(fixedControlsOpen, <FixedSubsectionControls {...props} />)}
+      {when(advancedControlsOpen, <AdvancedSubsectionControls {...props} />)}
+    </>
+  )
+})
 
 const mainAxisFixedProps = (parentFlexDirection: string | null): PropertyPath[] => {
   if (parentFlexDirection === 'row' || parentFlexDirection === 'row-reverse') {
@@ -184,59 +175,51 @@ const mainAxisFixedProps = (parentFlexDirection: string | null): PropertyPath[] 
 }
 const mainAxisAdvancedProps: PropertyPath[] = [createLayoutPropertyPath('alignSelf')]
 
-const FixedSubsectionControls = betterReactMemo(
-  'FixedSubsectionControls',
-  (props: FlexElementSubsectionProps) => {
-    const widthOrHeightControls =
-      props.parentFlexDirection === 'row' || props.parentFlexDirection === 'row-reverse' ? (
-        <FlexWidthControls />
-      ) : (
-        <FlexHeightControls />
-      )
-
-    const colorTheme = useColorTheme()
-    const { onUnsetValue } = React.useContext(InspectorCallbackContext)
-    const deleteFixedProps = React.useCallback(() => {
-      onUnsetValue(mainAxisFixedProps(props.parentFlexDirection), false)
-    }, [props.parentFlexDirection, onUnsetValue])
-
-    return (
-      <>
-        <InspectorSubsectionHeader>
-          <span style={{ color: colorTheme.primary.value, fontSize: 10, flexGrow: 1 }}>Fixed</span>
-          <SquareButton highlight onClick={deleteFixedProps}>
-            <FunctionIcons.Delete />
-          </SquareButton>
-        </InspectorSubsectionHeader>
-        {widthOrHeightControls}
-      </>
+const FixedSubsectionControls = React.memo((props: FlexElementSubsectionProps) => {
+  const widthOrHeightControls =
+    props.parentFlexDirection === 'row' || props.parentFlexDirection === 'row-reverse' ? (
+      <FlexWidthControls />
+    ) : (
+      <FlexHeightControls />
     )
-  },
-)
 
-const AdvancedSubsectionControls = betterReactMemo(
-  'AdvancedSubsectionControls',
-  (props: FlexElementSubsectionProps) => {
-    const { onUnsetValue } = React.useContext(InspectorCallbackContext)
-    const deleteAdvancedProps = React.useCallback(() => {
-      onUnsetValue(mainAxisAdvancedProps, false)
-    }, [onUnsetValue])
-    const colorTheme = useColorTheme()
-    return (
-      <>
-        <InspectorSubsectionHeader>
-          <span style={{ color: colorTheme.primary.value, fontSize: 10, flexGrow: 1 }}>
-            Advanced
-          </span>
-          <SquareButton highlight onClick={deleteAdvancedProps}>
-            <FunctionIcons.Delete />
-          </SquareButton>
-        </InspectorSubsectionHeader>
-        <AlignSelfControl variant='<--1fr--><--1fr-->' />
-      </>
-    )
-  },
-)
+  const colorTheme = useColorTheme()
+  const { onUnsetValue } = React.useContext(InspectorCallbackContext)
+  const deleteFixedProps = React.useCallback(() => {
+    onUnsetValue(mainAxisFixedProps(props.parentFlexDirection), false)
+  }, [props.parentFlexDirection, onUnsetValue])
+
+  return (
+    <>
+      <InspectorSubsectionHeader>
+        <span style={{ color: colorTheme.primary.value, fontSize: 10, flexGrow: 1 }}>Fixed</span>
+        <SquareButton highlight onClick={deleteFixedProps}>
+          <FunctionIcons.Delete />
+        </SquareButton>
+      </InspectorSubsectionHeader>
+      {widthOrHeightControls}
+    </>
+  )
+})
+
+const AdvancedSubsectionControls = React.memo((props: FlexElementSubsectionProps) => {
+  const { onUnsetValue } = React.useContext(InspectorCallbackContext)
+  const deleteAdvancedProps = React.useCallback(() => {
+    onUnsetValue(mainAxisAdvancedProps, false)
+  }, [onUnsetValue])
+  const colorTheme = useColorTheme()
+  return (
+    <>
+      <InspectorSubsectionHeader>
+        <span style={{ color: colorTheme.primary.value, fontSize: 10, flexGrow: 1 }}>Advanced</span>
+        <SquareButton highlight onClick={deleteAdvancedProps}>
+          <FunctionIcons.Delete />
+        </SquareButton>
+      </InspectorSubsectionHeader>
+      <AlignSelfControl variant='<--1fr--><--1fr-->' />
+    </>
+  )
+})
 
 export function useInitialCrossSectionState(parentFlexDirection: string | null): boolean {
   const isColumnLayouted =
@@ -258,44 +241,41 @@ export function useInitialCrossSectionState(parentFlexDirection: string | null):
         isNotUnsetDefaultOrDetected(maxHeight.controlStatus)
 }
 
-const CrossAxisControls = betterReactMemo(
-  'CrossAxisControls',
-  (props: FlexElementSubsectionProps) => {
-    const isCrossAxisVisible = useInitialCrossSectionState(props.parentFlexDirection)
+const CrossAxisControls = React.memo((props: FlexElementSubsectionProps) => {
+  const isCrossAxisVisible = useInitialCrossSectionState(props.parentFlexDirection)
 
-    const [crossAxisControlsOpen, setCrossAxisControlsOpen] = usePropControlledStateV2(
-      isCrossAxisVisible,
-    )
-    const toggleSection = React.useCallback(
-      () => setCrossAxisControlsOpen(!crossAxisControlsOpen),
-      [crossAxisControlsOpen, setCrossAxisControlsOpen],
-    )
-    const isColumnLayouted =
-      props.parentFlexDirection === 'column' || props.parentFlexDirection === 'column-reverse'
-    const widthOrHeightControls = isColumnLayouted ? <FlexWidthControls /> : <FlexHeightControls />
-    return (
-      <>
-        <InspectorSubsectionHeader style={{ display: 'flex', justifyContent: 'space-between' }}>
-          <div style={{ justifySelf: 'flex-start' }}>Cross Axis</div>
-          <div style={{ display: 'flex', alignItems: 'center' }}>
-            <InlineLink>+</InlineLink>
-            <SquareButton highlight onClick={toggleSection}>
-              <ExpandableIndicator
-                testId='flex-element-subsection'
-                visible
-                collapsed={!crossAxisControlsOpen}
-                selected={false}
-              />
-            </SquareButton>
-          </div>
-        </InspectorSubsectionHeader>
-        {when(crossAxisControlsOpen, widthOrHeightControls)}
-      </>
-    )
-  },
-)
+  const [crossAxisControlsOpen, setCrossAxisControlsOpen] = usePropControlledStateV2(
+    isCrossAxisVisible,
+  )
+  const toggleSection = React.useCallback(() => setCrossAxisControlsOpen(!crossAxisControlsOpen), [
+    crossAxisControlsOpen,
+    setCrossAxisControlsOpen,
+  ])
+  const isColumnLayouted =
+    props.parentFlexDirection === 'column' || props.parentFlexDirection === 'column-reverse'
+  const widthOrHeightControls = isColumnLayouted ? <FlexWidthControls /> : <FlexHeightControls />
+  return (
+    <>
+      <InspectorSubsectionHeader style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <div style={{ justifySelf: 'flex-start' }}>Cross Axis</div>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <InlineLink>+</InlineLink>
+          <SquareButton highlight onClick={toggleSection}>
+            <ExpandableIndicator
+              testId='flex-element-subsection'
+              visible
+              collapsed={!crossAxisControlsOpen}
+              selected={false}
+            />
+          </SquareButton>
+        </div>
+      </InspectorSubsectionHeader>
+      {when(crossAxisControlsOpen, widthOrHeightControls)}
+    </>
+  )
+})
 
-const FlexWidthControls = betterReactMemo('FlexWidthControls', () => {
+const FlexWidthControls = React.memo(() => {
   return (
     <>
       <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
@@ -308,7 +288,7 @@ const FlexWidthControls = betterReactMemo('FlexWidthControls', () => {
     </>
   )
 })
-const FlexHeightControls = betterReactMemo('FlexWidthControls', () => {
+const FlexHeightControls = React.memo(() => {
   return (
     <>
       <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
@@ -321,7 +301,7 @@ const FlexHeightControls = betterReactMemo('FlexWidthControls', () => {
     </>
   )
 })
-const FlexGrowShrinkRow = betterReactMemo('FlexGrowShrinkRow', () => {
+const FlexGrowShrinkRow = React.memo(() => {
   return (
     <UIGridRow padded={true} variant='<--1fr--><--1fr-->'>
       <FlexShorthandNumberControl label='G' styleProp='flexGrow' />

--- a/editor/src/components/inspector/sections/layout-section/layout-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-section.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { LayoutSystemSubsection } from './layout-system-subsection/layout-system-subsection'
 import { emptySpecialSizeMeasurements } from '../../../../core/shared/element-template'
-import { betterReactMemo } from '../../../../uuiui-deps'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { fastForEach } from '../../../../core/shared/utils'
 import * as EP from '../../../../core/shared/element-path'
@@ -17,7 +16,7 @@ interface LayoutSectionProps {
   toggleAspectRatioLock: () => void
 }
 
-export const LayoutSection = betterReactMemo('LayoutSection', (props: LayoutSectionProps) => {
+export const LayoutSection = React.memo((props: LayoutSectionProps) => {
   const specialSizeMeasurements = useEditorState(
     (state) => {
       let foundSpecialSizeMeasurements = emptySpecialSizeMeasurements

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -34,7 +34,6 @@ import {
   SquareButton,
   FunctionIcons,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
 
 function useDefaultedLayoutSystemInfo(): {
@@ -109,25 +108,22 @@ interface LayoutSystemControlProps {
   providesCoordinateSystemForChildren: boolean
 }
 
-export const LayoutSystemControl = betterReactMemo(
-  'LayoutSystemControl',
-  (props: LayoutSystemControlProps) => {
-    const layoutSystemData = useLayoutSystemData()
-    const detectedLayoutSystem = props.layoutSystem ?? layoutSystemData.value
-    return (
-      <OptionChainControl
-        id={'layoutSystem'}
-        key={'layoutSystem'}
-        testId={'layoutSystem'}
-        onSubmitValue={layoutSystemData.onSubmitValue}
-        value={detectedLayoutSystem}
-        options={layoutSystemOptions}
-        controlStatus={layoutSystemData.controlStatus}
-        controlStyles={layoutSystemData.controlStyles}
-      />
-    )
-  },
-)
+export const LayoutSystemControl = React.memo((props: LayoutSystemControlProps) => {
+  const layoutSystemData = useLayoutSystemData()
+  const detectedLayoutSystem = props.layoutSystem ?? layoutSystemData.value
+  return (
+    <OptionChainControl
+      id={'layoutSystem'}
+      key={'layoutSystem'}
+      testId={'layoutSystem'}
+      onSubmitValue={layoutSystemData.onSubmitValue}
+      value={detectedLayoutSystem}
+      options={layoutSystemOptions}
+      controlStatus={layoutSystemData.controlStatus}
+      controlStyles={layoutSystemData.controlStyles}
+    />
+  )
+})
 
 const layoutSystemOptions = [
   {
@@ -151,7 +147,7 @@ export const paddingPropsToUnset = [
   createLayoutPropertyPath('paddingBottom'),
 ]
 
-export const PaddingControl = betterReactMemo('PaddingControl', () => {
+export const PaddingControl = React.memo(() => {
   const {
     paddingTop,
     paddingRight,
@@ -275,15 +271,12 @@ function useDeleteAllLayoutConfig() {
   }, [onUnsetValue])
 }
 
-export const DeleteAllLayoutSystemConfigButton = betterReactMemo(
-  'DeleteAllLayoutSystemConfigButton',
-  () => {
-    const onDeleteAllConfig = useDeleteAllLayoutConfig()
+export const DeleteAllLayoutSystemConfigButton = React.memo(() => {
+  const onDeleteAllConfig = useDeleteAllLayoutConfig()
 
-    return (
-      <SquareButton highlight onClick={onDeleteAllConfig}>
-        <FunctionIcons.Remove />
-      </SquareButton>
-    )
-  },
-)
+  return (
+    <SquareButton highlight onClick={onDeleteAllConfig}>
+      <FunctionIcons.Remove />
+    </SquareButton>
+  )
+})

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-subsection.tsx
@@ -21,7 +21,6 @@ import {
   SquareButton,
   useColorTheme,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
 import { createLayoutPropertyPath } from '../../../../../core/layout/layout-helpers-new'
 import { isNotUnsetOrDefault } from '../../../common/control-status'
@@ -31,71 +30,68 @@ interface LayoutSystemSubsectionProps {
   specialSizeMeasurements: SpecialSizeMeasurements
 }
 
-export const LayoutSystemSubsection = betterReactMemo<LayoutSystemSubsectionProps>(
-  'LayoutSystemSubsection',
-  (props) => {
-    const isFlexParent = props.specialSizeMeasurements.layoutSystemForChildren === 'flex'
+export const LayoutSystemSubsection = React.memo<LayoutSystemSubsectionProps>((props) => {
+  const isFlexParent = props.specialSizeMeasurements.layoutSystemForChildren === 'flex'
 
-    const hasAnyLayoutProps = isFlexParent
-    const [layoutSectionOpen, setLayoutSectionOpen] = usePropControlledStateV2(hasAnyLayoutProps)
+  const hasAnyLayoutProps = isFlexParent
+  const [layoutSectionOpen, setLayoutSectionOpen] = usePropControlledStateV2(hasAnyLayoutProps)
 
-    const openSection = React.useCallback(() => setLayoutSectionOpen(true), [setLayoutSectionOpen])
+  const openSection = React.useCallback(() => setLayoutSectionOpen(true), [setLayoutSectionOpen])
 
-    const layoutSystemData = useLayoutSystemData()
+  const layoutSystemData = useLayoutSystemData()
 
-    const handleAddLayoutSystemClick = React.useCallback(() => {
-      layoutSystemData.onSubmitValue('flex')
-      openSection()
-    }, [layoutSystemData, openSection])
+  const handleAddLayoutSystemClick = React.useCallback(() => {
+    layoutSystemData.onSubmitValue('flex')
+    openSection()
+  }, [layoutSystemData, openSection])
 
-    const colorTheme = useColorTheme()
+  const colorTheme = useColorTheme()
 
-    return (
-      <React.Fragment>
-        <InspectorSectionHeader
-          css={{
-            marginTop: 8,
-            transition: 'color .1s ease-in-out',
-            color: layoutSectionOpen ? colorTheme.fg1.value : colorTheme.fg7.value,
-            '--buttonContentOpacity': 0.3,
-            '&:hover': {
-              color: colorTheme.fg1.value,
-              '--buttonContentOpacity': 1,
-            },
+  return (
+    <React.Fragment>
+      <InspectorSectionHeader
+        css={{
+          marginTop: 8,
+          transition: 'color .1s ease-in-out',
+          color: layoutSectionOpen ? colorTheme.fg1.value : colorTheme.fg7.value,
+          '--buttonContentOpacity': 0.3,
+          '&:hover': {
+            color: colorTheme.fg1.value,
+            '--buttonContentOpacity': 1,
+          },
+        }}
+      >
+        <FlexRow
+          onClick={handleAddLayoutSystemClick}
+          style={{
+            flexGrow: 1,
+            alignSelf: 'stretch',
+            gap: 8,
           }}
         >
-          <FlexRow
-            onClick={handleAddLayoutSystemClick}
-            style={{
-              flexGrow: 1,
-              alignSelf: 'stretch',
-              gap: 8,
-            }}
-          >
-            <InspectorSectionIcons.LayoutSystem />
-            <span>Layout System</span>
-          </FlexRow>
-          {layoutSectionOpen && <DeleteAllLayoutSystemConfigButton />}
-          {!layoutSectionOpen && (
-            <SquareButton highlight onClick={handleAddLayoutSystemClick}>
-              <Icons.Plus style={{ opacity: 'var(--buttonContentOpacity)' }} />
-            </SquareButton>
-          )}
-        </InspectorSectionHeader>
-        {layoutSectionOpen ? (
-          <React.Fragment>
-            <UIGridRow padded={true} variant='<-------------1fr------------->'>
-              <LayoutSystemControl
-                layoutSystem={props.specialSizeMeasurements.layoutSystemForChildren}
-                providesCoordinateSystemForChildren={
-                  props.specialSizeMeasurements.providesBoundsForChildren
-                }
-              />
-            </UIGridRow>
-            {isFlexParent ? <FlexContainerControls seeMoreVisible={true} /> : null}
-          </React.Fragment>
-        ) : null}
-      </React.Fragment>
-    )
-  },
-)
+          <InspectorSectionIcons.LayoutSystem />
+          <span>Layout System</span>
+        </FlexRow>
+        {layoutSectionOpen && <DeleteAllLayoutSystemConfigButton />}
+        {!layoutSectionOpen && (
+          <SquareButton highlight onClick={handleAddLayoutSystemClick}>
+            <Icons.Plus style={{ opacity: 'var(--buttonContentOpacity)' }} />
+          </SquareButton>
+        )}
+      </InspectorSectionHeader>
+      {layoutSectionOpen ? (
+        <React.Fragment>
+          <UIGridRow padded={true} variant='<-------------1fr------------->'>
+            <LayoutSystemControl
+              layoutSystem={props.specialSizeMeasurements.layoutSystemForChildren}
+              providesCoordinateSystemForChildren={
+                props.specialSizeMeasurements.providesBoundsForChildren
+              }
+            />
+          </UIGridRow>
+          {isFlexParent ? <FlexContainerControls seeMoreVisible={true} /> : null}
+        </React.Fragment>
+      ) : null}
+    </React.Fragment>
+  )
+})

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -38,7 +38,6 @@ import {
   SimpleNumberInput,
   useColorTheme,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import {
   InspectorInfoWithPropKeys,
   useInspectorInfoLonghandShorthand,
@@ -62,42 +61,39 @@ export const pinLabels: { [key in LayoutPinnedProp]: string } = {
   Height: 'H',
 }
 
-export const PinsLayoutNumberControl = betterReactMemo(
-  'PinsLayoutNumberControl',
-  (props: PinsLayoutNumberControlProps) => {
-    const framePoint = framePointForPinnedProp(props.prop)
-    const pointInfo = useInspectorLayoutInfo(props.prop)
+export const PinsLayoutNumberControl = React.memo((props: PinsLayoutNumberControlProps) => {
+  const framePoint = framePointForPinnedProp(props.prop)
+  const pointInfo = useInspectorLayoutInfo(props.prop)
 
-    const wrappedOnSubmit = useWrappedEmptyOrUnknownOnSubmitValue(
-      pointInfo.onSubmitValue,
-      pointInfo.onUnsetValues,
-    )
-    const wrappedOnTransientSubmit = useWrappedEmptyOrUnknownOnSubmitValue(
-      pointInfo.onTransientSubmitValue,
-      pointInfo.onUnsetValues,
-    )
+  const wrappedOnSubmit = useWrappedEmptyOrUnknownOnSubmitValue(
+    pointInfo.onSubmitValue,
+    pointInfo.onUnsetValues,
+  )
+  const wrappedOnTransientSubmit = useWrappedEmptyOrUnknownOnSubmitValue(
+    pointInfo.onTransientSubmitValue,
+    pointInfo.onUnsetValues,
+  )
 
-    return (
-      <InspectorContextMenuWrapper
-        id={`position-${props.prop}-context-menu`}
-        items={[unsetPropertyMenuItem(framePoint, pointInfo.onUnsetValues)]}
-        data={{}}
-      >
-        <NumberInput
-          value={pointInfo.value}
-          id={`position-${props.prop}-number-input`}
-          testId={`position-${props.prop}-number-input`}
-          labelInner={props.label}
-          onSubmitValue={wrappedOnSubmit}
-          onTransientSubmitValue={wrappedOnTransientSubmit}
-          controlStatus={pointInfo.controlStatus}
-          numberType={'LengthPercent'}
-          defaultUnitToHide={'px'}
-        />
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
+  return (
+    <InspectorContextMenuWrapper
+      id={`position-${props.prop}-context-menu`}
+      items={[unsetPropertyMenuItem(framePoint, pointInfo.onUnsetValues)]}
+      data={{}}
+    >
+      <NumberInput
+        value={pointInfo.value}
+        id={`position-${props.prop}-number-input`}
+        testId={`position-${props.prop}-number-input`}
+        labelInner={props.label}
+        onSubmitValue={wrappedOnSubmit}
+        onTransientSubmitValue={wrappedOnTransientSubmit}
+        controlStatus={pointInfo.controlStatus}
+        numberType={'LengthPercent'}
+        defaultUnitToHide={'px'}
+      />
+    </InspectorContextMenuWrapper>
+  )
+})
 
 export type StyleLayoutNumberProp =
   | 'paddingTop'
@@ -124,95 +120,88 @@ interface FlexStyleNumberControlProps {
   styleProp: StyleLayoutNumberProp
 }
 
-export const FlexStyleNumberControl = betterReactMemo(
-  'FlexStyleNumberControl',
-  (props: FlexStyleNumberControlProps) => {
-    const layoutPropInfo = useInspectorLayoutInfo(props.styleProp)
-    const value =
-      isCSSNumber(layoutPropInfo.value) || layoutPropInfo.value == null
-        ? layoutPropInfo.value
-        : undefined
+export const FlexStyleNumberControl = React.memo((props: FlexStyleNumberControlProps) => {
+  const layoutPropInfo = useInspectorLayoutInfo(props.styleProp)
+  const value =
+    isCSSNumber(layoutPropInfo.value) || layoutPropInfo.value == null
+      ? layoutPropInfo.value
+      : undefined
 
-    const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      layoutPropInfo.onSubmitValue,
-      layoutPropInfo.onUnsetValues,
-    )
-    const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      layoutPropInfo.onTransientSubmitValue,
-      layoutPropInfo.onUnsetValues,
-    )
-    return (
-      <InspectorContextMenuWrapper
-        id={`position-${props.styleProp}-context-menu`}
-        items={[unsetPropertyMenuItem(props.styleProp, layoutPropInfo.onUnsetValues)]}
-        data={{}}
-      >
-        <NumberInput
-          id={`position-${props.styleProp}-number-input`}
-          testId={`position-${props.styleProp}-number-input`}
-          value={value}
-          onSubmitValue={wrappedOnSubmitValue}
-          onTransientSubmitValue={wrappedOnTransientSubmitValue}
-          controlStatus={layoutPropInfo.controlStatus}
-          numberType={'UnitlessPercent'}
-          labelInner={props.label}
-          defaultUnitToHide={'px'}
-        />
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
+  const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+    layoutPropInfo.onSubmitValue,
+    layoutPropInfo.onUnsetValues,
+  )
+  const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+    layoutPropInfo.onTransientSubmitValue,
+    layoutPropInfo.onUnsetValues,
+  )
+  return (
+    <InspectorContextMenuWrapper
+      id={`position-${props.styleProp}-context-menu`}
+      items={[unsetPropertyMenuItem(props.styleProp, layoutPropInfo.onUnsetValues)]}
+      data={{}}
+    >
+      <NumberInput
+        id={`position-${props.styleProp}-number-input`}
+        testId={`position-${props.styleProp}-number-input`}
+        value={value}
+        onSubmitValue={wrappedOnSubmitValue}
+        onTransientSubmitValue={wrappedOnTransientSubmitValue}
+        controlStatus={layoutPropInfo.controlStatus}
+        numberType={'UnitlessPercent'}
+        labelInner={props.label}
+        defaultUnitToHide={'px'}
+      />
+    </InspectorContextMenuWrapper>
+  )
+})
 
 interface FlexShorthandNumberControlProps {
   label: string
   styleProp: 'flexGrow' | 'flexShrink'
 }
 
-export const FlexShorthandNumberControl = betterReactMemo(
-  'FlexShorthandNumberControl',
-  (props: FlexShorthandNumberControlProps) => {
-    const layoutPropInfo = useInspectorInfoLonghandShorthand(
-      ['flexGrow', 'flexShrink', 'flexBasis'],
-      'flex',
-      createLayoutPropertyPath,
-    )[props.styleProp] as InspectorInfoWithPropKeys<'flexGrow' | 'flexShrink', 'flex'>
-    const value = typeof layoutPropInfo.value === 'number' ? layoutPropInfo.value : undefined
+export const FlexShorthandNumberControl = React.memo((props: FlexShorthandNumberControlProps) => {
+  const layoutPropInfo = useInspectorInfoLonghandShorthand(
+    ['flexGrow', 'flexShrink', 'flexBasis'],
+    'flex',
+    createLayoutPropertyPath,
+  )[props.styleProp] as InspectorInfoWithPropKeys<'flexGrow' | 'flexShrink', 'flex'>
+  const value = typeof layoutPropInfo.value === 'number' ? layoutPropInfo.value : undefined
 
-    const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      layoutPropInfo.onSubmitValue,
-      layoutPropInfo.onUnsetValues,
-    )
-    const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      layoutPropInfo.onTransientSubmitValue,
-      layoutPropInfo.onUnsetValues,
-    )
-    return (
-      <InspectorContextMenuWrapper
-        id={`position-${props.styleProp}-context-menu`}
-        items={[unsetPropertyMenuItem(props.styleProp, layoutPropInfo.onUnsetValues)]}
-        data={{}}
-      >
-        <SimpleNumberInput
-          id={`position-${props.styleProp}-number-input`}
-          testId={`position-${props.styleProp}-number-input`}
-          value={value}
-          onForcedSubmitValue={wrappedOnSubmitValue}
-          onSubmitValue={wrappedOnSubmitValue}
-          onTransientSubmitValue={wrappedOnTransientSubmitValue}
-          controlStatus={layoutPropInfo.controlStatus}
-          labelInner={props.label}
-          defaultUnitToHide={'px'}
-        />
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
+  const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+    layoutPropInfo.onSubmitValue,
+    layoutPropInfo.onUnsetValues,
+  )
+  const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+    layoutPropInfo.onTransientSubmitValue,
+    layoutPropInfo.onUnsetValues,
+  )
+  return (
+    <InspectorContextMenuWrapper
+      id={`position-${props.styleProp}-context-menu`}
+      items={[unsetPropertyMenuItem(props.styleProp, layoutPropInfo.onUnsetValues)]}
+      data={{}}
+    >
+      <SimpleNumberInput
+        id={`position-${props.styleProp}-number-input`}
+        testId={`position-${props.styleProp}-number-input`}
+        value={value}
+        onForcedSubmitValue={wrappedOnSubmitValue}
+        onSubmitValue={wrappedOnSubmitValue}
+        onTransientSubmitValue={wrappedOnTransientSubmitValue}
+        controlStatus={layoutPropInfo.controlStatus}
+        labelInner={props.label}
+        defaultUnitToHide={'px'}
+      />
+    </InspectorContextMenuWrapper>
+  )
+})
 
 interface FlexShorthandCSSNumberControlProps {
   label: string
 }
-export const FlexBasisShorthandCSSNumberControl = betterReactMemo(
-  'FlexStyleNumberControl',
+export const FlexBasisShorthandCSSNumberControl = React.memo(
   (props: FlexShorthandCSSNumberControlProps) => {
     const layoutPropInfo = useInspectorInfoLonghandShorthand(
       ['flexBasis', 'flexGrow', 'flexShrink'],
@@ -254,41 +243,38 @@ interface FlexLayoutNumberControlProps {
   layoutProp: LayoutFlexElementNumericProp
 }
 
-export const FlexLayoutNumberControl = betterReactMemo(
-  'FlexLayoutNumberControl',
-  (props: FlexLayoutNumberControlProps) => {
-    const layoutPropInfo = useInspectorLayoutInfo(props.layoutProp)
+export const FlexLayoutNumberControl = React.memo((props: FlexLayoutNumberControlProps) => {
+  const layoutPropInfo = useInspectorLayoutInfo(props.layoutProp)
 
-    const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      layoutPropInfo.onSubmitValue,
-      layoutPropInfo.onUnsetValues,
-    )
-    const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-      layoutPropInfo.onTransientSubmitValue,
-      layoutPropInfo.onUnsetValues,
-    )
+  const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+    layoutPropInfo.onSubmitValue,
+    layoutPropInfo.onUnsetValues,
+  )
+  const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
+    layoutPropInfo.onTransientSubmitValue,
+    layoutPropInfo.onUnsetValues,
+  )
 
-    return (
-      <InspectorContextMenuWrapper
-        id={`position-${props.layoutProp}-context-menu`}
-        items={[unsetPropertyMenuItem(props.layoutProp, layoutPropInfo.onUnsetValues)]}
-        data={{}}
-      >
-        <NumberInput
-          id={`position-${props.layoutProp}-number-input`}
-          testId={`position-${props.layoutProp}-number-input`}
-          value={layoutPropInfo.value}
-          onSubmitValue={wrappedOnSubmitValue}
-          onTransientSubmitValue={wrappedOnTransientSubmitValue}
-          controlStatus={layoutPropInfo.controlStatus}
-          numberType={'LengthPercent'}
-          labelInner={props.label}
-          defaultUnitToHide={'px'}
-        />
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
+  return (
+    <InspectorContextMenuWrapper
+      id={`position-${props.layoutProp}-context-menu`}
+      items={[unsetPropertyMenuItem(props.layoutProp, layoutPropInfo.onUnsetValues)]}
+      data={{}}
+    >
+      <NumberInput
+        id={`position-${props.layoutProp}-number-input`}
+        testId={`position-${props.layoutProp}-number-input`}
+        value={layoutPropInfo.value}
+        onSubmitValue={wrappedOnSubmitValue}
+        onTransientSubmitValue={wrappedOnTransientSubmitValue}
+        controlStatus={layoutPropInfo.controlStatus}
+        numberType={'LengthPercent'}
+        labelInner={props.label}
+        defaultUnitToHide={'px'}
+      />
+    </InspectorContextMenuWrapper>
+  )
+})
 
 interface PinControlsProps {
   resetPins: () => void
@@ -296,7 +282,7 @@ interface PinControlsProps {
   togglePin: (prop: LayoutPinnedProp) => void
 }
 
-const PinControls = betterReactMemo('PinControls', (props: PinControlsProps) => {
+const PinControls = React.memo((props: PinControlsProps) => {
   const resetPinsItem = {
     name: 'Reset positioning',
     enabled: true,
@@ -339,7 +325,7 @@ interface WidthHeightRowProps {
   toggleAspectRatioLock: () => void
 }
 
-const WidthHeightRow = betterReactMemo('WidthHeightRow', (props: WidthHeightRowProps) => {
+const WidthHeightRow = React.memo((props: WidthHeightRowProps) => {
   const colorTheme = useColorTheme()
   const {
     layoutType,
@@ -422,7 +408,7 @@ const WidthHeightRow = betterReactMemo('WidthHeightRow', (props: WidthHeightRowP
 
 const minimumsProps = [createLayoutPropertyPath('minWidth'), createLayoutPropertyPath('minHeight')]
 
-const MinimumsRow = betterReactMemo('MinimumsRow', () => {
+const MinimumsRow = React.memo(() => {
   return (
     <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
       <PropertyLabel target={minimumsProps}>Minimum</PropertyLabel>
@@ -438,7 +424,7 @@ const MinimumsRow = betterReactMemo('MinimumsRow', () => {
 
 const maximumsProps = [createLayoutPropertyPath('maxWidth'), createLayoutPropertyPath('maxHeight')]
 
-const MaximumsRow = betterReactMemo('MaximumsRow', () => {
+const MaximumsRow = React.memo(() => {
   return (
     <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
       <PropertyLabel target={maximumsProps}>Maximum</PropertyLabel>
@@ -454,7 +440,7 @@ const MaximumsRow = betterReactMemo('MaximumsRow', () => {
 
 const flexWidthHeightProps = [createLayoutPropertyPath('Width'), createLayoutPropertyPath('Height')]
 
-const FlexWidthHeightRow = betterReactMemo('FixedWidthHeightRow', () => {
+const FlexWidthHeightRow = React.memo(() => {
   return (
     <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
       <PropertyLabel target={flexWidthHeightProps}>Size</PropertyLabel>
@@ -473,7 +459,7 @@ const flexGrowShrinkProps = [
   createLayoutPropertyPath('flexShrink'),
 ]
 
-const FlexGrowShrinkRow = betterReactMemo('FlexGrowShrinkRow', () => {
+const FlexGrowShrinkRow = React.memo(() => {
   return (
     <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
       <PropertyLabel target={flexGrowShrinkProps}>Flex</PropertyLabel>
@@ -487,7 +473,7 @@ const FlexGrowShrinkRow = betterReactMemo('FlexGrowShrinkRow', () => {
   )
 })
 
-const OtherPinsRow = betterReactMemo('OtherPinsRow', (props: PinControlsProps) => {
+const OtherPinsRow = React.memo((props: PinControlsProps) => {
   const { resetPins: resetPinsFn, framePins, togglePin } = props
   let firstXAxisControl: React.ReactElement = <div />
   let secondXAxisControl: React.ReactElement = <div />
@@ -560,55 +546,52 @@ interface GiganticSizePinsSubsectionProps {
   toggleAspectRatioLock: () => void
 }
 
-export const GiganticSizePinsSubsection = betterReactMemo(
-  'GiganticSizePinsSubsection',
-  (props: GiganticSizePinsSubsectionProps) => {
-    const { layoutType, parentFlexDirection, aspectRatioLocked, toggleAspectRatioLock } = props
+export const GiganticSizePinsSubsection = React.memo((props: GiganticSizePinsSubsectionProps) => {
+  const { layoutType, parentFlexDirection, aspectRatioLocked, toggleAspectRatioLock } = props
 
-    const minWidth = useInspectorLayoutInfo('minWidth')
-    const maxWidth = useInspectorLayoutInfo('maxWidth')
-    const minHeight = useInspectorLayoutInfo('minHeight')
-    const maxHeight = useInspectorLayoutInfo('maxHeight')
+  const minWidth = useInspectorLayoutInfo('minWidth')
+  const maxWidth = useInspectorLayoutInfo('maxWidth')
+  const minHeight = useInspectorLayoutInfo('minHeight')
+  const maxHeight = useInspectorLayoutInfo('maxHeight')
 
-    const hasMinMaxValues =
-      isNotUnsetOrDefault(minWidth.controlStatus) ||
-      isNotUnsetOrDefault(maxWidth.controlStatus) ||
-      isNotUnsetOrDefault(minHeight.controlStatus) ||
-      isNotUnsetOrDefault(maxHeight.controlStatus)
-    const [minMaxToggled, setMinMaxToggled] = usePropControlledStateV2(hasMinMaxValues)
-    const toggleMinMax = React.useCallback(() => {
-      setMinMaxToggled(!minMaxToggled)
-    }, [minMaxToggled, setMinMaxToggled])
+  const hasMinMaxValues =
+    isNotUnsetOrDefault(minWidth.controlStatus) ||
+    isNotUnsetOrDefault(maxWidth.controlStatus) ||
+    isNotUnsetOrDefault(minHeight.controlStatus) ||
+    isNotUnsetOrDefault(maxHeight.controlStatus)
+  const [minMaxToggled, setMinMaxToggled] = usePropControlledStateV2(hasMinMaxValues)
+  const toggleMinMax = React.useCallback(() => {
+    setMinMaxToggled(!minMaxToggled)
+  }, [minMaxToggled, setMinMaxToggled])
 
-    const { resetAllPins, framePins, togglePin } = usePinToggling()
+  const { resetAllPins, framePins, togglePin } = usePinToggling()
 
-    return (
-      <>
-        <WidthHeightRow
-          layoutType={layoutType}
-          togglePin={togglePin}
-          framePins={framePins}
-          toggleMinMax={toggleMinMax}
-          parentFlexDirection={parentFlexDirection}
-          aspectRatioLocked={aspectRatioLocked}
-          toggleAspectRatioLock={toggleAspectRatioLock}
-        />
-        {minMaxToggled ? (
-          <>
-            <MinimumsRow />
-            <MaximumsRow />
-          </>
-        ) : null}
-        {layoutType === 'flex' ? (
-          <>
-            <FlexGrowShrinkRow />
-            <FlexWidthHeightRow />
-          </>
-        ) : null}
-        {layoutType === 'absolute' ? (
-          <OtherPinsRow resetPins={resetAllPins} framePins={framePins} togglePin={togglePin} />
-        ) : null}
-      </>
-    )
-  },
-)
+  return (
+    <>
+      <WidthHeightRow
+        layoutType={layoutType}
+        togglePin={togglePin}
+        framePins={framePins}
+        toggleMinMax={toggleMinMax}
+        parentFlexDirection={parentFlexDirection}
+        aspectRatioLocked={aspectRatioLocked}
+        toggleAspectRatioLock={toggleAspectRatioLock}
+      />
+      {minMaxToggled ? (
+        <>
+          <MinimumsRow />
+          <MaximumsRow />
+        </>
+      ) : null}
+      {layoutType === 'flex' ? (
+        <>
+          <FlexGrowShrinkRow />
+          <FlexWidthHeightRow />
+        </>
+      ) : null}
+      {layoutType === 'absolute' ? (
+        <OtherPinsRow resetPins={resetAllPins} framePins={framePins} togglePin={togglePin} />
+      ) : null}
+    </>
+  )
+})

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-controls.tsx
@@ -3,58 +3,54 @@ import { OptionChainControl } from '../../../controls/option-chain-control'
 import { useInspectorStyleInfo } from '../../../common/property-path-hooks'
 import { SelfLayoutTab } from './self-layout-subsection'
 import { getControlStyles } from '../../../common/control-status'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 
 interface LayoutTypePickerProps {
   value: SelfLayoutTab
   setActiveTab: React.Dispatch<SelfLayoutTab>
 }
 
-export const LayoutTypePicker = betterReactMemo(
-  'LayoutTypePicker',
-  ({ value, setActiveTab }: LayoutTypePickerProps) => {
-    const { onSubmitValue, onUnsetValues, controlStatus, controlStyles } = useInspectorStyleInfo(
-      'position',
-    )
-    const changeSelectedType = React.useCallback(
-      (newValue: SelfLayoutTab) => {
-        setActiveTab(newValue)
-        switch (newValue) {
-          case 'absolute':
-          case 'sticky': {
-            onSubmitValue(newValue)
-            break
-          }
-          case 'flex':
-          case 'flow': {
-            onUnsetValues()
-            break
-          }
-          default: {
-            const _exhaustiveCheck: never = newValue
-            throw new Error(`SelfLayoutTab type ${newValue} not found`)
-          }
+export const LayoutTypePicker = React.memo(({ value, setActiveTab }: LayoutTypePickerProps) => {
+  const { onSubmitValue, onUnsetValues, controlStatus, controlStyles } = useInspectorStyleInfo(
+    'position',
+  )
+  const changeSelectedType = React.useCallback(
+    (newValue: SelfLayoutTab) => {
+      setActiveTab(newValue)
+      switch (newValue) {
+        case 'absolute':
+        case 'sticky': {
+          onSubmitValue(newValue)
+          break
         }
-      },
-      [onSubmitValue, setActiveTab, onUnsetValues],
-    )
+        case 'flex':
+        case 'flow': {
+          onUnsetValues()
+          break
+        }
+        default: {
+          const _exhaustiveCheck: never = newValue
+          throw new Error(`SelfLayoutTab type ${newValue} not found`)
+        }
+      }
+    },
+    [onSubmitValue, setActiveTab, onUnsetValues],
+  )
 
-    return (
-      <OptionChainControl
-        id='layoutSystem'
-        key='layoutSystem'
-        testId='layoutSystem'
-        onSubmitValue={changeSelectedType}
-        value={value}
-        options={layoutSystemOptions}
-        controlStatus={value === 'absolute' || value === 'sticky' ? controlStatus : 'simple'}
-        controlStyles={
-          value === 'absolute' || value === 'sticky' ? controlStyles : getControlStyles('simple')
-        }
-      />
-    )
-  },
-)
+  return (
+    <OptionChainControl
+      id='layoutSystem'
+      key='layoutSystem'
+      testId='layoutSystem'
+      onSubmitValue={changeSelectedType}
+      value={value}
+      options={layoutSystemOptions}
+      controlStatus={value === 'absolute' || value === 'sticky' ? controlStatus : 'simple'}
+      controlStyles={
+        value === 'absolute' || value === 'sticky' ? controlStyles : getControlStyles('simple')
+      }
+    />
+  )
+})
 
 const layoutSystemOptions = [
   {

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -17,7 +17,7 @@ import {
   Tooltip,
   useColorTheme,
 } from '../../../../../uuiui'
-import { usePropControlledState, betterReactMemo } from '../../../../../uuiui-deps'
+import { usePropControlledState } from '../../../../../uuiui-deps'
 import { InlineIndicator, InlineLink } from '../../../../../uuiui/inline-button'
 import { useEditorState, useRefEditorState } from '../../../../editor/store/store-hook'
 import { ExpandableIndicator } from '../../../../navigator/navigator-item/expandable-indicator'
@@ -91,61 +91,55 @@ const useLayoutSectionInitialToggleState = (
   }
 }
 
-export const LayoutSubsection = betterReactMemo(
-  'LayoutSubsection',
-  (props: SelfLayoutSubsectionProps) => {
-    const [activeTab, setActiveTab] = useActiveLayoutTab(props.position, props.parentLayoutSystem)
+export const LayoutSubsection = React.memo((props: SelfLayoutSubsectionProps) => {
+  const [activeTab, setActiveTab] = useActiveLayoutTab(props.position, props.parentLayoutSystem)
 
-    const initialLayoutSectionOpen = useLayoutSectionInitialToggleState(
-      activeTab,
-      props.parentFlexDirection,
-    )
+  const initialLayoutSectionOpen = useLayoutSectionInitialToggleState(
+    activeTab,
+    props.parentFlexDirection,
+  )
 
-    const [selfLayoutSectionOpen, setSelfLayoutSectionOpen] = usePropControlledStateV2(
-      initialLayoutSectionOpen,
-    )
+  const [selfLayoutSectionOpen, setSelfLayoutSectionOpen] = usePropControlledStateV2(
+    initialLayoutSectionOpen,
+  )
 
-    const toggleSection = React.useCallback(
-      () => setSelfLayoutSectionOpen(!selfLayoutSectionOpen),
-      [selfLayoutSectionOpen, setSelfLayoutSectionOpen],
-    )
-    return (
-      <>
-        <LayoutSectionHeader
+  const toggleSection = React.useCallback(() => setSelfLayoutSectionOpen(!selfLayoutSectionOpen), [
+    selfLayoutSectionOpen,
+    setSelfLayoutSectionOpen,
+  ])
+  return (
+    <>
+      <LayoutSectionHeader
+        layoutType={activeTab}
+        toggleSection={toggleSection}
+        selfLayoutSectionOpen={selfLayoutSectionOpen}
+      />
+      {when(selfLayoutSectionOpen, <LayoutSubsectionContent {...props} />)}
+    </>
+  )
+})
+
+export const LayoutSubsectionContent = React.memo((props: SelfLayoutSubsectionProps) => {
+  const [activeTab, setActiveTab] = useActiveLayoutTab(props.position, props.parentLayoutSystem)
+  return (
+    <>
+      {when(activeTab === 'flex', <FlexInfoBox />)}
+      {unless(
+        activeTab === 'flex',
+        <GiganticSizePinsSubsection
           layoutType={activeTab}
-          toggleSection={toggleSection}
-          selfLayoutSectionOpen={selfLayoutSectionOpen}
-        />
-        {when(selfLayoutSectionOpen, <LayoutSubsectionContent {...props} />)}
-      </>
-    )
-  },
-)
-
-export const LayoutSubsectionContent = betterReactMemo(
-  'LayoutSubsectionContent',
-  (props: SelfLayoutSubsectionProps) => {
-    const [activeTab, setActiveTab] = useActiveLayoutTab(props.position, props.parentLayoutSystem)
-    return (
-      <>
-        {when(activeTab === 'flex', <FlexInfoBox />)}
-        {unless(
-          activeTab === 'flex',
-          <GiganticSizePinsSubsection
-            layoutType={activeTab}
-            parentFlexDirection={props.parentFlexDirection}
-            aspectRatioLocked={props.aspectRatioLocked}
-            toggleAspectRatioLock={props.toggleAspectRatioLock}
-          />,
-        )}
-        {when(
-          activeTab === 'flex',
-          <FlexElementSubsectionExperiment parentFlexDirection={props.parentFlexDirection} />,
-        )}
-      </>
-    )
-  },
-)
+          parentFlexDirection={props.parentFlexDirection}
+          aspectRatioLocked={props.aspectRatioLocked}
+          toggleAspectRatioLock={props.toggleAspectRatioLock}
+        />,
+      )}
+      {when(
+        activeTab === 'flex',
+        <FlexElementSubsectionExperiment parentFlexDirection={props.parentFlexDirection} />,
+      )}
+    </>
+  )
+})
 
 interface LayoutSectionHeaderProps {
   layoutType: SelfLayoutTab | 'grid'
@@ -204,58 +198,55 @@ function useAddPositionAbsolute() {
   }, [onSubmitValue])
 }
 
-const LayoutSectionHeader = betterReactMemo(
-  'LayoutSectionHeader',
-  (props: LayoutSectionHeaderProps) => {
-    const colorTheme = useColorTheme()
-    const { layoutType, selfLayoutSectionOpen, toggleSection } = props
-    const onDeleteAllConfig = useDeleteAllSelfLayoutConfig()
-    const onAbsoluteButtonClick = useAddPositionAbsolute()
+const LayoutSectionHeader = React.memo((props: LayoutSectionHeaderProps) => {
+  const colorTheme = useColorTheme()
+  const { layoutType, selfLayoutSectionOpen, toggleSection } = props
+  const onDeleteAllConfig = useDeleteAllSelfLayoutConfig()
+  const onAbsoluteButtonClick = useAddPositionAbsolute()
 
-    return (
-      <InspectorSubsectionHeader>
-        <div style={{ flexGrow: 1, display: 'flex', gap: 8 }}>
-          <InspectorSectionIcons.Layout />
-          <span
-            style={{
-              textTransform: 'uppercase',
-              fontWeight: 600,
-              paddingRight: 8,
-              color: colorTheme.primary.value,
-              fontSize: 10,
-            }}
-          >
-            {layoutType}
-          </span>
-          <ParentIndicatorAndLink />
-          <ChildrenOrContentIndicator />
-        </div>
-        {when(
-          selfLayoutSectionOpen && layoutType !== 'absolute',
-          <Tooltip title='Use Absolute Positioning' placement='bottom'>
-            <SquareButton highlight onClick={onAbsoluteButtonClick}>
-              <div style={{ color: colorTheme.brandNeonPink.value }}>*</div>
-            </SquareButton>
-          </Tooltip>,
-        )}
-        {when(
-          selfLayoutSectionOpen,
-          <SquareButton highlight onClick={onDeleteAllConfig}>
-            <FunctionIcons.Delete />
-          </SquareButton>,
-        )}
-        <SquareButton highlight onClick={toggleSection}>
-          <ExpandableIndicator
-            testId='layout-system-expand'
-            visible
-            collapsed={!selfLayoutSectionOpen}
-            selected={false}
-          />
-        </SquareButton>
-      </InspectorSubsectionHeader>
-    )
-  },
-)
+  return (
+    <InspectorSubsectionHeader>
+      <div style={{ flexGrow: 1, display: 'flex', gap: 8 }}>
+        <InspectorSectionIcons.Layout />
+        <span
+          style={{
+            textTransform: 'uppercase',
+            fontWeight: 600,
+            paddingRight: 8,
+            color: colorTheme.primary.value,
+            fontSize: 10,
+          }}
+        >
+          {layoutType}
+        </span>
+        <ParentIndicatorAndLink />
+        <ChildrenOrContentIndicator />
+      </div>
+      {when(
+        selfLayoutSectionOpen && layoutType !== 'absolute',
+        <Tooltip title='Use Absolute Positioning' placement='bottom'>
+          <SquareButton highlight onClick={onAbsoluteButtonClick}>
+            <div style={{ color: colorTheme.brandNeonPink.value }}>*</div>
+          </SquareButton>
+        </Tooltip>,
+      )}
+      {when(
+        selfLayoutSectionOpen,
+        <SquareButton highlight onClick={onDeleteAllConfig}>
+          <FunctionIcons.Delete />
+        </SquareButton>,
+      )}
+      <SquareButton highlight onClick={toggleSection}>
+        <ExpandableIndicator
+          testId='layout-system-expand'
+          visible
+          collapsed={!selfLayoutSectionOpen}
+          selected={false}
+        />
+      </SquareButton>
+    </InspectorSubsectionHeader>
+  )
+})
 
 interface ParentIndicatorAndLinkProps {
   style?: React.CSSProperties
@@ -339,7 +330,7 @@ const ChildrenOrContentIndicator = () => {
   )
 }
 
-const FlexInfoBox = betterReactMemo('FlexInfoBox', () => {
+const FlexInfoBox = React.memo(() => {
   const { hasChildren, hasContent } = useElementHasChildrenOrContent()
 
   return (

--- a/editor/src/components/inspector/sections/layout-section/warning-subsection/warning-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/warning-subsection/warning-subsection.tsx
@@ -4,9 +4,8 @@ import { useInspectorWarningStatus } from '../../../common/property-path-hooks'
 import { WarningIcon } from '../../../../../uuiui/warning-icon'
 import { InfoBox } from '../../../../common/notices'
 import { Tooltip, FlexRow, UIRow } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 
-export const WarningSubsection = betterReactMemo('WarningSubsection', (props) => {
+export const WarningSubsection = React.memo((props) => {
   const shouldShowWarning = useInspectorWarningStatus()
   if (shouldShowWarning) {
     return (

--- a/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
+++ b/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
@@ -22,7 +22,7 @@ import {
   StringInput,
   HeadlessStringInput,
 } from '../../../../uuiui'
-import { betterReactMemo, getControlStyles } from '../../../../uuiui-deps'
+import { getControlStyles } from '../../../../uuiui-deps'
 import { load } from '../../../editor/actions/actions'
 import json5 from 'json5'
 import { NO_OP } from '../../../../core/shared/utils'
@@ -34,7 +34,7 @@ const StyledFlexRow = styled(FlexRow)({
   paddingRight: 12,
 })
 
-const FeatureSwitchesSection = betterReactMemo('Feature Switches', () => {
+const FeatureSwitchesSection = React.memo(() => {
   if (AllFeatureNames.length > 0) {
     return (
       <React.Fragment>
@@ -51,7 +51,7 @@ const FeatureSwitchesSection = betterReactMemo('Feature Switches', () => {
   }
 })
 
-const FeatureSwitchRow = betterReactMemo('Feature Switch Row', (props: { name: FeatureName }) => {
+const FeatureSwitchRow = React.memo((props: { name: FeatureName }) => {
   const name = props.name
   const id = `toggle-${name}`
   const [changeCount, setChangeCount] = React.useState(0)
@@ -73,7 +73,7 @@ const FeatureSwitchRow = betterReactMemo('Feature Switch Row', (props: { name: F
   )
 })
 
-export const SettingsPanel = betterReactMemo('SettingsPanel', () => {
+export const SettingsPanel = React.memo(() => {
   const colorTheme = useColorTheme()
   const dispatch = useEditorState((store) => store.dispatch, 'SettingsPanel dispatch')
   const interfaceDesigner = useEditorState(

--- a/editor/src/components/inspector/sections/style-section/background-subsection/background-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/background-subsection.tsx
@@ -35,10 +35,7 @@ import { LinearGradientBackgroundLayer } from './linear-gradient-layer'
 import { RadialGradientBackgroundLayer } from './radial-gradient-layer'
 import { SolidBackgroundLayer } from './solid-background-layer'
 import { URLBackgroundLayer } from './url-background-layer'
-import {
-  betterReactMemo,
-  useKeepReferenceEqualityIfPossible,
-} from '../../../../../utils/react-performance'
+import { useKeepReferenceEqualityIfPossible } from '../../../../../utils/react-performance'
 import {
   UtopiaTheme,
   InspectorSubsectionHeader,
@@ -162,7 +159,7 @@ export const backgroundLonghandPaths: Array<
 
 const rowHeight = UtopiaTheme.layout.rowHeight.max
 
-export const BackgroundSubsection = betterReactMemo('BackgroundSubsection', () => {
+export const BackgroundSubsection = React.memo(() => {
   const [openPopup, setOpenPopup] = React.useState<number | undefined>(undefined)
   const {
     controlStatus,

--- a/editor/src/components/inspector/sections/style-section/background-subsection/conic-gradient-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/conic-gradient-layer.tsx
@@ -26,14 +26,12 @@ import {
   PopupList,
   ChainedNumberInput,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 
 interface ConicGradientBackgroundLayerProps extends BackgroundLayerProps {
   value: CSSConicGradientBackgroundLayer
 }
 
-export const ConicGradientBackgroundLayer = betterReactMemo<ConicGradientBackgroundLayerProps>(
-  'ConicGradientBackgroundLayer',
+export const ConicGradientBackgroundLayer = React.memo<ConicGradientBackgroundLayerProps>(
   (props) => {
     const [gradientCheckboxSubmitValue] = props.useSubmitTransformedValuesFactory(
       getIndexedUpdateEnabled(props.index),

--- a/editor/src/components/inspector/sections/style-section/background-subsection/gradient-stop-editor.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/gradient-stop-editor.tsx
@@ -23,7 +23,6 @@ import {
 import { inspectorEdgePadding } from './background-picker'
 import { clampValue } from '../../../../../core/shared/math-utils'
 import { useColorTheme, FlexColumn, UtopiaTheme } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 
 interface GradientStopProps {
   stop: CSSGradientStop
@@ -35,8 +34,7 @@ interface GradientStopProps {
   indexedDeleteStop: () => void
 }
 
-const GradientStop = betterReactMemo<GradientStopProps>(
-  'GradientStop',
+const GradientStop = React.memo<GradientStopProps>(
   ({
     stop,
     selected,
@@ -360,8 +358,7 @@ function deleteStopAndUpdateIndex(
   }
 }
 
-export const GradientStopsEditor = betterReactMemo<GradientControlProps>(
-  'GradientStopsEditor',
+export const GradientStopsEditor = React.memo<GradientControlProps>(
   ({
     selectedStopUnorderedIndex,
     setSelectedStopUnorderedIndex,

--- a/editor/src/components/inspector/sections/style-section/background-subsection/linear-gradient-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/linear-gradient-layer.tsx
@@ -30,7 +30,6 @@ import {
   PopupList,
   NumberInput,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 
 export function getIndexedUpdateCSSBackgroundLayerLinearGradientAngle(index: number) {
   return function updateCSSBackgroundLayersLinearGradientAngle(
@@ -56,8 +55,7 @@ interface LinearGradientBackgroundLayerProps extends BackgroundLayerProps {
   value: CSSLinearGradientBackgroundLayer
 }
 
-export const LinearGradientBackgroundLayer = betterReactMemo<LinearGradientBackgroundLayerProps>(
-  'LinearGradientBackgroundLayer',
+export const LinearGradientBackgroundLayer = React.memo<LinearGradientBackgroundLayerProps>(
   (props) => {
     const [gradientCheckboxSubmitValue] = props.useSubmitTransformedValuesFactory(
       getIndexedUpdateEnabled(props.index),

--- a/editor/src/components/inspector/sections/style-section/background-subsection/picker-image-preview.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/picker-image-preview.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { useColorTheme, FlexRow, Icn, UtopiaTheme, SimpleFlexRow } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import { MetadataEditorModalPreviewHeight } from '../../../controls/color-picker'
 import { CSSURLFunctionBackgroundLayer } from '../../../common/css-utils'
 import { checkerboardBackground } from '../../../common/inspector-utils'
@@ -9,72 +8,69 @@ interface PickerImagePreviewProps {
   value: CSSURLFunctionBackgroundLayer
 }
 
-export const PickerImagePreview = betterReactMemo(
-  'BackgroundLayerMetadataModalURLImagePreview',
-  (props: PickerImagePreviewProps) => {
-    const colorTheme = useColorTheme()
-    const [imageNotFound, setImageNotFound] = React.useState(false)
-    const onError = React.useCallback(() => {
-      setImageNotFound(true)
-    }, [])
+export const PickerImagePreview = React.memo((props: PickerImagePreviewProps) => {
+  const colorTheme = useColorTheme()
+  const [imageNotFound, setImageNotFound] = React.useState(false)
+  const onError = React.useCallback(() => {
+    setImageNotFound(true)
+  }, [])
 
-    const imageURLempty = props.value.url === ''
+  const imageURLempty = props.value.url === ''
 
-    return (
-      <div
-        style={{
-          width: '100%',
-          height: MetadataEditorModalPreviewHeight,
-          ...checkerboardBackground,
-        }}
-      >
-        {imageNotFound ? (
-          <FlexRow
-            style={{
-              width: '100%',
-              height: '100%',
-              borderRadius: UtopiaTheme.inputBorderRadius,
-              backgroundColor: '#FFFFFF88',
-              boxShadow: imageURLempty
-                ? undefined
-                : `0 0 0 1px ${colorTheme.warningForeground.value} inset`,
-              justifyContent: 'center',
-              color: imageURLempty ? undefined : colorTheme.warningForeground.value,
-            }}
-          >
-            <div>
-              {imageURLempty ? (
-                <div style={{ paddingLeft: 8, whiteSpace: 'normal' }}>
-                  <p>
-                    Add an image URL, e.g. <span style={{ fontWeight: 600 }}>assets/image.png</span>{' '}
-                    or <span style={{ fontWeight: 600 }}>https://utopia.fm/smiangle.png</span>
-                  </p>
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: MetadataEditorModalPreviewHeight,
+        ...checkerboardBackground,
+      }}
+    >
+      {imageNotFound ? (
+        <FlexRow
+          style={{
+            width: '100%',
+            height: '100%',
+            borderRadius: UtopiaTheme.inputBorderRadius,
+            backgroundColor: '#FFFFFF88',
+            boxShadow: imageURLempty
+              ? undefined
+              : `0 0 0 1px ${colorTheme.warningForeground.value} inset`,
+            justifyContent: 'center',
+            color: imageURLempty ? undefined : colorTheme.warningForeground.value,
+          }}
+        >
+          <div>
+            {imageURLempty ? (
+              <div style={{ paddingLeft: 8, whiteSpace: 'normal' }}>
+                <p>
+                  Add an image URL, e.g. <span style={{ fontWeight: 600 }}>assets/image.png</span>{' '}
+                  or <span style={{ fontWeight: 600 }}>https://utopia.fm/smiangle.png</span>
+                </p>
 
-                  <p>
-                    NB You can add images by dropping them onto the canvas or into the file system,
-                    or with copy &amp; paste
-                  </p>
-                </div>
-              ) : (
-                <SimpleFlexRow>
-                  <Icn type='warningtriangle' color='warning' width={16} height={16} />
-                  <span style={{ paddingLeft: 8 }}>Unable to load {props.value.url}</span>
-                </SimpleFlexRow>
-              )}
-            </div>
-          </FlexRow>
-        ) : (
-          <img
-            src={props.value.url}
-            style={{
-              width: '100%',
-              height: '100%',
-              objectFit: 'contain',
-            }}
-            onError={onError}
-          />
-        )}
-      </div>
-    )
-  },
-)
+                <p>
+                  NB You can add images by dropping them onto the canvas or into the file system, or
+                  with copy &amp; paste
+                </p>
+              </div>
+            ) : (
+              <SimpleFlexRow>
+                <Icn type='warningtriangle' color='warning' width={16} height={16} />
+                <span style={{ paddingLeft: 8 }}>Unable to load {props.value.url}</span>
+              </SimpleFlexRow>
+            )}
+          </div>
+        </FlexRow>
+      ) : (
+        <img
+          src={props.value.url}
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'contain',
+          }}
+          onError={onError}
+        />
+      )}
+    </div>
+  )
+})

--- a/editor/src/components/inspector/sections/style-section/background-subsection/radial-gradient-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/radial-gradient-layer.tsx
@@ -26,14 +26,12 @@ import {
   PopupList,
   ChainedNumberInput,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 
 interface RadialGradientBackgroundLayerProps extends BackgroundLayerProps {
   value: CSSRadialGradientBackgroundLayer
 }
 
-export const RadialGradientBackgroundLayer = betterReactMemo<RadialGradientBackgroundLayerProps>(
-  'RadialGradientBackgroundLayer',
+export const RadialGradientBackgroundLayer = React.memo<RadialGradientBackgroundLayerProps>(
   (props) => {
     const [gradientCheckboxSubmitValue] = props.useSubmitTransformedValuesFactory(
       getIndexedUpdateEnabled(props.index),

--- a/editor/src/components/inspector/sections/style-section/background-subsection/solid-background-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/solid-background-layer.tsx
@@ -27,7 +27,6 @@ import {
   StringBackgroundColorControl,
 } from '../../../controls/background-solid-or-gradient-thumbnail-control'
 import { CheckboxInput, SimplePercentInput } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 
 function getIndexedUpdateStringCSSBackgroundLayerSolidColor(index: number) {
   return function indexedUpdateStringCSSBackgroundLayerSolidColor(
@@ -77,103 +76,99 @@ interface SolidBackgroundLayerProps extends BackgroundLayerProps {
   useSubmitTransformedValuesFactory: UseSubmitTransformedValuesFactory
 }
 
-export const SolidBackgroundLayer = betterReactMemo<SolidBackgroundLayerProps>(
-  'SolidBackgroundLayer',
-  (props) => {
-    const [onCheckboxSubmitValue] = props.useSubmitTransformedValuesFactory(
-      getIndexedUpdateEnabled(props.index),
-    )
-    const [
-      onAlphaSubmitValue,
-      onAlphaTransientSubmitValue,
-    ] = props.useSubmitTransformedValuesFactory(getIndexedUpdateNewAlpha(props.index))
-    const [onStringSubmitValue] = props.useSubmitTransformedValuesFactory(
-      getIndexedUpdateStringCSSBackgroundLayerSolidColor(props.index),
-    )
+export const SolidBackgroundLayer = React.memo<SolidBackgroundLayerProps>((props) => {
+  const [onCheckboxSubmitValue] = props.useSubmitTransformedValuesFactory(
+    getIndexedUpdateEnabled(props.index),
+  )
+  const [onAlphaSubmitValue, onAlphaTransientSubmitValue] = props.useSubmitTransformedValuesFactory(
+    getIndexedUpdateNewAlpha(props.index),
+  )
+  const [onStringSubmitValue] = props.useSubmitTransformedValuesFactory(
+    getIndexedUpdateStringCSSBackgroundLayerSolidColor(props.index),
+  )
 
-    const toggleCheckbox = React.useCallback(() => onCheckboxSubmitValue(!props.value.enabled), [
-      onCheckboxSubmitValue,
-      props,
-    ])
-    const [onRemoveRowSubmit] = props.useSubmitTransformedValuesFactory(
-      getIndexedSpliceArrayItem<CSSBackgroundLayer | CSSUnknownArrayItem>(props.index),
-    )
+  const toggleCheckbox = React.useCallback(() => onCheckboxSubmitValue(!props.value.enabled), [
+    onCheckboxSubmitValue,
+    props,
+  ])
+  const [onRemoveRowSubmit] = props.useSubmitTransformedValuesFactory(
+    getIndexedSpliceArrayItem<CSSBackgroundLayer | CSSUnknownArrayItem>(props.index),
+  )
 
-    const alpha = parseAlphaFromCSSColor(props.value.color)
-    return (
-      <InspectorContextMenuWrapper
-        id={`background-layer-subsection-context-menu-row-${props.index}`}
-        items={[removeRow(onRemoveRowSubmit), ...props.unsetContextMenuItem]}
-        data={null}
-      >
-        <UIGridRow tall alignItems='start' padded={true} variant='<---1fr--->|------172px-------|'>
-          <UIGridRow
-            tall
-            alignItems='start'
-            padded={false}
-            variant='<-auto-><----------1fr--------->'
-          >
-            <CheckboxInput
-              onChange={toggleCheckbox}
-              checked={props.value.enabled}
-              controlStatus={props.controlStatus}
-              onMouseDown={stopPropagation}
-            />
-            <BackgroundSolidOrGradientThumbnailControl
-              id={`background-layer-gradient-${props.index}`}
-              key={`background-layer-gradient-${props.index}`}
-              testId={`background-layer-gradient-${props.index}`}
-              value={props.value}
-              backgroundIndex={props.index}
-              useSubmitValueFactory={props.useSubmitTransformedValuesFactory}
-              onSubmitSolidStringValue={onStringSubmitValue}
-              controlStatus={props.controlStatus}
-              controlStyles={props.controlStyles}
-              modalOffset={{ x: -45, y: 0 }}
-              showString={false}
-              popupOpen={props.popupOpen}
-              setOpenPopup={props.setOpenPopup}
-            />
-          </UIGridRow>
-          <UIGridRow
-            tall
-            alignItems='start'
-            padded={false}
-            variant='<--------auto-------->|--45px--|'
-          >
-            <StringBackgroundColorControl
-              id={`background-layer-gradient-${props.index}`}
-              key={`background-layer-gradient-${props.index}`}
-              testId={`background-layer-gradient-${props.index}`}
-              value={props.value}
-              backgroundIndex={props.index}
-              useSubmitValueFactory={props.useSubmitTransformedValuesFactory}
-              onSubmitSolidStringValue={onStringSubmitValue}
-              controlStatus={props.controlStatus}
-              controlStyles={props.controlStyles}
-              modalOffset={{ x: -45, y: 0 }}
-              showString={true}
-              popupOpen={props.popupOpen}
-              setOpenPopup={props.setOpenPopup}
-            />
-            <SimplePercentInput
-              id={`background-layer-alpha-${props.index}`}
-              testId={`background-layer-alpha-${props.index}`}
-              value={alpha}
-              onSubmitValue={onAlphaSubmitValue}
-              onTransientSubmitValue={onAlphaTransientSubmitValue}
-              onForcedSubmitValue={onAlphaSubmitValue}
-              controlStatus={props.controlStatus}
-              DEPRECATED_labelBelow='alpha'
-              minimum={0}
-              maximum={1}
-              stepSize={0.01}
-              inputProps={{ onMouseDown: stopPropagation }}
-              defaultUnitToHide={null}
-            />
-          </UIGridRow>
+  const alpha = parseAlphaFromCSSColor(props.value.color)
+  return (
+    <InspectorContextMenuWrapper
+      id={`background-layer-subsection-context-menu-row-${props.index}`}
+      items={[removeRow(onRemoveRowSubmit), ...props.unsetContextMenuItem]}
+      data={null}
+    >
+      <UIGridRow tall alignItems='start' padded={true} variant='<---1fr--->|------172px-------|'>
+        <UIGridRow
+          tall
+          alignItems='start'
+          padded={false}
+          variant='<-auto-><----------1fr--------->'
+        >
+          <CheckboxInput
+            onChange={toggleCheckbox}
+            checked={props.value.enabled}
+            controlStatus={props.controlStatus}
+            onMouseDown={stopPropagation}
+          />
+          <BackgroundSolidOrGradientThumbnailControl
+            id={`background-layer-gradient-${props.index}`}
+            key={`background-layer-gradient-${props.index}`}
+            testId={`background-layer-gradient-${props.index}`}
+            value={props.value}
+            backgroundIndex={props.index}
+            useSubmitValueFactory={props.useSubmitTransformedValuesFactory}
+            onSubmitSolidStringValue={onStringSubmitValue}
+            controlStatus={props.controlStatus}
+            controlStyles={props.controlStyles}
+            modalOffset={{ x: -45, y: 0 }}
+            showString={false}
+            popupOpen={props.popupOpen}
+            setOpenPopup={props.setOpenPopup}
+          />
         </UIGridRow>
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
+        <UIGridRow
+          tall
+          alignItems='start'
+          padded={false}
+          variant='<--------auto-------->|--45px--|'
+        >
+          <StringBackgroundColorControl
+            id={`background-layer-gradient-${props.index}`}
+            key={`background-layer-gradient-${props.index}`}
+            testId={`background-layer-gradient-${props.index}`}
+            value={props.value}
+            backgroundIndex={props.index}
+            useSubmitValueFactory={props.useSubmitTransformedValuesFactory}
+            onSubmitSolidStringValue={onStringSubmitValue}
+            controlStatus={props.controlStatus}
+            controlStyles={props.controlStyles}
+            modalOffset={{ x: -45, y: 0 }}
+            showString={true}
+            popupOpen={props.popupOpen}
+            setOpenPopup={props.setOpenPopup}
+          />
+          <SimplePercentInput
+            id={`background-layer-alpha-${props.index}`}
+            testId={`background-layer-alpha-${props.index}`}
+            value={alpha}
+            onSubmitValue={onAlphaSubmitValue}
+            onTransientSubmitValue={onAlphaTransientSubmitValue}
+            onForcedSubmitValue={onAlphaSubmitValue}
+            controlStatus={props.controlStatus}
+            DEPRECATED_labelBelow='alpha'
+            minimum={0}
+            maximum={1}
+            stepSize={0.01}
+            inputProps={{ onMouseDown: stopPropagation }}
+            defaultUnitToHide={null}
+          />
+        </UIGridRow>
+      </UIGridRow>
+    </InspectorContextMenuWrapper>
+  )
+})

--- a/editor/src/components/inspector/sections/style-section/background-subsection/url-background-layer.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/url-background-layer.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { CheckboxInput, PopupList } from '../../../../../uuiui'
-import { betterReactMemo, InspectorContextMenuWrapper } from '../../../../../uuiui-deps'
+import { InspectorContextMenuWrapper } from '../../../../../uuiui-deps'
 import { removeRow } from '../../../common/context-menu-items'
 import {
   CSSBackgroundLayer,
@@ -51,85 +51,82 @@ function getIndexedUpdateNewURL(index: number) {
   }
 }
 
-export const URLBackgroundLayer = betterReactMemo<URLBackgroundLayerProps>(
-  'URLBackgroundLayer',
-  (props) => {
-    const [onCheckboxSubmitValue] = props.useSubmitTransformedValuesFactory(
-      getIndexedUpdateEnabled(props.index),
-    )
-    const [onURLSubmitValue] = props.useSubmitTransformedValuesFactory(
-      getIndexedUpdateNewURL(props.index),
-    )
-    const toggleCheckbox = React.useCallback(() => onCheckboxSubmitValue(!props.value.enabled), [
-      onCheckboxSubmitValue,
-      props,
-    ])
+export const URLBackgroundLayer = React.memo<URLBackgroundLayerProps>((props) => {
+  const [onCheckboxSubmitValue] = props.useSubmitTransformedValuesFactory(
+    getIndexedUpdateEnabled(props.index),
+  )
+  const [onURLSubmitValue] = props.useSubmitTransformedValuesFactory(
+    getIndexedUpdateNewURL(props.index),
+  )
+  const toggleCheckbox = React.useCallback(() => onCheckboxSubmitValue(!props.value.enabled), [
+    onCheckboxSubmitValue,
+    props,
+  ])
 
-    const [backgroundLayerType] = props.useSubmitTransformedValuesFactory(
-      getIndexedOnCSSBackgroundLayerTypeSelectSubmitValue(props.index),
-    )
-    const [onRemoveRowSubmit] = props.useSubmitTransformedValuesFactory(
-      getIndexedSpliceArrayItem<CSSBackgroundLayer | CSSUnknownArrayItem>(props.index),
-    )
+  const [backgroundLayerType] = props.useSubmitTransformedValuesFactory(
+    getIndexedOnCSSBackgroundLayerTypeSelectSubmitValue(props.index),
+  )
+  const [onRemoveRowSubmit] = props.useSubmitTransformedValuesFactory(
+    getIndexedSpliceArrayItem<CSSBackgroundLayer | CSSUnknownArrayItem>(props.index),
+  )
 
-    return (
-      <InspectorContextMenuWrapper
-        id={`background-layer-subsection-context-menu-row-${props.index}`}
-        items={[removeRow(onRemoveRowSubmit), ...props.unsetContextMenuItem]}
-        data={null}
-      >
-        <UIGridRow tall alignItems='start' padded={true} variant='<---1fr--->|------172px-------|'>
-          <UIGridRow
-            tall
-            alignItems='start'
-            padded={false}
-            variant='<-auto-><----------1fr--------->'
-          >
-            <CheckboxInput
-              onChange={toggleCheckbox}
-              checked={props.value.enabled}
-              controlStatus={props.controlStatus}
-              onMouseDown={stopPropagation}
-            />
-            <ImageThumbnailControl
-              id={`image-thumbnail-control-${props.index}`}
-              key={`image-thumbnail-control-${props.index}-${props.value.url}`}
-              testId={`image-thumbnail-control-${props.index}-${props.value.url}`}
-              value={props.value}
-              backgroundIndex={props.index}
-              controlStatus={props.controlStatus}
-              controlStyles={props.controlStyles}
-              setOpenPopup={props.setOpenPopup}
-              popupOpen={props.popupOpen}
-              useSubmitValueFactory={props.useSubmitTransformedValuesFactory}
-              modalOffset={{ x: -45, y: 0 }}
-            />
-          </UIGridRow>
-          <UIGridRow
-            tall
-            alignItems='start'
-            padded={false}
-            variant='<-------1fr------>|----80px----|'
-          >
-            <PopupList
-              value={imageSelectOption}
-              options={backgroundLayerTypeSelectOptions}
-              onSubmitValue={backgroundLayerType}
-              controlStyles={props.controlStyles}
-              containerMode='default'
-            />
-            <StringControl
-              id={`background-layer-image-${props.index}`}
-              key={`background-layer-image-${props.index}`}
-              testId={`background-layer-image-${props.index}`}
-              value={props.value.url}
-              onSubmitValue={onURLSubmitValue}
-              controlStatus={props.controlStatus}
-              controlStyles={props.controlStyles}
-            />
-          </UIGridRow>
+  return (
+    <InspectorContextMenuWrapper
+      id={`background-layer-subsection-context-menu-row-${props.index}`}
+      items={[removeRow(onRemoveRowSubmit), ...props.unsetContextMenuItem]}
+      data={null}
+    >
+      <UIGridRow tall alignItems='start' padded={true} variant='<---1fr--->|------172px-------|'>
+        <UIGridRow
+          tall
+          alignItems='start'
+          padded={false}
+          variant='<-auto-><----------1fr--------->'
+        >
+          <CheckboxInput
+            onChange={toggleCheckbox}
+            checked={props.value.enabled}
+            controlStatus={props.controlStatus}
+            onMouseDown={stopPropagation}
+          />
+          <ImageThumbnailControl
+            id={`image-thumbnail-control-${props.index}`}
+            key={`image-thumbnail-control-${props.index}-${props.value.url}`}
+            testId={`image-thumbnail-control-${props.index}-${props.value.url}`}
+            value={props.value}
+            backgroundIndex={props.index}
+            controlStatus={props.controlStatus}
+            controlStyles={props.controlStyles}
+            setOpenPopup={props.setOpenPopup}
+            popupOpen={props.popupOpen}
+            useSubmitValueFactory={props.useSubmitTransformedValuesFactory}
+            modalOffset={{ x: -45, y: 0 }}
+          />
         </UIGridRow>
-      </InspectorContextMenuWrapper>
-    )
-  },
-)
+        <UIGridRow
+          tall
+          alignItems='start'
+          padded={false}
+          variant='<-------1fr------>|----80px----|'
+        >
+          <PopupList
+            value={imageSelectOption}
+            options={backgroundLayerTypeSelectOptions}
+            onSubmitValue={backgroundLayerType}
+            controlStyles={props.controlStyles}
+            containerMode='default'
+          />
+          <StringControl
+            id={`background-layer-image-${props.index}`}
+            key={`background-layer-image-${props.index}`}
+            testId={`background-layer-image-${props.index}`}
+            value={props.value.url}
+            onSubmitValue={onURLSubmitValue}
+            controlStatus={props.controlStatus}
+            controlStyles={props.controlStyles}
+          />
+        </UIGridRow>
+      </UIGridRow>
+    </InspectorContextMenuWrapper>
+  )
+})

--- a/editor/src/components/inspector/sections/style-section/border-subsection/border-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/border-subsection/border-subsection.tsx
@@ -10,7 +10,6 @@ import {
   CheckboxInput,
   InspectorSectionIcons,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { addOnUnsetValues } from '../../../common/context-menu-items'
 import {
@@ -81,7 +80,7 @@ function insertBorder(_: null, oldValue: CSSBorder): CSSBorder {
   return { ...defaultCSSBorder }
 }
 
-export const BorderSubsection: React.FunctionComponent = betterReactMemo('BorderSubsection', () => {
+export const BorderSubsection: React.FunctionComponent = React.memo(() => {
   const isVisible = useIsSubSectionVisible('border')
 
   const {

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -33,7 +33,6 @@ import {
   useColorTheme,
   UtopiaTheme,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import * as EditorActions from '../../../../editor/actions/action-creators'
 import { useInputFocusOnCountIncrease } from '../../../../editor/hook-utils'
 import {
@@ -131,40 +130,37 @@ function valueTypeAsArray<T>(valueType: ValueType<T>): ReadonlyArray<T> {
   }
 }
 
-const FooterSection = betterReactMemo(
-  'ClassNameControlFooter',
-  (props: { filter: string; options: Array<TailWindOption> }) => {
-    const theme = useColorTheme()
-    const focusedOptionValue = usePubSubAtomReadOnly(focusedOptionAtom)
-    const focusedOption =
-      focusedOptionValue == null ? null : props.options.find((o) => o.value === focusedOptionValue)
-    const joinedAttributes = focusedOption?.attributes?.join(', ')
-    const attributesText =
-      joinedAttributes == null || joinedAttributes === '' ? '\u00a0' : `Sets: ${joinedAttributes}`
+const FooterSection = React.memo((props: { filter: string; options: Array<TailWindOption> }) => {
+  const theme = useColorTheme()
+  const focusedOptionValue = usePubSubAtomReadOnly(focusedOptionAtom)
+  const focusedOption =
+    focusedOptionValue == null ? null : props.options.find((o) => o.value === focusedOptionValue)
+  const joinedAttributes = focusedOption?.attributes?.join(', ')
+  const attributesText =
+    joinedAttributes == null || joinedAttributes === '' ? '\u00a0' : `Sets: ${joinedAttributes}`
 
-    return (
-      <div
-        css={{
-          label: 'focusedElementMetadata',
-          overflow: 'hidden',
-          boxShadow: `inset 0px 1px 1px 0px ${theme.neutralInvertedBackground.o(10).value}`,
-          padding: '8px 8px',
-          fontSize: '10px',
-          pointerEvents: 'none',
-          color: theme.textColor.value,
-        }}
-      >
-        <FlexColumn>
-          <FlexRow>
-            <span>
-              <MatchHighlighter text={attributesText} searchString={props.filter} />
-            </span>
-          </FlexRow>
-        </FlexColumn>
-      </div>
-    )
-  },
-)
+  return (
+    <div
+      css={{
+        label: 'focusedElementMetadata',
+        overflow: 'hidden',
+        boxShadow: `inset 0px 1px 1px 0px ${theme.neutralInvertedBackground.o(10).value}`,
+        padding: '8px 8px',
+        fontSize: '10px',
+        pointerEvents: 'none',
+        color: theme.textColor.value,
+      }}
+    >
+      <FlexColumn>
+        <FlexRow>
+          <span>
+            <MatchHighlighter text={attributesText} searchString={props.filter} />
+          </span>
+        </FlexRow>
+      </FlexColumn>
+    </div>
+  )
+})
 
 const Input = (props: InputProps) => {
   const value = (props as any).value
@@ -172,7 +168,7 @@ const Input = (props: InputProps) => {
   return <components.Input {...props} isHidden={isHidden} />
 }
 
-const ClassNameControl = betterReactMemo('ClassNameControl', () => {
+const ClassNameControl = React.memo(() => {
   const editorStoreRef = useRefEditorState((store) => store)
   const theme = useColorTheme()
   const targets = useEditorState(
@@ -548,6 +544,6 @@ const ClassNameControl = betterReactMemo('ClassNameControl', () => {
   )
 })
 
-export const ClassNameSubsection = betterReactMemo('ClassNameSubSection', () => {
+export const ClassNameSubsection = React.memo(() => {
   return <ClassNameControl />
 })

--- a/editor/src/components/inspector/sections/style-section/container-subsection/blendmode-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/blendmode-row.tsx
@@ -5,7 +5,6 @@ import { useInspectorStyleInfo } from '../../../common/property-path-hooks'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import { PopupList } from '../../../../../uuiui'
 import {
-  betterReactMemo,
   SelectOption,
   InspectorContextMenuItems,
   InspectorContextMenuWrapper,
@@ -20,7 +19,7 @@ const blendModeOptions = [
 
 const blendModeProp = [PP.create(['style', 'mixBlendMode'])]
 
-export const BlendModeRow = betterReactMemo('BlendModeRow', () => {
+export const BlendModeRow = React.memo(() => {
   const blendModeMetadata = useInspectorStyleInfo('mixBlendMode')
   const [onSubmitBlendModeOption] = blendModeMetadata.useSubmitValueFactory(
     (selectedOption: SelectOption) => selectedOption.value,

--- a/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
@@ -7,7 +7,6 @@ import {
   InspectorSectionIcons,
   InspectorSubsectionHeader,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import { PropertyLabel } from '../../../widgets/property-label'
 import { SeeMoreButton, SeeMoreHOC, useToggle } from '../../../widgets/see-more'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
@@ -20,7 +19,7 @@ import { OpacityRow } from './opacity-row'
 import { OverflowRow } from './overflow-row'
 import { RadiusRow } from './radius-row'
 
-export const ContainerSubsection = betterReactMemo('ContainerSubsection', () => {
+export const ContainerSubsection = React.memo(() => {
   const [seeMoreVisible, toggleSeeMoreVisible] = useToggle(false)
   return (
     <>

--- a/editor/src/components/inspector/sections/style-section/container-subsection/opacity-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/opacity-row.tsx
@@ -5,7 +5,6 @@ import { UIGridRow } from '../../../widgets/ui-grid-row'
 import { useInspectorStyleInfo, useIsSubSectionVisible } from '../../../common/property-path-hooks'
 import { useWrappedEmptyOrUnknownOnSubmitValue, NumberInput } from '../../../../../uuiui'
 import {
-  betterReactMemo,
   CSSUtils,
   InspectorContextMenuItems,
   InspectorContextMenuWrapper,
@@ -23,7 +22,7 @@ const sliderControlOptions = {
 // TODO: path should match target
 const opacityProp = [PP.create(['style', 'opacity'])]
 
-export const OpacityRow = betterReactMemo('OpacityRow', () => {
+export const OpacityRow = React.memo(() => {
   const opacityMetadata = useInspectorStyleInfo('opacity')
 
   const opacity = opacityMetadata.value

--- a/editor/src/components/inspector/sections/style-section/container-subsection/overflow-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/overflow-row.tsx
@@ -4,11 +4,7 @@ import { PropertyLabel } from '../../../widgets/property-label'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import { useInspectorStyleInfo } from '../../../common/property-path-hooks'
 import { OptionChainControl, OptionChainOption } from '../../../controls/option-chain-control'
-import {
-  betterReactMemo,
-  InspectorContextMenuItems,
-  InspectorContextMenuWrapper,
-} from '../../../../../uuiui-deps'
+import { InspectorContextMenuItems, InspectorContextMenuWrapper } from '../../../../../uuiui-deps'
 
 const overflowProp = [PP.create(['style', 'overflow'])]
 
@@ -25,7 +21,7 @@ const OverflowControlOptions: Array<OptionChainOption<boolean>> = [
   },
 ]
 
-export const OverflowRow = betterReactMemo('OverflowRow', () => {
+export const OverflowRow = React.memo(() => {
   const {
     value,
     controlStatus,

--- a/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
+import React from 'react'
 import { OptionsType } from 'react-select'
 import { FramePin } from 'utopia-api'
 import { isLeft, isRight, left, right } from '../../../../../core/shared/either'
@@ -27,7 +28,7 @@ import {
   ChainedNumberInput,
   NumberInput,
 } from '../../../../../uuiui'
-import { betterReactMemo, InspectorContextMenuItems } from '../../../../../uuiui-deps'
+import { InspectorContextMenuItems } from '../../../../../uuiui-deps'
 
 function updateRadiusType(
   newRadiusTypeValue: SelectOption,
@@ -168,7 +169,7 @@ function getSliderMax(widthPin: CSSNumber | undefined, heightPin: CSSNumber | un
   return Math.min(width, height)
 }
 
-export const RadiusRow = betterReactMemo('RadiusControls', () => {
+export const RadiusRow = React.memo(() => {
   const {
     value: borderRadiusValue,
     controlStatus,

--- a/editor/src/components/inspector/sections/style-section/shadow-subsection/shadow-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/shadow-subsection/shadow-subsection.tsx
@@ -12,7 +12,6 @@ import {
   Icn,
   InspectorSectionIcons,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import { ContextMenuItem } from '../../../../context-menu-items'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { addOnUnsetValues, removeRow } from '../../../common/context-menu-items'
@@ -145,7 +144,7 @@ interface ShadowItemProps {
 
 const rowHeight = UtopiaTheme.layout.rowHeight.max
 
-const ShadowItem = betterReactMemo<ShadowItemProps>('ShadowItem', (props) => {
+const ShadowItem = React.memo<ShadowItemProps>((props) => {
   const [enabledSubmitValueToggle] = props.useSubmitValueFactory(
     getIndexedToggleShadowEnabled(props.index),
   )
@@ -276,7 +275,7 @@ const ShadowItem = betterReactMemo<ShadowItemProps>('ShadowItem', (props) => {
   )
 })
 
-export const ShadowSubsection = betterReactMemo('ShadowSubsection', () => {
+export const ShadowSubsection = React.memo(() => {
   const isVisible = useIsSubSectionVisible('shadow')
   const {
     value,

--- a/editor/src/components/inspector/sections/style-section/style-section.tsx
+++ b/editor/src/components/inspector/sections/style-section/style-section.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { betterReactMemo } from '../../../../uuiui-deps'
 import { InspectorPartProps } from '../../inspector'
 import { BackgroundSubsection } from './background-subsection/background-subsection'
 import { BorderSubsection } from './border-subsection/border-subsection'
@@ -23,7 +22,7 @@ export enum StyleSubsection {
 
 export interface StyleSectionProps extends InspectorPartProps<React.CSSProperties> {}
 
-export const StyleSection = betterReactMemo('StyleSection', () => {
+export const StyleSection = React.memo(() => {
   return (
     <React.Fragment>
       <ContainerSubsection />

--- a/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select-popup.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select-popup.tsx
@@ -4,7 +4,7 @@ import { googleFontsList } from '../../../../../../assets/google-fonts-list'
 import { isRight } from '../../../../../core/shared/either'
 import { useExternalResources } from '../../../../../printer-parsers/html/external-resources-parser'
 import { FlexColumn, UtopiaTheme, FlexRow, StringInput, useColorTheme } from '../../../../../uuiui'
-import { ControlStyles, betterReactMemo, Utils } from '../../../../../uuiui-deps'
+import { ControlStyles, Utils } from '../../../../../uuiui-deps'
 import { updatePushNewFontFamilyVariant } from '../../../../navigator/external-resources/google-fonts-resources-list-search'
 import {
   cssFontStyleToWebFontStyle,
@@ -303,8 +303,7 @@ function filterData(
   }
 }
 
-export const FontFamilySelectPopup = betterReactMemo(
-  'FontFamilySelectPopup',
+export const FontFamilySelectPopup = React.memo(
   React.forwardRef<HTMLDivElement, FontFamilySelectPopupProps>(
     (
       {

--- a/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/font-family-select.tsx
@@ -3,14 +3,13 @@ import { usePopper } from 'react-popper'
 import { identity } from '../../../../../core/shared/utils'
 import utils from '../../../../../utils/utils'
 import { FlexRow, UtopiaTheme, Icons } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { addOnUnsetValues } from '../../../common/context-menu-items'
 import { stylePropPathMappingFn, useInspectorInfo } from '../../../common/property-path-hooks'
 import { PropertyRow } from '../../../widgets/property-row'
 import { FontFamilySelectPopup } from './font-family-select-popup'
 
-export const FontFamilySelect = betterReactMemo('FontFamilySelect', () => {
+export const FontFamilySelect = React.memo(() => {
   const [referenceElement, setReferenceElement] = React.useState<HTMLDivElement | null>(null)
   const [popperElement, setPopperElement] = React.useState<HTMLDivElement | null>(null)
   const { styles, attributes } = usePopper(referenceElement, popperElement, {

--- a/editor/src/components/inspector/sections/style-section/text-subsection/font-variant-select.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/font-variant-select.tsx
@@ -9,7 +9,6 @@ import {
 } from '../../../../../printer-parsers/html/external-resources-parser'
 import utils from '../../../../../utils/utils'
 import { Tooltip, PopupList } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import {
   defaultWebFontWeightsAndStyles,
@@ -90,7 +89,7 @@ interface FontWeightAndStyleSelectOption {
   value: WebFontFamilyVariant
 }
 
-export const FontVariantSelect = betterReactMemo('FontVariantSelect', () => {
+export const FontVariantSelect = React.memo(() => {
   const { value, controlStyles, onUnsetValues, useSubmitValueFactory } = useInspectorInfo(
     weightAndStylePaths,
     identity,

--- a/editor/src/components/inspector/sections/style-section/text-subsection/project-typeface-item.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/project-typeface-item.tsx
@@ -5,7 +5,6 @@ import {
   GoogleFontsResource,
 } from '../../../../../printer-parsers/html/external-resources-parser'
 import { FlexRow, Icons } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import { ProjectTypeface } from './font-family-select-popup'
 
 export function updateRemoveFontFamily(
@@ -34,8 +33,7 @@ interface ProjectTypefaceItemProps {
   updateSizes: () => void
 }
 
-export const ProjectTypefaceItem = betterReactMemo<ProjectTypefaceItemProps>(
-  'ProjectTypefaceItem',
+export const ProjectTypefaceItem = React.memo<ProjectTypefaceItemProps>(
   ({ typeface, selected, updateSizes }) => {
     const [hovered, setHovered] = React.useState(false)
     const onMouseOver = React.useCallback(() => {

--- a/editor/src/components/inspector/sections/style-section/text-subsection/text-shadow-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/text-shadow-subsection.tsx
@@ -31,7 +31,6 @@ import {
   Icons,
   InspectorSectionIcons,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 
 function getIndexedToggleTextShadowEnabled(index: number) {
   return function indexedToggleTextShadowEnabled(
@@ -133,7 +132,7 @@ type TextShadowItemProps = {
 
 const zeroBlurRadius = cssNumber(0, 'px')
 
-const TextShadowItem = betterReactMemo<TextShadowItemProps>('TextShadowItem', (props) => {
+const TextShadowItem = React.memo<TextShadowItemProps>((props) => {
   const [enabledSubmitValue] = props.useSubmitValueFactory(
     getIndexedToggleTextShadowEnabled(props.index),
   )
@@ -247,7 +246,7 @@ const TextShadowItem = betterReactMemo<TextShadowItemProps>('TextShadowItem', (p
   )
 })
 
-export const TextShadowSubsection = betterReactMemo('TextShadowSubsection', () => {
+export const TextShadowSubsection = React.memo(() => {
   const {
     value: textShadowsValue,
     controlStatus,

--- a/editor/src/components/inspector/sections/style-section/text-subsection/text-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/text-subsection.tsx
@@ -9,10 +9,7 @@ import {
 } from '../../../../../core/shared/element-template'
 import { PropertyPath } from '../../../../../core/shared/project-file-types'
 import * as PP from '../../../../../core/shared/property-path'
-import {
-  betterReactMemo,
-  useKeepShallowReferenceEquality,
-} from '../../../../../utils/react-performance'
+import { useKeepShallowReferenceEquality } from '../../../../../utils/react-performance'
 import utils from '../../../../../utils/utils'
 import {
   useWrappedEmptyOrUnknownOnSubmitValue,
@@ -58,7 +55,7 @@ function updateUnderlinedTextDecoration(newValue: boolean): CSSTextDecorationLin
 const normalLetterSpacingAsCSSNumber = cssNumber(0, 'px')
 const normalLineHeightAsCSSNumber = cssNumber(0, 'px')
 
-export const TextSubsection = betterReactMemo('TextSubsection', () => {
+export const TextSubsection = React.memo(() => {
   const [expanded, setExpanded] = React.useState(false)
 
   const colorMetadata = useInspectorStyleInfo('color')

--- a/editor/src/components/inspector/sections/style-section/transform-subsection/transform-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/transform-subsection/transform-subsection.tsx
@@ -10,7 +10,6 @@ import {
   InspectorSubsectionHeader,
   InspectorSectionIcons,
 } from '../../../../../uuiui'
-import { betterReactMemo } from '../../../../../uuiui-deps'
 import {
   NumberInput,
   useWrappedSubmitFactoryEmptyOrUnknownOnSubmitValue,
@@ -285,7 +284,7 @@ function getIndexedUpdateSingleLengthValue(
   }
 }
 
-const SingleLengthItem = betterReactMemo<SingleLengthItemProps>('SingleLengthItem', (props) => {
+const SingleLengthItem = React.memo<SingleLengthItemProps>((props) => {
   const [enabledSubmitValue] = props.useSubmitValueFactory(
     getIndexedToggleTransformItemEnabled(props.index),
   )
@@ -404,7 +403,7 @@ interface DoubleLengthItemProps extends TransformItemProps {
   emptyValue: CSSTransformDoubleLengthItem
 }
 
-const DoubleLengthItem = betterReactMemo<DoubleLengthItemProps>('DoubleLengthItem', (props) => {
+const DoubleLengthItem = React.memo<DoubleLengthItemProps>((props) => {
   const [enabledSubmitValue] = props.useSubmitValueFactory(
     getIndexedToggleTransformItemEnabled(props.index),
   )
@@ -534,7 +533,7 @@ const CSSTransformsToTransform = (transformedType: CSSTransforms) => {
 
 const rowHeight = UtopiaTheme.layout.rowHeight.normal
 
-export const TransformSubsection = betterReactMemo('TransformSubsection', () => {
+export const TransformSubsection = React.memo(() => {
   const {
     value,
     onSubmitValue,

--- a/editor/src/components/inspector/sections/target-selector-section.tsx
+++ b/editor/src/components/inspector/sections/target-selector-section.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Section, FlexColumn } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { TargetSelectorPanel, CSSTarget } from './header-section/target-selector'
 
 export interface TargetSelectorSectionProps {
@@ -14,22 +13,19 @@ export interface TargetSelectorSectionProps {
   onStyleSelectorInsert: (parent: CSSTarget, label: string) => void
 }
 
-export const TargetSelectorSection = betterReactMemo(
-  'TargetSelectorSection',
-  (props: TargetSelectorSectionProps) => {
-    return (
-      <Section className={props.className}>
-        <FlexColumn className='titledSectionContentColumn'>
-          <TargetSelectorPanel
-            targets={props.targets}
-            selectedTargetPath={props.selectedTargetPath}
-            onSelect={props.onSelectTarget}
-            onStyleSelectorRename={props.onStyleSelectorRename}
-            onStyleSelectorDelete={props.onStyleSelectorDelete}
-            onStyleSelectorInsert={props.onStyleSelectorInsert}
-          />
-        </FlexColumn>
-      </Section>
-    )
-  },
-)
+export const TargetSelectorSection = React.memo((props: TargetSelectorSectionProps) => {
+  return (
+    <Section className={props.className}>
+      <FlexColumn className='titledSectionContentColumn'>
+        <TargetSelectorPanel
+          targets={props.targets}
+          selectedTargetPath={props.selectedTargetPath}
+          onSelect={props.onSelectTarget}
+          onStyleSelectorRename={props.onStyleSelectorRename}
+          onStyleSelectorDelete={props.onStyleSelectorDelete}
+          onStyleSelectorInsert={props.onStyleSelectorInsert}
+        />
+      </FlexColumn>
+    </Section>
+  )
+})

--- a/editor/src/components/inspector/utility-controls/image-thumbnail-control.tsx
+++ b/editor/src/components/inspector/utility-controls/image-thumbnail-control.tsx
@@ -7,89 +7,85 @@ import {
 } from '../controls/background-solid-or-gradient-thumbnail-control'
 import { clampString } from '../common/inspector-utils'
 import { Tooltip, FlexRow, UtopiaTheme, useColorTheme, Icn } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 
 interface ImageThumbnailControlProps extends BackgroundThumbnailControlProps {
   value: CSSURLFunctionBackgroundLayer
 }
 
-export const ImageThumbnailControl = betterReactMemo<ImageThumbnailControlProps>(
-  'ImageThumbnailControl',
-  (props) => {
-    const colorTheme = useColorTheme()
-    const [imageNotFound, setImageNotFound] = React.useState(false)
-    const onError = React.useCallback(() => {
-      setImageNotFound(true)
-    }, [])
-    const setOpenPopup = props.setOpenPopup
-    const closePopup = React.useCallback(() => setOpenPopup(undefined), [setOpenPopup])
+export const ImageThumbnailControl = React.memo<ImageThumbnailControlProps>((props) => {
+  const colorTheme = useColorTheme()
+  const [imageNotFound, setImageNotFound] = React.useState(false)
+  const onError = React.useCallback(() => {
+    setImageNotFound(true)
+  }, [])
+  const setOpenPopup = props.setOpenPopup
+  const closePopup = React.useCallback(() => setOpenPopup(undefined), [setOpenPopup])
 
-    const backgroundIndex = props.backgroundIndex
-    const onMouseDown = React.useCallback(
-      (e) => {
-        e.stopPropagation()
-        setOpenPopup((openPopup) => {
-          if (openPopup != null) {
-            return undefined
-          } else {
-            return backgroundIndex
-          }
-        })
-      },
-      [setOpenPopup, backgroundIndex],
-    )
+  const backgroundIndex = props.backgroundIndex
+  const onMouseDown = React.useCallback(
+    (e) => {
+      e.stopPropagation()
+      setOpenPopup((openPopup) => {
+        if (openPopup != null) {
+          return undefined
+        } else {
+          return backgroundIndex
+        }
+      })
+    },
+    [setOpenPopup, backgroundIndex],
+  )
 
-    const modalOffset = props.modalOffset != null ? props.modalOffset : { x: 0, y: 0 }
+  const modalOffset = props.modalOffset != null ? props.modalOffset : { x: 0, y: 0 }
 
-    return (
-      <div>
-        {props.popupOpen ? (
-          <BackgroundPicker
-            id={props.id}
-            testId={props.testId}
-            offsetX={modalOffset.x}
-            offsetY={modalOffset.y}
-            closePopup={closePopup}
-            value={props.value}
-            useSubmitValueFactory={props.useSubmitValueFactory}
-            backgroundLayerIndex={props.backgroundIndex}
-            controlStatus={props.controlStatus}
-          />
-        ) : null}
-        {imageNotFound ? (
-          <Tooltip title={`Image URL "${clampString(props.value.url, 20)}" not found`}>
-            <FlexRow
-              onMouseDown={onMouseDown}
-              style={{
-                width: 28,
-                height: UtopiaTheme.layout.inputHeight.default,
-                borderRadius: UtopiaTheme.inputBorderRadius,
-                backgroundColor: colorTheme.warningBgTranslucent.value,
-                boxShadow: `0 0 0 1px ${colorTheme.warningForeground.value} inset`,
-                justifyContent: 'center',
-              }}
-            >
-              <Icn type='warningtriangle' color='warning' width={16} height={16} />
-            </FlexRow>
-          </Tooltip>
-        ) : (
-          <img
+  return (
+    <div>
+      {props.popupOpen ? (
+        <BackgroundPicker
+          id={props.id}
+          testId={props.testId}
+          offsetX={modalOffset.x}
+          offsetY={modalOffset.y}
+          closePopup={closePopup}
+          value={props.value}
+          useSubmitValueFactory={props.useSubmitValueFactory}
+          backgroundLayerIndex={props.backgroundIndex}
+          controlStatus={props.controlStatus}
+        />
+      ) : null}
+      {imageNotFound ? (
+        <Tooltip title={`Image URL "${clampString(props.value.url, 20)}" not found`}>
+          <FlexRow
             onMouseDown={onMouseDown}
-            id={`background-layer-gradient-${props.backgroundIndex}`}
-            alt={`background-layer-gradient-${props.backgroundIndex}`}
-            src={props.value.url}
             style={{
-              ...backgroundControlContainerStyle,
-              display: 'block',
               width: 28,
               height: UtopiaTheme.layout.inputHeight.default,
-              objectFit: 'cover',
-              boxShadow: `0 0 0 1px ${props.controlStyles.borderColor} inset`,
+              borderRadius: UtopiaTheme.inputBorderRadius,
+              backgroundColor: colorTheme.warningBgTranslucent.value,
+              boxShadow: `0 0 0 1px ${colorTheme.warningForeground.value} inset`,
+              justifyContent: 'center',
             }}
-            onError={onError}
-          />
-        )}
-      </div>
-    )
-  },
-)
+          >
+            <Icn type='warningtriangle' color='warning' width={16} height={16} />
+          </FlexRow>
+        </Tooltip>
+      ) : (
+        <img
+          onMouseDown={onMouseDown}
+          id={`background-layer-gradient-${props.backgroundIndex}`}
+          alt={`background-layer-gradient-${props.backgroundIndex}`}
+          src={props.value.url}
+          style={{
+            ...backgroundControlContainerStyle,
+            display: 'block',
+            width: 28,
+            height: UtopiaTheme.layout.inputHeight.default,
+            objectFit: 'cover',
+            boxShadow: `0 0 0 1px ${props.controlStyles.borderColor} inset`,
+          }}
+          onError={onError}
+        />
+      )}
+    </div>
+  )
+})

--- a/editor/src/components/inspector/utility-controls/pin-control.tsx
+++ b/editor/src/components/inspector/utility-controls/pin-control.tsx
@@ -5,7 +5,6 @@ import { FramePoint } from 'utopia-api'
 import { LayoutPinnedProp } from '../../../core/layout/layout-helpers-new'
 import { FramePinsInfo } from '../common/layout-property-path-hooks'
 import { UtopiaTheme, SquareButton } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 
 interface PinControlProps {
   handlePinMouseDown: (frameProp: LayoutPinnedProp) => void
@@ -240,7 +239,7 @@ interface PinWidthControlProps {
   toggleWidth: () => void
 }
 
-export const PinWidthControl = betterReactMemo('PinWidthControl', (props: PinWidthControlProps) => {
+export const PinWidthControl = React.memo((props: PinWidthControlProps) => {
   const controlStyles: ControlStyles = getControlStyles(props.controlStatus)
   return (
     <SquareButton onClick={props.toggleWidth} outline={true}>
@@ -285,42 +284,39 @@ interface PinHeightControlProps {
   toggleHeight: () => void
 }
 
-export const PinHeightControl = betterReactMemo(
-  'PinHeightControl',
-  (props: PinHeightControlProps) => {
-    const controlStyles: ControlStyles = getControlStyles(props.controlStatus)
-    return (
-      <SquareButton onClick={props.toggleHeight} outline={true}>
-        <svg width='20' height='20'>
-          <g
-            id='dimensioncontrols-pin-height'
-            stroke={getStrokeColor(controlStyles, props.framePins, props.mixed, FramePoint.Height)}
-          >
-            <path
-              d={`M${HorizontalDimensionButtStart},${DimensionStart} l${DimensionButt},0`}
-              id='dimensioncontrols-pin-height-EdgeEnd-t'
-              strokeLinecap='round'
-            />
-            <path
-              d={`M${HorizontalDimensionButtStart},${VerticalDimensionEnd} l${DimensionButt},0`}
-              id='dimensioncontrols-pin-height-EdgeEnd-b'
-              strokeLinecap='round'
-            />
-            <path
-              d={`M${DimensionHorizontalMid},${DimensionStart} L${DimensionHorizontalMid},${VerticalDimensionEnd}`}
-              id='dimensioncontrols-pin-height-line'
-              strokeDasharray={getStrokeDashArray(props.framePins, props.mixed, FramePoint.Height)}
-              strokeLinecap='round'
-            />
-            <path
-              d={`M 0,0 ${DimensionWidth},0 0,${DimensionHeight} ${DimensionWidth},${DimensionHeight} z`}
-              id='dimensioncontrols-pin-width-transparent'
-              stroke='transparent'
-              fill='transparent'
-            />
-          </g>
-        </svg>
-      </SquareButton>
-    )
-  },
-)
+export const PinHeightControl = React.memo((props: PinHeightControlProps) => {
+  const controlStyles: ControlStyles = getControlStyles(props.controlStatus)
+  return (
+    <SquareButton onClick={props.toggleHeight} outline={true}>
+      <svg width='20' height='20'>
+        <g
+          id='dimensioncontrols-pin-height'
+          stroke={getStrokeColor(controlStyles, props.framePins, props.mixed, FramePoint.Height)}
+        >
+          <path
+            d={`M${HorizontalDimensionButtStart},${DimensionStart} l${DimensionButt},0`}
+            id='dimensioncontrols-pin-height-EdgeEnd-t'
+            strokeLinecap='round'
+          />
+          <path
+            d={`M${HorizontalDimensionButtStart},${VerticalDimensionEnd} l${DimensionButt},0`}
+            id='dimensioncontrols-pin-height-EdgeEnd-b'
+            strokeLinecap='round'
+          />
+          <path
+            d={`M${DimensionHorizontalMid},${DimensionStart} L${DimensionHorizontalMid},${VerticalDimensionEnd}`}
+            id='dimensioncontrols-pin-height-line'
+            strokeDasharray={getStrokeDashArray(props.framePins, props.mixed, FramePoint.Height)}
+            strokeLinecap='round'
+          />
+          <path
+            d={`M 0,0 ${DimensionWidth},0 0,${DimensionHeight} ${DimensionWidth},${DimensionHeight} z`}
+            id='dimensioncontrols-pin-width-transparent'
+            stroke='transparent'
+            fill='transparent'
+          />
+        </g>
+      </svg>
+    </SquareButton>
+  )
+})

--- a/editor/src/components/inspector/widgets/property-label.tsx
+++ b/editor/src/components/inspector/widgets/property-label.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { css, jsx } from '@emotion/react'
 import { PropertyPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
-import { betterReactMemo, InspectorContextMenuWrapper } from '../../../uuiui-deps'
 import { optionalAddOnUnsetValues } from '../common/context-menu-items'
 import { useInspectorInfoSimpleUntyped } from '../common/property-path-hooks'
 import { ControlStyles } from '../common/control-status'
@@ -24,7 +23,7 @@ function useMetadataInfoForDomain(target: ReadonlyArray<PropertyPath>) {
   )
 }
 
-export const PropertyLabel = betterReactMemo('PropertyLabel', (props: PropertyLabelProps) => {
+export const PropertyLabel = React.memo((props: PropertyLabelProps) => {
   const metadata = useMetadataInfoForDomain(props.target)
   const propsToUnset = props.propNamesToUnset ?? props.target.map(PP.lastPart)
   const contextMenuItems = optionalAddOnUnsetValues(

--- a/editor/src/components/menubar/menubar.tsx
+++ b/editor/src/components/menubar/menubar.tsx
@@ -22,7 +22,7 @@ import {
   UtopiaTheme,
   useColorTheme,
 } from '../../uuiui'
-import { betterReactMemo, User } from '../../uuiui-deps'
+import { User } from '../../uuiui-deps'
 import { EditorAction } from '../editor/action-types'
 import { setLeftMenuTab, setPanelVisibility, togglePanel } from '../editor/actions/action-creators'
 import { LeftMenuTab } from '../editor/store/editor-state'
@@ -102,7 +102,7 @@ export const MenuTile: React.FunctionComponent<MenuTileProps> = (props) => {
   )
 }
 
-export const Menubar = betterReactMemo('Menubar', () => {
+export const Menubar = React.memo(() => {
   const {
     dispatch,
     selectedTab,

--- a/editor/src/components/navigator/dependecy-version-status-indicator.tsx
+++ b/editor/src/components/navigator/dependecy-version-status-indicator.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
-import { betterReactMemo } from '../../uuiui-deps'
 import type { PackageStatus } from '../../core/shared/npm-dependency-types'
 
-export const NpmDependencyVersionAndStatusIndicator = betterReactMemo<{
+export const NpmDependencyVersionAndStatusIndicator = React.memo<{
   status: PackageStatus
   version: string | null
-}>('NpmDependencyVersionAndStatusIndicator', (props) => {
+}>((props) => {
   switch (props.status) {
     case 'loaded':
     case 'default-package':

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -8,7 +8,6 @@ import {
   PackageStatus,
 } from '../../core/shared/npm-dependency-types'
 import { ProjectFile } from '../../core/shared/project-file-types'
-import { betterReactMemo } from '../../utils/react-performance'
 import Utils from '../../utils/utils'
 import { EditorPanel, setFocus } from '../common/actions'
 import { EditorDispatch } from '../editor/action-types'
@@ -90,7 +89,7 @@ function packageDetailsFromDependencies(
   return userAddedPackages
 }
 
-export const DependencyList = betterReactMemo('DependencyList', () => {
+export const DependencyList = React.memo(() => {
   const props = useEditorState((store) => {
     return {
       editorDispatch: store.dispatch,

--- a/editor/src/components/navigator/external-resources/generic-external-resources-input.tsx
+++ b/editor/src/components/navigator/external-resources/generic-external-resources-input.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { FlexRow, FunctionIcons, StringInput } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
 import { ResourcesListGridRowConfig } from './generic-external-resources-list'
 
@@ -11,8 +10,7 @@ interface MultiStringControlProps {
   onSubmitValues: (values: { hrefValue: string; relValue: string }) => void
 }
 
-export const GenericExternalResourcesInput = betterReactMemo(
-  'GenericExternalResourcesInput',
+export const GenericExternalResourcesInput = React.memo(
   ({ hrefValueToEdit, relValueToEdit, onSubmitValues, closeField }: MultiStringControlProps) => {
     const [hrefValue, setHrefValue] = React.useState(hrefValueToEdit ?? '')
     const [relValue, setRelValue] = React.useState(relValueToEdit ?? '')

--- a/editor/src/components/navigator/external-resources/generic-external-resources-list-item.tsx
+++ b/editor/src/components/navigator/external-resources/generic-external-resources-list-item.tsx
@@ -4,7 +4,7 @@ import {
   useExternalResources,
   ExternalResources,
 } from '../../../printer-parsers/html/external-resources-parser'
-import { betterReactMemo, MenuProvider, MomentumContextMenu } from '../../../uuiui-deps'
+import { MenuProvider, MomentumContextMenu } from '../../../uuiui-deps'
 import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
 import { ResourcesListGridRowConfig } from './generic-external-resources-list'
 import { ContextMenuItem } from '../../context-menu-items'
@@ -28,64 +28,64 @@ function indexedUpdateDeleteGenericResource(
   }
 }
 
-export const GenericExternalResourcesListItem = betterReactMemo<
-  GenericExternalResourcesListItemProps
->('GenericExternalResourcesListItem', ({ value, index, setEditingIndex }) => {
-  const { useSubmitValueFactory } = useExternalResources()
-  const [deleteResource] = useSubmitValueFactory(indexedUpdateDeleteGenericResource)
+export const GenericExternalResourcesListItem = React.memo<GenericExternalResourcesListItemProps>(
+  ({ value, index, setEditingIndex }) => {
+    const { useSubmitValueFactory } = useExternalResources()
+    const [deleteResource] = useSubmitValueFactory(indexedUpdateDeleteGenericResource)
 
-  const onDoubleClick = React.useCallback(() => {
-    setEditingIndex(index)
-  }, [index, setEditingIndex])
+    const onDoubleClick = React.useCallback(() => {
+      setEditingIndex(index)
+    }, [index, setEditingIndex])
 
-  const menuId = `generic-external-resources-list-item-contextmenu-${index}`
-  const menuItems: Array<ContextMenuItem<any>> = [
-    {
-      name: 'Delete',
-      enabled: true,
-      action: () => {
-        deleteResource(index)
+    const menuId = `generic-external-resources-list-item-contextmenu-${index}`
+    const menuItems: Array<ContextMenuItem<any>> = [
+      {
+        name: 'Delete',
+        enabled: true,
+        action: () => {
+          deleteResource(index)
+        },
       },
-    },
-    {
-      name: 'Rename',
-      enabled: true,
-      action: () => {
-        setEditingIndex(index)
+      {
+        name: 'Rename',
+        enabled: true,
+        action: () => {
+          setEditingIndex(index)
+        },
       },
-    },
-  ]
+    ]
 
-  return (
-    <MenuProvider id={menuId} itemsLength={menuItems.length}>
-      <UIGridRow
-        {...ResourcesListGridRowConfig}
-        style={{ paddingLeft: 12, paddingRight: 8 }}
-        onDoubleClick={onDoubleClick}
-      >
-        <div
-          style={{
-            textOverflow: 'ellipsis',
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-          }}
+    return (
+      <MenuProvider id={menuId} itemsLength={menuItems.length}>
+        <UIGridRow
+          {...ResourcesListGridRowConfig}
+          style={{ paddingLeft: 12, paddingRight: 8 }}
+          onDoubleClick={onDoubleClick}
         >
-          {value.href}
-        </div>
-        <div
-          style={{
-            textOverflow: 'ellipsis',
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            textAlign: 'right',
-            fontStyle: 'italic',
-            paddingRight: 1,
-          }}
-        >
-          {value.rel}
-        </div>
-        <MomentumContextMenu id={menuId} items={menuItems} getData={NO_OP} />
-      </UIGridRow>
-    </MenuProvider>
-  )
-})
+          <div
+            style={{
+              textOverflow: 'ellipsis',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {value.href}
+          </div>
+          <div
+            style={{
+              textOverflow: 'ellipsis',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              textAlign: 'right',
+              fontStyle: 'italic',
+              paddingRight: 1,
+            }}
+          >
+            {value.rel}
+          </div>
+          <MomentumContextMenu id={menuId} items={menuItems} getData={NO_OP} />
+        </UIGridRow>
+      </MenuProvider>
+    )
+  },
+)

--- a/editor/src/components/navigator/external-resources/generic-external-resources-list.tsx
+++ b/editor/src/components/navigator/external-resources/generic-external-resources-list.tsx
@@ -14,7 +14,6 @@ import {
   FunctionIcons,
   SectionBodyArea,
 } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { clearSelection, togglePanel } from '../../editor/actions/action-creators'
 import { useEditorState } from '../../editor/store/store-hook'
 import { GridRowProps } from '../../inspector/widgets/ui-grid-row'
@@ -49,7 +48,7 @@ function getIndexedUpdateGenericResource(index: number) {
   }
 }
 
-export const GenericExternalResourcesList = betterReactMemo('GenericExternalResourcesList', () => {
+export const GenericExternalResourcesList = React.memo(() => {
   const { values, useSubmitValueFactory } = useExternalResources()
 
   const [editingIndexOrInserting, setEditingIndexOrInserting] = React.useState<

--- a/editor/src/components/navigator/external-resources/google-fonts-resources-list-item.tsx
+++ b/editor/src/components/navigator/external-resources/google-fonts-resources-list-item.tsx
@@ -1,14 +1,12 @@
 import React from 'react'
 import { GoogleFontsResource } from '../../../printer-parsers/html/external-resources-parser'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
 
 interface GoogleFontsResourcesListItemProps {
   value: GoogleFontsResource
 }
 
-export const GoogleFontsResourcesListItem = betterReactMemo<GoogleFontsResourcesListItemProps>(
-  'GoogleFontsResourcesListItem',
+export const GoogleFontsResourcesListItem = React.memo<GoogleFontsResourcesListItemProps>(
   ({ value }) => {
     return (
       <UIGridRow padded={false} variant='<-------1fr------>|----80px----|'>

--- a/editor/src/components/navigator/external-resources/google-fonts-resources-list-search.tsx
+++ b/editor/src/components/navigator/external-resources/google-fonts-resources-list-search.tsx
@@ -8,7 +8,7 @@ import {
   googleFontsResource,
 } from '../../../printer-parsers/html/external-resources-parser'
 import { StringInput } from '../../../uuiui'
-import { betterReactMemo, Utils } from '../../../uuiui-deps'
+import { Utils } from '../../../uuiui-deps'
 import { UseSubmitValueFactory } from '../../inspector/common/property-path-hooks'
 import {
   fontFamilyData,
@@ -105,8 +105,7 @@ export function updateRemoveFontFamilyVariant(
 
 export const GoogleFontsResourcesListItemHeight = 26
 
-export const GoogleFontsResourcesListSearch = betterReactMemo<GoogleFontsResourcesListSearchProps>(
-  'GoogleFontsResourcesListSearch',
+export const GoogleFontsResourcesListSearch = React.memo<GoogleFontsResourcesListSearchProps>(
   ({ linkedResources, useSubmitValueFactory }) => {
     const [searchTerm, setSearchTerm] = React.useState('')
     const lowerCaseSearchTerm = searchTerm.toLowerCase()

--- a/editor/src/components/navigator/external-resources/google-fonts-resources-list.tsx
+++ b/editor/src/components/navigator/external-resources/google-fonts-resources-list.tsx
@@ -3,12 +3,11 @@ import { setFocus } from '../../../components/common/actions'
 import { isRight } from '../../../core/shared/either'
 import { useExternalResources } from '../../../printer-parsers/html/external-resources-parser'
 import { SectionTitleRow, FlexRow, Title, SectionBodyArea } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { clearSelection, togglePanel } from '../../editor/actions/action-creators'
 import { useEditorState } from '../../editor/store/store-hook'
 import { GoogleFontsResourcesListSearch } from './google-fonts-resources-list-search'
 
-export const GoogleFontsResourcesList = betterReactMemo('GoogleFontsResourcesList', () => {
+export const GoogleFontsResourcesList = React.memo(() => {
   const { values, useSubmitValueFactory } = useExternalResources()
   const { dispatch, minimised, focusedPanel } = useEditorState((store) => {
     return {

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -35,7 +35,7 @@ import {
   Icons,
   Avatar,
 } from '../../uuiui'
-import { betterReactMemo, SelectOption, User } from '../../uuiui-deps'
+import { SelectOption, User } from '../../uuiui-deps'
 import { setFocus } from '../common/actions'
 import { EditorDispatch, LoginState } from '../editor/action-types'
 import * as EditorActions from '../editor/actions/action-creators'
@@ -71,7 +71,7 @@ export const LeftPaneComponentId = 'left-pane'
 
 export const LeftPaneOverflowScrollId = 'left-pane-overflow-scroll'
 
-export const LeftPaneComponent = betterReactMemo('LeftPaneComponent', () => {
+export const LeftPaneComponent = React.memo(() => {
   const selectedTab = useEditorState(
     (store) => store.editor.leftMenu.selectedTab,
     'LeftPaneComponent selectedTab',
@@ -127,7 +127,7 @@ export const LeftPaneComponent = betterReactMemo('LeftPaneComponent', () => {
   )
 })
 
-const ForksGiven = betterReactMemo('ForkPanel', () => {
+const ForksGiven = React.memo(() => {
   const colorTheme = useColorTheme()
 
   const { id, projectName, description, isLoggedIn, forkedFrom } = useEditorState((store) => {
@@ -250,7 +250,7 @@ const ForksGiven = betterReactMemo('ForkPanel', () => {
   )
 })
 
-const ForkButton = betterReactMemo('ForkButton', () => {
+const ForkButton = React.memo(() => {
   const onClickOnForkProject = useTriggerForkProject()
 
   return (
@@ -270,7 +270,7 @@ const ForkButton = betterReactMemo('ForkButton', () => {
   )
 })
 
-const LoggedOutPane = betterReactMemo('LogInPane', () => {
+const LoggedOutPane = React.memo(() => {
   const colorTheme = useColorTheme()
   return (
     <Section data-name='Storyboards' tabIndex={-1}>
@@ -337,7 +337,7 @@ const StoryboardListItem = styled.div<StoryboardListItemProps>((props) => ({
   },
 }))
 
-const StoryboardsPane = betterReactMemo('StoryboardsPane', () => {
+const StoryboardsPane = React.memo(() => {
   const { dispatch, openFile, projectContents, isCanvasVisible } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
@@ -449,7 +449,7 @@ const StoryboardsPane = betterReactMemo('StoryboardsPane', () => {
   )
 })
 
-const ContentsPane = betterReactMemo('ProjectStructurePane', () => {
+const ContentsPane = React.memo(() => {
   return (
     <FlexColumn
       id='leftPaneContents'
@@ -468,7 +468,7 @@ const ContentsPane = betterReactMemo('ProjectStructurePane', () => {
   )
 })
 
-const SettingsPane = betterReactMemo('SettingsPane', () => {
+const SettingsPane = React.memo(() => {
   const { dispatch } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
@@ -551,7 +551,7 @@ const SettingsPane = betterReactMemo('SettingsPane', () => {
   )
 })
 
-const SharingPane = betterReactMemo('SharingPane', () => {
+const SharingPane = React.memo(() => {
   const [temporaryCopySuccess, setTemporaryCopySuccess] = React.useState(false)
   const { projectId, projectName } = useEditorState((store) => {
     return {
@@ -702,7 +702,7 @@ const SharingPane = betterReactMemo('SharingPane', () => {
   )
 })
 
-const GithubPane = betterReactMemo('GithubPane', () => {
+const GithubPane = React.memo(() => {
   const [githubRepoStr, setGithubRepoStr] = React.useState('')
   const parsedRepo = parseGithubProjectString(githubRepoStr)
 
@@ -766,7 +766,7 @@ const GithubPane = betterReactMemo('GithubPane', () => {
   )
 })
 
-export const InsertMenuPane = betterReactMemo('InsertMenuPane', () => {
+export const InsertMenuPane = React.memo(() => {
   const { dispatch, focusedPanel } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
@@ -811,7 +811,7 @@ const themeOptions = [
   },
 ]
 
-const ProjectPane = betterReactMemo('ProjectPane', () => {
+const ProjectPane = React.memo(() => {
   const colorTheme = useColorTheme()
   const {
     dispatch,

--- a/editor/src/components/navigator/navigator-item/component-preview.tsx
+++ b/editor/src/components/navigator/navigator-item/component-preview.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { IcnProps, Icn } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import * as EP from '../../../core/shared/element-path'
 import { useComponentIcon } from '../layout-element-icons'
 
@@ -10,8 +9,7 @@ interface ComponentPreviewProps {
   color: IcnProps['color']
 }
 
-export const ComponentPreview: React.FunctionComponent<ComponentPreviewProps> = betterReactMemo(
-  'ComponentPreview',
+export const ComponentPreview: React.FunctionComponent<ComponentPreviewProps> = React.memo(
   (props) => {
     const iconProps = useComponentIcon(props.path)
 

--- a/editor/src/components/navigator/navigator-item/expandable-indicator.tsx
+++ b/editor/src/components/navigator/navigator-item/expandable-indicator.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Icn, Icons } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 
 export const ExpansionArrowWidth = 8
 export const ExpansionArrowHeight = 8
@@ -15,8 +14,7 @@ interface ExpandableIndicatorProps {
   style?: React.CSSProperties
 }
 
-export const ExpandableIndicator: React.FunctionComponent<ExpandableIndicatorProps> = betterReactMemo(
-  'ExpandableIndicator',
+export const ExpandableIndicator: React.FunctionComponent<ExpandableIndicatorProps> = React.memo(
   (props) => {
     return (
       <div data-testid={props.testId} style={{ width: 16, height: 16, ...props.style }}>

--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -1,7 +1,6 @@
 import { ElementPath } from '../../../core/shared/project-file-types'
 import React from 'react'
 import { IcnProps, Icn, useColorTheme } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 import { WarningIcon } from '../../../uuiui/warning-icon'
 import { useLayoutOrElementIcon } from '../layout-element-icons'
 
@@ -19,45 +18,42 @@ const borderColorForIconColor = (color: IcnProps['color'], colorTheme: any): str
   }
 }
 
-export const LayoutIcon: React.FunctionComponent<LayoutIconProps> = betterReactMemo(
-  'LayoutIcon',
-  (props) => {
-    const colorTheme = useColorTheme()
-    const { iconProps, isPositionAbsolute } = useLayoutOrElementIcon(props.path)
+export const LayoutIcon: React.FunctionComponent<LayoutIconProps> = React.memo((props) => {
+  const colorTheme = useColorTheme()
+  const { iconProps, isPositionAbsolute } = useLayoutOrElementIcon(props.path)
 
-    return (
-      <div
-        style={{
-          width: 18,
-          height: 18,
-          display: 'flex',
-          alignItems: 'center',
-          justifyItems: 'center',
-          position: 'relative',
-          marginLeft: 8,
-        }}
-      >
-        {isPositionAbsolute ? (
-          <div
-            style={{
-              position: 'absolute',
-              left: -5,
-              top: 3,
-              color: '#ff00ff',
-              fontSize: 11,
-              fontWeight: 600,
-            }}
-          >
-            *
-          </div>
-        ) : null}
+  return (
+    <div
+      style={{
+        width: 18,
+        height: 18,
+        display: 'flex',
+        alignItems: 'center',
+        justifyItems: 'center',
+        position: 'relative',
+        marginLeft: 8,
+      }}
+    >
+      {isPositionAbsolute ? (
+        <div
+          style={{
+            position: 'absolute',
+            left: -5,
+            top: 3,
+            color: '#ff00ff',
+            fontSize: 11,
+            fontWeight: 600,
+          }}
+        >
+          *
+        </div>
+      ) : null}
 
-        {props.warningText != null ? (
-          <WarningIcon tooltipText={props.warningText} />
-        ) : (
-          <Icn {...iconProps} color={props.color} />
-        )}
-      </div>
-    )
-  },
-)
+      {props.warningText != null ? (
+        <WarningIcon tooltipText={props.warningText} />
+      ) : (
+        <Icn {...iconProps} color={props.color} />
+      )}
+    </div>
+  )
+})

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -6,40 +6,35 @@ import { EditorDispatch } from '../../editor/action-types'
 import * as EditorActions from '../../editor/actions/action-creators'
 import * as EP from '../../../core/shared/element-path'
 import { useColorTheme, Button, Icons, SectionActionSheet } from '../../../uuiui'
-import { betterReactMemo } from '../../../uuiui-deps'
 
 interface NavigatorHintProps {
   shouldBeShown: boolean
   getMarginForHint: () => number
 }
 
-export const NavigatorHintTop: React.FunctionComponent<NavigatorHintProps> = betterReactMemo(
-  'NavigatorHintTop',
-  (props) => {
-    const colorTheme = useColorTheme()
-    if (props.shouldBeShown) {
-      return (
-        <div
-          style={{
-            marginLeft: props.getMarginForHint(),
-            backgroundColor: colorTheme.navigatorResizeHintBorder.value,
-            height: 2,
-            position: 'absolute',
-            top: 0,
-            width: '100%',
-            borderRadius: '2px',
-            overflow: 'hidden',
-          }}
-        />
-      )
-    } else {
-      return null
-    }
-  },
-)
+export const NavigatorHintTop: React.FunctionComponent<NavigatorHintProps> = React.memo((props) => {
+  const colorTheme = useColorTheme()
+  if (props.shouldBeShown) {
+    return (
+      <div
+        style={{
+          marginLeft: props.getMarginForHint(),
+          backgroundColor: colorTheme.navigatorResizeHintBorder.value,
+          height: 2,
+          position: 'absolute',
+          top: 0,
+          width: '100%',
+          borderRadius: '2px',
+          overflow: 'hidden',
+        }}
+      />
+    )
+  } else {
+    return null
+  }
+})
 
-export const NavigatorHintBottom: React.FunctionComponent<NavigatorHintProps> = betterReactMemo(
-  'NavigatorHintBottom',
+export const NavigatorHintBottom: React.FunctionComponent<NavigatorHintProps> = React.memo(
   (props) => {
     const colorTheme = useColorTheme()
     if (props.shouldBeShown) {
@@ -70,8 +65,7 @@ interface VisiblityIndicatorProps {
   onClick: () => void
 }
 
-export const VisibilityIndicator: React.FunctionComponent<VisiblityIndicatorProps> = betterReactMemo(
-  'VisibilityIndicator',
+export const VisibilityIndicator: React.FunctionComponent<VisiblityIndicatorProps> = React.memo(
   (props) => {
     const color = props.selected ? 'on-highlight-main' : 'subdued'
 
@@ -100,8 +94,7 @@ interface OriginalComponentNameLabelProps {
   instanceOriginalComponentName: string | null
 }
 
-export const OriginalComponentNameLabel: React.FunctionComponent<OriginalComponentNameLabelProps> = betterReactMemo(
-  'OriginalComponentNameLabel',
+export const OriginalComponentNameLabel: React.FunctionComponent<OriginalComponentNameLabelProps> = React.memo(
   (props) => {
     const colorTheme = useColorTheme()
     return (
@@ -130,8 +123,7 @@ interface NavigatorItemActionSheetProps {
   dispatch: EditorDispatch
 }
 
-export const NavigatorItemActionSheet: React.FunctionComponent<NavigatorItemActionSheetProps> = betterReactMemo(
-  'NavigatorItemActionSheet',
+export const NavigatorItemActionSheet: React.FunctionComponent<NavigatorItemActionSheetProps> = React.memo(
   (props) => {
     const { elementPath, dispatch } = props
 

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -27,7 +27,6 @@ import { createSelector } from 'reselect'
 import { nullableDeepEquality } from '../../../utils/deep-equality'
 import { JSXElementNameKeepDeepEqualityCall } from '../../../utils/deep-equality-instances'
 import {
-  betterReactMemo,
   useHookUpdateAnalysisStrictEquals,
   useKeepDeepEqualityCall,
 } from '../../../utils/react-performance'
@@ -125,8 +124,7 @@ const nullableJSXElementNameKeepDeepEquality = nullableDeepEquality(
   JSXElementNameKeepDeepEqualityCall(),
 )
 
-export const NavigatorItemWrapper: React.FunctionComponent<NavigatorItemWrapperProps> = betterReactMemo(
-  'NavigatorItemWrapper',
+export const NavigatorItemWrapper: React.FunctionComponent<NavigatorItemWrapperProps> = React.memo(
   (props) => {
     const selector = React.useMemo(() => navigatorItemWrapperSelectorFactory(props.elementPath), [
       props.elementPath,

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -16,10 +16,7 @@ import { ComponentPreview } from './component-preview'
 import { NavigatorItemActionSheet } from './navigator-item-components'
 import { ElementWarnings } from '../../editor/store/editor-state'
 import { ChildWithPercentageSize } from '../../common/size-warnings'
-import {
-  betterReactMemo,
-  useKeepReferenceEqualityIfPossible,
-} from '../../../utils/react-performance'
+import { useKeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
 import { IcnProps, useColorTheme, UtopiaStyles, UtopiaTheme, FlexRow } from '../../../uuiui'
 import { LayoutIcon } from './layout-icon'
 import { useEditorState } from '../../editor/store/store-hook'
@@ -242,8 +239,7 @@ function useIsProbablyScene(path: ElementPath): boolean {
   )
 }
 
-export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = betterReactMemo(
-  'NavigatorItem',
+export const NavigatorItem: React.FunctionComponent<NavigatorItemInnerProps> = React.memo(
   (props) => {
     const {
       dispatch,
@@ -386,7 +382,7 @@ interface NavigatorRowLabelProps {
   dispatch: EditorDispatch
 }
 
-const NavigatorRowLabel = betterReactMemo('NavigatorRowLabel', (props: NavigatorRowLabelProps) => {
+const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
   return (
     <React.Fragment>
       <LayoutIcon

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -25,7 +25,6 @@ import {
   FlexColumn,
   InspectorSectionHeader,
 } from '../../uuiui'
-import { betterReactMemo } from '../../uuiui-deps'
 import { last } from '../../core/shared/array-utils'
 import { FlexCol } from 'utopia-api'
 // There's some weirdness between the types and the results in the two module systems.
@@ -37,8 +36,11 @@ const AutoSizerComponent: typeof AutoSizer =
 
 const NavigatorContainerId = 'navigator'
 
-export const NavigatorComponent = betterReactMemo(
-  'NavigatorComponent',
+interface NavigatorComponentProps {
+  style: React.CSSProperties
+}
+
+export const NavigatorComponent = React.memo<NavigatorComponentProps>(
   ({ style: navigatorStyle }) => {
     const editorSliceRef = useRefEditorState((store) => {
       const dragSelections = createDragSelections(
@@ -133,7 +135,7 @@ export const NavigatorComponent = betterReactMemo(
       dispatch([EditorActions.togglePanel('navigator')])
     }, [dispatch])
 
-    const Item = betterReactMemo('Item', ({ index, style }: ListChildComponentProps) => {
+    const Item = React.memo(({ index, style }: ListChildComponentProps) => {
       const targetPath = visibleNavigatorTargets[index]
       const componentKey = EP.toComponentId(targetPath)
       return (

--- a/editor/src/components/preview/preview-pane.tsx
+++ b/editor/src/components/preview/preview-pane.tsx
@@ -25,7 +25,6 @@ import {
   Icn,
   UIRow,
 } from '../../uuiui'
-import { betterReactMemo } from '../../utils/react-performance'
 import { setBranchNameFromURL } from '../../utils/branches'
 
 export const PreviewIframeId = 'preview-column-container'
@@ -82,7 +81,7 @@ export interface PreviewColumnState {
   height: number
 }
 
-export const PreviewColumn = betterReactMemo('PreviewColumn', () => {
+export const PreviewColumn = React.memo(() => {
   const { id, projectName, connected, mainJSFilename } = useEditorState((store) => {
     return {
       id: store.editor.id,

--- a/editor/src/core/tailwind/tailwind-options.tsx
+++ b/editor/src/core/tailwind/tailwind-options.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { betterReactMemo } from '../../uuiui-deps'
 import { filterDuplicates, flatMapArray, last, stripNulls } from '../shared/array-utils'
 import { mapToArray, mapValues } from '../shared/object-utils'
 import { NO_OP } from '../shared/utils'
@@ -343,12 +342,11 @@ export function useGetSelectedClasses(): {
   }
 }
 
-const Bold = betterReactMemo('Bold', ({ children }: { children: React.ReactNode }) => {
+const Bold = React.memo(({ children }: { children: React.ReactNode }) => {
   return <strong>{children}</strong>
 })
 
-export const MatchHighlighter = betterReactMemo(
-  'MatchHighlighter',
+export const MatchHighlighter = React.memo(
   ({ text, searchString }: { text: string; searchString: string | null | undefined }) => {
     const sanitisedFilter = searchString?.trim().toLowerCase() ?? ''
     const individualTerms = searchStringToIndividualTerms(sanitisedFilter)
@@ -397,7 +395,7 @@ const getColorForCategory = (category: AttributeCategory): string => {
   }
 }
 
-const AngledStripe = betterReactMemo('AngledStripe', (props: { category: AttributeCategory }) => {
+const AngledStripe = React.memo((props: { category: AttributeCategory }) => {
   return (
     <div
       style={{
@@ -411,8 +409,7 @@ const AngledStripe = betterReactMemo('AngledStripe', (props: { category: Attribu
   )
 })
 
-export const LabelWithStripes = betterReactMemo(
-  'LabelWithStripes',
+export const LabelWithStripes = React.memo(
   (props: { label: string; categories: Array<AttributeCategory> }) => {
     const { label, categories } = props
 

--- a/editor/src/utils/react-performance.ts
+++ b/editor/src/utils/react-performance.ts
@@ -441,22 +441,6 @@ export function useFlasher<T extends HTMLElement>() {
   return ref
 }
 
-export function betterReactMemo<P extends Record<string, any>>(
-  displayName: string,
-  componentToMemo: React.FunctionComponent<P>,
-  propsAreEqual?: (
-    prevProps: Readonly<React.PropsWithChildren<P>>,
-    nextProps: Readonly<React.PropsWithChildren<P>>,
-  ) => boolean,
-  whyDidYouRender: boolean = false,
-) {
-  componentToMemo.displayName = displayName
-  ;(componentToMemo as any).whyDidYouRender = whyDidYouRender
-  const memoized = React.memo(componentToMemo, propsAreEqual)
-  memoized.displayName = displayName
-  return memoized
-}
-
 export function createCallFromIntrospectiveKeepDeep<T>(): KeepDeepEqualityCall<T> {
   return (oldValue, newValue) => {
     const value = keepDeepReferenceEqualityIfPossible(oldValue, newValue)

--- a/editor/src/uuiui-deps/index.tsx
+++ b/editor/src/uuiui-deps/index.tsx
@@ -1,6 +1,3 @@
-import { betterReactMemo } from '../utils/react-performance'
-export { betterReactMemo }
-
 import { Resizable as _Resizable, ResizableProps as _ResizableProps } from 're-resizable'
 
 import _onClickOutside from 'react-onclickoutside'

--- a/editor/src/uuiui/icn.tsx
+++ b/editor/src/uuiui/icn.tsx
@@ -1,6 +1,5 @@
 import { Placement } from 'tippy.js'
 import React from 'react'
-import { betterReactMemo } from '../utils/react-performance'
 import { getPossiblyHashedURL } from '../utils/hashed-assets'
 import { Tooltip } from './tooltip'
 import { useEditorState } from '../components/editor/store/store-hook'
@@ -125,8 +124,7 @@ export function UNSAFE_getIconURL(
   )
 }
 
-export const Icn = betterReactMemo(
-  'Icn',
+export const Icn = React.memo(
   ({
     width = defaultIcnWidth,
     height = defaultIcnHeight,
@@ -184,8 +182,7 @@ export const Icn = betterReactMemo(
 )
 Icn.displayName = 'Icon'
 
-export const IcnSpacer = betterReactMemo(
-  'Icn Spacer',
+export const IcnSpacer = React.memo(
   ({ width = 16, height = 16 }: { width?: number; height?: number }) => {
     return <div style={{ width, height }} />
   },

--- a/editor/src/uuiui/icons.tsx
+++ b/editor/src/uuiui/icons.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import { Icn, IcnProps } from './icn'
-import { betterReactMemo } from '../utils/react-performance'
 
 const makeIcon = (appliedProps: IcnProps): React.FunctionComponent<Omit<IcnProps, 'type'>> =>
-  betterReactMemo(`icon-${appliedProps.type}`, (props) => <Icn {...appliedProps} {...props} />)
+  React.memo((props) => <Icn {...appliedProps} {...props} />)
 
 /**
  * Provides a set of Icon components with overrideable props

--- a/editor/src/uuiui/inputs/base-input.tsx
+++ b/editor/src/uuiui/inputs/base-input.tsx
@@ -1,7 +1,7 @@
 import type { CSSObject } from '@emotion/styled'
 import styled from '@emotion/styled'
 import { getChainSegmentEdge } from '../../utils/utils'
-import { ControlStyles, betterReactMemo, ControlStatus } from '../../uuiui-deps'
+import { ControlStyles, ControlStatus } from '../../uuiui-deps'
 import { UtopiaTheme } from '../styles/theme'
 import React from 'react'
 
@@ -154,8 +154,7 @@ export const InspectorInputEmotionStyle = ({
 
 const StyledInput = styled.input<InspectorInputProps>(InspectorInputEmotionStyle)
 
-export const InspectorInput = betterReactMemo(
-  'InspectorInput',
+export const InspectorInput = React.memo(
   React.forwardRef<HTMLInputElement, InspectorInputProps>((props, ref) => {
     return (
       <StyledInput

--- a/editor/src/uuiui/inputs/checkbox-input.tsx
+++ b/editor/src/uuiui/inputs/checkbox-input.tsx
@@ -8,7 +8,6 @@ import {
   ControlStyles,
 } from '../../components/inspector/common/control-status'
 import { useColorTheme, UtopiaTheme } from '../styles/theme'
-import { betterReactMemo } from '../../uuiui-deps'
 
 export interface CheckboxInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   controlStatus?: ControlStatus
@@ -16,8 +15,7 @@ export interface CheckboxInputProps extends React.InputHTMLAttributes<HTMLInputE
 }
 
 // TODO FIX MY REFs
-export const CheckboxInput = betterReactMemo(
-  'CheckboxInput',
+export const CheckboxInput = React.memo(
   React.forwardRef<HTMLInputElement, CheckboxInputProps>(
     ({ controlStatus = 'simple', focusOnMount = false, style, ...props }, propsRef) => {
       const ref = React.useRef<HTMLInputElement>(null)

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -32,12 +32,7 @@ import {
 import { Either, foldEither, isRight, mapEither, right } from '../../core/shared/either'
 import { clampValue } from '../../core/shared/math-utils'
 import { memoize } from '../../core/shared/memoize'
-import {
-  betterReactMemo,
-  getControlStyles,
-  usePropControlledState,
-  CSSCursor,
-} from '../../uuiui-deps'
+import { getControlStyles, usePropControlledState, CSSCursor } from '../../uuiui-deps'
 import { Icn, IcnProps } from '../icn'
 import { useColorTheme, UtopiaTheme } from '../styles/theme'
 import { FlexRow } from '../widgets/layout/flex-row'
@@ -151,8 +146,7 @@ export interface NumberInputProps extends AbstractNumberInputProps<CSSNumber> {
 
 const ScrubThreshold = 3
 
-export const NumberInput = betterReactMemo<NumberInputProps>(
-  'NumberInput',
+export const NumberInput = React.memo<NumberInputProps>(
   ({
     value: propsValue,
     style,
@@ -827,8 +821,7 @@ function wrappedSimpleOnSubmitValue(
   }
 }
 
-export const SimpleNumberInput = betterReactMemo(
-  'SimpleNumberInput',
+export const SimpleNumberInput = React.memo(
   ({
     value,
     onSubmitValue,
@@ -864,8 +857,7 @@ function wrappedPercentOnSubmitValue(
   }
 }
 
-export const SimplePercentInput = betterReactMemo(
-  'SimplePercentInput',
+export const SimplePercentInput = React.memo(
   ({
     value,
     onSubmitValue,
@@ -892,8 +884,7 @@ interface ChainedNumberControlProps {
   setGlobalCursor?: (cursor: CSSCursor | null) => void
 }
 
-export const ChainedNumberInput: React.FunctionComponent<ChainedNumberControlProps> = betterReactMemo(
-  'ChainedNumberInput',
+export const ChainedNumberInput: React.FunctionComponent<ChainedNumberControlProps> = React.memo(
   ({ propsArray, idPrefix, style, setGlobalCursor }) => {
     return (
       <FlexRow style={style}>

--- a/editor/src/uuiui/inputs/number-or-keyword-input.tsx
+++ b/editor/src/uuiui/inputs/number-or-keyword-input.tsx
@@ -21,7 +21,6 @@ import {
   ValidKeywords,
 } from '../../components/inspector/controls/keyword-control'
 import { isRight } from '../../core/shared/either'
-import { betterReactMemo } from '../../uuiui-deps'
 import { NumberInput, NumberInputOptions } from './number-input'
 
 function parseUnknownInputValueAsNumberOrKeyword(
@@ -50,8 +49,7 @@ interface NumberOrKeywordControlProps extends InspectorControlProps {
   keywordControlOptions: KeywordControlOptions
 }
 
-export const NumberOrKeywordControl = betterReactMemo<NumberOrKeywordControlProps>(
-  'NumberOrKeywordControl',
+export const NumberOrKeywordControl = React.memo<NumberOrKeywordControlProps>(
   ({
     value,
     numberInputOptions,

--- a/editor/src/uuiui/inputs/string-input.tsx
+++ b/editor/src/uuiui/inputs/string-input.tsx
@@ -9,7 +9,6 @@ import {
   getControlStyles,
 } from '../../components/inspector/common/control-status'
 import { preventDefault, stopPropagation } from '../../components/inspector/common/inspector-utils'
-import { betterReactMemo } from '../../uuiui-deps'
 import { useColorTheme, UtopiaTheme } from '../styles/theme'
 import { InspectorInput, InspectorInputEmotionStyle } from './base-input'
 
@@ -29,8 +28,7 @@ export interface StringInputProps
   controlStatus?: ControlStatus
 }
 
-export const StringInput = betterReactMemo(
-  'StringInput',
+export const StringInput = React.memo(
   React.forwardRef<HTMLInputElement, StringInputProps>(
     (
       {

--- a/editor/src/uuiui/tab.tsx
+++ b/editor/src/uuiui/tab.tsx
@@ -11,7 +11,6 @@ import { useColorTheme, UtopiaTheme } from './styles/theme'
 import { CSSObject } from '@emotion/serialize'
 import { defaultIfNull } from '../core/shared/optional-utils'
 import { NO_OP } from '../core/shared/utils'
-import { betterReactMemo } from '../uuiui-deps'
 
 interface TabComponentProps {
   modified?: boolean
@@ -28,99 +27,96 @@ interface TabComponentProps {
   className?: string
 }
 
-export const TabComponent: React.FunctionComponent<TabComponentProps> = betterReactMemo(
-  'TabComponent',
-  (props) => {
-    const colorTheme = useColorTheme()
-    const [tabIsHovered, setTabIsHovered] = React.useState(false)
-    const [indicatorIsHovered, setIndicatorIsHovered] = React.useState(false)
+export const TabComponent: React.FunctionComponent<TabComponentProps> = React.memo((props) => {
+  const colorTheme = useColorTheme()
+  const [tabIsHovered, setTabIsHovered] = React.useState(false)
+  const [indicatorIsHovered, setIndicatorIsHovered] = React.useState(false)
 
-    const modified = defaultIfNull<boolean>(false, props.showModifiedIndicator)
-    const showModifiedIndicator = defaultIfNull<boolean>(true, props.showModifiedIndicator)
-    const showCloseIndicator = defaultIfNull<boolean>(true, props.showCloseIndicator)
-    const selected = defaultIfNull<boolean>(false, props.selected)
-    const hasErrorMessages = defaultIfNull<boolean>(false, props.hasErrorMessages)
-    const label = defaultIfNull<React.ReactElement | string>('', props.label)
-    const icon = defaultIfNull<React.ReactElement | string>('', props.icon)
-    const onClose = defaultIfNull(NO_OP, props.onClose)
+  const modified = defaultIfNull<boolean>(false, props.showModifiedIndicator)
+  const showModifiedIndicator = defaultIfNull<boolean>(true, props.showModifiedIndicator)
+  const showCloseIndicator = defaultIfNull<boolean>(true, props.showCloseIndicator)
+  const selected = defaultIfNull<boolean>(false, props.selected)
+  const hasErrorMessages = defaultIfNull<boolean>(false, props.hasErrorMessages)
+  const label = defaultIfNull<React.ReactElement | string>('', props.label)
+  const icon = defaultIfNull<React.ReactElement | string>('', props.icon)
+  const onClose = defaultIfNull(NO_OP, props.onClose)
 
-    const baseStyle = {
-      paddingLeft: 4,
-      paddingRight: 4,
-      transition: 'all .05s ease-in-out',
-      '&:hover': {
-        backgroundColor: colorTheme.tabHoveredBackground.value,
-      },
-      cursor: 'pointer',
-    }
+  const baseStyle = {
+    paddingLeft: 4,
+    paddingRight: 4,
+    transition: 'all .05s ease-in-out',
+    '&:hover': {
+      backgroundColor: colorTheme.tabHoveredBackground.value,
+    },
+    cursor: 'pointer',
+  }
 
-    const selectionHandlingStyle = {
-      boxShadow: selected ? `inset 0px 2px 0px 0px ${colorTheme.primary.value}` : undefined,
-      color: hasErrorMessages
-        ? colorTheme.errorForeground.value
-        : colorTheme.tabSelectedForeground.value,
+  const selectionHandlingStyle = {
+    boxShadow: selected ? `inset 0px 2px 0px 0px ${colorTheme.primary.value}` : undefined,
+    color: hasErrorMessages
+      ? colorTheme.errorForeground.value
+      : colorTheme.tabSelectedForeground.value,
 
-      fontWeight: selected ? 500 : undefined,
-    }
+    fontWeight: selected ? 500 : undefined,
+  }
 
-    const modifiedIndicator = showModifiedIndicator ? <Icons.CircleSmall /> : null
-    const closeIndicator = showCloseIndicator ? <Icons.CrossSmall /> : null
-    const closeIndicatorHovered = showCloseIndicator ? <Icons.CrossInTranslucentCircle /> : null
+  const modifiedIndicator = showModifiedIndicator ? <Icons.CircleSmall /> : null
+  const closeIndicator = showCloseIndicator ? <Icons.CrossSmall /> : null
+  const closeIndicatorHovered = showCloseIndicator ? <Icons.CrossInTranslucentCircle /> : null
 
-    const tabUnhoveredIndicator = modified ? modifiedIndicator : selected ? closeIndicator : null
-    const tabHoveredIndicator = indicatorIsHovered ? closeIndicatorHovered : closeIndicator
+  const tabUnhoveredIndicator = modified ? modifiedIndicator : selected ? closeIndicator : null
+  const tabHoveredIndicator = indicatorIsHovered ? closeIndicatorHovered : closeIndicator
 
-    const setTabHoveredTrue = React.useCallback(() => setTabIsHovered(true), [setTabIsHovered])
-    const setTabHoveredFalse = React.useCallback(() => setTabIsHovered(false), [setTabIsHovered])
+  const setTabHoveredTrue = React.useCallback(() => setTabIsHovered(true), [setTabIsHovered])
+  const setTabHoveredFalse = React.useCallback(() => setTabIsHovered(false), [setTabIsHovered])
 
-    const setIndicatorHoveredTrue = React.useCallback(() => setIndicatorIsHovered(true), [
-      setIndicatorIsHovered,
-    ])
-    const setIndicatorHoveredFalse = React.useCallback(() => setIndicatorIsHovered(false), [
-      setIndicatorIsHovered,
-    ])
+  const setIndicatorHoveredTrue = React.useCallback(() => setIndicatorIsHovered(true), [
+    setIndicatorIsHovered,
+  ])
+  const setIndicatorHoveredFalse = React.useCallback(() => setIndicatorIsHovered(false), [
+    setIndicatorIsHovered,
+  ])
 
-    const close = React.useCallback(
-      (e) => {
-        onClose()
-        e.stopPropagation()
-      },
-      [onClose],
-    )
+  const close = React.useCallback(
+    (e) => {
+      onClose()
+      e.stopPropagation()
+    },
+    [onClose],
+  )
 
-    return (
-      <SimpleFlexRow
-        onMouseEnter={setTabHoveredTrue}
-        onMouseLeave={setTabHoveredFalse}
-        onClick={props.onClick}
-        onDoubleClick={props.onDoubleClick}
-        onMouseDown={props.onMouseDown}
-        style={{
-          ...baseStyle,
-          ...selectionHandlingStyle,
-        }}
-        className={props.className}
-      >
-        <SimpleFlexRow style={{ flexGrow: 1, marginRight: 32 }}>
-          <SimpleFlexRow style={{ marginLeft: 4 }}>{icon}</SimpleFlexRow>
-          <SimpleFlexRow style={{ marginLeft: 8 }}>{label}</SimpleFlexRow>
-        </SimpleFlexRow>
-        <Button
-          css={{
-            label: 'indicatorContainer',
-            width: 18,
-            height: 18,
-            '&:active': {
-              transform: 'scale(.92)',
-            },
-          }}
-          onMouseEnter={setIndicatorHoveredTrue}
-          onMouseLeave={setIndicatorHoveredFalse}
-          onClick={close}
-        >
-          {showCloseIndicator ? (tabIsHovered ? tabHoveredIndicator : tabUnhoveredIndicator) : null}
-        </Button>
+  return (
+    <SimpleFlexRow
+      onMouseEnter={setTabHoveredTrue}
+      onMouseLeave={setTabHoveredFalse}
+      onClick={props.onClick}
+      onDoubleClick={props.onDoubleClick}
+      onMouseDown={props.onMouseDown}
+      style={{
+        ...baseStyle,
+        ...selectionHandlingStyle,
+      }}
+      className={props.className}
+    >
+      <SimpleFlexRow style={{ flexGrow: 1, marginRight: 32 }}>
+        <SimpleFlexRow style={{ marginLeft: 4 }}>{icon}</SimpleFlexRow>
+        <SimpleFlexRow style={{ marginLeft: 8 }}>{label}</SimpleFlexRow>
       </SimpleFlexRow>
-    )
-  },
-)
+      <Button
+        css={{
+          label: 'indicatorContainer',
+          width: 18,
+          height: 18,
+          '&:active': {
+            transform: 'scale(.92)',
+          },
+        }}
+        onMouseEnter={setIndicatorHoveredTrue}
+        onMouseLeave={setIndicatorHoveredFalse}
+        onClick={close}
+      >
+        {showCloseIndicator ? (tabIsHovered ? tabHoveredIndicator : tabUnhoveredIndicator) : null}
+      </Button>
+    </SimpleFlexRow>
+  )
+})

--- a/editor/src/uuiui/warning-icon.tsx
+++ b/editor/src/uuiui/warning-icon.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { IcnColor, IcnProps } from './icn'
-import { betterReactMemo } from '../utils/react-performance'
 import { Icons } from './icons'
 
 interface WarningIconProps {
@@ -9,7 +8,7 @@ interface WarningIconProps {
   style?: React.CSSProperties
 }
 
-export const WarningIcon = betterReactMemo('Warning Icon', (props: WarningIconProps) => {
+export const WarningIcon = React.memo((props: WarningIconProps) => {
   const icnProps = getWarningIconProps(props.tooltipText, props.color, props.style)
   return <Icons.WarningTriangle {...icnProps} />
 })

--- a/editor/src/uuiui/widgets/avatar/avatar.tsx
+++ b/editor/src/uuiui/widgets/avatar/avatar.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { betterReactMemo, LoginState, User } from '../../../uuiui-deps'
+import { LoginState, User } from '../../../uuiui-deps'
 
 import { useColorTheme } from '../../styles/theme'
 
@@ -9,7 +9,7 @@ interface AvatarProps {
   size?: number
 }
 
-export const Avatar = betterReactMemo('Avatar', (props: AvatarProps) => {
+export const Avatar = React.memo((props: AvatarProps) => {
   const colorTheme = useColorTheme()
   const size: string = (props.size ?? '24') + 'px'
 

--- a/editor/src/uuiui/widgets/popup-list/popup-list.tsx
+++ b/editor/src/uuiui/widgets/popup-list/popup-list.tsx
@@ -21,13 +21,7 @@ import { Icn, IcnProps, IcnSpacer } from '../../icn'
 import { colorTheme, UtopiaStyles, UtopiaTheme } from '../../styles/theme'
 import { FlexRow } from '../layout/flex-row'
 import { isOptionType } from '../../../utils/utils'
-import {
-  betterReactMemo,
-  CommonUtils,
-  ControlStyles,
-  getControlStyles,
-  SelectOption,
-} from '../../../uuiui-deps'
+import { CommonUtils, ControlStyles, getControlStyles, SelectOption } from '../../../uuiui-deps'
 import { Icons, SmallerIcons } from '../../../uuiui/icons'
 
 type ContainerMode = 'default' | 'showBorderOnHover' | 'noBorder'
@@ -517,8 +511,7 @@ const Input = (props: InputProps) => {
   )
 }
 
-export const PopupList = betterReactMemo<PopupListProps>(
-  'PopupList',
+export const PopupList = React.memo<PopupListProps>(
   React.forwardRef(
     (
       {


### PR DESCRIPTION
**Problem:**
This PR is related to enabling fast refresh.

**Fix:**
Replacing betterReactMemo with React.memo. Originally betterReactMemo was created because the component names were missing from the react devtools.

**Commit Details:**
- remove betterReactMemo
- replace it in all places
- this surfaced minor issues: for example FormulaBar received a style prop but the component FormulaBar was not using it, and NumberInputPropertyControl used a hook inside an if-else.