### PR TITLE
Remove reliance on Inspector context in the property target selector

### DIFF
--- a/editor/src/components/canvas/controls/property-target-selector.tsx
+++ b/editor/src/components/canvas/controls/property-target-selector.tsx
@@ -13,10 +13,7 @@ import {
 } from '../../editor/actions/action-creators'
 import { usePrevious } from '../../editor/hook-utils'
 import { useEditorState } from '../../editor/store/store-hook'
-import {
-  InspectorPropsContext,
-  stylePropPathMappingFn,
-} from '../../inspector/common/property-path-hooks'
+import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 
 interface PropertyTargetSelectorProps {
   targetComponentMetadata: ElementInstanceMetadata | null
@@ -35,9 +32,6 @@ export const PropertyTargetSelector = React.memo(
       }
     }, 'PropertyTargetSelector resizeOptions')
 
-    const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
-      return contextData.targetPath
-    })
     const onKeyDown = React.useCallback(
       (event: KeyboardEvent) => {
         if (event.key === 'Tab') {
@@ -64,11 +58,11 @@ export const PropertyTargetSelector = React.memo(
         eitherToMaybe(
           getSimpleAttributeAtPath(
             left(props.targetComponentMetadata?.props ?? {}),
-            stylePropPathMappingFn(option, targetPath),
+            stylePropPathMappingFn(option, ['style']),
           ),
         ),
       )
-    }, [resizeOptions.propertyTargetOptions, props.targetComponentMetadata?.props, targetPath])
+    }, [resizeOptions.propertyTargetOptions, props.targetComponentMetadata?.props])
 
     const defaultSelectedOptionIndex = React.useMemo(() => {
       const indexOfFirstWithValue = valuesForProp.findIndex((value) => value != null)

--- a/editor/src/core/layout/layout-helpers.ts
+++ b/editor/src/core/layout/layout-helpers.ts
@@ -41,7 +41,7 @@ import {
   ValueAtPath,
 } from '../shared/jsx-attributes'
 import { Imports, NodeModules, PropertyPath, ElementPath } from '../shared/project-file-types'
-import { getLayoutProperty, getLayoutPropertyOr } from './getLayoutProperty'
+import { getLayoutProperty } from './getLayoutProperty'
 import { PropsOrJSXAttributes, getSimpleAttributeAtPath } from '../model/element-metadata-utils'
 import { EdgePosition } from '../../components/canvas/canvas-types'
 import {
@@ -149,28 +149,6 @@ export const FlexLayoutHelpers = {
           propertyTarget,
         ),
       ),
-    )
-  },
-  getFlexDirectionFromProps(
-    props: JSXAttributes,
-    propertyTarget: ReadonlyArray<string>,
-  ): 'row' | 'row-reverse' | 'column' | 'column-reverse' {
-    return getLayoutPropertyOr(
-      'row', // TODO read this value from spy
-      'flexDirection',
-      right(props),
-      propertyTarget,
-    )
-  },
-  getFlexWrap: function (
-    props: JSXAttributes,
-    propertyTarget: ReadonlyArray<string>,
-  ): 'wrap' | 'wrap-reverse' | 'nowrap' {
-    return getLayoutPropertyOr(
-      'nowrap', // TODO read this value from spy
-      'flexWrap',
-      right(props),
-      propertyTarget,
     )
   },
   getMainAxis(

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -373,16 +373,6 @@ export const MetadataUtils = {
   getFlexDirection: function (instance: ElementInstanceMetadata | null): string {
     return instance?.specialSizeMeasurements?.flexDirection ?? 'row'
   },
-  getFlexWrap: function (
-    instance: ElementInstanceMetadata | null,
-    propertyTarget: Array<string>,
-  ): 'wrap' | 'wrap-reverse' | 'nowrap' {
-    if (instance != null && isRight(instance.element) && isJSXElement(instance.element.value)) {
-      return FlexLayoutHelpers.getFlexWrap(instance.element.value.props, propertyTarget)
-    } else {
-      return 'nowrap' // TODO read this value from spy
-    }
-  },
   findParent(metadata: ElementInstanceMetadataMap, target: ElementPath): ElementPath | null {
     const parentPath = EP.parentPath(target)
 


### PR DESCRIPTION
**Problem:**
The property target selector (which shows when resizing on the canvas) regressed, as it was accidentally relying on context data that is specific to the Inspector

**Fix:**
Remove the reliance on the Inspector's context, instead using the hardcoded value `[ "style" ]` as the target path used for determining where to make style changes. I've also removed some redundant functions whilst searching for any other possible problematic uses of the `stylePropPathMappingFn`.
