### PR TITLE
Check if a view is already highlighted before dispatching to highlight it again.

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -43,6 +43,7 @@ import { WindowMousePositionRaw } from '../../../../utils/global-positions'
 import { isFeatureEnabled } from '../../../../utils/feature-switches'
 import { createInteractionViaMouse } from '../../canvas-strategies/interaction-state'
 import { Modifier } from '../../../../utils/modifiers'
+import { pathsEqual } from '../../../../core/shared/element-path'
 
 const DRAG_START_TRESHOLD = 2
 
@@ -95,13 +96,25 @@ export function useMaybeHighlightElement(): {
       dragging: isDragging(store.editor),
       selectionEnabled: pickSelectionEnabled(store.editor.canvas, store.editor.keysPressed),
       inserting: isInserting(store.editor),
+      highlightedViews: store.editor.highlightedViews,
     }
   })
 
   const maybeHighlightOnHover = React.useCallback(
     (target: ElementPath): void => {
-      const { dispatch, dragging, resizing, selectionEnabled, inserting } = stateRef.current
-      if (selectionEnabled && !dragging && !resizing && !inserting) {
+      /// target, parts, array, 0 contains [0: "0cd" 1: "478]
+      const {
+        dispatch,
+        dragging,
+        resizing,
+        selectionEnabled,
+        inserting,
+        highlightedViews,
+      } = stateRef.current
+
+      const alreadyHighlighted = pathsEqual(target, highlightedViews?.[0])
+
+      if (selectionEnabled && !dragging && !resizing && !inserting && !alreadyHighlighted) {
         dispatch([setHighlightedView(target)], 'canvas')
       }
     },


### PR DESCRIPTION
Fixes #2107 

**Problem:**
If you select a view in the in the canvas and then hover over it, it dispatches the state update to highlight it over and over with every mouse-move-pixel hundreds of times even if it is already highlighted

**Fix:**
Get the highlighted view, and compare it to the target to be highlighted before dispatching

