### PR TITLE
removing PathMappings

### DIFF
--- a/editor/src/components/canvas/commands/adjust-number-command.spec.tsx
+++ b/editor/src/components/canvas/commands/adjust-number-command.spec.tsx
@@ -44,7 +44,6 @@ describe('adjustNumberProperty', () => {
 
     const result = runAdjustNumberProperty(
       renderResult.getEditorState().editor,
-      [],
       adjustNumberPropertyCommand,
     )
 

--- a/editor/src/components/canvas/commands/adjust-number-command.ts
+++ b/editor/src/components/canvas/commands/adjust-number-command.ts
@@ -28,7 +28,7 @@ import {
   modifyUnderlyingForOpenFile,
   withUnderlyingTargetFromEditorState,
 } from '../../editor/store/editor-state'
-import type { BaseCommand, CommandFunction, PathMappings, TransientOrNot } from './commands'
+import type { BaseCommand, CommandFunction, TransientOrNot } from './commands'
 
 export interface AdjustNumberProperty extends BaseCommand {
   type: 'ADJUST_NUMBER_PROPERTY'
@@ -74,7 +74,6 @@ export function adjustNumberInequalityCondition(
 
 export const runAdjustNumberProperty: CommandFunction<AdjustNumberProperty> = (
   editorState: EditorState,
-  pathMappings: PathMappings,
   command: AdjustNumberProperty,
 ) => {
   // Handle updating the existing value, treating a value that can't be parsed
@@ -110,7 +109,6 @@ export const runAdjustNumberProperty: CommandFunction<AdjustNumberProperty> = (
   if (targetPropertyNonExistant && !command.createIfNonExistant) {
     return {
       editorStatePatch: {},
-      pathMappings: pathMappings,
       commandDescription: `Adjust Number Prop: ${EP.toUid(command.target)}/${PP.toString(
         command.property,
       )} not applied as the property does not exist.`,
@@ -130,7 +128,6 @@ export const runAdjustNumberProperty: CommandFunction<AdjustNumberProperty> = (
             if (inequalityValue <= currentValue) {
               return {
                 editorStatePatch: {},
-                pathMappings: pathMappings,
                 commandDescription: `Adjust Number Prop: ${EP.toUid(command.target)}/${PP.toString(
                   command.property,
                 )} not applied as value is large enough already.`,
@@ -143,7 +140,6 @@ export const runAdjustNumberProperty: CommandFunction<AdjustNumberProperty> = (
             if (inequalityValue >= currentValue) {
               return {
                 editorStatePatch: {},
-                pathMappings: pathMappings,
                 commandDescription: `Adjust Number Prop: ${EP.toUid(command.target)}/${PP.toString(
                   command.property,
                 )} not applied as value is small enough already.`,
@@ -175,7 +171,6 @@ export const runAdjustNumberProperty: CommandFunction<AdjustNumberProperty> = (
 
     return {
       editorStatePatch: propertyUpdatePatch,
-      pathMappings: pathMappings,
       commandDescription: `Adjust Number Prop: ${EP.toUid(command.target)}/${PP.toString(
         command.property,
       )} by ${command.value}`,

--- a/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
@@ -29,7 +29,7 @@ describe('runReparentElement', () => {
 
     const reparentCommand = reparentElement('permanent', targetPath, newParentPath)
 
-    const result = runReparentElement(originalEditorState, [], reparentCommand)
+    const result = runReparentElement(originalEditorState, reparentCommand)
 
     const patchedEditor = applyStatePatches(originalEditorState, originalEditorState, [
       result.editorStatePatch,

--- a/editor/src/components/canvas/commands/reparent-element-command.ts
+++ b/editor/src/components/canvas/commands/reparent-element-command.ts
@@ -19,7 +19,7 @@ import {
   insertElementAtPath,
   removeElementAtPath,
 } from '../../editor/store/editor-state'
-import type { BaseCommand, CommandFunction, PathMappings, TransientOrNot } from './commands'
+import type { BaseCommand, CommandFunction, TransientOrNot } from './commands'
 
 export interface ReparentElement extends BaseCommand {
   type: 'REPARENT_ELEMENT'
@@ -42,7 +42,6 @@ export function reparentElement(
 
 export const runReparentElement: CommandFunction<ReparentElement> = (
   editorState: EditorState,
-  pathMappings: PathMappings,
   command: ReparentElement,
 ) => {
   let editorStatePatch: EditorStatePatch = {}
@@ -112,7 +111,6 @@ export const runReparentElement: CommandFunction<ReparentElement> = (
 
   return {
     editorStatePatch: editorStatePatch,
-    pathMappings: pathMappings,
     commandDescription: `Reparent Element ${EP.toUid(command.target)} to new parent ${EP.toUid(
       command.newParent,
     )}`,

--- a/editor/src/components/canvas/commands/strategy-switched-command.ts
+++ b/editor/src/components/canvas/commands/strategy-switched-command.ts
@@ -1,4 +1,4 @@
-import type { BaseCommand, CommandFunctionResult, PathMappings } from './commands'
+import type { BaseCommand, CommandFunctionResult } from './commands'
 
 export interface StrategySwitched extends BaseCommand {
   type: 'STRATEGY_SWITCHED'
@@ -27,10 +27,7 @@ export function strategySwitched(
   }
 }
 
-export function runStrategySwitchedCommand(
-  pathMappings: PathMappings,
-  command: StrategySwitched,
-): CommandFunctionResult {
+export function runStrategySwitchedCommand(command: StrategySwitched): CommandFunctionResult {
   let commandDescription: string = `Strategy switched to ${command.newStrategy} ${
     command.reason === 'automatic'
       ? `automatically (fitness ${command.previousFitness} -> ${command.newFitness})`
@@ -39,7 +36,6 @@ export function runStrategySwitchedCommand(
 
   return {
     editorStatePatch: {},
-    pathMappings: pathMappings,
     commandDescription: commandDescription,
   }
 }

--- a/editor/src/components/canvas/commands/update-selected-views-command.spec.tsx
+++ b/editor/src/components/canvas/commands/update-selected-views-command.spec.tsx
@@ -23,7 +23,7 @@ describe('updateSelectedViews', () => {
 
     const updateSelectedViewsCommand = updateSelectedViews('permanent', [targetPath])
 
-    const result = runUpdateSelectedViews(originalEditorState, [], updateSelectedViewsCommand)
+    const result = runUpdateSelectedViews(originalEditorState, updateSelectedViewsCommand)
 
     const patchedEditor = applyStatePatches(originalEditorState, originalEditorState, [
       result.editorStatePatch,

--- a/editor/src/components/canvas/commands/update-selected-views-command.ts
+++ b/editor/src/components/canvas/commands/update-selected-views-command.ts
@@ -1,7 +1,7 @@
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
 import type { EditorState } from '../../editor/store/editor-state'
-import type { BaseCommand, CommandFunction, PathMappings, TransientOrNot } from './commands'
+import type { BaseCommand, CommandFunction, TransientOrNot } from './commands'
 
 export interface UpdateSelectedViews extends BaseCommand {
   type: 'UPDATE_SELECTED_VIEWS'
@@ -21,7 +21,6 @@ export function updateSelectedViews(
 
 export const runUpdateSelectedViews: CommandFunction<UpdateSelectedViews> = (
   _: EditorState,
-  pathMappings: PathMappings,
   command: UpdateSelectedViews,
 ) => {
   const editorStatePatch = {
@@ -31,7 +30,6 @@ export const runUpdateSelectedViews: CommandFunction<UpdateSelectedViews> = (
   }
   return {
     editorStatePatch: editorStatePatch,
-    pathMappings: pathMappings,
     commandDescription: `Update Selected Views: ${command.value.map(EP.toString).join(', ')}`,
   }
 }

--- a/editor/src/components/canvas/commands/wildcard-patch-command.spec.tsx
+++ b/editor/src/components/canvas/commands/wildcard-patch-command.spec.tsx
@@ -26,7 +26,7 @@ describe('wildcardPatch', () => {
 
     const wildcardCommand = wildcardPatch('permanent', { selectedViews: { $set: [] } })
 
-    const result = runWildcardPatch(renderResult.getEditorState().editor, [], wildcardCommand)
+    const result = runWildcardPatch(renderResult.getEditorState().editor, wildcardCommand)
 
     const patchedEditor = applyStatePatches(
       renderResult.getEditorState().editor,

--- a/editor/src/components/canvas/commands/wildcard-patch-command.ts
+++ b/editor/src/components/canvas/commands/wildcard-patch-command.ts
@@ -1,5 +1,5 @@
 import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
-import type { BaseCommand, CommandFunction, PathMappings, TransientOrNot } from './commands'
+import type { BaseCommand, CommandFunction, TransientOrNot } from './commands'
 
 export interface WildcardPatch extends BaseCommand {
   type: 'WILDCARD_PATCH'
@@ -16,12 +16,10 @@ export function wildcardPatch(transient: TransientOrNot, patch: EditorStatePatch
 
 export const runWildcardPatch: CommandFunction<WildcardPatch> = (
   editorState: EditorState,
-  pathMappings: PathMappings,
   command: WildcardPatch,
 ) => {
   return {
     editorStatePatch: command.patch,
-    pathMappings: pathMappings,
     commandDescription: `Wildcard Patch: ${JSON.stringify(command.patch, null, 2)}`,
   }
 }


### PR DESCRIPTION
**Problem:**
We have unused code around pathMappings in the strategy commands. I would like to remove them until we need them, because in these unused / untested form it will probably regress anyways.

**Fix:**
Remove the creation and needling through of pathMappings in the commands.
