### PR TITLE
Use a tree to hold parent-child relationships.

### DIFF
--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -16,6 +16,8 @@ import { EditorAction } from '../editor/action-types'
 import * as EditorActions from '../editor/actions/action-creators'
 import { DerivedState, EditorState } from '../editor/store/editor-state'
 import * as EP from '../../core/shared/element-path'
+import { buildTree, forEachChildOfTarget } from '../../core/shared/element-path-tree'
+import { objectValues } from '../../core/shared/object-utils'
 
 export enum TargetSearchType {
   ParentsOfSelected = 'ParentsOfSelected',
@@ -47,6 +49,8 @@ const Canvas = {
     metadata: ElementInstanceMetadataMap,
     useBoundingFrames: boolean,
   ): Array<FrameWithPath> {
+    const projectTree = buildTree(objectValues(metadata).map((m) => m.elementPath))
+
     function recurseChildren(
       component: ElementInstanceMetadata,
     ): { boundingRect: CanvasRectangle | null; frames: Array<FrameWithPath> } {
@@ -60,13 +64,20 @@ const Canvas = {
 
       const overflows = MetadataUtils.overflows(component)
       const includeClippedNext = useBoundingFrames && overflows
-      const {
-        children,
-        unfurledComponents,
-      } = MetadataUtils.getAllChildrenElementsIncludingUnfurledFocusedComponents(
-        component.elementPath,
-        metadata,
-      )
+
+      let children: Array<ElementInstanceMetadata> = []
+      let unfurledComponents: Array<ElementInstanceMetadata> = []
+      forEachChildOfTarget(projectTree, component.elementPath, (childPath) => {
+        const childMetadata = MetadataUtils.findElementByElementPath(metadata, childPath)
+        if (childMetadata != null) {
+          if (EP.isRootElementOfInstance(childPath)) {
+            unfurledComponents.push(childMetadata)
+          } else {
+            children.push(childMetadata)
+          }
+        }
+      })
+
       const childFrames = children.map((child) => {
         const recurseResults = recurseChildren(child)
         const rectToBoundWith = includeClippedNext ? recurseResults.boundingRect : globalFrame

--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -49,6 +49,8 @@ const Canvas = {
     metadata: ElementInstanceMetadataMap,
     useBoundingFrames: boolean,
   ): Array<FrameWithPath> {
+    // Note: This will not necessarily be representative of the structured ordering in
+    // the code that produced these elements.
     const projectTree = buildTree(objectValues(metadata).map((m) => m.elementPath))
 
     function recurseChildren(

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -533,6 +533,8 @@ export const MetadataUtils = {
   getAllPathsIncludingUnfurledFocusedComponents(
     metadata: ElementInstanceMetadataMap,
   ): ElementPath[] {
+    // Note: This will not necessarily be representative of the structured ordering in
+    // the code that produced these elements.
     const projectTree = buildTree(objectValues(metadata).map((m) => m.elementPath))
     // This function needs to explicitly return the paths in a depth first manner
     let result: Array<ElementPath> = []

--- a/editor/src/core/shared/element-path-tree.spec.ts
+++ b/editor/src/core/shared/element-path-tree.spec.ts
@@ -1,0 +1,60 @@
+import { buildTree, forEachChildOfTarget, printTree } from './element-path-tree'
+import * as EP from './element-path'
+import { ElementPath } from './project-file-types'
+
+describe('buildTree', () => {
+  it('should build a simple tree', () => {
+    const actualResult = buildTree([
+      EP.elementPath([['aaa', 'bbb'], ['ccc']]),
+      EP.elementPath([['aaa', 'bbb'], ['ddd']]),
+      EP.elementPath([
+        ['aaa', 'bbb'],
+        ['ccc', 'ccc1'],
+      ]),
+      EP.elementPath([
+        ['aaa', 'bbb'],
+        ['ccc', 'ccc2'],
+      ]),
+    ])
+    expect(printTree(actualResult)).toMatchInlineSnapshot(`
+      "aaa
+        aaa/bbb
+          aaa/bbb:ccc
+            aaa/bbb:ccc/ccc1
+            aaa/bbb:ccc/ccc2
+          aaa/bbb:ddd
+      "
+    `)
+  })
+})
+
+describe('forEachChildOfTarget', () => {
+  it('should run for just the children of the targeted element', () => {
+    const tree = buildTree([
+      EP.elementPath([['aaa', 'bbb'], ['ccc']]),
+      EP.elementPath([['aaa', 'bbb'], ['ddd']]),
+      EP.elementPath([
+        ['aaa', 'bbb'],
+        ['ccc', 'ccc1'],
+      ]),
+      EP.elementPath([
+        ['aaa', 'bbb'],
+        ['ccc', 'ccc2'],
+      ]),
+    ])
+    let actualResult: Array<ElementPath> = []
+    forEachChildOfTarget(tree, EP.elementPath([['aaa', 'bbb'], ['ccc']]), (elem) => {
+      actualResult.push(elem)
+    })
+    expect(actualResult).toEqual([
+      EP.elementPath([
+        ['aaa', 'bbb'],
+        ['ccc', 'ccc1'],
+      ]),
+      EP.elementPath([
+        ['aaa', 'bbb'],
+        ['ccc', 'ccc2'],
+      ]),
+    ])
+  })
+})

--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -1,0 +1,113 @@
+import { ElementPath, ElementPathPart } from './project-file-types'
+import * as EP from './element-path'
+import { fastForEach } from './utils'
+
+export interface ElementPathTree {
+  path: ElementPath
+  children: ElementPathTreeRoot
+}
+
+function emptyElementPathTree(path: ElementPath): ElementPathTree {
+  return {
+    path: path,
+    children: [],
+  }
+}
+
+export type ElementPathTreeRoot = Array<ElementPathTree>
+
+export function buildTree(elementPaths: Array<ElementPath>): ElementPathTreeRoot {
+  let result: ElementPathTreeRoot = []
+  let workingRoot: ElementPathTreeRoot = result
+  fastForEach(elementPaths, (elementPath) => {
+    workingRoot = result
+    const totalParts = elementPath.parts.reduce((workingCount, elem) => {
+      return workingCount + elem.length
+    }, 0)
+    for (let pathSize = 1; pathSize <= totalParts; pathSize++) {
+      let subElementPathParts: Array<ElementPathPart> = []
+      let workingCount = pathSize
+      fastForEach(elementPath.parts, (pathPart) => {
+        if (workingCount >= pathPart.length) {
+          subElementPathParts.push(pathPart)
+          workingCount = workingCount - pathPart.length
+        } else if (workingCount > 0) {
+          subElementPathParts.push(pathPart.slice(0, workingCount))
+          workingCount = 0
+        }
+      })
+      const subElementPath = EP.elementPath(subElementPathParts)
+
+      // See if there's an already existing part of the tree with this path.
+      const foundTree = workingRoot.find((elem) => EP.pathsEqual(elem.path, subElementPath))
+      let treeToTarget = foundTree ?? emptyElementPathTree(subElementPath)
+      // Add this if it doesn't already exist.
+      if (foundTree == null) {
+        workingRoot.push(treeToTarget)
+      }
+      workingRoot = treeToTarget.children
+    }
+  })
+  return result
+}
+
+export function printTree(treeRoot: ElementPathTreeRoot): string {
+  let outputText: string = ''
+  function printElement(element: ElementPathTree, depth: number): void {
+    for (let index = 0; index < depth; index++) {
+      outputText += '  '
+    }
+    outputText += EP.toString(element.path)
+    outputText += '\n'
+    printTreeWithDepth(element.children, depth + 1)
+  }
+  function printTreeWithDepth(subTreeRoot: ElementPathTreeRoot, depth: number): void {
+    fastForEach(subTreeRoot, (elem) => {
+      printElement(elem, depth)
+    })
+  }
+  printTreeWithDepth(treeRoot, 0)
+  return outputText
+}
+
+export function forEachChildOfTarget(
+  treeRoot: ElementPathTreeRoot,
+  target: ElementPath,
+  handler: (elementPath: ElementPath) => void,
+): void {
+  let workingRoot: ElementPathTreeRoot = treeRoot
+  const totalParts = target.parts.reduce((workingCount, elem) => {
+    return workingCount + elem.length
+  }, 0)
+  for (let pathSize = 1; pathSize <= totalParts; pathSize++) {
+    let subElementPathParts: Array<ElementPathPart> = []
+    let workingCount = pathSize
+    fastForEach(target.parts, (pathPart) => {
+      if (workingCount >= pathPart.length) {
+        subElementPathParts.push(pathPart)
+        workingCount = workingCount - pathPart.length
+      } else if (workingCount > 0) {
+        subElementPathParts.push(pathPart.slice(0, workingCount))
+        workingCount = 0
+      }
+    })
+    const subElementPath = EP.elementPath(subElementPathParts)
+
+    // See if there's an already existing part of the tree with this path.
+    const foundTree = workingRoot.find((elem) => EP.pathsEqual(elem.path, subElementPath))
+    // Should there not be something at this point of the tree, bail out.
+    if (foundTree == null) {
+      return
+    } else {
+      if (pathSize === totalParts) {
+        // When this is true, we're at the target element.
+        fastForEach(foundTree.children, (subTree) => {
+          handler(subTree.path)
+        })
+      } else {
+        // Otherwise continue working down the tree.
+        workingRoot = foundTree.children
+      }
+    }
+  }
+}

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -185,17 +185,6 @@ export function fromString(path: string): ElementPath {
   }
 }
 
-function allElementPaths(fullPath: ElementPathPart[]): Array<ElementPathPart[]> {
-  let paths: Array<ElementPathPart[]> = []
-  for (var index = 1; index < fullPath.length; index++) {
-    const prefix: ElementPathPart[] = fullPath.slice(0, index)
-    const suffixes = allElementPathsForPart(fullPath[index])
-    fastForEach(suffixes, (suffix) => paths.push(prefix.concat(suffix)))
-  }
-
-  return paths
-}
-
 function allElementPathsForPart(path: ElementPathPart): Array<ElementPathPart> {
   let paths: Array<ElementPathPart> = []
   for (var size = 1; size <= path.length; size++) {
@@ -387,7 +376,7 @@ function elementPathPartsEqual(l: ElementPathPart, r: ElementPathPart): boolean 
   }
 }
 
-function fullElementPathsEqual(l: ElementPathPart[], r: ElementPathPart[]): boolean {
+export function fullElementPathsEqual(l: ElementPathPart[], r: ElementPathPart[]): boolean {
   return l === r || arrayEquals(l, r, elementPathPartsEqual)
 }
 


### PR DESCRIPTION
**Problem:**
In a couple of places the hierarchy of elements was being traversed, but this was being done by starting at the roots and then for each element the children were identified by checking the path against each and every element in the metadata. That approximates O(n^2) where n is the number of elements, for a project with 161 elements it was making two calls to `isChildOf` for each element which equates to about 26,000 times.

**Fix:**
This introduces a simple tree of parents and children for element paths, which can be built once and is then used for all the lookups instead of iterating through the metadata.

Currently it is being created twice in two different places, but probably should be shared if it's used in more places than this in the future as it does (in a large project) have a cost of 1ms per invocation. However even with that cost it has dropped the runtime of the mouse move event by 6ms.

**Screenshots:**
Before:
![before](https://user-images.githubusercontent.com/217400/156593692-830d8768-ab4c-431d-bb3e-e1d584b29b1e.png)
After:
![after](https://user-images.githubusercontent.com/217400/156593720-6099c903-a4fb-48a7-b612-b1aa47d8ffbe.png)

**Commit Details:**
- Added `buildTree`, which takes a bunch of element paths and produces
  a n-way tree from the paths so that children of a target can be identified
  quickly.
- Implemented `printTree` which takes the tree produced by `buildTree` and
  returns a string formatted for testing purposes.
- Added `forEachChildOfTarget` to call a callback for each child path
  of a given path.
- Simplified some functions like `getRootViews`, `getChildrenPaths`,
  `getImmediateChildrenPaths` and `getStorboardMetadata`.
- `getAllPathsIncludingUnfurledFocusedComponents` and `getFramesInCanvasContext`
  now use the new tree to identify the children of targets.
