### PR TITLE
Improved DerivedStateKeepDeepEquality.

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1042,6 +1042,18 @@ export interface ElementWarnings {
   dynamicSceneChildWidthHeightPercentage: boolean
 }
 
+export function elementWarnings(
+  widthOrHeightZero: boolean,
+  absoluteWithUnpositionedParent: boolean,
+  dynamicSceneChildWidthHeightPercentage: boolean,
+): ElementWarnings {
+  return {
+    widthOrHeightZero: widthOrHeightZero,
+    absoluteWithUnpositionedParent: absoluteWithUnpositionedParent,
+    dynamicSceneChildWidthHeightPercentage: dynamicSceneChildWidthHeightPercentage,
+  }
+}
+
 export const defaultElementWarnings: ElementWarnings = {
   widthOrHeightZero: false,
   absoluteWithUnpositionedParent: false,
@@ -1334,12 +1346,12 @@ function getElementWarningsInner(
       }
 
       // Build the warnings object and add it to the map.
-      const elementWarnings: ElementWarnings = {
+      const warnings: ElementWarnings = {
         widthOrHeightZero: widthOrHeightZero,
         absoluteWithUnpositionedParent: absoluteWithUnpositionedParent,
         dynamicSceneChildWidthHeightPercentage: false,
       }
-      result = addToComplexMap(toString, result, elementMetadata.elementPath, elementWarnings)
+      result = addToComplexMap(toString, result, elementMetadata.elementPath, warnings)
     },
   )
   return result

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -110,6 +110,7 @@ import {
   combine14EqualityCalls,
   createCallWithShallowEquals,
   combine10EqualityCalls,
+  ComplexMapKeepDeepEquality,
 } from '../../../utils/deep-equality'
 import {
   ElementPathArrayKeepDeepEquality,
@@ -117,6 +118,7 @@ import {
   ElementPathKeepDeepEquality,
   EitherKeepDeepEquality,
   JSXElementNameKeepDeepEqualityCall,
+  ElementWarningsKeepDeepEquality,
 } from '../../../utils/deep-equality-instances'
 import { createCallFromIntrospectiveKeepDeep } from '../../../utils/react-performance'
 import {
@@ -154,7 +156,7 @@ export function DerivedStateKeepDeepEquality(): KeepDeepEqualityCall<DerivedStat
     (state) => state.canvas.transientState,
     TransientCanvasStateKeepDeepEquality(),
     (state) => state.elementWarnings,
-    createCallFromIntrospectiveKeepDeep(),
+    ComplexMapKeepDeepEquality(ElementPathKeepDeepEquality, ElementWarningsKeepDeepEquality),
     (
       navigatorTargets,
       visibleNavigatorTargets,

--- a/editor/src/utils/deep-equality-instances.spec.ts
+++ b/editor/src/utils/deep-equality-instances.spec.ts
@@ -79,17 +79,17 @@ describe('PropertyPathKeepDeepEquality', () => {
   }
 
   it('same reference returns the same reference', () => {
-    const result = PropertyPathKeepDeepEquality(oldValue, oldValue)
+    const result = PropertyPathKeepDeepEquality()(oldValue, oldValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const result = PropertyPathKeepDeepEquality(oldValue, newSameValue)
+    const result = PropertyPathKeepDeepEquality()(oldValue, newSameValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const result = PropertyPathKeepDeepEquality(oldValue, newDifferentValue)
+    const result = PropertyPathKeepDeepEquality()(oldValue, newDifferentValue)
     expect(result.value).toBe(newDifferentValue)
     expect(result.areEqual).toEqual(false)
   })

--- a/editor/src/utils/deep-equality-instances.ts
+++ b/editor/src/utils/deep-equality-instances.ts
@@ -1,6 +1,7 @@
 import {
   arrayDeepEquality,
   combine2EqualityCalls,
+  combine3EqualityCalls,
   combine4EqualityCalls,
   combine5EqualityCalls,
   createCallFromEqualsFunction,
@@ -20,7 +21,12 @@ import { ElementPath, PropertyPath } from '../core/shared/project-file-types'
 import { createCallFromIntrospectiveKeepDeep } from './react-performance'
 import { Either, foldEither, isLeft, left, right } from '../core/shared/either'
 import { NameAndIconResult } from '../components/inspector/common/name-and-icon-hook'
-import { DropTargetHint, NavigatorState } from '../components/editor/store/editor-state'
+import {
+  DropTargetHint,
+  elementWarnings,
+  ElementWarnings,
+  NavigatorState,
+} from '../components/editor/store/editor-state'
 import { LayoutTargetableProp } from '../core/layout/layout-helpers-new'
 
 export const ElementPathKeepDeepEquality: KeepDeepEqualityCall<ElementPath> = createCallFromEqualsFunction(
@@ -33,11 +39,11 @@ export const ElementPathArrayKeepDeepEquality: KeepDeepEqualityCall<Array<
   ElementPath
 >> = arrayDeepEquality(ElementPathKeepDeepEquality)
 
-export const PropertyPathKeepDeepEquality: KeepDeepEqualityCall<PropertyPath> = createCallFromEqualsFunction(
-  (oldPath: PropertyPath, newPath: PropertyPath) => {
+export function PropertyPathKeepDeepEquality(): KeepDeepEqualityCall<PropertyPath> {
+  return createCallFromEqualsFunction((oldPath: PropertyPath, newPath: PropertyPath) => {
     return PP.pathsEqual(oldPath, newPath)
-  },
-)
+  })
+}
 
 export const HigherOrderControlArrayKeepDeepEquality: KeepDeepEqualityCall<Array<
   HigherOrderControl
@@ -48,7 +54,7 @@ export function JSXElementNameKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXEl
     (name) => name.baseVariable,
     createCallWithTripleEquals(),
     (name) => name.propertyPath,
-    PropertyPathKeepDeepEquality,
+    PropertyPathKeepDeepEquality(),
     (baseVariable, propertyPath) => {
       return {
         baseVariable: baseVariable,
@@ -154,3 +160,13 @@ export const NavigatorStateKeepDeepEquality: KeepDeepEqualityCall<NavigatorState
 export const LayoutTargetablePropArrayKeepDeepEquality: KeepDeepEqualityCall<Array<
   LayoutTargetableProp
 >> = arrayDeepEquality(createCallWithTripleEquals())
+
+export const ElementWarningsKeepDeepEquality: KeepDeepEqualityCall<ElementWarnings> = combine3EqualityCalls(
+  (warnings) => warnings.widthOrHeightZero,
+  createCallWithTripleEquals(),
+  (warnings) => warnings.absoluteWithUnpositionedParent,
+  createCallWithTripleEquals(),
+  (warnings) => warnings.dynamicSceneChildWidthHeightPercentage,
+  createCallWithTripleEquals(),
+  elementWarnings,
+)

--- a/editor/src/utils/deep-equality.ts
+++ b/editor/src/utils/deep-equality.ts
@@ -1,5 +1,6 @@
 import { shallowEqual } from '../core/shared/equality-utils'
 import { fastForEach } from '../core/shared/utils'
+import { ComplexMap, complexMapValue, ComplexMapValue } from './map'
 
 export interface KeepDeepEqualityResult<T> {
   value: T
@@ -880,4 +881,19 @@ export function undefinableDeepEquality<T>(
       }
     }
   }
+}
+
+// Makes the assumption that the key value stored is consistent with the key value string used to key into the dictionary.
+export function ComplexMapKeepDeepEquality<K, V>(
+  keyDeepEquality: KeepDeepEqualityCall<K>,
+  valueDeepEquality: KeepDeepEqualityCall<V>,
+): KeepDeepEqualityCall<ComplexMap<K, V>> {
+  const mapValueDeepEquality: KeepDeepEqualityCall<ComplexMapValue<K, V>> = combine2EqualityCalls(
+    (value) => value.key,
+    keyDeepEquality,
+    (value) => value.value,
+    valueDeepEquality,
+    complexMapValue,
+  )
+  return objectDeepEquality(mapValueDeepEquality)
 }


### PR DESCRIPTION
**Problem:**
Keeping a deeply equal instance of `DerivedState` is especially slow because of the current handling of `elementWarnings`. 

**Fix:**
Replacing the introspective handling of `elementWarnings` with something that does less introspection improves the performance quite dramatically.

**Commit Details:**
- Switched out `createCallFromIntrospectiveKeepDeep` to a newly created
  `ComplexMapKeepDeepEquality` instance.
- Added `ElementWarningsKeepDeepEquality` and `CompleXMapKeepDeepEquality`.
- `PropertyPathKeepDeepEquality` made a function because of circular
  references.
