### PR TITLE
Apply accumulated commands when there is no strategy

### DIFF
--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -370,6 +370,32 @@ describe('interactionUpdate', () => {
   })
 })
 
+describe('interactionUpdate without strategy', () => {
+  it('processes the accumulated commands', () => {
+    const editorStore = createEditorStore(
+      createInteractionViaMouse(
+        canvasPoint({ x: 100, y: 200 }),
+        { alt: false, shift: false, ctrl: false, cmd: false },
+        { type: 'BOUNDING_AREA', target: EP.elementPath([['aaa']]) },
+      ),
+    )
+    editorStore.strategyState.currentStrategy = null
+    editorStore.strategyState.accumulatedCommands = [
+      {
+        commands: [wildcardPatch('permanent', { canvas: { scale: { $set: 100 } } })],
+        strategy: null,
+      },
+    ]
+    const actualResult = interactionUpdate(
+      [],
+      editorStore,
+      dispatchResultFromEditorStore(editorStore),
+    )
+    expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
+    expect(actualResult.unpatchedEditorState.canvas.scale).toEqual(1)
+  })
+})
+
 describe('interactionHardReset', () => {
   it('steps an interaction session correctly', () => {
     let interactionSession = createInteractionViaMouse(

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -64,32 +64,26 @@ export function interactionFinished(
       sortedApplicableStrategies: sortedApplicableStrategies,
     }
 
-    // If there is a current strategy, produce the commands from it.
-    if (strategy == null) {
-      return {
-        unpatchedEditorState: newEditorState,
-        patchedEditorState: newEditorState,
-        newStrategyState: newStrategyState,
-      }
-    } else {
-      const commands = applyCanvasStrategy(
-        strategy.strategy,
-        canvasState,
-        interactionSession,
-        result.strategyState,
-      )
-      const commandResult = foldAndApplyCommands(
-        newEditorState,
-        storedState.patchedEditor,
-        [...result.strategyState.accumulatedCommands.flatMap((c) => c.commands), ...commands],
-        'permanent',
-      )
+    const commands =
+      strategy != null
+        ? applyCanvasStrategy(
+            strategy.strategy,
+            canvasState,
+            interactionSession,
+            result.strategyState,
+          )
+        : []
+    const commandResult = foldAndApplyCommands(
+      newEditorState,
+      storedState.patchedEditor,
+      [...result.strategyState.accumulatedCommands.flatMap((c) => c.commands), ...commands],
+      'permanent',
+    )
 
-      return {
-        unpatchedEditorState: commandResult.editorState,
-        patchedEditorState: commandResult.editorState,
-        newStrategyState: newStrategyState,
-      }
+    return {
+      unpatchedEditorState: commandResult.editorState,
+      patchedEditorState: commandResult.editorState,
+      newStrategyState: newStrategyState,
     }
   }
 }
@@ -391,13 +385,16 @@ function handleUpdate(
 ): HandleStrategiesResult {
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
   // If there is a current strategy, produce the commands from it.
-  if (strategy != null && newEditorState.canvas.interactionSession != null) {
-    const commands = applyCanvasStrategy(
-      strategy.strategy,
-      canvasState,
-      newEditorState.canvas.interactionSession,
-      strategyState,
-    )
+  if (newEditorState.canvas.interactionSession != null) {
+    const commands =
+      strategy != null
+        ? applyCanvasStrategy(
+            strategy.strategy,
+            canvasState,
+            newEditorState.canvas.interactionSession,
+            strategyState,
+          )
+        : []
     const commandResult = foldAndApplyCommands(
       newEditorState,
       storedEditorState,
@@ -405,8 +402,8 @@ function handleUpdate(
       'transient',
     )
     const newStrategyState: StrategyState = {
-      currentStrategy: strategy.strategy.id,
-      currentStrategyFitness: strategy.fitness,
+      currentStrategy: strategy != null ? strategy.strategy.id : null,
+      currentStrategyFitness: strategy != null ? strategy.fitness : 0,
       currentStrategyCommands: commands,
       accumulatedCommands: strategyState.accumulatedCommands,
       commandDescriptions: commandResult.commandDescriptions,
@@ -438,28 +435,31 @@ function handleStrategyChangeStacked(
 ): HandleStrategiesResult {
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
   // If there is a current strategy, produce the commands from it.
-  if (strategy != null && newEditorState.canvas.interactionSession != null) {
+  if (newEditorState.canvas.interactionSession != null) {
     const strategyChangedLogCommands = [
       {
         strategy: null,
         commands: [
           strategySwitched(
             'user-input',
-            strategy.strategy.name,
+            strategy?.strategy.name ?? 'null',
             true,
             previousStrategy?.fitness ?? NaN,
-            strategy.fitness,
+            strategy?.fitness ?? 0,
           ),
         ],
       },
     ]
 
-    const commands = applyCanvasStrategy(
-      strategy.strategy,
-      canvasState,
-      newEditorState.canvas.interactionSession,
-      strategyState,
-    )
+    const commands =
+      strategy != null
+        ? applyCanvasStrategy(
+            strategy.strategy,
+            canvasState,
+            newEditorState.canvas.interactionSession,
+            strategyState,
+          )
+        : []
     const newAccumulatedCommands = [
       ...strategyState.accumulatedCommands,
       {
@@ -475,8 +475,8 @@ function handleStrategyChangeStacked(
       'transient',
     )
     const newStrategyState: StrategyState = {
-      currentStrategy: strategy.strategy.id,
-      currentStrategyFitness: strategy.fitness,
+      currentStrategy: strategy?.strategy.id ?? null,
+      currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
       accumulatedCommands: newAccumulatedCommands,
       commandDescriptions: commandResult.commandDescriptions,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -402,8 +402,8 @@ function handleUpdate(
       'transient',
     )
     const newStrategyState: StrategyState = {
-      currentStrategy: strategy != null ? strategy.strategy.id : null,
-      currentStrategyFitness: strategy != null ? strategy.fitness : 0,
+      currentStrategy: strategy?.strategy.id ?? null,
+      currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
       accumulatedCommands: strategyState.accumulatedCommands,
       commandDescriptions: commandResult.commandDescriptions,


### PR DESCRIPTION
When there is no applicable strategy, but we are in an active interaction with accumulated commands, we need to apply the accumulated commands to the unpatched editor state (even though there are no new commands to apply, because without an active strategy we don't generate new commands).