### PR TITLE
Reworked absolute resize into a strategy.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -1,20 +1,24 @@
 import type { Spec } from 'immutability-helper'
-import type { CanvasPoint, CanvasVector } from '../../../core/shared/math-utils'
+import type { CanvasPoint, CanvasRectangle, CanvasVector } from '../../../core/shared/math-utils'
 import type {
   EditorState,
   EditorStatePatch,
+  OriginalCanvasAndLocalFrame,
   TransientCanvasState,
   TransientFilesState,
 } from '../../editor/store/editor-state'
-import type { EdgePosition } from '../canvas-types'
+import type { EdgePosition, EnabledDirection, ResizeDragStatePropertyChange } from '../canvas-types'
 
 interface BoundingArea {
   type: 'BOUNDING_AREA'
 }
 
-interface ResizeHandle {
+export interface ResizeHandle {
   type: 'RESIZE_HANDLE'
   edgePosition: EdgePosition
+  enabledDirection: EnabledDirection
+  originalSize: CanvasRectangle
+  originalFrames: Array<OriginalCanvasAndLocalFrame>
 }
 
 interface FlexGapHandle {
@@ -64,7 +68,7 @@ export type CanvasStrategyFitnessFn = (
   editorState: EditorState,
   sessionProps: SelectModeCanvasSessionProps,
   sessionState: SelectModeCanvasSessionState,
-) => number
+) => number | null
 
 export type CanvasInteractionSession = SelectModeCanvasSession
 
@@ -82,14 +86,26 @@ export interface SelectModeCanvasSessionProps {
   lastTimeMouseMoved: number
 }
 
+export interface AbsoluteResizeStrategyState {
+  properties: Array<ResizeDragStatePropertyChange>
+  propertyTargetSelectedIndex: number
+}
+
+export const emptyAbsoluteResizeStrategyState: AbsoluteResizeStrategyState = {
+  properties: [],
+  propertyTargetSelectedIndex: 0,
+}
+
 export interface SelectModeCanvasSessionState {
   activeStrategy: CanvasStrategy | null
   dragDeltaMinimumPassed: boolean
+  absoluteResizeStrategy: AbsoluteResizeStrategyState | null
 }
 
 export const emptySelectModeCanvasSessionState: SelectModeCanvasSessionState = {
   activeStrategy: null,
   dragDeltaMinimumPassed: false,
+  absoluteResizeStrategy: null,
 }
 
 export function startNewSelectModeCanvasSession(

--- a/editor/src/components/canvas/canvas-strategies/resize-absolute-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/resize-absolute-strategy.ts
@@ -1,0 +1,473 @@
+import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
+import {
+  LayoutPinnedProp,
+  LayoutPinnedProps,
+  LayoutTargetableProp,
+} from '../../../core/layout/layout-helpers-new'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { safeIndex } from '../../../core/shared/array-utils'
+import { foldEither, isLeft, right } from '../../../core/shared/either'
+import {
+  ElementInstanceMetadataMap,
+  emptyComments,
+  jsxAttributeValue,
+  JSXElement,
+} from '../../../core/shared/element-template'
+import { setJSXValuesAtPaths, ValueAtPath } from '../../../core/shared/jsx-attributes'
+import {
+  canvasPoint,
+  CanvasPoint,
+  CanvasRectangle,
+  CanvasVector,
+} from '../../../core/shared/math-utils'
+import { optionalMap } from '../../../core/shared/optional-utils'
+import { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
+import * as PP from '../../../core/shared/property-path'
+import { fastForEach } from '../../../core/shared/utils'
+import { keepDeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
+import Utils from '../../../utils/utils'
+import { isAspectRatioLockedNew } from '../../aspect-ratio'
+import {
+  EditorState,
+  forUnderlyingTargetFromEditorState,
+  modifyUnderlyingForOpenFile,
+  TransientFilesState,
+  withUnderlyingTargetFromEditorState,
+} from '../../editor/store/editor-state'
+import * as Frame from '../../frame'
+import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
+import {
+  EdgePosition,
+  PinFrameChange,
+  pinFrameChange,
+  resizeDragStatePropertyChange,
+  updateResizeDragStatePropertyChange,
+} from '../canvas-types'
+import {
+  extendPartialFramePointsForResize,
+  findResizePropertyChange,
+  getOriginalFrameInCanvasCoords,
+  isEdgePositionOnSide,
+  pickPointOnRect,
+  snapPoint,
+  valueToUseForPin,
+} from '../canvas-utils'
+import { determineElementsToOperateOnForDragging } from '../controls/select-mode/move-utils'
+import {
+  AbsoluteResizeStrategyState,
+  CanvasStrategy,
+  CanvasStrategyUpdateFnResult,
+  emptyAbsoluteResizeStrategyState,
+  ResizeHandle,
+  SelectModeCanvasSessionProps,
+  SelectModeCanvasSessionState,
+} from './canvas-strategy-types'
+
+function calculateDraggedRectangle(
+  editor: EditorState,
+  resizeHandle: ResizeHandle,
+  sessionProps: SelectModeCanvasSessionProps,
+  sessionState: SelectModeCanvasSessionState,
+): CanvasRectangle {
+  const originalSize = resizeHandle.originalSize
+  const resizeOptions = editor.canvas.resizeOptions
+
+  const propertyChange = findResizePropertyChange(
+    sessionState.absoluteResizeStrategy?.properties ?? [],
+    resizeOptions,
+  )
+  if (propertyChange == null) {
+    return originalSize
+  } else {
+    // for center based resize, we need to calculate with double deltas
+    // for now, because scale is not a first-class citizen, we know that CanvasVector and LocalVector have the same dimensions
+    // this will break with the introduction of scale into the coordinate systems
+    const deltaScale = propertyChange.centerBasedResize ? 2 : 1
+    let delta: CanvasVector = canvasPoint({ x: 0, y: 0 })
+    const drag = sessionProps.drag
+    if (drag != null) {
+      delta = Utils.scaleVector(
+        Utils.scalePoint(drag, resizeHandle.enabledDirection as CanvasVector),
+        deltaScale,
+      )
+    }
+    const startingCorner: EdgePosition = {
+      x: 1 - resizeHandle.edgePosition.x,
+      y: 1 - resizeHandle.edgePosition.y,
+    } as EdgePosition
+    const startingPoint = pickPointOnRect(originalSize, startingCorner)
+    const originalCenter = Utils.getRectCenter(originalSize)
+    const draggedCorner = pickPointOnRect(originalSize, resizeHandle.edgePosition)
+
+    const newCorner = Utils.offsetPoint(draggedCorner, delta)
+    const snappedNewCorner = Utils.roundPointTo(
+      snapPoint(
+        editor,
+        newCorner,
+        propertyChange.enableSnapping,
+        propertyChange.keepAspectRatio,
+        startingPoint,
+        draggedCorner,
+        startingCorner,
+      ),
+      0,
+    )
+    const newSizeVector = Utils.pointDifference(startingPoint, snappedNewCorner)
+    const newRectangle = propertyChange.centerBasedResize
+      ? Utils.rectFromPointVector(originalCenter, Utils.scaleVector(newSizeVector, 0.5), true)
+      : Utils.rectFromPointVector(startingPoint, newSizeVector, false)
+    return newRectangle
+  }
+}
+
+export function calculateNewBounds(
+  editor: EditorState,
+  resizeHandle: ResizeHandle,
+  sessionProps: SelectModeCanvasSessionProps,
+  sessionState: SelectModeCanvasSessionState,
+): CanvasRectangle {
+  const originalSize = resizeHandle.originalSize
+  const aspectRatio = originalSize.width / originalSize.height
+  const newRectangle = calculateDraggedRectangle(editor, resizeHandle, sessionProps, sessionState)
+  const resizeOptions = editor.canvas.resizeOptions
+
+  const propertyChange = findResizePropertyChange(
+    sessionState.absoluteResizeStrategy?.properties ?? [],
+    resizeOptions,
+  )
+  if (propertyChange == null) {
+    return originalSize
+  } else {
+    // At this point I do ugly things to keep side drags in line
+    if (resizeHandle.edgePosition.x === 0.5) {
+      const newWidth = propertyChange.keepAspectRatio
+        ? Utils.roundTo(newRectangle.height * aspectRatio)
+        : originalSize.width
+      newRectangle.x -= newWidth / 2
+      newRectangle.width = newWidth
+    }
+    if (resizeHandle.edgePosition.y === 0.5) {
+      const newHeight = propertyChange.keepAspectRatio
+        ? Utils.roundTo(newRectangle.width / aspectRatio)
+        : originalSize.height
+      newRectangle.y -= newHeight / 2
+      newRectangle.height = newHeight
+    }
+
+    return newRectangle
+  }
+}
+
+function applyResize(
+  jsxMetadata: ElementInstanceMetadataMap,
+  frameAndTarget: PinFrameChange,
+  element: JSXElement,
+): Array<ValueAtPath> {
+  let propsToSet: Array<ValueAtPath> = []
+  let propsToSkip: Array<PropertyPath> = []
+  const nonGroupParent = MetadataUtils.findParent(jsxMetadata, frameAndTarget.target)
+  const parentFrame =
+    nonGroupParent == null
+      ? null
+      : MetadataUtils.getFrameInCanvasCoords(nonGroupParent, jsxMetadata)
+  const parentOffset =
+    parentFrame == null
+      ? ({ x: 0, y: 0 } as CanvasPoint)
+      : ({ x: parentFrame.x, y: parentFrame.y } as CanvasPoint)
+
+  if (frameAndTarget.frame != null) {
+    const newLocalFrame = Utils.getLocalRectangleInNewParentContext(
+      parentOffset,
+      frameAndTarget.frame,
+    )
+    const fullFrame = Frame.getFullFrame(newLocalFrame)
+    const elementProps = element.props
+
+    // Pinning layout.
+    const frameProps = LayoutPinnedProps.filter((p) => {
+      const value = getLayoutProperty(p, right(elementProps), ['style'])
+      return isLeft(value) || value.value != null
+    })
+
+    function whichPropsToUpdate(): Array<LayoutPinnedProp> {
+      if (
+        frameAndTarget.edgePosition != null &&
+        isEdgePositionOnSide(frameAndTarget.edgePosition)
+      ) {
+        // if it has partial positioning points set and dragged on an edge only the dragged edge should be added while keeping the existing frame points.
+        return extendPartialFramePointsForResize(frameProps, frameAndTarget.edgePosition)
+      } else {
+        // The "Old" behavior, for PIN_FRAME_CHANGE
+        return frameProps.length == 4 ? frameProps : ['left', 'top', 'width', 'height']
+      }
+    }
+
+    const propsToUpdate = whichPropsToUpdate()
+
+    Utils.fastForEach(propsToUpdate, (propToUpdate) => {
+      const absoluteValue = fullFrame[propToUpdate]
+
+      const propPathToUpdate = stylePropPathMappingFn(propToUpdate, ['style'])
+      const existingProp = getLayoutProperty(propToUpdate, right(elementProps), ['style'])
+      if (isLeft(existingProp)) {
+        // Only update pins that aren't set via code
+        propsToSkip.push(propPathToUpdate)
+      } else {
+        const pinIsPercentage = existingProp.value == null ? false : existingProp.value.unit === '%'
+        let valueToUse: string | number
+        if (parentFrame == null) {
+          valueToUse = absoluteValue
+        } else {
+          valueToUse = valueToUseForPin(propToUpdate, absoluteValue, pinIsPercentage, parentFrame)
+        }
+        propsToSet.push({
+          path: propPathToUpdate,
+          value: jsxAttributeValue(valueToUse, emptyComments),
+        })
+      }
+    })
+  }
+
+  return propsToSet
+}
+
+function updateResizeStrategyState(
+  current: AbsoluteResizeStrategyState,
+  startForNewProperties: CanvasPoint,
+  drag: CanvasVector | null,
+  targetProperty: LayoutTargetableProp | undefined,
+  enableSnapping: boolean,
+  centerBasedResize: boolean,
+  keepAspectRatio: boolean,
+): AbsoluteResizeStrategyState {
+  let propertyAlreadyExists: boolean = false
+  let updatedProperties = current.properties.map((prop) => {
+    if (prop.targetProperty === targetProperty) {
+      propertyAlreadyExists = true
+      return updateResizeDragStatePropertyChange(
+        prop,
+        drag,
+        targetProperty,
+        enableSnapping,
+        centerBasedResize,
+        keepAspectRatio,
+      )
+    } else {
+      return prop
+    }
+  })
+  if (!propertyAlreadyExists) {
+    updatedProperties = [
+      ...current.properties,
+      resizeDragStatePropertyChange(
+        startForNewProperties,
+        drag,
+        enableSnapping,
+        centerBasedResize,
+        keepAspectRatio,
+        targetProperty,
+      ),
+    ]
+  }
+  return keepDeepReferenceEqualityIfPossible(current, {
+    ...current,
+    properties: updatedProperties,
+  })
+}
+
+export const resizeAbsoluteStrategy: CanvasStrategy = {
+  name: 'Resize Absolute Elements',
+  fitnessFn: (editor, currentSession) => {
+    if (editor.selectedViews.length === 0) {
+      return null
+    }
+    for (const selectedView of editor.selectedViews) {
+      const isAbsolute = MetadataUtils.isPositionAbsolute(
+        MetadataUtils.findElementByElementPath(editor.jsxMetadata, selectedView),
+      )
+      if (!isAbsolute) {
+        return null
+      }
+    }
+    // More than one selected view which is absolute positioned, so this should work.
+    return 10
+  },
+  updateFn: (
+    lifecycle: 'transient' | 'final',
+    editorState: EditorState,
+    sessionProps: SelectModeCanvasSessionProps,
+    sessionState: SelectModeCanvasSessionState,
+  ): CanvasStrategyUpdateFnResult => {
+    if (sessionProps.activeControl.type === 'RESIZE_HANDLE') {
+      const resizeHandle = sessionProps.activeControl
+
+      const elementsToTarget = determineElementsToOperateOnForDragging(
+        editorState.selectedViews,
+        editorState.jsxMetadata,
+        false,
+        true,
+      )
+
+      const newSize = calculateNewBounds(editorState, resizeHandle, sessionProps, sessionState)
+      let framesAndTargets: Array<PinFrameChange> = []
+      let globalFrames: Array<CanvasRectangle> = []
+      fastForEach(editorState.selectedViews, (selectedView) => {
+        const frame = getOriginalFrameInCanvasCoords(resizeHandle.originalFrames, selectedView)
+        if (frame != null) {
+          globalFrames.push(frame)
+        }
+      })
+      const boundingBox = Utils.boundingRectangleArray(globalFrames)
+      if (boundingBox != null) {
+        Utils.fastForEach(elementsToTarget, (target) => {
+          const originalFrame = getOriginalFrameInCanvasCoords(resizeHandle.originalFrames, target)
+          if (originalFrame != null) {
+            const newTargetFrame = Utils.transformFrameUsingBoundingBox(
+              newSize,
+              boundingBox,
+              originalFrame,
+            )
+            const roundedFrame = {
+              x: Math.floor(newTargetFrame.x),
+              y: Math.floor(newTargetFrame.y),
+              width: Math.ceil(newTargetFrame.width),
+              height: Math.ceil(newTargetFrame.height),
+            } as CanvasRectangle
+
+            framesAndTargets.push(pinFrameChange(target, roundedFrame, resizeHandle.edgePosition))
+          }
+        })
+
+        let workingTransientFilesState: TransientFilesState = {}
+        let workingEditorState: EditorState = { ...editorState }
+        const preventAnimations = true
+        if (preventAnimations) {
+          const transitionValueToSet = [
+            {
+              path: PP.create(['style', 'transition']),
+              value: jsxAttributeValue('none', emptyComments),
+            },
+          ]
+          for (const elementToTarget of elementsToTarget) {
+            const withAnimationsPrevented = applyValuesAtPath(
+              workingEditorState,
+              workingTransientFilesState,
+              elementToTarget,
+              transitionValueToSet,
+            )
+            workingTransientFilesState = withAnimationsPrevented.transientFilesState
+            workingEditorState = withAnimationsPrevented.editorState
+          }
+        }
+
+        for (const frameAndTarget of framesAndTargets) {
+          const propsToSet = withUnderlyingTargetFromEditorState(
+            frameAndTarget.target,
+            workingEditorState,
+            [],
+            (_success, element) => {
+              return applyResize(workingEditorState.jsxMetadata, frameAndTarget, element)
+            },
+          )
+          const withUpdates = applyValuesAtPath(
+            workingEditorState,
+            workingTransientFilesState,
+            frameAndTarget.target,
+            propsToSet,
+          )
+          workingEditorState = withUpdates.editorState
+          workingTransientFilesState = withUpdates.transientFilesState
+        }
+
+        const absoluteStrategy =
+          sessionState.absoluteResizeStrategy ?? emptyAbsoluteResizeStrategyState
+        const targetProperty = safeIndex(
+          absoluteStrategy.properties,
+          absoluteStrategy.propertyTargetSelectedIndex,
+        )
+
+        const elementAspectRatioLockedFromProps = elementsToTarget.every((elementToTarget) => {
+          const metadata = MetadataUtils.findElementByElementPath(
+            workingEditorState.jsxMetadata,
+            elementToTarget,
+          )
+          if (metadata == null) {
+            return false
+          } else {
+            return isAspectRatioLockedNew(metadata)
+          }
+        })
+
+        const keepAspectRatio =
+          (editorState.keysPressed['shift'] ?? false) || elementAspectRatioLockedFromProps
+        const centerBasedResize = editorState.keysPressed['alt'] ?? false
+        const enableSnapping = editorState.keysPressed['cmd'] ?? false
+
+        const newStrategyState = updateResizeStrategyState(
+          absoluteStrategy,
+          sessionProps.start,
+          sessionProps.drag,
+          targetProperty?.targetProperty,
+          enableSnapping,
+          centerBasedResize,
+          keepAspectRatio,
+        )
+        const newSessionState: SelectModeCanvasSessionState = {
+          ...sessionState,
+          absoluteResizeStrategy: newStrategyState,
+        }
+
+        return {
+          newSessionState: newSessionState,
+          transientFilesState: workingTransientFilesState,
+          editorStatePatch: {},
+        }
+      }
+    }
+
+    // Fallback for when the checks above are not satisfied.
+    return {
+      newSessionState: sessionState,
+      transientFilesState: {},
+      editorStatePatch: {},
+    }
+  },
+}
+
+function applyValuesAtPath(
+  editorState: EditorState,
+  filesState: TransientFilesState,
+  target: ElementPath,
+  jsxValuesAndPathsToSet: ValueAtPath[],
+): { editorState: EditorState; transientFilesState: TransientFilesState } {
+  let workingEditorState = { ...editorState }
+  let transientFilesState = { ...filesState }
+
+  workingEditorState = modifyUnderlyingForOpenFile(target, editorState, (element: JSXElement) => {
+    return foldEither(
+      () => {
+        return element
+      },
+      (updatedProps) => {
+        return {
+          ...element,
+          props: updatedProps,
+        }
+      },
+      setJSXValuesAtPaths(element.props, jsxValuesAndPathsToSet),
+    )
+  })
+
+  forUnderlyingTargetFromEditorState(
+    target,
+    workingEditorState,
+    (success, underlyingElement, underlyingTarget, underlyingFilePath) => {
+      transientFilesState[underlyingFilePath] = {
+        topLevelElementsIncludingScenes: success.topLevelElements,
+        imports: success.imports,
+      }
+      return success
+    },
+  )
+  return { editorState: workingEditorState, transientFilesState: transientFilesState }
+}

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -417,7 +417,7 @@ function unsetValueWhenNegative(prop: LayoutTargetableProp): boolean {
   }
 }
 
-function cssNumberAsNumberIfPossible(
+export function cssNumberAsNumberIfPossible(
   cssNumber: CSSNumber | number | string | undefined,
 ): number | string | undefined {
   if (cssNumber == null) {
@@ -961,7 +961,7 @@ function getPropsToSetToMoveElement(
   return propsToSet
 }
 
-function getPropsToSetToResizeElement(
+export function getPropsToSetToResizeElement(
   edgePosition: EdgePosition,
   widthDelta: number,
   heightDelta: number,
@@ -1028,7 +1028,7 @@ function getPropsToSetToResizeElement(
   return propsToSet
 }
 
-function extendPartialFramePointsForResize(
+export function extendPartialFramePointsForResize(
   frameProps: Array<LayoutPinnedProp>,
   edgePosition: EdgePosition,
 ): Array<LayoutPinnedProp> {
@@ -1344,12 +1344,12 @@ function getTargetableProp(resizeOptions: ResizeOptions): LayoutTargetableProp |
   return resizeOptions.propertyTargetOptions[resizeOptions.propertyTargetSelectedIndex]
 }
 
-function findResizePropertyChange(
-  dragState: ResizeDragState,
+export function findResizePropertyChange(
+  properties: Array<ResizeDragStatePropertyChange>,
   resizeOptions: ResizeOptions,
 ): ResizeDragStatePropertyChange | undefined {
   const resizeProp: LayoutTargetableProp | undefined = getTargetableProp(resizeOptions)
-  return dragState.properties.find((prop) => prop.targetProperty === resizeProp)
+  return properties.find((prop) => prop.targetProperty === resizeProp)
 }
 
 function calculateDraggedRectangle(
@@ -1359,7 +1359,7 @@ function calculateDraggedRectangle(
   const originalSize = dragState.originalSize
   const resizeOptions = editor.canvas.resizeOptions
 
-  const propertyChange = findResizePropertyChange(dragState, resizeOptions)
+  const propertyChange = findResizePropertyChange(dragState.properties, resizeOptions)
   if (propertyChange == null) {
     return originalSize
   } else {
@@ -1413,7 +1413,7 @@ export function calculateNewBounds(
   const newRectangle = calculateDraggedRectangle(editor, dragState)
   const resizeOptions = editor.canvas.resizeOptions
 
-  const propertyChange = findResizePropertyChange(dragState, resizeOptions)
+  const propertyChange = findResizePropertyChange(dragState.properties, resizeOptions)
   if (propertyChange == null) {
     return originalSize
   } else {
@@ -3007,7 +3007,7 @@ export function getDragStatePositions(
       case 'SELECT_MODE_CANVAS_SESSION':
         return dragState.sessionProps
       case 'RESIZE_DRAG_STATE':
-        return findResizePropertyChange(dragState, resizeOptions) ?? null
+        return findResizePropertyChange(dragState.properties, resizeOptions) ?? null
       default:
         const _exhaustiveCheck: never = dragState
         throw new Error(`Unhandled drag state type ${JSON.stringify(dragState)}`)

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -49,6 +49,7 @@ import {
 import { safeIndex } from '../../../core/shared/array-utils'
 import { CSSPosition } from '../../inspector/common/css-utils'
 import * as EP from '../../../core/shared/element-path'
+import { startNewSelectModeCanvasSession } from '../canvas-strategies/canvas-strategy-types'
 
 interface ResizeControlProps extends ResizeRectangleProps {
   cursor: CSSCursor
@@ -116,24 +117,35 @@ class ResizeControl extends React.Component<ResizeControlProps> {
         propertyTargetOptions,
         this.props.propertyTargetSelectedIndex,
       )
-      const newDragState = updateResizeDragState(
-        resizeDragState(
-          this.props.measureSize,
-          originalFrames,
-          this.props.position,
-          this.props.enabledDirection,
-          this.props.metadata,
-          this.props.selectedViews,
-          isMultiSelect,
-          [],
-        ),
-        start,
-        null,
-        targetProperty,
-        enableSnapping,
-        centerBasedResize,
-        keepAspectRatio,
-      )
+      let newDragState: DragState
+      if (isFeatureEnabled('Canvas Strategies')) {
+        newDragState = startNewSelectModeCanvasSession(start, {
+          type: 'RESIZE_HANDLE',
+          edgePosition: this.props.position,
+          enabledDirection: this.props.enabledDirection,
+          originalSize: this.props.measureSize,
+          originalFrames: originalFrames,
+        })
+      } else {
+        newDragState = updateResizeDragState(
+          resizeDragState(
+            this.props.measureSize,
+            originalFrames,
+            this.props.position,
+            this.props.enabledDirection,
+            this.props.metadata,
+            this.props.selectedViews,
+            isMultiSelect,
+            [],
+          ),
+          start,
+          null,
+          targetProperty,
+          enableSnapping,
+          centerBasedResize,
+          keepAspectRatio,
+        )
+      }
 
       this.props.dispatch(
         [

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -295,6 +295,7 @@ export class Editor {
       }
       return { entireUpdateFinished: result.entireUpdateFinished }
     }
+
     if (PRODUCTION_ENV) {
       return runDispatch()
     } else {


### PR DESCRIPTION
**Problem:**
We want to handle more canvas behaviour with strategies.

**Fix:**
Move absolute resizing behaviour into a strategy.

**Commit Details:**
- Created `resize-absolute-strategy.ts` which ports over the existing
  resize logic and makes a canvas strategy out of it.
- `pickDefaultCanvasStrategy` filters out strategies with a null
  fitness and executes the fitness function only once per strategy.
- Added some fields to `ResizeHandle` as some context is needed
  which comes from the control.
- Created `AbsoluteResizeStrategyState` and attached it to
  `SelectModeCanvasSessionState`.
- A few functions in `canvas-utils.ts` have been exported and/or
  refactored lightly to take values _from_ `ResizeDragState` rather
  than `ResizeDragState` itself.
- `ResizeControl` now includes the feature switch handling to flip
  between the two styles of resizing.

