### PR TITLE
vastly simplifying the Redux Devtools logs to make it performant

### DIFF
--- a/editor/src/core/shared/redux-devtools.ts
+++ b/editor/src/core/shared/redux-devtools.ts
@@ -1,3 +1,4 @@
+import { EditorState } from 'draft-js'
 import type { EditorAction } from '../../components/editor/action-types'
 import type { EditorStoreFull } from '../../components/editor/store/editor-state'
 import { isFeatureEnabled } from '../../utils/feature-switches'
@@ -65,14 +66,6 @@ let lastDispatchedStore: SanitizedState
 
 const PlaceholderMessage = '<<SANITIZED_FROM_DEVTOOLS>>'
 
-type RecursivePartial<T> = {
-  [P in keyof T]?: T[P] extends (infer U)[]
-    ? RecursivePartial<U>[]
-    : T[P] extends object
-    ? RecursivePartial<T[P]>
-    : T[P]
-}
-
 function simplifiedMetadata(elementMetadata: Partial<ElementInstanceMetadata>) {
   return {
     globalFrame: elementMetadata.globalFrame,
@@ -87,11 +80,11 @@ function simplifiedMetadataMap(metadata: ElementInstanceMetadataMap) {
 }
 
 type SanitizedState = ReturnType<typeof sanitizeLoggedState>
-function sanitizeLoggedState(store: EditorStoreFull): RecursivePartial<EditorStoreFull> {
+function sanitizeLoggedState(store: EditorStoreFull) {
   return {
     patchedEditor: {
       jsxMetadata: simplifiedMetadataMap(store.patchedEditor.jsxMetadata) as any,
-    },
+    } as Partial<EditorState>,
   }
 }
 


### PR DESCRIPTION
**Problem:**
Redux Devtools is logging most of the EditorStore, and almost everything from the action's payload (including entire jsxMetadata among other large things) it makes it unusable on my machine, it spends 5-10 seconds stringifying a single action!

**Fix:**
* Reset what we are logging. We can re-add various EditorState parts as part of investigations, but we don't need the entire EditorState in the redux logs. 
* Instead of listing actions where we don't want to log the payload, list the actions where we _do_ want to log the payload.


