### PR TITLE
Fix/interaction performance control highlight

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -576,6 +576,10 @@ export function useSelectAndHover(
   onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 } {
   const modeType = useEditorState((store) => store.editor.mode.type, 'useSelectAndHover mode')
+  const hasInteractionState = useEditorState(
+    (store) => store.editor.canvas.interactionState != null,
+    'useSelectAndHover hasInteractionState',
+  )
   const selectModeCallbacks = useSelectOrLiveModeSelectAndHover(
     modeType === 'select' || modeType === 'select-lite' || modeType === 'live',
     modeType === 'select' || modeType === 'live',
@@ -584,17 +588,24 @@ export function useSelectAndHover(
   )
   const insertModeCallbacks = useInsertModeSelectAndHover(modeType === 'insert', cmdPressed)
 
-  switch (modeType) {
-    case 'select':
-      return selectModeCallbacks
-    case 'select-lite':
-      return selectModeCallbacks
-    case 'insert':
-      return insertModeCallbacks
-    case 'live':
-      return selectModeCallbacks
-    default:
-      const _exhaustiveCheck: never = modeType
-      throw new Error(`Unhandled editor mode ${JSON.stringify(modeType)}`)
+  if (hasInteractionState) {
+    return {
+      onMouseMove: Utils.NO_OP,
+      onMouseDown: Utils.NO_OP,
+    }
+  } else {
+    switch (modeType) {
+      case 'select':
+        return selectModeCallbacks
+      case 'select-lite':
+        return selectModeCallbacks
+      case 'insert':
+        return insertModeCallbacks
+      case 'live':
+        return selectModeCallbacks
+      default:
+        const _exhaustiveCheck: never = modeType
+        throw new Error(`Unhandled editor mode ${JSON.stringify(modeType)}`)
+    }
   }
 }

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -49,16 +49,18 @@ const DRAG_START_TRESHOLD = 2
 export function isResizing(editorState: EditorState): boolean {
   const dragState = editorState.canvas.dragState
   return (
-    dragState?.type === 'RESIZE_DRAG_STATE' &&
-    getDragStateDrag(dragState, editorState.canvas.resizeOptions) != null
+    (dragState?.type === 'RESIZE_DRAG_STATE' &&
+      getDragStateDrag(dragState, editorState.canvas.resizeOptions) != null) ||
+    editorState.canvas.interactionState != null
   )
 }
 
 export function isDragging(editorState: EditorState): boolean {
   const dragState = editorState.canvas.dragState
   return (
-    dragState?.type === 'MOVE_DRAG_STATE' &&
-    getDragStateDrag(dragState, editorState.canvas.resizeOptions) != null
+    (dragState?.type === 'MOVE_DRAG_STATE' &&
+      getDragStateDrag(dragState, editorState.canvas.resizeOptions) != null) ||
+    editorState.canvas.interactionState != null
   )
 }
 


### PR DESCRIPTION
**Problem:**
I was looking at the strategy proposal performance and noticed that during dragging `getValidTargetAtPoint` is called on every mouseevent. This quite expensive calculation adds 2-4ms to each mouseevent without actually using the result of it, because it's used for highlighting the elements under mouse while not dragging.

This was actually quite interesting because it didn't cause problems with the original dragstate. After some digging I found that there is a 'EditorCursorComponent' which catches the mouse events, so it never reaches the canvas controls.

**Fix:**
Found 2 helper functions `isResizing` and `isDragging` using the dragState, updating these to be aware of the interaction state too.
Changed the `useSelectAndHover` hook to return empty callbacks while an interaction state is active.

