### PR TITLE
Remove unused interactionSession.globalTime

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -47,7 +47,6 @@ export interface InteractionSession {
   userPreferredStrategy: CanvasStrategyId | null
 
   startedAt: number
-  globalTime: number
 }
 
 export type InteractionSessionWithoutMetadata = Omit<InteractionSession, 'metadata'>
@@ -107,7 +106,6 @@ export function createInteractionViaMouse(
     lastInteractionTime: Date.now(),
     userPreferredStrategy: null,
     startedAt: Date.now(),
-    globalTime: Date.now(),
   }
 }
 
@@ -141,13 +139,9 @@ export function updateInteractionViaMouse(
       lastInteractionTime: Date.now(),
       userPreferredStrategy: currentState.userPreferredStrategy,
       startedAt: currentState.startedAt,
-      globalTime: Date.now(),
     }
   } else {
-    return {
-      ...currentState,
-      globalTime: Date.now(),
-    }
+    return currentState
   }
 }
 
@@ -167,7 +161,6 @@ export function createInteractionViaKeyboard(
     lastInteractionTime: Date.now(),
     userPreferredStrategy: null,
     startedAt: Date.now(),
-    globalTime: Date.now(),
   }
 }
 
@@ -196,7 +189,6 @@ export function updateInteractionViaKeyboard(
         lastInteractionTime: Date.now(),
         userPreferredStrategy: currentState.userPreferredStrategy,
         startedAt: currentState.startedAt,
-        globalTime: Date.now(),
       }
     }
     case 'DRAG': {
@@ -215,7 +207,6 @@ export function updateInteractionViaKeyboard(
         lastInteractionTime: Date.now(),
         userPreferredStrategy: currentState.userPreferredStrategy,
         startedAt: currentState.startedAt,
-        globalTime: Date.now(),
       }
     }
     default:

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -293,8 +293,6 @@ function on(
   return additionalEvents
 }
 
-let interactionSessionTimerHandle: any = undefined
-
 export function runLocalCanvasAction(
   dispatch: EditorDispatch,
   model: EditorState,
@@ -359,10 +357,6 @@ export function runLocalCanvasAction(
       }
     }
     case 'CREATE_INTERACTION_SESSION':
-      clearInterval(interactionSessionTimerHandle)
-      interactionSessionTimerHandle = setInterval(() => {
-        dispatch([CanvasActions.updateInteractionSession({ globalTime: Date.now() })])
-      }, 200)
       return {
         ...model,
         canvas: {
@@ -374,7 +368,6 @@ export function runLocalCanvasAction(
         },
       }
     case 'CLEAR_INTERACTION_SESSION':
-      clearInterval(interactionSessionTimerHandle)
       const metadataToKeep =
         action.applyChanges && model.canvas.interactionSession != null
           ? model.canvas.interactionSession.metadata


### PR DESCRIPTION
We don't use globalTime for anything now, and it is really not optimal to maintain our own clock with action dispatches.
Let's remove it for now and we can readd later if necessary (or choose another solution instead)