### PR TITLE
keydown on modifier keys updates the interaction

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -144,7 +144,22 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 
         // TODO: maybe we should not whitelist keys, just check if Keyboard.keyIsModifer(key) is false
         const existingInteractionSession = editorStoreRef.current.editor.canvas.interactionSession
-        if (Keyboard.keyIsInteraction(key)) {
+        if (Keyboard.keyIsModifier(key) && existingInteractionSession != null) {
+          editorStoreRef.current.dispatch(
+            [
+              CanvasActions.createInteractionSession(
+                updateInteractionViaKeyboard(
+                  existingInteractionSession,
+                  [Keyboard.keyCharacterForCode(event.keyCode)],
+                  [],
+                  Modifier.modifiersForKeyboardEvent(event),
+                  { type: 'KEYBOARD_CATCHER_CONTROL' },
+                ),
+              ),
+            ],
+            'everyone',
+          )
+        } else if (Keyboard.keyIsInteraction(key)) {
           const action =
             existingInteractionSession == null
               ? CanvasActions.createInteractionSession(
@@ -166,23 +181,6 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 
           editorStoreRef.current.dispatch([action], 'everyone')
           setupClearKeyboardInteraction(editorStoreRef, keyboardTimeoutHandler)
-        } else if (Keyboard.keyIsModifier(key)) {
-          if (existingInteractionSession != null) {
-            editorStoreRef.current.dispatch(
-              [
-                CanvasActions.createInteractionSession(
-                  updateInteractionViaKeyboard(
-                    existingInteractionSession,
-                    [Keyboard.keyCharacterForCode(event.keyCode)],
-                    [],
-                    Modifier.modifiersForKeyboardEvent(event),
-                    { type: 'KEYBOARD_CATCHER_CONTROL' },
-                  ),
-                ),
-              ],
-              'everyone',
-            )
-          }
         }
       }
 

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -143,8 +143,8 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
         const key = Keyboard.keyCharacterForCode(event.keyCode)
 
         // TODO: maybe we should not whitelist keys, just check if Keyboard.keyIsModifer(key) is false
+        const existingInteractionSession = editorStoreRef.current.editor.canvas.interactionSession
         if (Keyboard.keyIsInteraction(key)) {
-          const existingInteractionSession = editorStoreRef.current.editor.canvas.interactionSession
           const action =
             existingInteractionSession == null
               ? CanvasActions.createInteractionSession(
@@ -166,6 +166,23 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 
           editorStoreRef.current.dispatch([action], 'everyone')
           setupClearKeyboardInteraction(editorStoreRef, keyboardTimeoutHandler)
+        } else if (Keyboard.keyIsModifier(key)) {
+          if (existingInteractionSession != null) {
+            editorStoreRef.current.dispatch(
+              [
+                CanvasActions.createInteractionSession(
+                  updateInteractionViaKeyboard(
+                    existingInteractionSession,
+                    [Keyboard.keyCharacterForCode(event.keyCode)],
+                    [],
+                    Modifier.modifiersForKeyboardEvent(event),
+                    { type: 'KEYBOARD_CATCHER_CONTROL' },
+                  ),
+                ),
+              ],
+              'everyone',
+            )
+          }
         }
       }
 


### PR DESCRIPTION
**Problem:**
Releasing a modifier key would correctly re-run the strategies code with the new set of modifier keys, as expected. However, pressing down a modifier key would not update the set of modifier keys, it would only happen on first mouse move. 

**Fix:**
When pressing down a modifier key, and if a canvas interaction session exists, update the list of modifier keys on the canvas interaction data, which will also trigger the re-execution of the strategies.

**Commit Details:**
- add `updateInteractionViaKeyboard` to `editor-component@onWindowKeyDown` when `Keyboard.keyIsModifier` and `existingInteractionSession != null`
