### PR TITLE
Typesafe CanvasStrategy ids

### DIFF
--- a/editor/src/components/canvas/canvas-actions.ts
+++ b/editor/src/components/canvas/canvas-actions.ts
@@ -1,4 +1,5 @@
 import type { CanvasPoint, CanvasVector } from '../../core/shared/math-utils'
+import { CanvasStrategyId } from './canvas-strategies/canvas-strategy-types'
 import {
   InteractionSession,
   InteractionSessionWithoutMetadata,
@@ -63,10 +64,10 @@ const CanvasActions = {
       applyChanges: applyChanges,
     }
   },
-  setUsersPreferredStrategy: function (strategyName: string): CanvasAction {
+  setUsersPreferredStrategy: function (strategyId: CanvasStrategyId): CanvasAction {
     return {
       action: 'SET_USERS_PREFERRED_STRATEGY',
-      strategyName: strategyName,
+      strategyId: strategyId,
     }
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -6,6 +6,7 @@ import * as EP from '../../../core/shared/element-path'
 import { CanvasStrategy } from './canvas-strategy-types'
 
 export const absoluteMoveStrategy: CanvasStrategy = {
+  id: 'ABSOLUTE_MOVE',
   name: 'Absolute Move',
   isApplicable: (canvasState, _interactionState, metadata) => {
     if (canvasState.selectedElements.length === 1) {

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
@@ -10,6 +10,7 @@ import { absoluteMoveStrategy } from './absolute-move-strategy'
 import { CanvasStrategy } from './canvas-strategy-types'
 
 export const absoluteReparentStrategy: CanvasStrategy = {
+  id: 'ABSOLUTE_REPARENT',
   name: 'Reparent Absolute Elements',
   isApplicable: (canvasState, interactionState, metadata) => {
     if (

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -25,8 +25,11 @@ export interface InteractionCanvasState {
   canvasOffset: CanvasVector
 }
 
+export type CanvasStrategyId = 'ABSOLUTE_MOVE' | 'ABSOLUTE_REPARENT'
+
 export interface CanvasStrategy {
-  name: string // We'd need to do something to guarantee uniqueness here if using this for the commands' reason
+  id: CanvasStrategyId // We'd need to do something to guarantee uniqueness here if using this for the commands' reason
+  name: string
 
   // Determines if we should show the controls that this strategy renders
   isApplicable: (

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -14,6 +14,7 @@ import { ProjectContentTreeRoot } from '../../assets'
 import { EdgePosition } from '../canvas-types'
 import { MoveIntoDragThreshold } from '../canvas-utils'
 import { CanvasCommand } from '../commands/commands'
+import { CanvasStrategyId } from './canvas-strategy-types'
 
 export interface DragInteractionData {
   type: 'DRAG'
@@ -64,7 +65,7 @@ export interface StrategyAndAccumulatedCommands {
 
 export interface StrategyState {
   // Need to track here which strategy is being applied.
-  currentStrategy: string | null
+  currentStrategy: CanvasStrategyId | null
   currentStrategyFitness: number
   currentStrategyCommands: Array<CanvasCommand>
   accumulatedCommands: Array<StrategyAndAccumulatedCommands>

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -28,6 +28,7 @@ import {
   InteractionSession,
   InteractionSessionWithoutMetadata,
 } from './canvas-strategies/interaction-state'
+import { CanvasStrategyId } from './canvas-strategies/canvas-strategy-types'
 
 export const CanvasContainerID = 'canvas-container'
 
@@ -671,7 +672,7 @@ type ZoomUI = {
 
 type SetUsersPreferredStrategy = {
   action: 'SET_USERS_PREFERRED_STRATEGY'
-  strategyName: string // TODO limit it to string literal union of registered strategy names?
+  strategyId: CanvasStrategyId
 }
 
 export type CanvasAction =

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-indicator.tsx
@@ -4,6 +4,7 @@ import { FlexRow, FlexColumn, useColorTheme, UtopiaStyles } from '../../../../uu
 import { useEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
 import { useGetApplicableStrategiesOrderedByFitness } from '../../canvas-strategies/canvas-strategies'
+import { CanvasStrategy, CanvasStrategyId } from '../../canvas-strategies/canvas-strategy-types'
 
 export const CanvasStrategyIndicator = React.memo(() => {
   const colorTheme = useColorTheme()
@@ -15,8 +16,8 @@ export const CanvasStrategyIndicator = React.memo(() => {
   const otherPossibleStrategies = useGetApplicableStrategiesOrderedByFitness()
 
   const onTabPressed = React.useCallback(
-    (newStrategyName: string) => {
-      dispatch([CanvasActions.setUsersPreferredStrategy(newStrategyName)])
+    (newStrategy: CanvasStrategy) => {
+      dispatch([CanvasActions.setUsersPreferredStrategy(newStrategy.id)])
     },
     [dispatch],
   )
@@ -34,12 +35,12 @@ export const CanvasStrategyIndicator = React.memo(() => {
         event.stopImmediatePropagation()
 
         const activeStrategyIndex = otherPossibleStrategies.findIndex(
-          (strategyName: string) => strategyName === activeStrategy,
+          (strategy: CanvasStrategy) => strategy.id === activeStrategy,
         )
         const nextStrategyIndex = (activeStrategyIndex + 1) % otherPossibleStrategies.length
-        const nextStrategyName = otherPossibleStrategies[nextStrategyIndex]
+        const nextStrategy = otherPossibleStrategies[nextStrategyIndex]
 
-        onTabPressed(nextStrategyName)
+        onTabPressed(nextStrategy)
       }
     }
     window.addEventListener('keydown', handleTabKey, true)
@@ -75,20 +76,20 @@ export const CanvasStrategyIndicator = React.memo(() => {
             {otherPossibleStrategies?.map((strategy) => {
               return (
                 <FlexRow
-                  key={strategy}
+                  key={strategy.id}
                   style={{
                     height: 29,
                     paddingLeft: 4,
                     paddingRight: 4,
                     backgroundColor:
-                      strategy === activeStrategy ? colorTheme.primary.value : undefined,
+                      strategy.id === activeStrategy ? colorTheme.primary.value : undefined,
                     color:
-                      strategy === activeStrategy
+                      strategy.id === activeStrategy
                         ? colorTheme.white.value
                         : colorTheme.textColor.value,
                   }}
                 >
-                  {strategy}
+                  {strategy.name}
                 </FlexRow>
               )
             })}

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -37,6 +37,7 @@ import {
 } from '../../canvas/canvas-strategies/interaction-state'
 import {
   CanvasStrategy,
+  CanvasStrategyId,
   InteractionCanvasState,
   StrategyApplicationResult,
 } from '../../canvas/canvas-strategies/canvas-strategy-types'
@@ -125,6 +126,7 @@ describe('interactionCancel', () => {
 })
 
 const testStrategy: CanvasStrategy = {
+  id: 'TEST_STRATEGY' as CanvasStrategyId,
   name: 'Test Strategy',
   isApplicable: function (
     canvasState: InteractionCanvasState,
@@ -179,7 +181,7 @@ describe('interactionStart', () => {
             "transient": false,
           },
         ],
-        "currentStrategy": "Test Strategy",
+        "currentStrategy": "TEST_STRATEGY",
         "currentStrategyCommands": Array [
           Object {
             "patch": Object {
@@ -277,7 +279,7 @@ describe('interactionUpdate', () => {
             "transient": false,
           },
         ],
-        "currentStrategy": "Test Strategy",
+        "currentStrategy": "TEST_STRATEGY",
         "currentStrategyCommands": Array [
           Object {
             "patch": Object {
@@ -379,7 +381,7 @@ describe('interactionHardReset', () => {
             "transient": false,
           },
         ],
-        "currentStrategy": "Test Strategy",
+        "currentStrategy": "TEST_STRATEGY",
         "currentStrategyCommands": Array [
           Object {
             "patch": Object {
@@ -510,7 +512,7 @@ describe('interactionStrategyChangeStacked', () => {
             "transient": false,
           },
         ],
-        "currentStrategy": "Test Strategy",
+        "currentStrategy": "TEST_STRATEGY",
         "currentStrategyCommands": Array [
           Object {
             "patch": Object {
@@ -635,7 +637,7 @@ describe('interactionUserChangedStrategy', () => {
             "transient": false,
           },
         ],
-        "currentStrategy": "Test Strategy",
+        "currentStrategy": "TEST_STRATEGY",
         "currentStrategyCommands": Array [
           Object {
             "patch": Object {

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -149,7 +149,7 @@ export function interactionHardReset(
         'transient',
       )
       const newStrategyState: StrategyState = {
-        currentStrategy: strategy.strategy.name,
+        currentStrategy: strategy.strategy.id,
         currentStrategyFitness: strategy.fitness,
         currentStrategyCommands: commands,
         accumulatedCommands: [],
@@ -218,7 +218,7 @@ export function interactionUpdate(
         'transient',
       )
       const newStrategyState: StrategyState = {
-        currentStrategy: strategy.strategy.name,
+        currentStrategy: strategy.strategy.id,
         currentStrategyFitness: strategy.fitness,
         currentStrategyCommands: commands,
         accumulatedCommands: result.strategyState.accumulatedCommands,
@@ -291,7 +291,7 @@ export function interactionStart(
       )
 
       const newStrategyState: StrategyState = {
-        currentStrategy: strategy.strategy.name,
+        currentStrategy: strategy.strategy.id,
         currentStrategyFitness: strategy.fitness,
         currentStrategyCommands: commands,
         accumulatedCommands: [],
@@ -363,8 +363,8 @@ export function interactionUserChangedStrategy(
       result.strategyState,
       result.strategyState.currentStrategy,
     )
-    const strategyName = strategy?.strategy.name
-    if (strategyName != result.unpatchedEditor.canvas.interactionSession?.userPreferredStrategy) {
+    const strategyId = strategy?.strategy.id
+    if (strategyId != result.unpatchedEditor.canvas.interactionSession?.userPreferredStrategy) {
       console.warn(
         'Entered interactionUserChangedStrategy but the user preferred strategy is not applied',
       )
@@ -378,7 +378,7 @@ export function interactionUserChangedStrategy(
           commands: [
             strategySwitched(
               'user-input',
-              strategyName!,
+              strategy.strategy.name,
               true,
               previousStrategy?.fitness ?? NaN,
               strategy.fitness,
@@ -404,7 +404,7 @@ export function interactionUserChangedStrategy(
         'transient',
       )
       const newStrategyState: StrategyState = {
-        currentStrategy: strategy.strategy.name,
+        currentStrategy: strategy.strategy.id,
         currentStrategyFitness: strategy.fitness,
         currentStrategyCommands: commands,
         accumulatedCommands: newAccumulatedCommands,
@@ -457,8 +457,8 @@ export function interactionStrategyChangeStacked(
       result.strategyState,
       result.strategyState.currentStrategy,
     )
-    const strategyName = strategy?.strategy.name
-    if (strategyName === result.strategyState.currentStrategy) {
+    const strategyId = strategy?.strategy.id
+    if (strategyId === result.strategyState.currentStrategy) {
       console.warn("Entered interactionStrategyChangeStacked but the strategy haven't changed")
     }
 
@@ -470,7 +470,7 @@ export function interactionStrategyChangeStacked(
           commands: [
             strategySwitched(
               'user-input',
-              strategyName!,
+              strategy.strategy.name,
               true,
               previousStrategy?.fitness ?? NaN,
               strategy.fitness,
@@ -500,7 +500,7 @@ export function interactionStrategyChangeStacked(
         'transient',
       )
       const newStrategyState: StrategyState = {
-        currentStrategy: strategy.strategy.name,
+        currentStrategy: strategy.strategy.id,
         currentStrategyFitness: strategy.fitness,
         currentStrategyCommands: commands,
         accumulatedCommands: newAccumulatedCommands,
@@ -606,7 +606,7 @@ function handleStrategiesInner(
         }
 
         const strategy = findCanvasStrategyFromDispatchResult(strategies, result)
-        if (strategy?.strategy.name !== result.strategyState.currentStrategy) {
+        if (strategy?.strategy.id !== result.strategyState.currentStrategy) {
           return interactionStrategyChangeStacked(strategies, storedState, result)
         }
 

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -410,7 +410,7 @@ export function runLocalCanvasAction(
             ...model.canvas,
             interactionSession: {
               ...model.canvas.interactionSession,
-              userPreferredStrategy: action.strategyName,
+              userPreferredStrategy: action.strategyId,
             },
           },
         }


### PR DESCRIPTION
We identify canvas strategies by names, which are simple strings. This is not typesafe, typos can cause problems, and uniqueness is not guaranteed.

In this PR I introduced an id field in CanvasStrategy, which has a string literal union type. This id is typesafe, and we can still use the name field to contain a user digestible name.

Questions:
- uniqueness is still not guaranteed, but maybe it is not that important, we don't have that quarantee with actions neither.
- do we need this at all? We could just store the strategy objects everywhere, they are constants and never recreated, so they always keep their references.