### PR TITLE
Feature/canvas strategy move constrain drag axis

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -1,10 +1,11 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
-import { CanvasPoint } from '../../../core/shared/math-utils'
+import { CanvasPoint, offsetPoint } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
 import { runLegacyAbsoluteMoveSnapping } from '../controls/guideline-helpers'
+import { determineConstrainedDragAxis } from '../controls/select-mode/move-utils'
 import { ConstrainedDragAxis, GuidelineWithSnappingVector } from '../guideline'
 import { CanvasStrategy } from './canvas-strategy-types'
 import {
@@ -44,9 +45,15 @@ export const absoluteMoveStrategy: CanvasStrategy = {
       interactionState.interactionData.drag != null
     ) {
       const drag = interactionState.interactionData.drag
+      const shiftKeyPressed = interactionState.interactionData.modifiers.shift
+      const constrainedDragAxis = shiftKeyPressed
+        ? determineConstrainedDragAxis(
+            offsetPoint(interactionState.interactionData.dragStart, drag),
+          )
+        : null
       const { snappedDragVector, guidelinesWithSnappingVector } = snapDrag(
         drag,
-        null, // TODO constrain drag axis!
+        constrainedDragAxis,
         sessionState.startingMetadata,
         canvasState.selectedElements,
         canvasState.scale,

--- a/editor/src/components/canvas/controls/guideline-helpers.ts
+++ b/editor/src/components/canvas/controls/guideline-helpers.ts
@@ -220,16 +220,23 @@ export function runLegacyAbsoluteMoveSnapping(
   )
 
   const snappedDragVector = offsetPoint(drag, delta)
+  const directionConstrainedDragVector = Guidelines.applyDirectionConstraint(
+    constrainedDragAxis,
+    snappedDragVector,
+  )
 
   if (multiselectBounds != null) {
-    const draggedBounds = offsetRect(multiselectBounds, snappedDragVector)
+    const draggedBounds = offsetRect(multiselectBounds, directionConstrainedDragVector)
     const updatedGuidelinesWithSnapping = pointGuidelineToBoundsEdge(
       guidelinesWithSnappingVector,
       draggedBounds,
     )
-    return { snappedDragVector, guidelinesWithSnappingVector: updatedGuidelinesWithSnapping }
+    return {
+      snappedDragVector: directionConstrainedDragVector,
+      guidelinesWithSnappingVector: updatedGuidelinesWithSnapping,
+    }
   } else {
-    return { snappedDragVector, guidelinesWithSnappingVector }
+    return { snappedDragVector: directionConstrainedDragVector, guidelinesWithSnappingVector }
   }
 }
 

--- a/editor/src/components/canvas/controls/select-mode/move-utils.ts
+++ b/editor/src/components/canvas/controls/select-mode/move-utils.ts
@@ -22,7 +22,7 @@ import { getSnapDelta } from '../guideline-helpers'
 import { getNewIndex } from './yoga-utils'
 import { flatMapArray } from '../../../../core/shared/array-utils'
 
-function determineConstrainedDragAxis(dragDelta: CanvasVector): 'x' | 'y' {
+export function determineConstrainedDragAxis(dragDelta: CanvasVector): 'x' | 'y' {
   if (Math.abs(dragDelta.x) > Math.abs(dragDelta.y)) {
     return 'x'
   } else {


### PR DESCRIPTION
Move strategy extended with `shift` modifier to constrain drag axis. 

 **Commit Details:**
- from drag delta calculate which axis is locked
- `runLegacyAbsoluteMoveSnapping` already had a placeholder parameter for axis locking
