### PR TITLE
re-run dom-walker after clearing interaction session

### DIFF
--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -384,6 +384,7 @@ export function runLocalCanvasAction(
         canvas: {
           ...model.canvas,
           interactionSession: null,
+          domWalkerInvalidateCount: model.canvas.domWalkerInvalidateCount + 1,
         },
         jsxMetadata: metadataToKeep,
       }


### PR DESCRIPTION
**Problem:**
The bug I was investigating: cmd + double-click on Card is supposed to focus it, and the navigator correctly turned orange, but the unfolded internal elements of Card did not appear in the navigator.

The bigger issue I uncovered: cancelling an interaction via CLEAR_INTERACTION_SESSION would reset the jsxMetadata to how it was before the interaction, and _most of the time_ we would re-run the dom-walker so everything is eventually correct. But if cancelling the interaction doesn't have visible changes on the canvas (because for example there was no real interaction to happen) then we just revert the metadata without running dom-walker. 
This led to an issue where the timing of actions dispatched during a cmd + double-click meant that we accidentally reverted the effects of focusing an element.

**Fix:**
The fix is to always ask the dom-walker to re-run after a CLEAR_INTERACTION_SESSION.

**Commit Details:**
- CLEAR_INTERACTION_SESSION now increases the domWalkerInvalidateCount
