### PR TITLE
Store applicable strategies in StrategyState

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -181,14 +181,21 @@ export function findCanvasStrategy(
   interactionSession: InteractionSession,
   strategyState: StrategyState,
   previousStrategyId: CanvasStrategyId | null,
-): { strategy: StrategyWithFitness | null; previousStrategy: StrategyWithFitness | null } {
+): {
+  strategy: StrategyWithFitness | null
+  previousStrategy: StrategyWithFitness | null
+  sortedApplicableStrategies: Array<CanvasStrategy>
+} {
   const sortedApplicableStrategies = getApplicableStrategiesOrderedByFitness(
     strategies,
     canvasState,
     interactionSession,
     strategyState,
   )
-  return pickStrategy(sortedApplicableStrategies, interactionSession, previousStrategyId)
+  return {
+    ...pickStrategy(sortedApplicableStrategies, interactionSession, previousStrategyId),
+    sortedApplicableStrategies: sortedApplicableStrategies.map((s) => s.strategy),
+  }
 }
 
 export function applyCanvasStrategy(

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -10,11 +10,10 @@ import {
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { KeyCharacter } from '../../../utils/keyboard'
 import { Modifiers } from '../../../utils/modifiers'
-import { ProjectContentTreeRoot } from '../../assets'
 import { EdgePosition } from '../canvas-types'
 import { MoveIntoDragThreshold } from '../canvas-utils'
 import { CanvasCommand } from '../commands/commands'
-import { CanvasStrategyId } from './canvas-strategy-types'
+import { CanvasStrategy, CanvasStrategyId } from './canvas-strategy-types'
 
 export interface DragInteractionData {
   type: 'DRAG'
@@ -70,6 +69,7 @@ export interface StrategyState {
   currentStrategyCommands: Array<CanvasCommand>
   accumulatedCommands: Array<StrategyAndAccumulatedCommands>
   commandDescriptions: Array<CommandDescription>
+  sortedApplicableStrategies: Array<CanvasStrategy>
 
   // Checkpointed metadata at the point at which a strategy change has occurred.
   startingMetadata: ElementInstanceMetadataMap
@@ -82,6 +82,7 @@ export function createEmptyStrategyState(metadata?: ElementInstanceMetadataMap):
     currentStrategyCommands: [],
     accumulatedCommands: [],
     commandDescriptions: [],
+    sortedApplicableStrategies: [],
     startingMetadata: metadata ?? {},
   }
 }

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-indicator.tsx
@@ -3,17 +3,18 @@ import { when } from '../../../../utils/react-conditionals'
 import { FlexRow, FlexColumn, useColorTheme, UtopiaStyles } from '../../../../uuiui'
 import { useEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
-import { useGetApplicableStrategiesOrderedByFitness } from '../../canvas-strategies/canvas-strategies'
-import { CanvasStrategy, CanvasStrategyId } from '../../canvas-strategies/canvas-strategy-types'
+import { CanvasStrategy } from '../../canvas-strategies/canvas-strategy-types'
 
 export const CanvasStrategyIndicator = React.memo(() => {
   const colorTheme = useColorTheme()
   const dispatch = useEditorState((store) => store.dispatch, 'CanvasStrategyIndicator dispatch')
-  const activeStrategy = useEditorState(
-    (store) => store.strategyState.currentStrategy,
+  const { activeStrategy, otherPossibleStrategies } = useEditorState(
+    (store) => ({
+      activeStrategy: store.strategyState.currentStrategy,
+      otherPossibleStrategies: store.strategyState.sortedApplicableStrategies,
+    }),
     'CanvasStrategyIndicator strategyState.currentStrategy',
   )
-  const otherPossibleStrategies = useGetApplicableStrategiesOrderedByFitness()
 
   const onTabPressed = React.useCallback(
     (newStrategy: CanvasStrategy) => {

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -196,6 +196,16 @@ describe('interactionStart', () => {
           },
         ],
         "currentStrategyFitness": 10,
+        "sortedApplicableStrategies": Array [
+          Object {
+            "apply": [Function],
+            "controlsToRender": Array [],
+            "fitness": [Function],
+            "id": "TEST_STRATEGY",
+            "isApplicable": [Function],
+            "name": "Test Strategy",
+          },
+        ],
         "startingMetadata": Object {},
       }
     `)
@@ -239,6 +249,7 @@ describe('interactionStart', () => {
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
         "currentStrategyFitness": 0,
+        "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},
       }
     `)
@@ -294,6 +305,16 @@ describe('interactionUpdate', () => {
           },
         ],
         "currentStrategyFitness": 10,
+        "sortedApplicableStrategies": Array [
+          Object {
+            "apply": [Function],
+            "controlsToRender": Array [],
+            "fitness": [Function],
+            "id": "TEST_STRATEGY",
+            "isApplicable": [Function],
+            "name": "Test Strategy",
+          },
+        ],
         "startingMetadata": Object {},
       }
     `)
@@ -337,6 +358,7 @@ describe('interactionUpdate', () => {
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
         "currentStrategyFitness": 0,
+        "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},
       }
     `)
@@ -396,6 +418,16 @@ describe('interactionHardReset', () => {
           },
         ],
         "currentStrategyFitness": 10,
+        "sortedApplicableStrategies": Array [
+          Object {
+            "apply": [Function],
+            "controlsToRender": Array [],
+            "fitness": [Function],
+            "id": "TEST_STRATEGY",
+            "isApplicable": [Function],
+            "name": "Test Strategy",
+          },
+        ],
         "startingMetadata": Object {},
       }
     `)
@@ -445,6 +477,7 @@ describe('interactionHardReset', () => {
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
         "currentStrategyFitness": 0,
+        "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},
       }
     `)
@@ -527,6 +560,16 @@ describe('interactionStrategyChangeStacked', () => {
           },
         ],
         "currentStrategyFitness": 10,
+        "sortedApplicableStrategies": Array [
+          Object {
+            "apply": [Function],
+            "controlsToRender": Array [],
+            "fitness": [Function],
+            "id": "TEST_STRATEGY",
+            "isApplicable": [Function],
+            "name": "Test Strategy",
+          },
+        ],
         "startingMetadata": Object {},
       }
     `)
@@ -573,6 +616,7 @@ describe('interactionStrategyChangeStacked', () => {
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
         "currentStrategyFitness": 0,
+        "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},
       }
     `)
@@ -652,6 +696,16 @@ describe('interactionUserChangedStrategy', () => {
           },
         ],
         "currentStrategyFitness": 10,
+        "sortedApplicableStrategies": Array [
+          Object {
+            "apply": [Function],
+            "controlsToRender": Array [],
+            "fitness": [Function],
+            "id": "TEST_STRATEGY",
+            "isApplicable": [Function],
+            "name": "Test Strategy",
+          },
+        ],
         "startingMetadata": Object {},
       }
     `)
@@ -701,6 +755,7 @@ describe('interactionUserChangedStrategy', () => {
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
         "currentStrategyFitness": 0,
+        "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},
       }
     `)

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -56,7 +56,7 @@ export function interactionFinished(
     }
   } else {
     // Determine the new canvas strategy to run this time around.
-    const { strategy } = findCanvasStrategy(
+    const { strategy, sortedApplicableStrategies } = findCanvasStrategy(
       strategies,
       canvasState,
       interactionSession,
@@ -64,12 +64,17 @@ export function interactionFinished(
       result.strategyState.currentStrategy,
     )
 
+    const newStrategyState = {
+      ...withClearedSession,
+      sortedApplicableStrategies: sortedApplicableStrategies,
+    }
+
     // If there is a current strategy, produce the commands from it.
     if (strategy == null) {
       return {
         unpatchedEditorState: newEditorState,
         patchedEditorState: newEditorState,
-        newStrategyState: withClearedSession,
+        newStrategyState: newStrategyState,
       }
     } else {
       const commands = applyCanvasStrategy(
@@ -88,7 +93,7 @@ export function interactionFinished(
       return {
         unpatchedEditorState: commandResult.editorState,
         patchedEditorState: commandResult.editorState,
-        newStrategyState: withClearedSession,
+        newStrategyState: newStrategyState,
       }
     }
   }
@@ -126,7 +131,7 @@ export function interactionHardReset(
       startingMetadata: storedState.unpatchedEditor.jsxMetadata,
     }
     // Determine the new canvas strategy to run this time around.
-    const { strategy, previousStrategy } = findCanvasStrategy(
+    const { strategy, sortedApplicableStrategies } = findCanvasStrategy(
       strategies,
       canvasState,
       resetInteractionSession,
@@ -154,6 +159,7 @@ export function interactionHardReset(
         currentStrategyCommands: commands,
         accumulatedCommands: [],
         commandDescriptions: commandResult.commandDescriptions,
+        sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: resetStrategyState.startingMetadata,
       }
 
@@ -195,7 +201,7 @@ export function interactionUpdate(
     }
   } else {
     // Determine the new canvas strategy to run this time around.
-    const { strategy } = findCanvasStrategy(
+    const { strategy, sortedApplicableStrategies } = findCanvasStrategy(
       strategies,
       canvasState,
       interactionSession,
@@ -223,6 +229,7 @@ export function interactionUpdate(
         currentStrategyCommands: commands,
         accumulatedCommands: result.strategyState.accumulatedCommands,
         commandDescriptions: commandResult.commandDescriptions,
+        sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: result.strategyState.startingMetadata,
       }
 
@@ -267,7 +274,7 @@ export function interactionStart(
     }
   } else {
     // Determine the new canvas strategy to run this time around.
-    const { strategy, previousStrategy } = findCanvasStrategy(
+    const { strategy, sortedApplicableStrategies } = findCanvasStrategy(
       strategies,
       canvasState,
       interactionSession,
@@ -296,6 +303,7 @@ export function interactionStart(
         currentStrategyCommands: commands,
         accumulatedCommands: [],
         commandDescriptions: commandResult.commandDescriptions,
+        sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: newEditorState.canvas.interactionSession.metadata,
       }
 
@@ -356,7 +364,7 @@ export function interactionUserChangedStrategy(
     }
   } else {
     // Determine the new canvas strategy to run this time around.
-    const { strategy, previousStrategy } = findCanvasStrategy(
+    const { strategy, previousStrategy, sortedApplicableStrategies } = findCanvasStrategy(
       strategies,
       canvasState,
       interactionSession,
@@ -409,6 +417,7 @@ export function interactionUserChangedStrategy(
         currentStrategyCommands: commands,
         accumulatedCommands: newAccumulatedCommands,
         commandDescriptions: commandResult.commandDescriptions,
+        sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: result.strategyState.startingMetadata,
       }
 
@@ -450,7 +459,7 @@ export function interactionStrategyChangeStacked(
     }
   } else {
     // Determine the new canvas strategy to run this time around.
-    const { strategy, previousStrategy } = findCanvasStrategy(
+    const { strategy, previousStrategy, sortedApplicableStrategies } = findCanvasStrategy(
       strategies,
       canvasState,
       interactionSession,
@@ -505,6 +514,7 @@ export function interactionStrategyChangeStacked(
         currentStrategyCommands: commands,
         accumulatedCommands: newAccumulatedCommands,
         commandDescriptions: commandResult.commandDescriptions,
+        sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: result.strategyState.startingMetadata,
       }
 


### PR DESCRIPTION
We have an inconsistency which affects the strategy indicator ui component:

In the dispatch function we check the applicable strategies based on the unpatched editor state (+ accumulated commands theoretically, but not IRL yet)

In the strategy indicator we check the applicable strategies using the `useEditorState` hook, which uses the patched editor state.

This can result in different applicable strategies on the ui then what we actually use in dispatch.

My fix is to store the sorted list of applicable strategies in StrategyState.