### PR TITLE
Force explicit choice of unpatched vs patched state in dispatch

### DIFF
--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -59,6 +59,7 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
 
   const initialEditorStore: EditorStore = {
     unpatchedEditor: emptyEditorState,
+    patchedEditor: emptyEditorState,
     editor: emptyEditorState,
     derived: derivedState,
     history: history,

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -220,6 +220,7 @@ export async function renderTestEditorWithModel(
       : createBuiltInDependenciesList(workers)
   const initialEditorStore: EditorStore = {
     unpatchedEditor: emptyEditorState,
+    patchedEditor: emptyEditorState,
     editor: emptyEditorState,
     derived: derivedState,
     history: history,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -242,9 +242,9 @@ export const defaultUserState: UserState = {
   shortcutConfig: {},
 }
 
-export type EditorStore = {
+export type EditorStoreExplicit = {
   unpatchedEditor: EditorState
-  editor: EditorState
+  patchedEditor: EditorState
   derived: DerivedState
   history: StateHistory
   userState: UserState
@@ -253,6 +253,10 @@ export type EditorStore = {
   dispatch: EditorDispatch
   builtInDependencies: BuiltInDependencies
   alreadySaved: boolean
+}
+
+export type EditorStore = EditorStoreExplicit & {
+  editor: EditorState
 }
 
 export interface FileDeleteModal {

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -13,6 +13,7 @@ function createEmptyEditorStoreHook() {
 
   const initialEditorStore: EditorStore = {
     unpatchedEditor: emptyEditorState,
+    patchedEditor: emptyEditorState,
     editor: emptyEditorState,
     derived: null as any,
     history: null as any,

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -46,6 +46,7 @@ export function getStoreHook(
   ])
   const defaultState: EditorStore = {
     unpatchedEditor: editor.editor,
+    patchedEditor: editor.editor,
     editor: editor.editor,
     derived: editor.derivedState,
     history: {

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -49,6 +49,7 @@ function getPaddingHookResult<P extends ParsedPropertiesKeys, S extends ParsedPr
 
     const initialEditorStore: EditorStore = {
       unpatchedEditor: null as any,
+      patchedEditor: null as any,
       editor: null as any,
       derived: null as any,
       history: null as any,

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -176,6 +176,7 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
 
   const initialEditorStore: EditorStore = {
     unpatchedEditor: editorState,
+    patchedEditor: editorState,
     editor: editorState,
     derived: null as any,
     history: null as any,

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -137,6 +137,7 @@ export class Editor {
 
     this.storedState = {
       unpatchedEditor: emptyEditorState,
+      patchedEditor: emptyEditorState,
       editor: emptyEditorState,
       derived: derivedState,
       history: history,


### PR DESCRIPTION
**Problem:**
With the introduction of `unpatchedEditor` as part of the canvas interactions investigation, we were incorrectly reading from the patched state during the dispatch function, whilst making changes to the unpatched state. This is suspected to be related to a number of recent regressions in the editor.

**Fix:**
Force the choice of unpatched vs patched to be explicit when working inside the dispatch function.

I'm actually not sure if this is enough, so I'm tempted to completely remove the `editor` field from `EditorStore`, as I fear we could also be updating that directly or indirectly elsewhere via object spreads, which this change won't protect us against.
