### PR TITLE
fix(editor) Fixed some broken deep equality checks and added tests

### DIFF
--- a/editor/src/components/editor/store/store-deep-equality-instances-2.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances-2.spec.ts
@@ -1,0 +1,1001 @@
+import {
+  ArbitraryJSBlock,
+  ElementsWithin,
+  emptyComments,
+  JSXArbitraryBlock,
+  jsxAttributesSpread,
+  jsxAttributeValue,
+  JSXElement,
+  JSXTextBlock,
+  JSXFragment,
+  RegularParam,
+  DestructuredParamPart,
+  DestructuredObject,
+  DestructuredArrayPart,
+  Param,
+  DestructuredArray,
+  BoundParam,
+  UtopiaJSXComponent,
+} from '../../../core/shared/element-template'
+import {
+  ArbitraryJsBlockKeepDeepEquality,
+  BoundParamKeepDeepEquality,
+  DestructuredArrayKeepDeepEquality,
+  DestructuredArrayPartKeepDeepEquality,
+  DestructuredObjectParamKeepDeepEquality,
+  DestructuredParamPartKeepDeepEquality,
+  ElementsWithinKeepDeepEqualityCall,
+  JSXArbitraryBlockKeepDeepEquality,
+  JSXElementChildArrayKeepDeepEquality,
+  JSXElementChildKeepDeepEquality,
+  JSXElementKeepDeepEquality,
+  JSXFragmentKeepDeepEquality,
+  JSXTextBlockKeepDeepEquality,
+  ParamKeepDeepEquality,
+  RegularParamKeepDeepEquality,
+  UtopiaJSXComponentKeepDeepEquality,
+} from './store-deep-equality-instances'
+
+describe('JSXElementKeepDeepEquality', () => {
+  const oldValue: JSXElement = {
+    type: 'JSX_ELEMENT',
+    name: {
+      baseVariable: 'React',
+      propertyPath: {
+        propertyElements: ['style', 'backgroundColor'],
+      },
+    },
+    props: [jsxAttributesSpread(jsxAttributeValue('prop', emptyComments), emptyComments)],
+    children: [
+      {
+        type: 'JSX_TEXT_BLOCK',
+        text: 'some text',
+        uniqueID: 'text-uid',
+      },
+    ],
+    uid: 'uid',
+  }
+  const newSameValue: JSXElement = {
+    type: 'JSX_ELEMENT',
+    name: {
+      baseVariable: 'React',
+      propertyPath: {
+        propertyElements: ['style', 'backgroundColor'],
+      },
+    },
+    props: [jsxAttributesSpread(jsxAttributeValue('prop', emptyComments), emptyComments)],
+    children: [
+      {
+        type: 'JSX_TEXT_BLOCK',
+        text: 'some text',
+        uniqueID: 'text-uid',
+      },
+    ],
+    uid: 'uid',
+  }
+  const newDifferentValue: JSXElement = {
+    type: 'JSX_ELEMENT',
+    name: {
+      baseVariable: 'React',
+      propertyPath: {
+        propertyElements: ['style', 'backgroundColor'],
+      },
+    },
+    props: [jsxAttributesSpread(jsxAttributeValue('prop', emptyComments), emptyComments)],
+    children: [
+      {
+        type: 'JSX_TEXT_BLOCK',
+        text: 'some text',
+        uniqueID: 'text-uid',
+      },
+    ],
+    uid: 'new-uid',
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = JSXElementKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXElementKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXElementKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.name).toBe(oldValue.name)
+    expect(result.value.props).toBe(oldValue.props)
+    expect(result.value.children).toBe(oldValue.children)
+    expect(result.value.uid).toBe(newDifferentValue.uid)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('ElementsWithinKeepDeepEqualityCall', () => {
+  const innerValue: JSXElement = {
+    type: 'JSX_ELEMENT',
+    name: {
+      baseVariable: 'React',
+      propertyPath: {
+        propertyElements: ['style', 'backgroundColor'],
+      },
+    },
+    props: [jsxAttributesSpread(jsxAttributeValue('prop', emptyComments), emptyComments)],
+    children: [
+      {
+        type: 'JSX_TEXT_BLOCK',
+        text: 'some text',
+        uniqueID: 'text-uid',
+      },
+    ],
+    uid: 'uid',
+  }
+  const oldValue: ElementsWithin = {
+    uid: innerValue,
+  }
+  const newSameValue: ElementsWithin = {
+    uid: innerValue,
+  }
+  const newDifferentValue: ElementsWithin = {
+    'new-uid': innerValue,
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = ElementsWithinKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = ElementsWithinKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = ElementsWithinKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value['new-uid']).toBe(oldValue['uid'])
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXArbitraryBlockKeepDeepEquality', () => {
+  const oldValue: JSXArbitraryBlock = {
+    type: 'JSX_ARBITRARY_BLOCK',
+    originalJavascript: 'old',
+    javascript: 'old',
+    transpiledJavascript: 'old',
+    definedElsewhere: ['old'],
+    sourceMap: { a: 1, b: [2] } as any,
+    uniqueID: 'old',
+    elementsWithin: {},
+  }
+  const newSameValue: JSXArbitraryBlock = {
+    type: 'JSX_ARBITRARY_BLOCK',
+    originalJavascript: 'old',
+    javascript: 'old',
+    transpiledJavascript: 'old',
+    definedElsewhere: ['old'],
+    sourceMap: { a: 1, b: [2] } as any,
+    uniqueID: 'old',
+    elementsWithin: {},
+  }
+  const newDifferentValue: JSXArbitraryBlock = {
+    type: 'JSX_ARBITRARY_BLOCK',
+    originalJavascript: 'new',
+    javascript: 'old',
+    transpiledJavascript: 'old',
+    definedElsewhere: ['old'],
+    sourceMap: { a: 1, b: [2] } as any,
+    uniqueID: 'old',
+    elementsWithin: {},
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = JSXArbitraryBlockKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXArbitraryBlockKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXArbitraryBlockKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.originalJavascript).toBe(newDifferentValue.originalJavascript)
+    expect(result.value.javascript).toBe(oldValue.javascript)
+    expect(result.value.transpiledJavascript).toBe(oldValue.transpiledJavascript)
+    expect(result.value.definedElsewhere).toBe(oldValue.definedElsewhere)
+    expect(result.value.sourceMap).toBe(oldValue.sourceMap)
+    expect(result.value.uniqueID).toBe(oldValue.uniqueID)
+    expect(result.value.elementsWithin).toBe(oldValue.elementsWithin)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('ArbitraryJsBlockKeepDeepEquality', () => {
+  const oldValue: ArbitraryJSBlock = {
+    type: 'ARBITRARY_JS_BLOCK',
+    javascript: 'old',
+    transpiledJavascript: 'old',
+    definedWithin: ['old'],
+    definedElsewhere: ['old'],
+    sourceMap: { a: 1, b: [2] } as any,
+    uniqueID: 'old',
+    elementsWithin: {},
+  }
+  const newSameValue: ArbitraryJSBlock = {
+    type: 'ARBITRARY_JS_BLOCK',
+    javascript: 'old',
+    transpiledJavascript: 'old',
+    definedWithin: ['old'],
+    definedElsewhere: ['old'],
+    sourceMap: { a: 1, b: [2] } as any,
+    uniqueID: 'old',
+    elementsWithin: {},
+  }
+  const newDifferentValue: ArbitraryJSBlock = {
+    type: 'ARBITRARY_JS_BLOCK',
+    javascript: 'new',
+    transpiledJavascript: 'old',
+    definedWithin: ['old'],
+    definedElsewhere: ['old'],
+    sourceMap: { a: 1, b: [2] } as any,
+    uniqueID: 'old',
+    elementsWithin: {},
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = ArbitraryJsBlockKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = ArbitraryJsBlockKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = ArbitraryJsBlockKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.javascript).toBe(newDifferentValue.javascript)
+    expect(result.value.transpiledJavascript).toBe(oldValue.transpiledJavascript)
+    expect(result.value.definedWithin).toBe(oldValue.definedWithin)
+    expect(result.value.definedElsewhere).toBe(oldValue.definedElsewhere)
+    expect(result.value.sourceMap).toBe(oldValue.sourceMap)
+    expect(result.value.uniqueID).toBe(oldValue.uniqueID)
+    expect(result.value.elementsWithin).toBe(oldValue.elementsWithin)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXTextBlockKeepDeepEquality', () => {
+  const oldValue: JSXTextBlock = {
+    type: 'JSX_TEXT_BLOCK',
+    text: 'old',
+    uniqueID: 'uid',
+  }
+  const newSameValue: JSXTextBlock = {
+    type: 'JSX_TEXT_BLOCK',
+    text: 'old',
+    uniqueID: 'uid',
+  }
+  const newDifferentValue: JSXTextBlock = {
+    type: 'JSX_TEXT_BLOCK',
+    text: 'new',
+    uniqueID: 'uid',
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = JSXTextBlockKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXTextBlockKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXTextBlockKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.text).toBe(newDifferentValue.text)
+    expect(result.value.uniqueID).toBe(oldValue.uniqueID)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXFragmentKeepDeepEquality', () => {
+  const oldValue: JSXFragment = {
+    type: 'JSX_FRAGMENT',
+    children: [
+      {
+        type: 'JSX_TEXT_BLOCK',
+        text: 'old',
+        uniqueID: 'uid',
+      },
+    ],
+    uniqueID: 'uid',
+    longForm: false,
+  }
+  const newSameValue: JSXFragment = {
+    type: 'JSX_FRAGMENT',
+    children: [
+      {
+        type: 'JSX_TEXT_BLOCK',
+        text: 'old',
+        uniqueID: 'uid',
+      },
+    ],
+    uniqueID: 'uid',
+    longForm: false,
+  }
+  const newDifferentValue: JSXFragment = {
+    type: 'JSX_FRAGMENT',
+    children: [
+      {
+        type: 'JSX_TEXT_BLOCK',
+        text: 'old',
+        uniqueID: 'uid',
+      },
+    ],
+    uniqueID: 'new-uid',
+    longForm: false,
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = JSXFragmentKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXFragmentKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXFragmentKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.children).toBe(oldValue.children)
+    expect(result.value.uniqueID).toBe(newDifferentValue.uniqueID)
+    expect(result.value.longForm).toBe(oldValue.longForm)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXElementChildKeepDeepEquality', () => {
+  const oldValue: JSXTextBlock = {
+    type: 'JSX_TEXT_BLOCK',
+    text: 'old',
+    uniqueID: 'uid',
+  }
+  const newSameValue: JSXTextBlock = {
+    type: 'JSX_TEXT_BLOCK',
+    text: 'old',
+    uniqueID: 'uid',
+  }
+  const newDifferentValue: JSXTextBlock = {
+    type: 'JSX_TEXT_BLOCK',
+    text: 'new',
+    uniqueID: 'uid',
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = JSXElementChildKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXElementChildKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXElementChildKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect((result.value as JSXTextBlock).text).toBe(newDifferentValue.text)
+    expect((result.value as JSXTextBlock).uniqueID).toBe(oldValue.uniqueID)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXElementChildArrayKeepDeepEquality', () => {
+  const oldValue: Array<JSXTextBlock> = [
+    {
+      type: 'JSX_TEXT_BLOCK',
+      text: 'old',
+      uniqueID: 'uid',
+    },
+  ]
+  const newSameValue: Array<JSXTextBlock> = [
+    {
+      type: 'JSX_TEXT_BLOCK',
+      text: 'old',
+      uniqueID: 'uid',
+    },
+  ]
+  const newDifferentValue: Array<JSXTextBlock> = [
+    {
+      type: 'JSX_TEXT_BLOCK',
+      text: 'new',
+      uniqueID: 'uid',
+    },
+  ]
+
+  it('same reference returns the same reference', () => {
+    const result = JSXElementChildArrayKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXElementChildArrayKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXElementChildArrayKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value[0].type).toBe(oldValue[0].type)
+    expect((result.value[0] as JSXTextBlock).text).toBe(newDifferentValue[0].text)
+    expect((result.value[0] as JSXTextBlock).uniqueID).toBe(oldValue[0].uniqueID)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('RegularParamKeepDeepEquality', () => {
+  const oldValue: RegularParam = {
+    type: 'REGULAR_PARAM',
+    paramName: 'old',
+    defaultExpression: null,
+  }
+  const newSameValue: RegularParam = {
+    type: 'REGULAR_PARAM',
+    paramName: 'old',
+    defaultExpression: null,
+  }
+  const newDifferentValue: RegularParam = {
+    type: 'REGULAR_PARAM',
+    paramName: 'new',
+    defaultExpression: null,
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = RegularParamKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = RegularParamKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = RegularParamKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.paramName).toBe(newDifferentValue.paramName)
+    expect(result.value.defaultExpression).toBe(oldValue.defaultExpression)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('DestructuredParamPartKeepDeepEquality', () => {
+  const oldValue: DestructuredParamPart = {
+    propertyName: 'old',
+    param: {
+      type: 'PARAM',
+      dotDotDotToken: false,
+      boundParam: {
+        type: 'REGULAR_PARAM',
+        paramName: 'param',
+        defaultExpression: null,
+      },
+    },
+    defaultExpression: null,
+  }
+  const newSameValue: DestructuredParamPart = {
+    propertyName: 'old',
+    param: {
+      type: 'PARAM',
+      dotDotDotToken: false,
+      boundParam: {
+        type: 'REGULAR_PARAM',
+        paramName: 'param',
+        defaultExpression: null,
+      },
+    },
+    defaultExpression: null,
+  }
+  const newDifferentValue: DestructuredParamPart = {
+    propertyName: 'new',
+    param: {
+      type: 'PARAM',
+      dotDotDotToken: false,
+      boundParam: {
+        type: 'REGULAR_PARAM',
+        paramName: 'param',
+        defaultExpression: null,
+      },
+    },
+    defaultExpression: null,
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = DestructuredParamPartKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = DestructuredParamPartKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = DestructuredParamPartKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value.propertyName).toBe(newDifferentValue.propertyName)
+    expect(result.value.param).toBe(oldValue.param)
+    expect(result.value.defaultExpression).toBe(oldValue.defaultExpression)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('DestructuredObjectParamKeepDeepEquality', () => {
+  const oldValue: DestructuredObject = {
+    type: 'DESTRUCTURED_OBJECT',
+    parts: [
+      {
+        propertyName: 'old',
+        param: {
+          type: 'PARAM',
+          dotDotDotToken: false,
+          boundParam: {
+            type: 'REGULAR_PARAM',
+            paramName: 'param',
+            defaultExpression: null,
+          },
+        },
+        defaultExpression: null,
+      },
+    ],
+  }
+  const newSameValue: DestructuredObject = {
+    type: 'DESTRUCTURED_OBJECT',
+    parts: [
+      {
+        propertyName: 'old',
+        param: {
+          type: 'PARAM',
+          dotDotDotToken: false,
+          boundParam: {
+            type: 'REGULAR_PARAM',
+            paramName: 'param',
+            defaultExpression: null,
+          },
+        },
+        defaultExpression: null,
+      },
+    ],
+  }
+  const newDifferentValue: DestructuredObject = {
+    type: 'DESTRUCTURED_OBJECT',
+    parts: [
+      {
+        propertyName: 'new',
+        param: {
+          type: 'PARAM',
+          dotDotDotToken: false,
+          boundParam: {
+            type: 'REGULAR_PARAM',
+            paramName: 'param',
+            defaultExpression: null,
+          },
+        },
+        defaultExpression: null,
+      },
+    ],
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = DestructuredObjectParamKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = DestructuredObjectParamKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = DestructuredObjectParamKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.parts[0].propertyName).toBe(newDifferentValue.parts[0].propertyName)
+    expect(result.value.parts[0].param).toBe(oldValue.parts[0].param)
+    expect(result.value.parts[0].defaultExpression).toBe(oldValue.parts[0].defaultExpression)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('DestructuredArrayPartKeepDeepEquality', () => {
+  const oldValue: DestructuredArrayPart = {
+    type: 'PARAM',
+    dotDotDotToken: false,
+    boundParam: {
+      type: 'REGULAR_PARAM',
+      paramName: 'param',
+      defaultExpression: null,
+    },
+  }
+  const newSameValue: DestructuredArrayPart = {
+    type: 'PARAM',
+    dotDotDotToken: false,
+    boundParam: {
+      type: 'REGULAR_PARAM',
+      paramName: 'param',
+      defaultExpression: null,
+    },
+  }
+  const newDifferentValue: DestructuredArrayPart = {
+    type: 'PARAM',
+    dotDotDotToken: true,
+    boundParam: {
+      type: 'REGULAR_PARAM',
+      paramName: 'param',
+      defaultExpression: null,
+    },
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = DestructuredArrayPartKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = DestructuredArrayPartKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = DestructuredArrayPartKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect((result.value as Param).dotDotDotToken).toBe(newDifferentValue.dotDotDotToken)
+    expect((result.value as Param).boundParam).toBe(oldValue.boundParam)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('DestructuredArrayKeepDeepEquality', () => {
+  const oldValue: DestructuredArray = {
+    type: 'DESTRUCTURED_ARRAY',
+    parts: [
+      {
+        type: 'PARAM',
+        dotDotDotToken: false,
+        boundParam: {
+          type: 'REGULAR_PARAM',
+          paramName: 'param',
+          defaultExpression: null,
+        },
+      },
+    ],
+  }
+  const newSameValue: DestructuredArray = {
+    type: 'DESTRUCTURED_ARRAY',
+    parts: [
+      {
+        type: 'PARAM',
+        dotDotDotToken: false,
+        boundParam: {
+          type: 'REGULAR_PARAM',
+          paramName: 'param',
+          defaultExpression: null,
+        },
+      },
+    ],
+  }
+  const newDifferentValue: DestructuredArray = {
+    type: 'DESTRUCTURED_ARRAY',
+    parts: [
+      {
+        type: 'PARAM',
+        dotDotDotToken: true,
+        boundParam: {
+          type: 'REGULAR_PARAM',
+          paramName: 'param',
+          defaultExpression: null,
+        },
+      },
+    ],
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = DestructuredArrayKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = DestructuredArrayKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = DestructuredArrayKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect((result.value.parts[0] as Param).dotDotDotToken).toBe(
+      (newDifferentValue.parts[0] as Param).dotDotDotToken,
+    )
+    expect((result.value.parts[0] as Param).boundParam).toBe(
+      (oldValue.parts[0] as Param).boundParam,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('BoundParamKeepDeepEquality', () => {
+  const oldValue: RegularParam = {
+    type: 'REGULAR_PARAM',
+    paramName: 'param',
+    defaultExpression: null,
+  }
+  const newSameValue: RegularParam = {
+    type: 'REGULAR_PARAM',
+    paramName: 'param',
+    defaultExpression: null,
+  }
+  const newDifferentValue: RegularParam = {
+    type: 'REGULAR_PARAM',
+    paramName: 'new-param',
+    defaultExpression: null,
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = BoundParamKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = BoundParamKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = BoundParamKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect((result.value as RegularParam).paramName).toBe(newDifferentValue.paramName)
+    expect((result.value as RegularParam).defaultExpression).toBe(oldValue.defaultExpression)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('ParamKeepDeepEquality', () => {
+  const oldValue: Param = {
+    type: 'PARAM',
+    dotDotDotToken: false,
+    boundParam: {
+      type: 'REGULAR_PARAM',
+      paramName: 'param',
+      defaultExpression: null,
+    },
+  }
+  const newSameValue: Param = {
+    type: 'PARAM',
+    dotDotDotToken: false,
+    boundParam: {
+      type: 'REGULAR_PARAM',
+      paramName: 'param',
+      defaultExpression: null,
+    },
+  }
+  const newDifferentValue: Param = {
+    type: 'PARAM',
+    dotDotDotToken: true,
+    boundParam: {
+      type: 'REGULAR_PARAM',
+      paramName: 'param',
+      defaultExpression: null,
+    },
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = ParamKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = ParamKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = ParamKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect((result.value as Param).dotDotDotToken).toBe((newDifferentValue as Param).dotDotDotToken)
+    expect((result.value as Param).boundParam).toBe((oldValue as Param).boundParam)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('UtopiaJSXComponentKeepDeepEquality', () => {
+  const oldValue: UtopiaJSXComponent = {
+    type: 'UTOPIA_JSX_COMPONENT',
+    name: 'old',
+    isFunction: true,
+    declarationSyntax: 'const',
+    blockOrExpression: 'block',
+    param: {
+      type: 'PARAM',
+      dotDotDotToken: false,
+      boundParam: {
+        type: 'REGULAR_PARAM',
+        paramName: 'props',
+        defaultExpression: null,
+      },
+    },
+    propsUsed: [],
+    rootElement: {
+      type: 'JSX_ELEMENT',
+      name: {
+        baseVariable: 'React',
+        propertyPath: {
+          propertyElements: ['style', 'backgroundColor'],
+        },
+      },
+      props: [jsxAttributesSpread(jsxAttributeValue('prop', emptyComments), emptyComments)],
+      children: [
+        {
+          type: 'JSX_TEXT_BLOCK',
+          text: 'some text',
+          uniqueID: 'text-uid',
+        },
+      ],
+      uid: 'uid',
+    },
+    arbitraryJSBlock: {
+      type: 'ARBITRARY_JS_BLOCK',
+      javascript: 'old',
+      transpiledJavascript: 'old',
+      definedWithin: ['old'],
+      definedElsewhere: ['old'],
+      sourceMap: { a: 1, b: [2] } as any,
+      uniqueID: 'old',
+      elementsWithin: {},
+    },
+    usedInReactDOMRender: false,
+    returnStatementComments: emptyComments,
+  }
+  const newSameValue: UtopiaJSXComponent = {
+    type: 'UTOPIA_JSX_COMPONENT',
+    name: 'old',
+    isFunction: true,
+    declarationSyntax: 'const',
+    blockOrExpression: 'block',
+    param: {
+      type: 'PARAM',
+      dotDotDotToken: false,
+      boundParam: {
+        type: 'REGULAR_PARAM',
+        paramName: 'props',
+        defaultExpression: null,
+      },
+    },
+    propsUsed: [],
+    rootElement: {
+      type: 'JSX_ELEMENT',
+      name: {
+        baseVariable: 'React',
+        propertyPath: {
+          propertyElements: ['style', 'backgroundColor'],
+        },
+      },
+      props: [jsxAttributesSpread(jsxAttributeValue('prop', emptyComments), emptyComments)],
+      children: [
+        {
+          type: 'JSX_TEXT_BLOCK',
+          text: 'some text',
+          uniqueID: 'text-uid',
+        },
+      ],
+      uid: 'uid',
+    },
+    arbitraryJSBlock: {
+      type: 'ARBITRARY_JS_BLOCK',
+      javascript: 'old',
+      transpiledJavascript: 'old',
+      definedWithin: ['old'],
+      definedElsewhere: ['old'],
+      sourceMap: { a: 1, b: [2] } as any,
+      uniqueID: 'old',
+      elementsWithin: {},
+    },
+    usedInReactDOMRender: false,
+    returnStatementComments: emptyComments,
+  }
+  const newDifferentValue: UtopiaJSXComponent = {
+    type: 'UTOPIA_JSX_COMPONENT',
+    name: 'new',
+    isFunction: true,
+    declarationSyntax: 'const',
+    blockOrExpression: 'block',
+    param: {
+      type: 'PARAM',
+      dotDotDotToken: false,
+      boundParam: {
+        type: 'REGULAR_PARAM',
+        paramName: 'props',
+        defaultExpression: null,
+      },
+    },
+    propsUsed: [],
+    rootElement: {
+      type: 'JSX_ELEMENT',
+      name: {
+        baseVariable: 'React',
+        propertyPath: {
+          propertyElements: ['style', 'backgroundColor'],
+        },
+      },
+      props: [jsxAttributesSpread(jsxAttributeValue('prop', emptyComments), emptyComments)],
+      children: [
+        {
+          type: 'JSX_TEXT_BLOCK',
+          text: 'some text',
+          uniqueID: 'text-uid',
+        },
+      ],
+      uid: 'uid',
+    },
+    arbitraryJSBlock: {
+      type: 'ARBITRARY_JS_BLOCK',
+      javascript: 'old',
+      transpiledJavascript: 'old',
+      definedWithin: ['old'],
+      definedElsewhere: ['old'],
+      sourceMap: { a: 1, b: [2] } as any,
+      uniqueID: 'old',
+      elementsWithin: {},
+    },
+    usedInReactDOMRender: false,
+    returnStatementComments: emptyComments,
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = UtopiaJSXComponentKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = UtopiaJSXComponentKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = UtopiaJSXComponentKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.name).toBe(newDifferentValue.name)
+    expect(result.value.isFunction).toBe(oldValue.isFunction)
+    expect(result.value.declarationSyntax).toBe(oldValue.declarationSyntax)
+    expect(result.value.blockOrExpression).toBe(oldValue.blockOrExpression)
+    expect(result.value.param).toBe(oldValue.param)
+    expect(result.value.propsUsed).toBe(oldValue.propsUsed)
+    expect(result.value.rootElement).toBe(oldValue.rootElement)
+    expect(result.value.arbitraryJSBlock).toBe(oldValue.arbitraryJSBlock)
+    expect(result.value.usedInReactDOMRender).toBe(oldValue.usedInReactDOMRender)
+    expect(result.value.returnStatementComments).toBe(oldValue.returnStatementComments)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})

--- a/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
@@ -1,0 +1,937 @@
+import { Sides } from 'utopia-api/core'
+import { left, Right } from '../../../core/shared/either'
+import {
+  createImportedFrom,
+  createNotImported,
+  ElementInstanceMetadata,
+  ElementInstanceMetadataMap,
+  FoundImportInfo,
+  ImportInfo,
+  SpecialSizeMeasurements,
+} from '../../../core/shared/element-template'
+import {
+  canvasRectangle,
+  CanvasRectangle,
+  LocalPoint,
+  localRectangle,
+  LocalRectangle,
+} from '../../../core/shared/math-utils'
+import {
+  CanvasRectangleKeepDeepEquality,
+  ElementInstanceMetadataKeepDeepEquality,
+  ElementInstanceMetadataMapKeepDeepEquality,
+  ImportInfoKeepDeepEquality,
+  LocalPointKeepDeepEquality,
+  LocalRectangleKeepDeepEquality,
+  SidesKeepDeepEquality,
+  SpecialSizeMeasurementsKeepDeepEquality,
+} from './store-deep-equality-instances'
+import * as EP from '../../../core/shared/element-path'
+
+describe('CanvasRectangleKeepDeepEquality', () => {
+  const oldValue: CanvasRectangle = canvasRectangle({
+    x: 10,
+    y: 20,
+    width: 100,
+    height: 200,
+  })
+  const newSameValue: CanvasRectangle = canvasRectangle({
+    x: 10,
+    y: 20,
+    width: 100,
+    height: 200,
+  })
+  const newDifferentValue: CanvasRectangle = canvasRectangle({
+    x: 100,
+    y: 20,
+    width: 100,
+    height: 200,
+  })
+
+  it('same reference returns the same reference', () => {
+    const result = CanvasRectangleKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = CanvasRectangleKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = CanvasRectangleKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value).toBe(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('LocalRectangleKeepDeepEquality', () => {
+  const oldValue: LocalRectangle = localRectangle({
+    x: 10,
+    y: 20,
+    width: 100,
+    height: 200,
+  })
+  const newSameValue: LocalRectangle = localRectangle({
+    x: 10,
+    y: 20,
+    width: 100,
+    height: 200,
+  })
+  const newDifferentValue: LocalRectangle = localRectangle({
+    x: 100,
+    y: 20,
+    width: 100,
+    height: 200,
+  })
+
+  it('same reference returns the same reference', () => {
+    const result = LocalRectangleKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = LocalRectangleKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = LocalRectangleKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value).toBe(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('LocalPointKeepDeepEquality', () => {
+  const oldValue: LocalPoint = {
+    x: 10,
+    y: 20,
+  } as LocalPoint
+  const newSameValue: LocalPoint = {
+    x: 10,
+    y: 20,
+  } as LocalPoint
+  const newDifferentValue: LocalPoint = {
+    x: 100,
+    y: 20,
+  } as LocalPoint
+
+  it('same reference returns the same reference', () => {
+    const result = LocalPointKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = LocalPointKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = LocalPointKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value).toBe(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('SidesKeepDeepEquality', () => {
+  const oldValue: Sides = {
+    top: 10,
+    right: 20,
+    bottom: 30,
+    left: 40,
+  }
+  const newSameValue: Sides = {
+    top: 10,
+    right: 20,
+    bottom: 30,
+    left: 40,
+  }
+  const newDifferentValue: Sides = {
+    top: 100,
+    right: 20,
+    bottom: 30,
+    left: 40,
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = SidesKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = SidesKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = SidesKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value).toBe(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('ImportInfoKeepDeepEquality', () => {
+  const oldNotImportedValue: ImportInfo = createNotImported()
+  const newSameNotImportedValue: ImportInfo = createNotImported()
+
+  const oldValue: ImportInfo = createImportedFrom('old', 'old', 'old')
+  const newSameValue: ImportInfo = createImportedFrom('old', 'old', 'old')
+  const newDifferentValue: ImportInfo = createImportedFrom('new', 'old', 'old')
+
+  it('same reference returns the same reference', () => {
+    const result = ImportInfoKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+
+    const resultNotImported = ImportInfoKeepDeepEquality(oldNotImportedValue, oldNotImportedValue)
+    expect(resultNotImported.value).toBe(oldNotImportedValue)
+    expect(resultNotImported.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = ImportInfoKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+
+    const resultNotImported = ImportInfoKeepDeepEquality(
+      oldNotImportedValue,
+      newSameNotImportedValue,
+    )
+    expect(resultNotImported.value).toBe(oldNotImportedValue)
+    expect(resultNotImported.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = ImportInfoKeepDeepEquality(oldValue, newDifferentValue)
+    expect((result.value as Right<FoundImportInfo>).value.variableName).toBe(
+      (newDifferentValue as Right<FoundImportInfo>).value.variableName,
+    )
+    expect((result.value as Right<FoundImportInfo>).value.originalName).toBe(
+      (oldValue as Right<FoundImportInfo>).value.originalName,
+    )
+    expect((result.value as Right<FoundImportInfo>).value.path).toBe(
+      (oldValue as Right<FoundImportInfo>).value.path,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('SpecialSizeMeasurementsKeepDeepEquality', () => {
+  const oldValue: SpecialSizeMeasurements = {
+    offset: {
+      x: 10,
+      y: 20,
+    } as LocalPoint,
+    coordinateSystemBounds: canvasRectangle({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 200,
+    }),
+    immediateParentBounds: canvasRectangle({
+      x: 100,
+      y: 200,
+      width: 1000,
+      height: 2000,
+    }),
+    immediateParentProvidesLayout: false,
+    usesParentBounds: false,
+    parentLayoutSystem: 'flex',
+    layoutSystemForChildren: 'flex',
+    providesBoundsForChildren: true,
+    display: 'flex',
+    position: 'absolute',
+    margin: {
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4,
+    },
+    padding: {
+      top: 10,
+      right: 20,
+      bottom: 30,
+      left: 40,
+    },
+    naturalWidth: 100,
+    naturalHeight: 200,
+    clientWidth: 300,
+    clientHeight: 400,
+    parentFlexDirection: 'row',
+    flexDirection: 'column',
+    htmlElementName: 'div',
+    renderedChildrenCount: 10,
+  }
+
+  const newSameValue: SpecialSizeMeasurements = {
+    offset: {
+      x: 10,
+      y: 20,
+    } as LocalPoint,
+    coordinateSystemBounds: canvasRectangle({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 200,
+    }),
+    immediateParentBounds: canvasRectangle({
+      x: 100,
+      y: 200,
+      width: 1000,
+      height: 2000,
+    }),
+    immediateParentProvidesLayout: false,
+    usesParentBounds: false,
+    parentLayoutSystem: 'flex',
+    layoutSystemForChildren: 'flex',
+    providesBoundsForChildren: true,
+    display: 'flex',
+    position: 'absolute',
+    margin: {
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4,
+    },
+    padding: {
+      top: 10,
+      right: 20,
+      bottom: 30,
+      left: 40,
+    },
+    naturalWidth: 100,
+    naturalHeight: 200,
+    clientWidth: 300,
+    clientHeight: 400,
+    parentFlexDirection: 'row',
+    flexDirection: 'column',
+    htmlElementName: 'div',
+    renderedChildrenCount: 10,
+  }
+  const newDifferentValue: SpecialSizeMeasurements = {
+    offset: {
+      x: 10,
+      y: 20,
+    } as LocalPoint,
+    coordinateSystemBounds: canvasRectangle({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 200,
+    }),
+    immediateParentBounds: canvasRectangle({
+      x: 100,
+      y: 200,
+      width: 1000,
+      height: 2000,
+    }),
+    immediateParentProvidesLayout: true,
+    usesParentBounds: false,
+    parentLayoutSystem: 'flex',
+    layoutSystemForChildren: 'flex',
+    providesBoundsForChildren: true,
+    display: 'flex',
+    position: 'absolute',
+    margin: {
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4,
+    },
+    padding: {
+      top: 10,
+      right: 20,
+      bottom: 30,
+      left: 40,
+    },
+    naturalWidth: 100,
+    naturalHeight: 200,
+    clientWidth: 300,
+    clientHeight: 400,
+    parentFlexDirection: 'row',
+    flexDirection: 'column',
+    htmlElementName: 'div',
+    renderedChildrenCount: 10,
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = SpecialSizeMeasurementsKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = SpecialSizeMeasurementsKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = SpecialSizeMeasurementsKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.offset).toBe(oldValue.offset)
+    expect(result.value.coordinateSystemBounds).toBe(oldValue.coordinateSystemBounds)
+    expect(result.value.immediateParentBounds).toBe(oldValue.immediateParentBounds)
+    expect(result.value.immediateParentProvidesLayout).toBe(
+      newDifferentValue.immediateParentProvidesLayout,
+    )
+    expect(result.value.usesParentBounds).toBe(oldValue.usesParentBounds)
+    expect(result.value.parentLayoutSystem).toBe(oldValue.parentLayoutSystem)
+    expect(result.value.layoutSystemForChildren).toBe(oldValue.layoutSystemForChildren)
+    expect(result.value.providesBoundsForChildren).toBe(oldValue.providesBoundsForChildren)
+    expect(result.value.display).toBe(oldValue.display)
+    expect(result.value.position).toBe(oldValue.position)
+    expect(result.value.margin).toBe(oldValue.margin)
+    expect(result.value.padding).toBe(oldValue.padding)
+    expect(result.value.naturalWidth).toBe(oldValue.naturalWidth)
+    expect(result.value.naturalHeight).toBe(oldValue.naturalHeight)
+    expect(result.value.clientWidth).toBe(oldValue.clientWidth)
+    expect(result.value.clientHeight).toBe(oldValue.clientHeight)
+    expect(result.value.parentFlexDirection).toBe(oldValue.parentFlexDirection)
+    expect(result.value.flexDirection).toBe(oldValue.flexDirection)
+    expect(result.value.htmlElementName).toBe(oldValue.htmlElementName)
+    expect(result.value.renderedChildrenCount).toBe(oldValue.renderedChildrenCount)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('ElementInstanceMetadataKeepDeepEquality', () => {
+  const oldValue: ElementInstanceMetadata = {
+    elementPath: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+    element: left('div'),
+    props: {
+      a: {
+        b: [],
+      },
+    },
+    globalFrame: canvasRectangle({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 200,
+    }),
+    localFrame: localRectangle({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 200,
+    }),
+    componentInstance: true,
+    isEmotionOrStyledComponent: false,
+    specialSizeMeasurements: {
+      offset: {
+        x: 10,
+        y: 20,
+      } as LocalPoint,
+      coordinateSystemBounds: canvasRectangle({
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 200,
+      }),
+      immediateParentBounds: canvasRectangle({
+        x: 100,
+        y: 200,
+        width: 1000,
+        height: 2000,
+      }),
+      immediateParentProvidesLayout: false,
+      usesParentBounds: false,
+      parentLayoutSystem: 'flex',
+      layoutSystemForChildren: 'flex',
+      providesBoundsForChildren: true,
+      display: 'flex',
+      position: 'absolute',
+      margin: {
+        top: 1,
+        right: 2,
+        bottom: 3,
+        left: 4,
+      },
+      padding: {
+        top: 10,
+        right: 20,
+        bottom: 30,
+        left: 40,
+      },
+      naturalWidth: 100,
+      naturalHeight: 200,
+      clientWidth: 300,
+      clientHeight: 400,
+      parentFlexDirection: 'row',
+      flexDirection: 'column',
+      htmlElementName: 'div',
+      renderedChildrenCount: 10,
+    },
+    computedStyle: {
+      a: 'a',
+      b: 'b',
+    },
+    attributeMetadatada: {
+      a: {
+        fromStyleSheet: false,
+      },
+    },
+    label: 'label',
+    importInfo: createImportedFrom('old', 'old', 'old'),
+  }
+  const newSameValue: ElementInstanceMetadata = {
+    elementPath: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+    element: left('div'),
+    props: {
+      a: {
+        b: [],
+      },
+    },
+    globalFrame: canvasRectangle({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 200,
+    }),
+    localFrame: localRectangle({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 200,
+    }),
+    componentInstance: true,
+    isEmotionOrStyledComponent: false,
+    specialSizeMeasurements: {
+      offset: {
+        x: 10,
+        y: 20,
+      } as LocalPoint,
+      coordinateSystemBounds: canvasRectangle({
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 200,
+      }),
+      immediateParentBounds: canvasRectangle({
+        x: 100,
+        y: 200,
+        width: 1000,
+        height: 2000,
+      }),
+      immediateParentProvidesLayout: false,
+      usesParentBounds: false,
+      parentLayoutSystem: 'flex',
+      layoutSystemForChildren: 'flex',
+      providesBoundsForChildren: true,
+      display: 'flex',
+      position: 'absolute',
+      margin: {
+        top: 1,
+        right: 2,
+        bottom: 3,
+        left: 4,
+      },
+      padding: {
+        top: 10,
+        right: 20,
+        bottom: 30,
+        left: 40,
+      },
+      naturalWidth: 100,
+      naturalHeight: 200,
+      clientWidth: 300,
+      clientHeight: 400,
+      parentFlexDirection: 'row',
+      flexDirection: 'column',
+      htmlElementName: 'div',
+      renderedChildrenCount: 10,
+    },
+    computedStyle: {
+      a: 'a',
+      b: 'b',
+    },
+    attributeMetadatada: {
+      a: {
+        fromStyleSheet: false,
+      },
+    },
+    label: 'label',
+    importInfo: createImportedFrom('old', 'old', 'old'),
+  }
+  const newDifferentValue: ElementInstanceMetadata = {
+    elementPath: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+    element: left('div'),
+    props: {
+      a: {
+        b: [],
+      },
+    },
+    globalFrame: canvasRectangle({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 200,
+    }),
+    localFrame: localRectangle({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 200,
+    }),
+    componentInstance: true,
+    isEmotionOrStyledComponent: false,
+    specialSizeMeasurements: {
+      offset: {
+        x: 10,
+        y: 20,
+      } as LocalPoint,
+      coordinateSystemBounds: canvasRectangle({
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 200,
+      }),
+      immediateParentBounds: canvasRectangle({
+        x: 100,
+        y: 200,
+        width: 1000,
+        height: 2000,
+      }),
+      immediateParentProvidesLayout: false,
+      usesParentBounds: false,
+      parentLayoutSystem: 'flex',
+      layoutSystemForChildren: 'flex',
+      providesBoundsForChildren: true,
+      display: 'flex',
+      position: 'absolute',
+      margin: {
+        top: 1,
+        right: 2,
+        bottom: 3,
+        left: 4,
+      },
+      padding: {
+        top: 10,
+        right: 20,
+        bottom: 30,
+        left: 40,
+      },
+      naturalWidth: 100,
+      naturalHeight: 200,
+      clientWidth: 300,
+      clientHeight: 400,
+      parentFlexDirection: 'row',
+      flexDirection: 'column',
+      htmlElementName: 'div',
+      renderedChildrenCount: 10,
+    },
+    computedStyle: {
+      a: 'a',
+      b: 'b',
+    },
+    attributeMetadatada: {
+      a: {
+        fromStyleSheet: false,
+      },
+    },
+    label: 'new-label',
+    importInfo: createImportedFrom('old', 'old', 'old'),
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = ElementInstanceMetadataKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = ElementInstanceMetadataKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = ElementInstanceMetadataKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.elementPath).toBe(oldValue.elementPath)
+    expect(result.value.element).toBe(oldValue.element)
+    expect(result.value.props).toBe(oldValue.props)
+    expect(result.value.globalFrame).toBe(oldValue.globalFrame)
+    expect(result.value.localFrame).toBe(oldValue.localFrame)
+    expect(result.value.componentInstance).toBe(oldValue.componentInstance)
+    expect(result.value.isEmotionOrStyledComponent).toBe(oldValue.isEmotionOrStyledComponent)
+    expect(result.value.specialSizeMeasurements).toBe(oldValue.specialSizeMeasurements)
+    expect(result.value.computedStyle).toBe(oldValue.computedStyle)
+    expect(result.value.attributeMetadatada).toBe(oldValue.attributeMetadatada)
+    expect(result.value.label).toBe(newDifferentValue.label)
+    expect(result.value.importInfo).toBe(oldValue.importInfo)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
+  const oldValue: ElementInstanceMetadataMap = {
+    elem: {
+      elementPath: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+      element: left('div'),
+      props: {
+        a: {
+          b: [],
+        },
+      },
+      globalFrame: canvasRectangle({
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 200,
+      }),
+      localFrame: localRectangle({
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 200,
+      }),
+      componentInstance: true,
+      isEmotionOrStyledComponent: false,
+      specialSizeMeasurements: {
+        offset: {
+          x: 10,
+          y: 20,
+        } as LocalPoint,
+        coordinateSystemBounds: canvasRectangle({
+          x: 10,
+          y: 20,
+          width: 100,
+          height: 200,
+        }),
+        immediateParentBounds: canvasRectangle({
+          x: 100,
+          y: 200,
+          width: 1000,
+          height: 2000,
+        }),
+        immediateParentProvidesLayout: false,
+        usesParentBounds: false,
+        parentLayoutSystem: 'flex',
+        layoutSystemForChildren: 'flex',
+        providesBoundsForChildren: true,
+        display: 'flex',
+        position: 'absolute',
+        margin: {
+          top: 1,
+          right: 2,
+          bottom: 3,
+          left: 4,
+        },
+        padding: {
+          top: 10,
+          right: 20,
+          bottom: 30,
+          left: 40,
+        },
+        naturalWidth: 100,
+        naturalHeight: 200,
+        clientWidth: 300,
+        clientHeight: 400,
+        parentFlexDirection: 'row',
+        flexDirection: 'column',
+        htmlElementName: 'div',
+        renderedChildrenCount: 10,
+      },
+      computedStyle: {
+        a: 'a',
+        b: 'b',
+      },
+      attributeMetadatada: {
+        a: {
+          fromStyleSheet: false,
+        },
+      },
+      label: 'label',
+      importInfo: createImportedFrom('old', 'old', 'old'),
+    },
+  }
+  const newSameValue: ElementInstanceMetadataMap = {
+    elem: {
+      elementPath: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+      element: left('div'),
+      props: {
+        a: {
+          b: [],
+        },
+      },
+      globalFrame: canvasRectangle({
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 200,
+      }),
+      localFrame: localRectangle({
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 200,
+      }),
+      componentInstance: true,
+      isEmotionOrStyledComponent: false,
+      specialSizeMeasurements: {
+        offset: {
+          x: 10,
+          y: 20,
+        } as LocalPoint,
+        coordinateSystemBounds: canvasRectangle({
+          x: 10,
+          y: 20,
+          width: 100,
+          height: 200,
+        }),
+        immediateParentBounds: canvasRectangle({
+          x: 100,
+          y: 200,
+          width: 1000,
+          height: 2000,
+        }),
+        immediateParentProvidesLayout: false,
+        usesParentBounds: false,
+        parentLayoutSystem: 'flex',
+        layoutSystemForChildren: 'flex',
+        providesBoundsForChildren: true,
+        display: 'flex',
+        position: 'absolute',
+        margin: {
+          top: 1,
+          right: 2,
+          bottom: 3,
+          left: 4,
+        },
+        padding: {
+          top: 10,
+          right: 20,
+          bottom: 30,
+          left: 40,
+        },
+        naturalWidth: 100,
+        naturalHeight: 200,
+        clientWidth: 300,
+        clientHeight: 400,
+        parentFlexDirection: 'row',
+        flexDirection: 'column',
+        htmlElementName: 'div',
+        renderedChildrenCount: 10,
+      },
+      computedStyle: {
+        a: 'a',
+        b: 'b',
+      },
+      attributeMetadatada: {
+        a: {
+          fromStyleSheet: false,
+        },
+      },
+      label: 'label',
+      importInfo: createImportedFrom('old', 'old', 'old'),
+    },
+  }
+  const newDifferentValue: ElementInstanceMetadataMap = {
+    elem: {
+      elementPath: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+      element: left('div'),
+      props: {
+        a: {
+          b: [],
+        },
+      },
+      globalFrame: canvasRectangle({
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 200,
+      }),
+      localFrame: localRectangle({
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 200,
+      }),
+      componentInstance: true,
+      isEmotionOrStyledComponent: false,
+      specialSizeMeasurements: {
+        offset: {
+          x: 10,
+          y: 20,
+        } as LocalPoint,
+        coordinateSystemBounds: canvasRectangle({
+          x: 10,
+          y: 20,
+          width: 100,
+          height: 200,
+        }),
+        immediateParentBounds: canvasRectangle({
+          x: 100,
+          y: 200,
+          width: 1000,
+          height: 2000,
+        }),
+        immediateParentProvidesLayout: false,
+        usesParentBounds: false,
+        parentLayoutSystem: 'flex',
+        layoutSystemForChildren: 'flex',
+        providesBoundsForChildren: true,
+        display: 'flex',
+        position: 'absolute',
+        margin: {
+          top: 1,
+          right: 2,
+          bottom: 3,
+          left: 4,
+        },
+        padding: {
+          top: 10,
+          right: 20,
+          bottom: 30,
+          left: 40,
+        },
+        naturalWidth: 100,
+        naturalHeight: 200,
+        clientWidth: 300,
+        clientHeight: 400,
+        parentFlexDirection: 'row',
+        flexDirection: 'column',
+        htmlElementName: 'div',
+        renderedChildrenCount: 10,
+      },
+      computedStyle: {
+        a: 'a',
+        b: 'b',
+      },
+      attributeMetadatada: {
+        a: {
+          fromStyleSheet: false,
+        },
+      },
+      label: 'new-label',
+      importInfo: createImportedFrom('old', 'old', 'old'),
+    },
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = ElementInstanceMetadataMapKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = ElementInstanceMetadataMapKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = ElementInstanceMetadataMapKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.elem.elementPath).toBe(oldValue.elem.elementPath)
+    expect(result.value.elem.element).toBe(oldValue.elem.element)
+    expect(result.value.elem.props).toBe(oldValue.elem.props)
+    expect(result.value.elem.globalFrame).toBe(oldValue.elem.globalFrame)
+    expect(result.value.elem.localFrame).toBe(oldValue.elem.localFrame)
+    expect(result.value.elem.componentInstance).toBe(oldValue.elem.componentInstance)
+    expect(result.value.elem.isEmotionOrStyledComponent).toBe(
+      oldValue.elem.isEmotionOrStyledComponent,
+    )
+    expect(result.value.elem.specialSizeMeasurements).toBe(oldValue.elem.specialSizeMeasurements)
+    expect(result.value.elem.computedStyle).toBe(oldValue.elem.computedStyle)
+    expect(result.value.elem.attributeMetadatada).toBe(oldValue.elem.attributeMetadatada)
+    expect(result.value.elem.label).toBe(newDifferentValue.elem.label)
+    expect(result.value.elem.importInfo).toBe(oldValue.elem.importInfo)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})

--- a/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
@@ -1,6 +1,22 @@
 import {
   emptyComments,
+  jsxArraySpread,
+  jsxArrayValue,
+  jsxAttributeFunctionCall,
+  jsxAttributeNestedArray,
+  jsxAttributeNestedObject,
+  JSXAttributeOtherJavaScript,
+  jsxAttributeOtherJavaScript,
+  jsxAttributesEntry,
+  jsxAttributesSpread,
+  jsxAttributeValue,
+  JSXAttributeValue,
   jsxElement,
+  jsxPropertyAssignment,
+  jsxSpreadAssignment,
+  MultiLineComment,
+  ParsedComments,
+  SingleLineComment,
   utopiaJSXComponent,
 } from '../../../core/shared/element-template'
 import * as EP from '../../../core/shared/element-path'
@@ -14,376 +30,1075 @@ import {
   transientFileState,
 } from './editor-state'
 import {
+  CommentKeepDeepEqualityCall,
   DerivedStateKeepDeepEquality,
+  JSXArrayElementKeepDeepEqualityCall,
+  JSXArraySpreadKeepDeepEqualityCall,
+  JSXArrayValueKeepDeepEqualityCall,
+  JSXAttributeFunctionCallKeepDeepEqualityCall,
+  JSXAttributeKeepDeepEqualityCall,
+  JSXAttributeNestedArrayKeepDeepEqualityCall,
+  JSXAttributeNestedObjectKeepDeepEqualityCall,
+  JSXAttributeOtherJavaScriptKeepDeepEqualityCall,
+  JSXAttributesEntryDeepEqualityCall,
+  JSXAttributesKeepDeepEqualityCall,
+  JSXAttributesPartDeepEqualityCall,
+  JSXAttributesSpreadDeepEqualityCall,
+  JSXAttributeValueKeepDeepEqualityCall,
+  JSXPropertyAssignmentKeepDeepEqualityCall,
+  JSXPropertyKeepDeepEqualityCall,
+  JSXSpreadAssignmentKeepDeepEqualityCall,
+  MultiLineCommentKeepDeepEqualityCall,
+  ParsedCommentsKeepDeepEqualityCall,
+  SingleLineCommentKeepDeepEqualityCall,
   TransientCanvasStateKeepDeepEquality,
 } from './store-deep-equality-instances'
 
 describe('TransientCanvasStateKeepDeepEquality', () => {
-  it('same reference returns the same reference', () => {
-    const state: TransientCanvasState = transientCanvasState(
-      [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      [EP.elementPath([['scene'], ['aaa', 'ccc']])],
-      {
-        ['/utopia/app.js']: transientFileState(
-          [
-            utopiaJSXComponent(
-              'App',
-              false,
-              'var',
-              'block',
-              null,
-              [],
-              jsxElement('div', 'eee', [], []),
-              null,
-              false,
-              emptyComments,
-            ),
-          ],
-          emptyImports(),
-        ),
-      },
-      [],
-      [],
-    )
+  const oldValue: TransientCanvasState = transientCanvasState(
+    [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+    [EP.elementPath([['scene'], ['aaa', 'ccc']])],
+    {
+      ['/utopia/app.js']: transientFileState(
+        [
+          utopiaJSXComponent(
+            'App',
+            false,
+            'var',
+            'block',
+            null,
+            [],
+            jsxElement('div', 'eee', [], []),
+            null,
+            false,
+            emptyComments,
+          ),
+        ],
+        emptyImports(),
+      ),
+    },
+    [],
+    [],
+  )
+  const newSameValue: TransientCanvasState = transientCanvasState(
+    [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+    [EP.elementPath([['scene'], ['aaa', 'ccc']])],
+    {
+      ['/utopia/app.js']: transientFileState(
+        [
+          utopiaJSXComponent(
+            'App',
+            false,
+            'var',
+            'block',
+            null,
+            [],
+            jsxElement('div', 'eee', [], []),
+            null,
+            false,
+            emptyComments,
+          ),
+        ],
+        emptyImports(),
+      ),
+    },
+    [],
+    [],
+  )
+  const newDifferentValue: TransientCanvasState = transientCanvasState(
+    [EP.elementPath([['scene'], ['aaa', 'ddd']])],
+    [EP.elementPath([['scene'], ['aaa', 'ccc']])],
+    {
+      ['/utopia/app.js']: transientFileState(
+        [
+          utopiaJSXComponent(
+            'App',
+            false,
+            'var',
+            'block',
+            null,
+            [],
+            jsxElement('div', 'eee', [], []),
+            null,
+            false,
+            emptyComments,
+          ),
+        ],
+        emptyImports(),
+      ),
+    },
+    [],
+    [],
+  )
 
-    const result = TransientCanvasStateKeepDeepEquality()(state, state)
-    expect(result.value).toBe(state)
+  it('same reference returns the same reference', () => {
+    const result = TransientCanvasStateKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const oldState: TransientCanvasState = transientCanvasState(
-      [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      [EP.elementPath([['scene'], ['aaa', 'ccc']])],
-      {
-        ['/utopia/app.js']: transientFileState(
-          [
-            utopiaJSXComponent(
-              'App',
-              false,
-              'var',
-              'block',
-              null,
-              [],
-              jsxElement('div', 'eee', [], []),
-              null,
-              false,
-              emptyComments,
-            ),
-          ],
-          emptyImports(),
-        ),
-      },
-      [],
-      [],
-    )
-    const newState: TransientCanvasState = transientCanvasState(
-      [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      [EP.elementPath([['scene'], ['aaa', 'ccc']])],
-      {
-        ['/utopia/app.js']: transientFileState(
-          [
-            utopiaJSXComponent(
-              'App',
-              false,
-              'var',
-              'block',
-              null,
-              [],
-              jsxElement('div', 'eee', [], []),
-              null,
-              false,
-              emptyComments,
-            ),
-          ],
-          emptyImports(),
-        ),
-      },
-      [],
-      [],
-    )
-
-    const result = TransientCanvasStateKeepDeepEquality()(oldState, newState)
-    expect(result.value).toBe(oldState)
+    const result = TransientCanvasStateKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const oldState: TransientCanvasState = transientCanvasState(
-      [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      [EP.elementPath([['scene'], ['aaa', 'ccc']])],
-      {
-        ['/utopia/app.js']: transientFileState(
-          [
-            utopiaJSXComponent(
-              'App',
-              false,
-              'var',
-              'block',
-              null,
-              [],
-              jsxElement('span', 'eee', [], []),
-              null,
-              false,
-              emptyComments,
-            ),
-          ],
-          emptyImports(),
-        ),
-      },
-      [],
-      [],
-    )
-    const newState: TransientCanvasState = transientCanvasState(
-      [EP.elementPath([['scene'], ['aaa', 'ddd']])],
-      [EP.elementPath([['scene'], ['aaa', 'ccc']])],
-      {
-        ['/utopia/app.js']: transientFileState(
-          [
-            utopiaJSXComponent(
-              'App',
-              false,
-              'var',
-              'block',
-              null,
-              [],
-              jsxElement('div', 'eee', [], []),
-              null,
-              false,
-              emptyComments,
-            ),
-          ],
-          emptyImports(),
-        ),
-      },
-      [],
-      [],
-    )
-
-    const result = TransientCanvasStateKeepDeepEquality()(oldState, newState)
-    expect(result.value).toEqual(newState)
-    expect(result.value.selectedViews).toEqual(newState.selectedViews)
-    expect(result.value.highlightedViews).toBe(oldState.highlightedViews)
-    expect(result.value.filesState).toEqual(newState.filesState)
+    const result = TransientCanvasStateKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.selectedViews![0].parts).toBe(newDifferentValue.selectedViews![0].parts)
+    expect(result.value.highlightedViews).toBe(oldValue.highlightedViews)
+    expect(result.value.filesState).toBe(oldValue.filesState)
+    expect(result.value).toEqual(newDifferentValue)
     expect(result.areEqual).toEqual(false)
   })
 })
 
 describe('DerivedStateKeepDeepEquality', () => {
-  it('same reference returns the same reference', () => {
-    const state: DerivedState = {
-      navigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      visibleNavigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      canvas: {
-        descendantsOfHiddenInstances: [],
-        controls: [],
-        transientState: transientCanvasState(
-          [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-          [EP.elementPath([['scene'], ['aaa', 'ccc']])],
-          {
-            ['/utopia/app.js']: transientFileState(
-              [
-                utopiaJSXComponent(
-                  'App',
-                  false,
-                  'var',
-                  'block',
-                  null,
-                  [],
-                  jsxElement('div', 'eee', [], []),
-                  null,
-                  false,
-                  emptyComments,
-                ),
-              ],
-              emptyImports(),
-            ),
-          },
-          [],
-          [],
-        ),
-      },
-      elementWarnings: addToComplexMap(
-        EP.toString,
-        emptyComplexMap(),
-        EP.elementPath([['scene'], ['aaa', 'bbb']]),
-        defaultElementWarnings,
+  const oldValue: DerivedState = {
+    navigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+    visibleNavigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+    canvas: {
+      descendantsOfHiddenInstances: [],
+      controls: [],
+      transientState: transientCanvasState(
+        [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+        [EP.elementPath([['scene'], ['aaa', 'ccc']])],
+        {
+          ['/utopia/app.js']: transientFileState(
+            [
+              utopiaJSXComponent(
+                'App',
+                false,
+                'var',
+                'block',
+                null,
+                [],
+                jsxElement('div', 'eee', [], []),
+                null,
+                false,
+                emptyComments,
+              ),
+            ],
+            emptyImports(),
+          ),
+        },
+        [],
+        [],
       ),
-    }
-    const result = DerivedStateKeepDeepEquality()(state, state)
-    expect(result.value).toBe(state)
+    },
+    elementWarnings: addToComplexMap(
+      EP.toString,
+      emptyComplexMap(),
+      EP.elementPath([['scene'], ['aaa', 'bbb']]),
+      defaultElementWarnings,
+    ),
+  }
+  const newSameValue: DerivedState = {
+    navigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+    visibleNavigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+    canvas: {
+      descendantsOfHiddenInstances: [],
+      controls: [],
+      transientState: transientCanvasState(
+        [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+        [EP.elementPath([['scene'], ['aaa', 'ccc']])],
+        {
+          ['/utopia/app.js']: transientFileState(
+            [
+              utopiaJSXComponent(
+                'App',
+                false,
+                'var',
+                'block',
+                null,
+                [],
+                jsxElement('div', 'eee', [], []),
+                null,
+                false,
+                emptyComments,
+              ),
+            ],
+            emptyImports(),
+          ),
+        },
+        [],
+        [],
+      ),
+    },
+    elementWarnings: addToComplexMap(
+      EP.toString,
+      emptyComplexMap(),
+      EP.elementPath([['scene'], ['aaa', 'bbb']]),
+      defaultElementWarnings,
+    ),
+  }
+  const newDifferentValue: DerivedState = {
+    navigatorTargets: [EP.elementPath([['scene'], ['aaa', 'ddd']])],
+    visibleNavigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+    canvas: {
+      descendantsOfHiddenInstances: [],
+      controls: [],
+      transientState: transientCanvasState(
+        [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+        [EP.elementPath([['scene'], ['aaa', 'ccc']])],
+        {
+          ['/utopia/app.js']: transientFileState(
+            [
+              utopiaJSXComponent(
+                'App',
+                false,
+                'var',
+                'block',
+                null,
+                [],
+                jsxElement('div', 'eee', [], []),
+                null,
+                false,
+                emptyComments,
+              ),
+            ],
+            emptyImports(),
+          ),
+        },
+        [],
+        [],
+      ),
+    },
+    elementWarnings: addToComplexMap(
+      EP.toString,
+      emptyComplexMap(),
+      EP.elementPath([['scene'], ['aaa', 'bbb']]),
+      defaultElementWarnings,
+    ),
+  }
+  it('same reference returns the same reference', () => {
+    const result = DerivedStateKeepDeepEquality()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const oldState: DerivedState = {
-      navigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      visibleNavigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      canvas: {
-        descendantsOfHiddenInstances: [],
-        controls: [],
-        transientState: transientCanvasState(
-          [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-          [EP.elementPath([['scene'], ['aaa', 'ccc']])],
-          {
-            ['/utopia/app.js']: transientFileState(
-              [
-                utopiaJSXComponent(
-                  'App',
-                  false,
-                  'var',
-                  'block',
-                  null,
-                  [],
-                  jsxElement('div', 'eee', [], []),
-                  null,
-                  false,
-                  emptyComments,
-                ),
-              ],
-              emptyImports(),
-            ),
-          },
-          [],
-          [],
-        ),
-      },
-      elementWarnings: addToComplexMap(
-        EP.toString,
-        emptyComplexMap(),
-        EP.elementPath([['scene'], ['aaa', 'bbb']]),
-        defaultElementWarnings,
-      ),
-    }
-    const newState: DerivedState = {
-      navigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      visibleNavigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      canvas: {
-        descendantsOfHiddenInstances: [],
-        controls: [],
-        transientState: transientCanvasState(
-          [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-          [EP.elementPath([['scene'], ['aaa', 'ccc']])],
-          {
-            ['/utopia/app.js']: transientFileState(
-              [
-                utopiaJSXComponent(
-                  'App',
-                  false,
-                  'var',
-                  'block',
-                  null,
-                  [],
-                  jsxElement('div', 'eee', [], []),
-                  null,
-                  false,
-                  emptyComments,
-                ),
-              ],
-              emptyImports(),
-            ),
-          },
-          [],
-          [],
-        ),
-      },
-      elementWarnings: addToComplexMap(
-        EP.toString,
-        emptyComplexMap(),
-        EP.elementPath([['scene'], ['aaa', 'bbb']]),
-        defaultElementWarnings,
-      ),
-    }
-    const result = DerivedStateKeepDeepEquality()(oldState, newState)
-    expect(result.value).toBe(oldState)
+    const result = DerivedStateKeepDeepEquality()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const oldState: DerivedState = {
-      navigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      visibleNavigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      canvas: {
-        descendantsOfHiddenInstances: [],
-        controls: [],
-        transientState: transientCanvasState(
-          [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-          [EP.elementPath([['scene'], ['aaa', 'ccc']])],
-          {
-            ['/utopia/app.js']: transientFileState(
-              [
-                utopiaJSXComponent(
-                  'App',
-                  false,
-                  'var',
-                  'block',
-                  null,
-                  [],
-                  jsxElement('div', 'eee', [], []),
-                  null,
-                  false,
-                  emptyComments,
-                ),
-              ],
-              emptyImports(),
-            ),
-          },
-          [],
-          [],
-        ),
-      },
-      elementWarnings: addToComplexMap(
-        EP.toString,
-        emptyComplexMap(),
-        EP.elementPath([['scene'], ['aaa', 'bbb']]),
-        defaultElementWarnings,
-      ),
-    }
-    const newState: DerivedState = {
-      navigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      visibleNavigatorTargets: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
-      canvas: {
-        descendantsOfHiddenInstances: [],
-        controls: [],
-        transientState: transientCanvasState(
-          [EP.elementPath([['scene'], ['aaa', 'ddd']])],
-          [EP.elementPath([['scene'], ['aaa', 'ccc']])],
-          {
-            ['/utopia/app.js']: transientFileState(
-              [
-                utopiaJSXComponent(
-                  'App',
-                  false,
-                  'var',
-                  'block',
-                  null,
-                  [],
-                  jsxElement('div', 'eee', [], []),
-                  null,
-                  false,
-                  emptyComments,
-                ),
-              ],
-              emptyImports(),
-            ),
-          },
-          [],
-          [],
-        ),
-      },
-      elementWarnings: addToComplexMap(
-        EP.toString,
-        emptyComplexMap(),
-        EP.elementPath([['scene'], ['aaa', 'bbb']]),
-        defaultElementWarnings,
-      ),
-    }
-    const result = DerivedStateKeepDeepEquality()(oldState, newState)
-    expect(result.value.navigatorTargets).toBe(oldState.navigatorTargets)
-    expect(result.value.visibleNavigatorTargets).toBe(oldState.visibleNavigatorTargets)
+    const result = DerivedStateKeepDeepEquality()(oldValue, newDifferentValue)
+    expect(result.value.navigatorTargets[0]).toBe(newDifferentValue.navigatorTargets[0])
+    expect(result.value.visibleNavigatorTargets).toBe(oldValue.visibleNavigatorTargets)
     expect(result.value.canvas.descendantsOfHiddenInstances).toBe(
-      oldState.canvas.descendantsOfHiddenInstances,
+      oldValue.canvas.descendantsOfHiddenInstances,
     )
-    expect(result.value.canvas.controls).toBe(oldState.canvas.controls)
-    expect(result.value.canvas.transientState).toEqual(newState.canvas.transientState)
-    expect(result.value.elementWarnings).toBe(oldState.elementWarnings)
-    expect(result.value).toEqual(newState)
+    expect(result.value.canvas.controls).toBe(oldValue.canvas.controls)
+    expect(result.value.canvas.transientState).toBe(oldValue.canvas.transientState)
+    expect(result.value.elementWarnings).toBe(oldValue.elementWarnings)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('MultiLineCommentKeepDeepEqualityCall', () => {
+  const oldValue: MultiLineComment = {
+    type: 'MULTI_LINE_COMMENT',
+    comment: 'A comment',
+    rawText: '/* A comment */',
+    trailingNewLine: false,
+    pos: 10,
+  }
+  const newSameValue: MultiLineComment = {
+    type: 'MULTI_LINE_COMMENT',
+    comment: 'A comment',
+    rawText: '/* A comment */',
+    trailingNewLine: false,
+    pos: 10,
+  }
+  const newDifferentValue: MultiLineComment = {
+    type: 'MULTI_LINE_COMMENT',
+    comment: 'A comment',
+    rawText: '/* A comment */',
+    trailingNewLine: true,
+    pos: 10,
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = MultiLineCommentKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = MultiLineCommentKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = MultiLineCommentKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.comment).toBe(oldValue.comment)
+    expect(result.value.rawText).toBe(oldValue.rawText)
+    expect(result.value.trailingNewLine).toBe(newDifferentValue.trailingNewLine)
+    expect(result.value.pos).toBe(oldValue.pos)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('SingleLineCommentKeepDeepEqualityCall', () => {
+  const oldValue: SingleLineComment = {
+    type: 'SINGLE_LINE_COMMENT',
+    comment: 'A comment',
+    rawText: '// A comment',
+    trailingNewLine: false,
+    pos: 10,
+  }
+  const newSameValue: SingleLineComment = {
+    type: 'SINGLE_LINE_COMMENT',
+    comment: 'A comment',
+    rawText: '// A comment',
+    trailingNewLine: false,
+    pos: 10,
+  }
+  const newDifferentValue: SingleLineComment = {
+    type: 'SINGLE_LINE_COMMENT',
+    comment: 'A comment',
+    rawText: '// A comment',
+    trailingNewLine: true,
+    pos: 10,
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = SingleLineCommentKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = SingleLineCommentKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = SingleLineCommentKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.comment).toBe(oldValue.comment)
+    expect(result.value.rawText).toBe(oldValue.rawText)
+    expect(result.value.trailingNewLine).toBe(newDifferentValue.trailingNewLine)
+    expect(result.value.pos).toBe(oldValue.pos)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('CommentKeepDeepEqualityCall', () => {
+  const oldMultiValue: MultiLineComment = {
+    type: 'MULTI_LINE_COMMENT',
+    comment: 'A comment',
+    rawText: '/* A comment */',
+    trailingNewLine: false,
+    pos: 10,
+  }
+  const newSameMultiValue: MultiLineComment = {
+    type: 'MULTI_LINE_COMMENT',
+    comment: 'A comment',
+    rawText: '/* A comment */',
+    trailingNewLine: false,
+    pos: 10,
+  }
+  const newDifferentMultiValue: MultiLineComment = {
+    type: 'MULTI_LINE_COMMENT',
+    comment: 'A comment',
+    rawText: '/* A comment */',
+    trailingNewLine: true,
+    pos: 10,
+  }
+
+  const oldSingleValue: SingleLineComment = {
+    type: 'SINGLE_LINE_COMMENT',
+    comment: 'A comment',
+    rawText: '// A comment',
+    trailingNewLine: false,
+    pos: 10,
+  }
+  const newSameSingleValue: SingleLineComment = {
+    type: 'SINGLE_LINE_COMMENT',
+    comment: 'A comment',
+    rawText: '// A comment',
+    trailingNewLine: false,
+    pos: 10,
+  }
+  const newDifferentSingleValue: SingleLineComment = {
+    type: 'SINGLE_LINE_COMMENT',
+    comment: 'A comment',
+    rawText: '// A comment',
+    trailingNewLine: true,
+    pos: 10,
+  }
+
+  it('same reference returns the same reference', () => {
+    const resultSingle = CommentKeepDeepEqualityCall()(oldSingleValue, oldSingleValue)
+    expect(resultSingle.value).toBe(oldSingleValue)
+    expect(resultSingle.areEqual).toEqual(true)
+
+    const resultMulti = CommentKeepDeepEqualityCall()(oldMultiValue, oldMultiValue)
+    expect(resultMulti.value).toBe(oldMultiValue)
+    expect(resultMulti.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const resultSingle = CommentKeepDeepEqualityCall()(oldSingleValue, newSameSingleValue)
+    expect(resultSingle.value).toBe(oldSingleValue)
+    expect(resultSingle.areEqual).toEqual(true)
+
+    const resultMulti = CommentKeepDeepEqualityCall()(oldMultiValue, newSameMultiValue)
+    expect(resultMulti.value).toBe(oldMultiValue)
+    expect(resultMulti.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const resultSingle = CommentKeepDeepEqualityCall()(oldSingleValue, newDifferentSingleValue)
+    expect(resultSingle.value.type).toBe(oldSingleValue.type)
+    expect(resultSingle.value.comment).toBe(oldSingleValue.comment)
+    expect(resultSingle.value.rawText).toBe(oldSingleValue.rawText)
+    expect(resultSingle.value.trailingNewLine).toBe(newDifferentSingleValue.trailingNewLine)
+    expect(resultSingle.value.pos).toBe(oldSingleValue.pos)
+    expect(resultSingle.value).toEqual(newDifferentSingleValue)
+    expect(resultSingle.areEqual).toEqual(false)
+
+    const resultMulti = CommentKeepDeepEqualityCall()(oldMultiValue, newDifferentMultiValue)
+    expect(resultMulti.value.type).toBe(oldMultiValue.type)
+    expect(resultMulti.value.comment).toBe(oldMultiValue.comment)
+    expect(resultMulti.value.rawText).toBe(oldMultiValue.rawText)
+    expect(resultMulti.value.trailingNewLine).toBe(newDifferentMultiValue.trailingNewLine)
+    expect(resultMulti.value.pos).toBe(oldMultiValue.pos)
+    expect(resultMulti.value).toEqual(newDifferentMultiValue)
+    expect(resultMulti.areEqual).toEqual(false)
+  })
+})
+
+describe('ParsedCommentsKeepDeepEqualityCall', () => {
+  const oldValue: ParsedComments = {
+    leadingComments: [
+      {
+        type: 'SINGLE_LINE_COMMENT',
+        comment: 'A comment',
+        rawText: '// A comment',
+        trailingNewLine: false,
+        pos: 10,
+      },
+    ],
+    trailingComments: [
+      {
+        type: 'MULTI_LINE_COMMENT',
+        comment: 'A comment',
+        rawText: '/* A comment */',
+        trailingNewLine: false,
+        pos: 10,
+      },
+    ],
+  }
+  const newSameValue: ParsedComments = {
+    leadingComments: [
+      {
+        type: 'SINGLE_LINE_COMMENT',
+        comment: 'A comment',
+        rawText: '// A comment',
+        trailingNewLine: false,
+        pos: 10,
+      },
+    ],
+    trailingComments: [
+      {
+        type: 'MULTI_LINE_COMMENT',
+        comment: 'A comment',
+        rawText: '/* A comment */',
+        trailingNewLine: false,
+        pos: 10,
+      },
+    ],
+  }
+  const newDifferentValue: ParsedComments = {
+    leadingComments: [
+      {
+        type: 'SINGLE_LINE_COMMENT',
+        comment: 'A comment',
+        rawText: '// A comment',
+        trailingNewLine: false,
+        pos: 10,
+      },
+    ],
+    trailingComments: [
+      {
+        type: 'MULTI_LINE_COMMENT',
+        comment: 'A comment',
+        rawText: '/* A comment */',
+        trailingNewLine: true,
+        pos: 10,
+      },
+    ],
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = ParsedCommentsKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = ParsedCommentsKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = ParsedCommentsKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.leadingComments).toBe(oldValue.leadingComments)
+    expect(result.value.trailingComments[0].type).toBe(oldValue.trailingComments[0].type)
+    expect(result.value.trailingComments[0].comment).toBe(oldValue.trailingComments[0].comment)
+    expect(result.value.trailingComments[0].rawText).toBe(oldValue.trailingComments[0].rawText)
+    expect(result.value.trailingComments[0].trailingNewLine).toBe(
+      newDifferentValue.trailingComments[0].trailingNewLine,
+    )
+    expect(result.value.trailingComments[0].pos).toBe(oldValue.trailingComments[0].pos)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXAttributeValueKeepDeepEqualityCall', () => {
+  const oldValue = jsxAttributeValue('old', emptyComments)
+  const newSameValue = jsxAttributeValue('old', emptyComments)
+  const newDifferentValue = jsxAttributeValue('new', emptyComments)
+
+  it('same reference returns the same reference', () => {
+    const result = JSXAttributeValueKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXAttributeValueKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXAttributeValueKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.comments).toBe(oldValue.comments)
+    expect(result.value.value).toBe(newDifferentValue.value)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXAttributeOtherJavaScriptKeepDeepEqualityCall', () => {
+  const oldValue: JSXAttributeOtherJavaScript = {
+    type: 'ATTRIBUTE_OTHER_JAVASCRIPT',
+    javascript: 'old',
+    transpiledJavascript: 'old',
+    definedElsewhere: ['old'],
+    sourceMap: { a: 1, b: [2] } as any,
+    uniqueID: 'old',
+    elementsWithin: {},
+  }
+  const newSameValue: JSXAttributeOtherJavaScript = {
+    type: 'ATTRIBUTE_OTHER_JAVASCRIPT',
+    javascript: 'old',
+    transpiledJavascript: 'old',
+    definedElsewhere: ['old'],
+    sourceMap: { a: 1, b: [2] } as any,
+    uniqueID: 'old',
+    elementsWithin: {},
+  }
+  const newDifferentValue: JSXAttributeOtherJavaScript = {
+    type: 'ATTRIBUTE_OTHER_JAVASCRIPT',
+    javascript: 'new',
+    transpiledJavascript: 'old',
+    definedElsewhere: ['old'],
+    sourceMap: { a: 1, b: [2] } as any,
+    uniqueID: 'old',
+    elementsWithin: {},
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = JSXAttributeOtherJavaScriptKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXAttributeOtherJavaScriptKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXAttributeOtherJavaScriptKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.javascript).toBe(newDifferentValue.javascript)
+    expect(result.value.transpiledJavascript).toBe(oldValue.transpiledJavascript)
+    expect(result.value.definedElsewhere).toBe(oldValue.definedElsewhere)
+    expect(result.value.sourceMap).toBe(oldValue.sourceMap)
+    expect(result.value.uniqueID).toBe(oldValue.uniqueID)
+    expect(result.value.elementsWithin).toBe(oldValue.elementsWithin)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXArrayValueKeepDeepEqualityCall', () => {
+  const oldValue = jsxArrayValue(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newSameValue = jsxArrayValue(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newDifferentValue = jsxArrayValue(jsxAttributeValue('new', emptyComments), emptyComments)
+
+  it('same reference returns the same reference', () => {
+    const result = JSXArrayValueKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXArrayValueKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXArrayValueKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.comments).toBe(oldValue.comments)
+    expect(result.value.value.type).toBe(newDifferentValue.value.type)
+    expect((result.value.value as JSXAttributeValue<string>).value).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).value,
+    )
+    expect((result.value.value as JSXAttributeValue<string>).comments).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).comments,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXArraySpreadKeepDeepEqualityCall', () => {
+  const oldValue = jsxArraySpread(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newSameValue = jsxArraySpread(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newDifferentValue = jsxArraySpread(jsxAttributeValue('new', emptyComments), emptyComments)
+
+  it('same reference returns the same reference', () => {
+    const result = JSXArraySpreadKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXArraySpreadKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXArraySpreadKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.comments).toBe(oldValue.comments)
+    expect(result.value.value.type).toBe(newDifferentValue.value.type)
+    expect((result.value.value as JSXAttributeValue<string>).value).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).value,
+    )
+    expect((result.value.value as JSXAttributeValue<string>).comments).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).comments,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXArrayElementKeepDeepEqualityCall', () => {
+  const oldValue = jsxArrayValue(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newSameValue = jsxArrayValue(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newDifferentValue = jsxArrayValue(jsxAttributeValue('new', emptyComments), emptyComments)
+
+  it('same reference returns the same reference', () => {
+    const result = JSXArrayElementKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXArrayElementKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXArrayElementKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.comments).toBe(oldValue.comments)
+    expect(result.value.value.type).toBe(newDifferentValue.value.type)
+    expect((result.value.value as JSXAttributeValue<string>).value).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).value,
+    )
+    expect((result.value.value as JSXAttributeValue<string>).comments).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).comments,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXAttributeNestedArrayKeepDeepEqualityCall', () => {
+  const oldValue = jsxAttributeNestedArray(
+    [jsxArrayValue(jsxAttributeValue('old', emptyComments), emptyComments)],
+    emptyComments,
+  )
+  const newSameValue = jsxAttributeNestedArray(
+    [jsxArrayValue(jsxAttributeValue('old', emptyComments), emptyComments)],
+    emptyComments,
+  )
+  const newDifferentValue = jsxAttributeNestedArray(
+    [jsxArrayValue(jsxAttributeValue('new', emptyComments), emptyComments)],
+    emptyComments,
+  )
+
+  it('same reference returns the same reference', () => {
+    const result = JSXAttributeNestedArrayKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXAttributeNestedArrayKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXAttributeNestedArrayKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.comments).toBe(oldValue.comments)
+    expect(result.value.content[0].value.type).toBe(newDifferentValue.content[0].value.type)
+    expect((result.value.content[0].value as JSXAttributeValue<string>).value).toBe(
+      (newDifferentValue.content[0].value as JSXAttributeValue<string>).value,
+    )
+    expect((result.value.content[0].value as JSXAttributeValue<string>).comments).toBe(
+      (newDifferentValue.content[0].value as JSXAttributeValue<string>).comments,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXSpreadAssignmentKeepDeepEqualityCall', () => {
+  const oldValue = jsxSpreadAssignment(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newSameValue = jsxSpreadAssignment(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newDifferentValue = jsxSpreadAssignment(
+    jsxAttributeValue('new', emptyComments),
+    emptyComments,
+  )
+
+  it('same reference returns the same reference', () => {
+    const result = JSXSpreadAssignmentKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXSpreadAssignmentKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXSpreadAssignmentKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.comments).toBe(oldValue.comments)
+    expect(result.value.value.type).toBe(newDifferentValue.value.type)
+    expect((result.value.value as JSXAttributeValue<string>).value).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).value,
+    )
+    expect((result.value.value as JSXAttributeValue<string>).comments).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).comments,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXPropertyAssignmentKeepDeepEqualityCall', () => {
+  const oldValue = jsxPropertyAssignment(
+    'key',
+    jsxAttributeValue('old', emptyComments),
+    emptyComments,
+    emptyComments,
+  )
+  const newSameValue = jsxPropertyAssignment(
+    'key',
+    jsxAttributeValue('old', emptyComments),
+    emptyComments,
+    emptyComments,
+  )
+  const newDifferentValue = jsxPropertyAssignment(
+    'key',
+    jsxAttributeValue('new', emptyComments),
+    emptyComments,
+    emptyComments,
+  )
+
+  it('same reference returns the same reference', () => {
+    const result = JSXPropertyAssignmentKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXPropertyAssignmentKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXPropertyAssignmentKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.key).toBe(oldValue.key)
+    expect(result.value.comments).toBe(oldValue.comments)
+    expect(result.value.keyComments).toBe(oldValue.keyComments)
+    expect(result.value.value.type).toBe(newDifferentValue.value.type)
+    expect((result.value.value as JSXAttributeValue<string>).value).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).value,
+    )
+    expect((result.value.value as JSXAttributeValue<string>).comments).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).comments,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXPropertyKeepDeepEqualityCall', () => {
+  const oldValue = jsxSpreadAssignment(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newSameValue = jsxSpreadAssignment(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newDifferentValue = jsxSpreadAssignment(
+    jsxAttributeValue('new', emptyComments),
+    emptyComments,
+  )
+
+  it('same reference returns the same reference', () => {
+    const result = JSXPropertyKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXPropertyKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXPropertyKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.comments).toBe(oldValue.comments)
+    expect(result.value.value.type).toBe(newDifferentValue.value.type)
+    expect((result.value.value as JSXAttributeValue<string>).value).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).value,
+    )
+    expect((result.value.value as JSXAttributeValue<string>).comments).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).comments,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXAttributeNestedObjectKeepDeepEqualityCall', () => {
+  const oldValue = jsxAttributeNestedObject(
+    [jsxSpreadAssignment(jsxAttributeValue('old', emptyComments), emptyComments)],
+    emptyComments,
+  )
+  const newSameValue = jsxAttributeNestedObject(
+    [jsxSpreadAssignment(jsxAttributeValue('old', emptyComments), emptyComments)],
+    emptyComments,
+  )
+  const newDifferentValue = jsxAttributeNestedObject(
+    [jsxSpreadAssignment(jsxAttributeValue('new', emptyComments), emptyComments)],
+    emptyComments,
+  )
+
+  it('same reference returns the same reference', () => {
+    const result = JSXAttributeNestedObjectKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXAttributeNestedObjectKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXAttributeNestedObjectKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.comments).toBe(oldValue.comments)
+    expect(result.value.content[0].value.type).toBe(newDifferentValue.content[0].value.type)
+    expect((result.value.content[0].value as JSXAttributeValue<string>).value).toBe(
+      (newDifferentValue.content[0].value as JSXAttributeValue<string>).value,
+    )
+    expect((result.value.content[0].value as JSXAttributeValue<string>).comments).toBe(
+      (newDifferentValue.content[0].value as JSXAttributeValue<string>).comments,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXAttributeFunctionCallKeepDeepEqualityCall', () => {
+  const oldValue = jsxAttributeFunctionCall('old', [jsxAttributeValue('old', emptyComments)])
+  const newSameValue = jsxAttributeFunctionCall('old', [jsxAttributeValue('old', emptyComments)])
+  const newDifferentValue = jsxAttributeFunctionCall('new', [
+    jsxAttributeValue('old', emptyComments),
+  ])
+
+  it('same reference returns the same reference', () => {
+    const result = JSXAttributeFunctionCallKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXAttributeFunctionCallKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXAttributeFunctionCallKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.functionName).toBe(newDifferentValue.functionName)
+    expect(result.value.parameters).toBe(oldValue.parameters)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXAttributeKeepDeepEqualityCall', () => {
+  const oldValue = jsxAttributeValue('old', emptyComments)
+  const newSameValue = jsxAttributeValue('old', emptyComments)
+  const newDifferentValue = jsxAttributeValue('new', emptyComments)
+
+  it('same reference returns the same reference', () => {
+    const result = JSXAttributeKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXAttributeKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXAttributeKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect((result.value as JSXAttributeValue<string>).value).toBe(
+      (newDifferentValue as JSXAttributeValue<string>).value,
+    )
+    expect((result.value as JSXAttributeValue<string>).comments).toBe(
+      (newDifferentValue as JSXAttributeValue<string>).comments,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXAttributesEntryDeepEqualityCall', () => {
+  const oldValue = jsxAttributesEntry('key', jsxAttributeValue('old', emptyComments), emptyComments)
+  const newSameValue = jsxAttributesEntry(
+    'key',
+    jsxAttributeValue('old', emptyComments),
+    emptyComments,
+  )
+  const newDifferentValue = jsxAttributesEntry(
+    'key',
+    jsxAttributeValue('new', emptyComments),
+    emptyComments,
+  )
+
+  it('same reference returns the same reference', () => {
+    const result = JSXAttributesEntryDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXAttributesEntryDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXAttributesEntryDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.key).toBe(oldValue.key)
+    expect(result.value.comments).toBe(oldValue.comments)
+    expect((result.value.value as JSXAttributeValue<string>).value).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).value,
+    )
+    expect((result.value.value as JSXAttributeValue<string>).comments).toBe(
+      (newDifferentValue.value as JSXAttributeValue<string>).comments,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXAttributesSpreadDeepEqualityCall', () => {
+  const oldValue = jsxAttributesSpread(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newSameValue = jsxAttributesSpread(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newDifferentValue = jsxAttributesSpread(
+    jsxAttributeValue('new', emptyComments),
+    emptyComments,
+  )
+
+  it('same reference returns the same reference', () => {
+    const result = JSXAttributesSpreadDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXAttributesSpreadDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXAttributesSpreadDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.comments).toBe(oldValue.comments)
+    expect((result.value.spreadValue as JSXAttributeValue<string>).value).toBe(
+      (newDifferentValue.spreadValue as JSXAttributeValue<string>).value,
+    )
+    expect((result.value.spreadValue as JSXAttributeValue<string>).comments).toBe(
+      (newDifferentValue.spreadValue as JSXAttributeValue<string>).comments,
+    )
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXAttributesPartDeepEqualityCall', () => {
+  const oldValue = jsxAttributesSpread(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newSameValue = jsxAttributesSpread(jsxAttributeValue('old', emptyComments), emptyComments)
+  const newDifferentValue = jsxAttributesSpread(
+    jsxAttributeValue('new', emptyComments),
+    emptyComments,
+  )
+
+  it('same reference returns the same reference', () => {
+    const result = JSXAttributesPartDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXAttributesPartDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXAttributesPartDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value.type).toBe(oldValue.type)
+    expect(result.value.comments).toBe(oldValue.comments)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('JSXAttributesKeepDeepEqualityCall', () => {
+  const oldValue = [jsxAttributesSpread(jsxAttributeValue('old', emptyComments), emptyComments)]
+  const newSameValue = [jsxAttributesSpread(jsxAttributeValue('old', emptyComments), emptyComments)]
+  const newDifferentValue = [
+    jsxAttributesSpread(jsxAttributeValue('new', emptyComments), emptyComments),
+  ]
+
+  it('same reference returns the same reference', () => {
+    const result = JSXAttributesKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = JSXAttributesKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = JSXAttributesKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value[0].type).toBe(oldValue[0].type)
+    expect(result.value[0].comments).toBe(oldValue[0].comments)
+    expect(result.value).toEqual(newDifferentValue)
     expect(result.areEqual).toEqual(false)
   })
 })

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -600,7 +600,7 @@ export function JSXElementChildArrayKeepDeepEquality(): KeepDeepEqualityCall<
   return arrayDeepEquality(JSXElementChildKeepDeepEquality())
 }
 
-const RegularParamKeepDeepEquality: KeepDeepEqualityCall<RegularParam> = combine2EqualityCalls(
+export const RegularParamKeepDeepEquality: KeepDeepEqualityCall<RegularParam> = combine2EqualityCalls(
   (param) => param.paramName,
   createCallWithTripleEquals(),
   (param) => param.defaultExpression,
@@ -608,7 +608,7 @@ const RegularParamKeepDeepEquality: KeepDeepEqualityCall<RegularParam> = combine
   regularParam,
 )
 
-const DestructuredParamPartKeepDeepEquality: KeepDeepEqualityCall<DestructuredParamPart> = combine3EqualityCalls(
+export const DestructuredParamPartKeepDeepEquality: KeepDeepEqualityCall<DestructuredParamPart> = combine3EqualityCalls(
   (paramPart) => paramPart.propertyName,
   createCallWithTripleEquals(),
   (paramPart) => paramPart.param,
@@ -618,13 +618,13 @@ const DestructuredParamPartKeepDeepEquality: KeepDeepEqualityCall<DestructuredPa
   destructuredParamPart,
 )
 
-const DestructuredObjectParamKeepDeepEquality: KeepDeepEqualityCall<DestructuredObject> = combine1EqualityCall(
+export const DestructuredObjectParamKeepDeepEquality: KeepDeepEqualityCall<DestructuredObject> = combine1EqualityCall(
   (paramPart) => paramPart.parts,
   arrayDeepEquality(DestructuredParamPartKeepDeepEquality),
   destructuredObject,
 )
 
-const DestructuredArrayPartKeepDeepEquality: KeepDeepEqualityCall<DestructuredArrayPart> = (
+export const DestructuredArrayPartKeepDeepEquality: KeepDeepEqualityCall<DestructuredArrayPart> = (
   oldValue,
   newValue,
 ) => {
@@ -637,13 +637,13 @@ const DestructuredArrayPartKeepDeepEquality: KeepDeepEqualityCall<DestructuredAr
   }
 }
 
-const DestructuredArrayKeepDeepEquality: KeepDeepEqualityCall<DestructuredArray> = combine1EqualityCall(
+export const DestructuredArrayKeepDeepEquality: KeepDeepEqualityCall<DestructuredArray> = combine1EqualityCall(
   (param) => param.parts,
   arrayDeepEquality(DestructuredArrayPartKeepDeepEquality),
   destructuredArray,
 )
 
-function BoundParamKeepDeepEquality(): KeepDeepEqualityCall<BoundParam> {
+export function BoundParamKeepDeepEquality(): KeepDeepEqualityCall<BoundParam> {
   return (oldValue, newValue) => {
     if (isRegularParam(oldValue) && isRegularParam(newValue)) {
       return RegularParamKeepDeepEquality(oldValue, newValue)
@@ -657,7 +657,7 @@ function BoundParamKeepDeepEquality(): KeepDeepEqualityCall<BoundParam> {
   }
 }
 
-function ParamKeepDeepEquality(): KeepDeepEqualityCall<Param> {
+export function ParamKeepDeepEquality(): KeepDeepEqualityCall<Param> {
   return combine2EqualityCalls(
     (param) => param.dotDotDotToken,
     createCallWithTripleEquals(),
@@ -879,7 +879,7 @@ export function ElementInstanceMetadataKeepDeepEquality(): KeepDeepEqualityCall<
     (metadata) => metadata.computedStyle,
     nullableDeepEquality(objectDeepEquality(createCallWithTripleEquals())),
     (metadata) => metadata.attributeMetadatada,
-    nullableDeepEquality(objectDeepEquality(createCallWithTripleEquals())),
+    createCallFromIntrospectiveKeepDeep(),
     (metadata) => metadata.label,
     nullableDeepEquality(createCallWithTripleEquals()),
     (metadata) => metadata.importInfo,

--- a/editor/src/utils/deep-equality-instances.spec.ts
+++ b/editor/src/utils/deep-equality-instances.spec.ts
@@ -5,113 +5,490 @@ import {
   JSXElementNameKeepDeepEqualityCall,
   PropertyPathKeepDeepEquality,
   ElementPathKeepDeepEquality,
+  ElementPathArrayKeepDeepEquality,
+  HigherOrderControlArrayKeepDeepEquality,
+  EitherKeepDeepEquality,
+  NameAndIconResultKeepDeepEquality,
+  NameAndIconResultArrayKeepDeepEquality,
+  DropTargetHintKeepDeepEquality,
+  NavigatorStateKeepDeepEquality,
+  LayoutTargetablePropArrayKeepDeepEquality,
 } from './deep-equality-instances'
+import { HigherOrderControl } from '../components/canvas/canvas-types'
+import { Either, left, right } from '../core/shared/either'
+import { arrayDeepEquality, createCallWithTripleEquals } from './deep-equality'
+import { NameAndIconResult } from '../components/inspector/common/name-and-icon-hook'
+import { DropTargetHint, NavigatorState } from '../components/editor/store/editor-state'
+import { LayoutTargetableProp } from '../core/layout/layout-helpers-new'
 
 describe('ElementPathKeepDeepEquality', () => {
+  const oldValue = EP.elementPath([['scene'], ['aaa', 'bbb']])
+  const newSameValue = EP.elementPath([['scene'], ['aaa', 'bbb']])
+  const newDifferentValue = EP.elementPath([['scene'], ['aaa', 'ccc']])
+
   it('same reference returns the same reference', () => {
-    const path = EP.elementPath([['scene'], ['aaa', 'bbb']])
-    const result = ElementPathKeepDeepEquality(path, path)
-    expect(result.value).toBe(path)
+    const result = ElementPathKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const oldPath = EP.elementPath([['scene'], ['aaa', 'bbb']])
-    const newPath = EP.elementPath([['scene'], ['aaa', 'bbb']])
-    const result = ElementPathKeepDeepEquality(oldPath, newPath)
-    expect(result.value).toBe(oldPath)
+    const result = ElementPathKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
-  xit('different but similar value handled appropriately', () => {
-    // FIXME Do we still want or care about this?
-    const oldPath = EP.elementPath([['scene'], ['aaa', 'bbb']])
-    const newPath = EP.elementPath([['scene'], ['aaa', 'ccc']])
-    const result = ElementPathKeepDeepEquality(oldPath, newPath)
-    expect(result.value).toEqual(newPath)
-    expect(result.value.parts[0]).toBe(oldPath.parts[0])
-    expect(result.value.parts[1]).toEqual(newPath.parts[1])
+  it('different but similar value handled appropriately', () => {
+    const result = ElementPathKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value.parts).toBe(newDifferentValue.parts)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('ElementPathArrayKeepDeepEquality', () => {
+  const oldValue = [EP.elementPath([['scene'], ['aaa', 'bbb']])]
+  const newSameValue = [EP.elementPath([['scene'], ['aaa', 'bbb']])]
+  const newDifferentValue = [EP.elementPath([['scene'], ['aaa', 'ccc']])]
+
+  it('same reference returns the same reference', () => {
+    const result = ElementPathArrayKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = ElementPathArrayKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = ElementPathArrayKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value[0]).toBe(newDifferentValue[0])
+    expect(result.value).toEqual(newDifferentValue)
     expect(result.areEqual).toEqual(false)
   })
 })
 
 describe('PropertyPathKeepDeepEquality', () => {
+  const oldValue: PropertyPath = {
+    propertyElements: ['style', 'backgroundColor'],
+  }
+  const newSameValue: PropertyPath = {
+    propertyElements: ['style', 'backgroundColor'],
+  }
+  const newDifferentValue: PropertyPath = {
+    propertyElements: ['style', 'someOtherColor'],
+  }
+
   it('same reference returns the same reference', () => {
-    const path: PropertyPath = {
-      propertyElements: ['style', 'backgroundColor'],
-    }
-    const result = PropertyPathKeepDeepEquality(path, path)
-    expect(result.value).toBe(path)
+    const result = PropertyPathKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const oldPath: PropertyPath = {
-      propertyElements: ['style', 'backgroundColor'],
-    }
-    const newPath: PropertyPath = {
-      propertyElements: ['style', 'backgroundColor'],
-    }
-    const result = PropertyPathKeepDeepEquality(oldPath, newPath)
-    expect(result.value).toBe(oldPath)
+    const result = PropertyPathKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const oldPath: PropertyPath = {
-      propertyElements: ['style', 'backgroundColor'],
-    }
-    const newPath: PropertyPath = {
-      propertyElements: ['style', 'someOtherColor'],
-    }
-    const result = PropertyPathKeepDeepEquality(oldPath, newPath)
-    expect(result.value).toEqual(newPath)
+    const result = PropertyPathKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value).toBe(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('HigherOrderControlArrayKeepDeepEquality', () => {
+  const oldValue: Array<HigherOrderControl> = [
+    {
+      type: 'divControl',
+      component: {
+        fakeKey: 'I am a component',
+      } as any,
+      controls: [],
+      controlid: 'test',
+      followCanvas: 'x',
+    },
+  ]
+  const newSameValue: Array<HigherOrderControl> = [
+    {
+      type: 'divControl',
+      component: {
+        fakeKey: 'I am a component',
+      } as any,
+      controls: [],
+      controlid: 'test',
+      followCanvas: 'x',
+    },
+  ]
+  const newDifferentValue: Array<HigherOrderControl> = [
+    {
+      type: 'divControl',
+      component: {
+        fakeKey: 'I am a component',
+      } as any,
+      controls: [],
+      controlid: 'test-different',
+      followCanvas: 'x',
+    },
+  ]
+
+  it('same reference returns the same reference', () => {
+    const result = HigherOrderControlArrayKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = HigherOrderControlArrayKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = HigherOrderControlArrayKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value[0].type).toBe(oldValue[0].type)
+    expect(result.value[0].component).toBe(oldValue[0].component)
+    expect(result.value[0].controls).toBe(oldValue[0].controls)
+    expect(result.value[0].controlid).toBe(newDifferentValue[0].controlid)
+    expect(result.value[0].followCanvas).toBe(oldValue[0].followCanvas)
+    expect(result.value).toEqual(newDifferentValue)
     expect(result.areEqual).toEqual(false)
   })
 })
 
 describe('JSXElementNameKeepDeepEqualityCall', () => {
+  const oldValue: JSXElementName = {
+    baseVariable: 'React',
+    propertyPath: {
+      propertyElements: ['style', 'backgroundColor'],
+    },
+  }
+  const newSameValue: JSXElementName = {
+    baseVariable: 'React',
+    propertyPath: {
+      propertyElements: ['style', 'backgroundColor'],
+    },
+  }
+  const newDifferentValue: JSXElementName = {
+    baseVariable: 'BetterReact',
+    propertyPath: {
+      propertyElements: ['style', 'backgroundColor'],
+    },
+  }
+
   it('same reference returns the same reference', () => {
-    const elementName: JSXElementName = {
-      baseVariable: 'React',
-      propertyPath: {
-        propertyElements: ['style', 'backgroundColor'],
-      },
-    }
-    const result = JSXElementNameKeepDeepEqualityCall()(elementName, elementName)
-    expect(result.value).toBe(elementName)
+    const result = JSXElementNameKeepDeepEqualityCall()(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const oldElementName: JSXElementName = {
-      baseVariable: 'React',
-      propertyPath: {
-        propertyElements: ['style', 'backgroundColor'],
-      },
-    }
-    const newElementName: JSXElementName = {
-      baseVariable: 'React',
-      propertyPath: {
-        propertyElements: ['style', 'backgroundColor'],
-      },
-    }
-    const result = JSXElementNameKeepDeepEqualityCall()(oldElementName, newElementName)
-    expect(result.value).toBe(oldElementName)
+    const result = JSXElementNameKeepDeepEqualityCall()(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const oldElementName: JSXElementName = {
+    const result = JSXElementNameKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.value.baseVariable).toBe(newDifferentValue.baseVariable)
+    expect(result.value.propertyPath).toBe(oldValue.propertyPath)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('EitherKeepDeepEquality', () => {
+  const oldLeftValue: Either<string, Array<number>> = left('left')
+  const newSameLeftValue: Either<string, Array<number>> = left('left')
+  const newDifferentLeftValue: Either<string, Array<number>> = left('right')
+
+  const oldRightValue: Either<string, Array<number>> = right([100])
+  const newSameRightValue: Either<string, Array<number>> = right([100])
+  const newDifferentRightValue: Either<string, Array<number>> = right([200])
+
+  const keepDeepEqualityFn = EitherKeepDeepEquality<string, Array<number>>(
+    createCallWithTripleEquals(),
+    arrayDeepEquality<number>(createCallWithTripleEquals()),
+  )
+  it('same reference returns the same reference', () => {
+    const leftResult = keepDeepEqualityFn(oldLeftValue, oldLeftValue)
+    expect(leftResult.value).toBe(oldLeftValue)
+    expect(leftResult.areEqual).toEqual(true)
+
+    const rightResult = keepDeepEqualityFn(oldRightValue, oldRightValue)
+    expect(rightResult.value).toBe(oldRightValue)
+    expect(rightResult.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const leftResult = keepDeepEqualityFn(oldLeftValue, newSameLeftValue)
+    expect(leftResult.value).toBe(oldLeftValue)
+    expect(leftResult.areEqual).toEqual(true)
+
+    const rightResult = keepDeepEqualityFn(oldRightValue, newSameRightValue)
+    expect(rightResult.value).toBe(oldRightValue)
+    expect(rightResult.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const leftResult = keepDeepEqualityFn(oldLeftValue, newDifferentLeftValue)
+    expect(leftResult.value.type).toBe(newDifferentLeftValue.type)
+    expect(leftResult.value.value).toBe(newDifferentLeftValue.value)
+    expect(leftResult.value).toEqual(newDifferentLeftValue)
+    expect(leftResult.areEqual).toEqual(false)
+
+    const rightResult = keepDeepEqualityFn(oldRightValue, newDifferentRightValue)
+    expect(rightResult.value.type).toBe(newDifferentRightValue.type)
+    expect(rightResult.value.value[0]).toBe(newDifferentRightValue.value[0])
+    expect(rightResult.value).toEqual(newDifferentRightValue)
+    expect(rightResult.areEqual).toEqual(false)
+  })
+})
+
+describe('NameAndIconResultKeepDeepEquality', () => {
+  const oldValue: NameAndIconResult = {
+    path: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+    name: {
       baseVariable: 'React',
       propertyPath: {
         propertyElements: ['style', 'backgroundColor'],
       },
-    }
-    const newElementName: JSXElementName = {
-      baseVariable: 'BetterReact',
+    },
+    label: 'label',
+    iconProps: {
+      type: 'magnifyingglass-larger',
+      color: 'main',
+      width: 18,
+      height: 18,
+    },
+  }
+  const newSameValue: NameAndIconResult = {
+    path: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+    name: {
+      baseVariable: 'React',
       propertyPath: {
         propertyElements: ['style', 'backgroundColor'],
       },
-    }
-    const result = JSXElementNameKeepDeepEqualityCall()(oldElementName, newElementName)
-    expect(result.value).toEqual(newElementName)
-    expect(result.value.baseVariable).toEqual(newElementName.baseVariable)
-    expect(result.value.propertyPath).toBe(oldElementName.propertyPath)
+    },
+    label: 'label',
+    iconProps: {
+      type: 'magnifyingglass-larger',
+      color: 'main',
+      width: 18,
+      height: 18,
+    },
+  }
+  const newDifferentValue: NameAndIconResult = {
+    path: EP.elementPath([['scene'], ['aaa', 'ccc']]),
+    name: {
+      baseVariable: 'React',
+      propertyPath: {
+        propertyElements: ['style', 'backgroundColor'],
+      },
+    },
+    label: 'label',
+    iconProps: {
+      type: 'magnifyingglass-small',
+      color: 'main',
+      width: 18,
+      height: 18,
+    },
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = NameAndIconResultKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = NameAndIconResultKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = NameAndIconResultKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value.path).toBe(newDifferentValue.path)
+    expect(result.value.name).toBe(oldValue.name)
+    expect(result.value.label).toBe(oldValue.label)
+    expect(result.value.iconProps).toBe(newDifferentValue.iconProps)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('NameAndIconResultArrayKeepDeepEquality', () => {
+  const oldValue: Array<NameAndIconResult> = [
+    {
+      path: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+      name: {
+        baseVariable: 'React',
+        propertyPath: {
+          propertyElements: ['style', 'backgroundColor'],
+        },
+      },
+      label: 'label',
+      iconProps: {
+        type: 'magnifyingglass-larger',
+        color: 'main',
+        width: 18,
+        height: 18,
+      },
+    },
+  ]
+  const newSameValue: Array<NameAndIconResult> = [
+    {
+      path: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+      name: {
+        baseVariable: 'React',
+        propertyPath: {
+          propertyElements: ['style', 'backgroundColor'],
+        },
+      },
+      label: 'label',
+      iconProps: {
+        type: 'magnifyingglass-larger',
+        color: 'main',
+        width: 18,
+        height: 18,
+      },
+    },
+  ]
+  const newDifferentValue: Array<NameAndIconResult> = [
+    {
+      path: EP.elementPath([['scene'], ['aaa', 'ccc']]),
+      name: {
+        baseVariable: 'React',
+        propertyPath: {
+          propertyElements: ['style', 'backgroundColor'],
+        },
+      },
+      label: 'label',
+      iconProps: {
+        type: 'magnifyingglass-small',
+        color: 'main',
+        width: 18,
+        height: 18,
+      },
+    },
+  ]
+
+  it('same reference returns the same reference', () => {
+    const result = NameAndIconResultArrayKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = NameAndIconResultArrayKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = NameAndIconResultArrayKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value[0].path).toBe(newDifferentValue[0].path)
+    expect(result.value[0].name).toBe(oldValue[0].name)
+    expect(result.value[0].label).toBe(oldValue[0].label)
+    expect(result.value[0].iconProps).toBe(newDifferentValue[0].iconProps)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('DropTargetHintKeepDeepEquality', () => {
+  const oldValue: DropTargetHint = {
+    target: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+    type: 'before',
+  }
+  const newSameValue: DropTargetHint = {
+    target: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+    type: 'before',
+  }
+  const newDifferentValue: DropTargetHint = {
+    target: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+    type: 'after',
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = DropTargetHintKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = DropTargetHintKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = DropTargetHintKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value.target).toBe(oldValue.target)
+    expect(result.value.type).toBe(newDifferentValue.type)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('NavigatorStateKeepDeepEquality', () => {
+  const oldValue: NavigatorState = {
+    minimised: false,
+    dropTargetHint: {
+      target: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+      type: 'before',
+    },
+    collapsedViews: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+    renamingTarget: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+  }
+  const newSameValue: NavigatorState = {
+    minimised: false,
+    dropTargetHint: {
+      target: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+      type: 'before',
+    },
+    collapsedViews: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+    renamingTarget: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+  }
+  const newDifferentValue: NavigatorState = {
+    minimised: true,
+    dropTargetHint: {
+      target: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+      type: 'before',
+    },
+    collapsedViews: [EP.elementPath([['scene'], ['aaa', 'bbb']])],
+    renamingTarget: EP.elementPath([['scene'], ['aaa', 'bbb']]),
+  }
+
+  it('same reference returns the same reference', () => {
+    const result = NavigatorStateKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = NavigatorStateKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = NavigatorStateKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value.minimised).toBe(newDifferentValue.minimised)
+    expect(result.value.dropTargetHint).toBe(oldValue.dropTargetHint)
+    expect(result.value.collapsedViews).toBe(oldValue.collapsedViews)
+    expect(result.value.renamingTarget).toBe(oldValue.renamingTarget)
+    expect(result.value).toEqual(newDifferentValue)
+    expect(result.areEqual).toEqual(false)
+  })
+})
+
+describe('LayoutTargetablePropArrayKeepDeepEquality', () => {
+  const oldValue: Array<LayoutTargetableProp> = ['width', 'height']
+  const newSameValue: Array<LayoutTargetableProp> = ['width', 'height']
+  const newDifferentValue: Array<LayoutTargetableProp> = ['left', 'top']
+
+  it('same reference returns the same reference', () => {
+    const result = LayoutTargetablePropArrayKeepDeepEquality(oldValue, oldValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('same value returns the same reference', () => {
+    const result = LayoutTargetablePropArrayKeepDeepEquality(oldValue, newSameValue)
+    expect(result.value).toBe(oldValue)
+    expect(result.areEqual).toEqual(true)
+  })
+  it('different but similar value handled appropriately', () => {
+    const result = LayoutTargetablePropArrayKeepDeepEquality(oldValue, newDifferentValue)
+    expect(result.value[0]).toBe(newDifferentValue[0])
+    expect(result.value[1]).toBe(newDifferentValue[1])
+    expect(result.value).toEqual(newDifferentValue)
     expect(result.areEqual).toEqual(false)
   })
 })

--- a/editor/src/utils/deep-equality-instances.ts
+++ b/editor/src/utils/deep-equality-instances.ts
@@ -64,7 +64,7 @@ export function EitherKeepDeepEquality<L, R>(
 ): KeepDeepEqualityCall<Either<L, R>> {
   type Result = KeepDeepEqualityResult<Either<L, R>>
   return (oldEither: Either<L, R>, newEither: Either<L, R>) => {
-    return foldEither<L, R, Result>(
+    const result = foldEither<L, R, Result>(
       (oldLeftValue) => {
         return foldEither<L, R, Result>(
           (newLeftValue) => {
@@ -91,6 +91,8 @@ export function EitherKeepDeepEquality<L, R>(
       },
       oldEither,
     )
+
+    return result.areEqual ? keepDeepEqualityResult(oldEither, true) : result
   }
 }
 
@@ -98,7 +100,7 @@ export const NameAndIconResultKeepDeepEquality: KeepDeepEqualityCall<NameAndIcon
   (result) => result.path,
   ElementPathKeepDeepEquality,
   (result) => result.name,
-  createCallWithTripleEquals(),
+  nullableDeepEquality(JSXElementNameKeepDeepEqualityCall()),
   (result) => result.label,
   createCallWithTripleEquals(),
   (result) => result.iconProps,


### PR DESCRIPTION
**Problem:**
A few of the `*KeepDeepEquality` instances were using incorrect equality functions, or incorrectly creating new objects, meaning we were failing reference equality checks later, indirectly leading to extra renders in some cases, or just excessively evaluation code blocks that were intended to be skipped.

**Fix:**
I've added tests for all of the instances to ensure they are working correctly, and fixed the offending ones. All of the tests are of the form:
```
describe('ThingKeepDeepEquality', () => {
  const oldValue: Thing = ...
  const newSameValue: Thing = ... // same value as oldValue, but explicitly created via a new reference
  const newDifferentValue: Thing = ... // almost the same value as oldValue, but with one minor change

  it('same reference returns the same reference', () => {
    const result = ThingKeepDeepEquality(oldValue, oldValue)
    expect(result.value).toBe(oldValue) // reference check
    expect(result.areEqual).toEqual(true)
  })
  it('same value returns the same reference', () => {
    const result = ThingKeepDeepEquality(oldValue, newSameValue)
    expect(result.value).toBe(oldValue) // reference check
    expect(result.areEqual).toEqual(true)
  })
  it('different but similar value handled appropriately', () => {
    const result = ThingKeepDeepEquality(oldValue, newDifferentValue)
    // individual expect calls to check that the unchanged values are referentially stable, and only the changed value has a new reference
    expect(result.value).toEqual(newDifferentValue) // Note the toEqual check here, since this is checking the value is equal, as the reference will have changed
    expect(result.areEqual).toEqual(false)
  })
```

**Note:**
I appreciate the size of the PR, but 99% of it is purely the addition of these new tests, so feel free to skim those.
The actual individual fixes of interest are in the non-spec files of course :)
