### PR TITLE
removing animationsEnabled and highlightsEnabled as they were mostly …

### DIFF
--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -304,8 +304,6 @@ const Canvas = {
   },
   handleKeyUp(key: KeyCharacter, editor: EditorState, derived: DerivedState): Array<EditorAction> {
     switch (key) {
-      case 'z':
-        return [EditorActions.setHighlightsEnabled(true)]
       default:
         return []
     }

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -101,7 +101,6 @@ export interface ControlProps {
   openFile: string | null
   hiddenInstances: Array<ElementPath>
   focusedElementPath: ElementPath | null
-  highlightsEnabled: boolean
   canvasOffset: CanvasPoint
   scale: number
   dispatch: EditorDispatch
@@ -129,11 +128,6 @@ export const NewCanvasControls = React.memo((props: NewCanvasControlsProps) => {
       editor: store.editor,
       derived: store.derived,
       canvasOffset: store.editor.canvas.roundedCanvasOffset,
-      animationEnabled:
-        (store.editor.canvas.dragState == null ||
-          getDragStateStart(store.editor.canvas.dragState, store.editor.canvas.resizeOptions) ==
-            null) &&
-        store.editor.canvas.animationsEnabled,
 
       controls: store.derived.canvas.controls,
       scale: store.editor.canvas.scale,
@@ -231,7 +225,6 @@ interface NewCanvasControlsInnerProps {
   derived: DerivedState
   dispatch: EditorDispatch
   canvasOffset: CanvasPoint
-  animationEnabled: boolean
   windowToCanvasPosition: (event: MouseEvent) => CanvasPositions
   localSelectedViews: Array<ElementPath>
   localHighlightedViews: Array<ElementPath>
@@ -298,7 +291,6 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       componentMetadata: componentMetadata,
       hiddenInstances: props.editor.hiddenInstances,
       focusedElementPath: props.editor.focusedElementPath,
-      highlightsEnabled: props.editor.canvas.highlightsEnabled,
       canvasOffset: props.canvasOffset,
       scale: props.editor.canvas.scale,
       dispatch: props.dispatch,

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -477,7 +477,6 @@ export class SelectModeControlContainer extends React.Component<
         child.element,
       )
     }, storyboardChildren)
-    let labelDirectlySelectable = this.props.highlightsEnabled
 
     return (
       <div
@@ -495,7 +494,7 @@ export class SelectModeControlContainer extends React.Component<
         {roots.map((root) => {
           return (
             <React.Fragment key={`${EP.toComponentId(root)}}-root-controls`}>
-              {this.renderLabel(root, allElementsDirectlySelectable || labelDirectlySelectable)}
+              {this.renderLabel(root, allElementsDirectlySelectable)}
             </React.Fragment>
           )
         })}

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -5,10 +5,7 @@ import React from 'react'
 import Utils from '../../../utils/utils'
 import { CanvasPoint, CanvasRectangle } from '../../../core/shared/math-utils'
 import { EditorDispatch } from '../../editor/action-types'
-import {
-  setCanvasAnimationsEnabled,
-  setResizeOptionsTargetOptions,
-} from '../../editor/actions/action-creators'
+import { setResizeOptionsTargetOptions } from '../../editor/actions/action-creators'
 import { ControlFontSize } from '../canvas-controls-frame'
 import {
   CSSCursor,
@@ -80,10 +77,6 @@ class ResizeControl extends React.Component<ResizeControlProps> {
     super(props)
   }
 
-  componentWillUnmount() {
-    this.props.dispatch([setCanvasAnimationsEnabled(true)], 'canvas')
-  }
-
   onMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation()
     if (event.buttons === 1) {
@@ -138,7 +131,6 @@ class ResizeControl extends React.Component<ResizeControlProps> {
       this.props.dispatch(
         [
           CanvasActions.createDragState(newDragState),
-          setCanvasAnimationsEnabled(false),
           setResizeOptionsTargetOptions(
             propertyTargetOptions,
             this.props.propertyTargetSelectedIndex,

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -451,11 +451,6 @@ export interface UnwrapGroupOrView {
   onlyForGroups: boolean
 }
 
-export interface SetCanvasAnimationsEnabled {
-  action: 'SET_CANVAS_ANIMATIONS_ENABLED'
-  value: boolean
-}
-
 export interface UpdateFrameDimensions {
   action: 'UPDATE_FRAME_DIMENSIONS'
   element: ElementPath
@@ -514,11 +509,6 @@ export interface UpdateThumbnailGenerated {
 export interface UpdatePreviewConnected {
   action: 'UPDATE_PREVIEW_CONNECTED'
   connected: boolean
-}
-
-export interface SetHighlightsEnabled {
-  action: 'SET_HIGHLIGHTS_ENABLED'
-  value: boolean
 }
 
 export interface AlignSelectedViews {
@@ -990,7 +980,6 @@ export type EditorAction =
   | OpenFloatingInsertMenu
   | CloseFloatingInsertMenu
   | UnwrapGroupOrView
-  | SetCanvasAnimationsEnabled
   | SetNavigatorRenamingTarget
   | RedrawOldCanvasControls
   | UpdateFrameDimensions
@@ -1004,7 +993,6 @@ export type EditorAction =
   | RegenerateThumbnail
   | UpdateThumbnailGenerated
   | UpdatePreviewConnected
-  | SetHighlightsEnabled
   | AlignSelectedViews
   | DistributeSelectedViews
   | SetCursorOverlay

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -113,7 +113,6 @@ import type {
   SendLinterRequestMessage,
   SendPreviewModel,
   SetAspectRatioLock,
-  SetCanvasAnimationsEnabled,
   SetCanvasFrames,
   SetCodeEditorBuildErrors,
   SetCodeEditorLintErrors,
@@ -121,7 +120,6 @@ import type {
   SetCursorOverlay,
   SetFilebrowserRenamingTarget,
   SetHighlightedView,
-  SetHighlightsEnabled,
   SetLeftMenuExpanded,
   SetLeftMenuTab,
   SetMainUIFile,
@@ -686,13 +684,6 @@ export function setCursorOverlay(cursor: CSSCursor | null): SetCursorOverlay {
   }
 }
 
-export function setCanvasAnimationsEnabled(value: boolean): SetCanvasAnimationsEnabled {
-  return {
-    action: 'SET_CANVAS_ANIMATIONS_ENABLED',
-    value: value,
-  }
-}
-
 export function setZIndex(target: ElementPath, index: number): SetZIndex {
   return {
     action: 'SET_Z_INDEX',
@@ -849,13 +840,6 @@ export function updatePreviewConnected(connected: boolean): UpdatePreviewConnect
   return {
     action: 'UPDATE_PREVIEW_CONNECTED',
     connected: connected,
-  }
-}
-
-export function setHighlightsEnabled(value: boolean): SetHighlightsEnabled {
-  return {
-    action: 'SET_HIGHLIGHTS_ENABLED',
-    value: value,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -46,7 +46,6 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'TOGGLE_INTERFACEDESIGNER_CODEEDITOR':
     case 'TOGGLE_INTERFACEDESIGNER_ADDITIONAL_CONTROLS':
     case 'SET_CURSOR_OVERLAY':
-    case 'SET_CANVAS_ANIMATIONS_ENABLED':
     case 'SET_NAVIGATOR_RENAMING_TARGET':
     case 'REDRAW_OLD_CANVAS_CONTROLS':
     case 'UPDATE_FRAME_DIMENSIONS':
@@ -55,7 +54,6 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_PROJECT_ID':
     case 'SET_CODE_EDITOR_VISIBILITY':
     case 'UPDATE_PREVIEW_CONNECTED':
-    case 'SET_HIGHLIGHTS_ENABLED':
     case 'SEND_PREVIEW_MODEL':
     case 'CLOSE_DESIGNER_FILE':
     case 'UPDATE_CODE_RESULT_CACHE':

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -279,7 +279,6 @@ import {
   SelectComponents,
   SendPreviewModel,
   SetAspectRatioLock,
-  SetCanvasAnimationsEnabled,
   SetCanvasFrames,
   SetCodeEditorBuildErrors,
   SetCodeEditorLintErrors,
@@ -287,7 +286,6 @@ import {
   SetCursorOverlay,
   SetFilebrowserRenamingTarget,
   SetHighlightedView,
-  SetHighlightsEnabled,
   SetLeftMenuExpanded,
   SetLeftMenuTab,
   SetRightMenuExpanded,
@@ -970,8 +968,6 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
       roundedCanvasOffset: currentEditor.canvas.roundedCanvasOffset,
       textEditor: null,
       selectionControlsVisible: currentEditor.canvas.selectionControlsVisible,
-      animationsEnabled: currentEditor.canvas.animationsEnabled,
-      highlightsEnabled: true,
       cursor: null,
       duplicationState: null,
       base64Blobs: {},
@@ -3053,21 +3049,6 @@ export const UPDATE_FNS = {
       },
     }
   },
-  SET_CANVAS_ANIMATIONS_ENABLED: (
-    action: SetCanvasAnimationsEnabled,
-    editor: EditorModel,
-  ): EditorModel => {
-    if (editor.canvas.animationsEnabled === action.value) {
-      return editor
-    }
-    return {
-      ...editor,
-      canvas: {
-        ...editor.canvas,
-        animationsEnabled: action.value,
-      },
-    }
-  },
   UPDATE_FRAME_DIMENSIONS: (
     action: UpdateFrameDimensions,
     editor: EditorModel,
@@ -3483,18 +3464,6 @@ export const UPDATE_FNS = {
     return produce(editor, (editorState) => {
       editorState.preview.connected = action.connected
     })
-  },
-  SET_HIGHLIGHTS_ENABLED: (action: SetHighlightsEnabled, editor: EditorModel): EditorModel => {
-    if (editor.canvas.highlightsEnabled === action.value) {
-      return editor
-    }
-    return {
-      ...editor,
-      canvas: {
-        ...editor.canvas,
-        highlightsEnabled: action.value,
-      },
-    }
   },
   ALIGN_SELECTED_VIEWS: (
     action: AlignSelectedViews,

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -55,7 +55,6 @@ import {
   DUPLICATE_SELECTION_SHORTCUT,
   FIRST_CHILD_OR_EDIT_TEXT_SHORTCUT,
   handleShortcuts,
-  HIDE_HIGHLIGHTS_SHORTCUT,
   INSERT_ELLIPSE_SHORTCUT,
   INSERT_IMAGE_SHORTCUT,
   INSERT_RECTANGLE_SHORTCUT,
@@ -86,7 +85,6 @@ import {
   RESIZE_ELEMENT_UP_SHORTCUT,
   SAVE_CURRENT_FILE_SHORTCUT,
   SELECT_ALL_SIBLINGS_SHORTCUT,
-  SHOW_HIGHLIGHTS_SHORTCUT,
   START_RENAMING_SHORTCUT,
   TOGGLE_BACKGROUND_SHORTCUT,
   TOGGLE_BORDER_SHORTCUT,
@@ -708,9 +706,6 @@ export function handleKeyDown(
       [REDO_CHANGES_SHORTCUT]: () => {
         return [EditorActions.redo()]
       },
-      [HIDE_HIGHLIGHTS_SHORTCUT]: () => {
-        return [EditorActions.setHighlightsEnabled(false), EditorActions.clearHighlightedViews()]
-      },
       [MOVE_ELEMENT_BACKWARD_SHORTCUT]: () => {
         return isSelectMode(editor.mode) || isSelectLiteMode(editor.mode)
           ? [EditorActions.moveSelectedBackward()]
@@ -824,9 +819,7 @@ export function handleKeyUp(
 
   function getUIFileActions(): Array<EditorAction> {
     return handleShortcuts<Array<EditorAction>>(namesByKey, event, [], {
-      [SHOW_HIGHLIGHTS_SHORTCUT]: () => {
-        return [EditorActions.setHighlightsEnabled(true)]
-      },
+      // no shortcuts at the moment
     })
   }
 

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -79,8 +79,6 @@ export const INSERT_VIEW_SHORTCUT = 'insert-view'
 export const CUT_SELECTION_SHORTCUT = 'cut-selection'
 export const UNDO_CHANGES_SHORTCUT = 'undo-changes'
 export const REDO_CHANGES_SHORTCUT = 'redo-changes'
-export const HIDE_HIGHLIGHTS_SHORTCUT = 'hide-highlights'
-export const SHOW_HIGHLIGHTS_SHORTCUT = 'show-highlights'
 export const MOVE_ELEMENT_FORWARD_SHORTCUT = 'move-element-forward'
 export const MOVE_ELEMENT_TO_FRONT_SHORTCUT = 'move-element-to-front'
 export const MOVE_ELEMENT_BACKWARD_SHORTCUT = 'move-element-backward'
@@ -245,9 +243,6 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
     'Redo the most recently undone change.',
     key('z', ['cmd', 'shift']),
   ),
-  // FIXME: Do these shortcuts need to specify keyup/keydown state?
-  [HIDE_HIGHLIGHTS_SHORTCUT]: shortcut('Hide the highlights.', key('z', [], 'keydown')),
-  [SHOW_HIGHLIGHTS_SHORTCUT]: shortcut('Show the highlights.', key('z', [], 'keyup')),
   [MOVE_ELEMENT_FORWARD_SHORTCUT]: shortcut(
     'Move element forward in z-index related to its siblings.',
     key(']', 'cmd'),

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -439,8 +439,6 @@ export interface EditorState {
       triggerMousePosition: WindowPoint | null
     } | null
     selectionControlsVisible: boolean
-    animationsEnabled: boolean
-    highlightsEnabled: boolean
     cursor: CSSCursor | null
     duplicationState: DuplicationState | null
     base64Blobs: CanvasBase64Blobs
@@ -1237,8 +1235,6 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
       roundedCanvasOffset: BaseCanvasOffsetLeftPane,
       textEditor: null,
       selectionControlsVisible: true,
-      animationsEnabled: true,
-      highlightsEnabled: true,
       cursor: null,
       duplicationState: null,
       base64Blobs: {},
@@ -1499,8 +1495,6 @@ export function editorModelFromPersistentModel(
       roundedCanvasOffset: BaseCanvasOffsetLeftPane,
       textEditor: null,
       selectionControlsVisible: true,
-      animationsEnabled: true,
-      highlightsEnabled: true,
       cursor: null,
       duplicationState: null,
       base64Blobs: {},

--- a/editor/src/components/editor/store/editor-update.ts
+++ b/editor/src/components/editor/store/editor-update.ts
@@ -151,8 +151,6 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.RESET_PINS(action, state, dispatch)
     case 'SET_CURSOR_OVERLAY':
       return UPDATE_FNS.SET_CURSOR_OVERLAY(action, state)
-    case 'SET_CANVAS_ANIMATIONS_ENABLED':
-      return UPDATE_FNS.SET_CANVAS_ANIMATIONS_ENABLED(action, state)
     case 'SET_Z_INDEX':
       return UPDATE_FNS.SET_Z_INDEX(action, state, derivedState)
     case 'UPDATE_FRAME_DIMENSIONS':
@@ -177,8 +175,6 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.UPDATE_THUMBNAIL_GENERATED(action, state)
     case 'UPDATE_PREVIEW_CONNECTED':
       return UPDATE_FNS.UPDATE_PREVIEW_CONNECTED(action, state)
-    case 'SET_HIGHLIGHTS_ENABLED':
-      return UPDATE_FNS.SET_HIGHLIGHTS_ENABLED(action, state)
     case 'SHOW_CONTEXT_MENU':
       return UPDATE_FNS.SHOW_CONTEXT_MENU(action, state)
     case 'DUPLICATE_SPECIFIC_ELEMENTS':


### PR DESCRIPTION
**Problem:**
@seanparsons and I were digging through some old code and we realized that `animationsEnabled` and `highlightsEnabled` are not respected anymore, and the Canvas Strategies' state patching system supersedes them.

**Fix:**
KILL EM'

**Note**
Highlights enabled was connected to a Keyboard Shortcut: pressing Z would set highlightsEnabled to false – and releasing Z would set highlightsEnabled to true. I deleted these shortcut alongside the editorState. Oddly enough pressing Z also hides all canvas controls - including highlights, so I think we are not losing any functionality with this deletion. I just wanted to call out to @maltenuhn if he remembers the reason we had a configurable shortcut to hide highlights – pre-set to 'Z'
