### PR TITLE
Pass existing uids when requesting parsed model

### DIFF
--- a/editor/src/core/property-controls/property-controls-local-parser-bridge.ts
+++ b/editor/src/core/property-controls/property-controls-local-parser-bridge.ts
@@ -7,6 +7,7 @@ import {
   UtopiaJSXComponent,
 } from '../shared/element-template'
 import { Imports, isParseFailure, isParseSuccess } from '../shared/project-file-types'
+import { emptySet } from '../shared/set-utils'
 import { createParseFile, getParseResult, UtopiaTsWorkers } from '../workers/common/worker-types'
 
 type ProcessedParseResult = Either<
@@ -36,20 +37,24 @@ async function getParseResultForUserStrings(
   imports: string,
   toInsert: string,
 ): Promise<ProcessedParseResult> {
-  const parseResult = await getParseResult(workers, [
-    createParseFile(
-      'code.tsx',
-      `${imports};
+  const parseResult = await getParseResult(
+    workers,
+    [
+      createParseFile(
+        'code.tsx',
+        `${imports};
 
        function Utopia$$$Component(props) {
           return (
             ${toInsert}
           )
          }`,
-      null,
-      Date.now(),
-    ),
-  ])
+        null,
+        Date.now(),
+      ),
+    ],
+    emptySet(),
+  )
 
   if (parseResult[0].type === 'parsefileresult') {
     const parseFileResult = parseResult[0]

--- a/editor/src/core/workers/common/worker-types.ts
+++ b/editor/src/core/workers/common/worker-types.ts
@@ -8,7 +8,6 @@ import {
   ParsedTextFile,
   ProjectFile,
 } from '../../shared/project-file-types'
-import { emptySet } from '../../shared/set-utils'
 import { RawSourceMap } from '../ts/ts-typings/RawSourceMap'
 
 export type FileContent = string | TextFile

--- a/editor/src/core/workers/common/worker-types.ts
+++ b/editor/src/core/workers/common/worker-types.ts
@@ -8,6 +8,7 @@ import {
   ParsedTextFile,
   ProjectFile,
 } from '../../shared/project-file-types'
+import { emptySet } from '../../shared/set-utils'
 import { RawSourceMap } from '../ts/ts-typings/RawSourceMap'
 
 export type FileContent = string | TextFile
@@ -140,15 +141,18 @@ export type ParsePrintResultMessage = ParsePrintFilesResult | ParsePrintFailedMe
 export interface ParsePrintFilesRequest extends ParsePrintBase {
   type: 'parseprintfiles'
   files: Array<ParseOrPrint>
+  alreadyExistingUIDs: Set<string>
 }
 
 export function createParsePrintFilesRequest(
   files: Array<ParseOrPrint>,
+  alreadyExistingUIDs: Set<string>,
   messageID: number,
 ): ParsePrintFilesRequest {
   return {
     type: 'parseprintfiles',
     files: files,
+    alreadyExistingUIDs: alreadyExistingUIDs,
     messageID: messageID,
   }
 }
@@ -158,6 +162,7 @@ let PARSE_PRINT_MESSAGE_COUNTER: number = 0
 export function getParseResult(
   workers: UtopiaTsWorkers,
   files: Array<ParseOrPrint>,
+  alreadyExistingUIDs: Set<string>,
 ): Promise<Array<ParseOrPrintResult>> {
   const messageIDForThisRequest = PARSE_PRINT_MESSAGE_COUNTER++
   return new Promise((resolve, reject) => {
@@ -181,7 +186,9 @@ export function getParseResult(
     }
 
     workers.addParserPrinterEventListener(handleMessage)
-    workers.sendParsePrintMessage(createParsePrintFilesRequest(files, messageIDForThisRequest))
+    workers.sendParsePrintMessage(
+      createParsePrintFilesRequest(files, alreadyExistingUIDs, messageIDForThisRequest),
+    )
   })
 }
 

--- a/editor/src/core/workers/parser-printer/parser-printer-worker.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-worker.ts
@@ -36,7 +36,7 @@ export function handleMessage(
   switch (workerMessage.type) {
     case 'parseprintfiles': {
       try {
-        const alreadyExistingUIDs_MUTABLE: Set<string> = emptySet()
+        const alreadyExistingUIDs_MUTABLE: Set<string> = new Set(workerMessage.alreadyExistingUIDs)
         const results = workerMessage.files.map((file) => {
           switch (file.type) {
             case 'parsefile':


### PR DESCRIPTION
**Problem:**
When parsing the code, we weren't preventing duplicate UIDs across multiple files if those files were parsed separately, since we were starting the parse with an [empty set for the existing UIDs](https://github.com/concrete-utopia/utopia/blob/a3cd28d96f20d7ba986cf89b977990834c2b3163/editor/src/core/workers/parser-printer/parser-printer-worker.ts#L39)

**Fix:**
Capture the existing UIDs (from the files that aren't about to be parsed), and use those to seed the set of all existing UIDs used during the parse. I've also added a test to explicitly cover this case.
