### PR TITLE
Refactor dispatch-strategies to reduce code duplication

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -73,7 +73,7 @@ function useGetApplicableStrategies(): Array<CanvasStrategy> {
   return useEditorState(getApplicableStrategiesSelector, 'useGetApplicableStrategies', arrayEquals)
 }
 
-interface StrategyWithFitness {
+export interface StrategyWithFitness {
   fitness: number
   strategy: CanvasStrategy
 }

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -44,7 +44,7 @@ export interface InteractionSession {
   metadata: ElementInstanceMetadataMap
 
   // To track if the user selected a strategy
-  userPreferredStrategy: string | null
+  userPreferredStrategy: CanvasStrategyId | null
 
   startedAt: number
   globalTime: number

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -16,9 +16,7 @@ import {
   interactionCancel,
   interactionHardReset,
   interactionStart,
-  handleStrategyChangeStacked,
   interactionUpdate,
-  handleUserChangedStrategy,
 } from './dispatch-strategies'
 import { createEditorState, deriveState, EditorStoreFull } from './editor-state'
 import * as EP from '../../../core/shared/element-path'

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -491,7 +491,7 @@ describe('interactionHardReset', () => {
   })
 })
 
-describe('interactionUpdate with strategy change', () => {
+describe('interactionUpdate with stacked strategy change', () => {
   it('steps an interaction session correctly', () => {
     let interactionSession = createInteractionViaMouse(
       canvasPoint({ x: 100, y: 200 }),

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -491,7 +491,7 @@ describe('interactionHardReset', () => {
   })
 })
 
-describe('interactionStrategyChangeStacked', () => {
+describe('interactionUpdate with strategy change', () => {
   it('steps an interaction session correctly', () => {
     let interactionSession = createInteractionViaMouse(
       canvasPoint({ x: 100, y: 200 }),
@@ -631,7 +631,7 @@ describe('interactionStrategyChangeStacked', () => {
   })
 })
 
-describe('interactionUserChangedStrategy', () => {
+describe('interactionUpdate with user changed strategy', () => {
   it('steps an interaction session correctly', () => {
     let interactionSession = createInteractionViaMouse(
       canvasPoint({ x: 100, y: 200 }),

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -153,33 +153,6 @@ const testStrategy: CanvasStrategy = {
   },
 }
 
-const emptyTestStrategy: CanvasStrategy = {
-  id: 'EMPTY_TEST_STRATEGY' as CanvasStrategyId,
-  name: 'Empty test strategy',
-  isApplicable: function (
-    canvasState: InteractionCanvasState,
-    interactionSession: InteractionSession | null,
-    metadata: ElementInstanceMetadataMap,
-  ): boolean {
-    return true
-  },
-  controlsToRender: [],
-  fitness: function (
-    canvasState: InteractionCanvasState,
-    interactionSession: InteractionSession,
-    strategyState: StrategyState,
-  ): number {
-    return 10
-  },
-  apply: function (
-    canvasState: InteractionCanvasState,
-    interactionSession: InteractionSession,
-    strategyState: StrategyState,
-  ): StrategyApplicationResult {
-    return [wildcardPatch('permanent', { canvas: { scale: { $set: 100 } } })]
-  },
-}
-
 describe('interactionStart', () => {
   it('creates the initial state with a simple test strategy', () => {
     const editorStore = createEditorStore(

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -314,7 +314,7 @@ export function interactionCancel(
   }
 }
 
-export function handleUserChangedStrategy(
+function handleUserChangedStrategy(
   newEditorState: EditorState,
   storedEditorState: EditorState,
   strategyState: StrategyState,
@@ -381,7 +381,7 @@ export function handleUserChangedStrategy(
   }
 }
 
-export function handleUpdate(
+function handleUpdate(
   newEditorState: EditorState,
   storedEditorState: EditorState,
   strategyState: StrategyState,
@@ -428,7 +428,7 @@ export function handleUpdate(
   }
 }
 
-export function handleStrategyChangeStacked(
+function handleStrategyChangeStacked(
   newEditorState: EditorState,
   storedEditorState: EditorState,
   strategyState: StrategyState,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -3,6 +3,7 @@ import {
   findCanvasStrategy,
   findCanvasStrategyFromDispatchResult,
   pickCanvasStateFromEditorState,
+  StrategyWithFitness,
 } from '../../canvas/canvas-strategies/canvas-strategies'
 import {
   createEmptyStrategyState,
@@ -181,7 +182,7 @@ export function interactionUpdate(
     }
   } else {
     // Determine the new canvas strategy to run this time around.
-    const { strategy, sortedApplicableStrategies } = findCanvasStrategy(
+    const { strategy, previousStrategy, sortedApplicableStrategies } = findCanvasStrategy(
       strategies,
       canvasState,
       interactionSession,
@@ -189,42 +190,41 @@ export function interactionUpdate(
       result.strategyState.currentStrategy,
     )
 
-    // If there is a current strategy, produce the commands from it.
-    if (strategy != null && newEditorState.canvas.interactionSession != null) {
-      const commands = applyCanvasStrategy(
-        strategy.strategy,
-        canvasState,
-        newEditorState.canvas.interactionSession,
-        result.strategyState,
-      )
-      const commandResult = foldAndApplyCommands(
-        newEditorState,
-        storedState.patchedEditor,
-        [...result.strategyState.accumulatedCommands.flatMap((c) => c.commands), ...commands],
-        'transient',
-      )
-      const newStrategyState: StrategyState = {
-        currentStrategy: strategy.strategy.id,
-        currentStrategyFitness: strategy.fitness,
-        currentStrategyCommands: commands,
-        accumulatedCommands: result.strategyState.accumulatedCommands,
-        commandDescriptions: commandResult.commandDescriptions,
-        sortedApplicableStrategies: sortedApplicableStrategies,
-        startingMetadata: result.strategyState.startingMetadata,
-      }
-
-      return {
-        unpatchedEditorState: newEditorState,
-        patchedEditorState: commandResult.editorState,
-        newStrategyState: newStrategyState,
-      }
-    } else {
-      return {
-        unpatchedEditorState: newEditorState,
-        patchedEditorState: newEditorState,
-        newStrategyState: result.strategyState,
+    if (interactionSession.userPreferredStrategy != null) {
+      const userChangedStrategy =
+        interactionSession.userPreferredStrategy !=
+        storedState.unpatchedEditor.canvas.interactionSession?.userPreferredStrategy
+      if (userChangedStrategy) {
+        return handleUserChangedStrategy(
+          newEditorState,
+          storedState.patchedEditor,
+          result.strategyState,
+          strategy,
+          previousStrategy,
+          sortedApplicableStrategies,
+        )
       }
     }
+
+    if (strategy?.strategy.id !== previousStrategy?.strategy.id) {
+      return handleStrategyChangeStacked(
+        newEditorState,
+        storedState.patchedEditor,
+        result.strategyState,
+        strategy,
+        previousStrategy,
+        sortedApplicableStrategies,
+      )
+    }
+
+    return handleUpdate(
+      newEditorState,
+      storedState.patchedEditor,
+      result.strategyState,
+      strategy,
+      previousStrategy,
+      sortedApplicableStrategies,
+    )
   }
 }
 
@@ -314,190 +314,196 @@ export function interactionCancel(
   }
 }
 
-export function interactionUserChangedStrategy(
-  strategies: Array<CanvasStrategy>,
-  storedState: EditorStoreFull,
-  result: InnerDispatchResult,
+export function handleUserChangedStrategy(
+  newEditorState: EditorState,
+  storedEditorState: EditorState,
+  strategyState: StrategyState,
+  strategy: StrategyWithFitness | null,
+  previousStrategy: StrategyWithFitness | null,
+  sortedApplicableStrategies: Array<CanvasStrategy>,
 ): HandleStrategiesResult {
-  const newEditorState = result.unpatchedEditor
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
-  const interactionSession = newEditorState.canvas.interactionSession
-  if (interactionSession == null) {
+
+  // If there is a current strategy, produce the commands from it.
+  if (strategy != null && newEditorState.canvas.interactionSession != null) {
+    const strategyChangedLogCommands = [
+      {
+        strategy: null,
+        commands: [
+          strategySwitched(
+            'user-input',
+            strategy.strategy.name,
+            true,
+            previousStrategy?.fitness ?? NaN,
+            strategy.fitness,
+          ),
+        ],
+      },
+    ]
+
+    const commands = applyCanvasStrategy(
+      strategy.strategy,
+      canvasState,
+      newEditorState.canvas.interactionSession,
+      strategyState,
+    )
+    const newAccumulatedCommands = [
+      ...strategyState.accumulatedCommands,
+      ...strategyChangedLogCommands,
+    ]
+    const commandResult = foldAndApplyCommands(
+      newEditorState,
+      storedEditorState,
+      [...newAccumulatedCommands.flatMap((c) => c.commands), ...commands],
+      'transient',
+    )
+    const newStrategyState: StrategyState = {
+      currentStrategy: strategy.strategy.id,
+      currentStrategyFitness: strategy.fitness,
+      currentStrategyCommands: commands,
+      accumulatedCommands: newAccumulatedCommands,
+      commandDescriptions: commandResult.commandDescriptions,
+      sortedApplicableStrategies: sortedApplicableStrategies,
+      startingMetadata: strategyState.startingMetadata,
+    }
+
+    return {
+      unpatchedEditorState: newEditorState,
+      patchedEditorState: commandResult.editorState,
+      newStrategyState: newStrategyState,
+    }
+  } else {
     return {
       unpatchedEditorState: newEditorState,
       patchedEditorState: newEditorState,
-      newStrategyState: result.strategyState,
-    }
-  } else {
-    // Determine the new canvas strategy to run this time around.
-    const { strategy, previousStrategy, sortedApplicableStrategies } = findCanvasStrategy(
-      strategies,
-      canvasState,
-      interactionSession,
-      result.strategyState,
-      result.strategyState.currentStrategy,
-    )
-    const strategyId = strategy?.strategy.id
-    if (strategyId != result.unpatchedEditor.canvas.interactionSession?.userPreferredStrategy) {
-      console.warn(
-        'Entered interactionUserChangedStrategy but the user preferred strategy is not applied',
-      )
-    }
-
-    // If there is a current strategy, produce the commands from it.
-    if (strategy != null && newEditorState.canvas.interactionSession != null) {
-      const strategyChangedLogCommands = [
-        {
-          strategy: null,
-          commands: [
-            strategySwitched(
-              'user-input',
-              strategy.strategy.name,
-              true,
-              previousStrategy?.fitness ?? NaN,
-              strategy.fitness,
-            ),
-          ],
-        },
-      ]
-
-      const commands = applyCanvasStrategy(
-        strategy.strategy,
-        canvasState,
-        newEditorState.canvas.interactionSession,
-        result.strategyState,
-      )
-      const newAccumulatedCommands = [
-        ...result.strategyState.accumulatedCommands,
-        ...strategyChangedLogCommands,
-      ]
-      const commandResult = foldAndApplyCommands(
-        newEditorState,
-        storedState.patchedEditor,
-        [...newAccumulatedCommands.flatMap((c) => c.commands), ...commands],
-        'transient',
-      )
-      const newStrategyState: StrategyState = {
-        currentStrategy: strategy.strategy.id,
-        currentStrategyFitness: strategy.fitness,
-        currentStrategyCommands: commands,
-        accumulatedCommands: newAccumulatedCommands,
-        commandDescriptions: commandResult.commandDescriptions,
-        sortedApplicableStrategies: sortedApplicableStrategies,
-        startingMetadata: result.strategyState.startingMetadata,
-      }
-
-      return {
-        unpatchedEditorState: newEditorState,
-        patchedEditorState: commandResult.editorState,
-        newStrategyState: newStrategyState,
-      }
-    } else {
-      return {
-        unpatchedEditorState: newEditorState,
-        patchedEditorState: newEditorState,
-        newStrategyState: result.strategyState,
-      }
+      newStrategyState: strategyState,
     }
   }
 }
 
-export function interactionStrategyChangeStacked(
-  strategies: Array<CanvasStrategy>,
-  storedState: EditorStoreFull,
-  result: InnerDispatchResult,
+export function handleUpdate(
+  newEditorState: EditorState,
+  storedEditorState: EditorState,
+  strategyState: StrategyState,
+  strategy: StrategyWithFitness | null,
+  previousStrategy: StrategyWithFitness | null,
+  sortedApplicableStrategies: Array<CanvasStrategy>,
 ): HandleStrategiesResult {
-  const newEditorState = result.unpatchedEditor
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
-  const interactionSession = newEditorState.canvas.interactionSession
-  if (interactionSession == null) {
+  // If there is a current strategy, produce the commands from it.
+  if (strategy != null && newEditorState.canvas.interactionSession != null) {
+    const commands = applyCanvasStrategy(
+      strategy.strategy,
+      canvasState,
+      newEditorState.canvas.interactionSession,
+      strategyState,
+    )
+    const commandResult = foldAndApplyCommands(
+      newEditorState,
+      storedEditorState,
+      [...strategyState.accumulatedCommands.flatMap((c) => c.commands), ...commands],
+      'transient',
+    )
+    const newStrategyState: StrategyState = {
+      currentStrategy: strategy.strategy.id,
+      currentStrategyFitness: strategy.fitness,
+      currentStrategyCommands: commands,
+      accumulatedCommands: strategyState.accumulatedCommands,
+      commandDescriptions: commandResult.commandDescriptions,
+      sortedApplicableStrategies: sortedApplicableStrategies,
+      startingMetadata: strategyState.startingMetadata,
+    }
+
+    return {
+      unpatchedEditorState: newEditorState,
+      patchedEditorState: commandResult.editorState,
+      newStrategyState: newStrategyState,
+    }
+  } else {
     return {
       unpatchedEditorState: newEditorState,
       patchedEditorState: newEditorState,
-      newStrategyState: result.strategyState,
+      newStrategyState: strategyState,
+    }
+  }
+}
+
+export function handleStrategyChangeStacked(
+  newEditorState: EditorState,
+  storedEditorState: EditorState,
+  strategyState: StrategyState,
+  strategy: StrategyWithFitness | null,
+  previousStrategy: StrategyWithFitness | null,
+  sortedApplicableStrategies: Array<CanvasStrategy>,
+): HandleStrategiesResult {
+  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
+  // If there is a current strategy, produce the commands from it.
+  if (strategy != null && newEditorState.canvas.interactionSession != null) {
+    const strategyChangedLogCommands = [
+      {
+        strategy: null,
+        commands: [
+          strategySwitched(
+            'user-input',
+            strategy.strategy.name,
+            true,
+            previousStrategy?.fitness ?? NaN,
+            strategy.fitness,
+          ),
+        ],
+      },
+    ]
+
+    const commands = applyCanvasStrategy(
+      strategy.strategy,
+      canvasState,
+      newEditorState.canvas.interactionSession,
+      strategyState,
+    )
+    const newAccumulatedCommands = [
+      ...strategyState.accumulatedCommands,
+      {
+        strategy: strategyState.currentStrategy,
+        commands: strategyState.currentStrategyCommands,
+      },
+      ...strategyChangedLogCommands,
+    ]
+    const commandResult = foldAndApplyCommands(
+      newEditorState,
+      storedEditorState,
+      [...newAccumulatedCommands.flatMap((c) => c.commands), ...commands],
+      'transient',
+    )
+    const newStrategyState: StrategyState = {
+      currentStrategy: strategy.strategy.id,
+      currentStrategyFitness: strategy.fitness,
+      currentStrategyCommands: commands,
+      accumulatedCommands: newAccumulatedCommands,
+      commandDescriptions: commandResult.commandDescriptions,
+      sortedApplicableStrategies: sortedApplicableStrategies,
+      startingMetadata: strategyState.startingMetadata,
+    }
+
+    const patchedEditorState = {
+      ...newEditorState,
+      canvas: {
+        ...newEditorState.canvas,
+        interactionSession: strategySwitchInteractionSessionReset(
+          newEditorState.canvas.interactionSession,
+        ),
+      },
+    }
+
+    return {
+      unpatchedEditorState: newEditorState,
+      patchedEditorState: patchedEditorState,
+      newStrategyState: newStrategyState,
     }
   } else {
-    // Determine the new canvas strategy to run this time around.
-    const { strategy, previousStrategy, sortedApplicableStrategies } = findCanvasStrategy(
-      strategies,
-      canvasState,
-      interactionSession,
-      result.strategyState,
-      result.strategyState.currentStrategy,
-    )
-    const strategyId = strategy?.strategy.id
-    if (strategyId === result.strategyState.currentStrategy) {
-      console.warn("Entered interactionStrategyChangeStacked but the strategy haven't changed")
-    }
-
-    // If there is a current strategy, produce the commands from it.
-    if (strategy != null && newEditorState.canvas.interactionSession != null) {
-      const strategyChangedLogCommands = [
-        {
-          strategy: null,
-          commands: [
-            strategySwitched(
-              'user-input',
-              strategy.strategy.name,
-              true,
-              previousStrategy?.fitness ?? NaN,
-              strategy.fitness,
-            ),
-          ],
-        },
-      ]
-
-      const commands = applyCanvasStrategy(
-        strategy.strategy,
-        canvasState,
-        newEditorState.canvas.interactionSession,
-        result.strategyState,
-      )
-      const newAccumulatedCommands = [
-        ...result.strategyState.accumulatedCommands,
-        {
-          strategy: result.strategyState.currentStrategy,
-          commands: result.strategyState.currentStrategyCommands,
-        },
-        ...strategyChangedLogCommands,
-      ]
-      const commandResult = foldAndApplyCommands(
-        newEditorState,
-        storedState.patchedEditor,
-        [...newAccumulatedCommands.flatMap((c) => c.commands), ...commands],
-        'transient',
-      )
-      const newStrategyState: StrategyState = {
-        currentStrategy: strategy.strategy.id,
-        currentStrategyFitness: strategy.fitness,
-        currentStrategyCommands: commands,
-        accumulatedCommands: newAccumulatedCommands,
-        commandDescriptions: commandResult.commandDescriptions,
-        sortedApplicableStrategies: sortedApplicableStrategies,
-        startingMetadata: result.strategyState.startingMetadata,
-      }
-
-      const patchedEditorState = {
-        ...newEditorState,
-        canvas: {
-          ...newEditorState.canvas,
-          interactionSession: strategySwitchInteractionSessionReset(
-            newEditorState.canvas.interactionSession,
-          ),
-        },
-      }
-
-      return {
-        unpatchedEditorState: newEditorState,
-        patchedEditorState: patchedEditorState,
-        newStrategyState: newStrategyState,
-      }
-    } else {
-      return {
-        unpatchedEditorState: newEditorState,
-        patchedEditorState: newEditorState,
-        newStrategyState: result.strategyState,
-      }
+    return {
+      unpatchedEditorState: newEditorState,
+      patchedEditorState: newEditorState,
+      newStrategyState: strategyState,
     }
   }
 }
@@ -565,20 +571,6 @@ function handleStrategiesInner(
       if (interactionHardResetNeeded) {
         return interactionHardReset(strategies, storedState, result)
       } else {
-        if (result.unpatchedEditor.canvas.interactionSession?.userPreferredStrategy != null) {
-          const userChangedStrategy =
-            result.unpatchedEditor.canvas.interactionSession?.userPreferredStrategy !=
-            storedState.unpatchedEditor.canvas.interactionSession?.userPreferredStrategy
-          if (userChangedStrategy) {
-            return interactionUserChangedStrategy(strategies, storedState, result)
-          }
-        }
-
-        const strategy = findCanvasStrategyFromDispatchResult(strategies, result)
-        if (strategy?.strategy.id !== result.strategyState.currentStrategy) {
-          return interactionStrategyChangeStacked(strategies, storedState, result)
-        }
-
         return interactionUpdate(strategies, storedState, result)
       }
     }


### PR DESCRIPTION
The motivation for this PR is this comment: https://github.com/concrete-utopia/utopia/pull/2112#discussion_r816051646

The decision whether there is a strategy change or not can only be made after the strategy has been chosen. This resulted in the hard to understand, inefficient, and not safe code in which we searched for the canvas strategy twice: First to decide which `interaction*` function to run, and then start everything from scratch again inside those functions. 

As a fix for this duplication I merged `interactionUpdate`, `interactionUserChangedStrategy` and `interactionStrategyChangeStacked` into `interactionUpdate`, and created 2 different handler functions on how to apply the new strategies.