### PR TITLE
Capture the full time of selection.

### DIFF
--- a/editor/src/components/canvas/canvas-actions.ts
+++ b/editor/src/components/canvas/canvas-actions.ts
@@ -13,6 +13,12 @@ const CanvasActions = {
       delta: delta,
     }
   },
+  positionCanvas: function (position: CanvasVector): CanvasAction {
+    return {
+      action: 'POSITION_CANVAS',
+      position: position,
+    }
+  },
   createDragState: function (dragState: DragState): CanvasAction {
     return {
       action: 'CREATE_DRAG_STATE',

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -629,6 +629,11 @@ type ScrollCanvas = {
   delta: CanvasVector
 }
 
+interface PositionCanvas {
+  action: 'POSITION_CANVAS'
+  position: CanvasVector
+}
+
 interface ClearDragState {
   action: 'CLEAR_DRAG_STATE'
   applyChanges: boolean
@@ -677,6 +682,7 @@ type SetUsersPreferredStrategy = {
 
 export type CanvasAction =
   | ScrollCanvas
+  | PositionCanvas
   | ClearDragState
   | CreateDragState
   | CreateInteractionSession

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -16,6 +16,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_KEYS_PRESSED':
     case 'SET_SELECTION_CONTROLS_VISIBILITY':
     case 'SCROLL_CANVAS':
+    case 'POSITION_CANVAS':
     case 'SET_FOCUS':
     case 'RESIZE_LEFTPANE':
     case 'CREATE_DRAG_STATE':

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../uuiui'
 import { last } from '../../core/shared/array-utils'
 
-const NavigatorContainerId = 'navigator'
+export const NavigatorContainerId = 'navigator'
 
 export const NavigatorComponent = React.memo(() => {
   const editorSliceRef = useRefEditorState((store) => {

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -32,6 +32,7 @@ import {
 import { CanvasControlsContainerID } from '../../components/canvas/controls/new-canvas-controls'
 import { forceNotNull } from '../shared/optional-utils'
 import { ElementPathArrayKeepDeepEquality } from '../../utils/deep-equality-instances'
+import { NavigatorContainerId } from '../../components/navigator/navigator'
 
 export function wait(timeout: number): Promise<void> {
   return new Promise((resolve) => {
@@ -227,13 +228,29 @@ export function useTriggerSelectionPerformanceTest(): () => void {
       'Container controls element should exist.',
       document.getElementById(CanvasControlsContainerID),
     )
+    const canvasContainerElement = forceNotNull(
+      'Canvas container element should exist.',
+      document.getElementById(CanvasContainerID),
+    )
+    const canvasContainerBounds = canvasContainerElement.getBoundingClientRect()
+    const navigatorElement = forceNotNull(
+      'Navigator element should exist.',
+      document.getElementById(NavigatorContainerId),
+    )
+    const navigatorBounds = navigatorElement.getBoundingClientRect()
 
     const targetElement = forceNotNull(
       'Target element should exist.',
       document.querySelector(`*[data-paths~="${EP.toString(targetPath)}"]`),
     )
-    await dispatch([CanvasActions.positionCanvas(canvasPoint({ x: -1900, y: -1100 }))], 'everyone')
-      .entireUpdateFinished
+    const originalTargetBounds = targetElement.getBoundingClientRect()
+    const leftToTarget =
+      canvasContainerBounds.left + navigatorBounds.width - originalTargetBounds.left + 100
+    const topToTarget = canvasContainerBounds.top - originalTargetBounds.top + 100
+    await dispatch(
+      [CanvasActions.positionCanvas(canvasPoint({ x: leftToTarget, y: topToTarget }))],
+      'everyone',
+    ).entireUpdateFinished
     const targetBounds = targetElement.getBoundingClientRect()
     if (allPaths.current.length === 0) {
       console.info('SELECT_TEST_ERROR')

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -259,7 +259,7 @@ export function useTriggerSelectionPerformanceTest(): () => void {
       }
       const startingTime = Date.now()
       while (!isTargetSelected() && Date.now() < startingTime + 3000) {
-        await wait(50)
+        await wait(5)
       }
       if (!isTargetSelected()) {
         throw new Error(`Element never ended up being selected.`)

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -232,9 +232,9 @@ export function useTriggerSelectionPerformanceTest(): () => void {
       'Target element should exist.',
       document.querySelector(`*[data-paths~="${EP.toString(targetPath)}"]`),
     )
-    const targetBounds = targetElement.getBoundingClientRect()
     await dispatch([CanvasActions.positionCanvas(canvasPoint({ x: -1900, y: -1100 }))], 'everyone')
       .entireUpdateFinished
+    const targetBounds = targetElement.getBoundingClientRect()
     if (allPaths.current.length === 0) {
       console.info('SELECT_TEST_ERROR')
       return

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -250,7 +250,6 @@ export function useTriggerSelectionPerformanceTest(): () => void {
       }
       fireEvent.pointerUp(targetElement, {})
       fireEvent.mouseUp(targetElement, {})
-      await dispatch([selectComponents([targetPath!], false)]).entireUpdateFinished
       performance.mark(`select_dispatch_finished_${framesPassed}`)
       performance.measure(
         `select_frame_${framesPassed}`,

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -317,6 +317,15 @@ export function runLocalCanvasAction(
         },
       }
     }
+    case 'POSITION_CANVAS':
+      return {
+        ...model,
+        canvas: {
+          ...model.canvas,
+          realCanvasOffset: action.position,
+          roundedCanvasOffset: Utils.roundPointTo(action.position, 0),
+        },
+      }
     case 'CLEAR_DRAG_STATE':
       return clearDragState(model, derivedState, action.applyChanges)
     case 'CREATE_DRAG_STATE':


### PR DESCRIPTION
**Problem:**
Selection really consists of a series of mouse events, but currently the only thing being measured is the time it takes to process the select components action. This means that not only is the code that fires that action excluded from the performance measurement, but also the additional mouse events which still needs to complete before any further actions can be taken by the user.

**Fix:**
Instead of dispatching the action directly that selects the components now the various mouse events are triggered in order.

**Commit Details:**
- Selection performance test now triggers a series of mouse events
  instead of dispatching the select components action.
- Added a `POSITION_CANVAS` action that explicitly repositions the canvas
  to a specific location.
- Selection performance test repositions the canvas first.
- Selection performance test now targets the controls container element.
- Copied the `wait` function to avoid clashing with one of our dependency cruiser rules.