### PR TITLE
strategy picker using tab

### DIFF
--- a/editor/src/components/canvas/canvas-actions.ts
+++ b/editor/src/components/canvas/canvas-actions.ts
@@ -52,6 +52,12 @@ const CanvasActions = {
       applyChanges: applyChanges,
     }
   },
+  setUsersPreferredStrategy: function (strategyName: string): CanvasAction {
+    return {
+      action: 'SET_USERS_PREFERRED_STRATEGY',
+      strategyName: strategyName,
+    }
+  },
 }
 
 export default CanvasActions

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -74,6 +74,7 @@ export interface SelectModeCanvasSession {
 }
 
 export interface SelectModeCanvasSessionProps {
+  userPreferredStrategy: CanvasStrategy['name'] | null
   start: CanvasPoint
   mousePosition: CanvasPoint
   drag: CanvasVector | null
@@ -84,11 +85,13 @@ export interface SelectModeCanvasSessionProps {
 
 export interface SelectModeCanvasSessionState {
   activeStrategy: CanvasStrategy | null
+  possibleStrategies: Array<CanvasStrategy>
   dragDeltaMinimumPassed: boolean
 }
 
 export const emptySelectModeCanvasSessionState: SelectModeCanvasSessionState = {
   activeStrategy: null,
+  possibleStrategies: [],
   dragDeltaMinimumPassed: false,
 }
 
@@ -99,6 +102,7 @@ export function startNewSelectModeCanvasSession(
   return {
     type: 'SELECT_MODE_CANVAS_SESSION',
     sessionProps: {
+      userPreferredStrategy: null,
       start: start,
       mousePosition: start,
       activeControl: activeControl,

--- a/editor/src/components/canvas/canvas-strategies/flex-gap-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/flex-gap-strategy.ts
@@ -46,6 +46,7 @@ import { optionalMap } from '../../../core/shared/optional-utils'
 export const flexGapStrategy: CanvasStrategy = {
   name: 'Change Flex Gap',
   fitnessFn: (editor, sessionProps) => {
+    return 5 // fit
     if (
       editor.selectedViews.length === 1 &&
       sessionProps.activeControl.type === 'FLEX_GAP_HANDLE'

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -658,6 +658,11 @@ type ZoomUI = {
   zoomIn: boolean
 }
 
+type SetUsersPreferredStrategy = {
+  action: 'SET_USERS_PREFERRED_STRATEGY'
+  strategyName: string // TODO limit it to string literal union of registered strategy names?
+}
+
 export type CanvasAction =
   | ScrollCanvas
   | ClearDragState
@@ -666,6 +671,7 @@ export type CanvasAction =
   | ZoomUI
   | SetSelectionControlsVisibility
   | UpdateCanvasSessionProps
+  | SetUsersPreferredStrategy
 
 export type CanvasModel = {
   controls: Array<HigherOrderControl>

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-indicator.tsx
@@ -1,14 +1,55 @@
 import * as React from 'react'
 import { when } from '../../../../utils/react-conditionals'
-import { FlexRow, useColorTheme, UtopiaStyles } from '../../../../uuiui'
+import { FlexRow, FlexColumn, useColorTheme, UtopiaStyles } from '../../../../uuiui'
 import { useEditorState } from '../../../editor/store/store-hook'
+import CanvasActions from '../../canvas-actions'
 
 export const CanvasStrategyIndicator = React.memo(() => {
   const colorTheme = useColorTheme()
+  const dispatch = useEditorState((store) => store.dispatch, 'CanvasStrategyIndicator dispatch')
   const activeStrategy = useEditorState(
     (store) => store.derived.canvas.transientState.canvasSessionState?.activeStrategy?.name,
     'CanvasStrategyIndicator activeStrategy.name',
   )
+  const otherPossibleStrategies = useEditorState(
+    (store) =>
+      store.derived.canvas.transientState.canvasSessionState?.possibleStrategies.map((s) => s.name),
+    'CanvasStrategyIndicator otherPossibleStrategies',
+  )
+
+  const onTabPressed = React.useCallback(
+    (newStrategyName: string) => {
+      dispatch([CanvasActions.setUsersPreferredStrategy(newStrategyName)])
+    },
+    [dispatch],
+  )
+
+  React.useEffect(() => {
+    function handleTabKey(event: KeyboardEvent) {
+      if (
+        event.key === 'Tab' &&
+        activeStrategy != null &&
+        otherPossibleStrategies != null &&
+        otherPossibleStrategies.length > 0
+      ) {
+        event.stopImmediatePropagation()
+        event.stopPropagation()
+        event.preventDefault()
+
+        const activeStrategyIndex = otherPossibleStrategies.findIndex(
+          (strategyName: string) => strategyName === activeStrategy,
+        )
+        const nextStrategyIndex = (activeStrategyIndex + 1) % otherPossibleStrategies.length
+        const nextStrategyName = otherPossibleStrategies[nextStrategyIndex]
+
+        onTabPressed(nextStrategyName)
+      }
+    }
+    window.addEventListener('keydown', handleTabKey)
+    return function cleanup() {
+      window.removeEventListener('keydown', handleTabKey)
+    }
+  }, [onTabPressed, activeStrategy, otherPossibleStrategies])
 
   return (
     <>
@@ -22,11 +63,11 @@ export const CanvasStrategyIndicator = React.memo(() => {
             left: 4,
           }}
         >
-          <FlexRow
+          <FlexColumn
             style={{
-              height: 29,
+              minHeight: 29,
               display: 'flex',
-              alignItems: 'center',
+              alignItems: 'stretch',
               padding: 4,
               gap: 4,
               borderRadius: 4,
@@ -34,8 +75,27 @@ export const CanvasStrategyIndicator = React.memo(() => {
               boxShadow: UtopiaStyles.popup.boxShadow,
             }}
           >
-            {activeStrategy}
-          </FlexRow>
+            {otherPossibleStrategies?.map((strategy) => {
+              return (
+                <FlexRow
+                  key={strategy}
+                  style={{
+                    height: 29,
+                    paddingLeft: 4,
+                    paddingRight: 4,
+                    backgroundColor:
+                      strategy === activeStrategy ? colorTheme.primary.value : undefined,
+                    color:
+                      strategy === activeStrategy
+                        ? colorTheme.white.value
+                        : colorTheme.textColor.value,
+                  }}
+                >
+                  {strategy}
+                </FlexRow>
+              )
+            })}
+          </FlexColumn>
         </div>,
       )}
     </>

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -106,6 +106,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_INDEXED_DB_FAILED':
     case 'FORCE_PARSE_FILE':
     case 'UPDATE_CANVAS_SESSION_PROPS':
+    case 'SET_USERS_PREFERRED_STRATEGY':
       return true
 
     case 'NEW':

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -358,6 +358,25 @@ export function runLocalCanvasAction(
         },
       }
     }
+    case 'SET_USERS_PREFERRED_STRATEGY': {
+      if (model.canvas.dragState?.type === 'SELECT_MODE_CANVAS_SESSION') {
+        return {
+          ...model,
+          canvas: {
+            ...model.canvas,
+            dragState: {
+              ...model.canvas.dragState,
+              sessionProps: {
+                ...model.canvas.dragState.sessionProps,
+                userPreferredStrategy: action.strategyName,
+              },
+            },
+          },
+        }
+      } else {
+        return model
+      }
+    }
     default:
       const _exhaustiveCheck: never = action
       return model


### PR DESCRIPTION
![strategy picker](https://user-images.githubusercontent.com/2226774/150390866-59de987e-c1c2-4efc-bd8f-339221abac5f.jpg)

I wanted to add a working strategy picker for two main reasons:
- As we will create more test strategies, we don't want to just see the "winner" strategy, we will probably want to debug the other strategies which return with positive fitness
- I wanted to have a place in code that lets us experimentally try various rulesets about how to let the user override the default strategy

**How to use**
During interaction press Tab to cycle through the available strategy options.

**Note:**
For this first version I went with the simplest and more conservative: if the user overrides the strategy, we keep using that strategy until the strategy is no longer available.
