### PR TITLE
Feature/canvas strategy resize center based

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-strategy.tsx
@@ -26,8 +26,11 @@ import { getMultiselectBounds } from './shared-absolute-move-strategy-helpers'
 export const absoluteResizeStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_RESIZE',
   name: 'Absolute Resize',
-  isApplicable: (canvasState, _interactionState, metadata) => {
-    if (canvasState.selectedElements.length === 1) {
+  isApplicable: (canvasState, interactionState, metadata) => {
+    if (
+      canvasState.selectedElements.length === 1 &&
+      !interactionState?.interactionData.modifiers.alt
+    ) {
       return canvasState.selectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
 

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
@@ -15,6 +15,7 @@ import {
   pointDifference,
   rectFromPointVector,
   rectFromTwoPoints,
+  zeroCanvasPoint,
 } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { getElementFromProjectContents } from '../../editor/store/editor-state'
@@ -99,6 +100,7 @@ export function resizeBoundingBox(
   boundingBox: CanvasRectangle,
   drag: CanvasPoint,
   edgePosition: EdgePosition,
+  centerBased: boolean,
 ): CanvasRectangle {
   let dragToUse = drag
   let cornerEdgePosition = edgePosition
@@ -118,9 +120,19 @@ export function resizeBoundingBox(
     }
   }
 
-  const startingPoint = pickPointOnRect(boundingBox, startingCornerPosition)
   const draggedCorner = pickPointOnRect(boundingBox, cornerEdgePosition)
   const newCorner = offsetPoint(draggedCorner, dragToUse)
-  const newBoundingBox = rectFromTwoPoints(startingPoint, newCorner)
-  return newBoundingBox
+  if (centerBased) {
+    const oppositeCornerPoint = pickPointOnRect(boundingBox, startingCornerPosition)
+    const oppositeCornerDragged = offsetPoint(
+      oppositeCornerPoint,
+      pointDifference(dragToUse, zeroCanvasPoint),
+    )
+    const newBoundingBox = rectFromTwoPoints(oppositeCornerDragged, newCorner)
+    return newBoundingBox
+  } else {
+    const fixedCornerPoint = pickPointOnRect(boundingBox, startingCornerPosition)
+    const newBoundingBox = rectFromTwoPoints(fixedCornerPoint, newCorner)
+    return newBoundingBox
+  }
 }


### PR DESCRIPTION
Resize strategy extended with center based resize. It is part of the bounding box based resize.

Bounding box based resize becomes active even for single selection if the alt modifier is pressed.

**Commit Details:**
- extend `resizeBoundingBox` to create the correct frame for center based resize
- changed `isApplicable` in both resize strategies
