### PR TITLE
TimedCacheMap

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -38,6 +38,7 @@ import { addRegisteredControls, ControlsToCheck } from '../../components/canvas/
 import { getGlobalEvaluatedFileName } from '../shared/code-exec-utils'
 import { memoize } from '../shared/memoize'
 import fastDeepEqual from 'fast-deep-equal'
+import { TimedCacheMap } from '../shared/timed-cache-map'
 
 async function parseInsertOption(
   insertOption: ComponentInsertOption,
@@ -214,10 +215,10 @@ const partiallyParseAndPrepareComponents = (
 export function createRegisterModuleFunction(
   workers: UtopiaTsWorkers | null,
 ): typeof registerModuleAPI {
-  let cachedParseAndPrepareComponentsMap: Map<
+  let cachedParseAndPrepareComponentsMap = new TimedCacheMap<
     string,
     PartiallyAppliedParseAndPrepareComponents
-  > = new Map()
+  >()
 
   // create a function with a signature that matches utopia-api/registerModule
   return function registerModule(

--- a/editor/src/core/shared/timed-cache-map.spec.ts
+++ b/editor/src/core/shared/timed-cache-map.spec.ts
@@ -1,9 +1,10 @@
-import { delay } from '../../utils/utils.test-utils'
 import { TimedCacheMap } from './timed-cache-map'
 
+jest.useFakeTimers()
+
 describe('Adding values to a TimedCacheMap', () => {
-  it('Retains all values if none have gone stale', async () => {
-    const timeToClean = 20
+  it('Retains all values if none have gone stale', () => {
+    const timeToClean = 200
     const timeToStale = 60000
     let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
     const input = [
@@ -15,13 +16,13 @@ describe('Adding values to a TimedCacheMap', () => {
       cache.set(k, v)
     })
 
-    await delay(timeToClean + 10)
+    jest.advanceTimersByTime(timeToClean + 10)
 
     const result = Array.from(cache.entries())
     expect(result).toEqual(input)
   })
 
-  it('Removes all stale values', async () => {
+  it('Removes all stale values', () => {
     const timeToClean = 20
     const timeToStale = timeToClean * 2
     let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
@@ -34,38 +35,38 @@ describe('Adding values to a TimedCacheMap', () => {
       cache.set(k, v)
     })
 
-    await delay(timeToClean + 10)
+    jest.advanceTimersByTime(timeToClean + 10)
 
     // All still there
     const result1 = Array.from(cache.entries())
     expect(result1).toEqual(input)
 
-    await delay(timeToClean + 10)
+    jest.advanceTimersByTime(timeToClean + 10)
 
     // Ensure one specific value remains
     cache.get('b')
 
-    await delay(timeToClean + 10)
+    jest.advanceTimersByTime(timeToClean + 10)
 
     // All others have gone
     const result2 = Array.from(cache.entries())
     expect(result2).toEqual([['b', 'second']])
   })
 
-  it('Calling cache.get() retains a value', async () => {
+  it('Calling cache.get() retains a value', () => {
     const timeToClean = 20
     const timeToStale = timeToClean * 2
     let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
     cache.set('a', 'first')
     cache.set('b', 'second')
 
-    await delay(timeToClean + 10)
+    jest.advanceTimersByTime(timeToClean + 10)
 
     // Still there
     const result1 = cache.get('a')
     expect(result1).toEqual('first')
 
-    await delay(timeToClean + 10)
+    jest.advanceTimersByTime(timeToClean + 10)
 
     // Still there after the other value has gone stale
     const result2 = cache.get('a')
@@ -75,19 +76,19 @@ describe('Adding values to a TimedCacheMap', () => {
     expect(expectedMissing).toBeUndefined()
   })
 
-  it('Calling cache.set() retains a value', async () => {
+  it('Calling cache.set() retains a value', () => {
     const timeToClean = 20
     const timeToStale = timeToClean * 2
     let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
     cache.set('a', 'first')
     cache.set('b', 'second')
 
-    await delay(timeToClean + 10)
+    jest.advanceTimersByTime(timeToClean + 10)
 
     // Update the value
     cache.set('a', 'third')
 
-    await delay(timeToClean + 10)
+    jest.advanceTimersByTime(timeToClean + 10)
 
     // Still there after the other value has gone stale
     const result = cache.get('a')
@@ -119,7 +120,7 @@ describe('Adding values to a TimedCacheMap', () => {
     expect(result2).toEqual([])
   })
 
-  it('Calling cache.entries() behaves as expected', async () => {
+  it('Calling cache.entries() behaves as expected', () => {
     const timeToClean = 20
     const timeToStale = timeToClean * 2
     let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
@@ -135,13 +136,13 @@ describe('Adding values to a TimedCacheMap', () => {
     const result1 = Array.from(cache.entries())
     expect(result1).toEqual(input)
 
-    await delay(timeToStale + 10)
+    jest.advanceTimersByTime(timeToStale + 10)
 
     const result2 = Array.from(cache.entries())
     expect(result2).toEqual([])
   })
 
-  it('Calling cache.keys() behaves as expected', async () => {
+  it('Calling cache.keys() behaves as expected', () => {
     const timeToClean = 20
     const timeToStale = timeToClean * 2
     let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
@@ -157,13 +158,13 @@ describe('Adding values to a TimedCacheMap', () => {
     const result1 = Array.from(cache.keys())
     expect(result1).toEqual(['a', 'b', 'c'])
 
-    await delay(timeToStale + 10)
+    jest.advanceTimersByTime(timeToStale + 10)
 
     const result2 = Array.from(cache.keys())
     expect(result2).toEqual([])
   })
 
-  it('Calling cache.values() behaves as expected', async () => {
+  it('Calling cache.values() behaves as expected', () => {
     const timeToClean = 20
     const timeToStale = timeToClean * 2
     let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
@@ -179,7 +180,7 @@ describe('Adding values to a TimedCacheMap', () => {
     const result1 = Array.from(cache.values())
     expect(result1).toEqual(['first', 'second', 'third'])
 
-    await delay(timeToStale + 10)
+    jest.advanceTimersByTime(timeToStale + 10)
 
     const result2 = Array.from(cache.values())
     expect(result2).toEqual([])

--- a/editor/src/core/shared/timed-cache-map.spec.ts
+++ b/editor/src/core/shared/timed-cache-map.spec.ts
@@ -15,7 +15,7 @@ describe('Adding values to a TimedCacheMap', () => {
       cache.set(k, v)
     })
 
-    await delay(timeToClean + 1)
+    await delay(timeToClean + 10)
 
     const result = Array.from(cache.entries())
     expect(result).toEqual(input)
@@ -34,16 +34,18 @@ describe('Adding values to a TimedCacheMap', () => {
       cache.set(k, v)
     })
 
-    await delay(timeToClean + 1)
+    await delay(timeToClean + 10)
 
     // All still there
     const result1 = Array.from(cache.entries())
     expect(result1).toEqual(input)
 
+    await delay(timeToClean + 10)
+
     // Ensure one specific value remains
     cache.get('b')
 
-    await delay(timeToClean + 1)
+    await delay(timeToClean + 10)
 
     // All others have gone
     const result2 = Array.from(cache.entries())
@@ -57,13 +59,13 @@ describe('Adding values to a TimedCacheMap', () => {
     cache.set('a', 'first')
     cache.set('b', 'second')
 
-    await delay(timeToClean + 1)
+    await delay(timeToClean + 10)
 
     // Still there
     const result1 = cache.get('a')
     expect(result1).toEqual('first')
 
-    await delay(timeToClean + 1)
+    await delay(timeToClean + 10)
 
     // Still there after the other value has gone stale
     const result2 = cache.get('a')
@@ -80,12 +82,12 @@ describe('Adding values to a TimedCacheMap', () => {
     cache.set('a', 'first')
     cache.set('b', 'second')
 
-    await delay(timeToClean + 1)
+    await delay(timeToClean + 10)
 
     // Update the value
     cache.set('a', 'third')
 
-    await delay(timeToClean + 1)
+    await delay(timeToClean + 10)
 
     // Still there after the other value has gone stale
     const result = cache.get('a')
@@ -133,7 +135,7 @@ describe('Adding values to a TimedCacheMap', () => {
     const result1 = Array.from(cache.entries())
     expect(result1).toEqual(input)
 
-    await delay(timeToStale + 1)
+    await delay(timeToStale + 10)
 
     const result2 = Array.from(cache.entries())
     expect(result2).toEqual([])
@@ -155,7 +157,7 @@ describe('Adding values to a TimedCacheMap', () => {
     const result1 = Array.from(cache.keys())
     expect(result1).toEqual(['a', 'b', 'c'])
 
-    await delay(timeToStale + 1)
+    await delay(timeToStale + 10)
 
     const result2 = Array.from(cache.keys())
     expect(result2).toEqual([])
@@ -177,7 +179,7 @@ describe('Adding values to a TimedCacheMap', () => {
     const result1 = Array.from(cache.values())
     expect(result1).toEqual(['first', 'second', 'third'])
 
-    await delay(timeToStale + 1)
+    await delay(timeToStale + 10)
 
     const result2 = Array.from(cache.values())
     expect(result2).toEqual([])

--- a/editor/src/core/shared/timed-cache-map.spec.ts
+++ b/editor/src/core/shared/timed-cache-map.spec.ts
@@ -1,0 +1,185 @@
+import { delay } from '../../utils/utils.test-utils'
+import { TimedCacheMap } from './timed-cache-map'
+
+describe('Adding values to a TimedCacheMap', () => {
+  it('Retains all values if none have gone stale', async () => {
+    const timeToClean = 20
+    const timeToStale = 60000
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    const input = [
+      ['a', 'first'],
+      ['b', 'second'],
+      ['c', 'third'],
+    ]
+    input.forEach(([k, v]) => {
+      cache.set(k, v)
+    })
+
+    await delay(timeToClean + 1)
+
+    const result = Array.from(cache.entries())
+    expect(result).toEqual(input)
+  })
+
+  it('Removes all stale values', async () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    const input = [
+      ['a', 'first'],
+      ['b', 'second'],
+      ['c', 'third'],
+    ]
+    input.forEach(([k, v]) => {
+      cache.set(k, v)
+    })
+
+    await delay(timeToClean + 1)
+
+    // All still there
+    const result1 = Array.from(cache.entries())
+    expect(result1).toEqual(input)
+
+    // Ensure one specific value remains
+    cache.get('b')
+
+    await delay(timeToClean + 1)
+
+    // All others have gone
+    const result2 = Array.from(cache.entries())
+    expect(result2).toEqual([['b', 'second']])
+  })
+
+  it('Calling cache.get() retains a value', async () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    cache.set('a', 'first')
+    cache.set('b', 'second')
+
+    await delay(timeToClean + 1)
+
+    // Still there
+    const result1 = cache.get('a')
+    expect(result1).toEqual('first')
+
+    await delay(timeToClean + 1)
+
+    // Still there after the other value has gone stale
+    const result2 = cache.get('a')
+    expect(result2).toEqual('first')
+
+    const expectedMissing = cache.get('b')
+    expect(expectedMissing).toBeUndefined()
+  })
+
+  it('Calling cache.set() retains a value', async () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    cache.set('a', 'first')
+    cache.set('b', 'second')
+
+    await delay(timeToClean + 1)
+
+    // Update the value
+    cache.set('a', 'third')
+
+    await delay(timeToClean + 1)
+
+    // Still there after the other value has gone stale
+    const result = cache.get('a')
+    expect(result).toEqual('third')
+
+    const expectedMissing = cache.get('b')
+    expect(expectedMissing).toBeUndefined()
+  })
+
+  it('Calling cache.clear() behaves as expected', () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    const input = [
+      ['a', 'first'],
+      ['b', 'second'],
+      ['c', 'third'],
+    ]
+    input.forEach(([k, v]) => {
+      cache.set(k, v)
+    })
+
+    const result1 = Array.from(cache.entries())
+    expect(result1).toEqual(input)
+
+    cache.clear()
+
+    const result2 = Array.from(cache.entries())
+    expect(result2).toEqual([])
+  })
+
+  it('Calling cache.entries() behaves as expected', async () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    const input = [
+      ['a', 'first'],
+      ['b', 'second'],
+      ['c', 'third'],
+    ]
+    input.forEach(([k, v]) => {
+      cache.set(k, v)
+    })
+
+    const result1 = Array.from(cache.entries())
+    expect(result1).toEqual(input)
+
+    await delay(timeToStale + 1)
+
+    const result2 = Array.from(cache.entries())
+    expect(result2).toEqual([])
+  })
+
+  it('Calling cache.keys() behaves as expected', async () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    const input = [
+      ['a', 'first'],
+      ['b', 'second'],
+      ['c', 'third'],
+    ]
+    input.forEach(([k, v]) => {
+      cache.set(k, v)
+    })
+
+    const result1 = Array.from(cache.keys())
+    expect(result1).toEqual(['a', 'b', 'c'])
+
+    await delay(timeToStale + 1)
+
+    const result2 = Array.from(cache.keys())
+    expect(result2).toEqual([])
+  })
+
+  it('Calling cache.values() behaves as expected', async () => {
+    const timeToClean = 20
+    const timeToStale = timeToClean * 2
+    let cache = new TimedCacheMap<string, string>(timeToStale, timeToClean)
+    const input = [
+      ['a', 'first'],
+      ['b', 'second'],
+      ['c', 'third'],
+    ]
+    input.forEach(([k, v]) => {
+      cache.set(k, v)
+    })
+
+    const result1 = Array.from(cache.values())
+    expect(result1).toEqual(['first', 'second', 'third'])
+
+    await delay(timeToStale + 1)
+
+    const result2 = Array.from(cache.values())
+    expect(result2).toEqual([])
+  })
+})

--- a/editor/src/core/shared/timed-cache-map.ts
+++ b/editor/src/core/shared/timed-cache-map.ts
@@ -3,7 +3,7 @@ import { fastForEach } from './utils'
 export class TimedCacheMap<K, V> {
   private innerMap: Map<K, V>
   private lastAccessTimes: Map<K, number>
-  private timeSinceLastClean: number
+  private timeOfLastClean: number
 
   constructor(
     private timeToStaleInMs: number = 60000,
@@ -11,13 +11,13 @@ export class TimedCacheMap<K, V> {
   ) {
     this.innerMap = new Map<K, V>()
     this.lastAccessTimes = new Map<K, number>()
-    this.timeSinceLastClean = Date.now()
+    this.timeOfLastClean = Date.now()
   }
 
   clear() {
     this.innerMap.clear()
     this.lastAccessTimes.clear()
-    this.timeSinceLastClean = Date.now()
+    this.timeOfLastClean = Date.now()
   }
 
   delete(k: K) {
@@ -99,8 +99,8 @@ export class TimedCacheMap<K, V> {
 
   private optionallyClean() {
     const now = Date.now()
-    if (now - this.timeSinceLastClean > this.timeToCleanInMs) {
-      this.timeSinceLastClean = now
+    if (now - this.timeOfLastClean > this.timeToCleanInMs) {
+      this.timeOfLastClean = now
       const staleKeys = this.getStaleKeys()
       fastForEach(staleKeys, (k) => {
         this.innerMap.delete(k)

--- a/editor/src/core/shared/timed-cache-map.ts
+++ b/editor/src/core/shared/timed-cache-map.ts
@@ -1,0 +1,100 @@
+import { fastForEach } from './utils'
+
+export class TimedCacheMap<K, V> {
+  private innerMap: Map<K, V>
+  private lastAccessTimes: Map<K, number>
+  private timeSinceLastClean: number
+
+  constructor(
+    private timeToStaleInMs: number = 60000,
+    private timeToCleanInMs: number = timeToStaleInMs,
+  ) {
+    this.innerMap = new Map<K, V>()
+    this.lastAccessTimes = new Map<K, number>()
+    this.timeSinceLastClean = Date.now()
+  }
+
+  clear() {
+    this.innerMap.clear()
+    this.lastAccessTimes.clear()
+    this.timeSinceLastClean = Date.now()
+  }
+
+  delete(k: K) {
+    this.innerMap.delete(k)
+    this.lastAccessTimes.delete(k)
+  }
+
+  has(k: K): boolean {
+    return this.innerMap.has(k)
+  }
+
+  keys(): IterableIterator<K> {
+    // TODO Should this update lastAccessTimes?
+    this.optionallyClean()
+
+    return this.innerMap.keys()
+  }
+
+  values(): IterableIterator<V> {
+    // TODO Should this update lastAccessTimes?
+    this.optionallyClean()
+
+    return this.innerMap.values()
+  }
+
+  entries(): IterableIterator<[K, V]> {
+    // TODO Should this update lastAccessTimes?
+    this.optionallyClean()
+
+    return this.innerMap.entries()
+  }
+
+  forEach(callback: (value: V, key: K) => void) {
+    // TODO Should this update lastAccessTimes?
+    this.optionallyClean()
+
+    this.innerMap.forEach(callback)
+  }
+
+  get(k: K): V | undefined {
+    this.optionallyClean()
+
+    const v = this.innerMap.get(k)
+    if (v != null) {
+      this.lastAccessTimes.set(k, Date.now())
+    }
+    return v
+  }
+
+  set(k: K, v: V) {
+    this.optionallyClean()
+
+    this.innerMap.set(k, v)
+    this.lastAccessTimes.set(k, Date.now())
+  }
+
+  private getStaleKeys(): Array<K> {
+    const now = Date.now()
+
+    let staleKeys: Array<K> = []
+    this.lastAccessTimes.forEach((lastAccessed, k) => {
+      if (now - lastAccessed > this.timeToStaleInMs) {
+        staleKeys.push(k)
+      }
+    })
+
+    return staleKeys
+  }
+
+  private optionallyClean() {
+    if (Date.now() - this.timeSinceLastClean > this.timeToCleanInMs) {
+      this.timeSinceLastClean = Date.now()
+      const staleKeys = this.getStaleKeys()
+      fastForEach(staleKeys, (k) => {
+        this.innerMap.delete(k)
+        this.lastAccessTimes.delete(k)
+      })
+    }
+  }
+}

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -67,7 +67,7 @@ import { contentsToTree } from '../components/assets'
 import { defaultSceneElement } from '../components/editor/defaults'
 import { objectMap } from '../core/shared/object-utils'
 
-export function delay<T>(time: number): Promise<T> {
+export function delay(time: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, time))
 }
 


### PR DESCRIPTION
**Problem:**
The caching introduced in #2069 is unconstrained, meaning that it will introduce a memory leak whenever `registerModule` is introduced.

**Fix:**
This PR introduces a variant of `Map` which cleans stale keys on all access operations after a given amount of time. It takes two (optional) times (in ms) as input - the time until an entry is considered stale, and the time to wait between removing stale entries.

~I have a number of questions in `TODO`s in the code, to which I'm pretty sure the answer is always "yes", so I'm going to make those changes now (but wanted to create the PR first so others could see the code)~ This has now been resolved