### PR TITLE
Store merged patches instead of accumulated commands

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -43,7 +43,6 @@ function dragBy15Pixels(editorState: EditorState): EditorState {
       currentStrategy: null as any, // the strategy does not use this
       currentStrategyFitness: null as any, // the strategy does not use this
       currentStrategyCommands: null as any, // the strategy does not use this
-      accumulatedCommands: null as any, // the strategy does not use this
       accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -44,6 +44,7 @@ function dragBy15Pixels(editorState: EditorState): EditorState {
       currentStrategyFitness: null as any, // the strategy does not use this
       currentStrategyCommands: null as any, // the strategy does not use this
       accumulatedCommands: null as any, // the strategy does not use this
+      accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: {
@@ -60,8 +61,13 @@ function dragBy15Pixels(editorState: EditorState): EditorState {
     } as StrategyState,
   )
 
-  const finalEditor = foldAndApplyCommands(editorState, editorState, strategyResult, 'permanent')
-    .editorState
+  const finalEditor = foldAndApplyCommands(
+    editorState,
+    editorState,
+    [],
+    strategyResult,
+    'permanent',
+  ).editorState
 
   return finalEditor
 }

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -64,6 +64,7 @@ function dragBy15Pixels(editorState: EditorState): EditorState {
     editorState,
     editorState,
     [],
+    [],
     strategyResult,
     'permanent',
   ).editorState

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-strategy.spec.tsx
@@ -45,7 +45,7 @@ function resizeElement(editor: EditorState, edgePosition: EdgePosition): EditorS
       },
     } as StrategyState,
   )
-  return foldAndApplyCommands(editor, editor, [], strategyResult, 'permanent').editorState
+  return foldAndApplyCommands(editor, editor, [], [], strategyResult, 'permanent').editorState
 }
 
 function createTestEditorAndResizeElement(

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-strategy.spec.tsx
@@ -34,6 +34,7 @@ function resizeElement(editor: EditorState, edgePosition: EdgePosition): EditorS
       currentStrategyFitness: null as any, // the strategy does not use this
       currentStrategyCommands: null as any, // the strategy does not use this
       accumulatedCommands: null as any, // the strategy does not use this
+      accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: {
@@ -45,7 +46,7 @@ function resizeElement(editor: EditorState, edgePosition: EdgePosition): EditorS
       },
     } as StrategyState,
   )
-  return foldAndApplyCommands(editor, editor, strategyResult, 'permanent').editorState
+  return foldAndApplyCommands(editor, editor, [], strategyResult, 'permanent').editorState
 }
 
 function createTestEditorAndResizeElement(

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-strategy.spec.tsx
@@ -33,7 +33,6 @@ function resizeElement(editor: EditorState, edgePosition: EdgePosition): EditorS
       currentStrategy: null as any, // the strategy does not use this
       currentStrategyFitness: null as any, // the strategy does not use this
       currentStrategyCommands: null as any, // the strategy does not use this
-      accumulatedCommands: null as any, // the strategy does not use this
       accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -257,6 +257,6 @@ export function findCanvasStrategyFromDispatchResult(
 
 export function isStrategyActive(strategyState: StrategyState): boolean {
   return (
-    strategyState.accumulatedCommands.length > 0 || strategyState.currentStrategyCommands.length > 0
+    strategyState.accumulatedPatches.length > 0 || strategyState.currentStrategyCommands.length > 0
   )
 }

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -57,17 +57,11 @@ export interface CommandDescription {
   transient: boolean
 }
 
-export interface StrategyAndAccumulatedCommands {
-  strategy: CanvasStrategyId | null
-  commands: Array<CanvasCommand>
-}
-
 export interface StrategyState {
   // Need to track here which strategy is being applied.
   currentStrategy: CanvasStrategyId | null
   currentStrategyFitness: number
   currentStrategyCommands: Array<CanvasCommand>
-  accumulatedCommands: Array<StrategyAndAccumulatedCommands>
   accumulatedPatches: Array<EditorStatePatch>
   commandDescriptions: Array<CommandDescription>
   sortedApplicableStrategies: Array<CanvasStrategy>
@@ -81,7 +75,6 @@ export function createEmptyStrategyState(metadata?: ElementInstanceMetadataMap):
     currentStrategy: null,
     currentStrategyFitness: 0,
     currentStrategyCommands: [],
-    accumulatedCommands: [],
     accumulatedPatches: [],
     commandDescriptions: [],
     sortedApplicableStrategies: [],

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -10,6 +10,7 @@ import {
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { KeyCharacter } from '../../../utils/keyboard'
 import { Modifiers } from '../../../utils/modifiers'
+import { EditorStatePatch } from '../../editor/store/editor-state'
 import { EdgePosition } from '../canvas-types'
 import { MoveIntoDragThreshold } from '../canvas-utils'
 import { CanvasCommand } from '../commands/commands'
@@ -67,6 +68,7 @@ export interface StrategyState {
   currentStrategyFitness: number
   currentStrategyCommands: Array<CanvasCommand>
   accumulatedCommands: Array<StrategyAndAccumulatedCommands>
+  accumulatedPatches: Array<EditorStatePatch>
   commandDescriptions: Array<CommandDescription>
   sortedApplicableStrategies: Array<CanvasStrategy>
 
@@ -80,6 +82,7 @@ export function createEmptyStrategyState(metadata?: ElementInstanceMetadataMap):
     currentStrategyFitness: 0,
     currentStrategyCommands: [],
     accumulatedCommands: [],
+    accumulatedPatches: [],
     commandDescriptions: [],
     sortedApplicableStrategies: [],
     startingMetadata: metadata ?? {},

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.spec.tsx
@@ -67,6 +67,7 @@ function pressKeys(editorState: EditorState, keys: Array<KeyCharacter>): EditorS
     editorState,
     editorState,
     [],
+    [],
     strategyResult,
     'permanent',
   ).editorState

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.spec.tsx
@@ -46,7 +46,6 @@ function pressKeys(editorState: EditorState, keys: Array<KeyCharacter>): EditorS
       currentStrategy: null as any, // the strategy does not use this
       currentStrategyFitness: null as any, // the strategy does not use this
       currentStrategyCommands: null as any, // the strategy does not use this
-      accumulatedCommands: null as any, // the strategy does not use this
       accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.spec.tsx
@@ -47,6 +47,7 @@ function pressKeys(editorState: EditorState, keys: Array<KeyCharacter>): EditorS
       currentStrategyFitness: null as any, // the strategy does not use this
       currentStrategyCommands: null as any, // the strategy does not use this
       accumulatedCommands: null as any, // the strategy does not use this
+      accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: {
@@ -63,8 +64,13 @@ function pressKeys(editorState: EditorState, keys: Array<KeyCharacter>): EditorS
     } as StrategyState,
   )
 
-  const finalEditor = foldAndApplyCommands(editorState, editorState, strategyResult, 'permanent')
-    .editorState
+  const finalEditor = foldAndApplyCommands(
+    editorState,
+    editorState,
+    [],
+    strategyResult,
+    'permanent',
+  ).editorState
 
   return finalEditor
 }

--- a/editor/src/components/canvas/canvas-strategies/multiselect-absolute-resize-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/multiselect-absolute-resize-strategy.spec.tsx
@@ -45,6 +45,7 @@ function multiselectResizeElements(
       currentStrategyFitness: null as any, // the strategy does not use this
       currentStrategyCommands: null as any, // the strategy does not use this
       accumulatedCommands: null as any, // the strategy does not use this
+      accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: {
@@ -67,7 +68,8 @@ function multiselectResizeElements(
       },
     } as StrategyState,
   )
-  return foldAndApplyCommands(initialEditor, initialEditor, strategyResult, 'permanent').editorState
+  return foldAndApplyCommands(initialEditor, initialEditor, [], strategyResult, 'permanent')
+    .editorState
 }
 
 describe('Absolute Multiselect Resize Strategy', () => {

--- a/editor/src/components/canvas/canvas-strategies/multiselect-absolute-resize-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/multiselect-absolute-resize-strategy.spec.tsx
@@ -67,7 +67,7 @@ function multiselectResizeElements(
       },
     } as StrategyState,
   )
-  return foldAndApplyCommands(initialEditor, initialEditor, [], strategyResult, 'permanent')
+  return foldAndApplyCommands(initialEditor, initialEditor, [], [], strategyResult, 'permanent')
     .editorState
 }
 

--- a/editor/src/components/canvas/canvas-strategies/multiselect-absolute-resize-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/multiselect-absolute-resize-strategy.spec.tsx
@@ -44,7 +44,6 @@ function multiselectResizeElements(
       currentStrategy: null as any, // the strategy does not use this
       currentStrategyFitness: null as any, // the strategy does not use this
       currentStrategyCommands: null as any, // the strategy does not use this
-      accumulatedCommands: null as any, // the strategy does not use this
       accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -5,6 +5,7 @@ import { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import { CommandDescription } from '../canvas-strategies/interaction-state'
 import { AdjustCssLengthProperty, runAdjustCssLengthProperty } from './adjust-css-length-command'
 import { AdjustNumberProperty, runAdjustNumberProperty } from './adjust-number-command'
+import { mergePatches } from './merge-patches'
 import { ReparentElement, runReparentElement } from './reparent-element-command'
 import { runSetSnappingGuidelines, SetSnappingGuidelines } from './set-snapping-guidelines-command'
 import { runStrategySwitchedCommand, StrategySwitched } from './strategy-switched-command'
@@ -98,7 +99,7 @@ function foldCommands(
   editorStatePatches: Array<EditorStatePatch>
   commandDescriptions: Array<CommandDescription>
 } {
-  let statePatches: Array<EditorStatePatch> = []
+  let statePatches: Array<EditorStatePatch> = [...patches]
   let workingEditorState: EditorState = patches.reduce((workingState, patch) => {
     return update(workingState, patch)
   }, editorState)
@@ -122,7 +123,7 @@ function foldCommands(
   }
 
   return {
-    editorStatePatches: statePatches,
+    editorStatePatches: mergePatches(statePatches),
     commandDescriptions: workingCommandDescriptions,
   }
 }

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -68,6 +68,7 @@ export const runCanvasCommand: CommandFunction<CanvasCommand> = (
 export function foldAndApplyCommands(
   editorState: EditorState,
   priorPatchedState: EditorState,
+  patches: Array<EditorStatePatch>,
   commands: Array<CanvasCommand>,
   transient: TransientOrNot,
 ): {
@@ -75,7 +76,7 @@ export function foldAndApplyCommands(
   editorStatePatches: Array<EditorStatePatch>
   commandDescriptions: Array<CommandDescription>
 } {
-  const commandResult = foldCommands(editorState, commands, transient)
+  const commandResult = foldCommands(editorState, patches, commands, transient)
   const updatedEditorState = applyStatePatches(
     editorState,
     priorPatchedState,
@@ -90,6 +91,7 @@ export function foldAndApplyCommands(
 
 function foldCommands(
   editorState: EditorState,
+  patches: Array<EditorStatePatch>,
   commands: Array<CanvasCommand>,
   transient: TransientOrNot,
 ): {
@@ -97,7 +99,9 @@ function foldCommands(
   commandDescriptions: Array<CommandDescription>
 } {
   let statePatches: Array<EditorStatePatch> = []
-  let workingEditorState: EditorState = editorState
+  let workingEditorState: EditorState = patches.reduce((workingState, patch) => {
+    return update(workingState, patch)
+  }, editorState)
   let workingCommandDescriptions: Array<CommandDescription> = []
   for (const command of commands) {
     // Allow every command if this is a transient fold, otherwise only allow commands that are not transient.

--- a/editor/src/components/canvas/commands/merge-patches.spec.ts
+++ b/editor/src/components/canvas/commands/merge-patches.spec.ts
@@ -1,0 +1,124 @@
+import { Spec } from 'immutability-helper'
+import { mergePatches } from './merge-patches'
+
+describe('Merge immutability-helper patches', () => {
+  it('Merge when path is the same', () => {
+    const patch1: Spec<any> = {
+      a: {
+        b: {
+          $set: 10,
+        },
+      },
+    }
+
+    const patch2: Spec<any> = {
+      a: {
+        b: {
+          $set: 20,
+        },
+      },
+    }
+
+    const mergedPatches = mergePatches<any>([patch1, patch2])
+
+    expect(mergedPatches).toEqual([patch2])
+  })
+  it('Do not merge when path is different', () => {
+    const patch1: Spec<any> = {
+      a: {
+        b: {
+          $set: 10,
+        },
+      },
+    }
+
+    const patch2: Spec<any> = {
+      a: {
+        c: {
+          $set: 20,
+        },
+      },
+    }
+
+    const mergedPatches = mergePatches<any>([patch1, patch2])
+
+    expect(mergedPatches).toEqual([patch1, patch2])
+  })
+  it('Merge non-neighbour patches', () => {
+    const patch1: Spec<any> = {
+      a: {
+        b: {
+          $set: 10,
+        },
+      },
+    }
+
+    const patch2: Spec<any> = {
+      a: {
+        c: {
+          $set: 20,
+        },
+      },
+    }
+
+    const patch3: Spec<any> = {
+      a: {
+        b: {
+          $set: 20,
+        },
+      },
+    }
+
+    const mergedPatches = mergePatches<any>([patch1, patch2, patch3])
+
+    expect(mergedPatches).toEqual([patch2, patch3])
+  })
+  it('Merge when newer patch contains previous path and other paths too', () => {
+    const patch1: Spec<any> = {
+      a: {
+        b: {
+          $set: 10,
+        },
+      },
+    }
+
+    const patch2: Spec<any> = {
+      a: {
+        b: {
+          $set: 15,
+        },
+        c: {
+          $set: 20,
+        },
+      },
+    }
+
+    const mergedPatches = mergePatches<any>([patch1, patch2])
+
+    expect(mergedPatches).toEqual([patch2])
+  })
+  it("Do not merge when older patch contains newer's path and other paths too", () => {
+    const patch1: Spec<any> = {
+      a: {
+        b: {
+          $set: 15,
+        },
+        c: {
+          $set: 20,
+        },
+      },
+    }
+
+    const patch2: Spec<any> = {
+      a: {
+        b: {
+          $set: 10,
+        },
+      },
+    }
+
+    const mergedPatches = mergePatches<any>([patch1, patch2])
+
+    expect(mergedPatches).toEqual([patch1, patch2])
+  })
+})

--- a/editor/src/components/canvas/commands/merge-patches.ts
+++ b/editor/src/components/canvas/commands/merge-patches.ts
@@ -26,6 +26,9 @@ function getPathsInner<T, K extends keyof Spec<T>>(
   prefix: string,
   paths: Array<string>,
 ) {
+  if (typeof spec !== 'object') {
+    return
+  }
   const keys = Object.keys(spec) as Array<K>
   if (keys.length === 0) {
     return

--- a/editor/src/components/canvas/commands/merge-patches.ts
+++ b/editor/src/components/canvas/commands/merge-patches.ts
@@ -1,0 +1,40 @@
+import { Spec } from 'immutability-helper'
+
+export function mergePatches<T>(patches: Array<Spec<T>>) {
+  let modifiedPaths: Set<string> = new Set()
+  let compressedPatches: Array<Spec<T>> = []
+
+  for (let i = patches.length - 1; i >= 0; i--) {
+    const currentPaths = getPaths(patches[i])
+    if (currentPaths.some((path) => !modifiedPaths.has(path))) {
+      compressedPatches = [patches[i], ...compressedPatches]
+    }
+    currentPaths.forEach((p) => modifiedPaths.add(p))
+  }
+
+  return compressedPatches
+}
+
+function getPaths<T>(spec: Spec<T>) {
+  let paths: Array<string> = []
+  getPathsInner(spec, '', paths)
+  return paths
+}
+
+function getPathsInner<T, K extends keyof Spec<T>>(
+  spec: Spec<T>,
+  prefix: string,
+  paths: Array<string>,
+) {
+  const keys = Object.keys(spec) as Array<K>
+  if (keys.length === 0) {
+    return
+  }
+  keys.forEach((key) => {
+    if (key === '$set') {
+      paths.push(prefix)
+    } else {
+      getPathsInner(spec[key] as Spec<T>, `${prefix}.${key}`, paths)
+    }
+  })
+}

--- a/editor/src/components/canvas/commands/merge-patches.ts
+++ b/editor/src/components/canvas/commands/merge-patches.ts
@@ -26,21 +26,21 @@ export function mergePatches<T>(patches: Array<Spec<T>>) {
   return compressedPatches
 }
 
-function getPaths<T>(spec: Spec<T>) {
+function getPaths<T>(patch: Spec<T>) {
   let paths: Array<string> = []
-  getPathsInner(spec, '', paths)
+  getPathsInner(patch, '', paths)
   return paths
 }
 
 function getPathsInner<T, K extends keyof Spec<T>>(
-  spec: Spec<T>,
+  patch: Spec<T>,
   prefix: string,
   paths: Array<string>,
 ) {
-  if (typeof spec !== 'object') {
+  if (typeof patch !== 'object') {
     return
   }
-  const keys = Object.keys(spec) as Array<K>
+  const keys = Object.keys(patch) as Array<K>
   if (keys.length === 0) {
     return
   }
@@ -51,7 +51,7 @@ function getPathsInner<T, K extends keyof Spec<T>>(
     if (key === '$set') {
       paths.push(prefix)
     } else {
-      getPathsInner(spec[key] as Spec<T>, `${prefix}.${key}`, paths)
+      getPathsInner(patch[key] as Spec<T>, `${prefix}.${key}`, paths)
     }
   })
 }

--- a/editor/src/components/canvas/commands/merge-patches.ts
+++ b/editor/src/components/canvas/commands/merge-patches.ts
@@ -1,5 +1,16 @@
 import { Spec } from 'immutability-helper'
 
+const SupportedCommands = ['$set']
+
+function isCommand(key: string) {
+  return key.startsWith('$')
+}
+
+function isSupportedCommand(key: string) {
+  SupportedCommands.indexOf(key) > -1
+}
+
+// TODO: modify Spec type so it only supports the $set command
 export function mergePatches<T>(patches: Array<Spec<T>>) {
   let modifiedPaths: Set<string> = new Set()
   let compressedPatches: Array<Spec<T>> = []
@@ -34,6 +45,9 @@ function getPathsInner<T, K extends keyof Spec<T>>(
     return
   }
   keys.forEach((key) => {
+    if (isCommand(key) && !isSupportedCommand) {
+      throw new Error(`${key} is an unsupported immutability-helper command`)
+    }
     if (key === '$set') {
       paths.push(prefix)
     } else {

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -169,6 +169,7 @@ describe('interactionStart', () => {
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
         "accumulatedCommands": Array [],
+        "accumulatedPatches": Array [],
         "commandDescriptions": Array [
           Object {
             "description": "Wildcard Patch: {
@@ -245,6 +246,7 @@ describe('interactionStart', () => {
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
         "accumulatedCommands": Array [],
+        "accumulatedPatches": Array [],
         "commandDescriptions": Array [],
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
@@ -280,6 +282,7 @@ describe('interactionUpdatex', () => {
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
         "accumulatedCommands": Array [],
+        "accumulatedPatches": Array [],
         "commandDescriptions": Array [
           Object {
             "description": "Wildcard Patch: {
@@ -357,6 +360,7 @@ describe('interactionUpdatex', () => {
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
         "accumulatedCommands": Array [],
+        "accumulatedPatches": Array [],
         "commandDescriptions": Array [],
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
@@ -421,6 +425,7 @@ describe('interactionHardReset', () => {
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
         "accumulatedCommands": Array [],
+        "accumulatedPatches": Array [],
         "commandDescriptions": Array [
           Object {
             "description": "Wildcard Patch: {
@@ -503,6 +508,7 @@ describe('interactionHardReset', () => {
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
         "accumulatedCommands": Array [],
+        "accumulatedPatches": Array [],
         "commandDescriptions": Array [],
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
@@ -559,6 +565,15 @@ describe('interactionUpdate with stacked strategy change', () => {
               },
             ],
             "strategy": null,
+          },
+        ],
+        "accumulatedPatches": Array [
+          Object {
+            "canvas": Object {
+              "scale": Object {
+                "$set": 100,
+              },
+            },
           },
         ],
         "commandDescriptions": Array [
@@ -645,6 +660,7 @@ describe('interactionUpdate with stacked strategy change', () => {
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
         "accumulatedCommands": Array [],
+        "accumulatedPatches": Array [],
         "commandDescriptions": Array [],
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
@@ -736,8 +752,7 @@ describe('interactionUpdate with accumulating keypresses', () => {
     // accumulatedCommands + currentStrategyCommands + the command coming from the strategy should all be applied to the patch
     expect(actualResult.patchedEditorState.canvas.scale).toEqual(100)
     expect(actualResult.unpatchedEditorState.canvas.scale).toEqual(1)
-    expect(actualResult.patchedEditorState.selectedViews).toMatchInlineSnapshot(
-      `
+    expect(actualResult.patchedEditorState.selectedViews).toMatchInlineSnapshot(`
       Array [
         Object {
           "parts": Array [
@@ -748,8 +763,7 @@ describe('interactionUpdate with accumulating keypresses', () => {
           "type": "elementpath",
         },
       ]
-    `,
-    )
+    `)
     expect(actualResult.unpatchedEditorState.selectedViews).toHaveLength(0)
     expect(actualResult.patchedEditorState.focusedPanel).toEqual('codeEditor')
     expect(actualResult.unpatchedEditorState.focusedPanel).toEqual('canvas')
@@ -800,6 +814,15 @@ describe('interactionUpdate with user changed strategy', () => {
               },
             ],
             "strategy": null,
+          },
+        ],
+        "accumulatedPatches": Array [
+          Object {
+            "canvas": Object {
+              "scale": Object {
+                "$set": 100,
+              },
+            },
           },
         ],
         "commandDescriptions": Array [
@@ -889,6 +912,7 @@ describe('interactionUpdate with user changed strategy', () => {
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
         "accumulatedCommands": Array [],
+        "accumulatedPatches": Array [],
         "commandDescriptions": Array [],
         "currentStrategy": null,
         "currentStrategyCommands": Array [],

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -542,15 +542,7 @@ describe('interactionUpdate with stacked strategy change', () => {
     )
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
-        "accumulatedPatches": Array [
-          Object {
-            "canvas": Object {
-              "scale": Object {
-                "$set": 100,
-              },
-            },
-          },
-        ],
+        "accumulatedPatches": Array [],
         "commandDescriptions": Array [
           Object {
             "description": "Strategy switched to Test Strategy by user input. Interaction data reset.",
@@ -702,13 +694,6 @@ describe('interactionUpdate with accumulating keypresses', () => {
             ],
           },
         },
-        Object {
-          "canvas": Object {
-            "scale": Object {
-              "$set": 100,
-            },
-          },
-        },
       ]
     `)
 
@@ -763,15 +748,7 @@ describe('interactionUpdate with user changed strategy', () => {
     const actualResult = interactionUpdate([testStrategy], editorStore, result, 'non-interaction')
     expect(actualResult.newStrategyState).toMatchInlineSnapshot(`
       Object {
-        "accumulatedPatches": Array [
-          Object {
-            "canvas": Object {
-              "scale": Object {
-                "$set": 100,
-              },
-            },
-          },
-        ],
+        "accumulatedPatches": Array [],
         "commandDescriptions": Array [
           Object {
             "description": "Strategy switched to Test Strategy by user input. Interaction data reset.",

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -26,6 +26,7 @@ import {
   CanvasStrategy,
   InteractionCanvasState,
 } from '../../canvas/canvas-strategies/canvas-strategy-types'
+import { mergePatches } from '../../canvas/commands/merge-patches'
 
 interface HandleStrategiesResult {
   unpatchedEditorState: EditorState
@@ -77,7 +78,8 @@ export function interactionFinished(
     const commandResult = foldAndApplyCommands(
       newEditorState,
       storedState.patchedEditor,
-      [...result.strategyState.accumulatedCommands.flatMap((c) => c.commands), ...commands],
+      result.strategyState.accumulatedPatches,
+      commands,
       'permanent',
     )
 
@@ -133,6 +135,7 @@ export function interactionHardReset(
       const commandResult = foldAndApplyCommands(
         newEditorState,
         storedState.patchedEditor,
+        [],
         commands,
         'transient',
       )
@@ -141,6 +144,7 @@ export function interactionHardReset(
         currentStrategyFitness: strategy.fitness,
         currentStrategyCommands: commands,
         accumulatedCommands: [],
+        accumulatedPatches: [],
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: resetStrategyState.startingMetadata,
@@ -275,6 +279,7 @@ export function interactionStart(
       const commandResult = foldAndApplyCommands(
         newEditorState,
         storedState.patchedEditor,
+        [],
         commands,
         'transient',
       )
@@ -284,6 +289,7 @@ export function interactionStart(
         currentStrategyFitness: strategy.fitness,
         currentStrategyCommands: commands,
         accumulatedCommands: [],
+        accumulatedPatches: [],
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: newEditorState.canvas.interactionSession.metadata,
@@ -363,7 +369,8 @@ function handleUserChangedStrategy(
     const commandResult = foldAndApplyCommands(
       newEditorState,
       storedEditorState,
-      [...newAccumulatedCommands.flatMap((c) => c.commands), ...commands],
+      strategyState.accumulatedPatches,
+      commands,
       'transient',
     )
     const newStrategyState: StrategyState = {
@@ -371,6 +378,7 @@ function handleUserChangedStrategy(
       currentStrategyFitness: strategy.fitness,
       currentStrategyCommands: commands,
       accumulatedCommands: newAccumulatedCommands,
+      accumulatedPatches: mergePatches(commandResult.editorStatePatches),
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
@@ -420,7 +428,8 @@ function handleAccumulatingKeypresses(
     const commandResult = foldAndApplyCommands(
       newEditorState,
       storedEditorState,
-      [...newAccumulatedCommands.flatMap((c) => c.commands), ...commands],
+      strategyState.accumulatedPatches,
+      [...strategyState.currentStrategyCommands, ...commands],
       'transient',
     )
     const newStrategyState: StrategyState = {
@@ -428,6 +437,7 @@ function handleAccumulatingKeypresses(
       currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
       accumulatedCommands: newAccumulatedCommands,
+      accumulatedPatches: mergePatches(commandResult.editorStatePatches),
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
@@ -470,7 +480,8 @@ function handleUpdate(
     const commandResult = foldAndApplyCommands(
       newEditorState,
       storedEditorState,
-      [...strategyState.accumulatedCommands.flatMap((c) => c.commands), ...commands],
+      strategyState.accumulatedPatches,
+      commands,
       'transient',
     )
     const newStrategyState: StrategyState = {
@@ -478,6 +489,7 @@ function handleUpdate(
       currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
       accumulatedCommands: strategyState.accumulatedCommands,
+      accumulatedPatches: strategyState.accumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
@@ -542,7 +554,8 @@ function handleStrategyChangeStacked(
     const commandResult = foldAndApplyCommands(
       newEditorState,
       storedEditorState,
-      [...newAccumulatedCommands.flatMap((c) => c.commands), ...commands],
+      strategyState.accumulatedPatches,
+      [...strategyState.currentStrategyCommands, ...commands],
       'transient',
     )
     const newStrategyState: StrategyState = {
@@ -550,6 +563,7 @@ function handleStrategyChangeStacked(
       currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
       accumulatedCommands: newAccumulatedCommands,
+      accumulatedPatches: mergePatches(commandResult.editorStatePatches),
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -143,7 +143,6 @@ export function interactionHardReset(
         currentStrategy: strategy.strategy.id,
         currentStrategyFitness: strategy.fitness,
         currentStrategyCommands: commands,
-        accumulatedCommands: [],
         accumulatedPatches: [],
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
@@ -288,7 +287,6 @@ export function interactionStart(
         currentStrategy: strategy.strategy.id,
         currentStrategyFitness: strategy.fitness,
         currentStrategyCommands: commands,
-        accumulatedCommands: [],
         accumulatedPatches: [],
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
@@ -362,10 +360,6 @@ function handleUserChangedStrategy(
       newEditorState.canvas.interactionSession,
       strategyState,
     )
-    const newAccumulatedCommands = [
-      ...strategyState.accumulatedCommands,
-      ...strategyChangedLogCommands,
-    ]
     const commandResult = foldAndApplyCommands(
       newEditorState,
       storedEditorState,
@@ -381,7 +375,6 @@ function handleUserChangedStrategy(
       currentStrategy: strategy.strategy.id,
       currentStrategyFitness: strategy.fitness,
       currentStrategyCommands: commands,
-      accumulatedCommands: newAccumulatedCommands,
       accumulatedPatches: newAccumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
@@ -422,13 +415,6 @@ function handleAccumulatingKeypresses(
             strategyState,
           )
         : []
-    const newAccumulatedCommands = [
-      ...strategyState.accumulatedCommands,
-      {
-        strategy: strategyState.currentStrategy,
-        commands: strategyState.currentStrategyCommands,
-      },
-    ]
     const commandResult = foldAndApplyCommands(
       newEditorState,
       storedEditorState,
@@ -444,7 +430,6 @@ function handleAccumulatingKeypresses(
       currentStrategy: strategy?.strategy.id ?? null,
       currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
-      accumulatedCommands: newAccumulatedCommands,
       accumulatedPatches: newAccumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
@@ -496,7 +481,6 @@ function handleUpdate(
       currentStrategy: strategy?.strategy.id ?? null,
       currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
-      accumulatedCommands: strategyState.accumulatedCommands,
       accumulatedPatches: strategyState.accumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
@@ -551,14 +535,6 @@ function handleStrategyChangeStacked(
             strategyState,
           )
         : []
-    const newAccumulatedCommands = [
-      ...strategyState.accumulatedCommands,
-      {
-        strategy: strategyState.currentStrategy,
-        commands: strategyState.currentStrategyCommands,
-      },
-      ...strategyChangedLogCommands,
-    ]
     const commandResult = foldAndApplyCommands(
       newEditorState,
       storedEditorState,
@@ -578,7 +554,6 @@ function handleStrategyChangeStacked(
       currentStrategy: strategy?.strategy.id ?? null,
       currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
-      accumulatedCommands: newAccumulatedCommands,
       accumulatedPatches: newAccumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -370,15 +370,19 @@ function handleUserChangedStrategy(
       newEditorState,
       storedEditorState,
       strategyState.accumulatedPatches,
-      commands,
+      [...strategyChangedLogCommands.flatMap((c) => c.commands), ...commands],
       'transient',
     )
+    const newAccumulatedPatches = mergePatches([
+      ...strategyState.accumulatedPatches,
+      ...commandResult.editorStatePatches,
+    ])
     const newStrategyState: StrategyState = {
       currentStrategy: strategy.strategy.id,
       currentStrategyFitness: strategy.fitness,
       currentStrategyCommands: commands,
       accumulatedCommands: newAccumulatedCommands,
-      accumulatedPatches: mergePatches(commandResult.editorStatePatches),
+      accumulatedPatches: newAccumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
@@ -432,12 +436,16 @@ function handleAccumulatingKeypresses(
       [...strategyState.currentStrategyCommands, ...commands],
       'transient',
     )
+    const newAccumulatedPatches = mergePatches([
+      ...strategyState.accumulatedPatches,
+      ...commandResult.editorStatePatches,
+    ])
     const newStrategyState: StrategyState = {
       currentStrategy: strategy?.strategy.id ?? null,
       currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
       accumulatedCommands: newAccumulatedCommands,
-      accumulatedPatches: mergePatches(commandResult.editorStatePatches),
+      accumulatedPatches: newAccumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
@@ -555,15 +563,23 @@ function handleStrategyChangeStacked(
       newEditorState,
       storedEditorState,
       strategyState.accumulatedPatches,
-      [...strategyState.currentStrategyCommands, ...commands],
+      [
+        ...strategyState.currentStrategyCommands,
+        ...strategyChangedLogCommands.flatMap((c) => c.commands),
+        ...commands,
+      ],
       'transient',
     )
+    const newAccumulatedPatches = mergePatches([
+      ...strategyState.accumulatedPatches,
+      ...commandResult.editorStatePatches,
+    ])
     const newStrategyState: StrategyState = {
       currentStrategy: strategy?.strategy.id ?? null,
       currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
       accumulatedCommands: newAccumulatedCommands,
-      accumulatedPatches: mergePatches(commandResult.editorStatePatches),
+      accumulatedPatches: newAccumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -367,15 +367,11 @@ function handleUserChangedStrategy(
       [...strategyChangedLogCommands.flatMap((c) => c.commands), ...commands],
       'transient',
     )
-    const newAccumulatedPatches = mergePatches([
-      ...strategyState.accumulatedPatches,
-      ...commandResult.editorStatePatches,
-    ])
     const newStrategyState: StrategyState = {
       currentStrategy: strategy.strategy.id,
       currentStrategyFitness: strategy.fitness,
       currentStrategyCommands: commands,
-      accumulatedPatches: newAccumulatedPatches,
+      accumulatedPatches: commandResult.editorStatePatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
@@ -422,15 +418,11 @@ function handleAccumulatingKeypresses(
       [...strategyState.currentStrategyCommands, ...commands],
       'transient',
     )
-    const newAccumulatedPatches = mergePatches([
-      ...strategyState.accumulatedPatches,
-      ...commandResult.editorStatePatches,
-    ])
     const newStrategyState: StrategyState = {
       currentStrategy: strategy?.strategy.id ?? null,
       currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
-      accumulatedPatches: newAccumulatedPatches,
+      accumulatedPatches: commandResult.editorStatePatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
@@ -546,15 +538,11 @@ function handleStrategyChangeStacked(
       ],
       'transient',
     )
-    const newAccumulatedPatches = mergePatches([
-      ...strategyState.accumulatedPatches,
-      ...commandResult.editorStatePatches,
-    ])
     const newStrategyState: StrategyState = {
       currentStrategy: strategy?.strategy.id ?? null,
       currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
-      accumulatedPatches: newAccumulatedPatches,
+      accumulatedPatches: commandResult.editorStatePatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -12,7 +12,7 @@ import {
   StrategyState,
   strategySwitchInteractionSessionReset,
 } from '../../canvas/canvas-strategies/interaction-state'
-import { foldAndApplyCommands } from '../../canvas/commands/commands'
+import { foldAndApplyCommands, runCanvasCommand } from '../../canvas/commands/commands'
 import { strategySwitched } from '../../canvas/commands/strategy-switched-command'
 import { EditorAction } from '../action-types'
 import {
@@ -79,6 +79,7 @@ export function interactionFinished(
       newEditorState,
       storedState.patchedEditor,
       result.strategyState.accumulatedPatches,
+      [],
       commands,
       'permanent',
     )
@@ -135,6 +136,7 @@ export function interactionHardReset(
       const commandResult = foldAndApplyCommands(
         newEditorState,
         storedState.patchedEditor,
+        [],
         [],
         commands,
         'transient',
@@ -279,6 +281,7 @@ export function interactionStart(
         newEditorState,
         storedState.patchedEditor,
         [],
+        [],
         commands,
         'transient',
       )
@@ -364,14 +367,15 @@ function handleUserChangedStrategy(
       newEditorState,
       storedEditorState,
       strategyState.accumulatedPatches,
-      [...strategyChangedLogCommands.flatMap((c) => c.commands), ...commands],
+      strategyChangedLogCommands.flatMap((c) => c.commands),
+      commands,
       'transient',
     )
     const newStrategyState: StrategyState = {
       currentStrategy: strategy.strategy.id,
       currentStrategyFitness: strategy.fitness,
       currentStrategyCommands: commands,
-      accumulatedPatches: commandResult.editorStatePatches,
+      accumulatedPatches: commandResult.accumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
@@ -415,14 +419,15 @@ function handleAccumulatingKeypresses(
       newEditorState,
       storedEditorState,
       strategyState.accumulatedPatches,
-      [...strategyState.currentStrategyCommands, ...commands],
+      strategyState.currentStrategyCommands,
+      commands,
       'transient',
     )
     const newStrategyState: StrategyState = {
       currentStrategy: strategy?.strategy.id ?? null,
       currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
-      accumulatedPatches: commandResult.editorStatePatches,
+      accumulatedPatches: commandResult.accumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
@@ -466,6 +471,7 @@ function handleUpdate(
       newEditorState,
       storedEditorState,
       strategyState.accumulatedPatches,
+      [],
       commands,
       'transient',
     )
@@ -534,15 +540,15 @@ function handleStrategyChangeStacked(
       [
         ...strategyState.currentStrategyCommands,
         ...strategyChangedLogCommands.flatMap((c) => c.commands),
-        ...commands,
       ],
+      commands,
       'transient',
     )
     const newStrategyState: StrategyState = {
       currentStrategy: strategy?.strategy.id ?? null,
       currentStrategyFitness: strategy?.fitness ?? 0,
       currentStrategyCommands: commands,
-      accumulatedPatches: commandResult.editorStatePatches,
+      accumulatedPatches: commandResult.accumulatedPatches,
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,


### PR DESCRIPTION
Summary
Because we collect the commands of the individual keypresses in StrategyState.accumulatedCommands, if you do a long press, this is an evergrowing list of commands to apply, and on every new keydown we apply all the commands.
Overall this means this is a quadratic algorithm, and it becomes unusable in a couple of seconds.

Solution:
Store patches instead of commands, and merge them so when the different patches modify to same property path only apple the last one.

Note:
The merging of the patches is a naive algorithm meant to to solve only the most trivial cases: omit an "older" patch if there  is a "newer" one which modifies the same path.
