### PR TITLE
Remove ambiguous "editor" field from EditorStore

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -11,7 +11,6 @@ import {
   DerivedState,
   EditorState,
   getMetadata,
-  EditorStore,
   getOpenUIJSFileKey,
   TransientCanvasState,
   TransientFilesState,

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -59,6 +59,7 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
 
   const initialEditorStore: EditorStore = {
     unpatchedEditor: emptyEditorState,
+    patchedEditor: emptyEditorState,
     editor: emptyEditorState,
     derived: derivedState,
     history: history,

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -18,7 +18,12 @@ import { EditorDispatch } from '../editor/action-types'
 import { load } from '../editor/actions/actions'
 import * as History from '../editor/history'
 import { editorDispatch } from '../editor/store/dispatch'
-import { createEditorState, deriveState, EditorStore } from '../editor/store/editor-state'
+import {
+  createEditorState,
+  deriveState,
+  EditorStorePatched,
+  patchedStoreFromFullStore,
+} from '../editor/store/editor-state'
 import Utils from '../../utils/utils'
 import { BakedInStoryboardUID } from '../../core/model/scene-utils'
 import { NO_OP } from '../../core/shared/utils'
@@ -53,13 +58,17 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
   const spyCollector = emptyUiJsxCanvasContextData()
 
   const dispatch: EditorDispatch = (actions) => {
-    const result = editorDispatch(dispatch, actions, storeHook.getState(), spyCollector)
-    storeHook.setState(result)
+    const storedState = storeHook.getState()
+    const result = editorDispatch(
+      dispatch,
+      actions,
+      { ...storedState, unpatchedEditor: storedState.editor, patchedEditor: storedState.editor },
+      spyCollector,
+    )
+    storeHook.setState(patchedStoreFromFullStore(result))
   }
 
-  const initialEditorStore: EditorStore = {
-    unpatchedEditor: emptyEditorState,
-    patchedEditor: emptyEditorState,
+  const initialEditorStore: EditorStorePatched = {
     editor: emptyEditorState,
     derived: derivedState,
     history: history,
@@ -78,7 +87,7 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
     builtInDependencies: createBuiltInDependenciesList(null),
   }
 
-  const storeHook = create<EditorStore>((set) => initialEditorStore)
+  const storeHook = create<EditorStorePatched>((set) => initialEditorStore)
 
   render(<EditorRoot api={storeHook} useStore={storeHook} spyCollector={spyCollector} />)
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper-third-party.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper-third-party.spec.browser2.tsx
@@ -19,7 +19,7 @@ import {
   domWalkerMetadataToSimplifiedMetadataMap,
 } from '../../../utils/utils.test-utils'
 import { addFileToProjectContents } from '../../assets'
-import type { EditorStore } from '../../editor/store/editor-state'
+import type { EditorStorePatched } from '../../editor/store/editor-state'
 import { StoryboardFilePath } from '../../editor/store/editor-state'
 import { applyUIDMonkeyPatch } from '../../../utils/canvas-react-utils'
 import { matchInlineSnapshotBrowser } from '../../../../test/karma-snapshots'
@@ -138,7 +138,7 @@ function renderTestProject() {
   return renderTestEditorWithModel(updatedProject, 'await-first-dom-report', builtInDependencies)
 }
 
-async function waitForFullMetadata(getEditorState: () => EditorStore): Promise<true> {
+async function waitForFullMetadata(getEditorState: () => EditorStorePatched): Promise<true> {
   let foundMetadata = false
   let totalWaitTime = 0
   do {

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -61,7 +61,9 @@ import {
   createEditorState,
   deriveState,
   EditorState,
-  EditorStore,
+  EditorStoreFull,
+  EditorStorePatched,
+  patchedStoreFromFullStore,
   PersistentModel,
   persistentModelForProjectContents,
   StoryboardFilePath,
@@ -143,7 +145,7 @@ export async function renderTestEditorWithModel(
   dispatch: (actions: ReadonlyArray<EditorAction>, waitForDOMReport: boolean) => Promise<void>
   getDomReportDispatched: () => Promise<void>
   getDispatchFollowUpactionsFinished: () => Promise<void>
-  getEditorState: () => EditorStore
+  getEditorState: () => EditorStorePatched
   renderedDOM: RenderResult
   getNumberOfCommits: () => number
   getNumberOfRenders: () => number
@@ -168,10 +170,10 @@ export async function renderTestEditorWithModel(
 
   resetPromises()
 
-  let workingEditorState: EditorStore
+  let workingEditorState: EditorStoreFull
 
   function updateEditor() {
-    storeHook.setState(workingEditorState)
+    storeHook.setState(patchedStoreFromFullStore(workingEditorState))
   }
 
   const spyCollector = emptyUiJsxCanvasContextData()
@@ -218,10 +220,9 @@ export async function renderTestEditorWithModel(
     mockBuiltInDependencies != null
       ? mockBuiltInDependencies
       : createBuiltInDependenciesList(workers)
-  const initialEditorStore: EditorStore = {
+  const initialEditorStore: EditorStoreFull = {
     unpatchedEditor: emptyEditorState,
     patchedEditor: emptyEditorState,
-    editor: emptyEditorState,
     derived: derivedState,
     history: history,
     userState: {
@@ -235,10 +236,12 @@ export async function renderTestEditorWithModel(
     builtInDependencies: builtInDependencies,
   }
 
-  const storeHook = create<EditorStore>((set) => initialEditorStore)
+  const storeHook = create<EditorStorePatched>((set) =>
+    patchedStoreFromFullStore(initialEditorStore),
+  )
 
   // initializing the local editor state
-  workingEditorState = storeHook.getState()
+  workingEditorState = initialEditorStore
 
   let numberOfCommits = 0
 
@@ -308,7 +311,7 @@ export async function renderTestEditorWithModel(
 }
 
 export function getPrintedUiJsCode(
-  store: EditorStore,
+  store: EditorStorePatched,
   filePath: string = StoryboardFilePath,
 ): string {
   const file = getContentsTreeFileFromString(store.editor.projectContents, filePath)
@@ -319,7 +322,7 @@ export function getPrintedUiJsCode(
   }
 }
 
-export function getPrintedUiJsCodeWithoutUIDs(store: EditorStore): string {
+export function getPrintedUiJsCodeWithoutUIDs(store: EditorStorePatched): string {
   const file = getContentsTreeFileFromString(store.editor.projectContents, StoryboardFilePath)
   if (isTextFile(file) && isParseSuccess(file.fileContents.parsed)) {
     return printCode(

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -220,6 +220,7 @@ export async function renderTestEditorWithModel(
       : createBuiltInDependenciesList(workers)
   const initialEditorStore: EditorStore = {
     unpatchedEditor: emptyEditorState,
+    patchedEditor: emptyEditorState,
     editor: emptyEditorState,
     derived: derivedState,
     history: history,

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -453,7 +453,7 @@ export function editorDispatch(
 
   const patchedEditorState = applyStatePatches(
     frozenEditorState,
-    storedState.unpatchedEditor,
+    storedState.patchedEditor,
     frozenDerivedState.canvas.transientState.editorStatePatch,
   )
 

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -94,15 +94,15 @@ import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { isJsOrTsFile, isCssFile } from '../../../core/shared/file-utils'
 import { applyStatePatches } from '../../canvas/commands/commands'
 
-interface DispatchResultFields {
+type DispatchResultFields = {
   nothingChanged: boolean
   entireUpdateFinished: Promise<any>
 }
 
 type EditorStoreUnpatched = Omit<EditorStoreFull, 'patchedEditor'>
 
-export interface InnerDispatchResult extends EditorStoreUnpatched, DispatchResultFields {}
-export interface DispatchResult extends EditorStoreFull, DispatchResultFields {}
+type InnerDispatchResult = EditorStoreUnpatched & DispatchResultFields
+export type DispatchResult = EditorStoreFull & DispatchResultFields
 
 function simpleStringifyAction(action: EditorAction): string {
   switch (action.action) {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -242,9 +242,7 @@ export const defaultUserState: UserState = {
   shortcutConfig: {},
 }
 
-export type EditorStoreExplicit = {
-  unpatchedEditor: EditorState
-  patchedEditor: EditorState
+type EditorStoreShared = {
   derived: DerivedState
   history: StateHistory
   userState: UserState
@@ -255,8 +253,20 @@ export type EditorStoreExplicit = {
   alreadySaved: boolean
 }
 
-export type EditorStore = EditorStoreExplicit & {
+export type EditorStoreFull = EditorStoreShared & {
+  unpatchedEditor: EditorState
+  patchedEditor: EditorState
+}
+
+export type EditorStorePatched = EditorStoreShared & {
   editor: EditorState
+}
+
+export function patchedStoreFromFullStore(store: EditorStoreFull): EditorStorePatched {
+  return {
+    ...store,
+    editor: store.patchedEditor,
+  }
 }
 
 export interface FileDeleteModal {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -242,9 +242,9 @@ export const defaultUserState: UserState = {
   shortcutConfig: {},
 }
 
-export type EditorStore = {
+export type EditorStoreExplicit = {
   unpatchedEditor: EditorState
-  editor: EditorState
+  patchedEditor: EditorState
   derived: DerivedState
   history: StateHistory
   userState: UserState
@@ -253,6 +253,10 @@ export type EditorStore = {
   dispatch: EditorDispatch
   builtInDependencies: BuiltInDependencies
   alreadySaved: boolean
+}
+
+export type EditorStore = EditorStoreExplicit & {
+  editor: EditorState
 }
 
 export interface FileDeleteModal {

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -13,6 +13,7 @@ function createEmptyEditorStoreHook() {
 
   const initialEditorStore: EditorStore = {
     unpatchedEditor: emptyEditorState,
+    patchedEditor: emptyEditorState,
     editor: emptyEditorState,
     derived: null as any,
     history: null as any,

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import create, { UseStore } from 'zustand'
 import { renderHook } from '@testing-library/react-hooks'
 import { EditorStateContext, useSelectorWithCallback } from './store-hook'
-import { createEditorState, EditorState, EditorStore } from './editor-state'
+import { createEditorState, EditorState, EditorStorePatched } from './editor-state'
 import { NO_OP } from '../../../core/shared/utils'
 import * as EP from '../../../core/shared/element-path'
 import { shallowEqual } from '../../../core/shared/equality-utils'
@@ -11,9 +11,7 @@ import { createBuiltInDependenciesList } from '../../../core/es-modules/package-
 function createEmptyEditorStoreHook() {
   let emptyEditorState = createEditorState(NO_OP)
 
-  const initialEditorStore: EditorStore = {
-    unpatchedEditor: emptyEditorState,
-    patchedEditor: emptyEditorState,
+  const initialEditorStore: EditorStorePatched = {
     editor: emptyEditorState,
     derived: null as any,
     history: null as any,
@@ -25,13 +23,13 @@ function createEmptyEditorStoreHook() {
     builtInDependencies: createBuiltInDependenciesList(null),
   }
 
-  const storeHook = create<EditorStore>((set) => initialEditorStore)
+  const storeHook = create<EditorStorePatched>((set) => initialEditorStore)
 
   return storeHook
 }
 
 const ContextProvider: React.FunctionComponent<{
-  storeHook: UseStore<EditorStore>
+  storeHook: UseStore<EditorStorePatched>
 }> = ({ storeHook, children }) => {
   return (
     <EditorStateContext.Provider value={{ api: storeHook, useStore: storeHook }}>
@@ -47,7 +45,7 @@ describe('useSelectorWithCallback', () => {
     let hookRenders = 0
     let callCount = 0
 
-    const { result } = renderHook<{ storeHook: UseStore<EditorStore> }, void>(
+    const { result } = renderHook<{ storeHook: UseStore<EditorStorePatched> }, void>(
       (props) => {
         hookRenders++
         return useSelectorWithCallback(
@@ -75,7 +73,7 @@ describe('useSelectorWithCallback', () => {
     let hookRenders = 0
     let callCount = 0
 
-    const { result } = renderHook<{ storeHook: UseStore<EditorStore> }, void>(
+    const { result } = renderHook<{ storeHook: UseStore<EditorStorePatched> }, void>(
       (props) => {
         hookRenders++
         return useSelectorWithCallback(
@@ -123,7 +121,7 @@ describe('useSelectorWithCallback', () => {
       (store) => store.editor.selectedViews,
     )
 
-    const { result, rerender } = renderHook<{ storeHook: UseStore<EditorStore> }, void>(
+    const { result, rerender } = renderHook<{ storeHook: UseStore<EditorStorePatched> }, void>(
       (props) => {
         hookRenders++
         return useSelectorWithCallback(

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -13,7 +13,7 @@ import { createEditorStates } from '../../../utils/utils.test-utils'
 import utils from '../../../utils/utils'
 import { EditorDispatch } from '../../editor/action-types'
 import {
-  EditorStore,
+  EditorStorePatched,
   modifyOpenJsxElementAtStaticPath,
   defaultUserState,
   StoryboardFilePath,
@@ -34,8 +34,8 @@ import { createBuiltInDependenciesList } from '../../../core/es-modules/package-
 import { NO_OP } from '../../../core/shared/utils'
 
 type UpdateFunctionHelpers = {
-  updateStoreWithImmer: (fn: (store: EditorStore) => void) => void
-  updateStore: (fn: (store: EditorStore) => EditorStore) => void
+  updateStoreWithImmer: (fn: (store: EditorStorePatched) => void) => void
+  updateStore: (fn: (store: EditorStorePatched) => EditorStorePatched) => void
 }
 
 export function getStoreHook(
@@ -44,9 +44,7 @@ export function getStoreHook(
   const editor = createEditorStates([
     EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa', 'bbb']),
   ])
-  const defaultState: EditorStore = {
-    unpatchedEditor: editor.editor,
-    patchedEditor: editor.editor,
+  const defaultState: EditorStorePatched = {
     editor: editor.editor,
     derived: editor.derivedState,
     history: {
@@ -62,10 +60,10 @@ export function getStoreHook(
     builtInDependencies: createBuiltInDependenciesList(null),
   }
 
-  const storeHook = create<EditorStore & UpdateFunctionHelpers>((set) => ({
+  const storeHook = create<EditorStorePatched & UpdateFunctionHelpers>((set) => ({
     ...defaultState,
-    updateStoreWithImmer: (fn: (store: EditorStore) => void) => set(produce(fn)),
-    updateStore: (fn: (store: EditorStore) => EditorStore) => set(fn),
+    updateStoreWithImmer: (fn: (store: EditorStorePatched) => void) => set(produce(fn)),
+    updateStore: (fn: (store: EditorStorePatched) => EditorStorePatched) => set(fn),
   }))
   return {
     api: storeHook,
@@ -89,10 +87,10 @@ export const TestInspectorContextProvider: React.FunctionComponent<{
 }
 
 export function editPropOfSelectedView(
-  store: EditorStore,
+  store: EditorStorePatched,
   path: PropertyPath,
   newValue: number | string,
-): EditorStore {
+): EditorStorePatched {
   return {
     ...store,
     editor: modifyOpenJsxElementAtStaticPath(

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -46,6 +46,7 @@ export function getStoreHook(
   ])
   const defaultState: EditorStore = {
     unpatchedEditor: editor.editor,
+    patchedEditor: editor.editor,
     editor: editor.editor,
     derived: editor.derivedState,
     history: {

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -13,7 +13,7 @@ import {
   getPropsForStyleProp,
   makeInspectorHookContextProvider,
 } from './property-path-hooks.test-utils'
-import { EditorStore } from '../../editor/store/editor-state'
+import { EditorStorePatched } from '../../editor/store/editor-state'
 import create from 'zustand'
 import { EditorStateContext } from '../../editor/store/store-hook'
 import * as EP from '../../../core/shared/element-path'
@@ -47,9 +47,7 @@ function getPaddingHookResult<P extends ParsedPropertiesKeys, S extends ParsedPr
       attributeMetadatas,
     )
 
-    const initialEditorStore: EditorStore = {
-      unpatchedEditor: null as any,
-      patchedEditor: null as any,
+    const initialEditorStore: EditorStorePatched = {
       editor: null as any,
       derived: null as any,
       history: null as any,
@@ -61,7 +59,7 @@ function getPaddingHookResult<P extends ParsedPropertiesKeys, S extends ParsedPr
       builtInDependencies: [],
     }
 
-    const storeHook = create<EditorStore>(() => initialEditorStore)
+    const storeHook = create<EditorStorePatched>(() => initialEditorStore)
 
     return (
       <EditorStateContext.Provider value={{ api: storeHook, useStore: storeHook }}>

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -49,6 +49,7 @@ function getPaddingHookResult<P extends ParsedPropertiesKeys, S extends ParsedPr
 
     const initialEditorStore: EditorStore = {
       unpatchedEditor: null as any,
+      patchedEditor: null as any,
       editor: null as any,
       derived: null as any,
       history: null as any,

--- a/editor/src/components/inspector/common/name-and-icon-hook.ts
+++ b/editor/src/components/inspector/common/name-and-icon-hook.ts
@@ -9,7 +9,7 @@ import {
   NameAndIconResultKeepDeepEquality,
 } from '../../../utils/deep-equality-instances'
 import { createSelector } from 'reselect'
-import { EditorStore } from '../../editor/store/editor-state'
+import { EditorStorePatched } from '../../editor/store/editor-state'
 import React from 'react'
 
 export interface NameAndIconResult {
@@ -24,7 +24,7 @@ export function useMetadata(): ElementInstanceMetadataMap {
 }
 
 const namesAndIconsAllPathsResultSelector = createSelector(
-  (store: EditorStore) => store.editor.jsxMetadata,
+  (store: EditorStorePatched) => store.editor.jsxMetadata,
   (metadata) => {
     return MetadataUtils.getAllPaths(metadata).map((path) => {
       return getNameAndIconResult(path, metadata)

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -7,7 +7,7 @@ import create from 'zustand'
 import {
   editorModelFromPersistentModel,
   EditorState,
-  EditorStore,
+  EditorStorePatched,
 } from '../../editor/store/editor-state'
 import { NO_OP } from '../../../core/shared/utils'
 import * as EP from '../../../core/shared/element-path'
@@ -174,9 +174,7 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
     jsxMetadata: metadata,
   }
 
-  const initialEditorStore: EditorStore = {
-    unpatchedEditor: editorState,
-    patchedEditor: editorState,
+  const initialEditorStore: EditorStorePatched = {
     editor: editorState,
     derived: null as any,
     history: null as any,
@@ -188,7 +186,7 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
     builtInDependencies: [],
   }
 
-  const storeHook = create<EditorStore>((set) => initialEditorStore)
+  const storeHook = create<EditorStorePatched>((set) => initialEditorStore)
 
   const inspectorCallbackContext: InspectorCallbackContextData = {
     selectedViewsRef: { current: selectedViews },

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -176,6 +176,7 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
 
   const initialEditorStore: EditorStore = {
     unpatchedEditor: editorState,
+    patchedEditor: editorState,
     editor: editorState,
     derived: null as any,
     history: null as any,

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -37,7 +37,7 @@ import {
 } from '../editor/actions/action-creators'
 
 import {
-  EditorStore,
+  EditorStorePatched,
   getJSXComponentsAndImportsForPathFromState,
   getOpenUtopiaJSXComponentsFromStateMultifile,
   isOpenFileUiJs,
@@ -544,9 +544,9 @@ export const SingleInspectorEntryPoint: React.FunctionComponent<{
 })
 
 const rootComponentsSelector = createSelector(
-  (store: EditorStore) => store.editor.projectContents,
-  (store: EditorStore) => store.editor.codeResultCache.curriedResolveFn,
-  (store: EditorStore) => store.editor.canvas.openFile?.filename ?? null,
+  (store: EditorStorePatched) => store.editor.projectContents,
+  (store: EditorStorePatched) => store.editor.codeResultCache.curriedResolveFn,
+  (store: EditorStorePatched) => store.editor.canvas.openFile?.filename ?? null,
   (projectContents, curriedResolveFn, openFilePath) => {
     const resolveFn = curriedResolveFn(projectContents)
     return getOpenUtopiaJSXComponentsFromStateMultifile(projectContents, resolveFn, openFilePath)

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -19,7 +19,7 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import {
   defaultElementWarnings,
   DropTargetHint,
-  EditorStore,
+  EditorStorePatched,
   TransientFileState,
 } from '../../editor/store/editor-state'
 import { UtopiaJSXComponent, isUtopiaJSXComponent } from '../../../core/shared/element-template'
@@ -51,15 +51,15 @@ interface NavigatorItemWrapperProps {
 
 const navigatorItemWrapperSelectorFactory = (elementPath: ElementPath) =>
   createSelector(
-    (store: EditorStore) => store.editor.jsxMetadata,
-    (store: EditorStore) => store.editor.selectedViews,
-    (store: EditorStore) => store.editor.highlightedViews,
-    (store: EditorStore) => store.derived.canvas.transientState,
-    (store: EditorStore) => store.derived.navigatorTargets,
-    (store: EditorStore) => store.derived.elementWarnings,
-    (store: EditorStore) => store.editor.projectContents,
-    (store: EditorStore) => store.editor.nodeModules.files,
-    (store: EditorStore) => store.editor.canvas.openFile?.filename ?? null,
+    (store: EditorStorePatched) => store.editor.jsxMetadata,
+    (store: EditorStorePatched) => store.editor.selectedViews,
+    (store: EditorStorePatched) => store.editor.highlightedViews,
+    (store: EditorStorePatched) => store.derived.canvas.transientState,
+    (store: EditorStorePatched) => store.derived.navigatorTargets,
+    (store: EditorStorePatched) => store.derived.elementWarnings,
+    (store: EditorStorePatched) => store.editor.projectContents,
+    (store: EditorStorePatched) => store.editor.nodeModules.files,
+    (store: EditorStorePatched) => store.editor.canvas.openFile?.filename ?? null,
     (
       jsxMetadata,
       selectedViews,

--- a/editor/src/core/shared/redux-devtools.ts
+++ b/editor/src/core/shared/redux-devtools.ts
@@ -1,5 +1,5 @@
 import type { EditorAction } from '../../components/editor/action-types'
-import type { EditorStore } from '../../components/editor/store/editor-state'
+import type { EditorStoreFull } from '../../components/editor/store/editor-state'
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import { pluck } from './array-utils'
 import { ElementInstanceMetadata, ElementInstanceMetadataMap } from './element-template'
@@ -79,17 +79,17 @@ function simplifiedMetadataMap(metadata: ElementInstanceMetadataMap) {
 }
 
 type SanitizedState = ReturnType<typeof sanitizeLoggedState>
-function sanitizeLoggedState(store: EditorStore) {
+function sanitizeLoggedState(store: EditorStoreFull) {
   return {
     ...store,
-    editor: {
-      ...store.editor,
-      spyMetadata: simplifiedMetadataMap(store.editor.jsxMetadata),
-      domMetadata: store.editor.domMetadata.map(simplifiedMetadata),
-      jsxMetadata: simplifiedMetadataMap(store.editor.jsxMetadata),
+    unpatchedEditor: {
+      ...store.unpatchedEditor,
+      spyMetadata: simplifiedMetadataMap(store.unpatchedEditor.jsxMetadata),
+      domMetadata: store.unpatchedEditor.domMetadata.map(simplifiedMetadata),
+      jsxMetadata: simplifiedMetadataMap(store.unpatchedEditor.jsxMetadata),
       codeResultCache: PlaceholderMessage,
       nodeModules: {
-        packageStatus: store.editor.nodeModules.packageStatus,
+        packageStatus: store.unpatchedEditor.nodeModules.packageStatus,
       },
       canvas: PlaceholderMessage,
     },
@@ -101,7 +101,7 @@ function sanitizeLoggedState(store: EditorStore) {
 
 export function reduxDevtoolsSendActions(
   actions: Array<Array<EditorAction>>,
-  newStore: EditorStore,
+  newStore: EditorStoreFull,
 ): void {
   if (
     maybeDevTools != null &&
@@ -124,7 +124,7 @@ export function reduxDevtoolsSendActions(
   }
 }
 
-export function reduxDevtoolsSendInitialState(newStore: EditorStore): void {
+export function reduxDevtoolsSendInitialState(newStore: EditorStoreFull): void {
   if (maybeDevTools != null) {
     maybeDevTools.init(newStore)
   }
@@ -150,7 +150,7 @@ export function reduxDevtoolsLogError(message: string, optionalPayload?: any): v
   }
 }
 
-export function reduxDevtoolsUpdateState(message: string, newStore: EditorStore): void {
+export function reduxDevtoolsUpdateState(message: string, newStore: EditorStoreFull): void {
   if (
     maybeDevTools != null &&
     sendActionUpdates &&

--- a/editor/src/core/tailwind/tailwind-options.tsx
+++ b/editor/src/core/tailwind/tailwind-options.tsx
@@ -10,7 +10,7 @@ import {
 import Highlighter from 'react-highlight-words'
 import { ElementPath, isParseSuccess, isTextFile, NodeModules } from '../shared/project-file-types'
 import { useEditorState, useRefEditorState } from '../../components/editor/store/store-hook'
-import { EditorStore, getOpenUIJSFileKey } from '../../components/editor/store/editor-state'
+import { getOpenUIJSFileKey } from '../../components/editor/store/editor-state'
 import { normalisePathToUnderlyingTarget } from '../../components/custom-code/code-file'
 import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../../components/assets'
 import {

--- a/editor/src/printer-parsers/html/external-resources-parser.tsx
+++ b/editor/src/printer-parsers/html/external-resources-parser.tsx
@@ -7,8 +7,7 @@ import { EditorDispatch } from '../../components/editor/action-types'
 import { addToast, updateFile } from '../../components/editor/actions/action-creators'
 import {
   defaultIndexHtmlFilePath,
-  EditorState,
-  EditorStore,
+  EditorStorePatched,
 } from '../../components/editor/store/editor-state'
 import { useEditorState } from '../../components/editor/store/store-hook'
 import {
@@ -456,8 +455,8 @@ export function getExternalResourcesInfo(
 }
 
 const getExternalResourcesInfoSelector = createSelector(
-  (store: EditorStore) => store.editor.projectContents,
-  (store: EditorStore) => store.dispatch,
+  (store: EditorStorePatched) => store.editor.projectContents,
+  (store: EditorStorePatched) => store.dispatch,
   getExternalResourcesInfo,
 )
 

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -137,6 +137,7 @@ export class Editor {
 
     this.storedState = {
       unpatchedEditor: emptyEditorState,
+      patchedEditor: emptyEditorState,
       editor: emptyEditorState,
       derived: derivedState,
       history: history,


### PR DESCRIPTION
**Problem:**
With the introduction of `unpatchedEditor` as part of the canvas interactions investigation, we were incorrectly reading from the patched state during the dispatch function, whilst making changes to the unpatched state. This is suspected to be related to a number of recent regressions in the editor.

**Fix:**
This PR goes further than #2091 by removing the type `EditorStore`, and replacing it with two separate types, `EditorStoreFull` (for use only as part of the dispatch function), and `EditorStorePatched` (for use everywhere else in the code):
```ts
type EditorStoreShared = {
  derived: DerivedState
  history: StateHistory
  userState: UserState
  workers: UtopiaTsWorkers
  persistence: PersistenceMachine
  dispatch: EditorDispatch
  builtInDependencies: BuiltInDependencies
  alreadySaved: boolean
}

export type EditorStoreFull = EditorStoreShared & {
  unpatchedEditor: EditorState
  patchedEditor: EditorState
}

export type EditorStorePatched = EditorStoreShared & {
  editor: EditorState
}
```

By making this change, we can then use `EditorStorePatched` in the various editor store hooks, meaning minimal changes elsewhere in the code.

I have also updated the `InnerDispatchResult` type to explicitly omit the `patchedEditor` field.