### PR TITLE
perf(editor) Wrapped some path calculations in memoize calls

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -157,6 +157,7 @@ import { PersistenceMachine } from '../persistence/persistence'
 import type { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { DefaultThirdPartyControlDefinitions } from '../../../core/third-party/third-party-controls'
 import { Spec } from 'immutability-helper'
+import { memoize } from '../../../core/shared/memoize'
 
 const ObjectPathImmutable: any = OPI
 
@@ -1305,7 +1306,7 @@ export interface OriginalCanvasAndLocalFrame {
   canvasFrame?: CanvasRectangle
 }
 
-export function getElementWarnings(
+function getElementWarningsInner(
   rootMetadata: ElementInstanceMetadataMap,
 ): ComplexMap<ElementPath, ElementWarnings> {
   let result: ComplexMap<ElementPath, ElementWarnings> = emptyComplexMap()
@@ -1340,6 +1341,8 @@ export function getElementWarnings(
   )
   return result
 }
+
+const getElementWarnings = memoize(getElementWarningsInner, { maxSize: 1 })
 
 export function deriveState(
   editor: EditorState,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -104,6 +104,7 @@ import { omit } from '../shared/object-utils'
 import { UTOPIA_LABEL_KEY } from './utopia-constants'
 import { withUnderlyingTarget } from '../../components/editor/store/editor-state'
 import { ProjectContentTreeRoot } from '../../components/assets'
+import { memoize } from '../shared/memoize'
 const ObjectPathImmutable: any = OPI
 
 export const getChildrenOfCollapsedViews = (
@@ -488,20 +489,23 @@ export const MetadataUtils = {
       }
     }, rootScenesAndElements)
   },
-  getAllPaths(metadata: ElementInstanceMetadataMap): ElementPath[] {
-    // This function needs to explicitly return the paths in a depth first manner
-    let result: Array<ElementPath> = []
-    function recurseElement(elementPath: ElementPath): void {
-      result.push(elementPath)
-      const descendants = MetadataUtils.getImmediateChildrenPaths(metadata, elementPath)
-      fastForEach(descendants, recurseElement)
-    }
+  getAllPaths: memoize(
+    (metadata: ElementInstanceMetadataMap): ElementPath[] => {
+      // This function needs to explicitly return the paths in a depth first manner
+      let result: Array<ElementPath> = []
+      function recurseElement(elementPath: ElementPath): void {
+        result.push(elementPath)
+        const descendants = MetadataUtils.getImmediateChildrenPaths(metadata, elementPath)
+        fastForEach(descendants, recurseElement)
+      }
 
-    const storyboardChildren = this.getAllStoryboardChildrenPaths(metadata)
-    fastForEach(storyboardChildren, recurseElement)
+      const storyboardChildren = MetadataUtils.getAllStoryboardChildrenPaths(metadata)
+      fastForEach(storyboardChildren, recurseElement)
 
-    return uniqBy<ElementPath>(result, EP.pathsEqual)
-  },
+      return uniqBy<ElementPath>(result, EP.pathsEqual)
+    },
+    { maxSize: 1 },
+  ),
   getAllPathsIncludingUnfurledFocusedComponents(
     metadata: ElementInstanceMetadataMap,
   ): ElementPath[] {
@@ -672,45 +676,50 @@ export const MetadataUtils = {
       unfurledComponents: MetadataUtils.getRootViews(metadata, path),
     }
   },
-  createOrderedElementPathsFromElements(
-    metadata: ElementInstanceMetadataMap,
-    collapsedViews: Array<ElementPath>,
-  ): {
-    navigatorTargets: Array<ElementPath>
-    visibleNavigatorTargets: Array<ElementPath>
-  } {
-    // This function exists separately from getAllPaths because the Navigator handles collapsed views
-    let navigatorTargets: Array<ElementPath> = []
-    let visibleNavigatorTargets: Array<ElementPath> = []
+  createOrderedElementPathsFromElements: memoize(
+    (
+      metadata: ElementInstanceMetadataMap,
+      collapsedViews: Array<ElementPath>,
+    ): {
+      navigatorTargets: Array<ElementPath>
+      visibleNavigatorTargets: Array<ElementPath>
+    } => {
+      // This function exists separately from getAllPaths because the Navigator handles collapsed views
+      let navigatorTargets: Array<ElementPath> = []
+      let visibleNavigatorTargets: Array<ElementPath> = []
 
-    function walkAndAddKeys(path: ElementPath, collapsedAncestor: boolean): void {
-      navigatorTargets.push(path)
-      if (!collapsedAncestor) {
-        visibleNavigatorTargets.push(path)
+      function walkAndAddKeys(path: ElementPath, collapsedAncestor: boolean): void {
+        navigatorTargets.push(path)
+        if (!collapsedAncestor) {
+          visibleNavigatorTargets.push(path)
+        }
+
+        const {
+          children,
+          unfurledComponents,
+        } = MetadataUtils.getAllChildrenIncludingUnfurledFocusedComponents(path, metadata)
+        const childrenIncludingFocusedElements = [...children, ...unfurledComponents]
+
+        const isCollapsed = EP.containsPath(path, collapsedViews)
+        fastForEach(childrenIncludingFocusedElements, (childElement) => {
+          walkAndAddKeys(childElement, collapsedAncestor || isCollapsed)
+        })
       }
 
-      const {
-        children,
-        unfurledComponents,
-      } = MetadataUtils.getAllChildrenIncludingUnfurledFocusedComponents(path, metadata)
-      const childrenIncludingFocusedElements = [...children, ...unfurledComponents]
-
-      const isCollapsed = EP.containsPath(path, collapsedViews)
-      fastForEach(childrenIncludingFocusedElements, (childElement) => {
-        walkAndAddKeys(childElement, collapsedAncestor || isCollapsed)
+      const canvasRoots = MetadataUtils.getAllStoryboardChildrenPaths(metadata)
+      fastForEach(canvasRoots, (childElement) => {
+        walkAndAddKeys(childElement, false)
       })
-    }
 
-    const canvasRoots = MetadataUtils.getAllStoryboardChildrenPaths(metadata)
-    fastForEach(canvasRoots, (childElement) => {
-      walkAndAddKeys(childElement, false)
-    })
-
-    return {
-      navigatorTargets: navigatorTargets,
-      visibleNavigatorTargets: visibleNavigatorTargets,
-    }
-  },
+      return {
+        navigatorTargets: navigatorTargets,
+        visibleNavigatorTargets: visibleNavigatorTargets,
+      }
+    },
+    {
+      maxSize: 1,
+    },
+  ),
   transformAtPathOptionally(
     elementMap: ElementInstanceMetadataMap,
     path: ElementPath,


### PR DESCRIPTION
Fixes #2101 

**Problem:**
We are performing expensive element path calculations based on unchanging metadata when scrolling on the canvas.

**Fix:**
Wrap the offending calls in `memoize` calls, as well as a function for determining element warnings (when deriving state).

**Performance Results:**
Both profiles were taken whilst running a local version of our own new performance testing project. The runs were performed in regular dev mode, but I had already confirmed that relevant function calls were roughly as expensive (and are the cause of slow scrolling) via a profile in production.

Before:
![Screenshot_20220223_123153](https://user-images.githubusercontent.com/1044774/155320099-b8dfddbb-6ab2-408f-9902-27e151041e6d.png)

After:
![Screenshot_20220223_123100](https://user-images.githubusercontent.com/1044774/155320086-49f456e4-5069-43e8-b15b-b3175fbc1e7e.png)

