### PR TITLE
Correct the calls to getFrameData.

### DIFF
--- a/puppeteer-tests/package.json
+++ b/puppeteer-tests/package.json
@@ -3,16 +3,18 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "performance-test": "ts-node src/performance-test.ts",
-    "screenshot-test": "ts-node src/screenshot-test.ts",
+    "performance-test": "ts-node --files src/performance-test.ts",
+    "screenshot-test": "ts-node --files src/screenshot-test.ts",
     "preinstall": "npx only-allow pnpm"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "@types/uuid": "8.3.0",
+    "@types/node": "17.0.21",
     "aws-sdk": "2.810.0",
     "dotenv": "8.2.0",
+    "JSONStream": "1.3.5", 
     "move-file": "2.0.0",
     "multer": "1.4.2",
     "multer-s3": "2.9.0",

--- a/puppeteer-tests/pnpm-lock.yaml
+++ b/puppeteer-tests/pnpm-lock.yaml
@@ -1,7 +1,9 @@
 lockfileVersion: 5.3
 
 specifiers:
+  '@types/node': 17.0.21
   '@types/uuid': 8.3.0
+  JSONStream: 1.3.5
   aws-sdk: 2.810.0
   dotenv: 8.2.0
   move-file: 2.0.0
@@ -15,7 +17,9 @@ specifiers:
   yn: ^4.0.0
 
 dependencies:
+  '@types/node': 17.0.21
   '@types/uuid': 8.3.0
+  JSONStream: 1.3.5
   aws-sdk: 2.810.0
   dotenv: 8.2.0
   move-file: 2.0.0
@@ -23,7 +27,7 @@ dependencies:
   multer-s3: 2.9.0
   plotly: 1.0.6
   puppeteer: 10.4.0
-  ts-node: 10.2.1_typescript@4.1.2
+  ts-node: 10.2.1_a85f9ca13f3750d8d489291745a73008
   typescript: 4.1.2
   uuid: 8.3.2
   yn: 4.0.0
@@ -58,10 +62,9 @@ packages:
     resolution: {integrity: sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==}
     dev: false
 
-  /@types/node/16.10.1:
-    resolution: {integrity: sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w==}
+  /@types/node/17.0.21:
+    resolution: {integrity: sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==}
     dev: false
-    optional: true
 
   /@types/uuid/8.3.0:
     resolution: {integrity: sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==}
@@ -70,9 +73,17 @@ packages:
   /@types/yauzl/2.9.2:
     resolution: {integrity: sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==}
     dependencies:
-      '@types/node': 16.10.1
+      '@types/node': 17.0.21
     dev: false
     optional: true
+
+  /JSONStream/1.3.5:
+    resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
+    hasBin: true
+    dependencies:
+      jsonparse: 1.3.1
+      through: 2.3.8
+    dev: false
 
   /acorn-walk/8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
@@ -368,6 +379,11 @@ packages:
   /jmespath/0.15.0:
     resolution: {integrity: sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=}
     engines: {node: '>= 0.6.0'}
+    dev: false
+
+  /jsonparse/1.3.1:
+    resolution: {integrity: sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=}
+    engines: {'0': node >= 0.2.0}
     dev: false
 
   /locate-path/5.0.0:
@@ -674,7 +690,7 @@ packages:
     resolution: {integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=}
     dev: false
 
-  /ts-node/10.2.1_typescript@4.1.2:
+  /ts-node/10.2.1_a85f9ca13f3750d8d489291745a73008:
     resolution: {integrity: sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==}
     engines: {node: '>=12.0.0'}
     hasBin: true
@@ -694,6 +710,7 @@ packages:
       '@tsconfig/node12': 1.0.9
       '@tsconfig/node14': 1.0.1
       '@tsconfig/node16': 1.0.2
+      '@types/node': 17.0.21
       acorn: 8.5.0
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/puppeteer-tests/src/missing-types.d.ts
+++ b/puppeteer-tests/src/missing-types.d.ts
@@ -1,0 +1,1 @@
+declare module 'JSONStream'

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -122,7 +122,7 @@ async function testBaselinePerformance(page: puppeteer.Page): Promise<FrameResul
 
   let traceData = fs.readFileSync('trace.json').toString()
   const traceJson = JSON.parse(traceData)
-  return getFrameData(traceJson, 'baseline_step_', 'Empty Dispatch')
+  return getFrameData(traceJson, 'baseline_frame_', 'Empty Dispatch')
 }
 
 async function initialiseTestsReturnScale(page: puppeteer.Page): Promise<Baselines> {
@@ -182,7 +182,7 @@ export const testPerformanceInner = async function (url: string): Promise<Perfor
   let resizeResult = EmptyResult
   let highlightRegularResult = EmptyResult
   let highlightAllElementsResult = EmptyResult
-  let selectionResult = EmptyResult
+  let selectionResult: Array<FrameResult> = []
   let basicCalc = EmptyResult
   let simpleDispatch = EmptyResult
   const { page, browser } = await setupBrowser(url, 120000)
@@ -203,7 +203,7 @@ export const testPerformanceInner = async function (url: string): Promise<Perfor
   const summaryImage = await uploadSummaryImage([
     highlightRegularResult,
     highlightAllElementsResult,
-    selectionResult,
+    ...selectionResult,
     scrollResult,
     resizeResult,
     basicCalc,
@@ -214,7 +214,7 @@ export const testPerformanceInner = async function (url: string): Promise<Perfor
     resizeResult,
   )} | ${consoleMessageForResult(highlightRegularResult)} | ${consoleMessageForResult(
     highlightAllElementsResult,
-  )} | ${consoleMessageForResult(selectionResult)} | ${consoleMessageForResult(
+  )} | ${selectionResult.map(consoleMessageForResult).join(' | ')} | ${consoleMessageForResult(
     basicCalc,
   )} | ${consoleMessageForResult(simpleDispatch)}`
 
@@ -250,7 +250,7 @@ export const testScrollingPerformance = async function (
   await page.tracing.stop()
   let traceData = fs.readFileSync('trace.json').toString()
   const traceJson = JSON.parse(traceData)
-  return getFrameData(traceJson, 'scroll_step_', 'Scroll Canvas')
+  return getFrameData(traceJson, 'scroll_frame_', 'Scroll Canvas')
 }
 
 export const testResizePerformance = async function (page: puppeteer.Page): Promise<FrameResult> {
@@ -286,7 +286,7 @@ export const testResizePerformance = async function (page: puppeteer.Page): Prom
   await page.tracing.stop()
   let traceData = fs.readFileSync('trace.json').toString()
   const traceJson = JSON.parse(traceData)
-  return getFrameData(traceJson, 'resize_step_', 'Resize')
+  return getFrameData(traceJson, 'resize_frame_', 'Resize')
 }
 
 export const testHighlightRegularPerformance = async function (
@@ -319,7 +319,7 @@ export const testHighlightRegularPerformance = async function (
   await page.tracing.stop()
   let traceData = fs.readFileSync('trace.json').toString()
   const traceJson = JSON.parse(traceData)
-  return getFrameData(traceJson, 'highlight_regular_step_', 'Highlight Regular')
+  return getFrameData(traceJson, 'highlight_regular_frame_', 'Highlight Regular')
 }
 
 export const testHighlightAllElementsPerformance = async function (
@@ -352,12 +352,12 @@ export const testHighlightAllElementsPerformance = async function (
   await page.tracing.stop()
   let traceData = fs.readFileSync('trace.json').toString()
   const traceJson = JSON.parse(traceData)
-  return getFrameData(traceJson, 'highlight_all-elements_step_', 'Highlight All Elements')
+  return getFrameData(traceJson, 'highlight_all-elements_frame_', 'Highlight All Elements')
 }
 
 export const testSelectionPerformance = async function (
   page: puppeteer.Page,
-): Promise<FrameResult> {
+): Promise<Array<FrameResult>> {
   console.log('Test Selection Performance')
   await page.waitForXPath("//a[contains(., 'P E')]")
   // we run it twice without measurements to warm up the environment
@@ -370,7 +370,10 @@ export const testSelectionPerformance = async function (
   await page.tracing.stop()
   let traceData = fs.readFileSync('trace.json').toString()
   const traceJson = JSON.parse(traceData)
-  return getFrameData(traceJson, 'select_step_', 'Selection')
+  return [
+    getFrameData(traceJson, 'select_frame_', 'Selection'),
+    getFrameData(traceJson, 'select_deselect_frame_', 'De-Selection'),
+  ]
 }
 
 const getFrameData = (traceJson: any, markNamePrefix: string, title: string): FrameResult => {


### PR DESCRIPTION
**Problem:**
The performance marks being used by the performance tests to analyse the time taken for the tests are the wrong ones.

**Fix:**
Instead of taking a measurement of the timestamp of step n + 1 and subtracting the timestamp of step n. The timestamp of the "end" performance mark has the timestamp of the "start" performance mark subtracted from it.

**Commit Details:**
- Added in a bonus deselection performance result which was being measured
  but ignored.
- Added some utility functions to wrap `performance.mark` and
  `performance.measure` to get consistent calls to them.
- Added `--files` to the `ts-node` invocation in the puppeter project
  so that the missing types for JSONStream are handled correctly.
- Added JSONStream to the puppeter-tests dependencies, along with a
  missing types module declaration for it.
- Replaced the original trace file loading with a streaming approach
  so that the entire file doesn't need to be loaded in full.
- Removed the categories filter so that any entries can be loaded in
  subsequently.
- Rewrote `getFrameData` to just use the start and end marks to bound
  the time a step took.