### PR TITLE
Apply the control styles for the padding field correctly.

### DIFF
--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -199,24 +199,6 @@ export class InspectorContextMenuWrapper<T> extends ReactComponent<ContextMenuWr
         css={{
           width: '100%',
           ...this.props.style,
-          '--control-styles-interactive-unset-main-color': UtopiaTheme.color.fg7.value,
-          '--control-styles-interactive-unset-secondary-color': UtopiaTheme.color.fg7.value,
-          '--control-styles-interactive-unset-track-color': UtopiaTheme.color.bg5.value,
-          '--control-styles-interactive-unset-rail-color': UtopiaTheme.color.bg3.value,
-          '&:hover': {
-            '--control-styles-interactive-unset-main-color': getControlStyles('simple').mainColor,
-            '--control-styles-interactive-unset-secondary-color': getControlStyles('simple')
-              .secondaryColor,
-            '--control-styles-interactive-unset-track-color': getControlStyles('simple').trackColor,
-            '--control-styles-interactive-unset-rail-color': getControlStyles('simple').railColor,
-          },
-          '&:focus-within': {
-            '--control-styles-interactive-unset-main-color': getControlStyles('simple').mainColor,
-            '--control-styles-interactive-unset-secondary-color': getControlStyles('simple')
-              .secondaryColor,
-            '--control-styles-interactive-unset-track-color': getControlStyles('simple').trackColor,
-            '--control-styles-interactive-unset-rail-color': getControlStyles('simple').railColor,
-          },
         }}
       >
         <React.Fragment>

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -1,3 +1,6 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { css, jsx } from '@emotion/react'
 import * as ObjectPath from 'object-path'
 import React from 'react'
 import {
@@ -81,6 +84,7 @@ import { ElementPath, PropertyPath } from '../../core/shared/project-file-types'
 import { when } from '../../utils/react-conditionals'
 import { createSelector } from 'reselect'
 import { isTwindEnabled } from '../../core/tailwind/tailwind'
+import { getControlStyles } from './common/control-status'
 
 export interface ElementPathElement {
   name?: string
@@ -336,6 +340,26 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
         width: '100%',
         position: 'relative',
         color: colorTheme.neutralForeground.value,
+      }}
+      css={{
+        '--control-styles-interactive-unset-main-color': UtopiaTheme.color.fg7.value,
+        '--control-styles-interactive-unset-secondary-color': UtopiaTheme.color.fg7.value,
+        '--control-styles-interactive-unset-track-color': UtopiaTheme.color.bg5.value,
+        '--control-styles-interactive-unset-rail-color': UtopiaTheme.color.bg3.value,
+        '&:hover': {
+          '--control-styles-interactive-unset-main-color': getControlStyles('simple').mainColor,
+          '--control-styles-interactive-unset-secondary-color': getControlStyles('simple')
+            .secondaryColor,
+          '--control-styles-interactive-unset-track-color': getControlStyles('simple').trackColor,
+          '--control-styles-interactive-unset-rail-color': getControlStyles('simple').railColor,
+        },
+        '&:focus-within': {
+          '--control-styles-interactive-unset-main-color': getControlStyles('simple').mainColor,
+          '--control-styles-interactive-unset-secondary-color': getControlStyles('simple')
+            .secondaryColor,
+          '--control-styles-interactive-unset-track-color': getControlStyles('simple').trackColor,
+          '--control-styles-interactive-unset-rail-color': getControlStyles('simple').railColor,
+        },
       }}
       onFocus={onFocus}
     >

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2344`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2345`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2498`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2499`)
   })
 })


### PR DESCRIPTION
**Problem:**
The label for the padding field in the inspector shows as if the value is set all the time.

**Fix:**
As the variables holding the styling were attached to the context menu wrapper component, anything that didn't use it would not have the variables and therefore look odd. The fix was to move the variables to the root of the inspector. As the `getControlStyles` function is part of the inspector code, the variables weren't moved any higher than their new location.

**Commit Details:**
- Moved the various style vars from `InspectorContextMenuWrapper`
  into the `Inspector` component.
