### PR TITLE
Refactor from nonsense `flexGap` to `gap`.

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4051,7 +4051,7 @@ export interface ParsedCSSProperties {
   width: CSSNumber | undefined
   height: CSSNumber | undefined
   flexBasis: CSSNumber | undefined
-  flexGap: number
+  gap: number
 }
 
 export type ParsedCSSPropertiesKeys = keyof ParsedCSSProperties
@@ -4225,7 +4225,7 @@ export const cssEmptyValues: ParsedCSSProperties = {
   flexGrow: 0,
   flexShrink: 1,
   display: 'block',
-  flexGap: 0,
+  gap: 0,
   width: {
     value: 0,
     unit: null,
@@ -4301,7 +4301,7 @@ export const cssParsers: CSSParsers = {
   flexGrow: parseCSSUnitlessAsNumber,
   flexShrink: parseCSSUnitlessAsNumber,
   display: parseDisplay,
-  flexGap: parseCSSUnitlessAsNumber,
+  gap: parseCSSUnitlessAsNumber,
   width: parseCSSLengthPercent,
   height: parseCSSLengthPercent,
   flexBasis: parseCSSLengthPercent,
@@ -4373,7 +4373,7 @@ const cssPrinters: CSSPrinters = {
   width: printCSSNumberOrUndefinedAsAttributeValue('px'),
   height: printCSSNumberOrUndefinedAsAttributeValue('px'),
   flexBasis: printCSSNumberOrUndefinedAsAttributeValue('px'),
-  flexGap: jsxAttributeValueWithNoComments,
+  gap: jsxAttributeValueWithNoComments,
 }
 
 export interface UtopianElementProperties {
@@ -4669,7 +4669,7 @@ const layoutEmptyValuesNew: LayoutPropertyTypes = {
   width: undefined,
   height: undefined,
 
-  flexGap: 0,
+  gap: 0,
   flexBasis: undefined,
 
   left: undefined,
@@ -4686,7 +4686,7 @@ const layoutParsersNew: LayoutParsersNew = {
   width: parseFramePin,
   height: parseFramePin,
 
-  flexGap: isNumberParser,
+  gap: isNumberParser,
   flexBasis: parseFramePin,
 
   left: parseFramePin,
@@ -4703,7 +4703,7 @@ const layoutPrintersNew: LayoutPrintersNew = {
   width: printCSSNumberOrUndefinedAsAttributeValue('px'),
   height: printCSSNumberOrUndefinedAsAttributeValue('px'),
 
-  flexGap: jsxAttributeValueWithNoComments,
+  gap: jsxAttributeValueWithNoComments,
   flexBasis: printCSSNumberOrUndefinedAsAttributeValue('px'),
 
   left: printCSSNumberOrUndefinedAsAttributeValue('px'),
@@ -5041,7 +5041,7 @@ export const trivialDefaultValues: ParsedPropertiesWithNonTrivial = {
   gapMain: 0,
   flexBasis: undefined,
 
-  flexGap: 0,
+  gap: 0,
 }
 
 export function isTrivialDefaultValue(

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -253,7 +253,7 @@ export const FlexGapControl = React.memo((props: FlexGapControlProps) => {
     return contextData.targetPath
   })
   const flexGapProp = React.useMemo(() => {
-    return [stylePropPathMappingFn('flexGap', targetPath)]
+    return [stylePropPathMappingFn('gap', targetPath)]
   }, [targetPath])
   return (
     <InspectorContextMenuWrapper id={`gap-context-menu`} items={menuItems} data={{}}>

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
@@ -22,7 +22,7 @@ export const FlexContainerControls = React.memo<{ seeMoreVisible: boolean }>((pr
   const alignItems = useInspectorLayoutInfo('alignItems')
   const alignContent = useInspectorLayoutInfo('alignContent')
   const justifyContent = useInspectorLayoutInfo('justifyContent')
-  const flexGap = useInspectorLayoutInfo('flexGap')
+  const gap = useInspectorLayoutInfo('gap')
 
   const {
     justifyFlexStart,
@@ -40,12 +40,12 @@ export const FlexContainerControls = React.memo<{ seeMoreVisible: boolean }>((pr
     flexWrap.value === FlexWrap.NoWrap ? getControlStyles('disabled') : alignItems.controlStyles
 
   const wrappedOnSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-    flexGap.onSubmitValue,
-    flexGap.onUnsetValues,
+    gap.onSubmitValue,
+    gap.onUnsetValues,
   )
   const wrappedOnTransientSubmitValue = useWrappedEmptyOrUnknownOnSubmitValue(
-    flexGap.onSubmitValue,
-    flexGap.onUnsetValues,
+    gap.onSubmitValue,
+    gap.onUnsetValues,
   )
 
   return (
@@ -71,12 +71,12 @@ export const FlexContainerControls = React.memo<{ seeMoreVisible: boolean }>((pr
         />
       </UIGridRow>
       <FlexGapControl
-        value={flexGap.value}
+        value={gap.value}
         onSubmitValue={wrappedOnSubmitValue}
         onTransientSubmitValue={wrappedOnTransientSubmitValue}
-        onUnset={flexGap.onUnsetValues}
-        controlStatus={flexGap.controlStatus}
-        controlStyles={flexGap.controlStyles}
+        onUnset={gap.onUnsetValues}
+        controlStatus={gap.controlStatus}
+        controlStyles={gap.controlStyles}
       />
       <FlexAlignItemsControl
         value={alignItems.value}

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -6,7 +6,7 @@ import { CSSNumber, ParsedCSSProperties } from '../../components/inspector/commo
 
 export type LayoutDimension = 'width' | 'height'
 
-export type LayoutFlexContainerProp = LayoutDimension | 'flexGap'
+export type LayoutFlexContainerProp = LayoutDimension | 'gap'
 
 export type LayoutFlexElementNumericProp = 'width' | 'height' | 'flexBasis'
 
@@ -60,7 +60,7 @@ export type StyleLayoutProp =
   | 'flexDirection'
   | 'flexGrow'
   | 'flexShrink'
-  | 'flexGap'
+  | 'gap'
   | 'alignItems'
   | 'alignContent'
   | 'justifyContent'
@@ -133,7 +133,7 @@ export interface LayoutPropertyTypes {
   width: CSSNumber | undefined
   height: CSSNumber | undefined
 
-  flexGap: number
+  gap: number
   flexBasis: CSSNumber | undefined
 
   left: CSSNumber | undefined


### PR DESCRIPTION
**Problem:**
This PR: https://github.com/concrete-utopia/utopia/pull/2058 accidentally introduced a regression where `flexGap` was being used as a style property instead of `gap`.

**Fix:**
Replaced everything that addresses `flexGap` with that of `gap`.

**Commit Details:**
- Switched `flexGap` to `gap` in `LayoutFlexContainerProp`.
- Switched `flexGap` to `gap` in `StyleLayoutProp`.
- Renamed `flexGap` field to `gap` in LayoutPropertyTypes.
- Updated various types and constants in `css-utils.ts`.
- Updated `FlexGapControl` and `FlexContainerControls` to use
  the correct property paths.
