### PR TITLE
tell Vite that editor.tsx is not hot-reloadable

### DIFF
--- a/editor/jest.config.js
+++ b/editor/jest.config.js
@@ -101,6 +101,7 @@ module.exports = {
         '\\.(css)$': '<rootDir>/test/jest/__mocks__/styleMock.js',
         'utopia-api/core': '<rootDir>/node_modules/utopia-api/dist/core.js',
         'worker-imports': '<rootDir>/src/core/workers/__mocks__/worker-import-utils.ts',
+        '../utils/vite-hmr-config': '<rootDir>/src/utils/__mocks__/vite-hmr-config.ts',
       },
       transform: {
         '\\.[jt]sx?$': 'babel-jest',

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -83,6 +83,20 @@ import { PersistenceBackend } from '../components/editor/persistence/persistence
 import { defaultProject } from '../sample-projects/sample-project-utils'
 import { createBuiltInDependenciesList } from '../core/es-modules/package-manager/built-in-dependencies-list'
 
+// TODO we should bump TS to latest (we are 0.4 versions behind!)
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+if (import.meta.hot) {
+  // this is written without the != null part to make sure Webpack (and Vite) recognizes and tree shakes it
+  import.meta.hot.decline() // this _should_ be working but does not for some reason
+  import.meta.hot.on('vite:beforeUpdate', (event) => {
+    if (event.updates.some((u) => u.path === '/editor.tsx')) {
+      // eslint-disable-next-line no-unused-expressions
+      import.meta.hot?.invalidate()
+    }
+  })
+}
+
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
   webFrame.setVisualZoomLevelLimits(1, 1)

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -6,6 +6,7 @@ import * as ReactDOM from 'react-dom'
 import { hot } from 'react-hot-loader/root'
 import { unstable_trace as trace } from 'scheduler/tracing'
 import create from 'zustand'
+import '../utils/vite-hmr-config'
 import {
   getProjectID,
   PROBABLY_ELECTRON,
@@ -82,19 +83,6 @@ import { PersistenceMachine } from '../components/editor/persistence/persistence
 import { PersistenceBackend } from '../components/editor/persistence/persistence-backend'
 import { defaultProject } from '../sample-projects/sample-project-utils'
 import { createBuiltInDependenciesList } from '../core/es-modules/package-manager/built-in-dependencies-list'
-
-// TODO we should bump TS to latest (we are 0.4 versions behind!)
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-if (import.meta.hot) {
-  // this is written without the != null part to make sure Webpack (and Vite) recognizes and tree shakes it
-  import.meta.hot?.decline() // this _should_ be working but does not for some reason
-  import.meta.hot?.on('vite:beforeUpdate', (event) => {
-    if (event.updates.some((u) => u.path === '/editor.tsx')) {
-      import.meta.hot?.invalidate()
-    }
-  })
-}
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -88,10 +88,9 @@ import { createBuiltInDependenciesList } from '../core/es-modules/package-manage
 // @ts-ignore
 if (import.meta.hot) {
   // this is written without the != null part to make sure Webpack (and Vite) recognizes and tree shakes it
-  import.meta.hot.decline() // this _should_ be working but does not for some reason
-  import.meta.hot.on('vite:beforeUpdate', (event) => {
+  import.meta.hot?.decline() // this _should_ be working but does not for some reason
+  import.meta.hot?.on('vite:beforeUpdate', (event) => {
     if (event.updates.some((u) => u.path === '/editor.tsx')) {
-      // eslint-disable-next-line no-unused-expressions
       import.meta.hot?.invalidate()
     }
   })

--- a/editor/src/utils/__mocks__/vite-hmr-config.ts
+++ b/editor/src/utils/__mocks__/vite-hmr-config.ts
@@ -1,0 +1,1 @@
+// we do nothing in a Jest environment

--- a/editor/src/utils/vite-hmr-config.ts
+++ b/editor/src/utils/vite-hmr-config.ts
@@ -1,0 +1,12 @@
+// TODO we should bump TS to latest (we are 0.4 versions behind!)
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+if (import.meta.hot) {
+  // this is written without the != null part to make sure Webpack (and Vite) recognizes and tree shakes it
+  import.meta.hot?.decline() // this _should_ be working but does not for some reason
+  import.meta.hot?.on('vite:beforeUpdate', (event) => {
+    if (event.updates.some((u) => u.path === '/editor.tsx')) {
+      import.meta.hot?.invalidate()
+    }
+  })
+}


### PR DESCRIPTION
**Problem:**
Changing something for example in `dispatch.ts` would make Vite think it has to emit a refresh to editor.tsx. However, something is wrong with how we set up the editor and/or we hit a limitation of HMR, and whenever Vite prints `[vite] hmr update /editor.tsx` it is effectively not doing anything, forcing us to manually reload the editor. This makes us distrust Vite and hate software development.

**Fix:**
I first tried to use `import.meta.hot.decline()` to tell Vite that editor.tsx is not hot-reloadable, but it wasn't working. 
So instead I'm using `import.meta.hot.on` to register to updates from Vite, and check if the updated path is `/editor.tsx` and then use `import.meta.hot?.invalidate()` to trigger a full reload.
