### PR TITLE
Feature/canvas controls performance cssvars

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -88,6 +88,7 @@ export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps
         style={{
           position: 'absolute',
           transition: canvasProps.scrollAnimation ? 'transform 0.3s ease-in-out' : 'initial',
+          transform: 'translate3d(0px, 0px, 0px)',
         }}
       >
         <CanvasErrorBoundary

--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -25,7 +25,7 @@ import { DomWalkerProps, useDomWalker } from './dom-walker'
 import { ResolvingRemoteDependencyErrorName } from '../../core/es-modules/package-manager/package-manager'
 import { CanvasLoadingScreen } from './canvas-loading-screen'
 import { isHooksErrorMessage } from '../../utils/canvas-react-utils'
-import { useApplyCanvasOffset } from './controls/canvas-offset-wrapper'
+import { useApplyCanvasOffsetToStyle } from './controls/canvas-offset-wrapper'
 
 interface CanvasComponentEntryProps {}
 
@@ -76,7 +76,7 @@ export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps
     clearRuntimeErrors()
   }, [clearRuntimeErrors])
 
-  const containerRef = useApplyCanvasOffset(canvasProps?.scale ?? null)
+  const containerRef = useApplyCanvasOffsetToStyle(canvasProps?.scale ?? null)
 
   if (canvasProps == null) {
     return <CanvasLoadingScreen />
@@ -87,7 +87,6 @@ export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps
         ref={containerRef}
         style={{
           position: 'absolute',
-          zoom: canvasProps.scale >= 1 ? `${canvasProps.scale * 100}%` : 1,
           transition: canvasProps.scrollAnimation ? 'transform 0.3s ease-in-out' : 'initial',
         }}
       >

--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
-import { useEditorState } from '../editor/store/store-hook'
+import {
+  useEditorState,
+  useRefEditorState,
+  useSelectorWithCallback,
+} from '../editor/store/store-hook'
 import {
   UiJsxCanvas,
   pickUiJsxCanvasProps,
@@ -25,10 +29,13 @@ import { DomWalkerProps, useDomWalker } from './dom-walker'
 import { ResolvingRemoteDependencyErrorName } from '../../core/es-modules/package-manager/package-manager'
 import { CanvasLoadingScreen } from './canvas-loading-screen'
 import { isHooksErrorMessage } from '../../utils/canvas-react-utils'
+import { CanvasVector } from '../../core/shared/math-utils'
+import { useApplyCanvasOffsetToComponentEntry } from './controls/canvas-offset-wrapper'
 
 interface CanvasComponentEntryProps {}
 
 export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps) => {
+  const containerRef = React.useRef<HTMLDivElement>(null)
   const dispatch = useEditorState((store) => store.dispatch, 'CanvasComponentEntry dispatch')
   const onDomReport = React.useCallback(
     (elementMetadata: ReadonlyArray<ElementInstanceMetadata>, cachedPaths: Array<ElementPath>) => {
@@ -75,18 +82,18 @@ export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps
     clearRuntimeErrors()
   }, [clearRuntimeErrors])
 
+  useApplyCanvasOffsetToComponentEntry(containerRef, canvasProps?.scale ?? null)
+
   if (canvasProps == null) {
     return <CanvasLoadingScreen />
   } else {
     return (
       <div
         id='canvas-container-outer'
+        ref={containerRef}
         style={{
           position: 'absolute',
           zoom: canvasProps.scale >= 1 ? `${canvasProps.scale * 100}%` : 1,
-          transform:
-            (canvasProps.scale < 1 ? `scale(${canvasProps.scale})` : '') +
-            ` translate3d(var(--utopia-canvas-offset-x), var(--utopia-canvas-offset-y), 0)`,
           transition: canvasProps.scrollAnimation ? 'transform 0.3s ease-in-out' : 'initial',
         }}
       >

--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -1,9 +1,5 @@
 import React from 'react'
-import {
-  useEditorState,
-  useRefEditorState,
-  useSelectorWithCallback,
-} from '../editor/store/store-hook'
+import { useEditorState } from '../editor/store/store-hook'
 import {
   UiJsxCanvas,
   pickUiJsxCanvasProps,
@@ -29,7 +25,6 @@ import { DomWalkerProps, useDomWalker } from './dom-walker'
 import { ResolvingRemoteDependencyErrorName } from '../../core/es-modules/package-manager/package-manager'
 import { CanvasLoadingScreen } from './canvas-loading-screen'
 import { isHooksErrorMessage } from '../../utils/canvas-react-utils'
-import { CanvasVector } from '../../core/shared/math-utils'
 import { useApplyCanvasOffsetToComponentEntry } from './controls/canvas-offset-wrapper'
 
 interface CanvasComponentEntryProps {}

--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -25,12 +25,11 @@ import { DomWalkerProps, useDomWalker } from './dom-walker'
 import { ResolvingRemoteDependencyErrorName } from '../../core/es-modules/package-manager/package-manager'
 import { CanvasLoadingScreen } from './canvas-loading-screen'
 import { isHooksErrorMessage } from '../../utils/canvas-react-utils'
-import { useApplyCanvasOffsetToComponentEntry } from './controls/canvas-offset-wrapper'
+import { useApplyCanvasOffset } from './controls/canvas-offset-wrapper'
 
 interface CanvasComponentEntryProps {}
 
 export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps) => {
-  const containerRef = React.useRef<HTMLDivElement>(null)
   const dispatch = useEditorState((store) => store.dispatch, 'CanvasComponentEntry dispatch')
   const onDomReport = React.useCallback(
     (elementMetadata: ReadonlyArray<ElementInstanceMetadata>, cachedPaths: Array<ElementPath>) => {
@@ -77,7 +76,7 @@ export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps
     clearRuntimeErrors()
   }, [clearRuntimeErrors])
 
-  useApplyCanvasOffsetToComponentEntry(containerRef, canvasProps?.scale ?? null)
+  const containerRef = useApplyCanvasOffset(canvasProps?.scale ?? null)
 
   if (canvasProps == null) {
     return <CanvasLoadingScreen />

--- a/editor/src/components/canvas/canvas-offset-hooks.ts
+++ b/editor/src/components/canvas/canvas-offset-hooks.ts
@@ -1,0 +1,27 @@
+import React from 'react'
+import { CanvasVector } from '../../core/shared/math-utils'
+import { useRefEditorState, useSelectorWithCallback } from '../editor/store/store-hook'
+
+export function useCanvasOffset(elementRef: React.RefObject<HTMLDivElement>): void {
+  const offsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
+
+  const transformCanvasOffset = React.useCallback(
+    (canvasOffset: CanvasVector) => {
+      // console.log('TRANFORM CANVASOFFSET', elementRef.current, canvasOffset.x, canvasOffset.y)
+      if (elementRef.current != null) {
+        elementRef.current.style.setProperty(
+          'transform',
+          `translate(${canvasOffset.x}px, ${canvasOffset.y}px)`,
+        )
+      }
+    },
+    [elementRef],
+  )
+
+  useSelectorWithCallback(
+    (store) => store.editor.canvas.roundedCanvasOffset,
+    (newOffset) => transformCanvasOffset(newOffset),
+  )
+
+  transformCanvasOffset(offsetRef.current)
+}

--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -17,10 +17,10 @@ export function useApplyCanvasOffset(scale: number | null): React.RefObject<HTML
   const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
   const applyCanvasOffset = React.useCallback(
     (roundedCanvasOffset: CanvasVector) => {
-      if (elementRef.current != null && scale != null) {
+      if (elementRef.current != null) {
         elementRef.current.style.setProperty(
           'transform',
-          (scale < 1 ? `scale(${scale})` : '') +
+          (scale != null && scale < 1 ? `scale(${scale})` : '') +
             ` translate3d(${roundedCanvasOffset.x}px, ${roundedCanvasOffset.y}px, 0)`,
         )
       }

--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -3,7 +3,7 @@ import { CanvasVector } from '../../../core/shared/math-utils'
 import { useRefEditorState, useSelectorWithCallback } from '../../editor/store/store-hook'
 
 export const CanvasOffsetWrapper = React.memo((props) => {
-  const elementRef = useApplyCanvasOffset(null)
+  const elementRef = useApplyCanvasOffsetToStyle(null)
 
   return (
     <div ref={elementRef} style={{ position: 'absolute' }}>
@@ -12,7 +12,7 @@ export const CanvasOffsetWrapper = React.memo((props) => {
   )
 })
 
-export function useApplyCanvasOffset(scale: number | null): React.RefObject<HTMLDivElement> {
+export function useApplyCanvasOffsetToStyle(scale: number | null): React.RefObject<HTMLDivElement> {
   const elementRef = React.useRef<HTMLDivElement>(null)
   const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
   const applyCanvasOffset = React.useCallback(
@@ -22,6 +22,10 @@ export function useApplyCanvasOffset(scale: number | null): React.RefObject<HTML
           'transform',
           (scale != null && scale < 1 ? `scale(${scale})` : '') +
             ` translate3d(${roundedCanvasOffset.x}px, ${roundedCanvasOffset.y}px, 0)`,
+        )
+        elementRef.current.style.setProperty(
+          'zoom',
+          scale != null && scale >= 1 ? `${scale * 100}%` : '1',
         )
       }
     },

--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -33,6 +33,11 @@ export function useApplyCanvasOffsetToStyle(scale: number | null): React.RefObje
   )
 
   useSelectorWithCallback((store) => store.editor.canvas.roundedCanvasOffset, applyCanvasOffset)
-  applyCanvasOffset(canvasOffsetRef.current)
+
+  const applyCanvasOffsetEffect = React.useCallback(
+    () => applyCanvasOffset(canvasOffsetRef.current),
+    [applyCanvasOffset, canvasOffsetRef],
+  )
+  React.useEffect(applyCanvasOffsetEffect, [applyCanvasOffsetEffect])
   return elementRef
 }

--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import { CanvasVector } from '../../core/shared/math-utils'
-import { useRefEditorState, useSelectorWithCallback } from '../editor/store/store-hook'
+import { CanvasVector } from '../../../core/shared/math-utils'
+import { useRefEditorState, useSelectorWithCallback } from '../../editor/store/store-hook'
 
-export function useCanvasOffset(elementRef: React.RefObject<HTMLDivElement>): void {
+export const CanvasOffsetWrapper = React.memo((props) => {
+  const elementRef = React.useRef<HTMLDivElement>(null)
   const offsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
 
   const transformCanvasOffset = React.useCallback(
     (canvasOffset: CanvasVector) => {
-      // console.log('TRANFORM CANVASOFFSET', elementRef.current, canvasOffset.x, canvasOffset.y)
       if (elementRef.current != null) {
         elementRef.current.style.setProperty(
           'transform',
@@ -24,4 +24,10 @@ export function useCanvasOffset(elementRef: React.RefObject<HTMLDivElement>): vo
   )
 
   transformCanvasOffset(offsetRef.current)
-}
+
+  return (
+    <div ref={elementRef} style={{ position: 'absolute' }}>
+      {props.children}
+    </div>
+  )
+})

--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -3,27 +3,7 @@ import { CanvasVector } from '../../../core/shared/math-utils'
 import { useRefEditorState, useSelectorWithCallback } from '../../editor/store/store-hook'
 
 export const CanvasOffsetWrapper = React.memo((props) => {
-  const elementRef = React.useRef<HTMLDivElement>(null)
-  const offsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
-
-  const transformCanvasOffset = React.useCallback(
-    (canvasOffset: CanvasVector) => {
-      if (elementRef.current != null) {
-        elementRef.current.style.setProperty(
-          'transform',
-          `translate(${canvasOffset.x}px, ${canvasOffset.y}px)`,
-        )
-      }
-    },
-    [elementRef],
-  )
-
-  useSelectorWithCallback(
-    (store) => store.editor.canvas.roundedCanvasOffset,
-    (newOffset) => transformCanvasOffset(newOffset),
-  )
-
-  transformCanvasOffset(offsetRef.current)
+  const elementRef = useApplyCanvasOffset(null)
 
   return (
     <div ref={elementRef} style={{ position: 'absolute' }}>
@@ -32,10 +12,8 @@ export const CanvasOffsetWrapper = React.memo((props) => {
   )
 })
 
-export function useApplyCanvasOffsetToComponentEntry(
-  elementRef: React.RefObject<HTMLDivElement>,
-  scale: number | null,
-): void {
+export function useApplyCanvasOffset(scale: number | null): React.RefObject<HTMLDivElement> {
+  const elementRef = React.useRef<HTMLDivElement>(null)
   const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
   const applyCanvasOffset = React.useCallback(
     (roundedCanvasOffset: CanvasVector) => {
@@ -52,4 +30,5 @@ export function useApplyCanvasOffsetToComponentEntry(
 
   useSelectorWithCallback((store) => store.editor.canvas.roundedCanvasOffset, applyCanvasOffset)
   applyCanvasOffset(canvasOffsetRef.current)
+  return elementRef
 }

--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -38,6 +38,6 @@ export function useApplyCanvasOffsetToStyle(scale: number | null): React.RefObje
     () => applyCanvasOffset(canvasOffsetRef.current),
     [applyCanvasOffset, canvasOffsetRef],
   )
-  React.useEffect(applyCanvasOffsetEffect, [applyCanvasOffsetEffect])
+  React.useLayoutEffect(applyCanvasOffsetEffect, [applyCanvasOffsetEffect])
   return elementRef
 }

--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -31,3 +31,25 @@ export const CanvasOffsetWrapper = React.memo((props) => {
     </div>
   )
 })
+
+export function useApplyCanvasOffsetToComponentEntry(
+  elementRef: React.RefObject<HTMLDivElement>,
+  scale: number | null,
+): void {
+  const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
+  const applyCanvasOffset = React.useCallback(
+    (roundedCanvasOffset: CanvasVector) => {
+      if (elementRef.current != null && scale != null) {
+        elementRef.current.style.setProperty(
+          'transform',
+          (scale < 1 ? `scale(${scale})` : '') +
+            ` translate3d(${roundedCanvasOffset.x}px, ${roundedCanvasOffset.y}px, 0)`,
+        )
+      }
+    },
+    [elementRef, scale],
+  )
+
+  useSelectorWithCallback((store) => store.editor.canvas.roundedCanvasOffset, applyCanvasOffset)
+  applyCanvasOffset(canvasOffsetRef.current)
+}

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -27,6 +27,7 @@ import {
 import { getOriginalFrames } from '../../canvas-utils'
 import { windowToCanvasCoordinatesGlobal } from '../../dom-lookup'
 import { useBoundingBox } from '../bounding-box-hooks'
+import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 
 interface AbsoluteResizeControlProps {
   localSelectedElements: Array<ElementPath>
@@ -83,49 +84,57 @@ export const AbsoluteResizeControl = React.memo<AbsoluteResizeControlProps>((pro
     ref.current.style.top = boundingBox.height + 'px'
   })
 
-  useCanvasOffset(controlRef)
-
   if (allSelectedElementsAbsolute) {
     return (
-      <div
-        ref={controlRef}
-        style={{
-          position: 'absolute',
-        }}
-      >
-        <ResizeEdge
-          ref={rightRef}
-          position={{ x: 1, y: 0.5 }}
-          cursor={CSSCursor.ResizeEW}
-          direction='vertical'
-          enabledDirection={DirectionHorizontal}
-        />
-        <ResizeEdge
-          ref={bottomRef}
-          position={{ x: 0.5, y: 1 }}
-          cursor={CSSCursor.ResizeNS}
-          direction='horizontal'
-          enabledDirection={DirectionVertical}
-        />
-        <ResizeEdge
-          ref={leftRef}
-          position={{ x: 0, y: 0.5 }}
-          cursor={CSSCursor.ResizeEW}
-          direction='vertical'
-          enabledDirection={DirectionHorizontal}
-        />
-        <ResizeEdge
-          ref={topRef}
-          position={{ x: 0.5, y: 0 }}
-          cursor={CSSCursor.ResizeNS}
-          direction='horizontal'
-          enabledDirection={DirectionVertical}
-        />
-        <ResizePoint ref={topLeftRef} position={{ x: 0, y: 0 }} cursor={CSSCursor.ResizeNWSE} />
-        <ResizePoint ref={topRightRef} position={{ x: 1, y: 0 }} cursor={CSSCursor.ResizeNESW} />
-        <ResizePoint ref={bottomLeftRef} position={{ x: 0, y: 1 }} cursor={CSSCursor.ResizeNESW} />
-        <ResizePoint ref={bottomRightRef} position={{ x: 1, y: 1 }} cursor={CSSCursor.ResizeNWSE} />
-      </div>
+      <CanvasOffsetWrapper>
+        <div
+          ref={controlRef}
+          style={{
+            position: 'absolute',
+          }}
+        >
+          <ResizeEdge
+            ref={rightRef}
+            position={{ x: 1, y: 0.5 }}
+            cursor={CSSCursor.ResizeEW}
+            direction='vertical'
+            enabledDirection={DirectionHorizontal}
+          />
+          <ResizeEdge
+            ref={bottomRef}
+            position={{ x: 0.5, y: 1 }}
+            cursor={CSSCursor.ResizeNS}
+            direction='horizontal'
+            enabledDirection={DirectionVertical}
+          />
+          <ResizeEdge
+            ref={leftRef}
+            position={{ x: 0, y: 0.5 }}
+            cursor={CSSCursor.ResizeEW}
+            direction='vertical'
+            enabledDirection={DirectionHorizontal}
+          />
+          <ResizeEdge
+            ref={topRef}
+            position={{ x: 0.5, y: 0 }}
+            cursor={CSSCursor.ResizeNS}
+            direction='horizontal'
+            enabledDirection={DirectionVertical}
+          />
+          <ResizePoint ref={topLeftRef} position={{ x: 0, y: 0 }} cursor={CSSCursor.ResizeNWSE} />
+          <ResizePoint ref={topRightRef} position={{ x: 1, y: 0 }} cursor={CSSCursor.ResizeNESW} />
+          <ResizePoint
+            ref={bottomLeftRef}
+            position={{ x: 0, y: 1 }}
+            cursor={CSSCursor.ResizeNESW}
+          />
+          <ResizePoint
+            ref={bottomRightRef}
+            position={{ x: 1, y: 1 }}
+            cursor={CSSCursor.ResizeNWSE}
+          />
+        </div>
+      </CanvasOffsetWrapper>
     )
   }
   return null

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -14,6 +14,7 @@ import { EditorDispatch } from '../../../editor/action-types'
 import { setResizeOptionsTargetOptions } from '../../../editor/actions/action-creators'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
+import { useCanvasOffset } from '../../canvas-offset-hooks'
 import {
   CSSCursor,
   DirectionAll,
@@ -82,13 +83,14 @@ export const AbsoluteResizeControl = React.memo<AbsoluteResizeControlProps>((pro
     ref.current.style.top = boundingBox.height + 'px'
   })
 
+  useCanvasOffset(controlRef)
+
   if (allSelectedElementsAbsolute) {
     return (
       <div
         ref={controlRef}
         style={{
           position: 'absolute',
-          transform: `translate(var(--utopia-canvas-offset-x), var(--utopia-canvas-offset-y))`,
         }}
       >
         <ResizeEdge

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -14,7 +14,6 @@ import { EditorDispatch } from '../../../editor/action-types'
 import { setResizeOptionsTargetOptions } from '../../../editor/actions/action-creators'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
-import { useCanvasOffset } from '../../canvas-offset-hooks'
 import {
   CSSCursor,
   DirectionAll,
@@ -146,10 +145,13 @@ interface ResizePointProps {
 }
 
 const ResizePointMouseAreaSize = 12
+const ResizePointMouseAreaOffset = ResizePointMouseAreaSize / 2
 const ResizePointSize = 6
+const ResizePointOffset = ResizePointSize / 2
 const ResizePoint = React.memo(
   React.forwardRef<HTMLDivElement, ResizePointProps>((props, ref) => {
     const colorTheme = useColorTheme()
+    const scale = useEditorState((store) => store.editor.canvas.scale, 'ResizeEdge scale')
     const dispatch = useEditorState((store) => store.dispatch, 'ResizeEdge dispatch')
     const jsxMetadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
     const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
@@ -173,8 +175,8 @@ const ResizePoint = React.memo(
         ref={ref}
         style={{
           position: 'absolute',
-          width: `calc(${ResizePointSize}px / var(--utopia-canvas-scale))`,
-          height: `calc(${ResizePointSize}px / var(--utopia-canvas-scale))`,
+          width: ResizePointSize / scale,
+          height: ResizePointSize / scale,
         }}
         onMouseDown={onPointMouseDown}
       >
@@ -184,27 +186,27 @@ const ResizePoint = React.memo(
             pointerEvents: 'initial',
             width: '100%',
             height: '100%',
-            top: `calc(${-ResizePointSize / 2}px / var(--utopia-canvas-scale))`,
-            left: `calc(${-ResizePointSize / 2}px / var(--utopia-canvas-scale))`,
+            top: -ResizePointOffset / scale,
+            left: -ResizePointOffset / scale,
             boxSizing: 'border-box',
-            borderWidth: `calc(1 / var(--utopia-canvas-scale))`,
+            borderWidth: 1 / scale,
             backgroundColor: colorTheme.canvasControlsSizeBoxBackground.value,
             borderRadius: '10%',
             borderStyle: 'none',
             borderColor: 'transparent',
             boxShadow: `${colorTheme.canvasControlsSizeBoxShadowColor.o(50).value} 0px 0px
-              calc(1px / var(--utopia-canvas-scale)), ${
-                colorTheme.canvasControlsSizeBoxShadowColor.o(21).value
-              } 0px calc(1px / var(--utopia-canvas-scale)) calc(2px / var(--utopia-canvas-scale)) calc(1px / var(--utopia-canvas-scale))`,
+              ${1 / scale}px, ${colorTheme.canvasControlsSizeBoxShadowColor.o(21).value} 0px ${
+              1 / scale
+            }px ${2 / scale}px ${1 / scale}px`,
           }}
         />
         <div
           style={{
             position: 'relative',
-            width: `calc(${ResizePointMouseAreaSize}px / var(--utopia-canvas-scale))`,
-            height: `calc(${ResizePointMouseAreaSize}px / var(--utopia-canvas-scale))`,
-            top: `calc(${-ResizePointMouseAreaSize / 2}px / var(--utopia-canvas-scale))`,
-            left: `calc(${-ResizePointMouseAreaSize / 2}px / var(--utopia-canvas-scale))`,
+            width: ResizePointMouseAreaSize / scale,
+            height: ResizePointMouseAreaSize / scale,
+            top: -ResizePointMouseAreaOffset / scale,
+            left: -ResizePointMouseAreaOffset / scale,
             backgroundColor: 'transparent',
             cursor: props.cursor,
           }}
@@ -224,6 +226,7 @@ interface ResizeEdgeProps {
 const ResizeMouseAreaSize = 10
 const ResizeEdge = React.memo(
   React.forwardRef<HTMLDivElement, ResizeEdgeProps>((props, ref) => {
+    const scale = useEditorState((store) => store.editor.canvas.scale, 'ResizeEdge scale')
     const dispatch = useEditorState((store) => store.dispatch, 'ResizeEdge dispatch')
     const jsxMetadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
     const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
@@ -242,17 +245,11 @@ const ResizeEdge = React.memo(
       [dispatch, props.position, props.enabledDirection, jsxMetadataRef, selectedViewsRef],
     )
 
-    const lineSize = `calc(${ResizeMouseAreaSize}px / var(--utopia-canvas-scale))`
+    const lineSize = ResizeMouseAreaSize / scale
     const width = props.direction === 'horizontal' ? undefined : lineSize
     const height = props.direction === 'vertical' ? undefined : lineSize
-    const offsetLeft =
-      props.direction === 'horizontal'
-        ? `0px`
-        : `calc(${-ResizeMouseAreaSize / 2}px / var(--utopia-canvas-scale))`
-    const offsetTop =
-      props.direction === 'vertical'
-        ? `0px`
-        : `calc(${-ResizeMouseAreaSize / 2}px / var(--utopia-canvas-scale))`
+    const offsetLeft = props.direction === 'horizontal' ? `0px` : `${-lineSize / 2}px`
+    const offsetTop = props.direction === 'vertical' ? `0px` : `${-lineSize / 2}px`
     return (
       <div
         ref={ref}

--- a/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
@@ -25,6 +25,7 @@ import {
 import { getOriginalFrames } from '../../canvas-utils'
 import { windowToCanvasCoordinatesGlobal } from '../../dom-lookup'
 import { useBoundingBox } from '../bounding-box-hooks'
+import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 
 interface FlexResizeControlProps {
   localSelectedElements: Array<ElementPath>
@@ -63,31 +64,31 @@ export const FlexResizeControl = React.memo<FlexResizeControlProps>((props) => {
     ref.current.style.top = boundingBox.height + 'px'
   })
 
-  useCanvasOffset(controlRef)
-
   if (allSelectedElementsFlex) {
     return (
-      <div
-        ref={controlRef}
-        style={{
-          position: 'absolute',
-        }}
-      >
-        <ResizeEdge
-          ref={rightRef}
-          position={{ x: 1, y: 0.5 }}
-          cursor={CSSCursor.ResizeEW}
-          direction='vertical'
-          enabledDirection={DirectionHorizontal}
-        />
-        <ResizeEdge
-          ref={bottomRef}
-          position={{ x: 0.5, y: 1 }}
-          cursor={CSSCursor.ResizeNS}
-          direction='horizontal'
-          enabledDirection={DirectionVertical}
-        />
-      </div>
+      <CanvasOffsetWrapper>
+        <div
+          ref={controlRef}
+          style={{
+            position: 'absolute',
+          }}
+        >
+          <ResizeEdge
+            ref={rightRef}
+            position={{ x: 1, y: 0.5 }}
+            cursor={CSSCursor.ResizeEW}
+            direction='vertical'
+            enabledDirection={DirectionHorizontal}
+          />
+          <ResizeEdge
+            ref={bottomRef}
+            position={{ x: 0.5, y: 1 }}
+            cursor={CSSCursor.ResizeNS}
+            direction='horizontal'
+            enabledDirection={DirectionVertical}
+          />
+        </div>
+      </CanvasOffsetWrapper>
     )
   }
   return null

--- a/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
@@ -13,6 +13,7 @@ import { EditorDispatch } from '../../../editor/action-types'
 import { setResizeOptionsTargetOptions } from '../../../editor/actions/action-creators'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
+import { useCanvasOffset } from '../../canvas-offset-hooks'
 import {
   CSSCursor,
   DirectionHorizontal,
@@ -62,13 +63,14 @@ export const FlexResizeControl = React.memo<FlexResizeControlProps>((props) => {
     ref.current.style.top = boundingBox.height + 'px'
   })
 
+  useCanvasOffset(controlRef)
+
   if (allSelectedElementsFlex) {
     return (
       <div
         ref={controlRef}
         style={{
           position: 'absolute',
-          transform: `translate(var(--utopia-canvas-offset-x), var(--utopia-canvas-offset-y))`,
         }}
       >
         <ResizeEdge

--- a/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
@@ -13,7 +13,6 @@ import { EditorDispatch } from '../../../editor/action-types'
 import { setResizeOptionsTargetOptions } from '../../../editor/actions/action-creators'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
-import { useCanvasOffset } from '../../canvas-offset-hooks'
 import {
   CSSCursor,
   DirectionHorizontal,
@@ -102,11 +101,13 @@ interface ResizeEdgeProps {
 }
 
 const ResizeEdgeMouseAreaSize = 12
+const ResizeEdgeMouseAreaOffset = ResizeEdgeMouseAreaSize / 2
 const ResizeEdge = React.memo(
   React.forwardRef<HTMLDivElement, ResizeEdgeProps>((props, ref) => {
     const LineSVGComponent =
       props.position.y === 0.5 ? DimensionableControlVertical : DimensionableControlHorizontal
     const dispatch = useEditorState((store) => store.dispatch, 'ResizeEdge dispatch')
+    const scale = useEditorState((store) => store.editor.canvas.scale, 'ResizeEdge scale')
     const jsxMetadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
     const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
 
@@ -131,10 +132,10 @@ const ResizeEdge = React.memo(
           style={{
             position: 'absolute',
             pointerEvents: 'initial',
-            width: `calc(${ResizeEdgeMouseAreaSize}px / var(--utopia-canvas-scale))`,
-            height: `calc(${ResizeEdgeMouseAreaSize}px / var(--utopia-canvas-scale))`,
-            top: `calc(${-ResizeEdgeMouseAreaSize / 2}px / var(--utopia-canvas-scale))`,
-            left: `calc(${-ResizeEdgeMouseAreaSize / 2}px / var(--utopia-canvas-scale))`,
+            width: ResizeEdgeMouseAreaSize / scale,
+            height: ResizeEdgeMouseAreaSize / scale,
+            top: -ResizeEdgeMouseAreaOffset / scale,
+            left: -ResizeEdgeMouseAreaOffset / scale,
             backgroundColor: 'transparent',
             cursor: props.cursor,
           }}
@@ -217,9 +218,14 @@ function startResizeInteraction(
 const ControlSideShort = 3
 const ControlSideLong = 15
 const DimensionableControlVertical = React.memo(() => {
+  const scale = useEditorState(
+    (store) => store.editor.canvas.scale,
+    'DimensionableControlVertical scale',
+  )
   const colorTheme = useColorTheme()
   const controlLength = ControlSideLong
   const controlWidth = ControlSideShort
+  const controlOffset = controlLength / 2
 
   return (
     <div
@@ -227,21 +233,28 @@ const DimensionableControlVertical = React.memo(() => {
       style={{
         position: 'relative',
         backgroundColor: colorTheme.primary.shade(10).value,
-        borderRadius: `calc(5px / var(--utopia-canvas-scale))`,
-        boxShadow: `0px 0px 0px calc(0.3px / var(--utopia-canvas-scale)) ${colorTheme.primary.value}, 0px calc(1px / var(--utopia-canvas-scale)) calc(3px / var(--utopia-canvas-scale)) rgba(140,140,140,.9)`,
-        height: `calc(${controlLength}px / var(--utopia-canvas-scale))`,
-        width: `calc(${controlWidth}px / var(--utopia-canvas-scale))`,
+        borderRadius: 5 / scale,
+        boxShadow: `0px 0px 0px ${0.3 / scale}px ${colorTheme.primary.value}, 0px ${1 / scale}px ${
+          3 / scale
+        }px rgba(140,140,140,.9)`,
+        height: controlLength / scale,
+        width: controlWidth / scale,
         left: -1,
-        top: `calc(${-controlLength / 2}px / var(--utopia-canvas-scale))`,
+        top: -controlOffset / scale,
       }}
     />
   )
 })
 
 const DimensionableControlHorizontal = React.memo(() => {
+  const scale = useEditorState(
+    (store) => store.editor.canvas.scale,
+    'DimensionableControlHorizontal scale',
+  )
   const colorTheme = useColorTheme()
   const controlLength = ControlSideShort
   const controlWidth = ControlSideLong
+  const controlOffset = controlWidth / 2
 
   return (
     <div
@@ -249,11 +262,13 @@ const DimensionableControlHorizontal = React.memo(() => {
       style={{
         position: 'relative',
         backgroundColor: colorTheme.primary.shade(10).value,
-        borderRadius: `calc(5px / var(--utopia-canvas-scale))`,
-        boxShadow: `0px 0px 0px calc(0.3px / var(--utopia-canvas-scale)) ${colorTheme.primary.value}, 0px calc(1px / var(--utopia-canvas-scale)) calc(3px / var(--utopia-canvas-scale)) rgba(140,140,140,.9)`,
-        height: `calc(${controlLength}px / var(--utopia-canvas-scale))`,
-        width: `calc(${controlWidth}px / var(--utopia-canvas-scale))`,
-        left: `calc(${-controlWidth / 2}px / var(--utopia-canvas-scale))`,
+        borderRadius: 5 / scale,
+        boxShadow: `0px 0px 0px ${0.3 / scale}px ${colorTheme.primary.value}, 0px ${1 / scale}px ${
+          3 / scale
+        }px rgba(140,140,140,.9)`,
+        height: controlLength / scale,
+        width: controlWidth / scale,
+        left: -controlOffset / scale,
         top: -1,
       }}
     />

--- a/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
@@ -239,7 +239,7 @@ const DimensionableControlVertical = React.memo(() => {
         }px rgba(140,140,140,.9)`,
         height: controlLength / scale,
         width: controlWidth / scale,
-        left: -1,
+        left: -1 / scale,
         top: -controlOffset / scale,
       }}
     />
@@ -269,7 +269,7 @@ const DimensionableControlHorizontal = React.memo(() => {
         height: controlLength / scale,
         width: controlWidth / scale,
         left: -controlOffset / scale,
-        top: -1,
+        top: -1 / scale,
       }}
     />
   )

--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -4,6 +4,7 @@ import { ElementPath } from '../../../../core/shared/project-file-types'
 import { when } from '../../../../utils/react-conditionals'
 import { useColorTheme } from '../../../../uuiui'
 import { useEditorState } from '../../../editor/store/store-hook'
+import { useCanvasOffset } from '../../canvas-offset-hooks'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { getSelectionColor } from '../outline-control'
 
@@ -56,6 +57,8 @@ const OutlineControl = React.memo<OutlineControlProps>((props) => {
     ref.current.style.height = `calc(${boundingBox.height}px - 0.5px / var(--utopia-canvas-scale) * 3)`
   })
 
+  useCanvasOffset(outlineRef)
+
   const color =
     props.color === 'primary' ? colors[0] : colorTheme.canvasSelectionSecondaryOutline.value
 
@@ -69,7 +72,6 @@ const OutlineControl = React.memo<OutlineControlProps>((props) => {
           boxSizing: 'border-box',
           boxShadow: `0px 0px 0px calc(1px / var(--utopia-canvas-scale)) ${color}`,
           pointerEvents: 'none',
-          transform: `translate(var(--utopia-canvas-offset-x), var(--utopia-canvas-offset-y))`,
         }}
       />
     )

--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -4,7 +4,6 @@ import { ElementPath } from '../../../../core/shared/project-file-types'
 import { when } from '../../../../utils/react-conditionals'
 import { useColorTheme } from '../../../../uuiui'
 import { useEditorState } from '../../../editor/store/store-hook'
-import { useCanvasOffset } from '../../canvas-offset-hooks'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import { getSelectionColor } from '../outline-control'
@@ -39,6 +38,7 @@ interface OutlineControlProps {
 const OutlineControl = React.memo<OutlineControlProps>((props) => {
   const colorTheme = useColorTheme()
   const targets = props.targets
+  const scale = useEditorState((store) => store.editor.canvas.scale, 'OutlineControl scale')
 
   const colors = useEditorState((store) => {
     return targets.map((path) =>
@@ -52,10 +52,10 @@ const OutlineControl = React.memo<OutlineControlProps>((props) => {
   }, 'OutlineControl colors')
 
   const outlineRef = useBoundingBox(targets, (ref, boundingBox) => {
-    ref.current.style.left = `calc(${boundingBox.x}px + 0.5px / var(--utopia-canvas-scale))`
-    ref.current.style.top = `calc(${boundingBox.y}px + 0.5px / var(--utopia-canvas-scale))`
-    ref.current.style.width = `calc(${boundingBox.width}px - 0.5px / var(--utopia-canvas-scale) * 3)`
-    ref.current.style.height = `calc(${boundingBox.height}px - 0.5px / var(--utopia-canvas-scale) * 3)`
+    ref.current.style.left = `${boundingBox.x + 0.5 / scale}px`
+    ref.current.style.top = `${boundingBox.y + 0.5 / scale}px`
+    ref.current.style.width = `${boundingBox.width - (0.5 / scale) * 3}px`
+    ref.current.style.height = `${boundingBox.height - (0.5 / scale) * 3}px`
   })
 
   const color =
@@ -69,7 +69,7 @@ const OutlineControl = React.memo<OutlineControlProps>((props) => {
         style={{
           position: 'absolute',
           boxSizing: 'border-box',
-          boxShadow: `0px 0px 0px calc(1px / var(--utopia-canvas-scale)) ${color}`,
+          boxShadow: `0px 0px 0px ${1 / scale}px ${color}`,
           pointerEvents: 'none',
         }}
       />

--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -6,6 +6,7 @@ import { useColorTheme } from '../../../../uuiui'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { useCanvasOffset } from '../../canvas-offset-hooks'
 import { useBoundingBox } from '../bounding-box-hooks'
+import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import { getSelectionColor } from '../outline-control'
 
 interface MultiSelectOutlineControlProps {
@@ -15,7 +16,7 @@ interface MultiSelectOutlineControlProps {
 export const MultiSelectOutlineControl = React.memo<MultiSelectOutlineControlProps>((props) => {
   const localSelectedElements = props.localSelectedElements
   return (
-    <>
+    <CanvasOffsetWrapper>
       {[
         <OutlineControl
           key='multiselect-outline'
@@ -26,7 +27,7 @@ export const MultiSelectOutlineControl = React.memo<MultiSelectOutlineControlPro
           <OutlineControl key={EP.toString(path)} targets={[path]} color='primary' />
         )),
       ]}
-    </>
+    </CanvasOffsetWrapper>
   )
 })
 
@@ -56,8 +57,6 @@ const OutlineControl = React.memo<OutlineControlProps>((props) => {
     ref.current.style.width = `calc(${boundingBox.width}px - 0.5px / var(--utopia-canvas-scale) * 3)`
     ref.current.style.height = `calc(${boundingBox.height}px - 0.5px / var(--utopia-canvas-scale) * 3)`
   })
-
-  useCanvasOffset(outlineRef)
 
   const color =
     props.color === 'primary' ? colors[0] : colorTheme.canvasSelectionSecondaryOutline.value

--- a/editor/src/components/canvas/utopia-canvas-vars.tsx
+++ b/editor/src/components/canvas/utopia-canvas-vars.tsx
@@ -18,8 +18,6 @@ export const UtopiaCanvasVarStyleTag = React.memo(() => {
   return (
     <style>{`
   .utopia-canvas-var-container {
-    --utopia-canvas-offset-x: ${roundedCanvasOffset.x}px;
-    --utopia-canvas-offset-y: ${roundedCanvasOffset.y}px;
     --utopia-canvas-scale: ${canvasScale};
   }
 `}</style>

--- a/editor/src/components/canvas/utopia-canvas-vars.tsx
+++ b/editor/src/components/canvas/utopia-canvas-vars.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { CanvasScale, CanvasScrollOffset } from '../../utils/global-positions'
 import { useEditorState } from '../editor/store/store-hook'
 
-export const UtopiaCanvasVarStyleTag = React.memo(() => {
+export const UtopiaCanvasVars = React.memo(() => {
   const roundedCanvasOffset = useEditorState(
     (store) => store.editor.canvas.roundedCanvasOffset,
     'DesignPanelRoot roundedCanvasOffset',
@@ -15,11 +15,5 @@ export const UtopiaCanvasVarStyleTag = React.memo(() => {
   CanvasScrollOffset.x = roundedCanvasOffset.x
   CanvasScrollOffset.y = roundedCanvasOffset.y
   CanvasScale.current = canvasScale
-  return (
-    <style>{`
-  .utopia-canvas-var-container {
-    --utopia-canvas-scale: ${canvasScale};
-  }
-`}</style>
-  )
+  return null
 })

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -56,7 +56,7 @@ import { isFeatureEnabled } from '../../utils/feature-switches'
 import Keyboard from '../../utils/keyboard'
 import { Modifier } from '../../utils/modifiers'
 import CanvasActions from '../canvas/canvas-actions'
-import { UtopiaCanvasVarStyleTag } from '../canvas/utopia-canvas-vars'
+import { UtopiaCanvasVars } from '../canvas/utopia-canvas-vars'
 import { updateInteractionViaKeyboard } from '../canvas/canvas-strategies/interaction-state'
 
 function pushProjectURLToBrowserHistory(projectId: string, projectName: string): void {
@@ -256,7 +256,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 
   return (
     <>
-      <UtopiaCanvasVarStyleTag />
+      <UtopiaCanvasVars />
       <SimpleFlexRow
         className='editor-main-vertical-and-modals'
         style={{

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -757,7 +757,6 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         id: 'canvas-root',
         key: 'canvas-root',
         'data-testid': 'canvas-root',
-        className: 'utopia-canvas-var-container',
         style: {
           ...canvasLiveEditingStyle,
           transition: 'all .2s linear',


### PR DESCRIPTION
**Problem:**
Solving performance problems with the new canvas controls. With the usage of css variables the new controls became very slow because the canvas offset css variable has to be outside of the canvas controls to be visible for them, but updating it causes Chrome to invalidate all child element styles that are using css variables (including css variables with a different name).

**Fix:**
Removing css variables for offset and scale. Offset is updated similarly how the new controls position themselves using the element ref directly. Scale is from editor state.

**Commit Details:**
- removed 3 css variables
- created a component for controls that automatically sets the offset
- set the offset on the container
- updated the 3 new canvas controls
