### PR TITLE
Measure Absolute Move Strategy Performance.

### DIFF
--- a/editor/src/components/menubar/menubar.tsx
+++ b/editor/src/components/menubar/menubar.tsx
@@ -11,6 +11,7 @@ import {
   useTriggerBaselinePerformanceTest,
   useTriggerRegularHighlightPerformanceTest,
   useTriggerAllElementsHighlightPerformanceTest,
+  useTriggerAbsoluteMovePerformanceTest,
 } from '../../core/model/performance-scripts'
 import { useReParseOpenProjectFile } from '../../core/model/project-file-helper-hooks'
 import { shareURLForProject } from '../../core/shared/utils'
@@ -192,6 +193,7 @@ export const Menubar = React.memo(() => {
   const onTriggerRegularHighlightTest = useTriggerRegularHighlightPerformanceTest()
   const onTriggerAllElementsHighlightTest = useTriggerAllElementsHighlightPerformanceTest()
   const onTriggerSelectionTest = useTriggerSelectionPerformanceTest()
+  const onTriggerAbsoluteMoveTest = useTriggerAbsoluteMovePerformanceTest()
   const onTriggerBaselineTest = useTriggerBaselinePerformanceTest()
 
   const previewURL =
@@ -367,6 +369,9 @@ export const Menubar = React.memo(() => {
           </Tile>
           <Tile style={{ marginTop: 12, marginBottom: 12 }} size='large'>
             <a onClick={onTriggerSelectionTest}>P E</a>
+          </Tile>
+          <Tile style={{ marginTop: 12, marginBottom: 12 }} size='large'>
+            <a onClick={onTriggerAbsoluteMoveTest}>PAM</a>
           </Tile>
           <Tile style={{ marginTop: 12, marginBottom: 12 }} size='large'>
             <a onClick={onTriggerBaselineTest}>B L</a>

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -47,7 +47,7 @@ export function wait(timeout: number): Promise<void> {
   })
 }
 
-const NumberOfIterations = 100
+const NumberOfIterations = 5
 
 export function useTriggerScrollPerformanceTest(): () => void {
   const dispatch = useEditorState(
@@ -457,17 +457,19 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
           buttons: 1,
         }),
       )
-      controlsContainerElement.dispatchEvent(
-        new MouseEvent('mousemove', {
-          detail: 1,
-          bubbles: true,
-          cancelable: true,
-          metaKey: false,
-          clientX: targetBounds.left + 35,
-          clientY: targetBounds.top + 45,
-          buttons: 1,
-        }),
-      )
+      for (let moveCount = 1; moveCount <= 10; moveCount++) {
+        controlsContainerElement.dispatchEvent(
+          new MouseEvent('mousemove', {
+            detail: 1,
+            bubbles: true,
+            cancelable: true,
+            metaKey: false,
+            clientX: targetBounds.left + (5 + moveCount * 3),
+            clientY: targetBounds.top + (5 + moveCount * 4),
+            buttons: 1,
+          }),
+        )
+      }
       controlsContainerElement.dispatchEvent(
         new MouseEvent('mouseup', {
           detail: 1,

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -443,7 +443,7 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
         ],
         'everyone',
       ).entireUpdateFinished
-      performance.mark(`absolute_move_step_${framesPassed}`)
+      performance.mark(`absolute_move_interaction_step_${framesPassed}`)
 
       // Move it down and to the right.
       controlsContainerElement.dispatchEvent(
@@ -457,6 +457,9 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
           buttons: 1,
         }),
       )
+
+      // Mouse move and performance marks for that.
+      performance.mark(`absolute_move_move_step_${framesPassed}`)
       for (let moveCount = 1; moveCount <= 10; moveCount++) {
         controlsContainerElement.dispatchEvent(
           new MouseEvent('mousemove', {
@@ -470,6 +473,8 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
           }),
         )
       }
+      performance.mark(`absolute_move_move_finished_${framesPassed}`)
+
       controlsContainerElement.dispatchEvent(
         new MouseEvent('mouseup', {
           detail: 1,
@@ -481,11 +486,16 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
           buttons: 1,
         }),
       )
-      performance.mark(`absolute_move_finished_${framesPassed}`)
+      performance.mark(`absolute_move_interaction_finished_${framesPassed}`)
       performance.measure(
-        `absolute_move_frame_${framesPassed}`,
-        `absolute_move_step_${framesPassed}`,
-        `absolute_move_finished_${framesPassed}`,
+        `absolute_move_interaction_frame_${framesPassed}`,
+        `absolute_move_interaction_step_${framesPassed}`,
+        `absolute_move_interaction_finished_${framesPassed}`,
+      )
+      performance.measure(
+        `absolute_move_move_frame_${framesPassed}`,
+        `absolute_move_move_step_${framesPassed}`,
+        `absolute_move_move_finished_${framesPassed}`,
       )
 
       if (framesPassed < NumberOfIterations) {

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -47,7 +47,7 @@ export function wait(timeout: number): Promise<void> {
   })
 }
 
-const NumberOfIterations = 5
+const NumberOfIterations = 100
 
 export function useTriggerScrollPerformanceTest(): () => void {
   const dispatch = useEditorState(

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -461,7 +461,7 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
 
       // Mouse move and performance marks for that.
       performance.mark(`absolute_move_move_step_${framesPassed}`)
-      for (let moveCount = 1; moveCount <= 10; moveCount++) {
+      for (let moveCount = 1; moveCount <= 1; moveCount++) {
         controlsContainerElement.dispatchEvent(
           new MouseEvent('mousemove', {
             detail: 1,

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -1,11 +1,15 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import * as ReactDOM from 'react-dom'
 import CanvasActions from '../../components/canvas/canvas-actions'
 import { DebugDispatch, DispatchPriority, EditorAction } from '../../components/editor/action-types'
 import {
   clearSelection,
+  deleteView,
   selectComponents,
+  setFocusedElement,
+  setProp_UNSAFE,
   switchEditorMode,
+  unsetProperty,
 } from '../../components/editor/actions/action-creators'
 import { useEditorState, useRefEditorState } from '../../components/editor/store/store-hook'
 import {
@@ -24,6 +28,7 @@ import {
 import { MetadataUtils } from './element-metadata-utils'
 import { getOriginalFrames } from '../../components/canvas/canvas-utils'
 import * as EP from '../shared/element-path'
+import * as PP from '../shared/property-path'
 import { EditorModes } from '../../components/editor/editor-modes'
 import {
   useCalculateHighlightedViews,
@@ -33,6 +38,8 @@ import { CanvasControlsContainerID } from '../../components/canvas/controls/new-
 import { forceNotNull } from '../shared/optional-utils'
 import { ElementPathArrayKeepDeepEquality } from '../../utils/deep-equality-instances'
 import { NavigatorContainerId } from '../../components/navigator/navigator'
+import { emptyComments, jsxAttributeValue } from '../shared/element-template'
+import { isFeatureEnabled, setFeatureEnabled } from '../../utils/feature-switches'
 
 export function wait(timeout: number): Promise<void> {
   return new Promise((resolve) => {
@@ -328,6 +335,174 @@ export function useTriggerSelectionPerformanceTest(): () => void {
     }
     requestAnimationFrame(step)
   }, [dispatch, allPaths, selectedViews])
+  return trigger
+}
+
+export function useTriggerAbsoluteMovePerformanceTest(): () => void {
+  const dispatch = useEditorState(
+    React.useCallback((store) => store.dispatch as DebugDispatch, []),
+    'useTriggerAbsoluteMovePerformanceTest dispatch',
+  )
+  const allPaths = useRefEditorState(
+    React.useCallback((store) => store.derived.navigatorTargets, []),
+  )
+  const metadata = useRefEditorState(React.useCallback((store) => store.editor.jsxMetadata, []))
+  const selectedViews = useRefEditorState(
+    React.useCallback((store) => store.editor.selectedViews, []),
+  )
+  const trigger = React.useCallback(async () => {
+    if (allPaths.current.length === 0) {
+      console.info('ABSOLUTE_MOVE_TEST_ERROR')
+      return
+    }
+    const targetPath = [...allPaths.current].sort(
+      (a, b) => EP.toString(b).length - EP.toString(a).length,
+    )[0]
+
+    // Switch Canvas Strategies on.
+    const strategiesCurrentlyEnabled = isFeatureEnabled('Canvas Strategies')
+    setFeatureEnabled('Canvas Strategies', true)
+    // Delete the other children that just get in the way.
+    const parentPath = EP.parentPath(targetPath)
+    const siblingPaths = allPaths.current.filter(
+      (path) => EP.isChildOf(path, parentPath) && !EP.pathsEqual(path, targetPath),
+    )
+    await dispatch(
+      siblingPaths.map((path) => deleteView(path)),
+      'everyone',
+    ).entireUpdateFinished
+    // Focus the target so that we can edit the child div inside it.
+    await dispatch([setFocusedElement(targetPath)], 'everyone').entireUpdateFinished
+    const childTargetPath = allPaths.current.find((path) => EP.isChildOf(path, targetPath))
+    if (childTargetPath == null) {
+      console.info('ABSOLUTE_MOVE_TEST_ERROR')
+      return
+    }
+    const childMetadata = MetadataUtils.findElementByElementPath(metadata.current, childTargetPath)
+    if (
+      childMetadata == null ||
+      childMetadata.globalFrame == null ||
+      childMetadata.specialSizeMeasurements.coordinateSystemBounds == null
+    ) {
+      console.info('ABSOLUTE_MOVE_TEST_ERROR')
+      return
+    }
+    const styleValue = {
+      position: 'absolute',
+      left:
+        childMetadata.globalFrame.x -
+        childMetadata.specialSizeMeasurements.coordinateSystemBounds.x,
+      top:
+        childMetadata.globalFrame.y -
+        childMetadata.specialSizeMeasurements.coordinateSystemBounds.y,
+      width: childMetadata.globalFrame.width,
+      height: childMetadata.globalFrame.height,
+    }
+
+    // Determine where the events should be fired.
+    const controlsContainerElement = forceNotNull(
+      'Container controls element should exist.',
+      document.getElementById(CanvasControlsContainerID),
+    )
+    const canvasContainerElement = forceNotNull(
+      'Canvas container element should exist.',
+      document.getElementById(CanvasContainerID),
+    )
+    const canvasContainerBounds = canvasContainerElement.getBoundingClientRect()
+    const navigatorElement = forceNotNull(
+      'Navigator element should exist.',
+      document.getElementById(NavigatorContainerId),
+    )
+    const navigatorBounds = navigatorElement.getBoundingClientRect()
+
+    const targetElement = forceNotNull(
+      'Target element should exist.',
+      document.querySelector(`*[data-paths~="${EP.toString(childTargetPath)}"]`),
+    )
+    const originalTargetBounds = targetElement.getBoundingClientRect()
+    const leftToTarget =
+      canvasContainerBounds.left + navigatorBounds.width - originalTargetBounds.left + 100
+    const topToTarget = canvasContainerBounds.top - originalTargetBounds.top + 100
+    await dispatch(
+      [CanvasActions.positionCanvas(canvasPoint({ x: leftToTarget, y: topToTarget }))],
+      'everyone',
+    ).entireUpdateFinished
+    const targetBounds = targetElement.getBoundingClientRect()
+
+    let framesPassed = 0
+    async function step() {
+      // Make the div inside the target absolute positioned and ensure it is selected.
+      await dispatch(
+        [
+          selectComponents([childTargetPath!], false),
+          setProp_UNSAFE(
+            childTargetPath!,
+            PP.create(['style']),
+            jsxAttributeValue(styleValue, emptyComments),
+          ),
+        ],
+        'everyone',
+      ).entireUpdateFinished
+      performance.mark(`absolute_move_step_${framesPassed}`)
+
+      // Move it down and to the right.
+      controlsContainerElement.dispatchEvent(
+        new MouseEvent('mousedown', {
+          detail: 1,
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: targetBounds.left + 5,
+          clientY: targetBounds.top + 5,
+          buttons: 1,
+        }),
+      )
+      controlsContainerElement.dispatchEvent(
+        new MouseEvent('mousemove', {
+          detail: 1,
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: targetBounds.left + 35,
+          clientY: targetBounds.top + 45,
+          buttons: 1,
+        }),
+      )
+      controlsContainerElement.dispatchEvent(
+        new MouseEvent('mouseup', {
+          detail: 1,
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: targetBounds.left + 35,
+          clientY: targetBounds.top + 45,
+          buttons: 1,
+        }),
+      )
+      performance.mark(`absolute_move_finished_${framesPassed}`)
+      performance.measure(
+        `absolute_move_frame_${framesPassed}`,
+        `absolute_move_step_${framesPassed}`,
+        `absolute_move_finished_${framesPassed}`,
+      )
+
+      if (framesPassed < NumberOfIterations) {
+        framesPassed++
+        requestAnimationFrame(step)
+      } else {
+        // Potentially turn off Canvas Strategies.
+        setFeatureEnabled('Canvas Strategies', strategiesCurrentlyEnabled)
+        // Reset the position.
+        await dispatch([unsetProperty(childTargetPath!, PP.create(['style']))], 'everyone')
+          .entireUpdateFinished
+        // Unfocus the target.
+        await dispatch([setFocusedElement(null)], 'everyone').entireUpdateFinished
+
+        console.info('ABSOLUTE_MOVE_TEST_FINISHED')
+      }
+    }
+    requestAnimationFrame(step)
+  }, [dispatch, allPaths, metadata])
   return trigger
 }
 

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -351,13 +351,13 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
     React.useCallback((store) => store.editor.selectedViews, []),
   )
   const trigger = React.useCallback(async () => {
-    if (allPaths.current.length === 0) {
-      console.info('ABSOLUTE_MOVE_TEST_ERROR')
-      return
-    }
-    const targetPath = [...allPaths.current].sort(
-      (a, b) => EP.toString(b).length - EP.toString(a).length,
-    )[0]
+    // This is very particularly tied to the test project, we _really_ need to pick the
+    // right element because our changes can cause other elements to end up on top of the
+    // target we want.
+    const targetPath = EP.elementPath([
+      ['same-file-app-div', '967', '194', '70b'],
+      ['20b', '887', '016', 'aar'],
+    ])
 
     // Switch Canvas Strategies on.
     const strategiesCurrentlyEnabled = isFeatureEnabled('Canvas Strategies')
@@ -387,7 +387,7 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
       console.info('ABSOLUTE_MOVE_TEST_ERROR')
       return
     }
-    const styleValue = {
+    const childStyleValue = {
       position: 'absolute',
       left:
         childMetadata.globalFrame.x -
@@ -438,7 +438,7 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
           setProp_UNSAFE(
             childTargetPath!,
             PP.create(['style']),
-            jsxAttributeValue(styleValue, emptyComments),
+            jsxAttributeValue(childStyleValue, emptyComments),
           ),
         ],
         'everyone',
@@ -452,11 +452,12 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
           bubbles: true,
           cancelable: true,
           metaKey: false,
-          clientX: targetBounds.left + 5,
-          clientY: targetBounds.top + 5,
+          clientX: targetBounds.left + 20,
+          clientY: targetBounds.top + 20,
           buttons: 1,
         }),
       )
+      await wait(0)
 
       // Mouse move and performance marks for that.
       performance.mark(`absolute_move_move_step_${framesPassed}`)
@@ -467,11 +468,12 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
             bubbles: true,
             cancelable: true,
             metaKey: false,
-            clientX: targetBounds.left + (5 + moveCount * 3),
-            clientY: targetBounds.top + (5 + moveCount * 4),
+            clientX: targetBounds.left + (20 + moveCount * 3),
+            clientY: targetBounds.top + (20 + moveCount * 4),
             buttons: 1,
           }),
         )
+        await wait(0)
       }
       performance.mark(`absolute_move_move_finished_${framesPassed}`)
 
@@ -481,11 +483,12 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
           bubbles: true,
           cancelable: true,
           metaKey: false,
-          clientX: targetBounds.left + 35,
-          clientY: targetBounds.top + 45,
+          clientX: targetBounds.left + 50,
+          clientY: targetBounds.top + 60,
           buttons: 1,
         }),
       )
+      await wait(0)
       performance.mark(`absolute_move_interaction_finished_${framesPassed}`)
       performance.measure(
         `absolute_move_interaction_frame_${framesPassed}`,

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -185,6 +185,7 @@ export const testPerformanceInner = async function (url: string): Promise<Perfor
   let selectionResult = EmptyResult
   let basicCalc = EmptyResult
   let simpleDispatch = EmptyResult
+  let absoluteMoveResult = EmptyResult
   const { page, browser } = await setupBrowser(url, 120000)
   try {
     const baselines = await initialiseTestsReturnScale(page)
@@ -195,6 +196,7 @@ export const testPerformanceInner = async function (url: string): Promise<Perfor
     selectionResult = await testSelectionPerformance(page)
     resizeResult = await testResizePerformance(page)
     scrollResult = await testScrollingPerformance(page)
+    absoluteMoveResult = await testAbsoluteMovePerformance(page)
   } catch (e) {
     throw new Error(`Error during measurements ${e}`)
   } finally {
@@ -206,6 +208,7 @@ export const testPerformanceInner = async function (url: string): Promise<Perfor
     selectionResult,
     scrollResult,
     resizeResult,
+    absoluteMoveResult,
     basicCalc,
     simpleDispatch,
   ])
@@ -215,8 +218,8 @@ export const testPerformanceInner = async function (url: string): Promise<Perfor
   )} | ${consoleMessageForResult(highlightRegularResult)} | ${consoleMessageForResult(
     highlightAllElementsResult,
   )} | ${consoleMessageForResult(selectionResult)} | ${consoleMessageForResult(
-    basicCalc,
-  )} | ${consoleMessageForResult(simpleDispatch)}`
+    absoluteMoveResult,
+  )} | ${consoleMessageForResult(basicCalc)} | ${consoleMessageForResult(simpleDispatch)}`
 
   return {
     message: message,

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -357,7 +357,7 @@ export const testHighlightAllElementsPerformance = async function (
   await page.tracing.stop()
   let traceData = fs.readFileSync('trace.json').toString()
   const traceJson = JSON.parse(traceData)
-  return getFrameData(traceJson, 'highlight_all-elements_frame_', 'Highlight All Elements')
+  return getFrameData(traceJson, 'highlight_all-elements_step_', 'Highlight All Elements')
 }
 
 export const testSelectionPerformance = async function (
@@ -375,7 +375,7 @@ export const testSelectionPerformance = async function (
   await page.tracing.stop()
   let traceData = fs.readFileSync('trace.json').toString()
   const traceJson = JSON.parse(traceData)
-  return getFrameData(traceJson, 'select_frame_', 'Selection')
+  return getFrameData(traceJson, 'select_step_', 'Selection')
 }
 
 export const testAbsoluteMovePerformance = async function (

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -62,7 +62,7 @@ export function consoleDoneMessage(
   })
   return timeLimitPromise(
     consoleDonePromise,
-    120000,
+    120000 * 5,
     `Missing console message ${expectedConsoleMessage} in test browser.`,
   )
 }

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -29,18 +29,30 @@ export const setupBrowser = async (
   }
 }
 
+interface ValueWithTimeout {
+  timeoutID: NodeJS.Timeout | null
+}
+
 export function timeLimitPromise<T>(
   promise: Promise<T>,
   limitms: number,
   message: string,
 ): Promise<T> {
+  let valueWithTimeout: ValueWithTimeout = { timeoutID: null }
   const timeoutPromise: Promise<any> = new Promise((resolve, reject) => {
-    const timeoutID = setTimeout(() => {
-      clearTimeout(timeoutID)
+    valueWithTimeout.timeoutID = setTimeout(() => {
+      if (valueWithTimeout.timeoutID != null) {
+        clearTimeout(valueWithTimeout.timeoutID)
+      }
       reject(message)
     }, limitms)
   })
-  return Promise.race([promise, timeoutPromise])
+  const promiseWithCleanup = promise.finally(() => {
+    if (valueWithTimeout.timeoutID != null) {
+      clearTimeout(valueWithTimeout.timeoutID)
+    }
+  })
+  return Promise.race([promiseWithCleanup, timeoutPromise])
 }
 
 export function consoleDoneMessage(

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -18,8 +18,8 @@ export const setupBrowser = async (
     executablePath: process.env.BROWSER,
   })
   const page = await browser.newPage()
-  await page.setDefaultNavigationTimeout(120000)
-  await page.setDefaultTimeout(defaultTimeout)
+  page.setDefaultNavigationTimeout(120000)
+  page.setDefaultTimeout(defaultTimeout)
   await page.setViewport({ width: 1500, height: 768 })
   console.info('loading editor at URL:', url)
   await page.goto(url)


### PR DESCRIPTION
**Problem:**
Currently there are no performance tests checking any of the canvas strategies work.

**Fix:**
Added a performance test which enables canvas strategies and then triggers the absolute move strategy by dragging an absolutely positioned element.

**Notes:**
- This does make one destructive change to the project, which is to delete the siblings of the target element in the project. This was necessary as they ended up on top of the target and ended up receiving the mouse events.

**Commit Details:**
- Added additional menubar item to trigger the test.
- Implemented `useTriggerAbsoluteMovePerformanceTest` to slightly
  manipulate the test project and then run the tests against it.
- Added `testAbsoluteMovePerformance` for triggering the performance
  test via the menubar.
