### PR TITLE
using css vars for canvas scroll

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -86,7 +86,7 @@ export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps
           zoom: canvasProps.scale >= 1 ? `${canvasProps.scale * 100}%` : 1,
           transform:
             (canvasProps.scale < 1 ? `scale(${canvasProps.scale})` : '') +
-            ` translate3d(${canvasProps.offset.x}px, ${canvasProps.offset.y}px, 0)`,
+            ` translate3d(var(--utopia-canvas-offset-x), var(--utopia-canvas-offset-y), 0)`,
           transition: canvasProps.scrollAnimation ? 'transform 0.3s ease-in-out' : 'initial',
         }}
       >

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -116,7 +116,7 @@ const NothingOpenCard = React.memo(() => {
   )
 })
 
-export const DesignPanelRoot = React.memo(() => {
+const DesignPanelRootInner = React.memo(() => {
   const dispatch = useEditorState((store) => store.dispatch, 'DesignPanelRoot dispatch')
   const interfaceDesigner = useEditorState(
     (store) => store.editor.interfaceDesigner,
@@ -198,15 +198,7 @@ export const DesignPanelRoot = React.memo(() => {
   )
 
   return (
-    <SimpleFlexRow
-      className='OpenFileEditorShell'
-      style={{
-        position: 'relative',
-        flexGrow: 1,
-        alignItems: 'stretch',
-        overflowX: 'hidden',
-      }}
-    >
+    <>
       <SimpleFlexRow
         className='CanvasCodeRow'
         style={{
@@ -320,18 +312,7 @@ export const DesignPanelRoot = React.memo(() => {
                     height: '100%',
                   }}
                 >
-                  <NavigatorComponent
-                    style={{
-                      zIndex: 1,
-                      flexGrow: 1,
-                      height: '100%',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'stretch',
-                      justifyContent: 'stretch',
-                      overscrollBehavior: 'contain',
-                    }}
-                  />
+                  <NavigatorComponent />
                 </ResizableFlexColumn>
               </div>
             ) : null}
@@ -348,7 +329,36 @@ export const DesignPanelRoot = React.memo(() => {
           ) : null}
         </>
       ) : null}
-    </SimpleFlexRow>
+    </>
+  )
+})
+
+export const DesignPanelRoot = React.memo(() => {
+  const roundedCanvasOffset = useEditorState(
+    (store) => store.editor.canvas.roundedCanvasOffset,
+    'DesignPanelRoot roundedCanvasOffset',
+  )
+
+  return (
+    <>
+      <style>{`
+      .utopia-css-var-container {
+        --utopia-canvas-offset-x: ${roundedCanvasOffset.x}px;
+        --utopia-canvas-offset-y: ${roundedCanvasOffset.y}px;
+      }
+    `}</style>
+      <SimpleFlexRow
+        className='OpenFileEditorShell utopia-css-var-container'
+        style={{
+          position: 'relative',
+          flexGrow: 1,
+          alignItems: 'stretch',
+          overflowX: 'hidden',
+        }}
+      >
+        <DesignPanelRootInner />
+      </SimpleFlexRow>
+    </>
   )
 })
 DesignPanelRoot.displayName = 'DesignPanelRoot'

--- a/editor/src/components/canvas/dom-walker-caching.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker-caching.spec.browser2.tsx
@@ -31,18 +31,17 @@ describe('Dom-walker Caching', () => {
       .getRecordedActions()
       .filter((action): action is SaveDOMReport => action.action === 'SAVE_DOM_REPORT')
 
-    expect(saveDomReportActions.length).toBe(3)
+    expect(saveDomReportActions.length).toBe(2)
     expect(saveDomReportActions[0].cachedPaths).toEqual([])
     expect(saveDomReportActions[1].cachedPaths).toEqual([])
-    expect(saveDomReportActions[2].cachedPaths).toEqual([EP.fromString(':storyboard-entity')])
   })
 
-  it('returns cached metadata for scroll', async () => {
+  it('returns cached metadata for zoom', async () => {
     const renderResult = await prepareTestProject()
 
     renderResult.clearRecordedActions()
 
-    await renderResult.dispatch([CanvasActions.scrollCanvas(canvasPoint({ x: 20, y: 30 }))], true)
+    await renderResult.dispatch([CanvasActions.zoom(2)], true)
 
     const saveDomReportActions = renderResult
       .getRecordedActions()

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -55,7 +55,6 @@ import type { CurriedResolveFn } from '../custom-code/code-file'
 import * as path from 'path'
 
 export interface PartialCanvasProps {
-  offset: UiJsxCanvasProps['offset']
   scale: UiJsxCanvasProps['scale']
   hiddenInstances: UiJsxCanvasProps['hiddenInstances']
   editedTextElement: UiJsxCanvasProps['editedTextElement']
@@ -209,7 +208,6 @@ export function renderCanvasReturnResultAndError(
       base64FileBlobs: {},
       onDomReport: Utils.NO_OP,
       clearErrors: clearErrors,
-      offset: canvasPoint({ x: 0, y: 0 }),
       scale: 1,
       hiddenInstances: [],
       editedTextElement: null,

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -136,7 +136,6 @@ export const DomWalkerInvalidatePathsCtxAtom = atomWithPubSub<DomWalkerInvalidat
 })
 
 export interface UiJsxCanvasProps {
-  offset: CanvasVector
   scale: number
   uiFilePath: string
   curriedRequireFn: CurriedUtopiaRequireFn
@@ -221,7 +220,6 @@ export function pickUiJsxCanvasProps(
       hiddenInstances = [...hiddenInstances, editedTextElement]
     }
     return {
-      offset: editor.canvas.roundedCanvasOffset,
       scale: editor.canvas.scale,
       uiFilePath: uiFilePath,
       curriedRequireFn: editor.codeResultCache.curriedRequireFn,
@@ -299,7 +297,6 @@ function clearSpyCollectorInvalidPaths(
 export const UiJsxCanvas = React.memo(
   React.forwardRef<HTMLDivElement, UiJsxCanvasPropsWithErrorCallback>((props, ref) => {
     const {
-      offset,
       scale,
       uiFilePath,
       curriedRequireFn,
@@ -504,7 +501,6 @@ export const UiJsxCanvas = React.memo(
               domWalkerInvalidateCount={props.domWalkerInvalidateCount}
               walkDOM={walkDOM}
               scale={scale}
-              offset={offset}
               onDomReport={onDomReport}
               validRootPaths={rootValidPaths}
               canvasRootElementElementPath={storyboardRootElementPath}
@@ -741,7 +737,6 @@ function useGetStoryboardRoot(
 export interface CanvasContainerProps {
   walkDOM: boolean
   scale: number
-  offset: CanvasVector
   onDomReport: (
     elementMetadata: ReadonlyArray<ElementInstanceMetadata>,
     cachedPaths: Array<ElementPath>,

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -30,190 +30,193 @@ import { last } from '../../core/shared/array-utils'
 
 const NavigatorContainerId = 'navigator'
 
-interface NavigatorComponentProps {
-  style: React.CSSProperties
-}
-
-export const NavigatorComponent = React.memo<NavigatorComponentProps>(
-  ({ style: navigatorStyle }) => {
-    const editorSliceRef = useRefEditorState((store) => {
-      const dragSelections = createDragSelections(
-        store.derived.navigatorTargets,
-        store.editor.selectedViews,
-      )
-      return {
-        selectedViews: store.editor.selectedViews,
-        navigatorTargets: store.derived.navigatorTargets,
-        dragSelections: dragSelections,
-      }
-    })
-    const colorTheme = useColorTheme()
-    const { dispatch, minimised, visibleNavigatorTargets } = useEditorState((store) => {
-      return {
-        dispatch: store.dispatch,
-        minimised: store.editor.navigator.minimised,
-        visibleNavigatorTargets: store.derived.visibleNavigatorTargets,
-      }
-    }, 'NavigatorComponent')
-
-    const onFocus = React.useCallback(
-      (e: React.FocusEvent<HTMLElement>) => {
-        dispatch([setFocus('navigator')])
-      },
-      [dispatch],
+export const NavigatorComponent = React.memo(() => {
+  const editorSliceRef = useRefEditorState((store) => {
+    const dragSelections = createDragSelections(
+      store.derived.navigatorTargets,
+      store.editor.selectedViews,
     )
-
-    const onMouseLeave = React.useCallback(
-      (e: React.MouseEvent<HTMLElement>) => {
-        dispatch([clearHighlightedViews()], 'everyone')
-      },
-      [dispatch],
-    )
-
-    const onContextMenu = React.useCallback(
-      (event: React.MouseEvent<HTMLElement>) => {
-        dispatch([showContextMenu('context-menu-navigator', event.nativeEvent)], 'everyone')
-      },
-      [dispatch],
-    )
-
-    const getDistanceFromAncestorWhereImTheLastLeaf = React.useCallback(
-      (componentId: string, distance: number): number => {
-        // TODO FIXME HOLY SHIT THIS IS STUCK IN OLDE WORLDE
-        console.error('FIX getDistanceFromAncestorWhereImTheLastLeaf')
-        return distance
-      },
-      [],
-    )
-
-    const getDragSelections = React.useCallback((): Array<DragSelection> => {
-      return editorSliceRef.current.dragSelections
-    }, [editorSliceRef])
-
-    const getSelectedViewsInRange = React.useCallback(
-      (index: number): Array<ElementPath> => {
-        const selectedItemIndexes = editorSliceRef.current.selectedViews
-          .map((selection) =>
-            editorSliceRef.current.navigatorTargets.findIndex((tp) => EP.pathsEqual(tp, selection)),
-          )
-          .sort((a, b) => a - b)
-        const lastSelectedItemIndex = last(selectedItemIndexes)
-        if (lastSelectedItemIndex == null) {
-          return [editorSliceRef.current.navigatorTargets[index]]
-        } else {
-          let start = 0
-          let end = 0
-          if (index > lastSelectedItemIndex) {
-            start = selectedItemIndexes[0]
-            end = index
-          } else if (index < lastSelectedItemIndex && index > selectedItemIndexes[0]) {
-            start = selectedItemIndexes[0]
-            end = index
-          } else {
-            start = index
-            end = lastSelectedItemIndex
-          }
-          let selectedViewTargets: Array<ElementPath> = editorSliceRef.current.selectedViews
-          Utils.fastForEach(editorSliceRef.current.navigatorTargets, (item, itemIndex) => {
-            if (itemIndex >= start && itemIndex <= end) {
-              selectedViewTargets = EP.addPathIfMissing(item, selectedViewTargets)
-            }
-          })
-          return selectedViewTargets
-        }
-      },
-      [editorSliceRef],
-    )
-
-    const toggleTwirler = React.useCallback(() => {
-      dispatch([EditorActions.togglePanel('navigator')])
-    }, [dispatch])
-
-    const Item = React.memo(({ index, style }: ListChildComponentProps) => {
-      const targetPath = visibleNavigatorTargets[index]
-      const componentKey = EP.toComponentId(targetPath)
-      return (
-        <NavigatorItemWrapper
-          key={componentKey}
-          index={index}
-          targetComponentKey={componentKey}
-          elementPath={targetPath}
-          getMaximumDistance={getDistanceFromAncestorWhereImTheLastLeaf}
-          getDragSelections={getDragSelections}
-          getSelectedViewsInRange={getSelectedViewsInRange}
-          windowStyle={style}
-        />
-      )
-    })
-
-    const ItemList = (size: Size) => {
-      if (size.height == null) {
-        return null
-      } else {
-        return (
-          <FixedSizeList
-            width={'100%'}
-            height={size.height}
-            itemSize={UtopiaTheme.layout.rowHeight.smaller}
-            itemCount={visibleNavigatorTargets.length}
-            layout={'vertical'}
-            style={{ overflowX: 'hidden' }}
-          >
-            {Item}
-          </FixedSizeList>
-        )
-      }
+    return {
+      selectedViews: store.editor.selectedViews,
+      navigatorTargets: store.derived.navigatorTargets,
+      dragSelections: dragSelections,
     }
+  })
+  const colorTheme = useColorTheme()
+  const { dispatch, minimised, visibleNavigatorTargets } = useEditorState((store) => {
+    return {
+      dispatch: store.dispatch,
+      minimised: store.editor.navigator.minimised,
+      visibleNavigatorTargets: store.derived.visibleNavigatorTargets,
+    }
+  }, 'NavigatorComponent')
 
+  const onFocus = React.useCallback(
+    (e: React.FocusEvent<HTMLElement>) => {
+      dispatch([setFocus('navigator')])
+    },
+    [dispatch],
+  )
+
+  const onMouseLeave = React.useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      dispatch([clearHighlightedViews()], 'everyone')
+    },
+    [dispatch],
+  )
+
+  const onContextMenu = React.useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      dispatch([showContextMenu('context-menu-navigator', event.nativeEvent)], 'everyone')
+    },
+    [dispatch],
+  )
+
+  const getDistanceFromAncestorWhereImTheLastLeaf = React.useCallback(
+    (componentId: string, distance: number): number => {
+      // TODO FIXME HOLY SHIT THIS IS STUCK IN OLDE WORLDE
+      console.error('FIX getDistanceFromAncestorWhereImTheLastLeaf')
+      return distance
+    },
+    [],
+  )
+
+  const getDragSelections = React.useCallback((): Array<DragSelection> => {
+    return editorSliceRef.current.dragSelections
+  }, [editorSliceRef])
+
+  const getSelectedViewsInRange = React.useCallback(
+    (index: number): Array<ElementPath> => {
+      const selectedItemIndexes = editorSliceRef.current.selectedViews
+        .map((selection) =>
+          editorSliceRef.current.navigatorTargets.findIndex((tp) => EP.pathsEqual(tp, selection)),
+        )
+        .sort((a, b) => a - b)
+      const lastSelectedItemIndex = last(selectedItemIndexes)
+      if (lastSelectedItemIndex == null) {
+        return [editorSliceRef.current.navigatorTargets[index]]
+      } else {
+        let start = 0
+        let end = 0
+        if (index > lastSelectedItemIndex) {
+          start = selectedItemIndexes[0]
+          end = index
+        } else if (index < lastSelectedItemIndex && index > selectedItemIndexes[0]) {
+          start = selectedItemIndexes[0]
+          end = index
+        } else {
+          start = index
+          end = lastSelectedItemIndex
+        }
+        let selectedViewTargets: Array<ElementPath> = editorSliceRef.current.selectedViews
+        Utils.fastForEach(editorSliceRef.current.navigatorTargets, (item, itemIndex) => {
+          if (itemIndex >= start && itemIndex <= end) {
+            selectedViewTargets = EP.addPathIfMissing(item, selectedViewTargets)
+          }
+        })
+        return selectedViewTargets
+      }
+    },
+    [editorSliceRef],
+  )
+
+  const toggleTwirler = React.useCallback(() => {
+    dispatch([EditorActions.togglePanel('navigator')])
+  }, [dispatch])
+
+  const Item = React.memo(({ index, style }: ListChildComponentProps) => {
+    const targetPath = visibleNavigatorTargets[index]
+    const componentKey = EP.toComponentId(targetPath)
     return (
-      <Section
-        data-name='Navigator'
-        onFocus={onFocus}
-        onMouseLeave={onMouseLeave}
-        onContextMenu={onContextMenu}
-        id={NavigatorContainerId}
-        tabIndex={-1}
-        style={navigatorStyle}
+      <NavigatorItemWrapper
+        key={componentKey}
+        index={index}
+        targetComponentKey={componentKey}
+        elementPath={targetPath}
+        getMaximumDistance={getDistanceFromAncestorWhereImTheLastLeaf}
+        getDragSelections={getDragSelections}
+        getSelectedViewsInRange={getSelectedViewsInRange}
+        windowStyle={style}
+      />
+    )
+  })
+
+  const ItemList = (size: Size) => {
+    if (size.height == null) {
+      return null
+    } else {
+      return (
+        <FixedSizeList
+          width={'100%'}
+          height={size.height}
+          itemSize={UtopiaTheme.layout.rowHeight.smaller}
+          itemCount={visibleNavigatorTargets.length}
+          layout={'vertical'}
+          style={{ overflowX: 'hidden' }}
+        >
+          {Item}
+        </FixedSizeList>
+      )
+    }
+  }
+
+  return (
+    <Section
+      data-name='Navigator'
+      onFocus={onFocus}
+      onMouseLeave={onMouseLeave}
+      onContextMenu={onContextMenu}
+      id={NavigatorContainerId}
+      tabIndex={-1}
+      style={{
+        zIndex: 1,
+        flexGrow: 1,
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'stretch',
+        justifyContent: 'stretch',
+        overscrollBehavior: 'contain',
+      }}
+    >
+      <SectionTitleRow minimised={minimised} toggleMinimised={toggleTwirler}>
+        <FlexRow flexGrow={1}>
+          <Title>Structure</Title>
+        </FlexRow>
+      </SectionTitleRow>
+      <SectionBodyArea
+        minimised={minimised}
+        flexGrow={1}
+        style={{
+          flexGrow: 1,
+          overscrollBehavior: 'contain',
+          display: 'flex',
+          alignItems: 'stretch',
+          justifyContent: 'stretch',
+        }}
       >
-        <SectionTitleRow minimised={minimised} toggleMinimised={toggleTwirler}>
-          <FlexRow flexGrow={1}>
-            <Title>Structure</Title>
-          </FlexRow>
-        </SectionTitleRow>
-        <SectionBodyArea
-          minimised={minimised}
-          flexGrow={1}
+        <ElementContextMenu contextMenuInstance={'context-menu-navigator'} />
+        <FlexColumn
           style={{
             flexGrow: 1,
-            overscrollBehavior: 'contain',
-            display: 'flex',
-            alignItems: 'stretch',
-            justifyContent: 'stretch',
+            flexShrink: 1,
+            flexBasis: '100%',
+            overflowX: 'hidden',
           }}
         >
-          <ElementContextMenu contextMenuInstance={'context-menu-navigator'} />
-          <FlexColumn
+          <AutoSizer
+            disableWidth={true}
             style={{
-              flexGrow: 1,
-              flexShrink: 1,
-              flexBasis: '100%',
+              overscrollBehavior: 'contain',
               overflowX: 'hidden',
+              height: '100%',
             }}
           >
-            <AutoSizer
-              disableWidth={true}
-              style={{
-                overscrollBehavior: 'contain',
-                overflowX: 'hidden',
-                height: '100%',
-              }}
-            >
-              {ItemList}
-            </AutoSizer>
-          </FlexColumn>
-        </SectionBodyArea>
-      </Section>
-    )
-  },
-)
+            {ItemList}
+          </AutoSizer>
+        </FlexColumn>
+      </SectionBodyArea>
+    </Section>
+  )
+})
 NavigatorComponent.displayName = 'NavigatorComponent'


### PR DESCRIPTION
**Problem:**
The canvas offset is a prop of the UiJsxCanvas root, which means every single scroll triggers a re-render of the entire canvas.

**Fix:**
I added a new wrapper around the DesignPanelRoot, which is a place where we can put css vars for our canvas and controls to use. The first two cssvars is canvas offset X and Y, which I use in the UiJsxCanvas. 

**Commit Details:**
- New wrapper around DesignPanelRoot which provides css vars
- I use a style tag to skip emotion's Dev Mode overhead, so we can have smooth scroll
- Removing canvasOffset prop from the canvas props
- Look at the Scroll Canvas test go from 63ms to 23ms

**Future Work TODO**
This approach should continue to replace all the places that are reading canvas offset from the editor state. 
The new canvas controls we are making should not even know that there are canvas offset and zoom properties in the editor state, they should be written for a cssvar world from the ground up. 
