### PR TITLE
Proposal/strategy picker

### DIFF
--- a/editor/src/components/canvas/canvas-actions.ts
+++ b/editor/src/components/canvas/canvas-actions.ts
@@ -59,6 +59,12 @@ const CanvasActions = {
       applyChanges: applyChanges,
     }
   },
+  setUsersPreferredStrategy: function (strategyName: string): CanvasAction {
+    return {
+      action: 'SET_USERS_PREFERRED_STRATEGY',
+      strategyName: strategyName,
+    }
+  },
 }
 
 export default CanvasActions

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -665,6 +665,11 @@ type ZoomUI = {
   zoomIn: boolean
 }
 
+type SetUsersPreferredStrategy = {
+  action: 'SET_USERS_PREFERRED_STRATEGY'
+  strategyName: string // TODO limit it to string literal union of registered strategy names?
+}
+
 export type CanvasAction =
   | ScrollCanvas
   | ClearDragState
@@ -674,6 +679,7 @@ export type CanvasAction =
   | ZoomUI
   | SetSelectionControlsVisibility
   | UpdateCanvasSessionProps
+  | SetUsersPreferredStrategy
 
 export type CanvasModel = {
   controls: Array<HigherOrderControl>

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -30,6 +30,7 @@ import { DummyPersistenceMachine } from '../editor/persistence/persistence.test-
 import { disableStoredStateforTests } from '../editor/stored-state'
 import { matchInlineSnapshotBrowser } from '../../../test/karma-snapshots'
 import { createBuiltInDependenciesList } from '../../core/es-modules/package-manager/built-in-dependencies-list'
+import { createEmptySessionStateState } from '../../interactions_proposal'
 
 disableStoredStateforTests()
 
@@ -61,6 +62,7 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
     unpatchedEditor: emptyEditorState,
     editor: emptyEditorState,
     derived: derivedState,
+    sessionStateState: createEmptySessionStateState(),
     history: history,
     userState: {
       loginState: notLoggedIn,

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -86,6 +86,7 @@ import {
   createBuiltInDependenciesList,
 } from '../../core/es-modules/package-manager/built-in-dependencies-list'
 import { clearAllRegisteredControls } from './canvas-globals'
+import { createEmptySessionStateState } from '../../interactions_proposal'
 
 // eslint-disable-next-line no-unused-expressions
 typeof process !== 'undefined' &&
@@ -222,6 +223,7 @@ export async function renderTestEditorWithModel(
     unpatchedEditor: emptyEditorState,
     editor: emptyEditorState,
     derived: derivedState,
+    sessionStateState: createEmptySessionStateState(),
     history: history,
     userState: {
       loginState: notLoggedIn,

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -107,6 +107,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'FORCE_PARSE_FILE':
     case 'UPDATE_CANVAS_SESSION_PROPS':
     case 'CREATE_INTERACTION_STATE':
+    case 'SET_USERS_PREFERRED_STRATEGY':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -191,6 +191,7 @@ function processAction(
       unpatchedEditor: editorAfterNavigator,
       editor: editorAfterNavigator,
       derived: working.derived,
+      sessionStateState: working.sessionStateState, // this means the actions cannot update sessionStateState – this piece of state lives outside our "redux" state
       history: newStateHistory,
       userState: working.userState,
       workers: working.workers,
@@ -463,6 +464,7 @@ export function editorDispatch(
     unpatchedEditor: frozenEditorState,
     editor: patchedEditorState,
     derived: frozenDerivedState,
+    sessionStateState: result.sessionStateState, // TODO SessionStateState needs updating inside the applyCanvasStrategy() function
     history: newHistory,
     userState: result.userState,
     workers: storedState.workers,
@@ -667,6 +669,7 @@ function editorDispatchInner(
       unpatchedEditor: frozenEditorState,
       editor: frozenEditorState,
       derived: frozenDerivedState,
+      sessionStateState: result.sessionStateState,
       history: result.history,
       userState: result.userState,
       workers: storedState.workers,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -163,7 +163,7 @@ import type {
   FlexGapControlRectProps,
 } from '../../canvas/canvas-strategies/canvas-strategy-types'
 import { Spec } from 'immutability-helper'
-import { InteractionState } from '../../../interactions_proposal'
+import { InteractionState, SessionStateState } from '../../../interactions_proposal'
 
 const ObjectPathImmutable: any = OPI
 
@@ -247,6 +247,7 @@ export type EditorStore = {
   unpatchedEditor: EditorState
   editor: EditorState
   derived: DerivedState
+  sessionStateState: SessionStateState
   history: StateHistory
   userState: UserState
   workers: UtopiaTsWorkers

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -15,6 +15,7 @@ function createEmptyEditorStoreHook() {
     unpatchedEditor: emptyEditorState,
     editor: emptyEditorState,
     derived: null as any,
+    sessionStateState: null as any,
     history: null as any,
     userState: null as any,
     workers: null as any,

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -48,6 +48,7 @@ export function getStoreHook(
     unpatchedEditor: editor.editor,
     editor: editor.editor,
     derived: editor.derivedState,
+    sessionStateState: editor.sessionStateState,
     history: {
       previous: [],
       next: [],

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -51,6 +51,7 @@ function getPaddingHookResult<P extends ParsedPropertiesKeys, S extends ParsedPr
       unpatchedEditor: null as any,
       editor: null as any,
       derived: null as any,
+      sessionStateState: null as any,
       history: null as any,
       userState: null as any,
       workers: null as any,

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -178,6 +178,7 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
     unpatchedEditor: editorState,
     editor: editorState,
     derived: null as any,
+    sessionStateState: null as any,
     history: null as any,
     userState: null as any,
     workers: null as any,

--- a/editor/src/interactions_proposal.ts
+++ b/editor/src/interactions_proposal.ts
@@ -92,8 +92,9 @@ export interface InteractionState {
   lastInteractionTime: number
   accumulatedCommands: Array<CanvasCommand>
 
-  // Need to track here which strategy is being applied.
-  currentStrategy: string | null
+  // To track if the user selected a strategy
+  userPreferredStrategy: string | null
+
   // Need to store some state to bridge across changes in a strategy - e.g. individual segments in a drag (which prop you are changing)
 
   // The latest strategy might want to replace the last commands based on the reason
@@ -115,6 +116,21 @@ export interface InteractionState {
   // The above is predicated on the commands setting discrete values and/or not changing something on another element at the same time.
 }
 
+export interface SessionStateState {
+  // Need to track here which strategy is being applied.
+  currentStrategy: string | null
+  possibleStrategies: Array<string>
+
+  // Need to store some state to bridge across changes in a strategy - e.g. individual segments in a drag (which prop you are changing) -- maybe here?
+}
+
+export function createEmptySessionStateState(): SessionStateState {
+  return {
+    currentStrategy: null,
+    possibleStrategies: [],
+  }
+}
+
 // Does this need to be split into a default mouse interaction state and a separate drag interaction state?
 // Thinking here in terms of highlight and selection
 export function createInteractionViaMouse(
@@ -134,7 +150,7 @@ export function createInteractionViaMouse(
     sourceOfUpdate: activeControl,
     lastInteractionTime: Date.now(),
     accumulatedCommands: [],
-    currentStrategy: null,
+    userPreferredStrategy: null,
   }
 }
 
@@ -165,7 +181,7 @@ export function updateInteractionViaMouse(
       sourceOfUpdate: sourceOfUpdate ?? currentState.activeControl,
       lastInteractionTime: Date.now(),
       accumulatedCommands: currentState.accumulatedCommands,
-      currentStrategy: currentState.currentStrategy,
+      userPreferredStrategy: currentState.userPreferredStrategy,
     }
   } else {
     return currentState
@@ -187,7 +203,7 @@ export function createInteractionViaKeyboard(
     sourceOfUpdate: activeControl,
     lastInteractionTime: Date.now(),
     accumulatedCommands: [],
-    currentStrategy: null,
+    userPreferredStrategy: null,
   }
 }
 
@@ -214,7 +230,7 @@ export function updateInteractionViaKeyboard(
       sourceOfUpdate: sourceOfUpdate,
       lastInteractionTime: Date.now(),
       accumulatedCommands: currentState.accumulatedCommands,
-      currentStrategy: currentState.currentStrategy,
+      userPreferredStrategy: currentState.userPreferredStrategy,
     }
   } else if (currentState.interactionData.type === 'DRAG') {
     return {
@@ -229,7 +245,7 @@ export function updateInteractionViaKeyboard(
       sourceOfUpdate: currentState.activeControl,
       lastInteractionTime: Date.now(),
       accumulatedCommands: currentState.accumulatedCommands,
-      currentStrategy: currentState.currentStrategy,
+      userPreferredStrategy: currentState.userPreferredStrategy,
     }
   } else {
     return currentState

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -374,6 +374,22 @@ export function runLocalCanvasAction(
           interactionState: action.interactionState,
         },
       }
+    case 'SET_USERS_PREFERRED_STRATEGY': {
+      if (model.canvas.interactionState != null) {
+        return {
+          ...model,
+          canvas: {
+            ...model.canvas,
+            interactionState: {
+              ...model.canvas.interactionState,
+              userPreferredStrategy: action.strategyName,
+            },
+          },
+        }
+      } else {
+        return model
+      }
+    }
     default:
       const _exhaustiveCheck: never = action
       return model

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -82,6 +82,7 @@ import { PersistenceMachine } from '../components/editor/persistence/persistence
 import { PersistenceBackend } from '../components/editor/persistence/persistence-backend'
 import { defaultProject } from '../sample-projects/sample-project-utils'
 import { createBuiltInDependenciesList } from '../core/es-modules/package-manager/built-in-dependencies-list'
+import { createEmptySessionStateState } from '../interactions_proposal'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
@@ -109,6 +110,8 @@ export class Editor {
 
     let emptyEditorState = createEditorState(this.boundDispatch)
     const derivedState = deriveState(emptyEditorState, null)
+
+    const sessionStateState = createEmptySessionStateState()
 
     const history = History.init(emptyEditorState, derivedState)
 
@@ -138,6 +141,7 @@ export class Editor {
       unpatchedEditor: emptyEditorState,
       editor: emptyEditorState,
       derived: derivedState,
+      sessionStateState: sessionStateState,
       history: history,
       userState: defaultUserState,
       workers: workers,

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -66,6 +66,7 @@ import { MapLike } from 'typescript'
 import { contentsToTree } from '../components/assets'
 import { defaultSceneElement } from '../components/editor/defaults'
 import { objectMap } from '../core/shared/object-utils'
+import { createEmptySessionStateState, SessionStateState } from '../interactions_proposal'
 
 export function delay(time: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, time))
@@ -104,6 +105,7 @@ export function createEditorStates(
   editor: EditorState
   derivedState: DerivedState
   dispatch: EditorDispatch
+  sessionStateState: SessionStateState
 } {
   const editor: EditorState = {
     ...createEditorState(NO_OP),
@@ -146,6 +148,7 @@ export function createEditorStates(
       jsxMetadata: componentMetadata,
     },
     derivedState: derivedState,
+    sessionStateState: createEmptySessionStateState(),
     dispatch: Utils.NO_OP,
   }
 }


### PR DESCRIPTION
This PR recreates #2074 but on the proposal branch.

The first commit adds EditorStore.sessionStateState – this is the Interaction Session's "State" – the part the strategies are allowed to modify and it persists during a single interaction session. It should be cleared when the session is cleared.

The second commit adds userPreferredStrategy and the strategy picker UI to the canvas-strategy-indicator. It also adds the strategy picking logic in canvas-strategies.ts

TODO:
- [ ] clear EditorStore.sessionStateState when clearing the canvas.interactionSession
