### PR TITLE
Improved keyboard absolute move strategy

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -25,7 +25,7 @@ import { wildcardPatch } from '../commands/wildcard-patch-command'
 import { runLegacySnapping } from '../controls/guideline-helpers'
 import { ConstrainedDragAxis, Guideline, GuidelineWithSnappingVector } from '../guideline'
 import { CanvasStrategy } from './canvas-strategy-types'
-import { getMoveCommandsForSelectedElement } from './shared-move-strategy-helpers'
+import { getAbsoluteMoveCommandsForSelectedElement } from './shared-absolute-move-strategy-helpers'
 
 export const absoluteMoveStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_MOVE',
@@ -67,7 +67,7 @@ export const absoluteMoveStrategy: CanvasStrategy = {
         canvasState.scale,
       )
       const commandsForSelectedElements = canvasState.selectedElements.flatMap((selectedElement) =>
-        getMoveCommandsForSelectedElement(
+        getAbsoluteMoveCommandsForSelectedElement(
           selectedElement,
           snappedDragVector,
           canvasState,

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -25,6 +25,7 @@ import { wildcardPatch } from '../commands/wildcard-patch-command'
 import { runLegacySnapping } from '../controls/guideline-helpers'
 import { ConstrainedDragAxis, Guideline, GuidelineWithSnappingVector } from '../guideline'
 import { CanvasStrategy } from './canvas-strategy-types'
+import { getMoveCommandsForSelectedElement } from './shared-move-strategy-helpers'
 
 export const absoluteMoveStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_MOVE',
@@ -65,30 +66,13 @@ export const absoluteMoveStrategy: CanvasStrategy = {
         canvasState.selectedElements,
         canvasState.scale,
       )
-      const commandsForSelectedElements = canvasState.selectedElements.flatMap(
-        (selectedElement) => {
-          const element: JSXElement | null = getElementFromProjectContents(
-            selectedElement,
-            canvasState.projectContents,
-            canvasState.openFile,
-          )
-          const elementParentBounds =
-            MetadataUtils.findElementByElementPath(
-              sessionState.startingMetadata, // TODO should this be using the current metadata?
-              selectedElement,
-            )?.specialSizeMeasurements.immediateParentBounds ?? null
-
-          if (element == null) {
-            return []
-          }
-
-          return createMoveCommandsForElement(
-            element,
-            selectedElement,
-            snappedDragVector,
-            elementParentBounds,
-          )
-        },
+      const commandsForSelectedElements = canvasState.selectedElements.flatMap((selectedElement) =>
+        getMoveCommandsForSelectedElement(
+          selectedElement,
+          snappedDragVector,
+          canvasState,
+          sessionState,
+        ),
       )
       return [
         ...commandsForSelectedElements,
@@ -99,38 +83,6 @@ export const absoluteMoveStrategy: CanvasStrategy = {
     // Fallback for when the checks above are not satisfied.
     return []
   },
-}
-
-function createMoveCommandsForElement(
-  element: JSXElement,
-  selectedElement: ElementPath,
-  drag: CanvasVector,
-  elementParentBounds: CanvasRectangle | null,
-): AdjustCssLengthProperty[] {
-  return mapDropNulls(
-    (pin) => {
-      const horizontal = isHorizontalPoint(
-        // TODO avoid using the loaded FramePoint enum
-        framePointForPinnedProp(pin),
-      )
-      const negative = pin === 'right' || pin === 'bottom'
-      const value = getLayoutProperty(pin, right(element.props), ['style'])
-      if (isRight(value) && value.value != null) {
-        // TODO what to do about missing properties?
-        return adjustCssLengthProperty(
-          'permanent',
-          selectedElement,
-          stylePropPathMappingFn(pin, ['style']),
-          (horizontal ? drag.x : drag.y) * (negative ? -1 : 1),
-          horizontal ? elementParentBounds?.width : elementParentBounds?.height,
-          true,
-        )
-      } else {
-        return null
-      }
-    },
-    ['top', 'bottom', 'left', 'right'] as const,
-  )
 }
 
 function snapDrag(

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.spec.tsx
@@ -5,6 +5,7 @@ import {
 } from '../../../core/shared/element-template'
 import { canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
+import { KeyCharacter } from '../../../utils/keyboard'
 import { emptyModifiers } from '../../../utils/modifiers'
 import { EditorState } from '../../editor/store/editor-state'
 import { foldAndApplyCommands } from '../commands/commands'
@@ -28,10 +29,10 @@ function prepareEditorState(codeSnippet: string, selectedViews: Array<ElementPat
   }
 }
 
-function pressLeft(editorState: EditorState): EditorState {
+function pressKeys(editorState: EditorState, keys: Array<KeyCharacter>): EditorState {
   const interactionSession: InteractionSession = {
     ...createInteractionViaKeyboard(
-      ['left'],
+      keys,
       emptyModifiers,
       null as any, // the strategy does not use this
     ),
@@ -68,6 +69,10 @@ function pressLeft(editorState: EditorState): EditorState {
   return finalEditor
 }
 
+function pressLeft(editorState: EditorState): EditorState {
+  return pressKeys(editorState, ['left'])
+}
+
 describe('Keyboard Absolute Move Strategy', () => {
   it('works with a TL pinned absolute element', async () => {
     const targetElement = elementPath([
@@ -94,6 +99,38 @@ describe('Keyboard Absolute Move Strategy', () => {
         `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
         <View
           style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 49, top: 50, width: 250, height: 300 }}
+          data-uid='bbb'
+        />
+      </View>`,
+      ),
+    )
+  })
+
+  it('works with left and top pressed simultaneously', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50, top: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = pressKeys(initialEditor, ['left', 'up'])
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 49, top: 49, width: 250, height: 300 }}
           data-uid='bbb'
         />
       </View>`,

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.spec.tsx
@@ -1,0 +1,259 @@
+import { elementPath } from '../../../core/shared/element-path'
+import {
+  ElementInstanceMetadata,
+  SpecialSizeMeasurements,
+} from '../../../core/shared/element-template'
+import { canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import { emptyModifiers } from '../../../utils/modifiers'
+import { EditorState } from '../../editor/store/editor-state'
+import { foldAndApplyCommands } from '../commands/commands'
+import {
+  getEditorState,
+  makeTestProjectCodeWithSnippet,
+  testPrintCodeFromEditorState,
+} from '../ui-jsx.test-utils'
+import { pickCanvasStateFromEditorState } from './canvas-strategies'
+import {
+  createInteractionViaKeyboard,
+  InteractionSession,
+  StrategyState,
+} from './interaction-state'
+import { keyboardAbsoluteMoveStrategy } from './keyboard-absolute-move-strategy'
+
+function prepareEditorState(codeSnippet: string, selectedViews: Array<ElementPath>): EditorState {
+  return {
+    ...getEditorState(makeTestProjectCodeWithSnippet(codeSnippet)),
+    selectedViews: selectedViews,
+  }
+}
+
+function pressLeft(editorState: EditorState): EditorState {
+  const interactionSession: InteractionSession = {
+    ...createInteractionViaKeyboard(
+      ['left'],
+      emptyModifiers,
+      null as any, // the strategy does not use this
+    ),
+    metadata: null as any, // the strategy does not use this
+  }
+
+  const strategyResult = keyboardAbsoluteMoveStrategy.apply(
+    pickCanvasStateFromEditorState(editorState),
+    interactionSession,
+    {
+      currentStrategy: null as any, // the strategy does not use this
+      currentStrategyFitness: null as any, // the strategy does not use this
+      currentStrategyCommands: null as any, // the strategy does not use this
+      accumulatedCommands: null as any, // the strategy does not use this
+      commandDescriptions: null as any, // the strategy does not use this
+      sortedApplicableStrategies: null as any, // the strategy does not use this
+      startingMetadata: {
+        'scene-aaa/app-entity:aaa/bbb': {
+          elementPath: elementPath([
+            ['scene-aaa', 'app-entity'],
+            ['aaa', 'bbb'],
+          ]),
+          specialSizeMeasurements: {
+            immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+          } as SpecialSizeMeasurements,
+        } as ElementInstanceMetadata,
+      },
+    } as StrategyState,
+  )
+
+  const finalEditor = foldAndApplyCommands(editorState, editorState, strategyResult, 'permanent')
+    .editorState
+
+  return finalEditor
+}
+
+describe('Keyboard Absolute Move Strategy', () => {
+  it('works with a TL pinned absolute element', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50, top: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = pressLeft(initialEditor)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 49, top: 50, width: 250, height: 300 }}
+          data-uid='bbb'
+        />
+      </View>`,
+      ),
+    )
+  })
+
+  it('works with a TL pinned absolute element with px values', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '50px', top: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = pressLeft(initialEditor)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '49px', top: 50, width: 250, height: 300 }}
+          data-uid='bbb'
+        />
+      </View>`,
+      ),
+    )
+  })
+
+  it('works with a RB pinned absolute element', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', right: 50, bottom: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = pressLeft(initialEditor)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', right: 51, bottom: 50, width: 250, height: 300 }}
+          data-uid='bbb'
+        />
+      </View>`,
+      ),
+    )
+  })
+
+  it('works with a TLRB pinned absolute element', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50, top: 50, right: 50, bottom: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = pressLeft(initialEditor)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 49, top: 50, right: 51, bottom: 50, width: 250, height: 300 }}
+          data-uid='bbb'
+        />
+      </View>`,
+      ),
+    )
+  })
+
+  // TODO needs design review
+  it('keeps expressions intact', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50 + 5, top: 50 + props.top, width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = pressLeft(initialEditor)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      testPrintCodeFromEditorState(initialEditor),
+    )
+  })
+
+  it('works with percentages', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '25%', top: '0%', width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = pressLeft(initialEditor)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).not.toEqual(
+      expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '24.75%', top: '0%', width: 250, height: 300 }}
+          data-uid='bbb'
+        />
+      </View>`,
+        ),
+      ),
+    )
+  })
+})

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -3,7 +3,7 @@ import { Keyboard, KeyCharacter } from '../../../utils/keyboard'
 import { CanvasStrategy } from './canvas-strategy-types'
 import { Modifiers } from '../../../utils/modifiers'
 import { CanvasVector } from '../../../core/shared/math-utils'
-import { getMoveCommandsForSelectedElement } from './shared-move-strategy-helpers'
+import { getAbsoluteMoveCommandsForSelectedElement } from './shared-absolute-move-strategy-helpers'
 
 export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
   id: 'KEYBOARD_ABSOLUTE_MOVE',
@@ -54,7 +54,12 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
       const drag = getDragDeltaFromKey(key, interactionState.interactionData.modifiers)
       if (drag.x !== 0 || drag.y !== 0) {
         return canvasState.selectedElements.flatMap((selectedElement) =>
-          getMoveCommandsForSelectedElement(selectedElement, drag, canvasState, sessionState),
+          getAbsoluteMoveCommandsForSelectedElement(
+            selectedElement,
+            drag,
+            canvasState,
+            sessionState,
+          ),
         )
       }
     }

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
@@ -19,12 +19,12 @@ import {
 import { InteractionCanvasState } from './canvas-strategy-types'
 import { StrategyState } from './interaction-state'
 
-export function getMoveCommandsForSelectedElement(
+export function getAbsoluteMoveCommandsForSelectedElement(
   selectedElement: ElementPath,
   drag: CanvasVector,
   canvasState: InteractionCanvasState,
   sessionState: StrategyState,
-) {
+): Array<AdjustCssLengthProperty> {
   const element: JSXElement | null = getElementFromProjectContents(
     selectedElement,
     canvasState.projectContents,

--- a/editor/src/components/canvas/canvas-strategies/shared-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-move-strategy-helpers.ts
@@ -1,0 +1,76 @@
+import { isHorizontalPoint } from 'utopia-api/core'
+import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
+import { framePointForPinnedProp } from '../../../core/layout/layout-helpers-new'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { mapDropNulls } from '../../../core/shared/array-utils'
+import { isRight, right } from '../../../core/shared/either'
+import { JSXElement } from '../../../core/shared/element-template'
+import { CanvasRectangle, CanvasVector } from '../../../core/shared/math-utils'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import {
+  getElementFromProjectContents,
+  withUnderlyingTarget,
+} from '../../editor/store/editor-state'
+import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
+import {
+  adjustCssLengthProperty,
+  AdjustCssLengthProperty,
+} from '../commands/adjust-css-length-command'
+import { InteractionCanvasState } from './canvas-strategy-types'
+import { StrategyState } from './interaction-state'
+
+export function getMoveCommandsForSelectedElement(
+  selectedElement: ElementPath,
+  drag: CanvasVector,
+  canvasState: InteractionCanvasState,
+  sessionState: StrategyState,
+) {
+  const element: JSXElement | null = getElementFromProjectContents(
+    selectedElement,
+    canvasState.projectContents,
+    canvasState.openFile,
+  )
+  const elementParentBounds =
+    MetadataUtils.findElementByElementPath(
+      sessionState.startingMetadata, // TODO should this be using the current metadata?
+      selectedElement,
+    )?.specialSizeMeasurements.immediateParentBounds ?? null
+
+  if (element == null) {
+    return []
+  }
+
+  return createMoveCommandsForElement(element, selectedElement, drag, elementParentBounds)
+}
+
+function createMoveCommandsForElement(
+  element: JSXElement,
+  selectedElement: ElementPath,
+  drag: CanvasVector,
+  elementParentBounds: CanvasRectangle | null,
+): AdjustCssLengthProperty[] {
+  return mapDropNulls(
+    (pin) => {
+      const horizontal = isHorizontalPoint(
+        // TODO avoid using the loaded FramePoint enum
+        framePointForPinnedProp(pin),
+      )
+      const negative = pin === 'right' || pin === 'bottom'
+      const value = getLayoutProperty(pin, right(element.props), ['style'])
+      if (isRight(value) && value.value != null) {
+        // TODO what to do about missing properties?
+        return adjustCssLengthProperty(
+          'permanent',
+          selectedElement,
+          stylePropPathMappingFn(pin, ['style']),
+          (horizontal ? drag.x : drag.y) * (negative ? -1 : 1),
+          horizontal ? elementParentBounds?.width : elementParentBounds?.height,
+          true,
+        )
+      } else {
+        return null
+      }
+    },
+    ['top', 'bottom', 'left', 'right'] as const,
+  )
+}


### PR DESCRIPTION
I improved the keyboard absolute move strategy:

- extracted the much better code from absolute move strategy into a shared file, and use that for the keyboard strategy. This makes it work with all different kinds off css props.
- Added shift key modifier (bigger step)
- Added unit tests (TODO: need to add more keys and shift)