### PR TITLE
rename the absolute strategies

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -18,7 +18,7 @@ import {
 import { pickCanvasStateFromEditorState } from './canvas-strategies'
 import { StrategyState } from './interaction-state'
 import { createMouseInteractionForTests } from './interaction-state.test-utils'
-import { multiselectAbsoluteResizeStrategy } from './multiselect-absolute-resize-strategy'
+import { multiselectAbsoluteResizeStrategy } from './absolute-resize-bounding-box-strategy'
 
 function multiselectResizeElements(
   snippet: string,
@@ -70,7 +70,7 @@ function multiselectResizeElements(
   return foldAndApplyCommands(initialEditor, initialEditor, strategyResult, 'permanent').editorState
 }
 
-describe('Absolute Multiselect Resize Strategy', () => {
+describe('Absolute Resize Bounding Box Strategy', () => {
   it('works with element resized from TL corner', async () => {
     const edgePosition: EdgePosition = { x: 0, y: 0 }
     const snippet = `

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -18,7 +18,7 @@ import {
 import { pickCanvasStateFromEditorState } from './canvas-strategies'
 import { StrategyState } from './interaction-state'
 import { createMouseInteractionForTests } from './interaction-state.test-utils'
-import { multiselectAbsoluteResizeStrategy } from './absolute-resize-bounding-box-strategy'
+import { absoluteResizeBoundingBoxStrategy } from './absolute-resize-bounding-box-strategy'
 
 function multiselectResizeElements(
   snippet: string,
@@ -37,7 +37,7 @@ function multiselectResizeElements(
     canvasPoint({ x: 15, y: 25 }),
   )
 
-  const strategyResult = multiselectAbsoluteResizeStrategy.apply(
+  const strategyResult = absoluteResizeBoundingBoxStrategy.apply(
     pickCanvasStateFromEditorState(initialEditor),
     { ...interactionSessionWithoutMetadata, metadata: {} },
     {

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -30,7 +30,7 @@ import {
   runLegacyAbsoluteResizeSnapping,
 } from './shared-absolute-move-strategy-helpers'
 
-export const multiselectAbsoluteResizeStrategy: CanvasStrategy = {
+export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
   name: 'Absolute Resize',
   isApplicable: (canvasState, interactionState, metadata) => {
@@ -53,7 +53,7 @@ export const multiselectAbsoluteResizeStrategy: CanvasStrategy = {
     { control: AbsoluteResizeControl, key: 'absolute-resize-control', show: 'always-visible' },
   ],
   fitness: (canvasState, interactionState, sessionState) => {
-    return multiselectAbsoluteResizeStrategy.isApplicable(
+    return absoluteResizeBoundingBoxStrategy.isApplicable(
       canvasState,
       interactionState,
       sessionState.startingMetadata,

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -31,8 +31,8 @@ import {
 } from './shared-absolute-move-strategy-helpers'
 
 export const multiselectAbsoluteResizeStrategy: CanvasStrategy = {
-  id: 'MULTISELECT_ABSOLUTE_RESIZE',
-  name: 'Multiselect Absolute Resize',
+  id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
+  name: 'Absolute Resize',
   isApplicable: (canvasState, interactionState, metadata) => {
     if (
       canvasState.selectedElements.length > 1 ||

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.spec.tsx
@@ -13,7 +13,7 @@ import {
   makeTestProjectCodeWithSnippet,
   testPrintCodeFromEditorState,
 } from '../ui-jsx.test-utils'
-import { absoluteResizeStrategy } from './absolute-resize-strategy'
+import { absoluteResizeDeltaStrategy } from './absolute-resize-delta-strategy'
 import { pickCanvasStateFromEditorState } from './canvas-strategies'
 import { StrategyState } from './interaction-state'
 import { createMouseInteractionForTests } from './interaction-state.test-utils'
@@ -26,7 +26,7 @@ function resizeElement(editor: EditorState, edgePosition: EdgePosition): EditorS
     canvasPoint({ x: 15, y: 25 }),
   )
 
-  const strategyResult = absoluteResizeStrategy.apply(
+  const strategyResult = absoluteResizeDeltaStrategy.apply(
     pickCanvasStateFromEditorState(editor),
     { ...interactionSessionWithoutMetadata, metadata: {} },
     {
@@ -76,7 +76,7 @@ function resizeTestWithTLWH(edgePosition: EdgePosition): EditorState {
   return createTestEditorAndResizeElement(edgePosition, snippet)
 }
 
-describe('Absolute Resize Strategy TLWH', () => {
+describe('Absolute Delta Resize Strategy TLWH', () => {
   it('works with element resized from TL corner', async () => {
     const edgePosition: EdgePosition = { x: 0, y: 0 }
     const editorAfterStrategy = resizeTestWithTLWH(edgePosition)
@@ -146,7 +146,7 @@ function resizeTestWithTLBR(edgePosition: EdgePosition): EditorState {
   `
   return createTestEditorAndResizeElement(edgePosition, snippet)
 }
-describe('Absolute Resize Strategy TLBR', () => {
+describe('Absolute Delta Resize Strategy TLBR', () => {
   it('works with element resized from TL corner', async () => {
     const edgePosition: EdgePosition = { x: 0, y: 0 }
     const editorAfterStrategy = resizeTestWithTLBR(edgePosition)
@@ -216,7 +216,7 @@ function resizeTestWithBRWH(edgePosition: EdgePosition): EditorState {
   `
   return createTestEditorAndResizeElement(edgePosition, snippet)
 }
-describe('Absolute Resize Strategy BRWH', () => {
+describe('Absolute Delta Resize Strategy BRWH', () => {
   it('works with element resized from TL corner', async () => {
     const edgePosition: EdgePosition = { x: 0, y: 0 }
     const editorAfterStrategy = resizeTestWithBRWH(edgePosition)
@@ -275,7 +275,7 @@ describe('Absolute Resize Strategy BRWH', () => {
   })
 })
 
-describe('Absolute Resize Strategy TLBRWH', () => {
+describe('Absolute Delta Resize Strategy TLBRWH', () => {
   it('works with element resized from TL corner with too many pins', async () => {
     const edgePosition: EdgePosition = { x: 0, y: 0 }
     const snippet = `

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
@@ -26,9 +26,9 @@ import {
   runLegacyAbsoluteResizeSnapping,
 } from './shared-absolute-move-strategy-helpers'
 
-export const absoluteResizeStrategy: CanvasStrategy = {
-  id: 'ABSOLUTE_RESIZE',
-  name: 'Absolute Resize',
+export const absoluteResizeDeltaStrategy: CanvasStrategy = {
+  id: 'ABSOLUTE_RESIZE_DELTA',
+  name: 'Absolute Resize (Delta-based)',
   isApplicable: (canvasState, interactionState, metadata) => {
     if (
       canvasState.selectedElements.length === 1 &&
@@ -47,7 +47,7 @@ export const absoluteResizeStrategy: CanvasStrategy = {
     { control: AbsoluteResizeControl, key: 'absolute-resize-control', show: 'always-visible' },
   ],
   fitness: (canvasState, interactionState, sessionState) => {
-    return absoluteResizeStrategy.isApplicable(
+    return absoluteResizeDeltaStrategy.isApplicable(
       canvasState,
       interactionState,
       sessionState.startingMetadata,

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -18,13 +18,13 @@ import {
 } from './canvas-strategy-types'
 import { InteractionSession, StrategyState } from './interaction-state'
 import { keyboardAbsoluteMoveStrategy } from './keyboard-absolute-move-strategy'
-import { multiselectAbsoluteResizeStrategy } from './absolute-resize-bounding-box-strategy'
+import { absoluteResizeBoundingBoxStrategy } from './absolute-resize-bounding-box-strategy'
 
 export const RegisteredCanvasStrategies: Array<CanvasStrategy> = [
   absoluteMoveStrategy,
   absoluteReparentStrategy,
   keyboardAbsoluteMoveStrategy,
-  multiselectAbsoluteResizeStrategy,
+  absoluteResizeBoundingBoxStrategy,
   absoluteResizeDeltaStrategy,
 ]
 

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -9,7 +9,7 @@ import { useEditorState } from '../../editor/store/store-hook'
 import { CanvasCommand } from '../commands/commands'
 import { absoluteMoveStrategy } from './absolute-move-strategy'
 import { absoluteReparentStrategy } from './absolute-reparent-strategy'
-import { absoluteResizeStrategy } from './absolute-resize-strategy'
+import { absoluteResizeDeltaStrategy } from './absolute-resize-delta-strategy'
 import {
   CanvasStrategy,
   CanvasStrategyId,
@@ -18,14 +18,14 @@ import {
 } from './canvas-strategy-types'
 import { InteractionSession, StrategyState } from './interaction-state'
 import { keyboardAbsoluteMoveStrategy } from './keyboard-absolute-move-strategy'
-import { multiselectAbsoluteResizeStrategy } from './multiselect-absolute-resize-strategy'
+import { multiselectAbsoluteResizeStrategy } from './absolute-resize-bounding-box-strategy'
 
 export const RegisteredCanvasStrategies: Array<CanvasStrategy> = [
   absoluteMoveStrategy,
   absoluteReparentStrategy,
   keyboardAbsoluteMoveStrategy,
   multiselectAbsoluteResizeStrategy,
-  absoluteResizeStrategy,
+  absoluteResizeDeltaStrategy,
 ]
 
 export function pickCanvasStateFromEditorState(editorState: EditorState): InteractionCanvasState {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -27,8 +27,8 @@ export interface InteractionCanvasState {
 export type CanvasStrategyId =
   | 'ABSOLUTE_MOVE'
   | 'ABSOLUTE_REPARENT'
-  | 'ABSOLUTE_RESIZE'
-  | 'MULTISELECT_ABSOLUTE_RESIZE'
+  | 'ABSOLUTE_RESIZE_DELTA'
+  | 'ABSOLUTE_RESIZE_BOUNDING_BOX'
   | 'KEYBOARD_ABSOLUTE_MOVE'
 
 export interface CanvasStrategy {


### PR DESCRIPTION
**Problem:**
We have two overlapping resize strategies, and they were badly named Resize and Multiselect Resize.

**Fix:**
Rename the two strategies to `absolute-resize-delta-strategy` (the user visible name is `Absolute Resize (Delta-based)`) and `absolute-resize-bounding-box-strategy` (user visible name printed as `Absolute Resize`)

