### PR TITLE
Keyboard absolute move strategy

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -16,10 +16,12 @@ import {
   InteractionCanvasState,
 } from './canvas-strategy-types'
 import { InteractionSession, StrategyState } from './interaction-state'
+import { keyboardAbsoluteMoveStrategy } from './keyboard-absolute-move-strategy'
 
 export const RegisteredCanvasStrategies: Array<CanvasStrategy> = [
   absoluteMoveStrategy,
   absoluteReparentStrategy,
+  keyboardAbsoluteMoveStrategy,
 ]
 
 export function pickCanvasStateFromEditorState(editorState: EditorState): InteractionCanvasState {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -24,7 +24,7 @@ export interface InteractionCanvasState {
   canvasOffset: CanvasVector
 }
 
-export type CanvasStrategyId = 'ABSOLUTE_MOVE' | 'ABSOLUTE_REPARENT'
+export type CanvasStrategyId = 'ABSOLUTE_MOVE' | 'ABSOLUTE_REPARENT' | 'KEYBOARD_ABSOLUTE_MOVE'
 
 export interface CanvasStrategy {
   id: CanvasStrategyId // We'd need to do something to guarantee uniqueness here if using this for the commands' reason

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -280,7 +280,7 @@ export function interactionSessionHardReset(
   }
 }
 
-export const KEYBOARD_INTERACTION_TIMEOUT = 3000
+export const KeyboardInteractionTimeout = 3000
 
 export function hasDragModifiersChanged(
   prevInteractionData: InputData | null,

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -26,7 +26,7 @@ export interface DragInteractionData {
 }
 
 interface KeyboardInteractionData {
-  type: 'KEYBOARD'
+  type: 'KEYBOARD_ARROW'
   keysPressed: Array<KeyCharacter>
   // keysPressed also includes modifiers, but we want the separate modifiers array since they are captured and mapped to a specific
   // set via modifiersForEvent in keyboard.ts
@@ -152,7 +152,7 @@ export function createInteractionViaKeyboard(
 ): InteractionSessionWithoutMetadata {
   return {
     interactionData: {
-      type: 'KEYBOARD',
+      type: 'KEYBOARD_ARROW',
       keysPressed: keysPressed,
       modifiers: modifiers,
     },
@@ -172,7 +172,7 @@ export function updateInteractionViaKeyboard(
   sourceOfUpdate: CanvasControlType,
 ): InteractionSessionWithoutMetadata {
   switch (currentState.interactionData.type) {
-    case 'KEYBOARD': {
+    case 'KEYBOARD_ARROW': {
       const withRemovedKeys = currentState.interactionData.keysPressed.filter(
         (k) => !keysReleased.includes(k),
       )
@@ -180,7 +180,7 @@ export function updateInteractionViaKeyboard(
 
       return {
         interactionData: {
-          type: 'KEYBOARD',
+          type: 'KEYBOARD_ARROW',
           keysPressed: newKeysPressed,
           modifiers: modifiers,
         },
@@ -228,7 +228,7 @@ export function strategySwitchInteractionDataReset(interactionData: InputData): 
           prevDrag: null,
         }
       }
-    case 'KEYBOARD':
+    case 'KEYBOARD_ARROW':
       return interactionData
     default:
       const _exhaustiveCheck: never = interactionData
@@ -253,7 +253,7 @@ export function interactionDataHardReset(interactionData: InputData): InputData 
           ),
         }
       }
-    case 'KEYBOARD':
+    case 'KEYBOARD_ARROW':
       return interactionData
     default:
       const _exhaustiveCheck: never = interactionData
@@ -279,6 +279,8 @@ export function interactionSessionHardReset(
     interactionData: interactionDataHardReset(interactionSession.interactionData),
   }
 }
+
+export const KEYBOARD_INTERACTION_TIMEOUT = 3000
 
 export function hasDragModifiersChanged(
   prevInteractionData: InputData | null,

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -25,7 +25,7 @@ export interface DragInteractionData {
   modifiers: Modifiers
 }
 
-interface KeyboardInteractionData {
+interface KeyboardArrowInteractionData {
   type: 'KEYBOARD_ARROW'
   keysPressed: Array<KeyCharacter>
   // keysPressed also includes modifiers, but we want the separate modifiers array since they are captured and mapped to a specific
@@ -33,7 +33,7 @@ interface KeyboardInteractionData {
   modifiers: Modifiers
 }
 
-export type InputData = KeyboardInteractionData | DragInteractionData
+export type InputData = KeyboardArrowInteractionData | DragInteractionData
 
 export interface InteractionSession {
   // This represents an actual interaction that has started as the result of a key press or a drag

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -57,7 +57,7 @@ export interface CommandDescription {
 }
 
 export interface StrategyAndAccumulatedCommands {
-  strategy: string | null
+  strategy: CanvasStrategyId | null
   commands: Array<CanvasCommand>
 }
 

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -25,15 +25,15 @@ export interface DragInteractionData {
   modifiers: Modifiers
 }
 
-interface KeyboardArrowInteractionData {
-  type: 'KEYBOARD_ARROW'
+interface KeyboardInteractionData {
+  type: 'KEYBOARD'
   keysPressed: Array<KeyCharacter>
   // keysPressed also includes modifiers, but we want the separate modifiers array since they are captured and mapped to a specific
   // set via modifiersForEvent in keyboard.ts
   modifiers: Modifiers
 }
 
-export type InputData = KeyboardArrowInteractionData | DragInteractionData
+export type InputData = KeyboardInteractionData | DragInteractionData
 
 export interface InteractionSession {
   // This represents an actual interaction that has started as the result of a key press or a drag
@@ -152,7 +152,7 @@ export function createInteractionViaKeyboard(
 ): InteractionSessionWithoutMetadata {
   return {
     interactionData: {
-      type: 'KEYBOARD_ARROW',
+      type: 'KEYBOARD',
       keysPressed: keysPressed,
       modifiers: modifiers,
     },
@@ -172,7 +172,7 @@ export function updateInteractionViaKeyboard(
   sourceOfUpdate: CanvasControlType,
 ): InteractionSessionWithoutMetadata {
   switch (currentState.interactionData.type) {
-    case 'KEYBOARD_ARROW': {
+    case 'KEYBOARD': {
       const withRemovedKeys = currentState.interactionData.keysPressed.filter(
         (k) => !keysReleased.includes(k),
       )
@@ -180,7 +180,7 @@ export function updateInteractionViaKeyboard(
 
       return {
         interactionData: {
-          type: 'KEYBOARD_ARROW',
+          type: 'KEYBOARD',
           keysPressed: newKeysPressed,
           modifiers: modifiers,
         },
@@ -228,7 +228,7 @@ export function strategySwitchInteractionDataReset(interactionData: InputData): 
           prevDrag: null,
         }
       }
-    case 'KEYBOARD_ARROW':
+    case 'KEYBOARD':
       return interactionData
     default:
       const _exhaustiveCheck: never = interactionData
@@ -253,7 +253,7 @@ export function interactionDataHardReset(interactionData: InputData): InputData 
           ),
         }
       }
-    case 'KEYBOARD_ARROW':
+    case 'KEYBOARD':
       return interactionData
     default:
       const _exhaustiveCheck: never = interactionData

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -28,7 +28,7 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
         interactionState,
         sessionState.startingMetadata,
       ) &&
-      interactionState.interactionData.type === 'KEYBOARD_ARROW'
+      interactionState.interactionData.type === 'KEYBOARD'
     ) {
       const { interactionData } = interactionState
 
@@ -47,7 +47,7 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
   },
   apply: (canvasState, interactionState, sessionState) => {
     // TODO: absolutely minimal implementation
-    if (interactionState.interactionData.type === 'KEYBOARD_ARROW') {
+    if (interactionState.interactionData.type === 'KEYBOARD') {
       const key = interactionState.interactionData.keysPressed[0]
       if (key == null) {
         return []

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -1,0 +1,101 @@
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
+import { adjustNumberProperty } from '../commands/adjust-number-command'
+import { wildcardPatch } from '../commands/wildcard-patch-command'
+import { Keyboard } from '../../../utils/keyboard'
+import { CanvasStrategy } from './canvas-strategy-types'
+
+export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
+  id: 'KEYBOARD_ABSOLUTE_MOVE',
+  name: 'Keyboard absolute Move',
+  isApplicable: (canvasState, _interactionState, metadata) => {
+    if (canvasState.selectedElements.length === 1) {
+      const elementMetadata = MetadataUtils.findElementByElementPath(
+        metadata,
+        canvasState.selectedElements[0],
+      )
+
+      return elementMetadata?.specialSizeMeasurements.position === 'absolute'
+    } else {
+      return false
+    }
+  },
+  controlsToRender: [], // Uses existing hooks in select-mode-hooks.tsx
+  fitness: (canvasState, interactionState, sessionState) => {
+    if (
+      keyboardAbsoluteMoveStrategy.isApplicable(
+        canvasState,
+        interactionState,
+        sessionState.startingMetadata,
+      ) &&
+      interactionState.interactionData.type === 'KEYBOARD_ARROW'
+    ) {
+      const { interactionData } = interactionState
+
+      const singleKeyPressed = interactionData.keysPressed.length === 1
+      const arrowKeyPressed = Keyboard.keyIsArrow(interactionData.keysPressed[0])
+      const shiftOrNoModifier =
+        !interactionState.interactionData.modifiers.alt &&
+        !interactionState.interactionData.modifiers.cmd &&
+        !interactionState.interactionData.modifiers.ctrl
+
+      if (singleKeyPressed && arrowKeyPressed && shiftOrNoModifier) {
+        return 1
+      }
+    }
+    return 0
+  },
+  apply: (canvasState, interactionState, sessionState) => {
+    // TODO: absolutely minimal implementation
+    if (interactionState.interactionData.type === 'KEYBOARD_ARROW') {
+      const key = interactionState.interactionData.keysPressed[0]
+      if (key == null) {
+        return []
+      }
+      switch (key) {
+        case 'left':
+          return canvasState.selectedElements.flatMap((selectedElement) => [
+            adjustNumberProperty(
+              'permanent',
+              selectedElement,
+              stylePropPathMappingFn('left', ['style']),
+              -10,
+              true,
+            ),
+          ])
+        case 'right':
+          return canvasState.selectedElements.flatMap((selectedElement) => [
+            adjustNumberProperty(
+              'permanent',
+              selectedElement,
+              stylePropPathMappingFn('left', ['style']),
+              10,
+              true,
+            ),
+          ])
+        case 'up':
+          return canvasState.selectedElements.flatMap((selectedElement) => [
+            adjustNumberProperty(
+              'permanent',
+              selectedElement,
+              stylePropPathMappingFn('top', ['style']),
+              -10,
+              true,
+            ),
+          ])
+        case 'down':
+          return canvasState.selectedElements.flatMap((selectedElement) => [
+            adjustNumberProperty(
+              'permanent',
+              selectedElement,
+              stylePropPathMappingFn('top', ['style']),
+              10,
+              true,
+            ),
+          ])
+      }
+    }
+    // Fallback for when the checks above are not satisfied.
+    return []
+  },
+}

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -661,8 +661,7 @@ export function setupClearKeyboardInteraction(
         keyboardTimeoutHandler.current = null
       }
       if (
-        editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type ===
-        'KEYBOARD_ARROW'
+        editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type === 'KEYBOARD'
       ) {
         editorStoreRef.current.dispatch([CanvasActions.clearInteractionSession(true)], 'everyone')
       }

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -13,7 +13,7 @@ import {
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import * as EP from '../../../../core/shared/element-path'
 import { fastForEach, NO_OP } from '../../../../core/shared/utils'
-import { KeysPressed } from '../../../../utils/keyboard'
+import { KeyCharacter, KeysPressed } from '../../../../utils/keyboard'
 import { useKeepShallowReferenceEquality } from '../../../../utils/react-performance'
 import Utils from '../../../../utils/utils'
 import {
@@ -23,7 +23,7 @@ import {
   setFocusedElement,
   setHighlightedView,
 } from '../../../editor/actions/action-creators'
-import { EditorState } from '../../../editor/store/editor-state'
+import { EditorState, EditorStorePatched } from '../../../editor/store/editor-state'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
 import { DragState, moveDragState } from '../../canvas-types'
@@ -41,7 +41,10 @@ import { useWindowToCanvasCoordinates } from '../../dom-lookup-hooks'
 import { useInsertModeSelectAndHover } from './insert-mode-hooks'
 import { WindowMousePositionRaw } from '../../../../utils/global-positions'
 import { isFeatureEnabled } from '../../../../utils/feature-switches'
-import { createInteractionViaMouse } from '../../canvas-strategies/interaction-state'
+import {
+  createInteractionViaMouse,
+  KeyboardInteractionTimeout,
+} from '../../canvas-strategies/interaction-state'
 import { Modifier } from '../../../../utils/modifiers'
 import { pathsEqual } from '../../../../core/shared/element-path'
 
@@ -53,7 +56,7 @@ export function isResizing(editorState: EditorState): boolean {
   return (
     (dragState?.type === 'RESIZE_DRAG_STATE' &&
       getDragStateDrag(dragState, editorState.canvas.resizeOptions) != null) ||
-    editorState.canvas.interactionSession != null
+    editorState.canvas.interactionSession?.interactionData.type === 'DRAG'
   )
 }
 
@@ -63,7 +66,7 @@ export function isDragging(editorState: EditorState): boolean {
   return (
     (dragState?.type === 'MOVE_DRAG_STATE' &&
       getDragStateDrag(dragState, editorState.canvas.resizeOptions) != null) ||
-    editorState.canvas.interactionSession != null
+    editorState.canvas.interactionSession?.interactionData.type === 'DRAG'
   )
 }
 
@@ -636,5 +639,35 @@ export function useSelectAndHover(
         const _exhaustiveCheck: never = modeType
         throw new Error(`Unhandled editor mode ${JSON.stringify(modeType)}`)
     }
+  }
+}
+
+export function setupClearKeyboardInteraction(
+  editorStoreRef: { readonly current: EditorStorePatched },
+  keyboardTimeoutHandler: React.MutableRefObject<NodeJS.Timeout | null>,
+) {
+  if (!isFeatureEnabled('Keyboard up clears interaction')) {
+    if (keyboardTimeoutHandler.current != null) {
+      clearTimeout(keyboardTimeoutHandler.current)
+      keyboardTimeoutHandler.current = null
+    }
+
+    keyboardTimeoutHandler.current = setTimeout(clearHighlightedViews, KeyboardInteractionTimeout)
+
+    const clearKeyboardInteraction = () => {
+      window.removeEventListener('mousedown', clearKeyboardInteraction)
+      if (keyboardTimeoutHandler.current != null) {
+        clearTimeout(keyboardTimeoutHandler.current)
+        keyboardTimeoutHandler.current = null
+      }
+      if (
+        editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type ===
+        'KEYBOARD_ARROW'
+      ) {
+        editorStoreRef.current.dispatch([CanvasActions.clearInteractionSession(true)], 'everyone')
+      }
+    }
+
+    window.addEventListener('mousedown', clearKeyboardInteraction, { once: true, capture: true })
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -233,6 +233,20 @@ export function isClearInteractionSession(action: EditorAction): boolean {
   }
 }
 
+export function isCreateOrUpdateInteractionSession(action: EditorAction): boolean {
+  switch (action.action) {
+    case 'TRANSIENT_ACTIONS':
+      return action.transientActions.some(isCreateOrUpdateInteractionSession)
+    case 'ATOMIC':
+      return action.actions.some(isCreateOrUpdateInteractionSession)
+    case 'CREATE_INTERACTION_SESSION':
+    case 'UPDATE_INTERACTION_SESSION':
+      return true
+    default:
+      return false
+  }
+}
+
 export function shouldApplyClearInteractionSessionResult(action: EditorAction): boolean {
   switch (action.action) {
     case 'TRANSIENT_ACTIONS':

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -58,9 +58,9 @@ import { Modifier } from '../../utils/modifiers'
 import CanvasActions from '../canvas/canvas-actions'
 import {
   createInteractionViaKeyboard,
-  KEYBOARD_INTERACTION_TIMEOUT,
   updateInteractionViaKeyboard,
 } from '../canvas/canvas-strategies/interaction-state'
+import { setupClearKeyboardInteraction } from '../canvas/controls/select-mode/select-mode-hooks'
 
 function pushProjectURLToBrowserHistory(projectId: string, projectName: string): void {
   // Make sure we don't replace the query params
@@ -165,24 +165,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
                 )
 
           editorStoreRef.current.dispatch([action], 'everyone')
-
-          if (!isFeatureEnabled('Keyboard up clears interaction')) {
-            if (keyboardTimeoutHandler.current != null) {
-              clearTimeout(keyboardTimeoutHandler.current)
-            }
-
-            keyboardTimeoutHandler.current = setTimeout(() => {
-              if (
-                editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type ===
-                'KEYBOARD_ARROW'
-              ) {
-                editorStoreRef.current.dispatch(
-                  [CanvasActions.clearInteractionSession(true)],
-                  'everyone',
-                )
-              }
-            }, KEYBOARD_INTERACTION_TIMEOUT)
-          }
+          setupClearKeyboardInteraction(editorStoreRef, keyboardTimeoutHandler)
         }
       }
 

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -302,7 +302,7 @@ describe('interactionUpdatex', () => {
       [testStrategy],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
-      false,
+      'non-interaction',
     )
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
@@ -379,7 +379,7 @@ describe('interactionUpdatex', () => {
       [testStrategy],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
-      false,
+      'non-interaction',
     )
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
@@ -420,7 +420,7 @@ describe('interactionUpdate without strategy', () => {
       [],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
-      false,
+      'non-interaction',
     )
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
     expect(actualResult.unpatchedEditorState.canvas.scale).toEqual(1)
@@ -564,7 +564,7 @@ describe('interactionUpdate with stacked strategy change', () => {
       [testStrategy],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
-      false,
+      'non-interaction',
     )
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
@@ -667,7 +667,7 @@ describe('interactionUpdate with stacked strategy change', () => {
       [testStrategy],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
-      false,
+      'non-interaction',
     )
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
@@ -707,7 +707,7 @@ describe('interactionUpdate with accumulating keypresses', () => {
       [emptyTestStrategy],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
-      true,
+      'interaction-create-or-update',
     )
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
@@ -793,7 +793,7 @@ describe('interactionUpdate with user changed strategy', () => {
       },
     }
 
-    const actualResult = interactionUpdate([testStrategy], editorStore, result, false)
+    const actualResult = interactionUpdate([testStrategy], editorStore, result, 'non-interaction')
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
         "accumulatedCommands": Array [
@@ -894,7 +894,7 @@ describe('interactionUpdate with user changed strategy', () => {
       [testStrategy],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
-      false,
+      'non-interaction',
     )
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -274,6 +274,7 @@ describe('interactionUpdate', () => {
       [testStrategy],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
+      false,
     )
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
@@ -350,6 +351,7 @@ describe('interactionUpdate', () => {
       [testStrategy],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
+      false,
     )
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
@@ -390,6 +392,7 @@ describe('interactionUpdate without strategy', () => {
       [],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
+      false,
     )
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
     expect(actualResult.unpatchedEditorState.canvas.scale).toEqual(1)
@@ -533,6 +536,7 @@ describe('interactionUpdate with stacked strategy change', () => {
       [testStrategy],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
+      false,
     )
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
@@ -635,6 +639,7 @@ describe('interactionUpdate with stacked strategy change', () => {
       [testStrategy],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
+      false,
     )
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
@@ -682,7 +687,7 @@ describe('interactionUpdate with user changed strategy', () => {
       },
     }
 
-    const actualResult = interactionUpdate([testStrategy], editorStore, result)
+    const actualResult = interactionUpdate([testStrategy], editorStore, result, false)
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
         "accumulatedCommands": Array [
@@ -783,6 +788,7 @@ describe('interactionUpdate with user changed strategy', () => {
       [testStrategy],
       editorStore,
       dispatchResultFromEditorStore(editorStore),
+      false,
     )
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -159,7 +159,7 @@ const emptyTestStrategy: CanvasStrategy = {
     interactionSession: InteractionSession | null,
     metadata: ElementInstanceMetadataMap,
   ): boolean {
-    return interactionSession?.interactionData.type === 'KEYBOARD_ARROW'
+    return interactionSession?.interactionData.type === 'KEYBOARD'
   },
   controlsToRender: [],
   fitness: function (
@@ -694,7 +694,7 @@ describe('interactionUpdate with accumulating keypresses', () => {
       { alt: false, shift: false, ctrl: false, cmd: false },
       { type: 'BOUNDING_AREA', target: EP.elementPath([['aaa']]) },
     )
-    if (interactionSession.interactionData.type === 'KEYBOARD_ARROW') {
+    if (interactionSession.interactionData.type === 'KEYBOARD') {
       interactionSession.interactionData.keysPressed = ['left']
     }
     const editorStore = createEditorStore(interactionSession)

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -532,7 +532,7 @@ describe('interactionUpdate with stacked strategy change', () => {
       interactionSession.interactionData.prevDrag = canvasPoint({ x: 30, y: 120 })
     }
     const editorStore = createEditorStore(interactionSession)
-    editorStore.strategyState.currentStrategy = 'TEST_STRATEGY' as CanvasStrategyId
+    editorStore.strategyState.currentStrategy = 'EMPTY_TEST_STRATEGY' as CanvasStrategyId
     const actualResult = interactionUpdate(
       [testStrategy],
       editorStore,
@@ -544,7 +544,7 @@ describe('interactionUpdate with stacked strategy change', () => {
         "accumulatedCommands": Array [
           Object {
             "commands": Array [],
-            "strategy": "TEST_STRATEGY",
+            "strategy": "EMPTY_TEST_STRATEGY",
           },
           Object {
             "commands": Array [

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -619,6 +619,8 @@ function handleStrategiesInner(
   const cancelInteraction =
     dispatchedActions.some(isClearInteractionSession) && !makeChangesPermanent
   const isInteractionAction = dispatchedActions.some(isCreateOrUpdateInteractionSession)
+    ? 'interaction-create-or-update'
+    : 'non-interaction'
   if (storedState.unpatchedEditor.canvas.interactionSession == null) {
     if (result.unpatchedEditor.canvas.interactionSession == null) {
       return {

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -165,7 +165,7 @@ export function interactionUpdate(
   strategies: Array<CanvasStrategy>,
   storedState: EditorStoreFull,
   result: InnerDispatchResult,
-  isInteractionAction: boolean,
+  actionType: 'interaction-create-or-update' | 'non-interaction',
 ): HandleStrategiesResult {
   const newEditorState = result.unpatchedEditor
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
@@ -215,7 +215,7 @@ export function interactionUpdate(
 
     if (
       result.unpatchedEditor.canvas.interactionSession?.interactionData.type === 'KEYBOARD' &&
-      isInteractionAction
+      actionType === 'interaction-create-or-update'
     ) {
       return handleAccumulatingKeypresses(
         newEditorState,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -214,7 +214,7 @@ export function interactionUpdate(
     }
 
     if (
-      result.unpatchedEditor.canvas.interactionSession?.interactionData.type === 'KEYBOARD_ARROW' &&
+      result.unpatchedEditor.canvas.interactionSession?.interactionData.type === 'KEYBOARD' &&
       isInteractionAction
     ) {
       return handleAccumulatingKeypresses(

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -14,6 +14,7 @@ export type FeatureName =
   | 'Insertion Plus Button'
   | 'Canvas Strategies'
   | 'Canvas Absolute Resize Controls'
+  | 'Keyboard up clears interaction'
 
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
@@ -27,6 +28,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Insertion Plus Button',
   'Canvas Strategies',
   'Canvas Absolute Resize Controls',
+  'Keyboard up clears interaction',
 ]
 
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {
@@ -41,6 +43,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Insertion Plus Button': true,
   'Canvas Strategies': false,
   'Canvas Absolute Resize Controls': false,
+  'Keyboard up clears interaction': false,
 }
 
 function settingKeyForName(featureName: FeatureName): string {

--- a/editor/src/utils/keyboard.ts
+++ b/editor/src/utils/keyboard.ts
@@ -254,6 +254,13 @@ export const Keyboard = {
       return char === keyChar
     })
   },
+  keyIsArrow: function (keyChar: KeyCharacter): boolean {
+    return ['left', 'right', 'up', 'down'].some((char) => char === keyChar)
+  },
+  // This needs to be extended when we introduce new keys in canvas strategies
+  keyIsInteraction: function (keyChar: KeyCharacter): boolean {
+    return this.keyIsArrow(keyChar)
+  },
   keyTriggersScroll: function (keyChar: KeyCharacter, keysPressed: KeysPressed): boolean {
     return (
       ['up', 'down', 'left', 'right', 'space'].some((char) => {

--- a/editor/src/utils/keyboard.ts
+++ b/editor/src/utils/keyboard.ts
@@ -255,7 +255,15 @@ export const Keyboard = {
     })
   },
   keyIsArrow: function (keyChar: KeyCharacter): boolean {
-    return ['left', 'right', 'up', 'down'].some((char) => char === keyChar)
+    switch (keyChar) {
+      case 'left':
+      case 'right':
+      case 'up':
+      case 'down':
+        return true
+      default:
+        return false
+    }
   },
   // This needs to be extended when we introduce new keys in canvas strategies
   keyIsInteraction: function (keyChar: KeyCharacter): boolean {


### PR DESCRIPTION
This PR introduces the first keyboard strategy.

Keyboard strategies are really different from drag strategies, mostly because they manage multiple keypresses as single interactions.
In this PR I handle a series of keypresses in the following way:
- the first keydown creates the interaction and starts a timer to clear the interaction later
- the subsequent keydowns update the interaction and reset the timer
- when the timer is off the interaction is cleared
- in dispatch we always accumulate the commands coming from the strategy so their result is not lost

Optionally you can enable the 'Keyboard up clears interaction' and then there is a much simple workflow: every keyboard up clears the interaction, so every separate keypress is a separate undo step. Multiple steps achieved by a long keypress stay as one undo step though (because there is no key up event between the steps).

I introduced a basic (prototype quality) keyboard absolute move strategy to demonstrate how this can work.
