### PR TITLE
Add some caching around the registerModule function

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -39,6 +39,7 @@ import { addRegisteredControls, ControlsToCheck } from '../../components/canvas/
 import { getGlobalEvaluatedFileName } from '../shared/code-exec-utils'
 import { memoize } from '../shared/memoize'
 import fastDeepEqual from 'fast-deep-equal'
+import { TimedCacheMap } from '../shared/timed-cache-map'
 
 async function parseInsertOption(
   insertOption: ComponentInsertOption,
@@ -215,10 +216,10 @@ const partiallyParseAndPrepareComponents = (
 export function createRegisterModuleFunction(
   workers: UtopiaTsWorkers | null,
 ): typeof registerModuleAPI {
-  let cachedParseAndPrepareComponentsMap: Map<
+  let cachedParseAndPrepareComponentsMap = new TimedCacheMap<
     string,
     PartiallyAppliedParseAndPrepareComponents
-  > = new Map()
+  >()
 
   // create a function with a signature that matches utopia-api/registerModule
   return function registerModule(

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -29,6 +29,7 @@ import {
   applicative3Either,
   bimapEither,
   Either,
+  foldEither,
   isLeft,
   mapEither,
   sequenceEither,
@@ -226,39 +227,45 @@ export function createRegisterModuleFunction(
   ): void {
     const parsedModuleName = parseString(unparsedModuleName)
 
-    if (isLeft(parsedModuleName)) {
-      const errorDetails = getParseErrorDetails(parsedModuleName.value)
-      throw new Error(`registerModule first param (moduleName): ${errorDetails.description}`)
-    } else {
-      if (workers != null) {
-        const moduleName = parsedModuleName.value
-        let parseAndPrepareComponentsFn = cachedParseAndPrepareComponentsMap.get(moduleName)
-        if (parseAndPrepareComponentsFn == null) {
-          // Create a memoized function for the handling of component descriptors for the specified module name
-          parseAndPrepareComponentsFn = memoize(
-            partiallyParseAndPrepareComponents(workers, moduleName),
-            {
-              equals: fastDeepEqual,
-              maxSize: 5,
-            },
-          )
-          cachedParseAndPrepareComponentsMap.set(moduleName, parseAndPrepareComponentsFn)
-        }
+    foldEither(
+      (parseFailure) => {
+        const errorDetails = getParseErrorDetails(parseFailure)
+        throw new Error(`registerModule first param (moduleName): ${errorDetails.description}`)
+      },
+      (moduleName) => {
+        if (workers != null) {
+          let parseAndPrepareComponentsFn = cachedParseAndPrepareComponentsMap.get(moduleName)
+          if (parseAndPrepareComponentsFn == null) {
+            // Create a memoized function for the handling of component descriptors for the specified module name
+            parseAndPrepareComponentsFn = memoize(
+              partiallyParseAndPrepareComponents(workers, moduleName),
+              {
+                equals: fastDeepEqual,
+                maxSize: 5,
+              },
+            )
+            cachedParseAndPrepareComponentsMap.set(moduleName, parseAndPrepareComponentsFn)
+          }
 
-        const parsedPreparedDescriptors = parseAndPrepareComponentsFn(unparsedComponents)
-        if (isLeft(parsedPreparedDescriptors)) {
-          throw new Error(parsedPreparedDescriptors.value)
-        } else {
-          const preparedDescriptors = parsedPreparedDescriptors.value
-          // Fires off asynchronously.
-          addRegisteredControls(
-            preparedDescriptors.sourceFile,
-            preparedDescriptors.moduleNameOrPath,
-            preparedDescriptors.componentDescriptors,
+          const parsedPreparedDescriptors = parseAndPrepareComponentsFn(unparsedComponents)
+          foldEither(
+            (parseFailureErrorMessage) => {
+              throw new Error(parseFailureErrorMessage)
+            },
+            (preparedDescriptors) => {
+              // Fires off asynchronously.
+              addRegisteredControls(
+                preparedDescriptors.sourceFile,
+                preparedDescriptors.moduleNameOrPath,
+                preparedDescriptors.componentDescriptors,
+              )
+            },
+            parsedPreparedDescriptors,
           )
         }
-      }
-    }
+      },
+      parsedModuleName,
+    )
   }
 }
 

--- a/editor/src/core/shared/timed-cache-map.spec.ts
+++ b/editor/src/core/shared/timed-cache-map.spec.ts
@@ -1,0 +1,188 @@
+import { TimedCacheMap } from './timed-cache-map'
+
+jest.useFakeTimers()
+
+describe('Adding values to a TimedCacheMap', () => {
+  it('Retains all values if none have gone stale', () => {
+    const timeToClean = 200
+    const timeToStale = 60000
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    const input = [
+      ['a', 'first'],
+      ['b', 'second'],
+      ['c', 'third'],
+    ]
+    input.forEach(([k, v]) => {
+      cache.set(k, v)
+    })
+
+    jest.advanceTimersByTime(timeToClean + 10)
+
+    const result = Array.from(cache.entries())
+    expect(result).toEqual(input)
+  })
+
+  it('Removes all stale values', () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    const input = [
+      ['a', 'first'],
+      ['b', 'second'],
+      ['c', 'third'],
+    ]
+    input.forEach(([k, v]) => {
+      cache.set(k, v)
+    })
+
+    jest.advanceTimersByTime(timeToClean + 10)
+
+    // All still there
+    const result1 = Array.from(cache.entries())
+    expect(result1).toEqual(input)
+
+    jest.advanceTimersByTime(timeToClean + 10)
+
+    // Ensure one specific value remains
+    cache.get('b')
+
+    jest.advanceTimersByTime(timeToClean + 10)
+
+    // All others have gone
+    const result2 = Array.from(cache.entries())
+    expect(result2).toEqual([['b', 'second']])
+  })
+
+  it('Calling cache.get() retains a value', () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    cache.set('a', 'first')
+    cache.set('b', 'second')
+
+    jest.advanceTimersByTime(timeToClean + 10)
+
+    // Still there
+    const result1 = cache.get('a')
+    expect(result1).toEqual('first')
+
+    jest.advanceTimersByTime(timeToClean + 10)
+
+    // Still there after the other value has gone stale
+    const result2 = cache.get('a')
+    expect(result2).toEqual('first')
+
+    const expectedMissing = cache.get('b')
+    expect(expectedMissing).toBeUndefined()
+  })
+
+  it('Calling cache.set() retains a value', () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    cache.set('a', 'first')
+    cache.set('b', 'second')
+
+    jest.advanceTimersByTime(timeToClean + 10)
+
+    // Update the value
+    cache.set('a', 'third')
+
+    jest.advanceTimersByTime(timeToClean + 10)
+
+    // Still there after the other value has gone stale
+    const result = cache.get('a')
+    expect(result).toEqual('third')
+
+    const expectedMissing = cache.get('b')
+    expect(expectedMissing).toBeUndefined()
+  })
+
+  it('Calling cache.clear() behaves as expected', () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    const input = [
+      ['a', 'first'],
+      ['b', 'second'],
+      ['c', 'third'],
+    ]
+    input.forEach(([k, v]) => {
+      cache.set(k, v)
+    })
+
+    const result1 = Array.from(cache.entries())
+    expect(result1).toEqual(input)
+
+    cache.clear()
+
+    const result2 = Array.from(cache.entries())
+    expect(result2).toEqual([])
+  })
+
+  it('Calling cache.entries() behaves as expected', () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    const input = [
+      ['a', 'first'],
+      ['b', 'second'],
+      ['c', 'third'],
+    ]
+    input.forEach(([k, v]) => {
+      cache.set(k, v)
+    })
+
+    const result1 = Array.from(cache.entries())
+    expect(result1).toEqual(input)
+
+    jest.advanceTimersByTime(timeToStale + 10)
+
+    const result2 = Array.from(cache.entries())
+    expect(result2).toEqual([])
+  })
+
+  it('Calling cache.keys() behaves as expected', () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    const input = [
+      ['a', 'first'],
+      ['b', 'second'],
+      ['c', 'third'],
+    ]
+    input.forEach(([k, v]) => {
+      cache.set(k, v)
+    })
+
+    const result1 = Array.from(cache.keys())
+    expect(result1).toEqual(['a', 'b', 'c'])
+
+    jest.advanceTimersByTime(timeToStale + 10)
+
+    const result2 = Array.from(cache.keys())
+    expect(result2).toEqual([])
+  })
+
+  it('Calling cache.values() behaves as expected', () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    const input = [
+      ['a', 'first'],
+      ['b', 'second'],
+      ['c', 'third'],
+    ]
+    input.forEach(([k, v]) => {
+      cache.set(k, v)
+    })
+
+    const result1 = Array.from(cache.values())
+    expect(result1).toEqual(['first', 'second', 'third'])
+
+    jest.advanceTimersByTime(timeToStale + 10)
+
+    const result2 = Array.from(cache.values())
+    expect(result2).toEqual([])
+  })
+})

--- a/editor/src/core/shared/timed-cache-map.ts
+++ b/editor/src/core/shared/timed-cache-map.ts
@@ -1,0 +1,111 @@
+import { fastForEach } from './utils'
+
+export class TimedCacheMap<K, V> {
+  private innerMap: Map<K, V>
+  private lastAccessTimes: Map<K, number>
+  private timeOfLastClean: number
+
+  constructor(
+    private timeToStaleInMs: number = 60000,
+    private timeToCleanInMs: number = timeToStaleInMs,
+  ) {
+    this.innerMap = new Map<K, V>()
+    this.lastAccessTimes = new Map<K, number>()
+    this.timeOfLastClean = Date.now()
+  }
+
+  clear() {
+    this.innerMap.clear()
+    this.lastAccessTimes.clear()
+    this.timeOfLastClean = Date.now()
+  }
+
+  delete(k: K) {
+    this.innerMap.delete(k)
+    this.lastAccessTimes.delete(k)
+  }
+
+  has(k: K): boolean {
+    return this.innerMap.has(k)
+  }
+
+  private updateLastAccessTimeForAllKeys() {
+    const now = Date.now()
+    for (const key of this.lastAccessTimes.keys()) {
+      this.lastAccessTimes.set(key, now)
+    }
+  }
+
+  keys(): IterableIterator<K> {
+    this.optionallyClean()
+
+    this.updateLastAccessTimeForAllKeys()
+    return this.innerMap.keys()
+  }
+
+  values(): IterableIterator<V> {
+    this.optionallyClean()
+
+    this.updateLastAccessTimeForAllKeys()
+    return this.innerMap.values()
+  }
+
+  entries(): IterableIterator<[K, V]> {
+    this.optionallyClean()
+
+    this.updateLastAccessTimeForAllKeys()
+    return this.innerMap.entries()
+  }
+
+  forEach(callback: (value: V, key: K) => void) {
+    this.optionallyClean()
+
+    const now = Date.now()
+    this.innerMap.forEach((v, k) => {
+      this.lastAccessTimes.set(k, now)
+      callback(v, k)
+    })
+  }
+
+  get(k: K): V | undefined {
+    this.optionallyClean()
+
+    const v = this.innerMap.get(k)
+    if (v != null) {
+      this.lastAccessTimes.set(k, Date.now())
+    }
+    return v
+  }
+
+  set(k: K, v: V) {
+    this.optionallyClean()
+
+    this.innerMap.set(k, v)
+    this.lastAccessTimes.set(k, Date.now())
+  }
+
+  private getStaleKeys(): Array<K> {
+    const now = Date.now()
+
+    let staleKeys: Array<K> = []
+    this.lastAccessTimes.forEach((lastAccessed, k) => {
+      if (now - lastAccessed > this.timeToStaleInMs) {
+        staleKeys.push(k)
+      }
+    })
+
+    return staleKeys
+  }
+
+  private optionallyClean() {
+    const now = Date.now()
+    if (now - this.timeOfLastClean > this.timeToCleanInMs) {
+      this.timeOfLastClean = now
+      const staleKeys = this.getStaleKeys()
+      fastForEach(staleKeys, (k) => {
+        this.innerMap.delete(k)
+        this.lastAccessTimes.delete(k)
+      })
+    }
+  }
+}

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -67,7 +67,7 @@ import { contentsToTree } from '../components/assets'
 import { defaultSceneElement } from '../components/editor/defaults'
 import { objectMap } from '../core/shared/object-utils'
 
-export function delay<T>(time: number): Promise<T> {
+export function delay(time: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, time))
 }
 


### PR DESCRIPTION
**Problem:**
The `registerModule` function includes parsing of the params and then updating the editor model, both of which we want to minimise for performance.

**Fix:**
This work adds a layer of caching around the parsing of the second param of `registerModule` (the object containing the property controls and insertion variants), and the creation of the component descriptors. This happens via a memoized function stored against the module name (the first param of `registerModule`), so that calling `registerModule` twice (with different module names) will use different memoized functions (to ensure that we're only memoizing the relevant parts).

There is a glaring memory leak problem him, which I'm open to suggestions about - since the `cachedParseAndPrepareComponentsMap` cache is unbounded, it will keep growing as more `registerModule` calls are added (and as the first input is being typed since that will be considered to be a different module each time). The simplest choice here seems to be to trim it when it passes a given size, but I'm not really sure what arbitrary size to give it.