### PR TITLE
Improve isParentOf.

### DIFF
--- a/editor/src/core/shared/element-path.spec.ts
+++ b/editor/src/core/shared/element-path.spec.ts
@@ -1,6 +1,8 @@
 import * as Chai from 'chai'
 import * as EP from './element-path'
 import { BakedInStoryboardUID } from '../model/scene-utils'
+import { ElementPath } from './project-file-types'
+import { TestSceneUID, TestAppUID } from '../../components/canvas/ui-jsx.test-utils'
 const chaiExpect = Chai.expect
 
 describe('serialization', () => {
@@ -616,5 +618,45 @@ describe('getCommonParent', () => {
     ])
     const expectedResult = EP.elementPath([[BakedInStoryboardUID, 'scene-aaa'], ['a']])
     expect(actualResult).toEqual(expectedResult)
+  })
+})
+
+describe('isParentOf', () => {
+  it('returns true for a child with a single array element lower down.', () => {
+    const parentPath: ElementPath = EP.elementPath([
+      [BakedInStoryboardUID, TestSceneUID, TestAppUID],
+      ['aaa', 'eee'],
+    ])
+    const childPath: ElementPath = EP.elementPath([
+      [BakedInStoryboardUID, TestSceneUID, TestAppUID],
+      ['aaa', 'eee'],
+      ['zzz'],
+    ])
+    expect(EP.isParentOf(parentPath, childPath)).toBe(true)
+  })
+  it('returns true for a child with a final array element with one less path part.', () => {
+    const parentPath: ElementPath = EP.elementPath([
+      [BakedInStoryboardUID, TestSceneUID, TestAppUID],
+      ['aaa', 'eee'],
+      ['zzz'],
+    ])
+    const childPath: ElementPath = EP.elementPath([
+      [BakedInStoryboardUID, TestSceneUID, TestAppUID],
+      ['aaa', 'eee'],
+      ['zzz', 'yyy'],
+    ])
+    expect(EP.isParentOf(parentPath, childPath)).toBe(true)
+  })
+  it('returns false for paths that differ by a full array element.', () => {
+    const parentPath: ElementPath = EP.elementPath([
+      [BakedInStoryboardUID, TestSceneUID, TestAppUID],
+      ['aaa', 'eee'],
+    ])
+    const childPath: ElementPath = EP.elementPath([
+      [BakedInStoryboardUID, TestSceneUID, TestAppUID],
+      ['aaa', 'eee'],
+      ['zzz', 'yyy'],
+    ])
+    expect(EP.isParentOf(parentPath, childPath)).toBe(false)
   })
 })

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -263,7 +263,56 @@ export function parentPath(path: ElementPath): ElementPath {
 }
 
 export function isParentOf(maybeParent: ElementPath, maybeChild: ElementPath): boolean {
-  return pathsEqual(parentPath(maybeChild), maybeParent)
+  const childLength = maybeChild.parts.length
+  const parentLength = maybeParent.parts.length
+  if (childLength === parentLength + 1) {
+    const lastChildPart = last(maybeChild.parts)
+    if (lastChildPart != null && lastChildPart.length === 1) {
+      for (let index = 0; index < parentLength; index++) {
+        const childParts = maybeChild.parts[index]
+        const parentParts = maybeParent.parts[index]
+        if (!elementPathPartsEqual(childParts, parentParts)) {
+          return false
+        }
+      }
+
+      // Otherwise this is a parent.
+      return true
+    } else {
+      return false
+    }
+  } else if (childLength === parentLength) {
+    const lastChildPart = last(maybeChild.parts)
+    const lastParentPart = last(maybeParent.parts)
+    if (
+      lastChildPart != null &&
+      lastParentPart != null &&
+      lastChildPart.length === lastParentPart.length + 1
+    ) {
+      // Check the main bulk of the parts to ensure those are the same.
+      for (let index = 0; index < parentLength - 1; index++) {
+        const childParts = maybeChild.parts[index]
+        const parentParts = maybeParent.parts[index]
+        if (!elementPathPartsEqual(childParts, parentParts)) {
+          return false
+        }
+      }
+
+      // Check the last array part.
+      for (let index = 0; index < lastChildPart.length - 1; index++) {
+        if (lastChildPart[index] !== lastParentPart[index]) {
+          return false
+        }
+      }
+
+      // Otherwise this is a parent.
+      return true
+    } else {
+      return false
+    }
+  } else {
+    return false
+  }
 }
 
 export function elementPathPartToUID(path: ElementPathPart): id {


### PR DESCRIPTION
**Problem:**
While testing the canvas strategies performance I noticed this function being a bit of a hotspot, where an invocation of `getAllChildrenIncludingUnfurledFocusedComponents` was taking 10ms.

**Fix:**
Changed the guts of `isParentOf` to avoid allocations as much as is reasonably possible in JavaScript where I think everything should be allocated on the stack. This brought down the cost of the above function to about 3ms.

**Commit Details:**
- Reworked `isParentOf` to avoid allocating new paths which are checked
  and then immediately discarded.
