### PR TITLE
create or update performance test comment 

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -140,13 +140,13 @@ jobs:
           PERFORMANCE_GRAPHS_PLOTLY_API_KEY: ${{secrets.PERFORMANCE_GRAPHS_PLOTLY_API_KEY}}
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "run-puppeteer-test"
-      - name: Find Comment
-        uses: peter-evans/find-comment@v1
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: [Link to test editor](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})
+      # - name: Find Comment
+      #   uses: peter-evans/find-comment@v1
+      #   id: fc
+      #   with:
+      #     issue-number: ${{ github.event.pull_request.number }}
+      #     comment-author: 'github-actions[bot]'
+      #     body-includes: [Link to test editor](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v1
         if: ${{ success() || failure() }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -153,6 +153,7 @@ jobs:
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
           body: |
             [Link to test editor](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})
             ${{ steps.run-performance-test.outputs.perf-result }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -139,7 +139,7 @@ jobs:
           PERFORMANCE_GRAPHS_PLOTLY_USERNAME: ${{ secrets.PERFORMANCE_GRAPHS_PLOTLY_USERNAME}}
           PERFORMANCE_GRAPHS_PLOTLY_API_KEY: ${{secrets.PERFORMANCE_GRAPHS_PLOTLY_API_KEY}}
         run: |
-          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; pnpm run performance-test"
+          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "run-puppeteer-test"
       - name: Find Comment
         uses: peter-evans/find-comment@v1
         id: fc

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -146,7 +146,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: Compare with last deployed Master
+          body-includes: Performance test results
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v1
         if: ${{ success() || failure() }}
@@ -156,6 +156,7 @@ jobs:
           edit-mode: replace
           body: |
             [Link to test editor](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})
+            Performance test results:
             ${{ steps.run-performance-test.outputs.perf-result }}
       - name: Build Discord Message
         env:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -140,13 +140,13 @@ jobs:
           PERFORMANCE_GRAPHS_PLOTLY_API_KEY: ${{secrets.PERFORMANCE_GRAPHS_PLOTLY_API_KEY}}
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "run-puppeteer-test"
-      # - name: Find Comment
-      #   uses: peter-evans/find-comment@v1
-      #   id: fc
-      #   with:
-      #     issue-number: ${{ github.event.pull_request.number }}
-      #     comment-author: 'github-actions[bot]'
-      #     body-includes: [Link to test editor](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Link to test editor
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v1
         if: ${{ success() || failure() }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -114,10 +114,18 @@ jobs:
           PERFORMANCE_GRAPHS_PLOTLY_API_KEY: ${{secrets.PERFORMANCE_GRAPHS_PLOTLY_API_KEY}}
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; pnpm run performance-test"
-      - name: Create comment
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: [Link to test editor](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})
+      - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v1
         if: ${{ success() || failure() }}
         with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             [Link to test editor](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -146,7 +146,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: Link to test editor
+          body-includes: Compare with last deployed Master
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v1
         if: ${{ success() || failure() }}

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -81,10 +81,6 @@ import {
 } from '../../../core/shared/redux-devtools'
 import { pick } from '../../../core/shared/object-utils'
 import {
-  getSavedCodeFromTextFile,
-  getUnsavedCodeFromTextFile,
-} from '../../../core/model/project-file-utils'
-import {
   ProjectChanges,
   emptyProjectChanges,
   combineProjectChanges,


### PR DESCRIPTION
**Problem:**
The performance test would keep adding new comments on our long-lived pull requests. For a while we thought it was the good tradeoff (we can keep an eye on the performance as it changes), but I'd like to try out how it feels if we have a single ever-updating comment at the top of the PR. (similar to Relative-CI)

**Fix:**
Use Find Comment to try to find a previous performance result comment and override it with the new one.
