### PR TITLE
feature(store) add patched and unpatched derived state

### DIFF
--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -62,7 +62,13 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
     const result = editorDispatch(
       dispatch,
       actions,
-      { ...storedState, unpatchedEditor: storedState.editor, patchedEditor: storedState.editor },
+      {
+        ...storedState,
+        unpatchedEditor: storedState.editor,
+        patchedEditor: storedState.editor,
+        unpatchedDerived: storedState.derived,
+        patchedDerived: storedState.derived,
+      },
       spyCollector,
     )
     storeHook.setState(patchedStoreFromFullStore(result))

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -223,7 +223,8 @@ export async function renderTestEditorWithModel(
   const initialEditorStore: EditorStoreFull = {
     unpatchedEditor: emptyEditorState,
     patchedEditor: emptyEditorState,
-    derived: derivedState,
+    unpatchedDerived: derivedState,
+    patchedDerived: derivedState,
     history: history,
     userState: {
       loginState: notLoggedIn,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -238,7 +238,6 @@ export const defaultUserState: UserState = {
 }
 
 type EditorStoreShared = {
-  derived: DerivedState
   history: StateHistory
   userState: UserState
   workers: UtopiaTsWorkers
@@ -251,16 +250,20 @@ type EditorStoreShared = {
 export type EditorStoreFull = EditorStoreShared & {
   unpatchedEditor: EditorState
   patchedEditor: EditorState
+  unpatchedDerived: DerivedState
+  patchedDerived: DerivedState
 }
 
 export type EditorStorePatched = EditorStoreShared & {
   editor: EditorState
+  derived: DerivedState
 }
 
 export function patchedStoreFromFullStore(store: EditorStoreFull): EditorStorePatched {
   return {
     ...store,
     editor: store.patchedEditor,
+    derived: store.patchedDerived,
   }
 }
 

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -140,7 +140,8 @@ export class Editor {
     this.storedState = {
       unpatchedEditor: emptyEditorState,
       patchedEditor: emptyEditorState,
-      derived: derivedState,
+      unpatchedDerived: derivedState,
+      patchedDerived: derivedState,
       history: history,
       userState: defaultUserState,
       workers: workers,


### PR DESCRIPTION
Part of https://github.com/concrete-utopia/utopia/pull/2112
This is in a new PR to make it easier to read.

**Fix:**
Since patched and unpatched editor state is already available from master, I'm adding the patched and unpatched derived state too. 
There is a TODO to actually use the patched derived state when the strategies PR is merged.

**Commit Details:**
- extend `EditorStoreFull` with unpatched and patched derived state
- add patched derived state to `EditorStorePatched`
