### PR TITLE
when multiselecting, show individual outlines of every selected element

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -58,7 +58,7 @@ import { usePrevious } from '../../editor/hook-utils'
 import { LayoutTargetableProp } from '../../../core/layout/layout-helpers-new'
 import { getDragStateStart } from '../canvas-utils'
 import { AbsoluteResizeControl } from './select-mode/absolute-resize-control'
-import { OutlineControl } from './select-mode/simple-outline-control'
+import { MultiSelectOutlineControl } from './select-mode/simple-outline-control'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -406,7 +406,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       <LayoutParentControl />
       {when(
         isFeatureEnabled('Canvas Absolute Resize Controls'),
-        <OutlineControl localSelectedElements={localSelectedViews} />,
+        <MultiSelectOutlineControl localSelectedElements={localSelectedViews} />,
       )}
       {when(
         isFeatureEnabled('Canvas Absolute Resize Controls'),

--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -1,20 +1,45 @@
 import React from 'react'
+import * as EP from '../../../../core/shared/element-path'
 import { ElementPath } from '../../../../core/shared/project-file-types'
+import { when } from '../../../../utils/react-conditionals'
 import { useColorTheme } from '../../../../uuiui'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { getSelectionColor } from '../outline-control'
 
-interface OutlineControlProps {
+interface MultiSelectOutlineControlProps {
   localSelectedElements: Array<ElementPath>
 }
 
-export const OutlineControl = React.memo<OutlineControlProps>((props) => {
-  const colorTheme = useColorTheme()
+export const MultiSelectOutlineControl = React.memo<MultiSelectOutlineControlProps>((props) => {
   const localSelectedElements = props.localSelectedElements
+  return (
+    <>
+      {[
+        <OutlineControl
+          key='multiselect-outline'
+          targets={localSelectedElements}
+          color='multiselect-bounds'
+        />,
+        ...localSelectedElements.map((path) => (
+          <OutlineControl key={EP.toString(path)} targets={[path]} color='primary' />
+        )),
+      ]}
+    </>
+  )
+})
+
+interface OutlineControlProps {
+  targets: Array<ElementPath>
+  color: 'primary' | 'multiselect-bounds'
+}
+
+const OutlineControl = React.memo<OutlineControlProps>((props) => {
+  const colorTheme = useColorTheme()
+  const targets = props.targets
 
   const colors = useEditorState((store) => {
-    return localSelectedElements.map((path) =>
+    return targets.map((path) =>
       getSelectionColor(
         path,
         store.editor.jsxMetadata,
@@ -24,14 +49,17 @@ export const OutlineControl = React.memo<OutlineControlProps>((props) => {
     )
   }, 'OutlineControl colors')
 
-  const outlineRef = useBoundingBox(localSelectedElements, (ref, boundingBox) => {
+  const outlineRef = useBoundingBox(targets, (ref, boundingBox) => {
     ref.current.style.left = `calc(${boundingBox.x}px + 0.5px / var(--utopia-canvas-scale))`
     ref.current.style.top = `calc(${boundingBox.y}px + 0.5px / var(--utopia-canvas-scale))`
     ref.current.style.width = `calc(${boundingBox.width}px - 0.5px / var(--utopia-canvas-scale) * 3)`
     ref.current.style.height = `calc(${boundingBox.height}px - 0.5px / var(--utopia-canvas-scale) * 3)`
   })
 
-  if (localSelectedElements.length > 0) {
+  const color =
+    props.color === 'primary' ? colors[0] : colorTheme.canvasSelectionSecondaryOutline.value
+
+  if (targets.length > 0) {
     return (
       <div
         ref={outlineRef}
@@ -39,7 +67,7 @@ export const OutlineControl = React.memo<OutlineControlProps>((props) => {
         style={{
           position: 'absolute',
           boxSizing: 'border-box',
-          boxShadow: `0px 0px 0px calc(1px / var(--utopia-canvas-scale)) ${colors[0]}`,
+          boxShadow: `0px 0px 0px calc(1px / var(--utopia-canvas-scale)) ${color}`,
           pointerEvents: 'none',
           transform: `translate(var(--utopia-canvas-offset-x), var(--utopia-canvas-offset-y))`,
         }}


### PR DESCRIPTION
**Problem:**
The new ref-using outline only showed the multiselect bounds, not revealing which of the elements are actually selected.
<p>
    <img width="346" alt="image" src="https://user-images.githubusercontent.com/2226774/155330793-5aa75d89-6e8f-40b9-ab8a-b3696db1b6c8.png"><br />
<em>is the middle Rectangle selected?</em>
</p>


**Fix:**
Resurrect the individual selection outlines:
<img width="336" alt="image" src="https://user-images.githubusercontent.com/2226774/155331356-4b716676-15ee-45a3-a85f-eee5d4e99e70.png">

_look! the middle rectangle is not selected_

**Commit Details:**
- OutlineControl now takes a color prop and a targets array
- Created new MultiSelectOutlineControl that renders an OutlineControl for the bounds, and an individual OutlineControl for each target