### PR TITLE
Fixing dom-walker returning outdated measurement

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -470,7 +470,7 @@ export function useDomWalker(
         !initComplete,
         props.scale,
         containerRect,
-        props.additionalElementsToUpdate,
+        [...props.additionalElementsToUpdate, ...props.selectedViews],
       )
       if (LogDomWalkerPerformance) {
         performance.mark('DOM_WALKER_END')
@@ -844,6 +844,7 @@ function walkCanvasRootFragment(
     invalidatedPaths.size === 0 &&
     invalidatedScenes.size === 0 &&
     rootMetadataInStateRef.current.length > 0 &&
+    additionalElementsToUpdate.length === 0 &&
     !invalidated
   ) {
     // no mutation happened on the entire canvas, just return the old metadata


### PR DESCRIPTION
**Problem:**
During the work on the canvas strategies, we noticed that the controls are often lagging 1 frame behind the canvas contents. That became very suspicious to me because in theory our update loop is:
Dispatch action -> update EditorState -> render canvas -> dom-walker -> update EditorState.jsxMetadata -> rerender controls -> Browser Draws to Screen.

There's no reason why the controls were visually lagging, so we investigated a bit.

**Fix:**
The dom-walker is timed by a useLayoutEffect in the canvas render. It seems like sometimes that useLayoutEffect fires before the ResizeObserver-based cache invalidation code would run, so the dom-walker just happily short circuited and returned the old (and very soon to-be-invalidated) frames!

The hotfix is to force the dom-walker to re-measure the selected views even if they are not invalidated yet.

The long term fix is to find a better way to reliably trigger the dom-walker AFTER the ResizeObservers were fired but still catch a point BEFORE the browser draws to the screen. 