### PR TITLE
Absolute resize snapping

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -1,8 +1,6 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
-import {
-  CanvasPoint
-} from '../../../core/shared/math-utils'
+import { CanvasPoint } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
@@ -11,7 +9,7 @@ import { ConstrainedDragAxis, GuidelineWithSnappingVector } from '../guideline'
 import { CanvasStrategy } from './canvas-strategy-types'
 import {
   getAbsoluteMoveCommandsForSelectedElement,
-  getMultiselectBounds
+  getMultiselectBounds,
 } from './shared-absolute-move-strategy-helpers'
 
 export const absoluteMoveStrategy: CanvasStrategy = {

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -1,31 +1,18 @@
-import { isHorizontalPoint } from 'utopia-api/core'
-import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
-import { framePointForPinnedProp } from '../../../core/layout/layout-helpers-new'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { mapDropNulls } from '../../../core/shared/array-utils'
-import { isRight, right } from '../../../core/shared/either'
-import { ElementInstanceMetadataMap, JSXElement } from '../../../core/shared/element-template'
+import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import {
-  boundingRectangleArray,
-  CanvasPoint,
-  CanvasRectangle,
-  CanvasVector,
-  offsetPoint,
+  CanvasPoint
 } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import { getElementFromProjectContents } from '../../editor/store/editor-state'
-import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
-import {
-  AdjustCssLengthProperty,
-  adjustCssLengthProperty,
-} from '../commands/adjust-css-length-command'
 import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
-import { wildcardPatch } from '../commands/wildcard-patch-command'
 import { runLegacyAbsoluteMoveSnapping } from '../controls/guideline-helpers'
-import { ConstrainedDragAxis, Guideline, GuidelineWithSnappingVector } from '../guideline'
+import { ConstrainedDragAxis, GuidelineWithSnappingVector } from '../guideline'
 import { CanvasStrategy } from './canvas-strategy-types'
-import { getAbsoluteMoveCommandsForSelectedElement } from './shared-absolute-move-strategy-helpers'
+import {
+  getAbsoluteMoveCommandsForSelectedElement,
+  getMultiselectBounds
+} from './shared-absolute-move-strategy-helpers'
 
 export const absoluteMoveStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_MOVE',
@@ -109,15 +96,4 @@ function snapDrag(
   )
 
   return { snappedDragVector, guidelinesWithSnappingVector }
-}
-
-function getMultiselectBounds(
-  jsxMetadata: ElementInstanceMetadataMap,
-  selectedElements: Array<ElementPath>,
-): CanvasRectangle | null {
-  const frames = mapDropNulls((element) => {
-    return MetadataUtils.getFrameInCanvasCoords(element, jsxMetadata)
-  }, selectedElements)
-
-  return boundingRectangleArray(frames)
 }

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-strategy.tsx
@@ -21,6 +21,7 @@ import {
   AdjustCssLengthProperty,
   adjustCssLengthProperty,
 } from '../commands/adjust-css-length-command'
+import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
 import { AbsoluteResizeControl } from '../controls/select-mode/absolute-resize-control'
 import { GuidelineWithSnappingVector } from '../guideline'
@@ -64,7 +65,7 @@ export const absoluteResizeStrategy: CanvasStrategy = {
     ) {
       const drag = interactionState.interactionData.drag
       const edgePosition = interactionState.activeControl.edgePosition
-      const snappedDrag = snapDrag(
+      const { snappedDragVector, guidelinesWithSnappingVector } = snapDrag(
         canvasState.selectedElements,
         sessionState.startingMetadata,
         canvasState.scale,
@@ -101,12 +102,16 @@ export const absoluteResizeStrategy: CanvasStrategy = {
             element,
             selectedElement,
             edgePosition,
-            snappedDrag.snappedDragVector,
+            snappedDragVector,
             elementParentBounds,
           )
         },
       )
-      return [...commandsForSelectedElements, updateHighlightedViews('transient', [])]
+      return [
+        ...commandsForSelectedElements,
+        updateHighlightedViews('transient', []),
+        setSnappingGuidelines('transient', guidelinesWithSnappingVector),
+      ]
     }
     // Fallback for when the checks above are not satisfied.
     return []

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-strategy.tsx
@@ -4,18 +4,26 @@ import { framePointForPinnedProp } from '../../../core/layout/layout-helpers-new
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../core/shared/array-utils'
 import { isRight, right } from '../../../core/shared/either'
-import { JSXElement } from '../../../core/shared/element-template'
-import { CanvasRectangle, CanvasVector } from '../../../core/shared/math-utils'
+import { ElementInstanceMetadataMap, JSXElement } from '../../../core/shared/element-template'
+import {
+  CanvasPoint,
+  CanvasRectangle,
+  CanvasVector,
+  offsetPoint,
+  vectorDifference,
+} from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { withUnderlyingTarget } from '../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { EdgePosition } from '../canvas-types'
+import { snapPoint } from '../canvas-utils'
 import {
   AdjustCssLengthProperty,
   adjustCssLengthProperty,
 } from '../commands/adjust-css-length-command'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
 import { AbsoluteResizeControl } from '../controls/select-mode/absolute-resize-control'
+import { GuidelineWithSnappingVector } from '../guideline'
 import { CanvasStrategy } from './canvas-strategy-types'
 
 type AbsolutePin = 'left' | 'top' | 'right' | 'bottom' | 'width' | 'height'
@@ -56,6 +64,18 @@ export const absoluteResizeStrategy: CanvasStrategy = {
     ) {
       const drag = interactionState.interactionData.drag
       const edgePosition = interactionState.activeControl.edgePosition
+      const snappedDrag = snapDrag(
+        canvasState.selectedElements,
+        sessionState.startingMetadata,
+        canvasState.scale,
+        interactionState.interactionData.dragStart,
+        drag,
+        true,
+        false,
+        null as any,
+        null as any,
+        edgePosition,
+      )
 
       const commandsForSelectedElements = canvasState.selectedElements.flatMap(
         (selectedElement) => {
@@ -81,7 +101,7 @@ export const absoluteResizeStrategy: CanvasStrategy = {
             element,
             selectedElement,
             edgePosition,
-            drag,
+            snappedDrag.snappedDragVector,
             elementParentBounds,
           )
         },
@@ -145,4 +165,38 @@ function createResizeCommands(
       return null
     }
   }, pins)
+}
+
+function snapDrag(
+  selectedViews: Array<ElementPath>,
+  jsxMetadata: ElementInstanceMetadataMap,
+  canvasScale: number,
+  dragStart: CanvasPoint,
+  drag: CanvasVector,
+  enableSnapping: boolean,
+  keepAspectRatio: boolean,
+  diagonalA: CanvasPoint,
+  diagonalB: CanvasPoint,
+  resizingFromPosition: EdgePosition | null,
+): {
+  snappedDragVector: CanvasPoint
+  guidelinesWithSnappingVector: Array<GuidelineWithSnappingVector>
+} {
+  const pointToSnap: CanvasPoint = offsetPoint(dragStart, drag)
+  const { snappedPointOnCanvas, guidelinesWithSnappingVector } = snapPoint(
+    selectedViews,
+    jsxMetadata,
+    canvasScale,
+    pointToSnap,
+    enableSnapping,
+    keepAspectRatio,
+    diagonalA,
+    diagonalB,
+    resizingFromPosition,
+  )
+  const snappedDragVector = vectorDifference(dragStart, snappedPointOnCanvas)
+  return {
+    snappedDragVector: snappedDragVector,
+    guidelinesWithSnappingVector: guidelinesWithSnappingVector,
+  }
 }

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
@@ -4,13 +4,14 @@ import { framePointForPinnedProp } from '../../../core/layout/layout-helpers-new
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../core/shared/array-utils'
 import { isRight, right } from '../../../core/shared/either'
-import { JSXElement } from '../../../core/shared/element-template'
-import { CanvasRectangle, CanvasVector } from '../../../core/shared/math-utils'
-import { ElementPath } from '../../../core/shared/project-file-types'
+import type { ElementInstanceMetadataMap, JSXElement } from '../../../core/shared/element-template'
 import {
-  getElementFromProjectContents,
-  withUnderlyingTarget,
-} from '../../editor/store/editor-state'
+  boundingRectangleArray,
+  CanvasRectangle,
+  CanvasVector,
+} from '../../../core/shared/math-utils'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import { getElementFromProjectContents } from '../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import {
   adjustCssLengthProperty,
@@ -73,4 +74,15 @@ function createMoveCommandsForElement(
     },
     ['top', 'bottom', 'left', 'right'] as const,
   )
+}
+
+export function getMultiselectBounds(
+  jsxMetadata: ElementInstanceMetadataMap,
+  selectedElements: Array<ElementPath>,
+): CanvasRectangle | null {
+  const frames = mapDropNulls((element) => {
+    return MetadataUtils.getFrameInCanvasCoords(element, jsxMetadata)
+  }, selectedElements)
+
+  return boundingRectangleArray(frames)
 }

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1239,18 +1239,14 @@ export function collectGuidelines(
 }
 
 function innerSnapPoint(
-  editor: EditorState,
+  selectedViews: Array<ElementPath>,
+  jsxMetadata: ElementInstanceMetadataMap,
+  canvasScale: number,
   point: CanvasPoint,
   resizingFromPosition: EdgePosition | null,
 ): { point: CanvasPoint; guideline: GuidelineWithSnappingVector | null } {
   const guidelines = oneGuidelinePerDimension(
-    collectGuidelines(
-      editor.jsxMetadata,
-      editor.selectedViews,
-      editor.canvas.scale,
-      point,
-      resizingFromPosition,
-    ),
+    collectGuidelines(jsxMetadata, selectedViews, canvasScale, point, resizingFromPosition),
   )
   let snappedPoint = point
   let snappedGuideline: GuidelineWithSnappingVector | null = null
@@ -1268,29 +1264,40 @@ function innerSnapPoint(
 }
 
 export function snapPoint(
-  editor: EditorState,
+  selectedViews: Array<ElementPath>,
+  jsxMetadata: ElementInstanceMetadataMap,
+  canvasScale: number,
   pointToSnap: CanvasPoint,
   enableSnapping: boolean,
   keepAspectRatio: boolean,
   diagonalA: CanvasPoint,
   diagonalB: CanvasPoint,
   resizingFromPosition: EdgePosition | null,
-): CanvasPoint {
+): {
+  snappedPointOnCanvas: CanvasPoint
+  guidelinesWithSnappingVector: Array<GuidelineWithSnappingVector>
+} {
   const elementsToTarget = determineElementsToOperateOnForDragging(
-    editor.selectedViews,
-    editor.jsxMetadata,
+    selectedViews,
+    jsxMetadata,
     true,
     false,
   )
   const anythingPinnedAndNotAbsolutePositioned = elementsToTarget.some((elementToTarget) => {
-    return MetadataUtils.isPinnedAndNotAbsolutePositioned(editor.jsxMetadata, elementToTarget)
+    return MetadataUtils.isPinnedAndNotAbsolutePositioned(jsxMetadata, elementToTarget)
   })
   const shouldSnap = enableSnapping && !anythingPinnedAndNotAbsolutePositioned
 
   if (keepAspectRatio) {
     const closestPointOnLine = Utils.closestPointOnLine(diagonalA, diagonalB, pointToSnap)
     if (shouldSnap) {
-      const { guideline } = innerSnapPoint(editor, closestPointOnLine, resizingFromPosition)
+      const { guideline } = innerSnapPoint(
+        selectedViews,
+        jsxMetadata,
+        canvasScale,
+        closestPointOnLine,
+        resizingFromPosition,
+      )
       if (guideline != null) {
         const guidelinePoints = Guidelines.convertGuidelineToPoints(guideline.guideline)
         // for now, because scale is not a first-class citizen, we know that CanvasVector and LocalVector have the same dimensions
@@ -1308,17 +1315,28 @@ export function snapPoint(
             )
         }
         if (snappedPoint != null) {
-          return snappedPoint
+          return { snappedPointOnCanvas: snappedPoint, guidelinesWithSnappingVector: [guideline] }
         }
       }
       // fallback to regular diagonal snapping
-      return closestPointOnLine
+      return { snappedPointOnCanvas: closestPointOnLine, guidelinesWithSnappingVector: [] }
     } else {
-      return pointToSnap
+      return { snappedPointOnCanvas: pointToSnap, guidelinesWithSnappingVector: [] }
     }
   } else {
-    const { point } = innerSnapPoint(editor, pointToSnap, resizingFromPosition)
-    return shouldSnap ? point : pointToSnap
+    const { point, guideline } = innerSnapPoint(
+      selectedViews,
+      jsxMetadata,
+      canvasScale,
+      pointToSnap,
+      resizingFromPosition,
+    )
+    return shouldSnap
+      ? {
+          snappedPointOnCanvas: point,
+          guidelinesWithSnappingVector: guideline != null ? [guideline] : [],
+        }
+      : { snappedPointOnCanvas: pointToSnap, guidelinesWithSnappingVector: [] }
   }
 }
 
@@ -1368,14 +1386,16 @@ function calculateDraggedRectangle(
     const newCorner = Utils.offsetPoint(draggedCorner, delta)
     const snappedNewCorner = Utils.roundPointTo(
       snapPoint(
-        editor,
+        editor.selectedViews,
+        editor.jsxMetadata,
+        editor.canvas.scale,
         newCorner,
         propertyChange.enableSnapping,
         propertyChange.keepAspectRatio,
         startingPoint,
         draggedCorner,
         startingCorner,
-      ),
+      ).snappedPointOnCanvas,
       0,
     )
     const newSizeVector = Utils.pointDifference(startingPoint, snappedNewCorner)

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -112,7 +112,9 @@ import {
   CanvasVector,
   localRectangle,
   LocalRectangle,
+  offsetPoint,
   Size,
+  vectorDifference,
 } from '../../core/shared/math-utils'
 import { insertionSubjectIsJSXElement } from '../editor/editor-modes'
 import {
@@ -1337,6 +1339,48 @@ export function snapPoint(
           guidelinesWithSnappingVector: guideline != null ? [guideline] : [],
         }
       : { snappedPointOnCanvas: pointToSnap, guidelinesWithSnappingVector: [] }
+  }
+}
+
+export function runLegacyAbsoluteResizeSnapping(
+  selectedElements: Array<ElementPath>,
+  jsxMetadata: ElementInstanceMetadataMap,
+  drag: CanvasVector,
+  draggedCorner: EdgePosition,
+  startingBounds: CanvasRectangle,
+  canvasScale: number,
+  keepAspectRatio: boolean,
+): {
+  snappedDragVector: CanvasVector
+  guidelinesWithSnappingVector: Array<GuidelineWithSnappingVector>
+} {
+  const oppositeCorner: EdgePosition = {
+    x: 1 - draggedCorner.x,
+    y: 1 - draggedCorner.y,
+  } as EdgePosition
+
+  const oppositePoint = pickPointOnRect(startingBounds, oppositeCorner)
+  const draggedPoint = pickPointOnRect(startingBounds, draggedCorner)
+  const draggedPointMovedWithoutSnap = offsetPoint(draggedPoint, drag)
+
+  const { snappedPointOnCanvas, guidelinesWithSnappingVector } = snapPoint(
+    selectedElements,
+    jsxMetadata,
+    canvasScale,
+    draggedPointMovedWithoutSnap,
+    true,
+    keepAspectRatio,
+    draggedPointMovedWithoutSnap,
+    oppositePoint,
+    draggedCorner,
+  )
+
+  const delta = vectorDifference(draggedPointMovedWithoutSnap, snappedPointOnCanvas)
+  const snappedDragVector = offsetPoint(drag, delta)
+
+  return {
+    snappedDragVector: snappedDragVector,
+    guidelinesWithSnappingVector: guidelinesWithSnappingVector,
   }
 }
 

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -113,6 +113,7 @@ import {
   localRectangle,
   LocalRectangle,
   offsetPoint,
+  rectFromTwoPoints,
   Size,
   vectorDifference,
 } from '../../core/shared/math-utils'
@@ -171,6 +172,7 @@ import {
   collectParentAndSiblingGuidelines,
   filterGuidelinesStaticAxis,
   oneGuidelinePerDimension,
+  pointGuidelineToBoundsEdge,
 } from './controls/guideline-helpers'
 import {
   determineElementsToOperateOnForDragging,
@@ -1386,9 +1388,15 @@ export function runLegacyAbsoluteResizeSnapping(
   const delta = vectorDifference(draggedPointMovedWithoutSnap, snappedPointOnCanvas)
   const snappedDragVector = offsetPoint(drag, delta)
 
+  const snappedBounds = rectFromTwoPoints(oppositePoint, snappedPointOnCanvas)
+  const updatedGuidelinesWithSnapping = pointGuidelineToBoundsEdge(
+    guidelinesWithSnappingVector,
+    snappedBounds,
+  )
+
   return {
     snappedDragVector: snappedDragVector,
-    guidelinesWithSnappingVector: guidelinesWithSnappingVector,
+    guidelinesWithSnappingVector: updatedGuidelinesWithSnapping,
   }
 }
 

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1246,7 +1246,11 @@ function innerSnapPoint(
   canvasScale: number,
   point: CanvasPoint,
   resizingFromPosition: EdgePosition | null,
-): { point: CanvasPoint; guideline: GuidelineWithSnappingVector | null } {
+): {
+  point: CanvasPoint
+  snappedGuideline: GuidelineWithSnappingVector | null
+  guidelinesWithSnappingVector: Array<GuidelineWithSnappingVector>
+} {
   const guidelines = oneGuidelinePerDimension(
     collectGuidelines(jsxMetadata, selectedViews, canvasScale, point, resizingFromPosition),
   )
@@ -1261,7 +1265,8 @@ function innerSnapPoint(
   })
   return {
     point: snappedPoint,
-    guideline: snappedGuideline,
+    snappedGuideline: snappedGuideline,
+    guidelinesWithSnappingVector: guidelines,
   }
 }
 
@@ -1293,7 +1298,7 @@ export function snapPoint(
   if (keepAspectRatio) {
     const closestPointOnLine = Utils.closestPointOnLine(diagonalA, diagonalB, pointToSnap)
     if (shouldSnap) {
-      const { guideline } = innerSnapPoint(
+      const { snappedGuideline: guideline, guidelinesWithSnappingVector } = innerSnapPoint(
         selectedViews,
         jsxMetadata,
         canvasScale,
@@ -1317,7 +1322,10 @@ export function snapPoint(
             )
         }
         if (snappedPoint != null) {
-          return { snappedPointOnCanvas: snappedPoint, guidelinesWithSnappingVector: [guideline] }
+          return {
+            snappedPointOnCanvas: snappedPoint,
+            guidelinesWithSnappingVector: guidelinesWithSnappingVector,
+          }
         }
       }
       // fallback to regular diagonal snapping
@@ -1326,7 +1334,7 @@ export function snapPoint(
       return { snappedPointOnCanvas: pointToSnap, guidelinesWithSnappingVector: [] }
     }
   } else {
-    const { point, guideline } = innerSnapPoint(
+    const { point, guidelinesWithSnappingVector } = innerSnapPoint(
       selectedViews,
       jsxMetadata,
       canvasScale,
@@ -1336,7 +1344,7 @@ export function snapPoint(
     return shouldSnap
       ? {
           snappedPointOnCanvas: point,
-          guidelinesWithSnappingVector: guideline != null ? [guideline] : [],
+          guidelinesWithSnappingVector: guidelinesWithSnappingVector,
         }
       : { snappedPointOnCanvas: pointToSnap, guidelinesWithSnappingVector: [] }
   }

--- a/editor/src/components/canvas/controls/guideline-helpers.ts
+++ b/editor/src/components/canvas/controls/guideline-helpers.ts
@@ -165,7 +165,7 @@ export function getSnapDelta(
   return { delta: Utils.roundPointTo(delta, 0), guidelinesWithSnappingVector: winningGuidelines }
 }
 
-function pointGuidelineToBoundsEdge(
+export function pointGuidelineToBoundsEdge(
   guidelinesWithSnappingVector: Array<GuidelineWithSnappingVector>,
   multiselectBounds: CanvasRectangle,
 ): Array<GuidelineWithSnappingVector> {

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -659,6 +659,13 @@ export function rectFromPointVector<C extends CoordinateMarker>(
   return normalizeRect(rectangle)
 }
 
+export function rectFromTwoPoints<C extends CoordinateMarker>(
+  corner: Point<C>,
+  oppositeCorner: Point<C>,
+): Rectangle<C> {
+  return rectFromPointVector(corner, vectorDifference(corner, oppositeCorner), false)
+}
+
 export function rectSizeToVector<C extends CoordinateMarker>(sizeOfVector: Size): Point<C> {
   return {
     x: sizeOfVector.width,


### PR DESCRIPTION
This PR adds snapping to the new absolute resize strategy.

**Commit Details:**
- Changed the return value of the old `snapPoint` function to provide us with data we need
- Created `runLegacyAbsoluteResizeSnapping` that runs `snapPoint` 
- Usig runLegacyAbsoluteResizeSnapping in absolute resize strategy
- Moved `getMultiselectBounds` to `shared-absolute-move-strategy-helpers.ts`