### PR TITLE
removed inner context provider, not needed anymore

### DIFF
--- a/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { ElementPath } from '../../../../core/shared/project-file-types'
+import { PropertyControls } from 'utopia-api/core'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { setCursorOverlay } from '../../../editor/actions/action-creators'
 import { useKeepReferenceEqualityIfPossible } from '../../../../utils/react-performance'
@@ -9,7 +10,6 @@ import { CSSCursor } from '../../../canvas/canvas-types'
 import { UIGridRow } from '../../widgets/ui-grid-row'
 import { VerySubdued } from '../../../../uuiui'
 import { specialPropertiesToIgnore } from '../../../../core/property-controls/property-controls-utils'
-import { PropertyControls } from 'utopia-api/core'
 
 interface PropertyControlsSectionProps {
   targets: ElementPath[]

--- a/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
@@ -1,12 +1,5 @@
 import React from 'react'
-import { useContext } from 'use-context-selector'
-import { UTOPIA_PATHS_KEY, UTOPIA_UIDS_KEY } from '../../../../core/model/utopia-constants'
-import { eitherToMaybe } from '../../../../core/shared/either'
-import { getJSXAttribute } from '../../../../core/shared/element-template'
-import { jsxSimpleAttributeToValue } from '../../../../core/shared/jsx-attributes'
 import { ElementPath } from '../../../../core/shared/project-file-types'
-import { InspectorPropsContext, InspectorPropsContextData } from '../../common/property-path-hooks'
-import * as EP from '../../../../core/shared/element-path'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { setCursorOverlay } from '../../../editor/actions/action-creators'
 import { useKeepReferenceEqualityIfPossible } from '../../../../utils/react-performance'
@@ -17,29 +10,6 @@ import { UIGridRow } from '../../widgets/ui-grid-row'
 import { VerySubdued } from '../../../../uuiui'
 import { specialPropertiesToIgnore } from '../../../../core/property-controls/property-controls-utils'
 import { PropertyControls } from 'utopia-api/core'
-
-function useFilterPropsContext(paths: ElementPath[]): InspectorPropsContextData {
-  const currentContext = useContext(InspectorPropsContext)
-  const spiedProps = currentContext.spiedProps.filter((props) =>
-    paths.some((path) => EP.toString(path) === props[UTOPIA_PATHS_KEY]),
-  )
-  const editedMultiSelectedProps = currentContext.editedMultiSelectedProps.filter((attributes) => {
-    const dataUidAttribute = getJSXAttribute(attributes, UTOPIA_UIDS_KEY)
-    if (dataUidAttribute != null) {
-      const uid = eitherToMaybe(jsxSimpleAttributeToValue(dataUidAttribute))
-      return paths.some((path) => EP.toUid(path) === uid)
-    } else {
-      return false
-    }
-  })
-
-  return {
-    ...currentContext,
-    spiedProps,
-    editedMultiSelectedProps,
-    selectedViews: paths,
-  }
-}
 
 interface PropertyControlsSectionProps {
   targets: ElementPath[]
@@ -52,7 +22,6 @@ interface PropertyControlsSectionProps {
 
 export const PropertyControlsSection = React.memo((props: PropertyControlsSectionProps) => {
   const {
-    targets,
     propertyControls,
     detectedPropsWithNoValue,
     detectedPropsAndValuesWithoutControls,
@@ -74,7 +43,6 @@ export const PropertyControlsSection = React.memo((props: PropertyControlsSectio
     [dispatch],
   )
 
-  const updatedContext = useKeepReferenceEqualityIfPossible(useFilterPropsContext(targets))
   const [visibleEmptyControls, showHiddenControl] = useHiddenElements()
 
   const rootFolder = (
@@ -91,7 +59,7 @@ export const PropertyControlsSection = React.memo((props: PropertyControlsSectio
   )
 
   return (
-    <InspectorPropsContext.Provider value={updatedContext}>
+    <>
       {rootFolder}
       {/** props set on the component instance and props used inside the component code */}
       {filteredDetectedPropsWithNoValue.length > 0 ? (
@@ -103,6 +71,6 @@ export const PropertyControlsSection = React.memo((props: PropertyControlsSectio
           </div>
         </UIGridRow>
       ) : null}
-    </InspectorPropsContext.Provider>
+    </>
   )
 })

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`493`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`489`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`531`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`527`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2355`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2348`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2509`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2501`)
   })
 })


### PR DESCRIPTION
No Ticket Number..?

**Problem:**
When dynamically generating components and their prop-values via something like iterating over an array/map, the values were not populating in the inspector when selected

**Fix:**
A redundant `InspectorPropsContext.Provider` was wrapping the UIGridRow and interfering with fetching the prop values. So it was determined that it could be removed. -Which fixes the issue

**Commit Details:**
- Removed `InspectorPropsContext.Provider` from `editor/src/components/inspector/sections/component-section/property-controls-section.tsx`
- Removed supporting code for the useContext/provider in that file
