### PR TITLE
Improving the canvas scroll css vars

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -334,19 +334,8 @@ const DesignPanelRootInner = React.memo(() => {
 })
 
 export const DesignPanelRoot = React.memo(() => {
-  const roundedCanvasOffset = useEditorState(
-    (store) => store.editor.canvas.roundedCanvasOffset,
-    'DesignPanelRoot roundedCanvasOffset',
-  )
-
   return (
     <>
-      <style>{`
-      .utopia-css-var-container {
-        --utopia-canvas-offset-x: ${roundedCanvasOffset.x}px;
-        --utopia-canvas-offset-y: ${roundedCanvasOffset.y}px;
-      }
-    `}</style>
       <SimpleFlexRow
         className='OpenFileEditorShell'
         style={{

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -348,7 +348,7 @@ export const DesignPanelRoot = React.memo(() => {
       }
     `}</style>
       <SimpleFlexRow
-        className='OpenFileEditorShell utopia-css-var-container'
+        className='OpenFileEditorShell'
         style={{
           position: 'relative',
           flexGrow: 1,

--- a/editor/src/components/canvas/utopia-canvas-vars.tsx
+++ b/editor/src/components/canvas/utopia-canvas-vars.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { useEditorState } from '../editor/store/store-hook'
+
+export const UtopiaCanvasVarStyleTag = React.memo(() => {
+  const roundedCanvasOffset = useEditorState(
+    (store) => store.editor.canvas.roundedCanvasOffset,
+    'DesignPanelRoot roundedCanvasOffset',
+  )
+
+  return (
+    <style>{`
+  .utopia-canvas-var-container {
+    --utopia-canvas-offset-x: ${roundedCanvasOffset.x}px;
+    --utopia-canvas-offset-y: ${roundedCanvasOffset.y}px;
+  }
+`}</style>
+  )
+})

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -1,5 +1,6 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
+/** @jsxFrag React.Fragment */
 import { jsx } from '@emotion/react'
 import { ResizeDirection } from 're-resizable'
 import React from 'react'
@@ -51,6 +52,7 @@ import {
 import { createIframeUrl, projectURLForProject } from '../../core/shared/utils'
 import { setBranchNameFromURL } from '../../utils/branches'
 import { FatalIndexedDBErrorComponent } from './fatal-indexeddb-error-component'
+import { UtopiaCanvasVarStyleTag } from '../canvas/utopia-canvas-vars'
 
 function pushProjectURLToBrowserHistory(projectId: string, projectName: string): void {
   // Make sure we don't replace the query params
@@ -215,115 +217,118 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
   }, 'EditorComponentInner vscodeBridgeReady')
 
   return (
-    <SimpleFlexRow
-      className='editor-main-vertical-and-modals'
-      style={{
-        height: '100%',
-        width: '100%',
-        overscrollBehaviorX: 'contain',
-      }}
-      onDragEnter={startDragInsertion}
-    >
-      <SimpleFlexColumn
-        className='editor-main-vertical'
+    <>
+      <UtopiaCanvasVarStyleTag />
+      <SimpleFlexRow
+        className='editor-main-vertical-and-modals'
         style={{
           height: '100%',
           width: '100%',
+          overscrollBehaviorX: 'contain',
         }}
+        onDragEnter={startDragInsertion}
       >
-        {(isChrome as boolean) ? null : <BrowserInfoBar />}
-        <LoginStatusBar />
-
-        <SimpleFlexRow
-          className='editor-main-horizontal'
+        <SimpleFlexColumn
+          className='editor-main-vertical'
           style={{
+            height: '100%',
             width: '100%',
-            flexGrow: 1,
-            overflowY: 'hidden',
-            alignItems: 'stretch',
           }}
         >
-          <SimpleFlexColumn
-            style={{
-              height: '100%',
-              width: 44,
-              backgroundColor: colorTheme.leftMenuBackground.value,
-            }}
-          >
-            <Menubar />
-          </SimpleFlexColumn>
-          <div
-            className='LeftPaneShell'
-            style={{
-              height: '100%',
-              flexShrink: 0,
-              transition: 'all .1s ease-in-out',
-              width: leftMenuExpanded ? LeftPaneDefaultWidth : 0,
-              overflowX: 'scroll',
-              backgroundColor: colorTheme.leftPaneBackground.value,
-            }}
-          >
-            {delayedLeftMenuExpanded ? <LeftPaneComponent /> : null}
-          </div>
+          {(isChrome as boolean) ? null : <BrowserInfoBar />}
+          <LoginStatusBar />
+
           <SimpleFlexRow
-            className='editor-shell'
+            className='editor-main-horizontal'
             style={{
+              width: '100%',
               flexGrow: 1,
+              overflowY: 'hidden',
               alignItems: 'stretch',
-              borderRight: `1px solid ${colorTheme.neutralBorder.value}`,
-              backgroundColor: colorTheme.neutralBackground.value,
             }}
           >
+            <SimpleFlexColumn
+              style={{
+                height: '100%',
+                width: 44,
+                backgroundColor: colorTheme.leftMenuBackground.value,
+              }}
+            >
+              <Menubar />
+            </SimpleFlexColumn>
+            <div
+              className='LeftPaneShell'
+              style={{
+                height: '100%',
+                flexShrink: 0,
+                transition: 'all .1s ease-in-out',
+                width: leftMenuExpanded ? LeftPaneDefaultWidth : 0,
+                overflowX: 'scroll',
+                backgroundColor: colorTheme.leftPaneBackground.value,
+              }}
+            >
+              {delayedLeftMenuExpanded ? <LeftPaneComponent /> : null}
+            </div>
             <SimpleFlexRow
-              className='openTabShell'
+              className='editor-shell'
               style={{
                 flexGrow: 1,
                 alignItems: 'stretch',
-                justifyContent: 'stretch',
-                overflowX: 'hidden',
+                borderRight: `1px solid ${colorTheme.neutralBorder.value}`,
+                backgroundColor: colorTheme.neutralBackground.value,
               }}
             >
-              <DesignPanelRoot />
-            </SimpleFlexRow>
-            {/* insert more columns here */}
-
-            {previewVisible ? (
-              <ResizableFlexColumn
-                style={{ borderLeft: `1px solid ${colorTheme.secondaryBorder.value}` }}
-                enable={{
-                  left: true,
-                  right: false,
-                }}
-                defaultSize={{
-                  width: 350,
-                  height: '100%',
+              <SimpleFlexRow
+                className='openTabShell'
+                style={{
+                  flexGrow: 1,
+                  alignItems: 'stretch',
+                  justifyContent: 'stretch',
+                  overflowX: 'hidden',
                 }}
               >
-                <SimpleFlexRow
-                  id='PreviewTabRail'
-                  style={{
-                    height: UtopiaTheme.layout.rowHeight.smaller,
-                    borderBottom: `1px solid ${colorTheme.subduedBorder.value}`,
-                    alignItems: 'stretch',
+                <DesignPanelRoot />
+              </SimpleFlexRow>
+              {/* insert more columns here */}
+
+              {previewVisible ? (
+                <ResizableFlexColumn
+                  style={{ borderLeft: `1px solid ${colorTheme.secondaryBorder.value}` }}
+                  enable={{
+                    left: true,
+                    right: false,
+                  }}
+                  defaultSize={{
+                    width: 350,
+                    height: '100%',
                   }}
                 >
-                  <TabComponent
-                    label='Preview'
-                    selected
-                    icon={<LargerIcons.PreviewPane color='primary' />}
-                    onClose={onClosePreview}
-                  />
-                </SimpleFlexRow>
-                <PreviewColumn />
-              </ResizableFlexColumn>
-            ) : null}
+                  <SimpleFlexRow
+                    id='PreviewTabRail'
+                    style={{
+                      height: UtopiaTheme.layout.rowHeight.smaller,
+                      borderBottom: `1px solid ${colorTheme.subduedBorder.value}`,
+                      alignItems: 'stretch',
+                    }}
+                  >
+                    <TabComponent
+                      label='Preview'
+                      selected
+                      icon={<LargerIcons.PreviewPane color='primary' />}
+                      onClose={onClosePreview}
+                    />
+                  </SimpleFlexRow>
+                  <PreviewColumn />
+                </ResizableFlexColumn>
+              ) : null}
+            </SimpleFlexRow>
           </SimpleFlexRow>
-        </SimpleFlexRow>
-      </SimpleFlexColumn>
-      <ModalComponent />
-      <ToastRenderer />
-      <EditorCursorComponent />
-    </SimpleFlexRow>
+        </SimpleFlexColumn>
+        <ModalComponent />
+        <ToastRenderer />
+        <EditorCursorComponent />
+      </SimpleFlexRow>
+    </>
   )
 })
 

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -696,7 +696,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         id: 'canvas-root',
         key: 'canvas-root',
         'data-testid': 'canvas-root',
-        className: 'utopia-css-var-container',
+        className: 'utopia-canvas-var-container',
         style: {
           ...canvasLiveEditingStyle,
           transition: 'all .2s linear',

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -696,6 +696,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         id: 'canvas-root',
         key: 'canvas-root',
         'data-testid': 'canvas-root',
+        className: 'utopia-css-var-container',
         style: {
           ...canvasLiveEditingStyle,
           transition: 'all .2s linear',


### PR DESCRIPTION
**Problem:**
The `.utopia-css-var-container` was placed very high up in the editor's component hierarchy, beacuse I thought we might benefit from a global store of css vars. But it turned out that placement caused a performance issue: every time the canvas would scroll and the canvas offset css-vars would update, we would incur a very heavy `Recalculating Style` penalty seemingly mostly coming from the (unchanged) Inspector.

**Fix:**
By moving down the `.utopia-css-var-container` to the canvas root, the inspector and other editor chrome is left out of the affected scope on a canvas scroll. In @enidemi and my measurements this shrunk Recalculating Style to 10-20% of its original size.

**Commit Details:**
- Move `.utopia-css-var-container` to the canvas-root and rename it to `.utopia-canvas-var-container`
- Move the css-var-providing style tag into its own component `UtopiaCanvasVarStyleTag`
- Move`UtopiaCanvasVarStyleTag` out of DesignPanelRoot, up into the EditorComponent

