### PR TITLE
Wrap offensive callbacks in `useCallback`

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
-import { useEditorState } from '../editor/store/store-hook'
+import {
+  useEditorDispatch,
+  useEditorSelectedViews,
+  useEditorState,
+} from '../editor/store/store-hook'
 import {
   UiJsxCanvas,
   pickUiJsxCanvasProps,
@@ -30,10 +34,7 @@ import { useApplyCanvasOffsetToStyle } from './controls/canvas-offset-wrapper'
 interface CanvasComponentEntryProps {}
 
 export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps) => {
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'CanvasComponentEntry dispatch',
-  )
+  const dispatch = useEditorDispatch('CanvasComponentEntry dispatch')
   const onDomReport = React.useCallback(
     (elementMetadata: ReadonlyArray<ElementInstanceMetadata>, cachedPaths: Array<ElementPath>) => {
       dispatch([saveDOMReport(elementMetadata, cachedPaths)])
@@ -120,10 +121,7 @@ export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps
 })
 
 function DomWalkerWrapper(props: UiJsxCanvasPropsWithErrorCallback) {
-  const selectedViews = useEditorState(
-    React.useCallback((store) => store.editor.selectedViews, []),
-    'DomWalkerWrapper selectedViews',
-  )
+  const selectedViews = useEditorSelectedViews('DomWalkerWrapper selectedViews')
   let [updateInvalidatedPaths, updateInvalidatedScenes, containerRef] = useDomWalker({
     selectedViews: selectedViews,
     canvasInteractionHappening: props.transientFilesState != null,

--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -30,7 +30,10 @@ import { useApplyCanvasOffsetToStyle } from './controls/canvas-offset-wrapper'
 interface CanvasComponentEntryProps {}
 
 export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps) => {
-  const dispatch = useEditorState((store) => store.dispatch, 'CanvasComponentEntry dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'CanvasComponentEntry dispatch',
+  )
   const onDomReport = React.useCallback(
     (elementMetadata: ReadonlyArray<ElementInstanceMetadata>, cachedPaths: Array<ElementPath>) => {
       dispatch([saveDOMReport(elementMetadata, cachedPaths)])
@@ -40,17 +43,23 @@ export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps
   const { addToRuntimeErrors, clearRuntimeErrors } = useWriteOnlyRuntimeErrors()
   const { addToConsoleLogs, clearConsoleLogs } = useWriteOnlyConsoleLogs()
 
-  const canvasProps = useEditorState((store) => {
-    return pickUiJsxCanvasProps(
-      store.editor,
-      store.derived,
-      store.dispatch,
-      true,
-      onDomReport,
-      clearConsoleLogs,
-      addToConsoleLogs,
-    )
-  }, 'CanvasComponentEntry canvasProps')
+  const canvasProps = useEditorState(
+    React.useCallback(
+      (store) => {
+        return pickUiJsxCanvasProps(
+          store.editor,
+          store.derived,
+          store.dispatch,
+          true,
+          onDomReport,
+          clearConsoleLogs,
+          addToConsoleLogs,
+        )
+      },
+      [addToConsoleLogs, clearConsoleLogs, onDomReport],
+    ),
+    'CanvasComponentEntry canvasProps',
+  )
 
   const canvasEditOrSelect = React.useMemo(() => {
     // Explicitly target the case where the canvas is not live, needs to handle `undefined`.
@@ -112,7 +121,7 @@ export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps
 
 function DomWalkerWrapper(props: UiJsxCanvasPropsWithErrorCallback) {
   const selectedViews = useEditorState(
-    (store) => store.editor.selectedViews,
+    React.useCallback((store) => store.editor.selectedViews, []),
     'DomWalkerWrapper selectedViews',
   )
   let [updateInvalidatedPaths, updateInvalidatedScenes, containerRef] = useDomWalker({

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -210,12 +210,11 @@ export function applyCanvasStrategy(
   return strategy.apply(canvasState, interactionSession, strategyState)
 }
 
+const currentStrategySelector = (store: EditorStorePatched) => store.strategyState.currentStrategy
+
 export function useGetApplicableStrategyControls(): Array<ControlWithKey> {
   const applicableStrategies = useGetApplicableStrategies()
-  const currentStrategy = useEditorState(
-    React.useCallback((store) => store.strategyState.currentStrategy, []),
-    'currentStrategy',
-  )
+  const currentStrategy = useEditorState(currentStrategySelector, 'currentStrategy')
   return React.useMemo(() => {
     return applicableStrategies.reduce<ControlWithKey[]>((working, s) => {
       const filteredControls = s.controlsToRender.filter(

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -213,7 +213,7 @@ export function applyCanvasStrategy(
 export function useGetApplicableStrategyControls(): Array<ControlWithKey> {
   const applicableStrategies = useGetApplicableStrategies()
   const currentStrategy = useEditorState(
-    (store) => store.strategyState.currentStrategy,
+    React.useCallback((store) => store.strategyState.currentStrategy, []),
     'currentStrategy',
   )
   return React.useMemo(() => {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-inspector.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-inspector.tsx
@@ -1,17 +1,23 @@
 import React from 'react'
 import { when } from '../../../utils/react-conditionals'
 import { useColorTheme } from '../../../uuiui'
+import { EditorStorePatched } from '../../editor/store/editor-state'
 import { useEditorState } from '../../editor/store/store-hook'
 import { isStrategyActive } from './canvas-strategies'
+
+const isStrategyActiveSelector = (store: EditorStorePatched) =>
+  isStrategyActive(store.strategyState)
+const commandDescriptionsSelector = (store: EditorStorePatched) =>
+  store.strategyState.commandDescriptions
 
 export const CanvasStrategyInspector = React.memo(() => {
   const colorTheme = useColorTheme()
   const activeStrategy = useEditorState(
-    React.useCallback((store) => isStrategyActive(store.strategyState), []),
+    isStrategyActiveSelector,
     'CanvasStrategyInspector activeStrategy',
   )
   const commandsToList = useEditorState(
-    React.useCallback((store) => store.strategyState.commandDescriptions, []),
+    commandDescriptionsSelector,
     'CanvasStrategyInspector accumulatedCommands',
   )
 

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-inspector.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-inspector.tsx
@@ -7,11 +7,11 @@ import { isStrategyActive } from './canvas-strategies'
 export const CanvasStrategyInspector = React.memo(() => {
   const colorTheme = useColorTheme()
   const activeStrategy = useEditorState(
-    (store) => isStrategyActive(store.strategyState),
+    React.useCallback((store) => isStrategyActive(store.strategyState), []),
     'CanvasStrategyInspector activeStrategy',
   )
   const commandsToList = useEditorState(
-    (store) => store.strategyState.commandDescriptions,
+    React.useCallback((store) => store.strategyState.commandDescriptions, []),
     'CanvasStrategyInspector accumulatedCommands',
   )
 

--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -59,11 +59,14 @@ export function filterOldPasses(errorMessages: Array<ErrorMessage>): Array<Error
 
 export const CanvasWrapperComponent = React.memo(() => {
   const { dispatch, editorState, derivedState } = useEditorState(
-    (store) => ({
-      dispatch: store.dispatch,
-      editorState: store.editor,
-      derivedState: store.derived,
-    }),
+    React.useCallback(
+      (store) => ({
+        dispatch: store.dispatch,
+        editorState: store.editor,
+        derivedState: store.derived,
+      }),
+      [],
+    ),
     'CanvasWrapperComponent',
   )
 
@@ -71,12 +74,15 @@ export const CanvasWrapperComponent = React.memo(() => {
     return getAllCodeEditorErrors(editorState, 'fatal', true)
   }, [editorState])
 
-  const safeMode = useEditorState((store) => {
-    return store.editor.safeMode
-  }, 'CanvasWrapperComponent safeMode')
+  const safeMode = useEditorState(
+    React.useCallback((store) => {
+      return store.editor.safeMode
+    }, []),
+    'CanvasWrapperComponent safeMode',
+  )
 
   const isNavigatorOverCanvas = useEditorState(
-    (store) => !store.editor.navigator.minimised,
+    React.useCallback((store) => !store.editor.navigator.minimised, []),
     'ErrorOverlayComponent isOverlappingWithNavigator',
   )
 
@@ -135,16 +141,25 @@ export const CanvasWrapperComponent = React.memo(() => {
 interface ErrorOverlayComponentProps {}
 
 const ErrorOverlayComponent = React.memo((props: ErrorOverlayComponentProps) => {
-  const dispatch = useEditorState((store) => store.dispatch, 'ErrorOverlayComponent dispatch')
-  const utopiaParserErrors = useEditorState((store) => {
-    return parseFailureAsErrorMessages(
-      getOpenUIJSFileKey(store.editor),
-      getOpenUIJSFile(store.editor),
-    )
-  }, 'ErrorOverlayComponent utopiaParserErrors')
-  const fatalCodeEditorErrors = useEditorState((store) => {
-    return getAllCodeEditorErrors(store.editor, 'error', true)
-  }, 'ErrorOverlayComponent fatalCodeEditorErrors')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'ErrorOverlayComponent dispatch',
+  )
+  const utopiaParserErrors = useEditorState(
+    React.useCallback((store) => {
+      return parseFailureAsErrorMessages(
+        getOpenUIJSFileKey(store.editor),
+        getOpenUIJSFile(store.editor),
+      )
+    }, []),
+    'ErrorOverlayComponent utopiaParserErrors',
+  )
+  const fatalCodeEditorErrors = useEditorState(
+    React.useCallback((store) => {
+      return getAllCodeEditorErrors(store.editor, 'error', true)
+    }, []),
+    'ErrorOverlayComponent fatalCodeEditorErrors',
+  )
 
   const runtimeErrors = useReadOnlyRuntimeErrors()
 
@@ -207,7 +222,10 @@ const ErrorOverlayComponent = React.memo((props: ErrorOverlayComponentProps) => 
 })
 
 export const SafeModeErrorOverlay = React.memo(() => {
-  const dispatch = useEditorState((store) => store.dispatch, 'SafeModeErrorOverlay dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'SafeModeErrorOverlay dispatch',
+  )
   const onTryAgain = React.useCallback(() => {
     dispatch([setSafeMode(false)], 'everyone')
   }, [dispatch])

--- a/editor/src/components/canvas/controls/bounding-box-hooks.ts
+++ b/editor/src/components/canvas/controls/bounding-box-hooks.ts
@@ -32,7 +32,7 @@ function useBoundingBoxFromMetadataRef(
   selectedElements: Array<ElementPath>,
   boundingBoxCallback: (boundingRectangle: CanvasRectangle | null) => void,
 ): void {
-  const metadataRef = useRefEditorState((store) => getMetadata(store.editor))
+  const metadataRef = useRefEditorState(React.useCallback((store) => getMetadata(store.editor), []))
 
   const boundingBoxCallbackRef = React.useRef(boundingBoxCallback)
   boundingBoxCallbackRef.current = boundingBoxCallback

--- a/editor/src/components/canvas/controls/bounding-box-hooks.ts
+++ b/editor/src/components/canvas/controls/bounding-box-hooks.ts
@@ -2,7 +2,7 @@ import React from 'react'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { fastForEach } from '../../../core/shared/utils'
 import { boundingRectangleArray, CanvasRectangle } from '../../../core/shared/math-utils'
-import { useRefEditorState, useSelectorWithCallback } from '../../editor/store/store-hook'
+import { useRefEditorMetadata, useSelectorWithCallback } from '../../editor/store/store-hook'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { getMetadata } from '../../editor/store/editor-state'
 
@@ -32,7 +32,7 @@ function useBoundingBoxFromMetadataRef(
   selectedElements: Array<ElementPath>,
   boundingBoxCallback: (boundingRectangle: CanvasRectangle | null) => void,
 ): void {
-  const metadataRef = useRefEditorState(React.useCallback((store) => getMetadata(store.editor), []))
+  const metadataRef = useRefEditorMetadata()
 
   const boundingBoxCallbackRef = React.useRef(boundingBoxCallback)
   boundingBoxCallbackRef.current = boundingBoxCallback

--- a/editor/src/components/canvas/controls/bounding-box-hooks.ts
+++ b/editor/src/components/canvas/controls/bounding-box-hooks.ts
@@ -52,10 +52,13 @@ function useBoundingBoxFromMetadataRef(
   }, [selectedElements, metadataRef])
 
   useSelectorWithCallback(
-    (store) => getMetadata(store.editor),
-    (newMetadata) => {
-      innerCallback()
-    },
+    React.useCallback((store) => getMetadata(store.editor), []),
+    React.useCallback(
+      (newMetadata) => {
+        innerCallback()
+      },
+      [innerCallback],
+    ),
   )
 
   React.useEffect(innerCallback, [innerCallback, selectedElements])

--- a/editor/src/components/canvas/controls/breadcrumb-trail.tsx
+++ b/editor/src/components/canvas/controls/breadcrumb-trail.tsx
@@ -14,13 +14,16 @@ interface ElementPathElement {
 }
 
 export const BreadcrumbTrail = React.memo(() => {
-  const { dispatch, jsxMetadata, selectedViews } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      jsxMetadata: store.editor.jsxMetadata,
-      selectedViews: store.editor.selectedViews,
-    }
-  }, 'TopMenuContextProvider')
+  const { dispatch, jsxMetadata, selectedViews } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        jsxMetadata: store.editor.jsxMetadata,
+        selectedViews: store.editor.selectedViews,
+      }
+    }, []),
+    'TopMenuContextProvider',
+  )
 
   const onSelect = React.useCallback(
     (path) => dispatch([selectComponents([path], false)], 'everyone'),

--- a/editor/src/components/canvas/controls/breadcrumb-trail.tsx
+++ b/editor/src/components/canvas/controls/breadcrumb-trail.tsx
@@ -7,21 +7,22 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { selectComponents } from '../../../components/editor/actions/action-creators'
 import { Icons, UIRow, UtopiaTheme } from '../../../uuiui'
 import { ElementPath } from '../../../core/shared/project-file-types'
+import { EditorStorePatched } from '../../editor/store/editor-state'
 
 interface ElementPathElement {
   name?: string
   path: ElementPath
 }
 
+const breadcrumbSelector = (store: EditorStorePatched) => ({
+  dispatch: store.dispatch,
+  jsxMetadata: store.editor.jsxMetadata,
+  selectedViews: store.editor.selectedViews,
+})
+
 export const BreadcrumbTrail = React.memo(() => {
   const { dispatch, jsxMetadata, selectedViews } = useEditorState(
-    React.useCallback((store) => {
-      return {
-        dispatch: store.dispatch,
-        jsxMetadata: store.editor.jsxMetadata,
-        selectedViews: store.editor.selectedViews,
-      }
-    }, []),
+    breadcrumbSelector,
     'TopMenuContextProvider',
   )
 

--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -17,8 +17,10 @@ export function useApplyCanvasOffsetToStyle(
   forceOffset?: boolean, // this is not so nice, but the element is optionally rendered in canvas-component-entry
 ): React.RefObject<HTMLDivElement> {
   const elementRef = React.useRef<HTMLDivElement>(null)
-  const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
-  const scaleRef = useRefEditorState((store) => store.editor.canvas.scale)
+  const canvasOffsetRef = useRefEditorState(
+    React.useCallback((store) => store.editor.canvas.roundedCanvasOffset, []),
+  )
+  const scaleRef = useRefEditorState(React.useCallback((store) => store.editor.canvas.scale, []))
   const applyCanvasOffset = React.useCallback(
     (roundedCanvasOffset: CanvasVector, _?: any) => {
       if (elementRef.current != null) {

--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { CanvasVector } from '../../../core/shared/math-utils'
+import { EditorStorePatched } from '../../editor/store/editor-state'
 import { useRefEditorState, useSelectorWithCallback } from '../../editor/store/store-hook'
 
 export const CanvasOffsetWrapper = React.memo((props) => {
@@ -12,15 +13,17 @@ export const CanvasOffsetWrapper = React.memo((props) => {
   )
 })
 
+const roundedCanvasOffsetSelector = (store: EditorStorePatched) =>
+  store.editor.canvas.roundedCanvasOffset
+const scaleSelector = (store: EditorStorePatched) => store.editor.canvas.scale
+
 export function useApplyCanvasOffsetToStyle(
   setScaleToo: boolean,
   forceOffset?: boolean, // this is not so nice, but the element is optionally rendered in canvas-component-entry
 ): React.RefObject<HTMLDivElement> {
   const elementRef = React.useRef<HTMLDivElement>(null)
-  const canvasOffsetRef = useRefEditorState(
-    React.useCallback((store) => store.editor.canvas.roundedCanvasOffset, []),
-  )
-  const scaleRef = useRefEditorState(React.useCallback((store) => store.editor.canvas.scale, []))
+  const canvasOffsetRef = useRefEditorState(roundedCanvasOffsetSelector)
+  const scaleRef = useRefEditorState(scaleSelector)
   const applyCanvasOffset = React.useCallback(
     (roundedCanvasOffset: CanvasVector, _?: any) => {
       if (elementRef.current != null) {
@@ -38,10 +41,7 @@ export function useApplyCanvasOffsetToStyle(
     [elementRef, setScaleToo, scaleRef],
   )
 
-  useSelectorWithCallback(
-    React.useCallback((store) => store.editor.canvas.roundedCanvasOffset, []),
-    applyCanvasOffset,
-  )
+  useSelectorWithCallback(roundedCanvasOffsetSelector, applyCanvasOffset)
 
   const applyCanvasOffsetEffect = React.useCallback(() => {
     applyCanvasOffset(canvasOffsetRef.current, forceOffset)

--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -38,7 +38,10 @@ export function useApplyCanvasOffsetToStyle(
     [elementRef, setScaleToo, scaleRef],
   )
 
-  useSelectorWithCallback((store) => store.editor.canvas.roundedCanvasOffset, applyCanvasOffset)
+  useSelectorWithCallback(
+    React.useCallback((store) => store.editor.canvas.roundedCanvasOffset, []),
+    applyCanvasOffset,
+  )
 
   const applyCanvasOffsetEffect = React.useCallback(() => {
     applyCanvasOffset(canvasOffsetRef.current, forceOffset)

--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -30,7 +30,11 @@ import {
 } from '../../../core/tailwind/tailwind-options'
 import { colorTheme, FlexColumn, FlexRow, useColorTheme, UtopiaTheme } from '../../../uuiui'
 import * as EditorActions from '../../editor/actions/action-creators'
-import { useEditorState } from '../../editor/store/store-hook'
+import {
+  useEditorDispatch,
+  useEditorSelectedViews,
+  useEditorState,
+} from '../../editor/store/store-hook'
 
 const DropdownIndicator = React.memo((props: IndicatorProps<TailWindOption, true>) => (
   <components.DropdownIndicator {...props}>
@@ -150,14 +154,8 @@ let queuedDispatchTimeout: number | undefined = undefined
 export const ClassNameSelect = React.memo(
   React.forwardRef<HTMLInputElement>((_, ref) => {
     const theme = useColorTheme()
-    const targets = useEditorState(
-      React.useCallback((store) => store.editor.selectedViews, []),
-      'ClassNameSelect targets',
-    )
-    const dispatch = useEditorState(
-      React.useCallback((store) => store.dispatch, []),
-      'ClassNameSelect dispatch',
-    )
+    const targets = useEditorSelectedViews('ClassNameSelect targets')
+    const dispatch = useEditorDispatch('ClassNameSelect dispatch')
     const [input, setInput] = React.useState('')
     const focusedValueRef = React.useRef<string | null>(null)
     const updateFocusedOption = usePubSubAtomWriteOnly(focusedOptionAtom)

--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -150,8 +150,14 @@ let queuedDispatchTimeout: number | undefined = undefined
 export const ClassNameSelect = React.memo(
   React.forwardRef<HTMLInputElement>((_, ref) => {
     const theme = useColorTheme()
-    const targets = useEditorState((store) => store.editor.selectedViews, 'ClassNameSelect targets')
-    const dispatch = useEditorState((store) => store.dispatch, 'ClassNameSelect dispatch')
+    const targets = useEditorState(
+      React.useCallback((store) => store.editor.selectedViews, []),
+      'ClassNameSelect targets',
+    )
+    const dispatch = useEditorState(
+      React.useCallback((store) => store.dispatch, []),
+      'ClassNameSelect dispatch',
+    )
     const [input, setInput] = React.useState('')
     const focusedValueRef = React.useRef<string | null>(null)
     const updateFocusedOption = usePubSubAtomWriteOnly(focusedOptionAtom)

--- a/editor/src/components/canvas/controls/formula-bar.tsx
+++ b/editor/src/components/canvas/controls/formula-bar.tsx
@@ -29,24 +29,30 @@ interface FormulaBarProps {
 
 export const FormulaBar = React.memo<FormulaBarProps>((props) => {
   const saveTimerRef = React.useRef<any>(null)
-  const dispatch = useEditorState((store) => store.dispatch, 'FormulaBar dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'FormulaBar dispatch',
+  )
 
   const selectedMode = useEditorState(
-    (store) => store.editor.topmenu.formulaBarMode,
+    React.useCallback((store) => store.editor.topmenu.formulaBarMode, []),
     'FormulaBar selectedMode',
   )
 
-  const selectedElement = useEditorState((store) => {
-    const metadata = store.editor.jsxMetadata
-    if (store.editor.selectedViews.length === 1) {
-      return MetadataUtils.findElementByElementPath(metadata, store.editor.selectedViews[0])
-    } else {
-      return null
-    }
-  }, 'FormulaBar selectedElement')
+  const selectedElement = useEditorState(
+    React.useCallback((store) => {
+      const metadata = store.editor.jsxMetadata
+      if (store.editor.selectedViews.length === 1) {
+        return MetadataUtils.findElementByElementPath(metadata, store.editor.selectedViews[0])
+      } else {
+        return null
+      }
+    }, []),
+    'FormulaBar selectedElement',
+  )
 
   const focusTriggerCount = useEditorState(
-    (store) => store.editor.topmenu.formulaBarFocusCounter,
+    React.useCallback((store) => store.editor.topmenu.formulaBarFocusCounter, []),
     'FormulaBar formulaBarFocusCounter',
   )
 
@@ -104,7 +110,7 @@ export const FormulaBar = React.memo<FormulaBarProps>((props) => {
   const classNameFieldVisible = selectedElement != null && selectedMode === 'css'
   const inputFieldVisible = !classNameFieldVisible
 
-  const editorStoreRef = useRefEditorState((store) => store)
+  const editorStoreRef = useRefEditorState(React.useCallback((store) => store, []))
   const onKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
       const namesByKey = applyShortcutConfigurationToDefaults(

--- a/editor/src/components/canvas/controls/insertion-plus-button.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.tsx
@@ -1,7 +1,7 @@
 import { ControlProps } from './new-canvas-controls'
 import React from 'react'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { useEditorState } from '../../editor/store/store-hook'
+import { useEditorDispatch, useEditorState } from '../../editor/store/store-hook'
 import uuid from 'uuid'
 import { IndexPosition } from '../../../utils/utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
@@ -249,10 +249,7 @@ const BlueDot = React.memo((props: ButtonControlProps) => {
 })
 
 const PlusButton = React.memo((props: ButtonControlProps) => {
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'PlusButton dispatch',
-  )
+  const dispatch = useEditorDispatch('PlusButton dispatch')
   const colorTheme = useColorTheme()
   const { parentPath, indexPosition } = props
   const insertElement = React.useCallback(

--- a/editor/src/components/canvas/controls/insertion-plus-button.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.tsx
@@ -249,7 +249,10 @@ const BlueDot = React.memo((props: ButtonControlProps) => {
 })
 
 const PlusButton = React.memo((props: ButtonControlProps) => {
-  const dispatch = useEditorState((store) => store.dispatch, 'PlusButton dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'PlusButton dispatch',
+  )
   const colorTheme = useColorTheme()
   const { parentPath, indexPosition } = props
   const insertElement = React.useCallback(

--- a/editor/src/components/canvas/controls/layout-parent-control.tsx
+++ b/editor/src/components/canvas/controls/layout-parent-control.tsx
@@ -31,14 +31,20 @@ const getFlexDirectionIcon = (
 export const LayoutParentControl = React.memo((): JSX.Element | null => {
   const colorTheme = useColorTheme()
 
-  const dispatch = useEditorState((store) => store.dispatch, 'LayoutParentControl dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'LayoutParentControl dispatch',
+  )
 
-  const { canvasOffset, scale } = useEditorState((store) => {
-    return {
-      canvasOffset: store.editor.canvas.roundedCanvasOffset,
-      scale: store.editor.canvas.scale,
-    }
-  }, 'LayoutParentControl canvas')
+  const { canvasOffset, scale } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        canvasOffset: store.editor.canvas.roundedCanvasOffset,
+        scale: store.editor.canvas.scale,
+      }
+    }, []),
+    'LayoutParentControl canvas',
+  )
   const {
     parentTarget,
     parentLayout,
@@ -46,27 +52,33 @@ export const LayoutParentControl = React.memo((): JSX.Element | null => {
     flexWrap,
     flexDirection,
     alignItems,
-  } = useEditorState((store) => {
-    if (store.editor.selectedViews.length !== 1) {
-      return {
-        parentTarget: null,
-        parentLayout: null,
-        parentFrame: null,
-        flexWrap: null,
-        flexDirection: null,
-        alignItems: null,
+  } = useEditorState(
+    React.useCallback((store) => {
+      if (store.editor.selectedViews.length !== 1) {
+        return {
+          parentTarget: null,
+          parentLayout: null,
+          parentFrame: null,
+          flexWrap: null,
+          flexDirection: null,
+          alignItems: null,
+        }
       }
-    }
-    const element = MetadataUtils.getParent(store.editor.jsxMetadata, store.editor.selectedViews[0])
-    return {
-      parentTarget: element?.elementPath,
-      parentLayout: element?.specialSizeMeasurements.layoutSystemForChildren,
-      parentFrame: element?.globalFrame,
-      flexWrap: element?.props?.style?.flexWrap ?? 'nowrap',
-      flexDirection: element?.props?.style?.flexDirection ?? 'row',
-      alignItems: element?.props?.style?.alignItems ?? 'flex-start',
-    }
-  }, 'LayoutParentControl')
+      const element = MetadataUtils.getParent(
+        store.editor.jsxMetadata,
+        store.editor.selectedViews[0],
+      )
+      return {
+        parentTarget: element?.elementPath,
+        parentLayout: element?.specialSizeMeasurements.layoutSystemForChildren,
+        parentFrame: element?.globalFrame,
+        flexWrap: element?.props?.style?.flexWrap ?? 'nowrap',
+        flexDirection: element?.props?.style?.flexDirection ?? 'row',
+        alignItems: element?.props?.style?.alignItems ?? 'flex-start',
+      }
+    }, []),
+    'LayoutParentControl',
+  )
 
   const {
     justifyFlexStart,

--- a/editor/src/components/canvas/controls/mode-toggle-button.tsx
+++ b/editor/src/components/canvas/controls/mode-toggle-button.tsx
@@ -2,20 +2,16 @@
 /** @jsx jsx */
 import React from 'react'
 import { css, jsx } from '@emotion/react'
-import { useEditorState } from '../../editor/store/store-hook'
+import { useEditorDispatch, useEditorState } from '../../editor/store/store-hook'
 import { updateFormulaBarMode } from '../../editor/actions/action-creators'
 import { useColorTheme } from '../../../uuiui'
+import { EditorStorePatched } from '../../editor/store/editor-state'
 
+const formulaBarModeSelector = (store: EditorStorePatched) => store.editor.topmenu.formulaBarMode
 export const ModeToggleButton = React.memo(() => {
   const colorTheme = useColorTheme()
-  const selectedMode = useEditorState(
-    React.useCallback((store) => store.editor.topmenu.formulaBarMode, []),
-    'ModeToggleButton selectedMode',
-  )
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'ModeToggleButton dispatch',
-  )
+  const selectedMode = useEditorState(formulaBarModeSelector, 'ModeToggleButton selectedMode')
+  const dispatch = useEditorDispatch('ModeToggleButton dispatch')
   const toggleMode = React.useCallback(
     (mode: 'css' | 'content') => {
       dispatch([updateFormulaBarMode(mode)], 'everyone')

--- a/editor/src/components/canvas/controls/mode-toggle-button.tsx
+++ b/editor/src/components/canvas/controls/mode-toggle-button.tsx
@@ -9,10 +9,13 @@ import { useColorTheme } from '../../../uuiui'
 export const ModeToggleButton = React.memo(() => {
   const colorTheme = useColorTheme()
   const selectedMode = useEditorState(
-    (store) => store.editor.topmenu.formulaBarMode,
+    React.useCallback((store) => store.editor.topmenu.formulaBarMode, []),
     'ModeToggleButton selectedMode',
   )
-  const dispatch = useEditorState((store) => store.dispatch, 'ModeToggleButton dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'ModeToggleButton dispatch',
+  )
   const toggleMode = React.useCallback(
     (mode: 'css' | 'content') => {
       dispatch([updateFormulaBarMode(mode)], 'everyone')

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -21,7 +21,7 @@ import { CanvasPositions, CSSCursor } from '../canvas-types'
 import { SelectModeControlContainer } from './select-mode-control-container'
 import { InsertModeControlContainer } from './insert-mode-control-container'
 import { HighlightControl } from './highlight-control'
-import { useEditorState, useRefEditorState } from '../../editor/store/store-hook'
+import { useEditorState } from '../../editor/store/store-hook'
 import {
   ElementInstanceMetadataMap,
   UtopiaJSXComponent,
@@ -126,17 +126,20 @@ interface NewCanvasControlsProps {
 
 export const NewCanvasControls = React.memo((props: NewCanvasControlsProps) => {
   const canvasControlProps = useEditorState(
-    (store) => ({
-      dispatch: store.dispatch,
-      editor: store.editor,
-      derived: store.derived,
-      canvasOffset: store.editor.canvas.roundedCanvasOffset,
+    React.useCallback(
+      (store) => ({
+        dispatch: store.dispatch,
+        editor: store.editor,
+        derived: store.derived,
+        canvasOffset: store.editor.canvas.roundedCanvasOffset,
 
-      controls: store.derived.canvas.controls,
-      scale: store.editor.canvas.scale,
-      focusedPanel: store.editor.focusedPanel,
-      transientCanvasState: store.derived.canvas.transientState,
-    }),
+        controls: store.derived.canvas.controls,
+        scale: store.editor.canvas.scale,
+        focusedPanel: store.editor.focusedPanel,
+        transientCanvasState: store.derived.canvas.transientState,
+      }),
+      [],
+    ),
     'NewCanvasControls',
   )
 
@@ -151,7 +154,7 @@ export const NewCanvasControls = React.memo((props: NewCanvasControlsProps) => {
   )
 
   const canvasScrollAnimation = useEditorState(
-    (store) => store.editor.canvas.scrollAnimation,
+    React.useCallback((store) => store.editor.canvas.scrollAnimation, []),
     'NewCanvasControls scrollAnimation',
   )
 

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -15,6 +15,7 @@ import {
   TransientCanvasState,
   TransientFilesState,
   ResizeOptions,
+  EditorStorePatched,
 } from '../../editor/store/editor-state'
 import { ElementPath, NodeModules } from '../../../core/shared/project-file-types'
 import { CanvasPositions, CSSCursor } from '../canvas-types'
@@ -124,24 +125,22 @@ interface NewCanvasControlsProps {
   cursor: CSSCursor
 }
 
-export const NewCanvasControls = React.memo((props: NewCanvasControlsProps) => {
-  const canvasControlProps = useEditorState(
-    React.useCallback(
-      (store) => ({
-        dispatch: store.dispatch,
-        editor: store.editor,
-        derived: store.derived,
-        canvasOffset: store.editor.canvas.roundedCanvasOffset,
+const canvasControlPropsSelector = (store: EditorStorePatched) => ({
+  dispatch: store.dispatch,
+  editor: store.editor,
+  derived: store.derived,
+  canvasOffset: store.editor.canvas.roundedCanvasOffset,
 
-        controls: store.derived.canvas.controls,
-        scale: store.editor.canvas.scale,
-        focusedPanel: store.editor.focusedPanel,
-        transientCanvasState: store.derived.canvas.transientState,
-      }),
-      [],
-    ),
-    'NewCanvasControls',
-  )
+  controls: store.derived.canvas.controls,
+  scale: store.editor.canvas.scale,
+  focusedPanel: store.editor.focusedPanel,
+  transientCanvasState: store.derived.canvas.transientState,
+})
+
+const scrollAnimationSelector = (store: EditorStorePatched) => store.editor.canvas.scrollAnimation
+
+export const NewCanvasControls = React.memo((props: NewCanvasControlsProps) => {
+  const canvasControlProps = useEditorState(canvasControlPropsSelector, 'NewCanvasControls')
 
   const {
     localSelectedViews,
@@ -154,7 +153,7 @@ export const NewCanvasControls = React.memo((props: NewCanvasControlsProps) => {
   )
 
   const canvasScrollAnimation = useEditorState(
-    React.useCallback((store) => store.editor.canvas.scrollAnimation, []),
+    scrollAnimationSelector,
     'NewCanvasControls scrollAnimation',
   )
 

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -21,6 +21,7 @@ import { useEditorState } from '../../editor/store/store-hook'
 import { KeysPressed } from '../../../utils/keyboard'
 import { PositionOutline } from './position-outline'
 import { stripNulls, uniqBy } from '../../../core/shared/array-utils'
+import { EditorStorePatched } from '../../editor/store/editor-state'
 
 export function getSelectionColor(
   path: ElementPath,
@@ -100,11 +101,14 @@ const CenteredCrossSVG = React.memo(({ id, centerX, centerY, scale }: CenteredCr
   )
 })
 
+const layoutSectionHoveredSelector = (store: EditorStorePatched) =>
+  store.editor.inspector.layoutSectionHovered
+
 export const OutlineControls = (props: OutlineControlsProps) => {
   const colorTheme = useColorTheme()
   const { dragState } = props
   const layoutInspectorSectionHovered = useEditorState(
-    React.useCallback((store) => store.editor.inspector.layoutSectionHovered, []),
+    layoutSectionHoveredSelector,
     'OutlineControls layoutInspectorSectionHovered',
   )
   const getDragStateFrame = React.useCallback(

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -104,7 +104,7 @@ export const OutlineControls = (props: OutlineControlsProps) => {
   const colorTheme = useColorTheme()
   const { dragState } = props
   const layoutInspectorSectionHovered = useEditorState(
-    (store) => store.editor.inspector.layoutSectionHovered,
+    React.useCallback((store) => store.editor.inspector.layoutSectionHovered, []),
     'OutlineControls layoutInspectorSectionHovered',
   )
   const getDragStateFrame = React.useCallback(
@@ -296,16 +296,22 @@ export const OutlineControls = (props: OutlineControlsProps) => {
   const targetPaths =
     props.dragState != null ? props.dragState.draggedElements : props.selectedViews
 
-  const selectionColors = useEditorState((store) => {
-    return targetPaths.map((path) => {
-      return getSelectionColor(
-        path,
-        store.editor.jsxMetadata,
-        store.editor.focusedElementPath,
-        colorTheme,
-      )
-    })
-  }, 'OutlineControls')
+  const selectionColors = useEditorState(
+    React.useCallback(
+      (store) => {
+        return targetPaths.map((path) => {
+          return getSelectionColor(
+            path,
+            store.editor.jsxMetadata,
+            store.editor.focusedElementPath,
+            colorTheme,
+          )
+        })
+      },
+      [colorTheme, targetPaths],
+    ),
+    'OutlineControls',
+  )
 
   fastForEach(targetPaths, (selectedView, index) => {
     const rect = getTargetFrame(selectedView)

--- a/editor/src/components/canvas/controls/position-outline.tsx
+++ b/editor/src/components/canvas/controls/position-outline.tsx
@@ -40,25 +40,40 @@ export const PositionOutline = React.memo((props: PositionOutlineProps) => {
 })
 
 const usePropsOrJSXAttributes = (path: ElementPath): PropsOrJSXAttributes => {
-  return useEditorState((store) => {
-    const element = MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, path)
-    if (element != null && isRight(element.element) && isJSXElement(element.element.value)) {
-      return right(element.element.value.props)
-    } else {
-      return left(element?.props ?? {})
-    }
-  }, 'usePropsOrJSXAttributes')
+  return useEditorState(
+    React.useCallback(
+      (store) => {
+        const element = MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, path)
+        if (element != null && isRight(element.element) && isJSXElement(element.element.value)) {
+          return right(element.element.value.props)
+        } else {
+          return left(element?.props ?? {})
+        }
+      },
+      [path],
+    ),
+    'usePropsOrJSXAttributes',
+  )
 }
 
 const useContainingFrameForElement = (path: ElementPath): CanvasRectangle | null => {
-  return useEditorState((store) => {
-    const containingBlockPath = MetadataUtils.findContainingBlock(store.editor.jsxMetadata, path)
-    if (containingBlockPath != null && !EP.isStoryboardPath(containingBlockPath)) {
-      return MetadataUtils.getFrameInCanvasCoords(containingBlockPath, store.editor.jsxMetadata)
-    } else {
-      return null
-    }
-  }, 'useContainingFrameForElement')
+  return useEditorState(
+    React.useCallback(
+      (store) => {
+        const containingBlockPath = MetadataUtils.findContainingBlock(
+          store.editor.jsxMetadata,
+          path,
+        )
+        if (containingBlockPath != null && !EP.isStoryboardPath(containingBlockPath)) {
+          return MetadataUtils.getFrameInCanvasCoords(containingBlockPath, store.editor.jsxMetadata)
+        } else {
+          return null
+        }
+      },
+      [path],
+    ),
+    'useContainingFrameForElement',
+  )
 }
 
 const collectPinOutlines = (

--- a/editor/src/components/canvas/controls/property-target-selector.tsx
+++ b/editor/src/components/canvas/controls/property-target-selector.tsx
@@ -25,12 +25,15 @@ interface PropertyTargetSelectorProps {
 export const PropertyTargetSelector = React.memo(
   (props: PropertyTargetSelectorProps): JSX.Element => {
     const colorTheme = useColorTheme()
-    const { resizeOptions, dispatch } = useEditorState((editorState) => {
-      return {
-        resizeOptions: editorState.editor.canvas.resizeOptions,
-        dispatch: editorState.dispatch,
-      }
-    }, 'PropertyTargetSelector resizeOptions')
+    const { resizeOptions, dispatch } = useEditorState(
+      React.useCallback((editorState) => {
+        return {
+          resizeOptions: editorState.editor.canvas.resizeOptions,
+          dispatch: editorState.dispatch,
+        }
+      }, []),
+      'PropertyTargetSelector resizeOptions',
+    )
 
     const onKeyDown = React.useCallback(
       (event: KeyboardEvent) => {

--- a/editor/src/components/canvas/controls/property-target-selector.tsx
+++ b/editor/src/components/canvas/controls/property-target-selector.tsx
@@ -11,7 +11,8 @@ import {
   setResizeOptionsTargetOptions,
 } from '../../editor/actions/action-creators'
 import { usePrevious } from '../../editor/hook-utils'
-import { useEditorState } from '../../editor/store/store-hook'
+import { EditorStorePatched } from '../../editor/store/editor-state'
+import { useEditorDispatch, useEditorState } from '../../editor/store/store-hook'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 
 interface PropertyTargetSelectorProps {
@@ -21,16 +22,14 @@ interface PropertyTargetSelectorProps {
   options: Array<LayoutTargetableProp>
 }
 
+const resizeOptionsSelector = (store: EditorStorePatched) => store.editor.canvas.resizeOptions
+
 export const PropertyTargetSelector = React.memo(
   (props: PropertyTargetSelectorProps): JSX.Element => {
     const colorTheme = useColorTheme()
-    const { resizeOptions, dispatch } = useEditorState(
-      React.useCallback((editorState) => {
-        return {
-          resizeOptions: editorState.editor.canvas.resizeOptions,
-          dispatch: editorState.dispatch,
-        }
-      }, []),
+    const dispatch = useEditorDispatch('PropertyTargetSelector dispatch')
+    const resizeOptions = useEditorState(
+      resizeOptionsSelector,
       'PropertyTargetSelector resizeOptions',
     )
 

--- a/editor/src/components/canvas/controls/property-target-selector.tsx
+++ b/editor/src/components/canvas/controls/property-target-selector.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { useContextSelector } from 'use-context-selector'
 import { LayoutTargetableProp, StyleLayoutProp } from '../../../core/layout/layout-helpers-new'
 import { getSimpleAttributeAtPath } from '../../../core/model/element-metadata-utils'
 import { eitherToMaybe, left } from '../../../core/shared/either'

--- a/editor/src/components/canvas/controls/render-as.tsx
+++ b/editor/src/components/canvas/controls/render-as.tsx
@@ -17,20 +17,28 @@ import { usePossiblyResolvedPackageDependencies } from '../../../components/edit
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 
 export const RenderAsRow = React.memo(() => {
-  const dispatch = useEditorState((store) => {
-    return store.dispatch
-  }, 'RenderAsRow dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => {
+      return store.dispatch
+    }, []),
+    'RenderAsRow dispatch',
+  )
 
-  const selectedElementName = useEditorState((store) => {
-    return MetadataUtils.getJSXElementNameFromMetadata(
-      store.editor.jsxMetadata,
-      store.editor.selectedViews[0],
-    )
-  }, 'RenderAsRow selectedElementName')
+  const selectedElementName = useEditorState(
+    React.useCallback((store) => {
+      return MetadataUtils.getJSXElementNameFromMetadata(
+        store.editor.jsxMetadata,
+        store.editor.selectedViews[0],
+      )
+    }, []),
+    'RenderAsRow selectedElementName',
+  )
 
-  const refElementsToTargetForUpdates = useRefEditorState((store) => {
-    return getElementsToTarget(store.editor.selectedViews)
-  })
+  const refElementsToTargetForUpdates = useRefEditorState(
+    React.useCallback((store) => {
+      return getElementsToTarget(store.editor.selectedViews)
+    }, []),
+  )
 
   const onElementTypeChange = React.useCallback(
     (newElementName: JSXElementName, importsToAdd: Imports) => {
@@ -53,14 +61,14 @@ export const RenderAsRow = React.memo(() => {
   const dependencies = usePossiblyResolvedPackageDependencies()
 
   const { packageStatus, propertyControlsInfo, projectContents, fullPath } = useEditorState(
-    (store) => {
+    React.useCallback((store) => {
       return {
         packageStatus: store.editor.nodeModules.packageStatus,
         propertyControlsInfo: store.editor.propertyControlsInfo,
         projectContents: store.editor.projectContents,
         fullPath: store.editor.canvas.openFile?.filename ?? null,
       }
-    },
+    }, []),
     'RenderAsRow',
   )
 

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -35,17 +35,23 @@ interface AbsoluteResizeControlProps {
 
 export const AbsoluteResizeControl = React.memo<AbsoluteResizeControlProps>((props) => {
   const localSelectedElements = props.localSelectedElements
-  const allSelectedElementsAbsolute = useEditorState((store) => {
-    return (
-      localSelectedElements.length > 0 &&
-      localSelectedElements.every((path) => {
+  const allSelectedElementsAbsolute = useEditorState(
+    React.useCallback(
+      (store) => {
         return (
-          MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, path)
-            ?.specialSizeMeasurements.position === 'absolute'
+          localSelectedElements.length > 0 &&
+          localSelectedElements.every((path) => {
+            return (
+              MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, path)
+                ?.specialSizeMeasurements.position === 'absolute'
+            )
+          })
         )
-      })
-    )
-  }, 'AbsoluteResizeControl allSelectedElementsAbsolute')
+      },
+      [localSelectedElements],
+    ),
+    'AbsoluteResizeControl allSelectedElementsAbsolute',
+  )
 
   const absoluteElements = allSelectedElementsAbsolute ? localSelectedElements : []
 
@@ -152,11 +158,23 @@ const ResizePointOffset = ResizePointSize / 2
 const ResizePoint = React.memo(
   React.forwardRef<HTMLDivElement, ResizePointProps>((props, ref) => {
     const colorTheme = useColorTheme()
-    const scale = useEditorState((store) => store.editor.canvas.scale, 'ResizeEdge scale')
-    const dispatch = useEditorState((store) => store.dispatch, 'ResizeEdge dispatch')
-    const jsxMetadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
-    const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
-    const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
+    const scale = useEditorState(
+      React.useCallback((store) => store.editor.canvas.scale, []),
+      'ResizeEdge scale',
+    )
+    const dispatch = useEditorState(
+      React.useCallback((store) => store.dispatch, []),
+      'ResizeEdge dispatch',
+    )
+    const jsxMetadataRef = useRefEditorState(
+      React.useCallback((store) => store.editor.jsxMetadata, []),
+    )
+    const selectedViewsRef = useRefEditorState(
+      React.useCallback((store) => store.editor.selectedViews, []),
+    )
+    const canvasOffsetRef = useRefEditorState(
+      React.useCallback((store) => store.editor.canvas.roundedCanvasOffset, []),
+    )
 
     const onPointMouseDown = React.useCallback(
       (event: React.MouseEvent<HTMLDivElement>) => {
@@ -230,11 +248,23 @@ interface ResizeEdgeProps {
 const ResizeMouseAreaSize = 10
 const ResizeEdge = React.memo(
   React.forwardRef<HTMLDivElement, ResizeEdgeProps>((props, ref) => {
-    const scale = useEditorState((store) => store.editor.canvas.scale, 'ResizeEdge scale')
-    const dispatch = useEditorState((store) => store.dispatch, 'ResizeEdge dispatch')
-    const jsxMetadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
-    const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
-    const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
+    const scale = useEditorState(
+      React.useCallback((store) => store.editor.canvas.scale, []),
+      'ResizeEdge scale',
+    )
+    const dispatch = useEditorState(
+      React.useCallback((store) => store.dispatch, []),
+      'ResizeEdge dispatch',
+    )
+    const jsxMetadataRef = useRefEditorState(
+      React.useCallback((store) => store.editor.jsxMetadata, []),
+    )
+    const selectedViewsRef = useRefEditorState(
+      React.useCallback((store) => store.editor.selectedViews, []),
+    )
+    const canvasOffsetRef = useRefEditorState(
+      React.useCallback((store) => store.editor.canvas.roundedCanvasOffset, []),
+    )
 
     const onEdgeMouseDown = React.useCallback(
       (event: React.MouseEvent<HTMLDivElement>) => {

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -13,7 +13,12 @@ import { NO_OP } from '../../../../core/shared/utils'
 import { useColorTheme } from '../../../../uuiui'
 import { EditorDispatch } from '../../../editor/action-types'
 import { setResizeOptionsTargetOptions } from '../../../editor/actions/action-creators'
-import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
+import { EditorStorePatched } from '../../../editor/store/editor-state'
+import {
+  useEditorDispatch,
+  useEditorState,
+  useRefEditorState,
+} from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
 import {
   CSSCursor,
@@ -151,6 +156,12 @@ interface ResizePointProps {
   position: EdgePosition
 }
 
+const scaleSelector = (store: EditorStorePatched) => store.editor.canvas.scale
+const metadataSelector = (store: EditorStorePatched) => store.editor.jsxMetadata
+const selectedViewsSelector = (store: EditorStorePatched) => store.editor.selectedViews
+const roundedCanvasOffsetSelector = (store: EditorStorePatched) =>
+  store.editor.canvas.roundedCanvasOffset
+
 const ResizePointMouseAreaSize = 12
 const ResizePointMouseAreaOffset = ResizePointMouseAreaSize / 2
 const ResizePointSize = 6
@@ -158,23 +169,11 @@ const ResizePointOffset = ResizePointSize / 2
 const ResizePoint = React.memo(
   React.forwardRef<HTMLDivElement, ResizePointProps>((props, ref) => {
     const colorTheme = useColorTheme()
-    const scale = useEditorState(
-      React.useCallback((store) => store.editor.canvas.scale, []),
-      'ResizeEdge scale',
-    )
-    const dispatch = useEditorState(
-      React.useCallback((store) => store.dispatch, []),
-      'ResizeEdge dispatch',
-    )
-    const jsxMetadataRef = useRefEditorState(
-      React.useCallback((store) => store.editor.jsxMetadata, []),
-    )
-    const selectedViewsRef = useRefEditorState(
-      React.useCallback((store) => store.editor.selectedViews, []),
-    )
-    const canvasOffsetRef = useRefEditorState(
-      React.useCallback((store) => store.editor.canvas.roundedCanvasOffset, []),
-    )
+    const scale = useEditorState(scaleSelector, 'ResizeEdge scale')
+    const dispatch = useEditorDispatch('ResizeEdge dispatch')
+    const jsxMetadataRef = useRefEditorState(metadataSelector)
+    const selectedViewsRef = useRefEditorState(selectedViewsSelector)
+    const canvasOffsetRef = useRefEditorState(roundedCanvasOffsetSelector)
 
     const onPointMouseDown = React.useCallback(
       (event: React.MouseEvent<HTMLDivElement>) => {
@@ -248,23 +247,11 @@ interface ResizeEdgeProps {
 const ResizeMouseAreaSize = 10
 const ResizeEdge = React.memo(
   React.forwardRef<HTMLDivElement, ResizeEdgeProps>((props, ref) => {
-    const scale = useEditorState(
-      React.useCallback((store) => store.editor.canvas.scale, []),
-      'ResizeEdge scale',
-    )
-    const dispatch = useEditorState(
-      React.useCallback((store) => store.dispatch, []),
-      'ResizeEdge dispatch',
-    )
-    const jsxMetadataRef = useRefEditorState(
-      React.useCallback((store) => store.editor.jsxMetadata, []),
-    )
-    const selectedViewsRef = useRefEditorState(
-      React.useCallback((store) => store.editor.selectedViews, []),
-    )
-    const canvasOffsetRef = useRefEditorState(
-      React.useCallback((store) => store.editor.canvas.roundedCanvasOffset, []),
-    )
+    const scale = useEditorState(scaleSelector, 'ResizeEdge scale')
+    const dispatch = useEditorDispatch('ResizeEdge dispatch')
+    const jsxMetadataRef = useRefEditorState(metadataSelector)
+    const selectedViewsRef = useRefEditorState(selectedViewsSelector)
+    const canvasOffsetRef = useRefEditorState(roundedCanvasOffsetSelector)
 
     const onEdgeMouseDown = React.useCallback(
       (event: React.MouseEvent<HTMLDivElement>) => {

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-indicator.tsx
@@ -7,12 +7,18 @@ import { CanvasStrategy } from '../../canvas-strategies/canvas-strategy-types'
 
 export const CanvasStrategyIndicator = React.memo(() => {
   const colorTheme = useColorTheme()
-  const dispatch = useEditorState((store) => store.dispatch, 'CanvasStrategyIndicator dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'CanvasStrategyIndicator dispatch',
+  )
   const { activeStrategy, otherPossibleStrategies } = useEditorState(
-    (store) => ({
-      activeStrategy: store.strategyState.currentStrategy,
-      otherPossibleStrategies: store.strategyState.sortedApplicableStrategies,
-    }),
+    React.useCallback(
+      (store) => ({
+        activeStrategy: store.strategyState.currentStrategy,
+        otherPossibleStrategies: store.strategyState.sortedApplicableStrategies,
+      }),
+      [],
+    ),
     'CanvasStrategyIndicator strategyState.currentStrategy',
   )
 

--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-indicator.tsx
@@ -1,24 +1,21 @@
 import * as React from 'react'
 import { when } from '../../../../utils/react-conditionals'
 import { FlexRow, FlexColumn, useColorTheme, UtopiaStyles } from '../../../../uuiui'
-import { useEditorState } from '../../../editor/store/store-hook'
+import { EditorStorePatched } from '../../../editor/store/editor-state'
+import { useEditorDispatch, useEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
 import { CanvasStrategy } from '../../canvas-strategies/canvas-strategy-types'
 
+const strategiesSelector = (store: EditorStorePatched) => ({
+  activeStrategy: store.strategyState.currentStrategy,
+  otherPossibleStrategies: store.strategyState.sortedApplicableStrategies,
+})
+
 export const CanvasStrategyIndicator = React.memo(() => {
   const colorTheme = useColorTheme()
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'CanvasStrategyIndicator dispatch',
-  )
+  const dispatch = useEditorDispatch('CanvasStrategyIndicator dispatch')
   const { activeStrategy, otherPossibleStrategies } = useEditorState(
-    React.useCallback(
-      (store) => ({
-        activeStrategy: store.strategyState.currentStrategy,
-        otherPossibleStrategies: store.strategyState.sortedApplicableStrategies,
-      }),
-      [],
-    ),
+    strategiesSelector,
     'CanvasStrategyIndicator strategyState.currentStrategy',
   )
 

--- a/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
@@ -12,7 +12,12 @@ import { ElementPath } from '../../../../core/shared/project-file-types'
 import { useColorTheme } from '../../../../uuiui'
 import { EditorDispatch } from '../../../editor/action-types'
 import { setResizeOptionsTargetOptions } from '../../../editor/actions/action-creators'
-import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
+import { EditorStorePatched } from '../../../editor/store/editor-state'
+import {
+  useEditorDispatch,
+  useEditorState,
+  useRefEditorState,
+} from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
 import {
   CSSCursor,
@@ -107,29 +112,23 @@ interface ResizeEdgeProps {
   enabledDirection: EdgePosition
 }
 
+const scaleSelector = (store: EditorStorePatched) => store.editor.canvas.scale
+const metadataSelector = (store: EditorStorePatched) => store.editor.jsxMetadata
+const selectedViewsSelector = (store: EditorStorePatched) => store.editor.selectedViews
+const roundedCanvasOffsetSelector = (store: EditorStorePatched) =>
+  store.editor.canvas.roundedCanvasOffset
+
 const ResizeEdgeMouseAreaSize = 12
 const ResizeEdgeMouseAreaOffset = ResizeEdgeMouseAreaSize / 2
 const ResizeEdge = React.memo(
   React.forwardRef<HTMLDivElement, ResizeEdgeProps>((props, ref) => {
     const LineSVGComponent =
       props.position.y === 0.5 ? DimensionableControlVertical : DimensionableControlHorizontal
-    const dispatch = useEditorState(
-      React.useCallback((store) => store.dispatch, []),
-      'ResizeEdge dispatch',
-    )
-    const scale = useEditorState(
-      React.useCallback((store) => store.editor.canvas.scale, []),
-      'ResizeEdge scale',
-    )
-    const jsxMetadataRef = useRefEditorState(
-      React.useCallback((store) => store.editor.jsxMetadata, []),
-    )
-    const selectedViewsRef = useRefEditorState(
-      React.useCallback((store) => store.editor.selectedViews, []),
-    )
-    const canvasOffsetRef = useRefEditorState(
-      React.useCallback((store) => store.editor.canvas.roundedCanvasOffset, []),
-    )
+    const dispatch = useEditorDispatch('ResizeEdge dispatch')
+    const scale = useEditorState(scaleSelector, 'ResizeEdge scale')
+    const jsxMetadataRef = useRefEditorState(metadataSelector)
+    const selectedViewsRef = useRefEditorState(selectedViewsSelector)
+    const canvasOffsetRef = useRefEditorState(roundedCanvasOffsetSelector)
 
     const onEdgeMouseDown = React.useCallback(
       (event: React.MouseEvent<HTMLDivElement>) => {
@@ -252,10 +251,7 @@ function startResizeInteraction(
 const ControlSideShort = 3
 const ControlSideLong = 15
 const DimensionableControlVertical = React.memo(() => {
-  const scale = useEditorState(
-    React.useCallback((store) => store.editor.canvas.scale, []),
-    'DimensionableControlVertical scale',
-  )
+  const scale = useEditorState(scaleSelector, 'DimensionableControlVertical scale')
   const colorTheme = useColorTheme()
   const controlLength = ControlSideLong
   const controlWidth = ControlSideShort
@@ -281,10 +277,7 @@ const DimensionableControlVertical = React.memo(() => {
 })
 
 const DimensionableControlHorizontal = React.memo(() => {
-  const scale = useEditorState(
-    React.useCallback((store) => store.editor.canvas.scale, []),
-    'DimensionableControlHorizontal scale',
-  )
+  const scale = useEditorState(scaleSelector, 'DimensionableControlHorizontal scale')
   const colorTheme = useColorTheme()
   const controlLength = ControlSideShort
   const controlWidth = ControlSideLong

--- a/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-resize-control.tsx
@@ -33,17 +33,23 @@ interface FlexResizeControlProps {
 
 export const FlexResizeControl = React.memo<FlexResizeControlProps>((props) => {
   const localSelectedElements = props.localSelectedElements
-  const allSelectedElementsFlex = useEditorState((store) => {
-    return (
-      localSelectedElements.length > 0 &&
-      localSelectedElements.every((path) => {
+  const allSelectedElementsFlex = useEditorState(
+    React.useCallback(
+      (store) => {
         return (
-          MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, path)
-            ?.specialSizeMeasurements.parentLayoutSystem === 'flex'
+          localSelectedElements.length > 0 &&
+          localSelectedElements.every((path) => {
+            return (
+              MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, path)
+                ?.specialSizeMeasurements.parentLayoutSystem === 'flex'
+            )
+          })
         )
-      })
-    )
-  }, 'FlexResizeControl allSelectedElementsFlex')
+      },
+      [localSelectedElements],
+    ),
+    'FlexResizeControl allSelectedElementsFlex',
+  )
 
   const flexElements = allSelectedElementsFlex ? localSelectedElements : []
 
@@ -107,11 +113,23 @@ const ResizeEdge = React.memo(
   React.forwardRef<HTMLDivElement, ResizeEdgeProps>((props, ref) => {
     const LineSVGComponent =
       props.position.y === 0.5 ? DimensionableControlVertical : DimensionableControlHorizontal
-    const dispatch = useEditorState((store) => store.dispatch, 'ResizeEdge dispatch')
-    const scale = useEditorState((store) => store.editor.canvas.scale, 'ResizeEdge scale')
-    const jsxMetadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
-    const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
-    const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
+    const dispatch = useEditorState(
+      React.useCallback((store) => store.dispatch, []),
+      'ResizeEdge dispatch',
+    )
+    const scale = useEditorState(
+      React.useCallback((store) => store.editor.canvas.scale, []),
+      'ResizeEdge scale',
+    )
+    const jsxMetadataRef = useRefEditorState(
+      React.useCallback((store) => store.editor.jsxMetadata, []),
+    )
+    const selectedViewsRef = useRefEditorState(
+      React.useCallback((store) => store.editor.selectedViews, []),
+    )
+    const canvasOffsetRef = useRefEditorState(
+      React.useCallback((store) => store.editor.canvas.roundedCanvasOffset, []),
+    )
 
     const onEdgeMouseDown = React.useCallback(
       (event: React.MouseEvent<HTMLDivElement>) => {
@@ -235,7 +253,7 @@ const ControlSideShort = 3
 const ControlSideLong = 15
 const DimensionableControlVertical = React.memo(() => {
   const scale = useEditorState(
-    (store) => store.editor.canvas.scale,
+    React.useCallback((store) => store.editor.canvas.scale, []),
     'DimensionableControlVertical scale',
   )
   const colorTheme = useColorTheme()
@@ -264,7 +282,7 @@ const DimensionableControlVertical = React.memo(() => {
 
 const DimensionableControlHorizontal = React.memo(() => {
   const scale = useEditorState(
-    (store) => store.editor.canvas.scale,
+    React.useCallback((store) => store.editor.canvas.scale, []),
     'DimensionableControlHorizontal scale',
   )
   const colorTheme = useColorTheme()

--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx
@@ -12,18 +12,20 @@ import { useRefEditorState } from '../../../editor/store/store-hook'
 import { useHighlightCallbacks } from './select-mode-hooks'
 
 function useGetHighlightableViewsForInsertMode() {
-  const storeRef = useRefEditorState((store) => {
-    const resolveFn = store.editor.codeResultCache.curriedResolveFn(store.editor.projectContents)
-    return {
-      componentMetadata: store.editor.jsxMetadata,
-      mode: store.editor.mode,
-      openFile: store.editor.canvas.openFile?.filename ?? null,
-      projectContents: store.editor.projectContents,
-      nodeModules: store.editor.nodeModules.files,
-      transientState: store.derived.canvas.transientState,
-      resolve: resolveFn,
-    }
-  })
+  const storeRef = useRefEditorState(
+    React.useCallback((store) => {
+      const resolveFn = store.editor.codeResultCache.curriedResolveFn(store.editor.projectContents)
+      return {
+        componentMetadata: store.editor.jsxMetadata,
+        mode: store.editor.mode,
+        openFile: store.editor.canvas.openFile?.filename ?? null,
+        projectContents: store.editor.projectContents,
+        nodeModules: store.editor.nodeModules.files,
+        transientState: store.derived.canvas.transientState,
+        resolve: resolveFn,
+      }
+    }, []),
+  )
   return React.useCallback(() => {
     const { componentMetadata, mode } = storeRef.current
     if (!isInsertMode(mode)) {

--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx
@@ -8,24 +8,25 @@ import {
   insertionSubjectIsJSXElement,
   isInsertMode,
 } from '../../../editor/editor-modes'
+import { EditorStorePatched } from '../../../editor/store/editor-state'
 import { useRefEditorState } from '../../../editor/store/store-hook'
 import { useHighlightCallbacks } from './select-mode-hooks'
 
+const getHighlightableViewsForInsertModePropsSelector = (store: EditorStorePatched) => {
+  const resolveFn = store.editor.codeResultCache.curriedResolveFn(store.editor.projectContents)
+  return {
+    componentMetadata: store.editor.jsxMetadata,
+    mode: store.editor.mode,
+    openFile: store.editor.canvas.openFile?.filename ?? null,
+    projectContents: store.editor.projectContents,
+    nodeModules: store.editor.nodeModules.files,
+    transientState: store.derived.canvas.transientState,
+    resolve: resolveFn,
+  }
+}
+
 function useGetHighlightableViewsForInsertMode() {
-  const storeRef = useRefEditorState(
-    React.useCallback((store) => {
-      const resolveFn = store.editor.codeResultCache.curriedResolveFn(store.editor.projectContents)
-      return {
-        componentMetadata: store.editor.jsxMetadata,
-        mode: store.editor.mode,
-        openFile: store.editor.canvas.openFile?.filename ?? null,
-        projectContents: store.editor.projectContents,
-        nodeModules: store.editor.nodeModules.files,
-        transientState: store.derived.canvas.transientState,
-        resolve: resolveFn,
-      }
-    }, []),
-  )
+  const storeRef = useRefEditorState(getHighlightableViewsForInsertModePropsSelector)
   return React.useCallback(() => {
     const { componentMetadata, mode } = storeRef.current
     if (!isInsertMode(mode)) {

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -89,16 +89,18 @@ export function useMaybeHighlightElement(): {
   maybeHighlightOnHover: (target: ElementPath) => void
   maybeClearHighlightsOnHoverEnd: () => void
 } {
-  const stateRef = useRefEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      resizing: isResizing(store.editor),
-      dragging: isDragging(store.editor),
-      selectionEnabled: pickSelectionEnabled(store.editor.canvas, store.editor.keysPressed),
-      inserting: isInserting(store.editor),
-      highlightedViews: store.editor.highlightedViews,
-    }
-  })
+  const stateRef = useRefEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        resizing: isResizing(store.editor),
+        dragging: isDragging(store.editor),
+        selectionEnabled: pickSelectionEnabled(store.editor.canvas, store.editor.keysPressed),
+        inserting: isInserting(store.editor),
+        highlightedViews: store.editor.highlightedViews,
+      }
+    }, []),
+  )
 
   const maybeHighlightOnHover = React.useCallback(
     (target: ElementPath): void => {
@@ -205,16 +207,18 @@ function useFindValidTarget(): (
   elementPath: ElementPath
   isSelected: boolean
 } | null {
-  const storeRef = useRefEditorState((store) => {
-    return {
-      componentMetadata: store.editor.jsxMetadata,
-      selectedViews: store.editor.selectedViews,
-      hiddenInstances: store.editor.hiddenInstances,
-      canvasScale: store.editor.canvas.scale,
-      canvasOffset: store.editor.canvas.realCanvasOffset,
-      focusedElementPath: store.editor.focusedElementPath,
-    }
-  })
+  const storeRef = useRefEditorState(
+    React.useCallback((store) => {
+      return {
+        componentMetadata: store.editor.jsxMetadata,
+        selectedViews: store.editor.selectedViews,
+        hiddenInstances: store.editor.hiddenInstances,
+        canvasScale: store.editor.canvas.scale,
+        canvasOffset: store.editor.canvas.realCanvasOffset,
+        focusedElementPath: store.editor.focusedElementPath,
+      }
+    }, []),
+  )
 
   return React.useCallback(
     (selectableViews: Array<ElementPath>, mousePoint: WindowPoint | null) => {
@@ -256,8 +260,11 @@ function useStartDragState(): (
   target: ElementPath,
   start: CanvasPoint | null,
 ) => (event: MouseEvent) => void {
-  const dispatch = useEditorState((store) => store.dispatch, 'useStartDragState dispatch')
-  const entireEditorStoreRef = useRefEditorState((store) => store)
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'useStartDragState dispatch',
+  )
+  const entireEditorStoreRef = useRefEditorState(React.useCallback((store) => store, []))
 
   return React.useCallback(
     (target: ElementPath, start: CanvasPoint | null) => (event: MouseEvent) => {
@@ -318,7 +325,10 @@ function useStartDragState(): (
 }
 
 function useStartCanvasSession(): (event: MouseEvent, target: ElementPath) => void {
-  const dispatch = useEditorState((store) => store.dispatch, 'useStartDragState dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'useStartDragState dispatch',
+  )
   const windowToCanvasCoordinates = useWindowToCanvasCoordinates()
 
   return React.useCallback(
@@ -392,14 +402,16 @@ export function useStartDragStateAfterDragExceedsThreshold(): (
 }
 
 export function useGetSelectableViewsForSelectMode() {
-  const storeRef = useRefEditorState((store) => {
-    return {
-      componentMetadata: store.editor.jsxMetadata,
-      selectedViews: store.editor.selectedViews,
-      hiddenInstances: store.editor.hiddenInstances,
-      focusedElementPath: store.editor.focusedElementPath,
-    }
-  })
+  const storeRef = useRefEditorState(
+    React.useCallback((store) => {
+      return {
+        componentMetadata: store.editor.jsxMetadata,
+        selectedViews: store.editor.selectedViews,
+        hiddenInstances: store.editor.hiddenInstances,
+        focusedElementPath: store.editor.focusedElementPath,
+      }
+    }, []),
+  )
 
   return React.useCallback(
     (allElementsDirectlySelectable: boolean, childrenSelectable: boolean) => {
@@ -495,8 +507,13 @@ function useSelectOrLiveModeSelectAndHover(
   onMouseMove: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 } {
-  const dispatch = useEditorState((store) => store.dispatch, 'useSelectAndHover dispatch')
-  const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'useSelectAndHover dispatch',
+  )
+  const selectedViewsRef = useRefEditorState(
+    React.useCallback((store) => store.editor.selectedViews, []),
+  )
   const findValidTarget = useFindValidTarget()
   const getSelectableViewsForSelectMode = useGetSelectableViewsForSelectMode()
   const startDragStateAfterDragExceedsThreshold = useStartDragStateAfterDragExceedsThreshold()
@@ -509,10 +526,15 @@ function useSelectOrLiveModeSelectAndHover(
     getSelectableViewsForSelectMode,
   )
 
-  const editorStoreRef = useRefEditorState((store) => ({
-    editor: store.editor,
-    derived: store.derived,
-  }))
+  const editorStoreRef = useRefEditorState(
+    React.useCallback(
+      (store) => ({
+        editor: store.editor,
+        derived: store.derived,
+      }),
+      [],
+    ),
+  )
 
   const innerAnimationFrameRef = React.useRef<number | null>(null)
 
@@ -604,7 +626,10 @@ export function useSelectAndHover(
   onMouseMove: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 } {
-  const modeType = useEditorState((store) => store.editor.mode.type, 'useSelectAndHover mode')
+  const modeType = useEditorState(
+    React.useCallback((store) => store.editor.mode.type, []),
+    'useSelectAndHover mode',
+  )
   const hasInteractionSession = useEditorState(
     (store) => store.editor.canvas.interactionSession != null,
     'useSelectAndHover hasInteractionSession',

--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -38,18 +38,27 @@ interface OutlineControlProps {
 const OutlineControl = React.memo<OutlineControlProps>((props) => {
   const colorTheme = useColorTheme()
   const targets = props.targets
-  const scale = useEditorState((store) => store.editor.canvas.scale, 'OutlineControl scale')
+  const scale = useEditorState(
+    React.useCallback((store) => store.editor.canvas.scale, []),
+    'OutlineControl scale',
+  )
 
-  const colors = useEditorState((store) => {
-    return targets.map((path) =>
-      getSelectionColor(
-        path,
-        store.editor.jsxMetadata,
-        store.editor.focusedElementPath,
-        colorTheme,
-      ),
-    )
-  }, 'OutlineControl colors')
+  const colors = useEditorState(
+    React.useCallback(
+      (store) => {
+        return targets.map((path) =>
+          getSelectionColor(
+            path,
+            store.editor.jsxMetadata,
+            store.editor.focusedElementPath,
+            colorTheme,
+          ),
+        )
+      },
+      [colorTheme, targets],
+    ),
+    'OutlineControl colors',
+  )
 
   const outlineRef = useBoundingBox(targets, (ref, boundingBox) => {
     ref.current.style.left = `${boundingBox.x + 0.5 / scale}px`

--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -3,6 +3,7 @@ import * as EP from '../../../../core/shared/element-path'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { when } from '../../../../utils/react-conditionals'
 import { useColorTheme } from '../../../../uuiui'
+import { EditorStorePatched } from '../../../editor/store/editor-state'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
@@ -35,13 +36,12 @@ interface OutlineControlProps {
   color: 'primary' | 'multiselect-bounds'
 }
 
+const scaleSelector = (store: EditorStorePatched) => store.editor.canvas.scale
+
 const OutlineControl = React.memo<OutlineControlProps>((props) => {
   const colorTheme = useColorTheme()
   const targets = props.targets
-  const scale = useEditorState(
-    React.useCallback((store) => store.editor.canvas.scale, []),
-    'OutlineControl scale',
-  )
+  const scale = useEditorState(scaleSelector, 'OutlineControl scale')
 
   const colors = useEditorState(
     React.useCallback(

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -49,7 +49,10 @@ const TopMenuHeight = 35
 
 const NothingOpenCard = React.memo(() => {
   const colorTheme = useColorTheme()
-  const dispatch = useEditorState((store) => store.dispatch, 'NothingOpenCard dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'NothingOpenCard dispatch',
+  )
   const handleOpenCanvasClick = React.useCallback(() => {
     dispatch([EditorActions.setPanelVisibility('canvas', true)])
   }, [dispatch])
@@ -118,9 +121,12 @@ const NothingOpenCard = React.memo(() => {
 })
 
 const DesignPanelRootInner = React.memo(() => {
-  const dispatch = useEditorState((store) => store.dispatch, 'DesignPanelRoot dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'DesignPanelRoot dispatch',
+  )
   const interfaceDesigner = useEditorState(
-    (store) => store.editor.interfaceDesigner,
+    React.useCallback((store) => store.editor.interfaceDesigner, []),
     'DesignPanelRoot interfaceDesigner',
   )
 
@@ -129,27 +135,22 @@ const DesignPanelRootInner = React.memo(() => {
     interfaceDesigner.codePaneWidth,
   )
   const navigatorVisible = useEditorState(
-    (store) => !store.editor.navigator.minimised,
+    React.useCallback((store) => !store.editor.navigator.minimised, []),
     'DesignPanelRoot navigatorVisible',
   )
 
   const isRightMenuExpanded = useEditorState(
-    (store) => store.editor.rightMenu.expanded,
+    React.useCallback((store) => store.editor.rightMenu.expanded, []),
     'DesignPanelRoot isRightMenuExpanded',
   )
 
   const rightMenuSelectedTab = useEditorState(
-    (store) => store.editor.rightMenu.selectedTab,
+    React.useCallback((store) => store.editor.rightMenu.selectedTab, []),
     'DesignPanelRoot rightMenuSelectedTab',
   )
 
-  const leftMenuExpanded = useEditorState(
-    (store) => store.editor.leftMenu.expanded,
-    'EditorComponentInner leftMenuExpanded',
-  )
-
   const isCanvasVisible = useEditorState(
-    (store) => store.editor.canvas.visible,
+    React.useCallback((store) => store.editor.canvas.visible, []),
     'design panel root',
   )
 

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -8,9 +8,10 @@ import {
   LeftPaneDefaultWidth,
   RightMenuTab,
   NavigatorWidthAtom,
+  EditorStorePatched,
 } from '../editor/store/editor-state'
 
-import { useEditorState } from '../editor/store/store-hook'
+import { useEditorDispatch, useEditorState } from '../editor/store/store-hook'
 import { InspectorEntryPoint } from '../inspector/inspector'
 import { CanvasWrapperComponent } from './canvas-wrapper-component'
 import { InsertMenuPane } from '../navigator/left-pane'
@@ -49,10 +50,7 @@ const TopMenuHeight = 35
 
 const NothingOpenCard = React.memo(() => {
   const colorTheme = useColorTheme()
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'NothingOpenCard dispatch',
-  )
+  const dispatch = useEditorDispatch('NothingOpenCard dispatch')
   const handleOpenCanvasClick = React.useCallback(() => {
     dispatch([EditorActions.setPanelVisibility('canvas', true)])
   }, [dispatch])
@@ -120,13 +118,17 @@ const NothingOpenCard = React.memo(() => {
   )
 })
 
+const interfaceDesignerSelector = (store: EditorStorePatched) => store.editor.interfaceDesigner
+const isNavigatorVisibleSelector = (store: EditorStorePatched) => !store.editor.navigator.minimised
+const isRightMenuExpandedSelector = (store: EditorStorePatched) => store.editor.rightMenu.expanded
+const rightMenuSelectedTabSelector = (store: EditorStorePatched) =>
+  store.editor.rightMenu.selectedTab
+const isCanvasVisibleSelector = (store: EditorStorePatched) => store.editor.canvas.visible
+
 const DesignPanelRootInner = React.memo(() => {
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'DesignPanelRoot dispatch',
-  )
+  const dispatch = useEditorDispatch('DesignPanelRoot dispatch')
   const interfaceDesigner = useEditorState(
-    React.useCallback((store) => store.editor.interfaceDesigner, []),
+    interfaceDesignerSelector,
     'DesignPanelRoot interfaceDesigner',
   )
 
@@ -135,24 +137,21 @@ const DesignPanelRootInner = React.memo(() => {
     interfaceDesigner.codePaneWidth,
   )
   const navigatorVisible = useEditorState(
-    React.useCallback((store) => !store.editor.navigator.minimised, []),
+    isNavigatorVisibleSelector,
     'DesignPanelRoot navigatorVisible',
   )
 
   const isRightMenuExpanded = useEditorState(
-    React.useCallback((store) => store.editor.rightMenu.expanded, []),
+    isRightMenuExpandedSelector,
     'DesignPanelRoot isRightMenuExpanded',
   )
 
   const rightMenuSelectedTab = useEditorState(
-    React.useCallback((store) => store.editor.rightMenu.selectedTab, []),
+    rightMenuSelectedTabSelector,
     'DesignPanelRoot rightMenuSelectedTab',
   )
 
-  const isCanvasVisible = useEditorState(
-    React.useCallback((store) => store.editor.canvas.visible, []),
-    'design panel root',
-  )
+  const isCanvasVisible = useEditorState(isCanvasVisibleSelector, 'design panel root')
 
   const isInsertMenuSelected = rightMenuSelectedTab === RightMenuTab.Insert
 

--- a/editor/src/components/canvas/dom-lookup-hooks.ts
+++ b/editor/src/components/canvas/dom-lookup-hooks.ts
@@ -1,11 +1,14 @@
 import React from 'react'
 import { WindowPoint } from '../../core/shared/math-utils'
+import { EditorStorePatched } from '../editor/store/editor-state'
 import { useRefEditorState } from '../editor/store/store-hook'
 import { CanvasPositions } from './canvas-types'
 import { windowToCanvasCoordinates } from './dom-lookup'
 
+const canvasSelector = (store: EditorStorePatched) => store.editor.canvas
+
 export function useWindowToCanvasCoordinates(): (screenPoint: WindowPoint) => CanvasPositions {
-  const canvasStateRef = useRefEditorState(React.useCallback((store) => store.editor.canvas, []))
+  const canvasStateRef = useRefEditorState(canvasSelector)
   return React.useCallback(
     (screenPoint: WindowPoint) => {
       return windowToCanvasCoordinates(

--- a/editor/src/components/canvas/dom-lookup-hooks.ts
+++ b/editor/src/components/canvas/dom-lookup-hooks.ts
@@ -5,7 +5,7 @@ import { CanvasPositions } from './canvas-types'
 import { windowToCanvasCoordinates } from './dom-lookup'
 
 export function useWindowToCanvasCoordinates(): (screenPoint: WindowPoint) => CanvasPositions {
-  const canvasStateRef = useRefEditorState((store) => store.editor.canvas)
+  const canvasStateRef = useRefEditorState(React.useCallback((store) => store.editor.canvas, []))
   return React.useCallback(
     (screenPoint: WindowPoint) => {
       return windowToCanvasCoordinates(

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -268,17 +268,20 @@ function useInvalidateScenesWhenSelectedViewChanges(
   invalidatedPathsForStylesheetCacheRef: React.MutableRefObject<Set<string>>,
 ): void {
   return useSelectorWithCallback(
-    (store) => store.editor.selectedViews,
-    (newSelectedViews) => {
-      newSelectedViews.forEach((sv) => {
-        const scenePath = EP.createBackwardsCompatibleScenePath(sv)
-        if (scenePath != null) {
-          const sceneID = EP.toString(scenePath)
-          updateInvalidatedScenes((current) => current.add(sceneID), 'invalidate')
-          invalidatedPathsForStylesheetCacheRef.current.add(EP.toString(sv))
-        }
-      })
-    },
+    React.useCallback((store) => store.editor.selectedViews, []),
+    React.useCallback(
+      (newSelectedViews) => {
+        newSelectedViews.forEach((sv) => {
+          const scenePath = EP.createBackwardsCompatibleScenePath(sv)
+          if (scenePath != null) {
+            const sceneID = EP.toString(scenePath)
+            updateInvalidatedScenes((current) => current.add(sceneID), 'invalidate')
+            invalidatedPathsForStylesheetCacheRef.current.add(EP.toString(sv))
+          }
+        })
+      },
+      [invalidatedPathsForStylesheetCacheRef, updateInvalidatedScenes],
+    ),
   )
 }
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -40,11 +40,7 @@ import {
 } from '../inspector/common/css-utils'
 import { CanvasContainerProps } from './ui-jsx-canvas'
 import { camelCaseToDashed } from '../../core/shared/string-utils'
-import {
-  useEditorState,
-  useRefEditorState,
-  useSelectorWithCallback,
-} from '../editor/store/store-hook'
+import { useRefEditorState, useSelectorWithCallback } from '../editor/store/store-hook'
 import {
   UTOPIA_DO_NOT_TRAVERSE_KEY,
   UTOPIA_PATHS_KEY,
@@ -486,7 +482,10 @@ export function useDomWalker(
   })
 
   const rootMetadataInStateRef = useRefEditorState(
-    (store) => store.editor.domMetadata as ReadonlyArray<ElementInstanceMetadata>,
+    React.useCallback(
+      (store) => store.editor.domMetadata as ReadonlyArray<ElementInstanceMetadata>,
+      [],
+    ),
   )
   const [invalidatedPaths, updateInvalidatedPaths] = useStateAsyncInvalidate<Set<string>>(
     fireThrottledCallback,

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -57,6 +57,7 @@ import { optionalMap } from '../../core/shared/optional-utils'
 import { fastForEach } from '../../core/shared/utils'
 import { MapLike } from 'typescript'
 import { isFeatureEnabled } from '../../utils/feature-switches'
+import { EditorStorePatched } from '../editor/store/editor-state'
 
 const MutationObserverConfig = { attributes: true, childList: true, subtree: true }
 const ObserversAvailable = (window as any).MutationObserver != null && ResizeObserver != null
@@ -426,6 +427,9 @@ function mergeFragmentMetadata(
   return Object.values(working)
 }
 
+const domMetadataSelector = (store: EditorStorePatched) =>
+  store.editor.domMetadata as ReadonlyArray<ElementInstanceMetadata>
+
 export function useDomWalker(
   props: DomWalkerProps,
 ): [SetValueCallback<Set<string>>, SetValueCallback<Set<string>>, React.Ref<HTMLDivElement>] {
@@ -484,12 +488,7 @@ export function useDomWalker(
     }
   })
 
-  const rootMetadataInStateRef = useRefEditorState(
-    React.useCallback(
-      (store) => store.editor.domMetadata as ReadonlyArray<ElementInstanceMetadata>,
-      [],
-    ),
-  )
+  const rootMetadataInStateRef = useRefEditorState(domMetadataSelector)
   const [invalidatedPaths, updateInvalidatedPaths] = useStateAsyncInvalidate<Set<string>>(
     fireThrottledCallback,
     emptySet(),

--- a/editor/src/components/canvas/mode-select-buttons.tsx
+++ b/editor/src/components/canvas/mode-select-buttons.tsx
@@ -5,7 +5,8 @@ import React from 'react'
 import { useColorTheme, FlexRow, UtopiaStyles } from '../../uuiui'
 import { switchEditorMode } from '../editor/actions/action-creators'
 import { EditorModes, isLiveMode, isSelectLiteMode, isSelectMode } from '../editor/editor-modes'
-import { useEditorState } from '../editor/store/store-hook'
+import { EditorStorePatched } from '../editor/store/editor-state'
+import { useEditorDispatch, useEditorState } from '../editor/store/store-hook'
 
 interface ModeSelectButtonProps {
   selected: boolean
@@ -51,16 +52,12 @@ const ModeSelectButton = React.memo((props: ModeSelectButtonProps) => {
   )
 })
 
+const currentModeSelector = (store: EditorStorePatched) => store.editor.mode
+
 export const ModeSelectButtons = React.memo(() => {
   const colorTheme = useColorTheme()
-  const currentMode = useEditorState(
-    React.useCallback((store) => store.editor.mode, []),
-    'ModeSelectButtons editor.mode',
-  )
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'ModeSelectButtons dispatch',
-  )
+  const currentMode = useEditorState(currentModeSelector, 'ModeSelectButtons editor.mode')
+  const dispatch = useEditorDispatch('ModeSelectButtons dispatch')
 
   const switchToSelectMode = React.useCallback(
     () => dispatch([switchEditorMode(EditorModes.selectMode())]),

--- a/editor/src/components/canvas/mode-select-buttons.tsx
+++ b/editor/src/components/canvas/mode-select-buttons.tsx
@@ -53,8 +53,14 @@ const ModeSelectButton = React.memo((props: ModeSelectButtonProps) => {
 
 export const ModeSelectButtons = React.memo(() => {
   const colorTheme = useColorTheme()
-  const currentMode = useEditorState((store) => store.editor.mode, 'ModeSelectButtons editor.mode')
-  const dispatch = useEditorState((store) => store.dispatch, 'ModeSelectButtons dispatch')
+  const currentMode = useEditorState(
+    React.useCallback((store) => store.editor.mode, []),
+    'ModeSelectButtons editor.mode',
+  )
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'ModeSelectButtons dispatch',
+  )
 
   const switchToSelectMode = React.useCallback(
     () => dispatch([switchEditorMode(EditorModes.selectMode())]),

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import fastDeepEquals from 'fast-deep-equal'
-import { useContextSelector } from 'use-context-selector'
 import { Scene, SceneProps } from 'utopia-api'
 import { useColorTheme, UtopiaStyles } from '../../../uuiui'
 import { RerenderUtopiaCtxAtom } from './ui-jsx-canvas-contexts'

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -28,7 +28,6 @@ import {
   renderCoreElement,
   utopiaCanvasJSXLookup,
 } from './ui-jsx-canvas-element-renderer-utils'
-import { useContextSelector } from 'use-context-selector'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { UTOPIA_INSTANCE_PATH, UTOPIA_PATHS_KEY } from '../../../core/model/utopia-constants'
 import { getPathsFromString } from '../../../core/shared/uid-utils'

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.tsx
@@ -39,7 +39,6 @@ import {
 } from '../../../core/shared/project-file-types'
 import { defaultIfNull, optionalFlatMap } from '../../../core/shared/optional-utils'
 import { getParseSuccessOrTransientForFilePath } from '../canvas-utils'
-import { useContextSelector } from 'use-context-selector'
 import { shallowEqual } from '../../../core/shared/equality-utils'
 import { usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/shared/dom-utils'

--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -104,14 +104,14 @@ function useGetInsertableComponents(): InsertableComponentFlatList {
   const dependencies = usePossiblyResolvedPackageDependencies()
 
   const { packageStatus, propertyControlsInfo, projectContents, fullPath } = useEditorState(
-    (store) => {
+    React.useCallback((store) => {
       return {
         packageStatus: store.editor.nodeModules.packageStatus,
         propertyControlsInfo: store.editor.propertyControlsInfo,
         projectContents: store.editor.projectContents,
         fullPath: store.editor.canvas.openFile?.filename ?? null,
       }
-    },
+    }, []),
     'RenderAsRow',
   )
 
@@ -390,7 +390,7 @@ export var FloatingMenu = React.memo(() => {
   }, [])
 
   const floatingMenuState = useEditorState(
-    (store) => store.editor.floatingInsertMenu,
+    React.useCallback((store) => store.editor.floatingInsertMenu, []),
     'FloatingMenu floatingMenuState',
   )
 
@@ -400,24 +400,33 @@ export var FloatingMenu = React.memo(() => {
   const menuTitle: string = getMenuTitle(floatingMenuState.insertMenuMode)
 
   const componentSelectorStyles = useComponentSelectorStyles()
-  const dispatch = useEditorState((store) => store.dispatch, 'FloatingMenu dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'FloatingMenu dispatch',
+  )
 
-  const projectContentsRef = useRefEditorState((store) => store.editor.projectContents)
-  const selectedViewsref = useRefEditorState((store) => store.editor.selectedViews)
+  const projectContentsRef = useRefEditorState(
+    React.useCallback((store) => store.editor.projectContents, []),
+  )
+  const selectedViewsref = useRefEditorState(
+    React.useCallback((store) => store.editor.selectedViews, []),
+  )
   const insertableComponents = useGetInsertableComponents()
-  const shouldWrapContentsByDefault = useRefEditorState((store) => {
-    // We only care about this when the menu is first opened
-    const firstSelectedView = store.editor.selectedViews[0]
-    if (firstSelectedView != null) {
-      const selectedJSXElement = MetadataUtils.getJSXElementFromMetadata(
-        store.editor.jsxMetadata,
-        firstSelectedView,
-      )
-      return selectedJSXElement != null && elementOnlyHasSingleTextChild(selectedJSXElement)
-    }
+  const shouldWrapContentsByDefault = useRefEditorState(
+    React.useCallback((store) => {
+      // We only care about this when the menu is first opened
+      const firstSelectedView = store.editor.selectedViews[0]
+      if (firstSelectedView != null) {
+        const selectedJSXElement = MetadataUtils.getJSXElementFromMetadata(
+          store.editor.jsxMetadata,
+          firstSelectedView,
+        )
+        return selectedJSXElement != null && elementOnlyHasSingleTextChild(selectedJSXElement)
+      }
 
-    return false
-  })
+      return false
+    }, []),
+  )
 
   const [addContentForInsertion, setAddContentForInsertion] = React.useState(false)
   const [wrapContentForInsertion, setWrapContentForInsertion] = React.useState(
@@ -658,9 +667,12 @@ export var FloatingMenu = React.memo(() => {
 interface FloatingInsertMenuProps {}
 
 export const FloatingInsertMenu = React.memo((props: FloatingInsertMenuProps) => {
-  const dispatch = useEditorState((store) => store.dispatch, 'FloatingInsertMenu dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'FloatingInsertMenu dispatch',
+  )
   const isVisible = useEditorState(
-    (store) => store.editor.floatingInsertMenu.insertMenuMode !== 'closed',
+    React.useCallback((store) => store.editor.floatingInsertMenu.insertMenuMode !== 'closed', []),
     'FloatingInsertMenu insertMenuOpen',
   )
   const onClickOutside = React.useCallback(() => {

--- a/editor/src/components/code-editor/code-editor-container.tsx
+++ b/editor/src/components/code-editor/code-editor-container.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useEditorState } from '../editor/store/store-hook'
 import { MONACO_EDITOR_IFRAME_BASE_URL } from '../../common/env-vars'
 import { createIframeUrl } from '../../core/shared/utils'
-import { getUnderlyingVSCodeBridgeID } from '../editor/store/editor-state'
+import { EditorStorePatched, getUnderlyingVSCodeBridgeID } from '../editor/store/editor-state'
 import { VSCodeLoadingScreen } from './vscode-editor-loading-screen'
 import { getEditorBranchNameFromURL, setBranchNameFromURL } from '../../utils/branches'
 
@@ -43,15 +43,11 @@ const VSCodeIframeContainer = React.memo((props: { projectID: string }) => {
   )
 })
 
-export const CodeEditorWrapper = React.memo(() => {
-  const selectedProps = useEditorState(
-    React.useCallback((store) => {
-      return {
-        vscodeBridgeId: getUnderlyingVSCodeBridgeID(store.editor.vscodeBridgeId),
-      }
-    }, []),
-    'CodeEditorWrapper',
-  )
+const vscodeBridgeIdSelector = (store: EditorStorePatched) =>
+  getUnderlyingVSCodeBridgeID(store.editor.vscodeBridgeId)
 
-  return <VSCodeIframeContainer projectID={selectedProps.vscodeBridgeId} />
+export const CodeEditorWrapper = React.memo(() => {
+  const vscodeBridgeId = useEditorState(vscodeBridgeIdSelector, 'CodeEditorWrapper')
+
+  return <VSCodeIframeContainer projectID={vscodeBridgeId} />
 })

--- a/editor/src/components/code-editor/code-editor-container.tsx
+++ b/editor/src/components/code-editor/code-editor-container.tsx
@@ -44,11 +44,14 @@ const VSCodeIframeContainer = React.memo((props: { projectID: string }) => {
 })
 
 export const CodeEditorWrapper = React.memo(() => {
-  const selectedProps = useEditorState((store) => {
-    return {
-      vscodeBridgeId: getUnderlyingVSCodeBridgeID(store.editor.vscodeBridgeId),
-    }
-  }, 'CodeEditorWrapper')
+  const selectedProps = useEditorState(
+    React.useCallback((store) => {
+      return {
+        vscodeBridgeId: getUnderlyingVSCodeBridgeID(store.editor.vscodeBridgeId),
+      }
+    }, []),
+    'CodeEditorWrapper',
+  )
 
   return <VSCodeIframeContainer projectID={selectedProps.vscodeBridgeId} />
 })

--- a/editor/src/components/code-editor/console-and-errors-pane.tsx
+++ b/editor/src/components/code-editor/console-and-errors-pane.tsx
@@ -2,24 +2,19 @@ import React from 'react'
 import { useReadOnlyConsoleLogs } from '../../core/shared/runtime-report-logs'
 import { setFocus } from '../common/actions'
 import { openCodeEditorFile } from '../editor/actions/action-creators'
-import { getAllCodeEditorErrors } from '../editor/store/editor-state'
-import { useEditorState } from '../editor/store/store-hook'
+import { EditorStorePatched, getAllCodeEditorErrors } from '../editor/store/editor-state'
+import { useEditorDispatch, useEditorState } from '../editor/store/store-hook'
 import { CodeEditorTabPane } from './code-problems'
 
+const errorMessagesSelector = (store: EditorStorePatched) =>
+  getAllCodeEditorErrors(store.editor, 'warning', false)
+
 export const ConsoleAndErrorsPane = React.memo(() => {
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'ConsoleAndErrorsPane dispatch',
-  )
+  const dispatch = useEditorDispatch('ConsoleAndErrorsPane dispatch')
 
   const canvasConsoleLogs = useReadOnlyConsoleLogs()
 
-  const errorMessages = useEditorState(
-    React.useCallback((store) => {
-      return getAllCodeEditorErrors(store.editor, 'warning', false)
-    }, []),
-    'ConsoleAndErrorsPane errorMessages',
-  )
+  const errorMessages = useEditorState(errorMessagesSelector, 'ConsoleAndErrorsPane errorMessages')
 
   const onOpenFile = React.useCallback(
     (path: string) => {

--- a/editor/src/components/code-editor/console-and-errors-pane.tsx
+++ b/editor/src/components/code-editor/console-and-errors-pane.tsx
@@ -7,13 +7,19 @@ import { useEditorState } from '../editor/store/store-hook'
 import { CodeEditorTabPane } from './code-problems'
 
 export const ConsoleAndErrorsPane = React.memo(() => {
-  const dispatch = useEditorState((store) => store.dispatch, 'ConsoleAndErrorsPane dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'ConsoleAndErrorsPane dispatch',
+  )
 
   const canvasConsoleLogs = useReadOnlyConsoleLogs()
 
-  const errorMessages = useEditorState((store) => {
-    return getAllCodeEditorErrors(store.editor, 'warning', false)
-  }, 'ConsoleAndErrorsPane errorMessages')
+  const errorMessages = useEditorState(
+    React.useCallback((store) => {
+      return getAllCodeEditorErrors(store.editor, 'warning', false)
+    }, []),
+    'ConsoleAndErrorsPane errorMessages',
+  )
 
   const onOpenFile = React.useCallback(
     (path: string) => {

--- a/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
+++ b/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
@@ -84,7 +84,7 @@ const JSIcon = () => (
 
 export const VSCodeLoadingScreen = React.memo((): React.ReactElement | null => {
   const vscodeLoadingScreenVisible = useEditorState(
-    (store) => store.editor.vscodeLoadingScreenVisible,
+    React.useCallback((store) => store.editor.vscodeLoadingScreenVisible, []),
     'VSCodeIframeContainer',
   )
   if (!vscodeLoadingScreenVisible) {

--- a/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
+++ b/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Global, css } from '@emotion/react'
 import { useEditorState } from '../editor/store/store-hook'
+import { EditorStorePatched } from '../editor/store/editor-state'
 
 const SampleCode = [
   {
@@ -82,9 +83,12 @@ const JSIcon = () => (
   </svg>
 )
 
+const vscodeLoadingScreenVisibleSelector = (store: EditorStorePatched) =>
+  store.editor.vscodeLoadingScreenVisible
+
 export const VSCodeLoadingScreen = React.memo((): React.ReactElement | null => {
   const vscodeLoadingScreenVisible = useEditorState(
-    React.useCallback((store) => store.editor.vscodeLoadingScreenVisible, []),
+    vscodeLoadingScreenVisibleSelector,
     'VSCodeIframeContainer',
   )
   if (!vscodeLoadingScreenVisible) {

--- a/editor/src/components/common/notices.tsx
+++ b/editor/src/components/common/notices.tsx
@@ -36,7 +36,10 @@ const ToastTimeout = 5500
  * **Level**: see NoticeLevel jsdoc
  */
 export const Toast: React.FunctionComponent<NoticeProps> = (props) => {
-  const dispatch = useEditorState((store) => store.dispatch, 'Toast dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'Toast dispatch',
+  )
   const deleteToast = React.useCallback(() => {
     dispatch([EditorActions.removeToast(props.id)])
   }, [dispatch, props.id])

--- a/editor/src/components/common/notices.tsx
+++ b/editor/src/components/common/notices.tsx
@@ -4,7 +4,7 @@ import { jsx } from '@emotion/react'
 import * as EditorActions from '../editor/actions/action-creators'
 import React from 'react'
 import { UtopiaStyles, SimpleFlexRow, UtopiaTheme, SimpleFlexColumn } from '../../uuiui'
-import { useEditorState } from '../editor/store/store-hook'
+import { useEditorDispatch, useEditorState } from '../editor/store/store-hook'
 import { Notice, NoticeLevel } from './notice'
 
 interface NoticeProps extends Notice {
@@ -36,10 +36,7 @@ const ToastTimeout = 5500
  * **Level**: see NoticeLevel jsdoc
  */
 export const Toast: React.FunctionComponent<NoticeProps> = (props) => {
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'Toast dispatch',
-  )
+  const dispatch = useEditorDispatch('Toast dispatch')
   const deleteToast = React.useCallback(() => {
     dispatch([EditorActions.removeToast(props.id)])
   }, [dispatch, props.id])

--- a/editor/src/components/editor/component-button.tsx
+++ b/editor/src/components/editor/component-button.tsx
@@ -21,15 +21,21 @@ import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { setFocusedElement } from './actions/action-creators'
 
 export const ComponentOrInstanceIndicator = React.memo(() => {
-  const { metadata, focusedElementPath, selectedViews } = useEditorState((store) => {
-    return {
-      metadata: store.editor.jsxMetadata,
-      focusedElementPath: store.editor.focusedElementPath,
-      selectedViews: store.editor.selectedViews,
-    }
-  }, 'Component-button')
+  const { metadata, focusedElementPath, selectedViews } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        metadata: store.editor.jsxMetadata,
+        focusedElementPath: store.editor.focusedElementPath,
+        selectedViews: store.editor.selectedViews,
+      }
+    }, []),
+    'Component-button',
+  )
 
-  const dispatch = useEditorState((state) => state.dispatch, 'ComponentOrInstanceIndicator')
+  const dispatch = useEditorState(
+    React.useCallback((state) => state.dispatch, []),
+    'ComponentOrInstanceIndicator',
+  )
   const colorTheme = useColorTheme()
   const popupEnabled = selectedViews.length > 0
 

--- a/editor/src/components/editor/component-button.tsx
+++ b/editor/src/components/editor/component-button.tsx
@@ -15,27 +15,27 @@ import {
   UtopiaTheme,
 } from '../../uuiui'
 import { RenderAsRow } from '../canvas/controls/render-as'
-import { useEditorState } from './store/store-hook'
+import { useEditorDispatch, useEditorState } from './store/store-hook'
 import * as EP from '../../core/shared/element-path'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { setFocusedElement } from './actions/action-creators'
+import { EditorStorePatched } from './store/editor-state'
+
+const combinedSelector = (store: EditorStorePatched) => {
+  return {
+    metadata: store.editor.jsxMetadata,
+    focusedElementPath: store.editor.focusedElementPath,
+    selectedViews: store.editor.selectedViews,
+  }
+}
 
 export const ComponentOrInstanceIndicator = React.memo(() => {
   const { metadata, focusedElementPath, selectedViews } = useEditorState(
-    React.useCallback((store) => {
-      return {
-        metadata: store.editor.jsxMetadata,
-        focusedElementPath: store.editor.focusedElementPath,
-        selectedViews: store.editor.selectedViews,
-      }
-    }, []),
+    combinedSelector,
     'Component-button',
   )
 
-  const dispatch = useEditorState(
-    React.useCallback((state) => state.dispatch, []),
-    'ComponentOrInstanceIndicator',
-  )
+  const dispatch = useEditorDispatch('ComponentOrInstanceIndicator')
   const colorTheme = useColorTheme()
   const popupEnabled = selectedViews.length > 0
 

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -93,7 +93,7 @@ function useDelayedValueHook(inputValue: boolean, delayMs: number): boolean {
 }
 
 export const EditorComponentInner = React.memo((props: EditorProps) => {
-  const editorStoreRef = useRefEditorState((store) => store)
+  const editorStoreRef = useRefEditorState(React.useCallback((store) => store, []))
   const colorTheme = useColorTheme()
   const onWindowMouseDown = React.useCallback(
     (event: MouseEvent) => {
@@ -201,18 +201,24 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
     }
   }, [onWindowMouseDown, onWindowKeyDown, onWindowKeyUp, preventDefault])
 
-  const dispatch = useEditorState((store) => store.dispatch, 'EditorComponentInner dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'EditorComponentInner dispatch',
+  )
   const projectName = useEditorState(
-    (store) => store.editor.projectName,
+    React.useCallback((store) => store.editor.projectName, []),
     'EditorComponentInner projectName',
   )
-  const projectId = useEditorState((store) => store.editor.id, 'EditorComponentInner projectId')
+  const projectId = useEditorState(
+    React.useCallback((store) => store.editor.id, []),
+    'EditorComponentInner projectId',
+  )
   const previewVisible = useEditorState(
-    (store) => store.editor.preview.visible,
+    React.useCallback((store) => store.editor.preview.visible, []),
     'EditorComponentInner previewVisible',
   )
   const leftMenuExpanded = useEditorState(
-    (store) => store.editor.leftMenu.expanded,
+    React.useCallback((store) => store.editor.leftMenu.expanded, []),
     'EditorComponentInner leftMenuExpanded',
   )
 
@@ -248,10 +254,6 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
     },
     [dispatch],
   )
-
-  const vscodeBridgeReady = useEditorState((store) => {
-    return store.editor.vscodeBridgeReady
-  }, 'EditorComponentInner vscodeBridgeReady')
 
   return (
     <>
@@ -369,12 +371,15 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 })
 
 const ModalComponent = React.memo((): React.ReactElement<any> | null => {
-  const { modal, dispatch } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      modal: store.editor.modal,
-    }
-  }, 'ModalComponent')
+  const { modal, dispatch } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        modal: store.editor.modal,
+      }
+    }, []),
+    'ModalComponent',
+  )
   if (modal != null) {
     if (modal.type === 'file-delete') {
       return <ConfirmDeleteDialog dispatch={dispatch} filePath={modal.filePath} />
@@ -385,7 +390,7 @@ const ModalComponent = React.memo((): React.ReactElement<any> | null => {
 
 export function EditorComponent(props: EditorProps) {
   const indexedDBFailed = useEditorState(
-    (store) => store.editor.indexedDBFailed,
+    React.useCallback((store) => store.editor.indexedDBFailed, []),
     'EditorComponent indexedDBFailed',
   )
 
@@ -399,9 +404,12 @@ export function EditorComponent(props: EditorProps) {
 }
 
 const EditorCursorComponent = React.memo(() => {
-  const cursor = useEditorState((store) => {
-    return Utils.defaultIfNull(store.editor.canvas.cursor, getCursorFromDragState(store.editor))
-  }, 'EditorCursorComponent cursor')
+  const cursor = useEditorState(
+    React.useCallback((store) => {
+      return Utils.defaultIfNull(store.editor.canvas.cursor, getCursorFromDragState(store.editor))
+    }, []),
+    'EditorCursorComponent cursor',
+  )
 
   const styleProps = React.useMemo(() => {
     let workingStyleProps: React.CSSProperties = {
@@ -424,7 +432,10 @@ const EditorCursorComponent = React.memo(() => {
 })
 
 const ToastRenderer = React.memo(() => {
-  const toasts = useEditorState((store) => store.editor.toasts, 'ToastRenderer')
+  const toasts = useEditorState(
+    React.useCallback((store) => store.editor.toasts, []),
+    'ToastRenderer',
+  )
 
   return (
     <FlexColumn

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -42,7 +42,7 @@ import {
   insertionSubjectIsJSXElement,
 } from './editor-modes'
 import { insertImage } from './image-insert'
-import { getOpenFilename, getOpenUIJSFile } from './store/editor-state'
+import { EditorStorePatched, getOpenFilename, getOpenUIJSFile } from './store/editor-state'
 import { useEditorState } from './store/store-hook'
 import { last } from '../../core/shared/array-utils'
 import { defaultIfNull } from '../../core/shared/optional-utils'
@@ -90,24 +90,23 @@ interface InsertMenuProps {
   projectContents: ProjectContentTreeRoot
 }
 
-export const InsertMenu = React.memo(() => {
-  const props = useEditorState(
-    React.useCallback((store) => {
-      const openFileFullPath = getOpenFilename(store.editor)
+const insertMenuPropsSelector = (store: EditorStorePatched) => {
+  const openFileFullPath = getOpenFilename(store.editor)
 
-      return {
-        lastFontSettings: store.editor.lastUsedFont,
-        editorDispatch: store.dispatch,
-        selectedViews: store.editor.selectedViews,
-        mode: store.editor.mode,
-        currentlyOpenFilename: openFileFullPath,
-        packageStatus: store.editor.nodeModules.packageStatus,
-        propertyControlsInfo: store.editor.propertyControlsInfo,
-        projectContents: store.editor.projectContents,
-      }
-    }, []),
-    'InsertMenu',
-  )
+  return {
+    lastFontSettings: store.editor.lastUsedFont,
+    editorDispatch: store.dispatch,
+    selectedViews: store.editor.selectedViews,
+    mode: store.editor.mode,
+    currentlyOpenFilename: openFileFullPath,
+    packageStatus: store.editor.nodeModules.packageStatus,
+    propertyControlsInfo: store.editor.propertyControlsInfo,
+    projectContents: store.editor.projectContents,
+  }
+}
+
+export const InsertMenu = React.memo(() => {
+  const props = useEditorState(insertMenuPropsSelector, 'InsertMenu')
 
   const dependencies = usePossiblyResolvedPackageDependencies()
 

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -91,20 +91,23 @@ interface InsertMenuProps {
 }
 
 export const InsertMenu = React.memo(() => {
-  const props = useEditorState((store) => {
-    const openFileFullPath = getOpenFilename(store.editor)
+  const props = useEditorState(
+    React.useCallback((store) => {
+      const openFileFullPath = getOpenFilename(store.editor)
 
-    return {
-      lastFontSettings: store.editor.lastUsedFont,
-      editorDispatch: store.dispatch,
-      selectedViews: store.editor.selectedViews,
-      mode: store.editor.mode,
-      currentlyOpenFilename: openFileFullPath,
-      packageStatus: store.editor.nodeModules.packageStatus,
-      propertyControlsInfo: store.editor.propertyControlsInfo,
-      projectContents: store.editor.projectContents,
-    }
-  }, 'InsertMenu')
+      return {
+        lastFontSettings: store.editor.lastUsedFont,
+        editorDispatch: store.dispatch,
+        selectedViews: store.editor.selectedViews,
+        mode: store.editor.mode,
+        currentlyOpenFilename: openFileFullPath,
+        packageStatus: store.editor.nodeModules.packageStatus,
+        propertyControlsInfo: store.editor.propertyControlsInfo,
+        projectContents: store.editor.projectContents,
+      }
+    }, []),
+    'InsertMenu',
+  )
 
   const dependencies = usePossiblyResolvedPackageDependencies()
 

--- a/editor/src/components/editor/notification-bar.tsx
+++ b/editor/src/components/editor/notification-bar.tsx
@@ -23,9 +23,12 @@ const EditorOfflineBar = React.memo(() => {
 })
 
 export const LoginStatusBar = React.memo(() => {
-  const loginState = useEditorState((store) => store.userState.loginState, 'LoginStatusBar')
+  const loginState = useEditorState(
+    React.useCallback((store) => store.userState.loginState, []),
+    'LoginStatusBar',
+  )
   const saveError = useEditorState(
-    (store) => store.editor.saveError,
+    React.useCallback((store) => store.editor.saveError, []),
     'EditorComponentInner saveError',
   )
 

--- a/editor/src/components/editor/notification-bar.tsx
+++ b/editor/src/components/editor/notification-bar.tsx
@@ -6,6 +6,7 @@ import { useEditorState } from './store/store-hook'
 
 import { NotificationBar } from '../common/notices'
 import { NoticeLevel } from '../common/notice'
+import { EditorStorePatched } from './store/editor-state'
 
 export const BrowserInfoBar = React.memo(() => {
   return (
@@ -22,15 +23,12 @@ const EditorOfflineBar = React.memo(() => {
   )
 })
 
+const loginStateSelector = (store: EditorStorePatched) => store.userState.loginState
+const saveErrorSelector = (store: EditorStorePatched) => store.editor.saveError
+
 export const LoginStatusBar = React.memo(() => {
-  const loginState = useEditorState(
-    React.useCallback((store) => store.userState.loginState, []),
-    'LoginStatusBar',
-  )
-  const saveError = useEditorState(
-    React.useCallback((store) => store.editor.saveError, []),
-    'EditorComponentInner saveError',
-  )
+  const loginState = useEditorState(loginStateSelector, 'LoginStatusBar')
+  const saveError = useEditorState(saveErrorSelector, 'EditorComponentInner saveError')
 
   const onClickLoginNewTab = React.useCallback(() => {
     window.open(auth0Url('auto-close'), '_blank')

--- a/editor/src/components/editor/npm-dependency/npm-dependency.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.ts
@@ -437,9 +437,12 @@ export function immediatelyResolvableDependenciesWithEditorRequirements(
 }
 
 export function usePackageDependencies(): Array<RequestedNpmDependency> {
-  const packageJsonFile = useEditorState((store) => {
-    return packageJsonFileFromProjectContents(store.editor.projectContents)
-  }, 'usePackageDependencies')
+  const packageJsonFile = useEditorState(
+    React.useCallback((store) => {
+      return packageJsonFileFromProjectContents(store.editor.projectContents)
+    }, []),
+    'usePackageDependencies',
+  )
 
   return React.useMemo(() => {
     if (isTextFile(packageJsonFile)) {
@@ -452,9 +455,15 @@ export function usePackageDependencies(): Array<RequestedNpmDependency> {
 
 export function usePossiblyResolvedPackageDependencies(): Array<PossiblyUnversionedNpmDependency> {
   const basePackageDependencies = usePackageDependencies()
-  const { files, builtInDependencies } = useEditorState((store) => {
-    return { files: store.editor.nodeModules.files, builtInDependencies: store.builtInDependencies }
-  }, 'usePossiblyResolvedPackageDependencies')
+  const { files, builtInDependencies } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        files: store.editor.nodeModules.files,
+        builtInDependencies: store.builtInDependencies,
+      }
+    }, []),
+    'usePossiblyResolvedPackageDependencies',
+  )
   return React.useMemo(() => {
     return resolvedDependencyVersions(basePackageDependencies, files, builtInDependencies)
   }, [basePackageDependencies, files, builtInDependencies])

--- a/editor/src/components/editor/persistence-hooks.ts
+++ b/editor/src/components/editor/persistence-hooks.ts
@@ -2,7 +2,7 @@ import React from 'react'
 import { useRefEditorState } from './store/store-hook'
 
 export function useTriggerForkProject(): () => void {
-  const storeRef = useRefEditorState((store) => store)
+  const storeRef = useRefEditorState(React.useCallback((store) => store, []))
   return React.useCallback(async () => {
     const store = storeRef.current
     store.persistence.fork()

--- a/editor/src/components/editor/persistence-hooks.ts
+++ b/editor/src/components/editor/persistence-hooks.ts
@@ -1,8 +1,9 @@
 import React from 'react'
+import { identity } from '../../core/shared/utils'
 import { useRefEditorState } from './store/store-hook'
 
 export function useTriggerForkProject(): () => void {
-  const storeRef = useRefEditorState(React.useCallback((store) => store, []))
+  const storeRef = useRefEditorState(identity)
   return React.useCallback(async () => {
     const store = storeRef.current
     store.persistence.fork()

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -50,10 +50,10 @@ describe('useSelectorWithCallback', () => {
       (props) => {
         hookRenders++
         return useSelectorWithCallback(
-          (store) => store.editor.selectedViews,
-          (newSelectedViews) => {
+          React.useCallback((store) => store.editor.selectedViews, []),
+          React.useCallback((newSelectedViews) => {
             callCount++
-          },
+          }, []),
         )
       },
       {
@@ -78,10 +78,10 @@ describe('useSelectorWithCallback', () => {
       (props) => {
         hookRenders++
         return useSelectorWithCallback(
-          (store) => store.editor.selectedViews,
-          (newSelectedViews) => {
+          React.useCallback((store) => store.editor.selectedViews, []),
+          React.useCallback((newSelectedViews) => {
             callCount++
-          },
+          }, []),
         )
       },
       {
@@ -126,10 +126,10 @@ describe('useSelectorWithCallback', () => {
       (props) => {
         hookRenders++
         return useSelectorWithCallback(
-          (store) => store.editor.selectedViews,
-          (newSelectedViews) => {
+          React.useCallback((store) => store.editor.selectedViews, []),
+          React.useCallback((newSelectedViews) => {
             callCount++
-          },
+          }, []),
         )
       },
       {

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -68,6 +68,18 @@ function useWrapSelectorInPerformanceMeasureBlock<U>(
   }
 }
 
+const dispatchSelector = (store: EditorStorePatched) => store.dispatch
+export const useEditorDispatch = (selectorName: string) =>
+  useEditorState(dispatchSelector, selectorName)
+
+const selectedViewsSelector = (store: EditorStorePatched) => store.editor.selectedViews
+export const useEditorSelectedViews = (selectorName: string) =>
+  useEditorState(selectedViewsSelector, selectorName)
+
+const metadataSelector = (store: EditorStorePatched) => store.editor.jsxMetadata
+export const useEditorMetadata = (selectorName: string) =>
+  useEditorState(metadataSelector, selectorName)
+
 /**
  * Like useEditorState, but DOES NOT TRIGGER A RE-RENDER
  *
@@ -125,6 +137,9 @@ export const useRefEditorState = <U>(
   }, [api, explainMe])
   return sliceRef
 }
+
+export const useRefEditorSelectedViews = () => useRefEditorState(selectedViewsSelector)
+export const useRefEditorMetadata = () => useRefEditorState(metadataSelector)
 
 export type UtopiaStoreHook = UseStore<EditorStorePatched>
 export type UtopiaStoreAPI = StoreApi<EditorStorePatched>

--- a/editor/src/components/editor/top-menu.tsx
+++ b/editor/src/components/editor/top-menu.tsx
@@ -34,9 +34,12 @@ function useShouldResetCanvas(invalidateCount: number): [boolean, (value: boolea
 }
 
 const TopMenuLeftControls = React.memo(() => {
-  const dispatch = useEditorState((store) => store.dispatch, 'TopMenuLeftControls dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'TopMenuLeftControls dispatch',
+  )
   const navigatorVisible = useEditorState(
-    (store) => !store.editor.navigator.minimised,
+    React.useCallback((store) => !store.editor.navigator.minimised, []),
     'TopMenuLeftControls navigatorVisible',
   )
 
@@ -53,7 +56,7 @@ const TopMenuLeftControls = React.memo(() => {
   }, [dispatch, navigatorVisible, navigatorWidth])
 
   const followSelection = useEditorState(
-    (store) => store.editor.config.followSelection,
+    React.useCallback((store) => store.editor.config.followSelection, []),
     'TopMenu followSelection',
   )
   const onToggleFollow = React.useCallback(() => {
@@ -81,13 +84,19 @@ const TopMenuLeftControls = React.memo(() => {
 })
 
 const TopMenuRightControls = React.memo(() => {
-  const dispatch = useEditorState((store) => store.dispatch, 'TopMenuRightControls dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'TopMenuRightControls dispatch',
+  )
   const canvasContentInvalidateCount = useEditorState(
-    (store) => store.editor.canvas.canvasContentInvalidateCount,
+    React.useCallback((store) => store.editor.canvas.canvasContentInvalidateCount, []),
     'RightMenu canvasContentInvalidateCount',
   )
 
-  const zoomLevel = useEditorState((store) => store.editor.canvas.scale, 'RightMenu zoomLevel')
+  const zoomLevel = useEditorState(
+    React.useCallback((store) => store.editor.canvas.scale, []),
+    'RightMenu zoomLevel',
+  )
   const zoomIn = React.useCallback(
     () => dispatch([CanvasActions.zoom(Utils.increaseScale(zoomLevel))]),
     [dispatch, zoomLevel],
@@ -107,7 +116,7 @@ const TopMenuRightControls = React.memo(() => {
   const zoom100pct = React.useCallback(() => dispatch([CanvasActions.zoom(1)]), [dispatch])
 
   const rightMenuSelectedTab = useEditorState(
-    (store) => store.editor.rightMenu.selectedTab,
+    React.useCallback((store) => store.editor.rightMenu.selectedTab, []),
     'RightMenu rightMenuSelectedTab',
   )
 

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -139,7 +139,10 @@ const SelectableElementItem = (props: SelectableElementItemProps) => {
   const rawRef = React.useRef<HTMLDivElement>(null)
   const { dispatch, path, iconProps, label } = props
   const isHighlighted = useEditorState(
-    (store) => store.editor.highlightedViews.some((view) => EP.pathsEqual(path, view)),
+    React.useCallback(
+      (store) => store.editor.highlightedViews.some((view) => EP.pathsEqual(path, view)),
+      [path],
+    ),
     'SelectableElementItem isHighlighted',
   )
   const highlightElement = React.useCallback(() => dispatch([setHighlightedView(path)]), [
@@ -172,26 +175,29 @@ const SelectableElementItem = (props: SelectableElementItemProps) => {
 }
 
 export const ElementContextMenu = React.memo(({ contextMenuInstance }: ElementContextMenuProps) => {
-  const { dispatch } = useEditorState((store) => {
-    return { dispatch: store.dispatch }
-  }, 'ElementContextMenu dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'ElementContextMenu dispatch',
+  )
 
-  const editorSliceRef = useRefEditorState((store) => {
-    const resolveFn = store.editor.codeResultCache.curriedResolveFn(store.editor.projectContents)
-    return {
-      canvasOffset: store.editor.canvas.roundedCanvasOffset,
-      selectedViews: store.editor.selectedViews,
-      jsxMetadata: store.editor.jsxMetadata,
-      editorDispatch: store.dispatch,
-      projectContents: store.editor.projectContents,
-      nodeModules: store.editor.nodeModules.files,
-      transientFilesState: store.derived.canvas.transientState.filesState,
-      resolve: resolveFn,
-      hiddenInstances: store.editor.hiddenInstances,
-      scale: store.editor.canvas.scale,
-      focusedElementPath: store.editor.focusedElementPath,
-    }
-  })
+  const editorSliceRef = useRefEditorState(
+    React.useCallback((store) => {
+      const resolveFn = store.editor.codeResultCache.curriedResolveFn(store.editor.projectContents)
+      return {
+        canvasOffset: store.editor.canvas.roundedCanvasOffset,
+        selectedViews: store.editor.selectedViews,
+        jsxMetadata: store.editor.jsxMetadata,
+        editorDispatch: store.dispatch,
+        projectContents: store.editor.projectContents,
+        nodeModules: store.editor.nodeModules.files,
+        transientFilesState: store.derived.canvas.transientState.filesState,
+        resolve: resolveFn,
+        hiddenInstances: store.editor.hiddenInstances,
+        scale: store.editor.canvas.scale,
+        focusedElementPath: store.editor.focusedElementPath,
+      }
+    }, []),
+  )
 
   const getData: () => CanvasData = React.useCallback(() => {
     const currentEditor = editorSliceRef.current

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -30,6 +30,7 @@ import { setFocus } from '../common/actions'
 import { CodeResultCache, isJavascriptOrTypescript } from '../custom-code/code-file'
 import * as EditorActions from '../editor/actions/action-creators'
 import {
+  EditorStorePatched,
   getAllCodeEditorErrors,
   getOpenFilename,
   getOpenUIJSFile,
@@ -132,15 +133,17 @@ function collectFileBrowserItems(
   return fileBrowserItems
 }
 
+const fileBrowserPropsSelector = (store: EditorStorePatched) => {
+  return {
+    dispatch: store.dispatch,
+    minimised: store.editor.fileBrowser.minimised,
+    focusedPanel: store.editor.focusedPanel,
+  }
+}
+
 export const FileBrowser = React.memo(() => {
   const { dispatch, minimised, focusedPanel } = useEditorState(
-    React.useCallback((store) => {
-      return {
-        dispatch: store.dispatch,
-        minimised: store.editor.fileBrowser.minimised,
-        focusedPanel: store.editor.focusedPanel,
-      }
-    }, []),
+    fileBrowserPropsSelector,
     'FileBrowser',
   )
 
@@ -234,6 +237,19 @@ interface FileBrowserActionSheetProps {
   setAddingFileOrFolder: (fileOrFolder: 'file' | 'folder') => void
 }
 
+const fileBrowserItemsPropsSelector = (store: EditorStorePatched) => {
+  return {
+    dispatch: store.dispatch,
+    projectContents: store.editor.projectContents,
+    editorSelectedFile: getOpenFilename(store.editor),
+    errorMessages: getAllCodeEditorErrors(store.editor, 'warning', true),
+    codeResultCache: store.editor.codeResultCache,
+    propertyControlsInfo: store.editor.propertyControlsInfo,
+    renamingTarget: store.editor.fileBrowser.renamingTarget,
+    dropTarget: store.editor.fileBrowser.dropTarget,
+  }
+}
+
 const FileBrowserItems = React.memo(() => {
   const {
     dispatch,
@@ -243,21 +259,7 @@ const FileBrowserItems = React.memo(() => {
     codeResultCache,
     renamingTarget,
     dropTarget,
-  } = useEditorState(
-    React.useCallback((store) => {
-      return {
-        dispatch: store.dispatch,
-        projectContents: store.editor.projectContents,
-        editorSelectedFile: getOpenFilename(store.editor),
-        errorMessages: getAllCodeEditorErrors(store.editor, 'warning', true),
-        codeResultCache: store.editor.codeResultCache,
-        propertyControlsInfo: store.editor.propertyControlsInfo,
-        renamingTarget: store.editor.fileBrowser.renamingTarget,
-        dropTarget: store.editor.fileBrowser.dropTarget,
-      }
-    }, []),
-    'FileBrowserItems',
-  )
+  } = useEditorState(fileBrowserItemsPropsSelector, 'FileBrowserItems')
 
   const [selectedPath, setSelectedPath] = React.useState(editorSelectedFile)
 

--- a/editor/src/components/filebrowser/filebrowser.tsx
+++ b/editor/src/components/filebrowser/filebrowser.tsx
@@ -133,13 +133,16 @@ function collectFileBrowserItems(
 }
 
 export const FileBrowser = React.memo(() => {
-  const { dispatch, minimised, focusedPanel } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      minimised: store.editor.fileBrowser.minimised,
-      focusedPanel: store.editor.focusedPanel,
-    }
-  }, 'FileBrowser')
+  const { dispatch, minimised, focusedPanel } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        minimised: store.editor.fileBrowser.minimised,
+        focusedPanel: store.editor.focusedPanel,
+      }
+    }, []),
+    'FileBrowser',
+  )
 
   const toggleMinimised = React.useCallback(() => {
     dispatch([EditorActions.togglePanel('filebrowser')], 'leftpane')
@@ -240,18 +243,21 @@ const FileBrowserItems = React.memo(() => {
     codeResultCache,
     renamingTarget,
     dropTarget,
-  } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      projectContents: store.editor.projectContents,
-      editorSelectedFile: getOpenFilename(store.editor),
-      errorMessages: getAllCodeEditorErrors(store.editor, 'warning', true),
-      codeResultCache: store.editor.codeResultCache,
-      propertyControlsInfo: store.editor.propertyControlsInfo,
-      renamingTarget: store.editor.fileBrowser.renamingTarget,
-      dropTarget: store.editor.fileBrowser.dropTarget,
-    }
-  }, 'FileBrowserItems')
+  } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        projectContents: store.editor.projectContents,
+        editorSelectedFile: getOpenFilename(store.editor),
+        errorMessages: getAllCodeEditorErrors(store.editor, 'warning', true),
+        codeResultCache: store.editor.codeResultCache,
+        propertyControlsInfo: store.editor.propertyControlsInfo,
+        renamingTarget: store.editor.fileBrowser.renamingTarget,
+        dropTarget: store.editor.fileBrowser.dropTarget,
+      }
+    }, []),
+    'FileBrowserItems',
+  )
 
   const [selectedPath, setSelectedPath] = React.useState(editorSelectedFile)
 
@@ -315,10 +321,6 @@ const FileBrowserItems = React.memo(() => {
 })
 
 const FileBrowserActionSheet = React.memo((props: FileBrowserActionSheetProps) => {
-  const { dispatch } = useEditorState(
-    (store) => ({ dispatch: store.dispatch }),
-    'FileBrowserActionSheet dispatch',
-  )
   const addFolderClick = React.useCallback(() => props.setAddingFileOrFolder('folder'), [props])
   const addTextFileClick = React.useCallback(() => props.setAddingFileOrFolder('file'), [props])
   if (props.visible) {

--- a/editor/src/components/inspector/common/layout-property-path-hooks.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.ts
@@ -276,9 +276,12 @@ export function usePinToggling(): UsePinTogglingResult {
       [selectedViewsRef],
     ),
   )
-  const propertyTarget = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
+  const propertyTarget = useContextSelector(
+    InspectorPropsContext,
+    React.useCallback((contextData) => {
+      return contextData.targetPath
+    }, []),
+  )
 
   const elementFrames = useEditorState(
     React.useCallback(

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -120,10 +120,10 @@ export function useInspectorInfoLonghandShorthand<
 
   const shorthandInfo = useInspectorInfo(
     [shorthand],
-    (v) => v[shorthand],
-    () => {
+    useCallback((v) => v[shorthand], [shorthand]),
+    useCallback(() => {
       throw new Error(`do not use useInspectorInfo's built-in onSubmitValue!`)
-    },
+    }, []),
     pathMappingFn,
   )
 
@@ -134,10 +134,12 @@ export function useInspectorInfoLonghandShorthand<
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const longhandInfo = useInspectorInfo(
       [longhand],
-      (v) => v[longhand],
-      () => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useCallback((v) => v[longhand], [longhand]),
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useCallback(() => {
         throw new Error(`do not use useInspectorInfo's built-in onSubmitValue!`)
-      },
+      }, []),
       pathMappingFn,
     )
 

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -1,4 +1,5 @@
 import deepEqual from 'fast-deep-equal'
+import { useCallback } from 'react'
 import { useContextSelector } from 'use-context-selector'
 import { flatMapArray, last, mapArrayToDictionary } from '../../../core/shared/array-utils'
 import { emptyComments, jsxAttributeValue } from '../../../core/shared/element-template'
@@ -109,7 +110,7 @@ export function useInspectorInfoLonghandShorthand<
   [longhand in LonghandKey]: InspectorInfoWithPropKeys<LonghandKey, ShorthandKey>
 } {
   const dispatch = useEditorState(
-    (store) => store.dispatch,
+    useCallback((store) => store.dispatch, []),
     'useInspectorInfoLonghandShorthand dispatch',
   )
   const inspectorTargetPath = useKeepReferenceEqualityIfPossible(

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -114,7 +114,11 @@ export function useInspectorInfoLonghandShorthand<
     'useInspectorInfoLonghandShorthand dispatch',
   )
   const inspectorTargetPath = useKeepReferenceEqualityIfPossible(
-    useContextSelector(InspectorPropsContext, (contextData) => contextData.targetPath, deepEqual),
+    useContextSelector(
+      InspectorPropsContext,
+      useCallback((contextData) => contextData.targetPath, []),
+      deepEqual,
+    ),
   )
   const { selectedViewsRef } = useInspectorContext()
 

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.ts
@@ -12,7 +12,7 @@ import {
   transientActions,
   unsetProperty,
 } from '../../editor/actions/action-creators'
-import { useEditorState } from '../../editor/store/store-hook'
+import { useEditorDispatch, useEditorState } from '../../editor/store/store-hook'
 import {
   getControlStatusFromPropertyStatus,
   getControlStyles,
@@ -23,6 +23,7 @@ import { ReadonlyRef } from './inspector-utils'
 import {
   InspectorInfo,
   InspectorPropsContext,
+  InspectorPropsContextTargetPathSelector,
   ParsedValues,
   PathMappingFn,
   useGetOrderedPropertyKeys,
@@ -109,16 +110,9 @@ export function useInspectorInfoLonghandShorthand<
 ): {
   [longhand in LonghandKey]: InspectorInfoWithPropKeys<LonghandKey, ShorthandKey>
 } {
-  const dispatch = useEditorState(
-    useCallback((store) => store.dispatch, []),
-    'useInspectorInfoLonghandShorthand dispatch',
-  )
+  const dispatch = useEditorDispatch('useInspectorInfoLonghandShorthand dispatch')
   const inspectorTargetPath = useKeepReferenceEqualityIfPossible(
-    useContextSelector(
-      InspectorPropsContext,
-      useCallback((contextData) => contextData.targetPath, []),
-      deepEqual,
-    ),
+    useContextSelector(InspectorPropsContext, InspectorPropsContextTargetPathSelector, deepEqual),
   )
   const { selectedViewsRef } = useInspectorContext()
 

--- a/editor/src/components/inspector/common/name-and-icon-hook.ts
+++ b/editor/src/components/inspector/common/name-and-icon-hook.ts
@@ -19,11 +19,10 @@ export interface NameAndIconResult {
   iconProps: IcnProps
 }
 
+const metadataSelector = (store: EditorStorePatched) => store.editor.jsxMetadata
+
 export function useMetadata(): ElementInstanceMetadataMap {
-  return useEditorState(
-    React.useCallback((store) => store.editor.jsxMetadata, []),
-    'useMetadata',
-  )
+  return useEditorState(metadataSelector, 'useMetadata')
 }
 
 const namesAndIconsAllPathsResultSelector = createSelector(
@@ -35,15 +34,14 @@ const namesAndIconsAllPathsResultSelector = createSelector(
   },
 )
 
+const NameAndIconResultArrayEquality = (
+  oldResult: Array<NameAndIconResult>,
+  newResult: Array<NameAndIconResult>,
+) => NameAndIconResultArrayKeepDeepEquality(oldResult, newResult).areEqual
+
 export function useNamesAndIconsAllPaths(): NameAndIconResult[] {
   const selector = React.useMemo(() => namesAndIconsAllPathsResultSelector, [])
-  return useEditorState(
-    selector,
-    'useNamesAndIconsAllPaths',
-    React.useCallback((oldResult, newResult) => {
-      return NameAndIconResultArrayKeepDeepEquality(oldResult, newResult).areEqual
-    }, []),
-  )
+  return useEditorState(selector, 'useNamesAndIconsAllPaths', NameAndIconResultArrayEquality)
 }
 
 function getNameAndIconResult(

--- a/editor/src/components/inspector/common/name-and-icon-hook.ts
+++ b/editor/src/components/inspector/common/name-and-icon-hook.ts
@@ -20,7 +20,10 @@ export interface NameAndIconResult {
 }
 
 export function useMetadata(): ElementInstanceMetadataMap {
-  return useEditorState((store) => store.editor.jsxMetadata, 'useMetadata')
+  return useEditorState(
+    React.useCallback((store) => store.editor.jsxMetadata, []),
+    'useMetadata',
+  )
 }
 
 const namesAndIconsAllPathsResultSelector = createSelector(

--- a/editor/src/components/inspector/common/name-and-icon-hook.ts
+++ b/editor/src/components/inspector/common/name-and-icon-hook.ts
@@ -37,9 +37,13 @@ const namesAndIconsAllPathsResultSelector = createSelector(
 
 export function useNamesAndIconsAllPaths(): NameAndIconResult[] {
   const selector = React.useMemo(() => namesAndIconsAllPathsResultSelector, [])
-  return useEditorState(selector, 'useNamesAndIconsAllPaths', (oldResult, newResult) => {
-    return NameAndIconResultArrayKeepDeepEquality(oldResult, newResult).areEqual
-  })
+  return useEditorState(
+    selector,
+    'useNamesAndIconsAllPaths',
+    React.useCallback((oldResult, newResult) => {
+      return NameAndIconResultArrayKeepDeepEquality(oldResult, newResult).areEqual
+    }, []),
+  )
 }
 
 function getNameAndIconResult(

--- a/editor/src/components/inspector/common/property-controls-hooks.ts
+++ b/editor/src/components/inspector/common/property-controls-hooks.ts
@@ -248,9 +248,9 @@ export function useGetPropertyControlsForSelectedComponents(): Array<
       [selectedViews],
     ),
     'useSelectedPropertyControls',
-    (oldResult, newResult) => {
+    React.useCallback((oldResult, newResult) => {
       return deepEqual(oldResult, newResult) // TODO better equality
-    },
+    }, []),
   )
 
   const selectedElementsFIXME = useEditorState(
@@ -266,9 +266,12 @@ export function useGetPropertyControlsForSelectedComponents(): Array<
       [selectedPropertyControls],
     ),
     'useGetPropertyControlsForSelectedComponents selectedElements',
-    (a, b) =>
-      arrayDeepEquality(arrayDeepEquality(ElementInstanceMetadataKeepDeepEquality()))(a, b)
-        .areEqual,
+    React.useCallback(
+      (a, b) =>
+        arrayDeepEquality(arrayDeepEquality(ElementInstanceMetadataKeepDeepEquality()))(a, b)
+          .areEqual,
+      [],
+    ),
   )
 
   const selectedComponentsFIXME = useEditorState(
@@ -297,8 +300,11 @@ export function useGetPropertyControlsForSelectedComponents(): Array<
       [selectedPropertyControls],
     ),
     'useUsedPropsWithoutControls',
-    (a, b) =>
-      arrayDeepEquality(arrayDeepEquality(UtopiaJSXComponentKeepDeepEquality))(a, b).areEqual,
+    React.useCallback(
+      (a, b) =>
+        arrayDeepEquality(arrayDeepEquality(UtopiaJSXComponentKeepDeepEquality))(a, b).areEqual,
+      [],
+    ),
   )
 
   return selectedPropertyControls.map(({ controls, targets }, index) => {

--- a/editor/src/components/inspector/common/property-controls-hooks.ts
+++ b/editor/src/components/inspector/common/property-controls-hooks.ts
@@ -87,11 +87,14 @@ export function useInspectorInfoForPropertyControl(
   const rawValues: RawValues = useKeepReferenceEqualityIfPossible(
     useContextSelector(
       InspectorPropsContext,
-      (contextData) => {
-        return contextData.editedMultiSelectedProps.map((props) => {
-          return getModifiableJSXAttributeAtPath(props, propertyPath)
-        })
-      },
+      React.useCallback(
+        (contextData) => {
+          return contextData.editedMultiSelectedProps.map((props) => {
+            return getModifiableJSXAttributeAtPath(props, propertyPath)
+          })
+        },
+        [propertyPath],
+      ),
       deepEqual,
     ),
   )
@@ -99,11 +102,14 @@ export function useInspectorInfoForPropertyControl(
   const realValues: RealValues = useKeepReferenceEqualityIfPossible(
     useContextSelector(
       InspectorPropsContext,
-      (contextData) => {
-        return contextData.spiedProps.map((props) => {
-          return ObjectPath.get(props, PP.getElements(propertyPath))
-        })
-      },
+      React.useCallback(
+        (contextData) => {
+          return contextData.spiedProps.map((props) => {
+            return ObjectPath.get(props, PP.getElements(propertyPath))
+          })
+        },
+        [propertyPath],
+      ),
       deepEqual,
     ),
   )
@@ -163,10 +169,13 @@ function useFirstRawValue(propertyPath: PropertyPath): Either<string, Modifiable
   return useKeepReferenceEqualityIfPossible(
     useContextSelector(
       InspectorPropsContext,
-      (contextData) => {
-        const firstElemProps = contextData.editedMultiSelectedProps[0] ?? {}
-        return getModifiableJSXAttributeAtPath(firstElemProps, propertyPath)
-      },
+      React.useCallback(
+        (contextData) => {
+          const firstElemProps = contextData.editedMultiSelectedProps[0] ?? {}
+          return getModifiableJSXAttributeAtPath(firstElemProps, propertyPath)
+        },
+        [propertyPath],
+      ),
       deepEqual,
     ),
   )
@@ -176,10 +185,13 @@ function useFirstRealValue(propertyPath: PropertyPath): unknown {
   return useKeepReferenceEqualityIfPossible(
     useContextSelector(
       InspectorPropsContext,
-      (contextData) => {
-        const firstElemProps = contextData.spiedProps[0] ?? {}
-        return ObjectPath.get(firstElemProps, PP.getElements(propertyPath))
-      },
+      React.useCallback(
+        (contextData) => {
+          const firstElemProps = contextData.spiedProps[0] ?? {}
+          return ObjectPath.get(firstElemProps, PP.getElements(propertyPath))
+        },
+        [propertyPath],
+      ),
       deepEqual,
     ),
   )

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -118,6 +118,9 @@ export const InspectorPropsContext = createContext<InspectorPropsContextData>({
   selectedAttributeMetadatas: [],
 })
 
+export const InspectorPropsContextTargetPathSelector = (contextData: InspectorPropsContextData) =>
+  contextData.targetPath
+
 export const InspectorCallbackContext = React.createContext<InspectorCallbackContextData>({
   selectedViewsRef: { current: [] },
   onSubmitValue: Utils.NO_OP,
@@ -181,6 +184,9 @@ function getAttributeMetadatas(
   return selectedAttributeMetadatas[key] ?? []
 }
 
+const multiselectLengthSelector = (contextData: InspectorPropsContextData) =>
+  contextData.editedMultiSelectedProps.length
+
 // TODO also memoize me!
 export function useInspectorInfoFromMultiselectMultiStyleAttribute<
   PropertiesToControl extends ParsedPropertiesKeys
@@ -200,12 +206,7 @@ export function useInspectorInfoFromMultiselectMultiStyleAttribute<
     attributeMetadatas: ReadonlyArray<StyleAttributeMetadataEntry>
   }
 } {
-  const multiselectLength = useContextSelector(
-    InspectorPropsContext,
-    React.useCallback((c) => {
-      return c.editedMultiSelectedProps.length
-    }, []),
-  )
+  const multiselectLength = useContextSelector(InspectorPropsContext, multiselectLengthSelector)
 
   return React.useMemo(() => {
     const multiselectAtPropsKeys = Object.keys(multiselectAtProps)
@@ -260,12 +261,7 @@ export function useInspectorInfoFromMultiselectMultiPropAttribute(
     spiedValues: ReadonlyArray<any>
   }
 } {
-  const multiselectLength = useContextSelector(
-    InspectorPropsContext,
-    React.useCallback((c) => {
-      return c.editedMultiSelectedProps.length
-    }, []),
-  )
+  const multiselectLength = useContextSelector(InspectorPropsContext, multiselectLengthSelector)
 
   return React.useMemo(() => {
     const multiselectAtPropsKeys = Object.keys(multiselectAtProps)
@@ -542,11 +538,7 @@ export function useInspectorInfo<P extends ParsedPropertiesKeys, T = ParsedPrope
   } = useInspectorContext()
 
   const target = useKeepReferenceEqualityIfPossible(
-    useContextSelector(
-      InspectorPropsContext,
-      React.useCallback((contextData) => contextData.targetPath, []),
-      deepEqual,
-    ),
+    useContextSelector(InspectorPropsContext, InspectorPropsContextTargetPathSelector, deepEqual),
   )
   const onUnsetValues = React.useCallback(() => {
     onUnsetValue(
@@ -1149,11 +1141,10 @@ export function useInspectorWarningStatus(): boolean {
   )
 }
 
+const selectedViewsSelector = (contextData: InspectorPropsContextData) => contextData.selectedViews
+
 export function useSelectedViews() {
-  const selectedViews = useContextSelector(
-    InspectorPropsContext,
-    React.useCallback((context) => context.selectedViews, []),
-  )
+  const selectedViews = useContextSelector(InspectorPropsContext, selectedViewsSelector)
   return selectedViews
 }
 

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -42,7 +42,12 @@ import {
   getOpenUtopiaJSXComponentsFromStateMultifile,
   isOpenFileUiJs,
 } from '../editor/store/editor-state'
-import { useEditorState } from '../editor/store/store-hook'
+import {
+  useEditorDispatch,
+  useEditorMetadata,
+  useEditorSelectedViews,
+  useEditorState,
+} from '../editor/store/store-hook'
 import {
   InspectorCallbackContext,
   InspectorPropsContext,
@@ -127,10 +132,7 @@ const AlignDistributeButton = React.memo<AlignDistributeButtonProps>(
 AlignDistributeButton.displayName = 'AlignDistributeButton'
 
 const AlignmentButtons = React.memo((props: { numberOfTargets: number }) => {
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'AlignmentButtons dispatch',
-  )
+  const dispatch = useEditorDispatch('AlignmentButtons dispatch')
   const alignSelected = React.useCallback(
     (alignment: Alignment) => {
       dispatch([alignSelectedViews(alignment)], 'everyone')
@@ -398,10 +400,7 @@ Inspector.displayName = 'Inspector'
 const DefaultStyleTargets: Array<CSSTarget> = [cssTarget(['style'], 0), cssTarget(['css'], 0)]
 
 export const InspectorEntryPoint: React.FunctionComponent = React.memo(() => {
-  const selectedViews = useEditorState(
-    React.useCallback((store) => store.editor.selectedViews, []),
-    'InspectorEntryPoint selectedViews',
-  )
+  const selectedViews = useEditorSelectedViews('InspectorEntryPoint selectedViews')
 
   return (
     <SingleInspectorEntryPoint
@@ -444,20 +443,15 @@ function updateTargets(localJSXElement: JSXElement): Array<CSSTarget> {
   return localTargets
 }
 
+const isUIJSFileSelector = (store: EditorStorePatched) => isOpenFileUiJs(store.editor)
+
 export const SingleInspectorEntryPoint: React.FunctionComponent<{
   selectedViews: Array<ElementPath>
 }> = React.memo((props) => {
   const { selectedViews } = props
-  const { dispatch, jsxMetadata, isUIJSFile } = useEditorState(
-    React.useCallback((store) => {
-      return {
-        dispatch: store.dispatch,
-        jsxMetadata: store.editor.jsxMetadata,
-        isUIJSFile: isOpenFileUiJs(store.editor),
-      }
-    }, []),
-    'SingleInspectorEntryPoint',
-  )
+  const dispatch = useEditorDispatch('SingleInspectorEntryPoint dispatch')
+  const jsxMetadata = useEditorMetadata('SingleInspectorEntryPoint metadata')
+  const isUIJSFile = useEditorState(isUIJSFileSelector, 'SingleInspectorEntryPoint isUIJSFile')
 
   let targets: Array<CSSTarget> = [...DefaultStyleTargets]
 
@@ -587,15 +581,8 @@ export const InspectorContextProvider = React.memo<{
   children: React.ReactNode
 }>((props) => {
   const { selectedViews } = props
-  const { dispatch, jsxMetadata } = useEditorState(
-    React.useCallback((store) => {
-      return {
-        dispatch: store.dispatch,
-        jsxMetadata: store.editor.jsxMetadata,
-      }
-    }, []),
-    'InspectorContextProvider',
-  )
+  const dispatch = useEditorDispatch('InspectorContextProvider dispatch')
+  const jsxMetadata = useEditorMetadata('InspectorContextProvider metadata')
 
   const rootComponents = useKeepReferenceEqualityIfPossible(
     useEditorState(rootComponentsSelector, 'InspectorContextProvider rootComponents'),

--- a/editor/src/components/inspector/sections/component-section/component-info-box.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-info-box.tsx
@@ -19,37 +19,46 @@ import { when } from '../../../../utils/react-conditionals'
 import { safeIndex } from '../../../../core/shared/array-utils'
 
 function useComponentType(path: ElementPath | null): string | null {
-  return useEditorState((store) => {
-    const metadata = store.editor.jsxMetadata
-    const elementMetadata = MetadataUtils.findElementByElementPath(metadata, path)
-    if (path != null && MetadataUtils.isProbablySceneFromMetadata(metadata, path)) {
-      return 'Scene'
-    }
-    if (path != null && MetadataUtils.isEmotionOrStyledComponent(path, metadata)) {
-      return 'Styled Component'
-    }
-    const isAnimatedComponent = isAnimatedElement(elementMetadata)
-    if (isAnimatedComponent) {
-      return 'Animated Component'
-    }
-    const isImported = isImportedComponentNPM(elementMetadata)
-    if (isImported) {
-      return 'Component'
-    }
-    const isComponent = path != null && MetadataUtils.isFocusableComponent(path, metadata)
-    return isComponent ? 'Component' : null
-  }, 'useComponentType')
+  return useEditorState(
+    React.useCallback(
+      (store) => {
+        const metadata = store.editor.jsxMetadata
+        const elementMetadata = MetadataUtils.findElementByElementPath(metadata, path)
+        if (path != null && MetadataUtils.isProbablySceneFromMetadata(metadata, path)) {
+          return 'Scene'
+        }
+        if (path != null && MetadataUtils.isEmotionOrStyledComponent(path, metadata)) {
+          return 'Styled Component'
+        }
+        const isAnimatedComponent = isAnimatedElement(elementMetadata)
+        if (isAnimatedComponent) {
+          return 'Animated Component'
+        }
+        const isImported = isImportedComponentNPM(elementMetadata)
+        if (isImported) {
+          return 'Component'
+        }
+        const isComponent = path != null && MetadataUtils.isFocusableComponent(path, metadata)
+        return isComponent ? 'Component' : null
+      },
+      [path],
+    ),
+    'useComponentType',
+  )
 }
 
 export const ComponentInfoBox = () => {
-  const dispatch = useEditorState((state) => state.dispatch, 'ComponentInfoBox dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((state) => state.dispatch, []),
+    'ComponentInfoBox dispatch',
+  )
   const selectedViews = useEditorState(
-    (store) => store.editor.selectedViews,
+    React.useCallback((store) => store.editor.selectedViews, []),
     'ComponentInfoBox selectedViews',
   )
 
   const focusedElementPath = useEditorState(
-    (store) => store.editor.focusedElementPath,
+    React.useCallback((store) => store.editor.focusedElementPath, []),
     'ComponentInfoBox focusedElementPath',
   )
 
@@ -62,45 +71,71 @@ export const ComponentInfoBox = () => {
     dispatch([setFocusedElement(isFocused ? null : target)])
   }, [dispatch, isFocused, target])
 
-  const locationOfComponentInstance = useEditorState((state) => {
-    const element = MetadataUtils.findElementByElementPath(state.editor.jsxMetadata, target)
-    const importResult = getFilePathForImportedComponent(element)
-    if (importResult == null) {
-      const underlyingTarget = normalisePathToUnderlyingTarget(
-        state.editor.projectContents,
-        state.editor.nodeModules.files,
-        state.editor.canvas.openFile?.filename ?? '',
-        target,
-      )
+  const locationOfComponentInstance = useEditorState(
+    React.useCallback(
+      (state) => {
+        const element = MetadataUtils.findElementByElementPath(state.editor.jsxMetadata, target)
+        const importResult = getFilePathForImportedComponent(element)
+        if (importResult == null) {
+          const underlyingTarget = normalisePathToUnderlyingTarget(
+            state.editor.projectContents,
+            state.editor.nodeModules.files,
+            state.editor.canvas.openFile?.filename ?? '',
+            target,
+          )
 
-      return underlyingTarget.type === 'NORMALISE_PATH_SUCCESS' ? underlyingTarget.filePath : null
-    } else {
-      return importResult
-    }
-  }, 'ComponentSectionInner locationOfComponentInstance')
+          return underlyingTarget.type === 'NORMALISE_PATH_SUCCESS'
+            ? underlyingTarget.filePath
+            : null
+        } else {
+          return importResult
+        }
+      },
+      [target],
+    ),
+    'ComponentSectionInner locationOfComponentInstance',
+  )
 
-  const componentPackageName = useEditorState((state) => {
-    const componentMetadata = MetadataUtils.findElementByElementPath(
-      state.editor.jsxMetadata,
-      target,
-    )
-    return maybeEitherToMaybe(componentMetadata?.importInfo)?.path
-  }, 'ComponentSectionInner componentPackageName')
+  const componentPackageName = useEditorState(
+    React.useCallback(
+      (state) => {
+        const componentMetadata = MetadataUtils.findElementByElementPath(
+          state.editor.jsxMetadata,
+          target,
+        )
+        return maybeEitherToMaybe(componentMetadata?.importInfo)?.path
+      },
+      [target],
+    ),
+    'ComponentSectionInner componentPackageName',
+  )
 
   const componentPackageMgrLink = `https://www.npmjs.com/package/${componentPackageName}`
 
-  const isFocusable = useEditorState((state) => {
-    return target == null
-      ? false
-      : MetadataUtils.isFocusableComponent(target, state.editor.jsxMetadata)
-  }, 'ComponentSectionInner isFocusable')
-  const isImportedComponent = useEditorState((state) => {
-    const componentMetadata = MetadataUtils.findElementByElementPath(
-      state.editor.jsxMetadata,
-      target,
-    )
-    return isImportedComponentNPM(componentMetadata)
-  }, 'ComponentSectionInner isImportedComponent')
+  const isFocusable = useEditorState(
+    React.useCallback(
+      (state) => {
+        return target == null
+          ? false
+          : MetadataUtils.isFocusableComponent(target, state.editor.jsxMetadata)
+      },
+      [target],
+    ),
+    'ComponentSectionInner isFocusable',
+  )
+  const isImportedComponent = useEditorState(
+    React.useCallback(
+      (state) => {
+        const componentMetadata = MetadataUtils.findElementByElementPath(
+          state.editor.jsxMetadata,
+          target,
+        )
+        return isImportedComponentNPM(componentMetadata)
+      },
+      [target],
+    ),
+    'ComponentSectionInner isImportedComponent',
+  )
 
   const componentType = useComponentType(target)
 

--- a/editor/src/components/inspector/sections/component-section/component-info-box.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-info-box.tsx
@@ -12,11 +12,16 @@ import { IconToggleButton } from '../../../../uuiui/icon-toggle-button'
 import { InlineButton, InlineLink } from '../../../../uuiui/inline-button'
 import { normalisePathToUnderlyingTarget } from '../../../custom-code/code-file'
 import { openCodeEditorFile, setFocusedElement } from '../../../editor/actions/action-creators'
-import { useEditorState } from '../../../editor/store/store-hook'
+import {
+  useEditorDispatch,
+  useEditorSelectedViews,
+  useEditorState,
+} from '../../../editor/store/store-hook'
 import { UIGridRow } from '../../widgets/ui-grid-row'
 import * as EP from '../../../../core/shared/element-path'
 import { when } from '../../../../utils/react-conditionals'
 import { safeIndex } from '../../../../core/shared/array-utils'
+import { EditorStorePatched } from '../../../editor/store/editor-state'
 
 function useComponentType(path: ElementPath | null): string | null {
   return useEditorState(
@@ -47,18 +52,14 @@ function useComponentType(path: ElementPath | null): string | null {
   )
 }
 
+const focusedElementPathSelector = (store: EditorStorePatched) => store.editor.focusedElementPath
+
 export const ComponentInfoBox = () => {
-  const dispatch = useEditorState(
-    React.useCallback((state) => state.dispatch, []),
-    'ComponentInfoBox dispatch',
-  )
-  const selectedViews = useEditorState(
-    React.useCallback((store) => store.editor.selectedViews, []),
-    'ComponentInfoBox selectedViews',
-  )
+  const dispatch = useEditorDispatch('ComponentInfoBox dispatch')
+  const selectedViews = useEditorSelectedViews('ComponentInfoBox selectedViews')
 
   const focusedElementPath = useEditorState(
-    React.useCallback((store) => store.editor.focusedElementPath, []),
+    focusedElementPathSelector,
     'ComponentInfoBox focusedElementPath',
   )
 

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -117,25 +117,28 @@ export const ExpressionInputPropertyControl = React.memo(
   (props: ControlForPropProps<ExpressionInputControlDescription>) => {
     const { propName, propMetadata, controlDescription } = props
     const dispatch = useEditorState(
-      (store) => store.dispatch,
+      React.useCallback((store) => store.dispatch, []),
       'ExpressionInputPropertyControl dispatch',
     )
 
-    const targetFilePaths = useEditorState((store) => {
-      const currentFilePath = forceNotNull(
-        'Missing open file',
-        store.editor.canvas.openFile?.filename,
-      )
-      return store.editor.selectedViews.map((selectedView) => {
-        const normalisedPath = normalisePathToUnderlyingTarget(
-          store.editor.projectContents,
-          store.editor.nodeModules.files,
-          currentFilePath,
-          selectedView,
+    const targetFilePaths = useEditorState(
+      React.useCallback((store) => {
+        const currentFilePath = forceNotNull(
+          'Missing open file',
+          store.editor.canvas.openFile?.filename,
         )
-        return normalisePathSuccessOrThrowError(normalisedPath).filePath
-      })
-    }, 'ExpressionInputPropertyControl targetFilePaths')
+        return store.editor.selectedViews.map((selectedView) => {
+          const normalisedPath = normalisePathToUnderlyingTarget(
+            store.editor.projectContents,
+            store.editor.nodeModules.files,
+            currentFilePath,
+            selectedView,
+          )
+          return normalisePathSuccessOrThrowError(normalisedPath).filePath
+        })
+      }, []),
+      'ExpressionInputPropertyControl targetFilePaths',
+    )
 
     const controlId = `${propName}-expression-input-property-control`
     const value = propMetadata.propertyStatus.set ? propMetadata.value : undefined
@@ -228,29 +231,35 @@ export const PopUpListPropertyControl = React.memo(
 export const ExpressionPopUpListPropertyControl = React.memo(
   (props: ControlForPropProps<ExpressionPopUpListControlDescription>) => {
     const dispatch = useEditorState(
-      (store) => store.dispatch,
+      React.useCallback((store) => store.dispatch, []),
       'ExpressionPopUpListPropertyControl dispatch',
     )
     const selectedViews = useEditorState(
-      (store) => store.editor.selectedViews,
+      React.useCallback((store) => store.editor.selectedViews, []),
       'ExpressionPopUpListPropertyControl selectedViews',
     )
 
-    const targetFilePaths = useEditorState((store) => {
-      const currentFilePath = forceNotNull(
-        'Missing open file',
-        store.editor.canvas.openFile?.filename,
-      )
-      return selectedViews.map((selectedView) => {
-        const normalisedPath = normalisePathToUnderlyingTarget(
-          store.editor.projectContents,
-          store.editor.nodeModules.files,
-          currentFilePath,
-          selectedView,
-        )
-        return normalisePathSuccessOrThrowError(normalisedPath).filePath
-      })
-    }, 'ExpressionPopUpListPropertyControl targetFilePaths')
+    const targetFilePaths = useEditorState(
+      React.useCallback(
+        (store) => {
+          const currentFilePath = forceNotNull(
+            'Missing open file',
+            store.editor.canvas.openFile?.filename,
+          )
+          return selectedViews.map((selectedView) => {
+            const normalisedPath = normalisePathToUnderlyingTarget(
+              store.editor.projectContents,
+              store.editor.nodeModules.files,
+              currentFilePath,
+              selectedView,
+            )
+            return normalisePathSuccessOrThrowError(normalisedPath).filePath
+          })
+        },
+        [selectedViews],
+      ),
+      'ExpressionPopUpListPropertyControl targetFilePaths',
+    )
 
     const target = forceNotNull('Inspector control without selected element', selectedViews[0])
     const { propMetadata, controlDescription } = props

--- a/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
@@ -35,7 +35,10 @@ export const PropertyControlsSection = React.memo((props: PropertyControlsSectio
     }),
   )
 
-  const dispatch = useEditorState((state) => state.dispatch, 'ComponentSectionInner')
+  const dispatch = useEditorState(
+    React.useCallback((state) => state.dispatch, []),
+    'ComponentSectionInner',
+  )
   const setGlobalCursor = React.useCallback(
     (cursor: CSSCursor | null) => {
       dispatch([setCursorOverlay(cursor)], 'everyone')

--- a/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { PropertyControls } from 'utopia-api/core'
-import { useEditorState } from '../../../editor/store/store-hook'
+import { useEditorDispatch } from '../../../editor/store/store-hook'
 import { setCursorOverlay } from '../../../editor/actions/action-creators'
 import { useKeepReferenceEqualityIfPossible } from '../../../../utils/react-performance'
 import { useHiddenElements } from './hidden-controls-section'
@@ -35,10 +35,7 @@ export const PropertyControlsSection = React.memo((props: PropertyControlsSectio
     }),
   )
 
-  const dispatch = useEditorState(
-    React.useCallback((state) => state.dispatch, []),
-    'ComponentSectionInner',
-  )
+  const dispatch = useEditorDispatch('ComponentSectionInner')
   const setGlobalCursor = React.useCallback(
     (cursor: CSSCursor | null) => {
       dispatch([setCursorOverlay(cursor)], 'everyone')

--- a/editor/src/components/inspector/sections/header-section/target-selector.tsx
+++ b/editor/src/components/inspector/sections/header-section/target-selector.tsx
@@ -18,7 +18,7 @@ import {
   UIRow,
 } from '../../../../uuiui'
 import { ContextMenuWrapper } from '../../../../uuiui-deps'
-import { useEditorState } from '../../../editor/store/store-hook'
+import { useEditorDispatch } from '../../../editor/store/store-hook'
 import { ExpandableIndicator } from '../../../navigator/navigator-item/expandable-indicator'
 
 export type TargetSelectorLength = number | 'mixed'
@@ -245,10 +245,7 @@ const TargetListItem = React.memo((props: TargetListItemProps) => {
   const [itemBeingRenamedId, setItemBeingRenamedId] = React.useState<number | null>(null)
   const [renameValue, setRenameValue] = React.useState<string | null>(null)
 
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'TargetListItem',
-  )
+  const dispatch = useEditorDispatch('TargetListItem')
 
   const startRename = React.useCallback(() => {
     setItemBeingRenamedId(fixedItemIndex)

--- a/editor/src/components/inspector/sections/header-section/target-selector.tsx
+++ b/editor/src/components/inspector/sections/header-section/target-selector.tsx
@@ -245,10 +245,8 @@ const TargetListItem = React.memo((props: TargetListItemProps) => {
   const [itemBeingRenamedId, setItemBeingRenamedId] = React.useState<number | null>(null)
   const [renameValue, setRenameValue] = React.useState<string | null>(null)
 
-  const { dispatch } = useEditorState(
-    (store) => ({
-      dispatch: store.dispatch,
-    }),
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
     'TargetListItem',
   )
 

--- a/editor/src/components/inspector/sections/image-section/image-section.tsx
+++ b/editor/src/components/inspector/sections/image-section/image-section.tsx
@@ -4,7 +4,7 @@ import { emptySpecialSizeMeasurements } from '../../../../core/shared/element-te
 import * as PP from '../../../../core/shared/property-path'
 import utils from '../../../../utils/utils'
 import { InspectorContextMenuWrapper } from '../../../context-menu-wrapper'
-import { useEditorState } from '../../../editor/store/store-hook'
+import { useEditorDispatch, useEditorState } from '../../../editor/store/store-hook'
 import { StringControl } from '../../controls/string-control'
 import { addOnUnsetValues } from '../../common/context-menu-items'
 import {
@@ -22,31 +22,25 @@ import {
   FunctionIcons,
   InspectorSectionIcons,
 } from '../../../../uuiui'
+import { EditorStorePatched } from '../../../editor/store/editor-state'
 
 const imgSrcProp = [PP.create(['src'])]
 const imgAltProp = [PP.create(['alt'])]
 
+const firstElementInstanceMetadataSelector = (store: EditorStorePatched) =>
+  MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, store.editor.selectedViews[0])
+
 export const ImgSection = React.memo(() => {
   const colorTheme = useColorTheme()
   const selectedViews = useSelectedViews()
+  const dispatch = useEditorDispatch('ImgSection dispatch')
 
-  const { dispatch, zerothElementInstanceMetadata } = useEditorState(
-    React.useCallback(
-      (store) => {
-        return {
-          dispatch: store.dispatch,
-          zerothElementInstanceMetadata: MetadataUtils.findElementByElementPath(
-            store.editor.jsxMetadata,
-            selectedViews[0],
-          ),
-        }
-      },
-      [selectedViews],
-    ),
-    'ImgSection',
+  const firstElementInstanceMetadata = useEditorState(
+    firstElementInstanceMetadataSelector,
+    'ImgSection firstElementInstanceMetadata',
   )
   const { naturalWidth, naturalHeight, clientWidth, clientHeight } =
-    zerothElementInstanceMetadata?.specialSizeMeasurements ?? emptySpecialSizeMeasurements
+    firstElementInstanceMetadata?.specialSizeMeasurements ?? emptySpecialSizeMeasurements
   const {
     value: srcValue,
     controlStyles: srcControlStyles,

--- a/editor/src/components/inspector/sections/image-section/image-section.tsx
+++ b/editor/src/components/inspector/sections/image-section/image-section.tsx
@@ -30,15 +30,21 @@ export const ImgSection = React.memo(() => {
   const colorTheme = useColorTheme()
   const selectedViews = useSelectedViews()
 
-  const { dispatch, zerothElementInstanceMetadata } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      zerothElementInstanceMetadata: MetadataUtils.findElementByElementPath(
-        store.editor.jsxMetadata,
-        selectedViews[0],
-      ),
-    }
-  }, 'ImgSection')
+  const { dispatch, zerothElementInstanceMetadata } = useEditorState(
+    React.useCallback(
+      (store) => {
+        return {
+          dispatch: store.dispatch,
+          zerothElementInstanceMetadata: MetadataUtils.findElementByElementPath(
+            store.editor.jsxMetadata,
+            selectedViews[0],
+          ),
+        }
+      },
+      [selectedViews],
+    ),
+    'ImgSection',
+  )
   const { naturalWidth, naturalHeight, clientWidth, clientHeight } =
     zerothElementInstanceMetadata?.specialSizeMeasurements ?? emptySpecialSizeMeasurements
   const {

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -5,13 +5,7 @@ import { FlexDirection } from 'utopia-api/core'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { OptionChainControl, OptionChainOption } from '../../../controls/option-chain-control'
 import { SliderControl, DEPRECATEDSliderControlOptions } from '../../../controls/slider-control'
-import {
-  InspectorPropsContext,
-  stylePropPathMappingFn,
-  useInspectorInfoSimpleUntyped,
-  useInspectorLayoutInfo,
-  useInspectorStyleInfo,
-} from '../../../common/property-path-hooks'
+import { InspectorPropsContext, stylePropPathMappingFn } from '../../../common/property-path-hooks'
 import { SelectOption } from '../../../controls/select-control'
 import { OptionsType } from 'react-select'
 import { unsetPropertyMenuItem } from '../../../common/context-menu-items'

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -103,9 +103,12 @@ interface FlexAlignItemsControlProps extends FlexFieldControlProps<FlexAlignment
 }
 
 export const FlexAlignItemsControl = React.memo((props: FlexAlignItemsControlProps) => {
-  const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
+  const targetPath = useContextSelector(
+    InspectorPropsContext,
+    React.useCallback((contextData) => {
+      return contextData.targetPath
+    }, []),
+  )
   const alignItemsProp = React.useMemo(() => {
     return [stylePropPathMappingFn('alignItems', targetPath)]
   }, [targetPath])
@@ -243,9 +246,12 @@ export const FlexGapControl = React.memo((props: FlexGapControlProps) => {
     props.onTransientSubmitValue,
     props.onUnset,
   )
-  const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
+  const targetPath = useContextSelector(
+    InspectorPropsContext,
+    React.useCallback((contextData) => {
+      return contextData.targetPath
+    }, []),
+  )
   const flexGapProp = React.useMemo(() => {
     return [stylePropPathMappingFn('gap', targetPath)]
   }, [targetPath])

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -5,7 +5,11 @@ import { FlexDirection } from 'utopia-api/core'
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { OptionChainControl, OptionChainOption } from '../../../controls/option-chain-control'
 import { SliderControl, DEPRECATEDSliderControlOptions } from '../../../controls/slider-control'
-import { InspectorPropsContext, stylePropPathMappingFn } from '../../../common/property-path-hooks'
+import {
+  InspectorPropsContext,
+  InspectorPropsContextTargetPathSelector,
+  stylePropPathMappingFn,
+} from '../../../common/property-path-hooks'
 import { SelectOption } from '../../../controls/select-control'
 import { OptionsType } from 'react-select'
 import { unsetPropertyMenuItem } from '../../../common/context-menu-items'
@@ -105,9 +109,7 @@ interface FlexAlignItemsControlProps extends FlexFieldControlProps<FlexAlignment
 export const FlexAlignItemsControl = React.memo((props: FlexAlignItemsControlProps) => {
   const targetPath = useContextSelector(
     InspectorPropsContext,
-    React.useCallback((contextData) => {
-      return contextData.targetPath
-    }, []),
+    InspectorPropsContextTargetPathSelector,
   )
   const alignItemsProp = React.useMemo(() => {
     return [stylePropPathMappingFn('alignItems', targetPath)]
@@ -248,9 +250,7 @@ export const FlexGapControl = React.memo((props: FlexGapControlProps) => {
   )
   const targetPath = useContextSelector(
     InspectorPropsContext,
-    React.useCallback((contextData) => {
-      return contextData.targetPath
-    }, []),
+    InspectorPropsContextTargetPathSelector,
   )
   const flexGapProp = React.useMemo(() => {
     return [stylePropPathMappingFn('gap', targetPath)]

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-subsection.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FlexWrap } from 'utopia-api/core'
 import { ControlStatus, ControlStyles, getControlStyles } from '../../../common/control-status'
-import { useInspectorLayoutInfo, useInspectorStyleInfo } from '../../../common/property-path-hooks'
+import { useInspectorLayoutInfo } from '../../../common/property-path-hooks'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import {
   FlexAlignContentControl,

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-controls.tsx
@@ -6,6 +6,7 @@ import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { addSetProperty, unsetPropertyMenuItem } from '../../../common/context-menu-items'
 import {
   InspectorPropsContext,
+  InspectorPropsContextTargetPathSelector,
   stylePropPathMappingFn,
   useInspectorLayoutInfo,
 } from '../../../common/property-path-hooks'
@@ -74,9 +75,7 @@ export const AlignSelfControl = React.memo((props: AlignSelfControlProps) => {
   const alignSelf = useInspectorLayoutInfo('alignSelf')
   const targetPath = useContextSelector(
     InspectorPropsContext,
-    React.useCallback((contextData) => {
-      return contextData.targetPath
-    }, []),
+    InspectorPropsContextTargetPathSelector,
   )
   const alignSelfProp = React.useMemo(() => {
     return [stylePropPathMappingFn('alignSelf', targetPath)]

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-controls.tsx
@@ -72,9 +72,12 @@ interface AlignSelfControlProps {
 
 export const AlignSelfControl = React.memo((props: AlignSelfControlProps) => {
   const alignSelf = useInspectorLayoutInfo('alignSelf')
-  const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
+  const targetPath = useContextSelector(
+    InspectorPropsContext,
+    React.useCallback((contextData) => {
+      return contextData.targetPath
+    }, []),
+  )
   const alignSelfProp = React.useMemo(() => {
     return [stylePropPathMappingFn('alignSelf', targetPath)]
   }, [targetPath])

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -22,6 +22,7 @@ import { when } from '../../../../../utils/react-conditionals'
 import {
   InspectorCallbackContext,
   InspectorPropsContext,
+  InspectorPropsContextTargetPathSelector,
   stylePropPathMappingFn,
   useInspectorLayoutInfo,
 } from '../../../common/property-path-hooks'
@@ -42,9 +43,7 @@ function buildMarginProps(propertyTarget: ReadonlyArray<string>): Array<Property
 export const FlexElementSubsection = React.memo(() => {
   const targetPath = useContextSelector(
     InspectorPropsContext,
-    React.useCallback((contextData) => {
-      return contextData.targetPath
-    }, []),
+    InspectorPropsContextTargetPathSelector,
   )
   const marginProps = React.useMemo(() => {
     return buildMarginProps(targetPath)
@@ -196,9 +195,7 @@ function buildMainAxisAdvancedProps(propertyTarget: ReadonlyArray<string>): Prop
 const FixedSubsectionControls = React.memo((props: FlexElementSubsectionProps) => {
   const targetPath = useContextSelector(
     InspectorPropsContext,
-    React.useCallback((contextData) => {
-      return contextData.targetPath
-    }, []),
+    InspectorPropsContextTargetPathSelector,
   )
   const mainAxisFixedProps = React.useMemo(() => {
     return buildMainAxisFixedProps(targetPath, props.parentFlexDirection)
@@ -232,9 +229,7 @@ const FixedSubsectionControls = React.memo((props: FlexElementSubsectionProps) =
 const AdvancedSubsectionControls = React.memo((props: FlexElementSubsectionProps) => {
   const targetPath = useContextSelector(
     InspectorPropsContext,
-    React.useCallback((contextData) => {
-      return contextData.targetPath
-    }, []),
+    InspectorPropsContextTargetPathSelector,
   )
   const mainAxisAdvancedProps = React.useMemo(() => {
     return buildMainAxisAdvancedProps(targetPath)

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -40,9 +40,12 @@ function buildMarginProps(propertyTarget: ReadonlyArray<string>): Array<Property
 }
 
 export const FlexElementSubsection = React.memo(() => {
-  const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
+  const targetPath = useContextSelector(
+    InspectorPropsContext,
+    React.useCallback((contextData) => {
+      return contextData.targetPath
+    }, []),
+  )
   const marginProps = React.useMemo(() => {
     return buildMarginProps(targetPath)
   }, [targetPath])
@@ -191,9 +194,12 @@ function buildMainAxisAdvancedProps(propertyTarget: ReadonlyArray<string>): Prop
 }
 
 const FixedSubsectionControls = React.memo((props: FlexElementSubsectionProps) => {
-  const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
+  const targetPath = useContextSelector(
+    InspectorPropsContext,
+    React.useCallback((contextData) => {
+      return contextData.targetPath
+    }, []),
+  )
   const mainAxisFixedProps = React.useMemo(() => {
     return buildMainAxisFixedProps(targetPath, props.parentFlexDirection)
   }, [targetPath, props.parentFlexDirection])
@@ -224,9 +230,12 @@ const FixedSubsectionControls = React.memo((props: FlexElementSubsectionProps) =
 })
 
 const AdvancedSubsectionControls = React.memo((props: FlexElementSubsectionProps) => {
-  const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
+  const targetPath = useContextSelector(
+    InspectorPropsContext,
+    React.useCallback((contextData) => {
+      return contextData.targetPath
+    }, []),
+  )
   const mainAxisAdvancedProps = React.useMemo(() => {
     return buildMainAxisAdvancedProps(targetPath)
   }, [targetPath])

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -26,7 +26,6 @@ import {
   useInspectorLayoutInfo,
 } from '../../../common/property-path-hooks'
 import { isNotUnsetDefaultOrDetected } from '../../../common/control-status'
-import { useEditorState } from '../../../../editor/store/store-hook'
 import { PropertyPath } from '../../../../../core/shared/project-file-types'
 import { usePropControlledStateV2 } from '../../../common/inspector-utils'
 import { useContextSelector } from 'use-context-selector'

--- a/editor/src/components/inspector/sections/layout-section/layout-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-section.tsx
@@ -18,7 +18,7 @@ interface LayoutSectionProps {
 
 export const LayoutSection = React.memo((props: LayoutSectionProps) => {
   const specialSizeMeasurements = useEditorState(
-    (state) => {
+    React.useCallback((state) => {
       let foundSpecialSizeMeasurements = emptySpecialSizeMeasurements
       fastForEach(state.editor.selectedViews, (path) => {
         // TODO multiselect
@@ -29,12 +29,15 @@ export const LayoutSection = React.memo((props: LayoutSectionProps) => {
         }
       })
       return foundSpecialSizeMeasurements
-    },
+    }, []),
     'LayoutSection specialSizeMeasurements',
     (old, next) => SpecialSizeMeasurementsKeepDeepEquality()(old, next).areEqual,
   )
 
-  const dispatch = useEditorState((store) => store.dispatch, 'LayoutSection dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'LayoutSection dispatch',
+  )
 
   return (
     <div

--- a/editor/src/components/inspector/sections/layout-section/layout-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-section.tsx
@@ -31,7 +31,10 @@ export const LayoutSection = React.memo((props: LayoutSectionProps) => {
       return foundSpecialSizeMeasurements
     }, []),
     'LayoutSection specialSizeMeasurements',
-    (old, next) => SpecialSizeMeasurementsKeepDeepEquality()(old, next).areEqual,
+    React.useCallback(
+      (old, next) => SpecialSizeMeasurementsKeepDeepEquality()(old, next).areEqual,
+      [],
+    ),
   )
 
   const dispatch = useEditorState(

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -5,7 +5,6 @@ import { OptionChainControl } from '../../../controls/option-chain-control'
 import {
   useInspectorLayoutInfo,
   InspectorCallbackContext,
-  useInspectorInfo,
   useInspectorStyleInfo,
   InspectorInfo,
   stylePropPathMappingFn,

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -73,9 +73,12 @@ export function useLayoutSystemData() {
     React.useCallback((store) => store.dispatch, []),
     'useLayoutSystemData dispatch',
   )
-  const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
+  const targetPath = useContextSelector(
+    InspectorPropsContext,
+    React.useCallback((contextData) => {
+      return contextData.targetPath
+    }, []),
+  )
   const onLayoutSystemChange = React.useCallback(
     (layoutSystem: SettableLayoutSystem) => {
       switch (layoutSystem) {
@@ -272,9 +275,12 @@ function layoutSystemConfigPropertyPaths(
 
 function useDeleteAllLayoutConfig() {
   const { onUnsetValue } = React.useContext(InspectorCallbackContext)
-  const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
+  const targetPath = useContextSelector(
+    InspectorPropsContext,
+    React.useCallback((contextData) => {
+      return contextData.targetPath
+    }, []),
+  )
   return React.useCallback(() => {
     onUnsetValue(layoutSystemConfigPropertyPaths(targetPath), false)
   }, [onUnsetValue, targetPath])

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -70,7 +70,10 @@ function useDefaultedLayoutSystemInfo(): {
 }
 
 export function useLayoutSystemData() {
-  const dispatch = useEditorState((store) => store.dispatch, 'useLayoutSystemData dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'useLayoutSystemData dispatch',
+  )
   const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
     return contextData.targetPath
   })

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -9,8 +9,9 @@ import {
   InspectorInfo,
   stylePropPathMappingFn,
   InspectorPropsContext,
+  InspectorPropsContextTargetPathSelector,
 } from '../../../common/property-path-hooks'
-import { useEditorState } from '../../../../editor/store/store-hook'
+import { useEditorDispatch } from '../../../../editor/store/store-hook'
 import { switchLayoutSystem } from '../../../../editor/actions/action-creators'
 import {
   getControlStatusFromPropertyStatus,
@@ -69,15 +70,10 @@ function useDefaultedLayoutSystemInfo(): {
 }
 
 export function useLayoutSystemData() {
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'useLayoutSystemData dispatch',
-  )
+  const dispatch = useEditorDispatch('useLayoutSystemData dispatch')
   const targetPath = useContextSelector(
     InspectorPropsContext,
-    React.useCallback((contextData) => {
-      return contextData.targetPath
-    }, []),
+    InspectorPropsContextTargetPathSelector,
   )
   const onLayoutSystemChange = React.useCallback(
     (layoutSystem: SettableLayoutSystem) => {
@@ -277,9 +273,7 @@ function useDeleteAllLayoutConfig() {
   const { onUnsetValue } = React.useContext(InspectorCallbackContext)
   const targetPath = useContextSelector(
     InspectorPropsContext,
-    React.useCallback((contextData) => {
-      return contextData.targetPath
-    }, []),
+    InspectorPropsContextTargetPathSelector,
   )
   return React.useCallback(() => {
     onUnsetValue(layoutSystemConfigPropertyPaths(targetPath), false)

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -21,6 +21,7 @@ import { FramePinsInfo, usePinToggling } from '../../../common/layout-property-p
 import {
   InspectorInfo,
   InspectorPropsContext,
+  InspectorPropsContextData,
   stylePropPathMappingFn,
   useInspectorLayoutInfo,
 } from '../../../common/property-path-hooks'
@@ -408,13 +409,15 @@ const WidthHeightRow = React.memo((props: WidthHeightRowProps) => {
   )
 })
 
+const minimumsPropsSelector = (contextData: InspectorPropsContextData) => {
+  return [
+    stylePropPathMappingFn('minWidth', contextData.targetPath),
+    stylePropPathMappingFn('minHeight', contextData.targetPath),
+  ]
+}
+
 const MinimumsRow = React.memo(() => {
-  const minimumsProps = useContextSelector(InspectorPropsContext, (contextData) => {
-    return [
-      stylePropPathMappingFn('minWidth', contextData.targetPath),
-      stylePropPathMappingFn('minHeight', contextData.targetPath),
-    ]
-  })
+  const minimumsProps = useContextSelector(InspectorPropsContext, minimumsPropsSelector)
 
   return (
     <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
@@ -429,13 +432,15 @@ const MinimumsRow = React.memo(() => {
   )
 })
 
+const maximumsPropsSelector = (contextData: InspectorPropsContextData) => {
+  return [
+    stylePropPathMappingFn('maxWidth', contextData.targetPath),
+    stylePropPathMappingFn('maxHeight', contextData.targetPath),
+  ]
+}
+
 const MaximumsRow = React.memo(() => {
-  const maximumsProps = useContextSelector(InspectorPropsContext, (contextData) => {
-    return [
-      stylePropPathMappingFn('maxWidth', contextData.targetPath),
-      stylePropPathMappingFn('maxHeight', contextData.targetPath),
-    ]
-  })
+  const maximumsProps = useContextSelector(InspectorPropsContext, maximumsPropsSelector)
 
   return (
     <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
@@ -450,13 +455,18 @@ const MaximumsRow = React.memo(() => {
   )
 })
 
+const flexWidthHeightPropsSelector = (contextData: InspectorPropsContextData) => {
+  return [
+    stylePropPathMappingFn('maxWidth', contextData.targetPath),
+    stylePropPathMappingFn('maxHeight', contextData.targetPath),
+  ]
+}
+
 const FlexWidthHeightRow = React.memo(() => {
-  const flexWidthHeightProps = useContextSelector(InspectorPropsContext, (contextData) => {
-    return [
-      stylePropPathMappingFn('maxWidth', contextData.targetPath),
-      stylePropPathMappingFn('maxHeight', contextData.targetPath),
-    ]
-  })
+  const flexWidthHeightProps = useContextSelector(
+    InspectorPropsContext,
+    flexWidthHeightPropsSelector,
+  )
 
   return (
     <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>
@@ -471,13 +481,15 @@ const FlexWidthHeightRow = React.memo(() => {
   )
 })
 
+const flexGrowShrinkPropsSelector = (contextData: InspectorPropsContextData) => {
+  return [
+    stylePropPathMappingFn('flexGrow', contextData.targetPath),
+    stylePropPathMappingFn('flexShrink', contextData.targetPath),
+  ]
+}
+
 const FlexGrowShrinkRow = React.memo(() => {
-  const flexGrowShrinkProps = useContextSelector(InspectorPropsContext, (contextData) => {
-    return [
-      stylePropPathMappingFn('flexGrow', contextData.targetPath),
-      stylePropPathMappingFn('flexShrink', contextData.targetPath),
-    ]
-  })
+  const flexGrowShrinkProps = useContextSelector(InspectorPropsContext, flexGrowShrinkPropsSelector)
 
   return (
     <UIGridRow padded={true} variant='<---1fr--->|------172px-------|'>

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -159,9 +159,6 @@ interface FlexShorthandNumberControlProps {
 }
 
 export const FlexShorthandNumberControl = React.memo((props: FlexShorthandNumberControlProps) => {
-  const propertyTarget = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
   const layoutPropInfo = useInspectorInfoLonghandShorthand(
     ['flexGrow', 'flexShrink', 'flexBasis'],
     'flex',
@@ -203,9 +200,6 @@ interface FlexShorthandCSSNumberControlProps {
 }
 export const FlexBasisShorthandCSSNumberControl = React.memo(
   (props: FlexShorthandCSSNumberControlProps) => {
-    const propertyTarget = useContextSelector(InspectorPropsContext, (contextData) => {
-      return contextData.targetPath
-    })
     const layoutPropInfo = useInspectorInfoLonghandShorthand(
       ['flexGrow', 'flexShrink', 'flexBasis'],
       'flex',

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../../../uuiui'
 import { usePropControlledState } from '../../../../../uuiui-deps'
 import { InlineIndicator, InlineLink } from '../../../../../uuiui/inline-button'
-import { useEditorState, useRefEditorState } from '../../../../editor/store/store-hook'
+import { useEditorState } from '../../../../editor/store/store-hook'
 import { ExpandableIndicator } from '../../../../navigator/navigator-item/expandable-indicator'
 import { CSSPosition } from '../../../common/css-utils'
 import * as EP from '../../../../../core/shared/element-path'
@@ -263,16 +263,22 @@ interface ParentIndicatorAndLinkProps {
   style?: React.CSSProperties
 }
 const ParentIndicatorAndLink = (props: ParentIndicatorAndLinkProps) => {
-  const parentPath = useEditorState((store) => {
-    if (store.editor.selectedViews.length !== 1) {
-      return null
-    }
-    const target = store.editor.selectedViews[0]
-    const parent = EP.parentPath(target)
-    return EP.isStoryboardPath(parent) ? null : parent
-  }, 'ParentIndicatorAndLink parentPath')
+  const parentPath = useEditorState(
+    React.useCallback((store) => {
+      if (store.editor.selectedViews.length !== 1) {
+        return null
+      }
+      const target = store.editor.selectedViews[0]
+      const parent = EP.parentPath(target)
+      return EP.isStoryboardPath(parent) ? null : parent
+    }, []),
+    'ParentIndicatorAndLink parentPath',
+  )
 
-  const dispatch = useEditorState((store) => store.dispatch, 'ParentIndicatorAndLink dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'ParentIndicatorAndLink dispatch',
+  )
 
   const handleClick = React.useCallback(() => {
     if (parentPath != null) {
@@ -302,23 +308,26 @@ const ParentIndicatorAndLink = (props: ParentIndicatorAndLinkProps) => {
 }
 
 function useElementHasChildrenOrContent() {
-  return useEditorState((store) => {
-    if (store.editor.selectedViews.length !== 1) {
-      return {
-        hasChildren: false,
-        hasContent: false,
+  return useEditorState(
+    React.useCallback((store) => {
+      if (store.editor.selectedViews.length !== 1) {
+        return {
+          hasChildren: false,
+          hasContent: false,
+        }
       }
-    }
-    const element = MetadataUtils.findElementByElementPath(
-      store.editor.jsxMetadata,
-      store.editor.selectedViews[0],
-    )
-    const textContent = element != null ? MetadataUtils.getTextContentOfElement(element) : null
-    return {
-      hasChildren: (element?.specialSizeMeasurements.renderedChildrenCount ?? 0) > 0,
-      hasContent: textContent != null && textContent.length > 0,
-    }
-  }, 'ChildrenLink children')
+      const element = MetadataUtils.findElementByElementPath(
+        store.editor.jsxMetadata,
+        store.editor.selectedViews[0],
+      )
+      const textContent = element != null ? MetadataUtils.getTextContentOfElement(element) : null
+      return {
+        hasChildren: (element?.specialSizeMeasurements.renderedChildrenCount ?? 0) > 0,
+        hasContent: textContent != null && textContent.length > 0,
+      }
+    }, []),
+    'ChildrenLink children',
+  )
 }
 
 const ChildrenOrContentIndicator = () => {

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -186,9 +186,12 @@ function selfLayoutConfigPropertyPaths(propertyTarget: ReadonlyArray<string>): A
 }
 
 function useDeleteAllSelfLayoutConfig() {
-  const propertyTarget = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
+  const propertyTarget = useContextSelector(
+    InspectorPropsContext,
+    React.useCallback((contextData) => {
+      return contextData.targetPath
+    }, []),
+  )
   const { onUnsetValue } = React.useContext(InspectorCallbackContext)
   return React.useCallback(() => {
     onUnsetValue(selfLayoutConfigPropertyPaths(propertyTarget), false)
@@ -196,9 +199,12 @@ function useDeleteAllSelfLayoutConfig() {
 }
 
 function useAddPositionAbsolute() {
-  const propertyTarget = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
+  const propertyTarget = useContextSelector(
+    InspectorPropsContext,
+    React.useCallback((contextData) => {
+      return contextData.targetPath
+    }, []),
+  )
   const { onSubmitValue } = React.useContext(InspectorCallbackContext)
   return React.useCallback(() => {
     onSubmitValue(

--- a/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
+++ b/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
@@ -76,21 +76,28 @@ const FeatureSwitchRow = React.memo((props: { name: FeatureName }) => {
 
 export const SettingsPanel = React.memo(() => {
   const colorTheme = useColorTheme()
-  const dispatch = useEditorState((store) => store.dispatch, 'SettingsPanel dispatch')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'SettingsPanel dispatch',
+  )
   const interfaceDesigner = useEditorState(
-    (store) => store.editor.interfaceDesigner,
+    React.useCallback((store) => store.editor.interfaceDesigner, []),
     'SettingsPanel interfaceDesigner',
   )
 
-  const entireStateRef = useRefEditorState((store) => store)
+  const entireStateRef = useRefEditorState(React.useCallback((store) => store, []))
 
-  const openUiJsFile = useRefEditorState((store) => {
-    return getOpenUIJSFile(store.editor)
-  })
+  const openUiJsFile = useRefEditorState(
+    React.useCallback((store) => {
+      return getOpenUIJSFile(store.editor)
+    }, []),
+  )
 
-  const jsxMetadata = useRefEditorState((store) => {
-    return store.editor.jsxMetadata
-  })
+  const jsxMetadata = useRefEditorState(
+    React.useCallback((store) => {
+      return store.editor.jsxMetadata
+    }, []),
+  )
 
   const toggleCodeEditorVisible = React.useCallback(() => {
     dispatch([EditorActions.toggleInterfaceDesignerCodeEditor()])

--- a/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
+++ b/editor/src/components/inspector/sections/settings-panel/inspector-settingspanel.tsx
@@ -4,14 +4,19 @@ import React from 'react'
 import { jsx } from '@emotion/react'
 import * as EditorActions from '../../../editor/actions/action-creators'
 import styled from '@emotion/styled'
-import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
+import {
+  useEditorDispatch,
+  useEditorState,
+  useRefEditorMetadata,
+  useRefEditorState,
+} from '../../../editor/store/store-hook'
 import {
   FeatureName,
   toggleFeatureEnabled,
   isFeatureEnabled,
   AllFeatureNames,
 } from '../../../../utils/feature-switches'
-import { getOpenUIJSFile } from '../../../editor/store/editor-state'
+import { EditorStorePatched, getOpenUIJSFile } from '../../../editor/store/editor-state'
 import {
   FlexRow,
   UtopiaTheme,
@@ -26,7 +31,7 @@ import {
 import { getControlStyles } from '../../../../uuiui-deps'
 import { load } from '../../../editor/actions/actions'
 import json5 from 'json5'
-import { NO_OP } from '../../../../core/shared/utils'
+import { identity, NO_OP } from '../../../../core/shared/utils'
 import { InspectorInputEmotionStyle } from '../../../../uuiui/inputs/base-input'
 
 const StyledFlexRow = styled(FlexRow)({
@@ -74,30 +79,22 @@ const FeatureSwitchRow = React.memo((props: { name: FeatureName }) => {
   )
 })
 
+const interfaceDesignerSelector = (store: EditorStorePatched) => store.editor.interfaceDesigner
+const openUiJsFileSelector = (store: EditorStorePatched) => getOpenUIJSFile(store.editor)
+
 export const SettingsPanel = React.memo(() => {
   const colorTheme = useColorTheme()
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'SettingsPanel dispatch',
-  )
+  const dispatch = useEditorDispatch('SettingsPanel dispatch')
   const interfaceDesigner = useEditorState(
-    React.useCallback((store) => store.editor.interfaceDesigner, []),
+    interfaceDesignerSelector,
     'SettingsPanel interfaceDesigner',
   )
 
-  const entireStateRef = useRefEditorState(React.useCallback((store) => store, []))
+  const entireStateRef = useRefEditorState(identity)
 
-  const openUiJsFile = useRefEditorState(
-    React.useCallback((store) => {
-      return getOpenUIJSFile(store.editor)
-    }, []),
-  )
+  const openUiJsFile = useRefEditorState(openUiJsFileSelector)
 
-  const jsxMetadata = useRefEditorState(
-    React.useCallback((store) => {
-      return store.editor.jsxMetadata
-    }, []),
-  )
+  const jsxMetadata = useRefEditorMetadata()
 
   const toggleCodeEditorVisible = React.useCallback(() => {
     dispatch([EditorActions.toggleInterfaceDesignerCodeEditor()])

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -170,10 +170,10 @@ const Input = (props: InputProps) => {
 }
 
 const ClassNameControl = React.memo(() => {
-  const editorStoreRef = useRefEditorState((store) => store)
+  const editorStoreRef = useRefEditorState(React.useCallback((store) => store, []))
   const theme = useColorTheme()
   const targets = useEditorState(
-    (store) => store.editor.selectedViews,
+    React.useCallback((store) => store.editor.selectedViews, []),
     'ClassNameSubsection targets',
   )
   const dispatch = useEditorState((store) => store.dispatch, 'ClassNameSubsection dispatch')
@@ -185,7 +185,7 @@ const ClassNameControl = React.memo(() => {
   const focusedValueRef = React.useRef<string | null>(null)
 
   const focusTriggerCount = useEditorState(
-    (store) => store.editor.inspector.classnameFocusCounter,
+    React.useCallback((store) => store.editor.inspector.classnameFocusCounter, []),
     'ClassNameSubsection classnameFocusCounter',
   )
   const inputRef = useInputFocusOnCountIncrease<CreatableSelect<TailWindOption>>(focusTriggerCount)

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../../../core/shared/atom-with-pub-sub'
 import { emptyComments, jsxAttributeValue } from '../../../../../core/shared/element-template'
 import * as PP from '../../../../../core/shared/property-path'
+import { identity } from '../../../../../core/shared/utils'
 import {
   getTailwindOptionForClassName,
   LabelWithStripes,
@@ -42,7 +43,13 @@ import {
   REDO_CHANGES_SHORTCUT,
   UNDO_CHANGES_SHORTCUT,
 } from '../../../../editor/shortcut-definitions'
-import { useEditorState, useRefEditorState } from '../../../../editor/store/store-hook'
+import { EditorStorePatched } from '../../../../editor/store/editor-state'
+import {
+  useEditorDispatch,
+  useEditorSelectedViews,
+  useEditorState,
+  useRefEditorState,
+} from '../../../../editor/store/store-hook'
 import { ExpandableIndicator } from '../../../../navigator/navigator-item/expandable-indicator'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 
@@ -169,14 +176,14 @@ const Input = (props: InputProps) => {
   return <components.Input {...props} isHidden={isHidden} />
 }
 
+const classnameFocusCounterSelector = (store: EditorStorePatched) =>
+  store.editor.inspector.classnameFocusCounter
+
 const ClassNameControl = React.memo(() => {
-  const editorStoreRef = useRefEditorState(React.useCallback((store) => store, []))
+  const editorStoreRef = useRefEditorState(identity)
   const theme = useColorTheme()
-  const targets = useEditorState(
-    React.useCallback((store) => store.editor.selectedViews, []),
-    'ClassNameSubsection targets',
-  )
-  const dispatch = useEditorState((store) => store.dispatch, 'ClassNameSubsection dispatch')
+  const targets = useEditorSelectedViews('ClassNameSubsection targets')
+  const dispatch = useEditorDispatch('ClassNameSubsection dispatch')
 
   const [filter, setFilter] = React.useState('')
   const isFocusedRef = React.useRef(false)
@@ -185,7 +192,7 @@ const ClassNameControl = React.memo(() => {
   const focusedValueRef = React.useRef<string | null>(null)
 
   const focusTriggerCount = useEditorState(
-    React.useCallback((store) => store.editor.inspector.classnameFocusCounter, []),
+    classnameFocusCounterSelector,
     'ClassNameSubsection classnameFocusCounter',
   )
   const inputRef = useInputFocusOnCountIncrease<CreatableSelect<TailWindOption>>(focusTriggerCount)

--- a/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
@@ -8,7 +8,10 @@ import {
   InspectorSectionIcons,
   InspectorSubsectionHeader,
 } from '../../../../../uuiui'
-import { InspectorPropsContext } from '../../../common/property-path-hooks'
+import {
+  InspectorPropsContext,
+  InspectorPropsContextTargetPathSelector,
+} from '../../../common/property-path-hooks'
 import { PropertyLabel } from '../../../widgets/property-label'
 import { SeeMoreButton, SeeMoreHOC, useToggle } from '../../../widgets/see-more'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
@@ -25,9 +28,7 @@ export const ContainerSubsection = React.memo(() => {
   const [seeMoreVisible, toggleSeeMoreVisible] = useToggle(false)
   const targetPath = useContextSelector(
     InspectorPropsContext,
-    React.useCallback((contextData) => {
-      return contextData.targetPath
-    }, []),
+    InspectorPropsContextTargetPathSelector,
   )
   const paddingPropsToUnset = React.useMemo(() => {
     return buildPaddingPropsToUnset(targetPath)

--- a/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
@@ -23,9 +23,12 @@ import { RadiusRow } from './radius-row'
 
 export const ContainerSubsection = React.memo(() => {
   const [seeMoreVisible, toggleSeeMoreVisible] = useToggle(false)
-  const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
+  const targetPath = useContextSelector(
+    InspectorPropsContext,
+    React.useCallback((contextData) => {
+      return contextData.targetPath
+    }, []),
+  )
   const paddingPropsToUnset = React.useMemo(() => {
     return buildPaddingPropsToUnset(targetPath)
   }, [targetPath])

--- a/editor/src/components/inspector/sections/style-section/text-subsection/text-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/text-subsection/text-subsection.tsx
@@ -21,7 +21,6 @@ import {
 import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
 import { EditorAction } from '../../../../editor/action-types'
 import * as EditorActions from '../../../../editor/actions/action-creators'
-import { useRefEditorState } from '../../../../editor/store/store-hook'
 import { addOnUnsetValues } from '../../../common/context-menu-items'
 import { CSSFontStyle, cssNumber, CSSTextDecorationLine } from '../../../common/css-utils'
 import { usePropControlledRef_DANGEROUS } from '../../../common/inspector-utils'

--- a/editor/src/components/inspector/widgets/property-label.tsx
+++ b/editor/src/components/inspector/widgets/property-label.tsx
@@ -7,6 +7,7 @@ import * as PP from '../../../core/shared/property-path'
 import { optionalAddOnUnsetValues } from '../common/context-menu-items'
 import { useInspectorInfoSimpleUntyped } from '../common/property-path-hooks'
 import { ControlStyles } from '../common/control-status'
+import { identity } from '../../../core/shared/utils'
 
 type PropertyLabelProps = {
   target: ReadonlyArray<PropertyPath>
@@ -17,11 +18,7 @@ type PropertyLabelProps = {
 }
 
 function useMetadataInfoForDomain(target: ReadonlyArray<PropertyPath>) {
-  return useInspectorInfoSimpleUntyped(
-    target,
-    (v) => v,
-    (v) => v,
-  )
+  return useInspectorInfoSimpleUntyped(target, identity, identity)
 }
 
 export const PropertyLabel = React.memo((props: PropertyLabelProps) => {

--- a/editor/src/components/menubar/menubar.tsx
+++ b/editor/src/components/menubar/menubar.tsx
@@ -116,19 +116,22 @@ export const Menubar = React.memo(() => {
     isPreviewPaneVisible,
     isCanvasVisible,
     isCodeEditorVisible,
-  } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      selectedTab: store.editor.leftMenu.selectedTab,
-      userState: store.userState,
-      leftMenuExpanded: store.editor.leftMenu.expanded,
-      projectId: store.editor.id,
-      projectName: store.editor.projectName,
-      isPreviewPaneVisible: store.editor.preview.visible,
-      isCanvasVisible: store.editor.canvas.visible,
-      isCodeEditorVisible: store.editor.interfaceDesigner.codePaneVisible,
-    }
-  }, 'Menubar')
+  } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        selectedTab: store.editor.leftMenu.selectedTab,
+        userState: store.userState,
+        leftMenuExpanded: store.editor.leftMenu.expanded,
+        projectId: store.editor.id,
+        projectName: store.editor.projectName,
+        isPreviewPaneVisible: store.editor.preview.visible,
+        isCanvasVisible: store.editor.canvas.visible,
+        isCodeEditorVisible: store.editor.interfaceDesigner.codePaneVisible,
+      }
+    }, []),
+    'Menubar',
+  )
 
   const colorTheme = useColorTheme()
 
@@ -197,11 +200,13 @@ export const Menubar = React.memo(() => {
   const previewURL =
     projectId == null ? '' : shareURLForProject(FLOATING_PREVIEW_BASE_URL, projectId, projectName)
 
-  const entireStateRef = useRefEditorState((store) => store)
+  const entireStateRef = useRefEditorState(React.useCallback((store) => store, []))
 
-  const jsxMetadata = useRefEditorState((store) => {
-    return store.editor.jsxMetadata
-  })
+  const jsxMetadata = useRefEditorState(
+    React.useCallback((store) => {
+      return store.editor.jsxMetadata
+    }, []),
+  )
 
   const printEditorState = React.useCallback(() => {
     console.info('Current Editor State:', entireStateRef.current)

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -91,16 +91,19 @@ function packageDetailsFromDependencies(
 }
 
 export const DependencyList = React.memo(() => {
-  const props = useEditorState((store) => {
-    return {
-      editorDispatch: store.dispatch,
-      minimised: store.editor.dependencyList.minimised,
-      focusedPanel: store.editor.focusedPanel,
-      packageJsonFile: packageJsonFileFromProjectContents(store.editor.projectContents),
-      packageStatus: store.editor.nodeModules.packageStatus,
-      builtInDependencies: store.builtInDependencies,
-    }
-  }, 'DependencyList')
+  const props = useEditorState(
+    React.useCallback((store) => {
+      return {
+        editorDispatch: store.dispatch,
+        minimised: store.editor.dependencyList.minimised,
+        focusedPanel: store.editor.focusedPanel,
+        packageJsonFile: packageJsonFileFromProjectContents(store.editor.projectContents),
+        packageStatus: store.editor.nodeModules.packageStatus,
+        builtInDependencies: store.builtInDependencies,
+      }
+    }, []),
+    'DependencyList',
+  )
 
   const dispatch = props.editorDispatch
 
@@ -458,7 +461,10 @@ interface AddTailwindButtonProps {
 }
 
 const AddTailwindButton = (props: AddTailwindButtonProps) => {
-  const dispatch = useEditorState((store) => store.dispatch, 'AddTailwindButton')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'AddTailwindButton',
+  )
   const onButtonClicked = React.useCallback(() => {
     dispatch([EditorActions.addTailwindConfig()])
   }, [dispatch])

--- a/editor/src/components/navigator/dependency-list.tsx
+++ b/editor/src/components/navigator/dependency-list.tsx
@@ -23,9 +23,10 @@ import {
 import {
   DefaultPackagesList,
   DependencyPackageDetails,
+  EditorStorePatched,
   packageJsonFileFromProjectContents,
 } from '../editor/store/editor-state'
-import { useEditorState } from '../editor/store/store-hook'
+import { useEditorDispatch, useEditorState } from '../editor/store/store-hook'
 import { DependencyListItems } from './dependency-list-items'
 import { fetchNodeModules } from '../../core/es-modules/package-manager/fetch-packages'
 import {
@@ -90,20 +91,19 @@ function packageDetailsFromDependencies(
   return userAddedPackages
 }
 
+const dependencyListPropsSelector = (store: EditorStorePatched) => {
+  return {
+    editorDispatch: store.dispatch,
+    minimised: store.editor.dependencyList.minimised,
+    focusedPanel: store.editor.focusedPanel,
+    packageJsonFile: packageJsonFileFromProjectContents(store.editor.projectContents),
+    packageStatus: store.editor.nodeModules.packageStatus,
+    builtInDependencies: store.builtInDependencies,
+  }
+}
+
 export const DependencyList = React.memo(() => {
-  const props = useEditorState(
-    React.useCallback((store) => {
-      return {
-        editorDispatch: store.dispatch,
-        minimised: store.editor.dependencyList.minimised,
-        focusedPanel: store.editor.focusedPanel,
-        packageJsonFile: packageJsonFileFromProjectContents(store.editor.projectContents),
-        packageStatus: store.editor.nodeModules.packageStatus,
-        builtInDependencies: store.builtInDependencies,
-      }
-    }, []),
-    'DependencyList',
-  )
+  const props = useEditorState(dependencyListPropsSelector, 'DependencyList')
 
   const dispatch = props.editorDispatch
 
@@ -461,10 +461,7 @@ interface AddTailwindButtonProps {
 }
 
 const AddTailwindButton = (props: AddTailwindButtonProps) => {
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch, []),
-    'AddTailwindButton',
-  )
+  const dispatch = useEditorDispatch('AddTailwindButton')
   const onButtonClicked = React.useCallback(() => {
     dispatch([EditorActions.addTailwindConfig()])
   }, [dispatch])

--- a/editor/src/components/navigator/external-resources/generic-external-resources-list.tsx
+++ b/editor/src/components/navigator/external-resources/generic-external-resources-list.tsx
@@ -59,13 +59,16 @@ export const GenericExternalResourcesList = React.memo(() => {
     setEditingIndexOrInserting(null)
   }, [])
 
-  const { dispatch, minimised, focusedPanel } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      minimised: store.editor.genericExternalResources.minimised,
-      focusedPanel: store.editor.focusedPanel,
-    }
-  }, 'GenericExternalResourcesList')
+  const { dispatch, minimised, focusedPanel } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        minimised: store.editor.genericExternalResources.minimised,
+        focusedPanel: store.editor.focusedPanel,
+      }
+    }, []),
+    'GenericExternalResourcesList',
+  )
 
   const toggleMinimised = React.useCallback(() => {
     dispatch([togglePanel('genericExternalResources')], 'leftpane')

--- a/editor/src/components/navigator/external-resources/generic-external-resources-list.tsx
+++ b/editor/src/components/navigator/external-resources/generic-external-resources-list.tsx
@@ -15,7 +15,8 @@ import {
   SectionBodyArea,
 } from '../../../uuiui'
 import { clearSelection, togglePanel } from '../../editor/actions/action-creators'
-import { useEditorState } from '../../editor/store/store-hook'
+import { EditorStorePatched } from '../../editor/store/editor-state'
+import { useEditorDispatch, useEditorState } from '../../editor/store/store-hook'
 import { GridRowProps } from '../../inspector/widgets/ui-grid-row'
 import { GenericExternalResourcesInput } from './generic-external-resources-input'
 import { GenericExternalResourcesListItem } from './generic-external-resources-list-item'
@@ -48,6 +49,13 @@ function getIndexedUpdateGenericResource(index: number) {
   }
 }
 
+const genericExternalResourcesListPropsSelector = (store: EditorStorePatched) => {
+  return {
+    minimised: store.editor.genericExternalResources.minimised,
+    focusedPanel: store.editor.focusedPanel,
+  }
+}
+
 export const GenericExternalResourcesList = React.memo(() => {
   const { values, useSubmitValueFactory } = useExternalResources()
 
@@ -59,14 +67,10 @@ export const GenericExternalResourcesList = React.memo(() => {
     setEditingIndexOrInserting(null)
   }, [])
 
-  const { dispatch, minimised, focusedPanel } = useEditorState(
-    React.useCallback((store) => {
-      return {
-        dispatch: store.dispatch,
-        minimised: store.editor.genericExternalResources.minimised,
-        focusedPanel: store.editor.focusedPanel,
-      }
-    }, []),
+  const dispatch = useEditorDispatch('GenericExternalResourcesList dispatch')
+
+  const { minimised, focusedPanel } = useEditorState(
+    genericExternalResourcesListPropsSelector,
     'GenericExternalResourcesList',
   )
 

--- a/editor/src/components/navigator/external-resources/google-fonts-resources-list.tsx
+++ b/editor/src/components/navigator/external-resources/google-fonts-resources-list.tsx
@@ -4,19 +4,22 @@ import { isRight } from '../../../core/shared/either'
 import { useExternalResources } from '../../../printer-parsers/html/external-resources-parser'
 import { SectionTitleRow, FlexRow, Title, SectionBodyArea } from '../../../uuiui'
 import { clearSelection, togglePanel } from '../../editor/actions/action-creators'
-import { useEditorState } from '../../editor/store/store-hook'
+import { EditorStorePatched } from '../../editor/store/editor-state'
+import { useEditorDispatch, useEditorState } from '../../editor/store/store-hook'
 import { GoogleFontsResourcesListSearch } from './google-fonts-resources-list-search'
+
+const googleFontsResourcesListPropsSelector = (store: EditorStorePatched) => {
+  return {
+    minimised: store.editor.genericExternalResources.minimised,
+    focusedPanel: store.editor.focusedPanel,
+  }
+}
 
 export const GoogleFontsResourcesList = React.memo(() => {
   const { values, useSubmitValueFactory } = useExternalResources()
-  const { dispatch, minimised, focusedPanel } = useEditorState(
-    React.useCallback((store) => {
-      return {
-        dispatch: store.dispatch,
-        minimised: store.editor.googleFontsResources.minimised,
-        focusedPanel: store.editor.focusedPanel,
-      }
-    }, []),
+  const dispatch = useEditorDispatch('GoogleFontsResourcesList dispatch')
+  const { minimised, focusedPanel } = useEditorState(
+    googleFontsResourcesListPropsSelector,
     'GoogleFontsResourcesList',
   )
 

--- a/editor/src/components/navigator/external-resources/google-fonts-resources-list.tsx
+++ b/editor/src/components/navigator/external-resources/google-fonts-resources-list.tsx
@@ -9,13 +9,16 @@ import { GoogleFontsResourcesListSearch } from './google-fonts-resources-list-se
 
 export const GoogleFontsResourcesList = React.memo(() => {
   const { values, useSubmitValueFactory } = useExternalResources()
-  const { dispatch, minimised, focusedPanel } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      minimised: store.editor.googleFontsResources.minimised,
-      focusedPanel: store.editor.focusedPanel,
-    }
-  }, 'GoogleFontsResourcesList')
+  const { dispatch, minimised, focusedPanel } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        minimised: store.editor.googleFontsResources.minimised,
+        focusedPanel: store.editor.focusedPanel,
+      }
+    }, []),
+    'GoogleFontsResourcesList',
+  )
 
   const toggleMinimised = React.useCallback(() => {
     dispatch([togglePanel('googleFontsResources')], 'leftpane')

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -19,6 +19,13 @@ interface LayoutIconResult {
   isPositionAbsolute: boolean
 }
 
+const layoutIconResultEquality = (oldResult: LayoutIconResult, newResult: LayoutIconResult) => {
+  return (
+    oldResult.isPositionAbsolute === newResult.isPositionAbsolute &&
+    shallowEqual(oldResult.iconProps, newResult.iconProps)
+  )
+}
+
 export function useLayoutOrElementIcon(path: ElementPath): LayoutIconResult {
   return useEditorState(
     useCallback(
@@ -29,12 +36,7 @@ export function useLayoutOrElementIcon(path: ElementPath): LayoutIconResult {
       [path],
     ),
     'useLayoutOrElementIcon',
-    useCallback((oldResult: LayoutIconResult, newResult: LayoutIconResult) => {
-      return (
-        oldResult.isPositionAbsolute === newResult.isPositionAbsolute &&
-        shallowEqual(oldResult.iconProps, newResult.iconProps)
-      )
-    }, []),
+    layoutIconResultEquality,
   )
 }
 

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -12,6 +12,7 @@ import { useEditorState } from '../editor/store/store-hook'
 import { isRight, maybeEitherToMaybe } from '../../core/shared/either'
 import { IcnPropsBase } from '../../uuiui'
 import { shallowEqual } from '../../core/shared/equality-utils'
+import { useCallback } from 'react'
 
 interface LayoutIconResult {
   iconProps: IcnPropsBase
@@ -20,10 +21,13 @@ interface LayoutIconResult {
 
 export function useLayoutOrElementIcon(path: ElementPath): LayoutIconResult {
   return useEditorState(
-    (store) => {
-      const metadata = store.editor.jsxMetadata
-      return createLayoutOrElementIconResult(path, metadata)
-    },
+    useCallback(
+      (store) => {
+        const metadata = store.editor.jsxMetadata
+        return createLayoutOrElementIconResult(path, metadata)
+      },
+      [path],
+    ),
     'useLayoutOrElementIcon',
     (oldResult: LayoutIconResult, newResult: LayoutIconResult) => {
       return (
@@ -35,10 +39,16 @@ export function useLayoutOrElementIcon(path: ElementPath): LayoutIconResult {
 }
 
 export function useComponentIcon(path: ElementPath): IcnPropsBase | null {
-  return useEditorState((store) => {
-    const metadata = store.editor.jsxMetadata
-    return createComponentIconProps(path, metadata)
-  }, 'useComponentIcon') // TODO Memoize Icon Result
+  return useEditorState(
+    useCallback(
+      (store) => {
+        const metadata = store.editor.jsxMetadata
+        return createComponentIconProps(path, metadata)
+      },
+      [path],
+    ),
+    'useComponentIcon',
+  ) // TODO Memoize Icon Result
 }
 
 export function createComponentOrElementIconProps(

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -29,12 +29,12 @@ export function useLayoutOrElementIcon(path: ElementPath): LayoutIconResult {
       [path],
     ),
     'useLayoutOrElementIcon',
-    (oldResult: LayoutIconResult, newResult: LayoutIconResult) => {
+    useCallback((oldResult: LayoutIconResult, newResult: LayoutIconResult) => {
       return (
         oldResult.isPositionAbsolute === newResult.isPositionAbsolute &&
         shallowEqual(oldResult.iconProps, newResult.iconProps)
       )
-    },
+    }, []),
   )
 }
 

--- a/editor/src/components/navigator/left-pane.tsx
+++ b/editor/src/components/navigator/left-pane.tsx
@@ -74,16 +74,22 @@ export const LeftPaneOverflowScrollId = 'left-pane-overflow-scroll'
 
 export const LeftPaneComponent = React.memo(() => {
   const selectedTab = useEditorState(
-    (store) => store.editor.leftMenu.selectedTab,
+    React.useCallback((store) => store.editor.leftMenu.selectedTab, []),
     'LeftPaneComponent selectedTab',
   )
-  const projectId = useEditorState((store) => store.editor.id, 'LeftPaneComponent projectId')
-  const dispatch = useEditorState((store) => store.dispatch, 'LeftPaneComponent dispatch')
+  const projectId = useEditorState(
+    React.useCallback((store) => store.editor.id, []),
+    'LeftPaneComponent projectId',
+  )
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'LeftPaneComponent dispatch',
+  )
 
   const isMyProject = useIsMyProject(projectId)
 
   const loggedIn = useEditorState(
-    (store) => User.isLoggedIn(store.userState.loginState),
+    React.useCallback((store) => User.isLoggedIn(store.userState.loginState), []),
     'LeftPaneComponent loggedIn',
   )
 
@@ -131,16 +137,19 @@ export const LeftPaneComponent = React.memo(() => {
 const ForksGiven = React.memo(() => {
   const colorTheme = useColorTheme()
 
-  const { id, projectName, description, isLoggedIn, forkedFrom } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      id: store.editor.id,
-      projectName: store.editor.projectName,
-      description: store.editor.projectDescription,
-      isLoggedIn: User.isLoggedIn(store.userState.loginState),
-      forkedFrom: store.editor.forkedFromProjectId,
-    }
-  }, 'ForkPanel')
+  const { id, projectName, description, isLoggedIn, forkedFrom } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        id: store.editor.id,
+        projectName: store.editor.projectName,
+        description: store.editor.projectDescription,
+        isLoggedIn: User.isLoggedIn(store.userState.loginState),
+        forkedFrom: store.editor.forkedFromProjectId,
+      }
+    }, []),
+    'ForkPanel',
+  )
 
   const projectOwnerMetadata = useGetProjectMetadata(id)
   const forkedFromMetadata = useGetProjectMetadata(forkedFrom)
@@ -339,14 +348,17 @@ const StoryboardListItem = styled.div<StoryboardListItemProps>((props) => ({
 }))
 
 const StoryboardsPane = React.memo(() => {
-  const { dispatch, openFile, projectContents, isCanvasVisible } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      openFile: store.editor.canvas.openFile?.filename,
-      projectContents: store.editor.projectContents,
-      isCanvasVisible: store.editor.canvas.visible,
-    }
-  }, 'StoryboardsPane')
+  const { dispatch, openFile, projectContents, isCanvasVisible } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        openFile: store.editor.canvas.openFile?.filename,
+        projectContents: store.editor.projectContents,
+        isCanvasVisible: store.editor.canvas.visible,
+      }
+    }, []),
+    'StoryboardsPane',
+  )
 
   const colorTheme = useColorTheme()
   const handleStoryboardAdd = React.useCallback(() => {
@@ -470,11 +482,10 @@ const ContentsPane = React.memo(() => {
 })
 
 const SettingsPane = React.memo(() => {
-  const { dispatch } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-    }
-  }, 'ProjectPane')
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch, []),
+    'ProjectPane',
+  )
   const [theme, setTheme] = React.useState<SelectOption>({
     label: 'Light',
     value: 'light',
@@ -554,12 +565,15 @@ const SettingsPane = React.memo(() => {
 
 const SharingPane = React.memo(() => {
   const [temporaryCopySuccess, setTemporaryCopySuccess] = React.useState(false)
-  const { projectId, projectName } = useEditorState((store) => {
-    return {
-      projectId: store.editor.id,
-      projectName: store.editor.projectName,
-    }
-  }, 'Menubar')
+  const { projectId, projectName } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        projectId: store.editor.id,
+        projectName: store.editor.projectName,
+      }
+    }, []),
+    'Menubar',
+  )
   const previewURL =
     projectId == null ? '' : shareURLForProject(FLOATING_PREVIEW_BASE_URL, projectId, projectName)
 
@@ -768,12 +782,15 @@ const GithubPane = React.memo(() => {
 })
 
 export const InsertMenuPane = React.memo(() => {
-  const { dispatch, focusedPanel } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      focusedPanel: store.editor.focusedPanel,
-    }
-  }, 'InsertMenuPane')
+  const { dispatch, focusedPanel } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        focusedPanel: store.editor.focusedPanel,
+      }
+    }, []),
+    'InsertMenuPane',
+  )
 
   const onFocus = React.useCallback(
     (event: React.FocusEvent<HTMLElement>) => {
@@ -824,19 +841,22 @@ const ProjectPane = React.memo(() => {
     focusedPanel,
     minimised,
     forkedFrom,
-  } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      projectName: store.editor.projectName,
-      projectDescription: store.editor.projectDescription,
-      projectId: store.editor.id,
-      thumbnailLastGenerated: store.editor.thumbnailLastGenerated,
-      userState: store.userState,
-      focusedPanel: store.editor.focusedPanel,
-      minimised: store.editor.projectSettings.minimised,
-      forkedFrom: store.editor.forkedFromProjectId,
-    }
-  }, 'ProjectPane')
+  } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        projectName: store.editor.projectName,
+        projectDescription: store.editor.projectDescription,
+        projectId: store.editor.id,
+        thumbnailLastGenerated: store.editor.thumbnailLastGenerated,
+        userState: store.userState,
+        focusedPanel: store.editor.focusedPanel,
+        minimised: store.editor.projectSettings.minimised,
+        forkedFrom: store.editor.forkedFromProjectId,
+      }
+    }, []),
+    'ProjectPane',
+  )
 
   const [name, changeProjectName] = React.useState(projectName)
   const [description, changeProjectDescription] = React.useState(projectDescription)

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -154,22 +154,28 @@ export const NavigatorItemWrapper: React.FunctionComponent<NavigatorItemWrapperP
       collapsedViews,
       appropriateDropTargetHint,
       dispatch,
-    } = useEditorState((store) => {
-      // Only capture this if it relates to the current navigator item, as it may change while
-      // dragging around the navigator but we don't want the entire navigator to re-render each time.
-      let possiblyAppropriateDropTargetHint: DropTargetHint | null = null
-      if (EP.pathsEqual(store.editor.navigator.dropTargetHint.target, props.elementPath)) {
-        possiblyAppropriateDropTargetHint = store.editor.navigator.dropTargetHint
-      }
-      return {
-        dispatch: store.dispatch,
-        selectedViews: store.editor.selectedViews,
-        collapsedViews: store.editor.navigator.collapsedViews,
-        appropriateDropTargetHint: possiblyAppropriateDropTargetHint,
-        renamingTarget: store.editor.navigator.renamingTarget,
-        isElementVisible: !EP.containsPath(props.elementPath, store.editor.hiddenInstances),
-      }
-    }, 'NavigatorItemWrapper')
+    } = useEditorState(
+      React.useCallback(
+        (store) => {
+          // Only capture this if it relates to the current navigator item, as it may change while
+          // dragging around the navigator but we don't want the entire navigator to re-render each time.
+          let possiblyAppropriateDropTargetHint: DropTargetHint | null = null
+          if (EP.pathsEqual(store.editor.navigator.dropTargetHint.target, props.elementPath)) {
+            possiblyAppropriateDropTargetHint = store.editor.navigator.dropTargetHint
+          }
+          return {
+            dispatch: store.dispatch,
+            selectedViews: store.editor.selectedViews,
+            collapsedViews: store.editor.navigator.collapsedViews,
+            appropriateDropTargetHint: possiblyAppropriateDropTargetHint,
+            renamingTarget: store.editor.navigator.renamingTarget,
+            isElementVisible: !EP.containsPath(props.elementPath, store.editor.hiddenInstances),
+          }
+        },
+        [props.elementPath],
+      ),
+      'NavigatorItemWrapper',
+    )
 
     const isCollapsed = EP.containsPath(props.elementPath, collapsedViews)
 

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -31,25 +31,30 @@ import { last } from '../../core/shared/array-utils'
 export const NavigatorContainerId = 'navigator'
 
 export const NavigatorComponent = React.memo(() => {
-  const editorSliceRef = useRefEditorState((store) => {
-    const dragSelections = createDragSelections(
-      store.derived.navigatorTargets,
-      store.editor.selectedViews,
-    )
-    return {
-      selectedViews: store.editor.selectedViews,
-      navigatorTargets: store.derived.navigatorTargets,
-      dragSelections: dragSelections,
-    }
-  })
+  const editorSliceRef = useRefEditorState(
+    React.useCallback((store) => {
+      const dragSelections = createDragSelections(
+        store.derived.navigatorTargets,
+        store.editor.selectedViews,
+      )
+      return {
+        selectedViews: store.editor.selectedViews,
+        navigatorTargets: store.derived.navigatorTargets,
+        dragSelections: dragSelections,
+      }
+    }, []),
+  )
   const colorTheme = useColorTheme()
-  const { dispatch, minimised, visibleNavigatorTargets } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      minimised: store.editor.navigator.minimised,
-      visibleNavigatorTargets: store.derived.visibleNavigatorTargets,
-    }
-  }, 'NavigatorComponent')
+  const { dispatch, minimised, visibleNavigatorTargets } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        minimised: store.editor.navigator.minimised,
+        visibleNavigatorTargets: store.derived.visibleNavigatorTargets,
+      }
+    }, []),
+    'NavigatorComponent',
+  )
 
   const onFocus = React.useCallback(
     (e: React.FocusEvent<HTMLElement>) => {

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -10,7 +10,7 @@ import * as EditorActions from '../editor/actions/action-creators'
 import { clearHighlightedViews, showContextMenu } from '../editor/actions/action-creators'
 import { DragSelection } from './navigator-item/navigator-item-dnd-container'
 import { NavigatorItemWrapper } from './navigator-item/navigator-item-wrapper'
-import { useEditorState, useRefEditorState } from '../editor/store/store-hook'
+import { useEditorDispatch, useEditorState, useRefEditorState } from '../editor/store/store-hook'
 import { ElementContextMenu } from '../element-context-menu'
 import { createDragSelections } from '../../templates/editor-navigator'
 import { FixedSizeList, ListChildComponentProps } from 'react-window'
@@ -27,32 +27,34 @@ import {
   InspectorSectionHeader,
 } from '../../uuiui'
 import { last } from '../../core/shared/array-utils'
+import { EditorStorePatched } from '../editor/store/editor-state'
 
 export const NavigatorContainerId = 'navigator'
 
-export const NavigatorComponent = React.memo(() => {
-  const editorSliceRef = useRefEditorState(
-    React.useCallback((store) => {
-      const dragSelections = createDragSelections(
-        store.derived.navigatorTargets,
-        store.editor.selectedViews,
-      )
-      return {
-        selectedViews: store.editor.selectedViews,
-        navigatorTargets: store.derived.navigatorTargets,
-        dragSelections: dragSelections,
-      }
-    }, []),
+const navigatorComponentPropsSelector = (store: EditorStorePatched) => {
+  return {
+    minimised: store.editor.navigator.minimised,
+    visibleNavigatorTargets: store.derived.visibleNavigatorTargets,
+  }
+}
+
+const editorSliceSelector = (store: EditorStorePatched) => {
+  const dragSelections = createDragSelections(
+    store.derived.navigatorTargets,
+    store.editor.selectedViews,
   )
-  const colorTheme = useColorTheme()
-  const { dispatch, minimised, visibleNavigatorTargets } = useEditorState(
-    React.useCallback((store) => {
-      return {
-        dispatch: store.dispatch,
-        minimised: store.editor.navigator.minimised,
-        visibleNavigatorTargets: store.derived.visibleNavigatorTargets,
-      }
-    }, []),
+  return {
+    selectedViews: store.editor.selectedViews,
+    navigatorTargets: store.derived.navigatorTargets,
+    dragSelections: dragSelections,
+  }
+}
+
+export const NavigatorComponent = React.memo(() => {
+  const editorSliceRef = useRefEditorState(editorSliceSelector)
+  const dispatch = useEditorDispatch('NavigatorComponent dispatch')
+  const { minimised, visibleNavigatorTargets } = useEditorState(
+    navigatorComponentPropsSelector,
     'NavigatorComponent',
   )
 

--- a/editor/src/components/preview/preview-pane.tsx
+++ b/editor/src/components/preview/preview-pane.tsx
@@ -83,14 +83,17 @@ export interface PreviewColumnState {
 }
 
 export const PreviewColumn = React.memo(() => {
-  const { id, projectName, connected, mainJSFilename } = useEditorState((store) => {
-    return {
-      id: store.editor.id,
-      projectName: store.editor.projectName,
-      connected: store.editor.preview.connected,
-      mainJSFilename: getMainJSFilename(store.editor.projectContents),
-    }
-  }, 'PreviewColumn')
+  const { id, projectName, connected, mainJSFilename } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        id: store.editor.id,
+        projectName: store.editor.projectName,
+        connected: store.editor.preview.connected,
+        mainJSFilename: getMainJSFilename(store.editor.projectContents),
+      }
+    }, []),
+    'PreviewColumn',
+  )
   return (
     <PreviewColumnContent
       id={id}

--- a/editor/src/components/preview/preview-pane.tsx
+++ b/editor/src/components/preview/preview-pane.tsx
@@ -27,6 +27,7 @@ import {
   UIRow,
 } from '../../uuiui'
 import { setBranchNameFromURL } from '../../utils/branches'
+import { EditorStorePatched } from '../editor/store/editor-state'
 
 export const PreviewIframeId = 'preview-column-container'
 
@@ -82,16 +83,18 @@ export interface PreviewColumnState {
   height: number
 }
 
+const previewColumnPropsSelector = (store: EditorStorePatched) => {
+  return {
+    id: store.editor.id,
+    projectName: store.editor.projectName,
+    connected: store.editor.preview.connected,
+    mainJSFilename: getMainJSFilename(store.editor.projectContents),
+  }
+}
+
 export const PreviewColumn = React.memo(() => {
   const { id, projectName, connected, mainJSFilename } = useEditorState(
-    React.useCallback((store) => {
-      return {
-        id: store.editor.id,
-        projectName: store.editor.projectName,
-        connected: store.editor.preview.connected,
-        mainJSFilename: getMainJSFilename(store.editor.projectContents),
-      }
-    }, []),
+    previewColumnPropsSelector,
     'PreviewColumn',
   )
   return (

--- a/editor/src/components/user-configuration.tsx
+++ b/editor/src/components/user-configuration.tsx
@@ -6,7 +6,7 @@ import { Table, Checkbox } from 'antd'
 import Column from 'antd/lib/table/Column'
 import 'antd/dist/antd.css'
 import { RenderedCell, GetComponentProps } from 'rc-table/lib/interface'
-import { useEditorState } from './editor/store/store-hook'
+import { useEditorDispatch, useEditorState } from './editor/store/store-hook'
 import { getShortcutDetails, Shortcut } from './editor/shortcut-definitions'
 import { comparePrimitive } from '../utils/compare'
 import { mapToArray } from '../core/shared/object-utils'
@@ -14,6 +14,7 @@ import { Key } from '../utils/keyboard'
 import { capitalize } from '../core/shared/string-utils'
 import Keyboard from '../utils/keyboard'
 import { setShortcut } from './editor/actions/action-creators'
+import { EditorStorePatched } from './editor/store/editor-state'
 
 interface ShortcutWithName extends Shortcut {
   name: string
@@ -26,16 +27,11 @@ interface DataSourceEntry {
   name: string
 }
 
+const shortcutConfigSelector = (store: EditorStorePatched) => store.userState.shortcutConfig
+
 export function UserConfiguration() {
-  const { dispatch, shortcutConfig } = useEditorState(
-    React.useCallback((store) => {
-      return {
-        dispatch: store.dispatch,
-        shortcutConfig: store.userState.shortcutConfig,
-      }
-    }, []),
-    'UserConfiguration',
-  )
+  const dispatch = useEditorDispatch('UserConfiguration dispatch')
+  const shortcutConfig = useEditorState(shortcutConfigSelector, 'UserConfiguration')
 
   const [editingIndex, setEditingIndex] = React.useState<number | null>(null)
 

--- a/editor/src/components/user-configuration.tsx
+++ b/editor/src/components/user-configuration.tsx
@@ -27,12 +27,15 @@ interface DataSourceEntry {
 }
 
 export function UserConfiguration() {
-  const { dispatch, shortcutConfig } = useEditorState((store) => {
-    return {
-      dispatch: store.dispatch,
-      shortcutConfig: store.userState.shortcutConfig,
-    }
-  }, 'UserConfiguration')
+  const { dispatch, shortcutConfig } = useEditorState(
+    React.useCallback((store) => {
+      return {
+        dispatch: store.dispatch,
+        shortcutConfig: store.userState.shortcutConfig,
+      }
+    }, []),
+    'UserConfiguration',
+  )
 
   const [editingIndex, setEditingIndex] = React.useState<number | null>(null)
 

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -44,10 +44,12 @@ const NumberOfIterations = 100
 
 export function useTriggerScrollPerformanceTest(): () => void {
   const dispatch = useEditorState(
-    (store) => store.dispatch as DebugDispatch,
+    React.useCallback((store) => store.dispatch as DebugDispatch, []),
     'useTriggerScrollPerformanceTest dispatch',
   )
-  const allPaths = useRefEditorState((store) => store.derived.navigatorTargets)
+  const allPaths = useRefEditorState(
+    React.useCallback((store) => store.derived.navigatorTargets, []),
+  )
   const trigger = React.useCallback(async () => {
     if (allPaths.current.length === 0) {
       console.info('SELECT_TEST_ERROR')
@@ -85,11 +87,13 @@ export function useTriggerScrollPerformanceTest(): () => void {
 
 export function useTriggerResizePerformanceTest(): () => void {
   const dispatch = useEditorState(
-    (store) => store.dispatch as DebugDispatch,
+    React.useCallback((store) => store.dispatch as DebugDispatch, []),
     'useTriggerResizePerformanceTest dispatch',
   )
-  const metadata = useRefEditorState((store) => store.editor.jsxMetadata)
-  const selectedViews = useRefEditorState((store) => store.editor.selectedViews)
+  const metadata = useRefEditorState(React.useCallback((store) => store.editor.jsxMetadata, []))
+  const selectedViews = useRefEditorState(
+    React.useCallback((store) => store.editor.selectedViews, []),
+  )
   const trigger = React.useCallback(async () => {
     if (selectedViews.current.length === 0) {
       console.info('RESIZE_TEST_MISSING_SELECTEDVIEW')
@@ -151,7 +155,9 @@ export function useTriggerResizePerformanceTest(): () => void {
 }
 
 function useTriggerHighlightPerformanceTest(key: 'regular' | 'all-elements'): () => void {
-  const allPaths = useRefEditorState((store) => store.derived.navigatorTargets)
+  const allPaths = useRefEditorState(
+    React.useCallback((store) => store.derived.navigatorTargets, []),
+  )
   const getHighlightableViews = useGetSelectableViewsForSelectMode()
   const calculateHighlightedViews = useCalculateHighlightedViews(true, getHighlightableViews)
   const trigger = React.useCallback(async () => {
@@ -214,11 +220,15 @@ export const useTriggerAllElementsHighlightPerformanceTest = () =>
 
 export function useTriggerSelectionPerformanceTest(): () => void {
   const dispatch = useEditorState(
-    (store) => store.dispatch as DebugDispatch,
+    React.useCallback((store) => store.dispatch as DebugDispatch, []),
     'useTriggerSelectionPerformanceTest dispatch',
   )
-  const allPaths = useRefEditorState((store) => store.derived.navigatorTargets)
-  const selectedViews = useRefEditorState((store) => store.editor.selectedViews)
+  const allPaths = useRefEditorState(
+    React.useCallback((store) => store.derived.navigatorTargets, []),
+  )
+  const selectedViews = useRefEditorState(
+    React.useCallback((store) => store.editor.selectedViews, []),
+  )
   const trigger = React.useCallback(async () => {
     const targetPath = [...allPaths.current].sort(
       (a, b) => EP.toString(b).length - EP.toString(a).length,
@@ -333,7 +343,7 @@ export function useTriggerSelectionPerformanceTest(): () => void {
 
 export function useTriggerBaselinePerformanceTest(): () => void {
   const dispatch = useEditorState(
-    (store) => store.dispatch as DebugDispatch,
+    React.useCallback((store) => store.dispatch as DebugDispatch, []),
     'useTriggerSelectionPerformanceTest dispatch',
   )
 

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -7,7 +7,12 @@ import {
   selectComponents,
   switchEditorMode,
 } from '../../components/editor/actions/action-creators'
-import { useEditorState, useRefEditorState } from '../../components/editor/store/store-hook'
+import {
+  useEditorDispatch,
+  useRefEditorMetadata,
+  useRefEditorSelectedViews,
+  useRefEditorState,
+} from '../../components/editor/store/store-hook'
 import {
   canvasPoint,
   CanvasRectangle,
@@ -33,6 +38,7 @@ import { CanvasControlsContainerID } from '../../components/canvas/controls/new-
 import { forceNotNull } from '../shared/optional-utils'
 import { ElementPathArrayKeepDeepEquality } from '../../utils/deep-equality-instances'
 import { NavigatorContainerId } from '../../components/navigator/navigator'
+import { EditorStorePatched } from '../../components/editor/store/editor-state'
 
 export function wait(timeout: number): Promise<void> {
   return new Promise((resolve) => {
@@ -40,16 +46,13 @@ export function wait(timeout: number): Promise<void> {
   })
 }
 
-const NumberOfIterations = 100
+const NumberOfIterations = 5
+
+const navigatorTargetsSelector = (store: EditorStorePatched) => store.derived.navigatorTargets
 
 export function useTriggerScrollPerformanceTest(): () => void {
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch as DebugDispatch, []),
-    'useTriggerScrollPerformanceTest dispatch',
-  )
-  const allPaths = useRefEditorState(
-    React.useCallback((store) => store.derived.navigatorTargets, []),
-  )
+  const dispatch = useEditorDispatch('useTriggerScrollPerformanceTest dispatch') as DebugDispatch
+  const allPaths = useRefEditorState(navigatorTargetsSelector)
   const trigger = React.useCallback(async () => {
     if (allPaths.current.length === 0) {
       console.info('SELECT_TEST_ERROR')
@@ -86,14 +89,9 @@ export function useTriggerScrollPerformanceTest(): () => void {
 }
 
 export function useTriggerResizePerformanceTest(): () => void {
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch as DebugDispatch, []),
-    'useTriggerResizePerformanceTest dispatch',
-  )
-  const metadata = useRefEditorState(React.useCallback((store) => store.editor.jsxMetadata, []))
-  const selectedViews = useRefEditorState(
-    React.useCallback((store) => store.editor.selectedViews, []),
-  )
+  const dispatch = useEditorDispatch('useTriggerResizePerformanceTest dispatch') as DebugDispatch
+  const metadata = useRefEditorMetadata()
+  const selectedViews = useRefEditorSelectedViews()
   const trigger = React.useCallback(async () => {
     if (selectedViews.current.length === 0) {
       console.info('RESIZE_TEST_MISSING_SELECTEDVIEW')
@@ -155,9 +153,7 @@ export function useTriggerResizePerformanceTest(): () => void {
 }
 
 function useTriggerHighlightPerformanceTest(key: 'regular' | 'all-elements'): () => void {
-  const allPaths = useRefEditorState(
-    React.useCallback((store) => store.derived.navigatorTargets, []),
-  )
+  const allPaths = useRefEditorState(navigatorTargetsSelector)
   const getHighlightableViews = useGetSelectableViewsForSelectMode()
   const calculateHighlightedViews = useCalculateHighlightedViews(true, getHighlightableViews)
   const trigger = React.useCallback(async () => {
@@ -219,16 +215,9 @@ export const useTriggerAllElementsHighlightPerformanceTest = () =>
   useTriggerHighlightPerformanceTest('all-elements')
 
 export function useTriggerSelectionPerformanceTest(): () => void {
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch as DebugDispatch, []),
-    'useTriggerSelectionPerformanceTest dispatch',
-  )
-  const allPaths = useRefEditorState(
-    React.useCallback((store) => store.derived.navigatorTargets, []),
-  )
-  const selectedViews = useRefEditorState(
-    React.useCallback((store) => store.editor.selectedViews, []),
-  )
+  const dispatch = useEditorDispatch('useTriggerSelectionPerformanceTest dispatch') as DebugDispatch
+  const allPaths = useRefEditorState(navigatorTargetsSelector)
+  const selectedViews = useRefEditorSelectedViews()
   const trigger = React.useCallback(async () => {
     const targetPath = [...allPaths.current].sort(
       (a, b) => EP.toString(b).length - EP.toString(a).length,
@@ -342,10 +331,7 @@ export function useTriggerSelectionPerformanceTest(): () => void {
 }
 
 export function useTriggerBaselinePerformanceTest(): () => void {
-  const dispatch = useEditorState(
-    React.useCallback((store) => store.dispatch as DebugDispatch, []),
-    'useTriggerSelectionPerformanceTest dispatch',
-  )
+  const dispatch = useEditorDispatch('useTriggerSelectionPerformanceTest dispatch') as DebugDispatch
 
   const trigger = React.useCallback(async () => {
     let framesPassed = 0

--- a/editor/src/core/model/project-file-helper-hooks.ts
+++ b/editor/src/core/model/project-file-helper-hooks.ts
@@ -1,15 +1,18 @@
 import React from 'react'
 import { updateFile } from '../../components/editor/actions/action-creators'
-import { getOpenUIJSFile, getOpenUIJSFileKey } from '../../components/editor/store/editor-state'
-import { useEditorState, useRefEditorState } from '../../components/editor/store/store-hook'
+import {
+  EditorStorePatched,
+  getOpenUIJSFile,
+  getOpenUIJSFileKey,
+} from '../../components/editor/store/editor-state'
+import { useEditorDispatch, useRefEditorState } from '../../components/editor/store/store-hook'
 import { RevisionsState, textFile, textFileContents } from '../shared/project-file-types'
 
+const editorSelector = (store: EditorStorePatched) => store.editor
+
 export function useReParseOpenProjectFile(): () => void {
-  const dispatch = useEditorState(
-    React.useCallback((s) => s.dispatch, []),
-    'useReParseOpenProjectFile dispatch',
-  )
-  const refEditorState = useRefEditorState(React.useCallback((store) => store.editor, []))
+  const dispatch = useEditorDispatch('useReParseOpenProjectFile dispatch')
+  const refEditorState = useRefEditorState(editorSelector)
   return React.useCallback(() => {
     const openFile = getOpenUIJSFile(refEditorState.current)
     const openFilePath = getOpenUIJSFileKey(refEditorState.current)

--- a/editor/src/core/model/project-file-helper-hooks.ts
+++ b/editor/src/core/model/project-file-helper-hooks.ts
@@ -5,8 +5,11 @@ import { useEditorState, useRefEditorState } from '../../components/editor/store
 import { RevisionsState, textFile, textFileContents } from '../shared/project-file-types'
 
 export function useReParseOpenProjectFile(): () => void {
-  const dispatch = useEditorState((s) => s.dispatch, 'useReParseOpenProjectFile dispatch')
-  const refEditorState = useRefEditorState((store) => store.editor)
+  const dispatch = useEditorState(
+    React.useCallback((s) => s.dispatch, []),
+    'useReParseOpenProjectFile dispatch',
+  )
+  const refEditorState = useRefEditorState(React.useCallback((store) => store.editor, []))
   return React.useCallback(() => {
     const openFile = getOpenUIJSFile(refEditorState.current)
     const openFilePath = getOpenUIJSFileKey(refEditorState.current)

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`352`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`364`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`412`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`424`)
   })
 
   it('Changing the selected view with a simple project', async () => {

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2348`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2174`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2501`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2327`)
   })
 })

--- a/editor/src/core/tailwind/tailwind-options.tsx
+++ b/editor/src/core/tailwind/tailwind-options.tsx
@@ -275,25 +275,28 @@ export function useGetSelectedClasses(): {
   elementPaths: Array<ElementPath>
   isSettable: boolean
 } {
-  const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
-  const elements = useEditorState((store) => {
-    const openUIJSFileKey = getOpenUIJSFileKey(store.editor)
-    if (openUIJSFileKey == null) {
-      return []
-    } else {
-      return store.editor.selectedViews.map((elementPath) =>
-        getJSXElementForTarget(
-          elementPath,
-          openUIJSFileKey,
-          store.editor.projectContents,
-          store.editor.nodeModules.files,
-        ),
-      )
-    }
-  }, 'ClassNameSelect elements')
+  const metadataRef = useRefEditorState(React.useCallback((store) => store.editor.jsxMetadata, []))
+  const elements = useEditorState(
+    React.useCallback((store) => {
+      const openUIJSFileKey = getOpenUIJSFileKey(store.editor)
+      if (openUIJSFileKey == null) {
+        return []
+      } else {
+        return store.editor.selectedViews.map((elementPath) =>
+          getJSXElementForTarget(
+            elementPath,
+            openUIJSFileKey,
+            store.editor.projectContents,
+            store.editor.nodeModules.files,
+          ),
+        )
+      }
+    }, []),
+    'ClassNameSelect elements',
+  )
 
   const elementPaths = useEditorState(
-    (store) => store.editor.selectedViews,
+    React.useCallback((store) => store.editor.selectedViews, []),
     'ClassNameSelect elementPaths',
   )
 

--- a/editor/src/uuiui/icn.tsx
+++ b/editor/src/uuiui/icn.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { getPossiblyHashedURL } from '../utils/hashed-assets'
 import { Tooltip } from './tooltip'
 import { useEditorState } from '../components/editor/store/store-hook'
-import { Theme } from '../components/editor/store/editor-state'
+import { EditorStorePatched, Theme } from '../components/editor/store/editor-state'
 
 export type IcnColor =
   | 'main'
@@ -28,11 +28,10 @@ export type IcnResultingColor =
   | 'orange'
   | 'colourful'
 
+const themeSelector = (store: EditorStorePatched) => store.editor.theme
+
 function useIconColor(intent: IcnColor): IcnResultingColor {
-  const currentTheme: Theme = useEditorState(
-    React.useCallback((store) => store.editor.theme, []),
-    'currentTheme',
-  )
+  const currentTheme: Theme = useEditorState(themeSelector, 'currentTheme')
   if (currentTheme === 'light') {
     switch (intent) {
       case 'main':

--- a/editor/src/uuiui/icn.tsx
+++ b/editor/src/uuiui/icn.tsx
@@ -29,7 +29,10 @@ export type IcnResultingColor =
   | 'colourful'
 
 function useIconColor(intent: IcnColor): IcnResultingColor {
-  const currentTheme: Theme = useEditorState((store) => store.editor.theme, 'currentTheme')
+  const currentTheme: Theme = useEditorState(
+    React.useCallback((store) => store.editor.theme, []),
+    'currentTheme',
+  )
   if (currentTheme === 'light') {
     switch (intent) {
       case 'main':

--- a/editor/src/uuiui/styles/theme.ts
+++ b/editor/src/uuiui/styles/theme.ts
@@ -1,8 +1,7 @@
 import { useEditorState } from './../../components/editor/store/store-hook'
 import { Interpolation } from '@emotion/react'
-import { Theme } from './../../components/editor/store/editor-state'
+import { EditorStorePatched, Theme } from './../../components/editor/store/editor-state'
 import { createUtopiColor } from './utopi-color-helpers'
-import { useCallback } from 'react'
 
 const base = {
   blue: createUtopiColor('#007AFF'),
@@ -306,11 +305,9 @@ export const darkColorTheme = { ...dark, inverted: light }
 
 // TODO: don't export colorTheme anymore and just export useUtopiaTheme() hook
 // prerequisites: no class components and usage of UtopiaTheme.color instead of colorTheme
+const themeSelector = (store: EditorStorePatched) => store.editor.theme
 export const useColorTheme = () => {
-  const currentTheme: Theme = useEditorState(
-    useCallback((store) => store.editor.theme, []),
-    'currentTheme',
-  )
+  const currentTheme: Theme = useEditorState(themeSelector, 'currentTheme')
   return currentTheme === 'dark' ? darkColorTheme : colorTheme
 }
 

--- a/editor/src/uuiui/styles/theme.ts
+++ b/editor/src/uuiui/styles/theme.ts
@@ -2,6 +2,7 @@ import { useEditorState } from './../../components/editor/store/store-hook'
 import { Interpolation } from '@emotion/react'
 import { Theme } from './../../components/editor/store/editor-state'
 import { createUtopiColor } from './utopi-color-helpers'
+import { useCallback } from 'react'
 
 const base = {
   blue: createUtopiColor('#007AFF'),
@@ -306,7 +307,10 @@ export const darkColorTheme = { ...dark, inverted: light }
 // TODO: don't export colorTheme anymore and just export useUtopiaTheme() hook
 // prerequisites: no class components and usage of UtopiaTheme.color instead of colorTheme
 export const useColorTheme = () => {
-  const currentTheme: Theme = useEditorState((store) => store.editor.theme, 'currentTheme')
+  const currentTheme: Theme = useEditorState(
+    useCallback((store) => store.editor.theme, []),
+    'currentTheme',
+  )
   return currentTheme === 'dark' ? darkColorTheme : colorTheme
 }
 


### PR DESCRIPTION
Fixes #2148 

**Problem:**
We are using a lot of inlined anonymous callbacks for a our core custom hooks used for accessing the editor store or for providing data to the Inspector. Though that majority of these wouldn't have been triggering unnecessary re-renders, the use of anonymous functions that aren't wrapped in `useCallback` will result in new selectors being created each time, resulting in excessive calls of those selectors.

**Fix:**
Wrap all of the ones I have found with `useCallback`. These are all based on references of the exported functions from `store-hook.ts` (which are for accessing the core editor store), and `property-path-hooks.ts` (which exist for populating the Inspector), as well as uses of `useContextSelector`.

I'm not confident at all that I've caught all of these kinds of offences. I'm going to look for a eslint rule that would help out here, as if one doesn't exist we should certainly consider writing one.
