### PR TITLE
Tests for some of the core strategies code.

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -56,6 +56,7 @@ import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { handleStrategies } from './dispatch-strategies'
 
 import { emptySet } from '../../../core/shared/set-utils'
+import { RegisteredCanvasStrategies } from '../../canvas/canvas-strategies/canvas-strategies'
 
 type DispatchResultFields = {
   nothingChanged: boolean
@@ -421,7 +422,13 @@ export function editorDispatch(
     newStrategyState,
     patchedDerivedState,
   } = isFeatureEnabled('Canvas Strategies')
-    ? handleStrategies(dispatchedActions, storedState, result, storedState.patchedDerived)
+    ? handleStrategies(
+        RegisteredCanvasStrategies,
+        dispatchedActions,
+        storedState,
+        result,
+        storedState.patchedDerived,
+      )
     : {
         unpatchedEditorState: result.unpatchedEditor,
         patchedEditorState: result.unpatchedEditor,


### PR DESCRIPTION
**Problem:**
There's not enough tests covering the internals of the strategy code.

**Fix:**
Implemented some tests for the internals of the strategy code.

**Commit Details:**
- Strategies can now be supplied directly to a bunch of the functions rather
  than relying on the embedded `RegisteredCanvasStrategies`.
- Added unit test code for the internal strategy functions.
