### PR TITLE
Stop printing all paths to DOM

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`UiJsxCanvas #747 - DOM object constructor cannot be called as a functio
   >
     <div
       data-utopia-scene-id=\\"sb/scene\\"
-      data-paths=\\"sb/scene\\"
+      data-path=\\"sb/scene\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -22,10 +22,7 @@ exports[`UiJsxCanvas #747 - DOM object constructor cannot be called as a functio
       \\"
       data-uid=\\"scene sb\\"
     >
-      <div
-        data-uid=\\"comment-root 5c5~~~1 app\\"
-        data-paths=\\"5c5~~~1:comment-root\\"
-      >
+      <div data-uid=\\"comment-root 5c5~~~1 app\\" data-path=\\"5c5~~~1:comment-root\\">
         hat
       </div>
     </div>
@@ -146,7 +143,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "sb/scene",
+      "data-path": "sb/scene",
       "data-uid": "scene sb",
       "data-utopia-scene-id": "sb/scene",
       "skipDeepFreeze": true,
@@ -249,7 +246,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "sb/scene/app",
+      "data-path": "sb/scene/app",
       "data-uid": "app",
       "skipDeepFreeze": true,
     },

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`UiJsxCanvas #747 - DOM object constructor cannot be called as a functio
   >
     <div
       data-utopia-scene-id=\\"sb/scene\\"
-      data-paths=\\"sb/scene sb\\"
+      data-paths=\\"sb/scene\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -24,7 +24,7 @@ exports[`UiJsxCanvas #747 - DOM object constructor cannot be called as a functio
     >
       <div
         data-uid=\\"comment-root 5c5~~~1 app\\"
-        data-paths=\\"5c5~~~1:comment-root 5c5~~~1 sb/scene/app\\"
+        data-paths=\\"5c5~~~1:comment-root\\"
       >
         hat
       </div>
@@ -146,7 +146,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "sb/scene sb",
+      "data-paths": "sb/scene",
       "data-uid": "scene sb",
       "data-utopia-scene-id": "sb/scene",
       "skipDeepFreeze": true,

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -25,7 +25,7 @@ exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
       <div
         style=\\"position: absolute; bottom: 0; left: 0; right: 0; top: 0;\\"
         data-uid=\\"aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       >
         <div
           data-uid=\\"bbb~~~1\\"
@@ -183,7 +183,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -601,7 +601,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -1009,7 +1009,7 @@ exports[`UiJsxCanvas render Label carried through for normal elements 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -1025,7 +1025,7 @@ exports[`UiJsxCanvas render Label carried through for normal elements 1`] = `
         style=\\"position: absolute; bottom: 0; left: 0; right: 0; top: 0;\\"
         data-uid=\\"aaa app-entity\\"
         data-label=\\"Hat\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       ></div>
     </div>
   </div>
@@ -1167,7 +1167,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -1494,7 +1494,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-label": "Hat",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -1554,7 +1554,7 @@ exports[`UiJsxCanvas render Renders input tag without errors 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -1569,7 +1569,7 @@ exports[`UiJsxCanvas render Renders input tag without errors 1`] = `
       <input
         data-uid=\\"00f 567 app-entity\\"
         style=\\"top: 10px;\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:567:00f utopia-storyboard-uid/scene-aaa/app-entity:567 utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:567:00f\\"
       />
     </div>
   </div>
@@ -1711,7 +1711,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -1951,7 +1951,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:567 utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:567",
       "data-uid": "567 app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -2017,7 +2017,7 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -2031,7 +2031,7 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"aaa~~~1\\"
@@ -2192,7 +2192,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -2574,7 +2574,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -3077,7 +3077,7 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -3091,7 +3091,7 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"aaa~~~1\\"
@@ -3303,7 +3303,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -3804,7 +3804,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -6032,7 +6032,7 @@ exports[`UiJsxCanvas render class component is available from arbitrary block in
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -6046,7 +6046,7 @@ exports[`UiJsxCanvas render class component is available from arbitrary block in
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"ccc-unparsed-no-template-path aaa\\"
@@ -6201,7 +6201,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -6500,7 +6500,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -6751,7 +6751,7 @@ exports[`UiJsxCanvas render console logging does not do anything bizarre 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -6766,7 +6766,7 @@ exports[`UiJsxCanvas render console logging does not do anything bizarre 1`] = `
       <div
         style=\\"position: absolute; bottom: 0; left: 0; right: 0; top: 0;\\"
         data-uid=\\"aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       ></div>
     </div>
   </div>
@@ -6908,7 +6908,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -7220,7 +7220,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -7280,7 +7280,7 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are not the ap
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -7293,24 +7293,24 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are not the ap
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"xxx bbb~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
           data-uid=\\"xxx bbb~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
           data-uid=\\"xxx bbb~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
         </div>
@@ -7455,7 +7455,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -7850,7 +7850,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -8425,7 +8425,7 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are undefined 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -8438,24 +8438,24 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are undefined 
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"xxx bbb~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
           data-uid=\\"xxx bbb~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
           data-uid=\\"xxx bbb~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
         </div>
@@ -8600,7 +8600,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -8995,7 +8995,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -9570,7 +9570,7 @@ exports[`UiJsxCanvas render function component is available from arbitrary block
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -9584,17 +9584,17 @@ exports[`UiJsxCanvas render function component is available from arbitrary block
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"ccc aaa\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa:ccc utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa:ccc\\"
         >
           Thing
         </div>
         <div
           data-uid=\\"ccc bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb:ccc utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb:ccc\\"
         >
           Thing
         </div>
@@ -9739,7 +9739,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -10038,7 +10038,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -10317,7 +10317,7 @@ exports[`UiJsxCanvas render function component works inside a map 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -10331,17 +10331,17 @@ exports[`UiJsxCanvas render function component works inside a map 1`] = `
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"ccc aaa~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1:ccc utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1:ccc\\"
         >
           Thing
         </div>
         <div
           data-uid=\\"ccc aaa~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2:ccc utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2:ccc\\"
         >
           Thing
         </div>
@@ -10486,7 +10486,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -10818,7 +10818,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -11097,7 +11097,7 @@ exports[`UiJsxCanvas render handles a component that destructures its props obje
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -11116,13 +11116,13 @@ exports[`UiJsxCanvas render handles a component that destructures its props obje
           width: 100%;
           background-color: #ffffff;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           style=\\"position: absolute; background-color: #000000;\\"
           data-uid=\\"xxx bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
         >
           Hi there!
         </div>
@@ -11281,7 +11281,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -11751,7 +11751,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -12011,7 +12011,7 @@ exports[`UiJsxCanvas render handles a component that renames its props object 1`
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -12030,12 +12030,12 @@ exports[`UiJsxCanvas render handles a component that renames its props object 1`
           width: 100%;
           background-color: #ffffff;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"xxx bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
         >
           Hi there!
         </div>
@@ -12194,7 +12194,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -12664,7 +12664,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -12924,7 +12924,7 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -12943,13 +12943,13 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
           width: 100%;
           background-color: #ffffff;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           style=\\"position: absolute; background-color: #000000;\\"
           data-uid=\\"xxx bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
         >
           Hi there! - and hello!
         </div>
@@ -13108,7 +13108,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -13626,7 +13626,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -13940,7 +13940,7 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -13959,13 +13959,13 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
           width: 100%;
           background-color: #ffffff;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           style=\\"position: absolute; background-color: #000000;\\"
           data-uid=\\"xxx bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
         >
           Hi there! - and hello! - Now begone!
         </div>
@@ -14124,7 +14124,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -14642,7 +14642,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -14956,7 +14956,7 @@ exports[`UiJsxCanvas render handles chaining dependencies into the appropriate o
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -14969,7 +14969,7 @@ exports[`UiJsxCanvas render handles chaining dependencies into the appropriate o
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:bbb:aaa utopia-storyboard-uid/scene-aaa/app-entity:bbb utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:bbb:aaa\\"
         data-uid=\\"aaa bbb app-entity\\"
       ></div>
     </div>
@@ -15112,7 +15112,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -15352,7 +15352,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:bbb utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:bbb",
       "data-uid": "bbb app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -15418,7 +15418,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -15444,7 +15444,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
           height: 812px;
           background-color: #171111;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
@@ -15454,7 +15454,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
             grid-auto-rows: 31px;
           \\"
           data-uid=\\"eb1 03a\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a:eb1 utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a:eb1\\"
         >
           <div
             data-uid=\\"834~~~1\\"
@@ -15470,7 +15470,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
           >
             <span
               data-uid=\\"6a8 000\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000:6a8 utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000\\"
+              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000:6a8\\"
               ><span
                 style=\\"padding: 6px;\\"
                 data-uid=\\"726~~~1\\"
@@ -15503,7 +15503,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
           >
             <span
               data-uid=\\"6a8 000\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000:6a8 utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000\\"
+              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000:6a8\\"
               ><span
                 style=\\"padding: 6px;\\"
                 data-uid=\\"726~~~1\\"
@@ -15536,7 +15536,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
           >
             <span
               data-uid=\\"6a8 000\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000:6a8 utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000\\"
+              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000:6a8\\"
               ><span
                 style=\\"padding: 6px;\\"
                 data-uid=\\"726~~~1\\"
@@ -15697,7 +15697,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -17015,7 +17015,7 @@ export var storyboard = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -20890,7 +20890,7 @@ exports[`UiJsxCanvas render props can be accessed inside the arbitrary js block 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -20904,17 +20904,17 @@ exports[`UiJsxCanvas render props can be accessed inside the arbitrary js block 
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"ccc aaa\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa:ccc utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa:ccc\\"
         >
           Hello World!!
         </div>
         <div
           data-uid=\\"ddd bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb:ddd utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb:ddd\\"
         >
           Hello Dolly!!
         </div>
@@ -21059,7 +21059,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -21390,7 +21390,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -21703,7 +21703,7 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a class 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -21717,7 +21717,7 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a class 
     >
       <div
         data-uid=\\"ccc-unparsed-no-template-path aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       >
         Thing
       </div>
@@ -21861,7 +21861,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -22165,7 +22165,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "ref": [Function],
       "skipDeepFreeze": true,
@@ -22219,7 +22219,7 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a functi
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -22234,7 +22234,7 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a functi
       <div
         style=\\"position: absolute; bottom: 0; left: 0; right: 0; top: 0;\\"
         data-uid=\\"aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       ></div>
     </div>
   </div>
@@ -22376,7 +22376,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -22745,7 +22745,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "ref": [Function],
       "skipDeepFreeze": true,
@@ -22806,7 +22806,7 @@ exports[`UiJsxCanvas render renderrs correctly when a component is passed in via
   >
     <div
       data-utopia-scene-id=\\"eee/fff\\"
-      data-paths=\\"eee/fff eee\\"
+      data-paths=\\"eee/fff\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -22821,13 +22821,13 @@ exports[`UiJsxCanvas render renderrs correctly when a component is passed in via
       <div
         data-uid=\\"aaa app-entity\\"
         style=\\"width: 100%; height: 100%; background-color: #ffffff;\\"
-        data-paths=\\"eee/fff/app-entity:aaa eee/fff/app-entity\\"
+        data-paths=\\"eee/fff/app-entity:aaa\\"
       >
         Test
         <div
           data-uid=\\"ddd bbb\\"
           style=\\"background-color: pink; width: 100%; height: 20px;\\"
-          data-paths=\\"eee/fff/app-entity:aaa/bbb:ddd eee/fff/app-entity:aaa/bbb\\"
+          data-paths=\\"eee/fff/app-entity:aaa/bbb:ddd\\"
         >
           <div data-uid=\\"ccc~~~1\\" data-paths=\\"eee/fff/app-entity:aaa/ccc~~~1\\">
             test
@@ -22952,7 +22952,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "eee/fff eee",
+      "data-paths": "eee/fff",
       "data-uid": "fff eee",
       "data-utopia-scene-id": "eee/fff",
       "skipDeepFreeze": true,
@@ -23324,7 +23324,7 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "eee/fff/app-entity:aaa eee/fff/app-entity",
+      "data-paths": "eee/fff/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -23605,7 +23605,7 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -23619,7 +23619,7 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
     >
       <div
         style=\\"position: absolute; background-color: lightgrey;\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
@@ -23630,7 +23630,7 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
             height: 348px;
             background-color: #dddddd;
           \\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59:6be utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59:6be\\"
           data-uid=\\"6be d59\\"
         >
           <div
@@ -23808,7 +23808,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -24174,7 +24174,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -24556,7 +24556,7 @@ exports[`UiJsxCanvas render renders a canvas defined by a utopia storyboard comp
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -24575,7 +24575,7 @@ exports[`UiJsxCanvas render renders a canvas defined by a utopia storyboard comp
           width: 100%;
           background-color: #ffffff;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
@@ -24740,7 +24740,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -25150,7 +25150,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -25339,7 +25339,7 @@ exports[`UiJsxCanvas render renders a canvas reliant on another file that uses m
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -25358,7 +25358,7 @@ exports[`UiJsxCanvas render renders a canvas reliant on another file that uses m
           width: 100%;
           background-color: #ffffff;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
@@ -25667,7 +25667,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -26078,7 +26078,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -26267,7 +26267,7 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -26281,7 +26281,7 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
     >
       <div
         data-uid=\\"b93 app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93 utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93\\"
       >
         <div
           data-uid=\\"2f0\\"
@@ -26291,13 +26291,13 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
         </div>
         <div
           data-uid=\\"4cf 59c\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/59c:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/59c\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/59c:4cf\\"
         >
           Originally Assigned
         </div>
         <div
           data-uid=\\"4cf 54b\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/54b:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/54b\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/54b:4cf\\"
         >
           Named Function
         </div>
@@ -26309,13 +26309,13 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
         </div>
         <div
           data-uid=\\"4cf 995\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/995:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/995\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/995:4cf\\"
         >
           Named Export
         </div>
         <div
           data-uid=\\"b93 0cf\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf:b93 utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf:b93\\"
         >
           Renamed Export
         </div>
@@ -26339,7 +26339,7 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
         </div>
         <div
           data-uid=\\"4cf d7f\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f:4cf\\"
         >
           Default Function
         </div>
@@ -26351,49 +26351,49 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
         </div>
         <div
           data-uid=\\"4cf 5b9\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9:4cf\\"
         >
           Default Named Function
         </div>
         <div
           data-uid=\\"4cf 1a1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1:4cf\\"
         >
           Defined Then Default Exported
         </div>
         <div
           data-uid=\\"4cf 301\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/301:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/301\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/301:4cf\\"
         >
           Named As Default
         </div>
         <div
           data-uid=\\"4cf 8ce\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce:4cf\\"
         >
           Originally Assigned
         </div>
         <div
           data-uid=\\"4cf f77\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/f77:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/f77\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/f77:4cf\\"
         >
           Originally Assigned
         </div>
         <div
           data-uid=\\"4cf 218\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/218:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/218\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/218:4cf\\"
         >
           Originally Assigned
         </div>
         <div
           data-uid=\\"4cf a17\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/a17:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/a17\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/a17:4cf\\"
         >
           Originally Assigned
         </div>
         <div
           data-uid=\\"4cf 8aa\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa:4cf utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa:4cf\\"
         >
           Default Function
         </div>
@@ -26536,7 +26536,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -27406,7 +27406,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93 utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93",
       "data-uid": "b93 app-entity",
       "skipDeepFreeze": true,
     },
@@ -29672,7 +29672,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -29685,24 +29685,24 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"xxx bbb~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
           data-uid=\\"xxx bbb~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
           data-uid=\\"xxx bbb~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
         </div>
@@ -29847,7 +29847,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -30242,7 +30242,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -30817,7 +30817,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -30830,24 +30830,24 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"xxx bbb~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
           data-uid=\\"xxx bbb~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
           data-uid=\\"xxx bbb~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
         </div>
@@ -30992,7 +30992,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -31388,7 +31388,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -31966,7 +31966,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block with 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -31979,24 +31979,24 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block with 
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"xxx bbb~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
           data-uid=\\"xxx bbb~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
           data-uid=\\"xxx bbb~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
         </div>
@@ -32141,7 +32141,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -32543,7 +32543,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -33118,7 +33118,7 @@ exports[`UiJsxCanvas render renders a component using the spread operator 1`] = 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -33133,7 +33133,7 @@ exports[`UiJsxCanvas render renders a component using the spread operator 1`] = 
       <div
         style=\\"position: absolute; height: 99.9; width: 77.7;\\"
         title=\\"Hi there!\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
@@ -33298,7 +33298,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -33670,7 +33670,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -33859,7 +33859,7 @@ exports[`UiJsxCanvas render renders a component with a fragment at the root 1`] 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -33874,13 +33874,13 @@ exports[`UiJsxCanvas render renders a component with a fragment at the root 1`] 
     >
       <div
         data-uid=\\"aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       >
         hello
       </div>
       <div
         data-uid=\\"bbb app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:bbb utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:bbb\\"
       >
         bello
       </div>
@@ -34019,7 +34019,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-label": "Scene 2",
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -34236,7 +34236,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -34340,7 +34340,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:bbb utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:bbb",
       "data-uid": "bbb app-entity",
       "skipDeepFreeze": true,
     },
@@ -34393,7 +34393,7 @@ exports[`UiJsxCanvas render renders correctly with a context 1`] = `
   >
     <div
       data-utopia-scene-id=\\"ccc/ddd\\"
-      data-paths=\\"ccc/ddd ccc\\"
+      data-paths=\\"ccc/ddd\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -34408,7 +34408,7 @@ exports[`UiJsxCanvas render renders correctly with a context 1`] = `
       <div
         data-uid=\\"bbb aaa app-entity\\"
         style=\\"width: 100%; height: 100%; background-color: #eb1010;\\"
-        data-paths=\\"ccc/ddd/app-entity:aaa/bbb ccc/ddd/app-entity:aaa ccc/ddd/app-entity\\"
+        data-paths=\\"ccc/ddd/app-entity:aaa/bbb\\"
       ></div>
     </div>
   </div>
@@ -34528,7 +34528,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd ccc",
+      "data-paths": "ccc/ddd",
       "data-uid": "ddd ccc",
       "data-utopia-scene-id": "ccc/ddd",
       "skipDeepFreeze": true,
@@ -34855,7 +34855,7 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd/app-entity:aaa ccc/ddd/app-entity",
+      "data-paths": "ccc/ddd/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "value": Object {
@@ -34977,7 +34977,7 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd/app-entity:aaa/bbb ccc/ddd/app-entity:aaa ccc/ddd/app-entity",
+      "data-paths": "ccc/ddd/app-entity:aaa/bbb",
       "data-uid": "bbb aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -35035,7 +35035,7 @@ exports[`UiJsxCanvas render renders correctly with a nested context in another c
   >
     <div
       data-utopia-scene-id=\\"ccc/ddd\\"
-      data-paths=\\"ccc/ddd ccc\\"
+      data-paths=\\"ccc/ddd\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -35050,7 +35050,7 @@ exports[`UiJsxCanvas render renders correctly with a nested context in another c
       <div
         data-uid=\\"bbb inner aaa card app-entity\\"
         style=\\"width: 100%; height: 100%; background-color: #eb1010;\\"
-        data-paths=\\"ccc/ddd/app-entity:card:aaa/inner/bbb ccc/ddd/app-entity:card:aaa/inner ccc/ddd/app-entity:card:aaa ccc/ddd/app-entity:card ccc/ddd/app-entity\\"
+        data-paths=\\"ccc/ddd/app-entity:card:aaa/inner/bbb\\"
       ></div>
     </div>
   </div>
@@ -35170,7 +35170,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd ccc",
+      "data-paths": "ccc/ddd",
       "data-uid": "ddd ccc",
       "data-utopia-scene-id": "ccc/ddd",
       "skipDeepFreeze": true,
@@ -35381,7 +35381,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd/app-entity:card ccc/ddd/app-entity",
+      "data-paths": "ccc/ddd/app-entity:card",
       "data-uid": "card app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -35447,7 +35447,7 @@ exports[`UiJsxCanvas render renders fine with a valid registerModule call 1`] = 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -35461,7 +35461,7 @@ exports[`UiJsxCanvas render renders fine with a valid registerModule call 1`] = 
     >
       <div
         style=\\"position: absolute; height: 99.9; width: 77.7;\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
@@ -35590,7 +35590,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -35879,7 +35879,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -36067,7 +36067,7 @@ exports[`UiJsxCanvas render renders fine with two circularly referencing arbitra
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene\\"
-      data-paths=\\"utopia-storyboard-uid/scene utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -36082,7 +36082,7 @@ exports[`UiJsxCanvas render renders fine with two circularly referencing arbitra
       <div
         data-uid=\\"aaa app-entity\\"
         style=\\"width: 100%; height: 100%; background-color: #ffffff;\\"
-        data-paths=\\"utopia-storyboard-uid/scene/app-entity:aaa utopia-storyboard-uid/scene/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene/app-entity:aaa\\"
       >
         0 - 0
       </div>
@@ -36204,7 +36204,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene",
       "data-uid": "scene utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene",
       "skipDeepFreeze": true,
@@ -36575,7 +36575,7 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene/app-entity:aaa utopia-storyboard-uid/scene/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -36633,7 +36633,7 @@ exports[`UiJsxCanvas render renders fine with two components that reference each
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene\\"
-      data-paths=\\"utopia-storyboard-uid/scene utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -36647,7 +36647,7 @@ exports[`UiJsxCanvas render renders fine with two components that reference each
     >
       <div
         data-uid=\\"1a9~~~1 aaa-unparsed-no-template-path bbb-unparsed-no-template-path BBB app-entity\\"
-        data-paths=\\"1a9~~~1 utopia-storyboard-uid/scene/app-entity:BBB utopia-storyboard-uid/scene/app-entity\\"
+        data-paths=\\"1a9~~~1\\"
       >
         great
       </div>
@@ -36769,7 +36769,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene",
       "data-uid": "scene utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene",
       "skipDeepFreeze": true,
@@ -36996,7 +36996,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene/app-entity:BBB utopia-storyboard-uid/scene/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene/app-entity:BBB",
       "data-uid": "BBB app-entity",
       "skipDeepFreeze": true,
       "x": 5,
@@ -37050,7 +37050,7 @@ exports[`UiJsxCanvas render renders fragments correctly 1`] = `
   >
     <div
       data-utopia-scene-id=\\"eee/fff\\"
-      data-paths=\\"eee/fff eee\\"
+      data-paths=\\"eee/fff\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -37071,7 +37071,7 @@ exports[`UiJsxCanvas render renders fragments correctly 1`] = `
           top: 0;
           background-color: #ffffff;
         \\"
-        data-paths=\\"eee/fff/app:aaa eee/fff/app\\"
+        data-paths=\\"eee/fff/app:aaa\\"
         data-uid=\\"aaa app\\"
       >
         <div
@@ -37230,7 +37230,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "eee/fff eee",
+      "data-paths": "eee/fff",
       "data-uid": "fff eee",
       "data-utopia-scene-id": "eee/fff",
       "skipDeepFreeze": true,
@@ -37787,7 +37787,7 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "eee/fff/app:aaa eee/fff/app",
+      "data-paths": "eee/fff/app:aaa",
       "data-uid": "aaa app",
       "skipDeepFreeze": true,
       "style": Object {
@@ -38309,7 +38309,7 @@ exports[`UiJsxCanvas render renders img tag 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -38322,7 +38322,7 @@ exports[`UiJsxCanvas render renders img tag 1`] = `
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <img
@@ -38471,7 +38471,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -38761,7 +38761,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -38930,7 +38930,7 @@ exports[`UiJsxCanvas render respects a jsx pragma 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       data-factory-function-works=\\"true\\"
       style=\\"
         position: absolute;
@@ -38945,7 +38945,7 @@ exports[`UiJsxCanvas render respects a jsx pragma 1`] = `
     >
       <div
         data-uid=\\"4cf aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:4cf utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:4cf\\"
         data-factory-function-works=\\"true\\"
       >
         Utopia
@@ -39091,7 +39091,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-factory-function-works": "true",
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -39333,7 +39333,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-factory-function-works": "true",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -39399,7 +39399,7 @@ exports[`UiJsxCanvas render supports passing down the scope to children of compo
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -39412,7 +39412,7 @@ exports[`UiJsxCanvas render supports passing down the scope to children of compo
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
@@ -39589,7 +39589,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -40013,7 +40013,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -41077,7 +41077,7 @@ exports[`UiJsxCanvas render the canvas supports emotion CSS prop 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -41091,7 +41091,7 @@ exports[`UiJsxCanvas render the canvas supports emotion CSS prop 1`] = `
     >
       <div
         data-uid=\\"ba3 aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:ba3 utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:ba3\\"
         class=\\"css-16au7uv\\"
       >
         Utopia
@@ -41236,7 +41236,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -41476,7 +41476,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -41542,7 +41542,7 @@ exports[`UiJsxCanvas render the spy wrapper is compatible with React.cloneElemen
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -41556,11 +41556,11 @@ exports[`UiJsxCanvas render the spy wrapper is compatible with React.cloneElemen
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity\\"
+        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"cloner-root cloner\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner:cloner-root utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner\\"
+          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner:cloner-root\\"
         >
           <div
             data-uid=\\"cloned\\"
@@ -41711,7 +41711,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa utopia-storyboard-uid",
+      "data-paths": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -42017,7 +42017,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -25,22 +25,22 @@ exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
       <div
         style=\\"position: absolute; bottom: 0; left: 0; right: 0; top: 0;\\"
         data-uid=\\"aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       >
         <div
           data-uid=\\"bbb~~~1\\"
           data-label=\\"Plane\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1\\"
         ></div>
         <div
           data-uid=\\"bbb~~~2\\"
           data-label=\\"Plane\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2\\"
         ></div>
         <div
           data-uid=\\"bbb~~~3\\"
           data-label=\\"Plane\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3\\"
         ></div>
       </div>
     </div>
@@ -183,7 +183,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -308,7 +308,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -601,7 +601,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -724,7 +724,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-label": "Plane",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
       "data-uid": "bbb~~~1",
       "skipDeepFreeze": true,
     },
@@ -840,7 +840,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-label": "Plane",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
       "data-uid": "bbb~~~2",
       "skipDeepFreeze": true,
     },
@@ -956,7 +956,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-label": "Plane",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
       "data-uid": "bbb~~~3",
       "skipDeepFreeze": true,
     },
@@ -1009,7 +1009,7 @@ exports[`UiJsxCanvas render Label carried through for normal elements 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -1025,7 +1025,7 @@ exports[`UiJsxCanvas render Label carried through for normal elements 1`] = `
         style=\\"position: absolute; bottom: 0; left: 0; right: 0; top: 0;\\"
         data-uid=\\"aaa app-entity\\"
         data-label=\\"Hat\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       ></div>
     </div>
   </div>
@@ -1167,7 +1167,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -1292,7 +1292,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -1494,7 +1494,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-label": "Hat",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -1554,7 +1554,7 @@ exports[`UiJsxCanvas render Renders input tag without errors 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -1569,7 +1569,7 @@ exports[`UiJsxCanvas render Renders input tag without errors 1`] = `
       <input
         data-uid=\\"00f 567 app-entity\\"
         style=\\"top: 10px;\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:567:00f\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:567:00f\\"
       />
     </div>
   </div>
@@ -1711,7 +1711,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -1836,7 +1836,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -1951,7 +1951,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:567",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:567",
       "data-uid": "567 app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -2017,7 +2017,7 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -2031,23 +2031,23 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"aaa~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1\\"
         >
           1
         </div>
         <div
           data-uid=\\"aaa~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2\\"
         >
           2
         </div>
         <div
           data-uid=\\"aaa~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3\\"
         >
           3
         </div>
@@ -2192,7 +2192,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -2317,7 +2317,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -2574,7 +2574,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -2724,7 +2724,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1",
       "data-uid": "aaa~~~1",
       "skipDeepFreeze": true,
     },
@@ -2874,7 +2874,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2",
       "data-uid": "aaa~~~2",
       "skipDeepFreeze": true,
     },
@@ -3024,7 +3024,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3",
       "data-uid": "aaa~~~3",
       "skipDeepFreeze": true,
     },
@@ -3077,7 +3077,7 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -3091,73 +3091,73 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"aaa~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1\\"
         >
           <div
             data-uid=\\"bbb~~~1\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~1\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~1\\"
           >
             4
           </div>
           <div
             data-uid=\\"bbb~~~2\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~2\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~2\\"
           >
             5
           </div>
           <div
             data-uid=\\"bbb~~~3\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~3\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~3\\"
           >
             6
           </div>
         </div>
         <div
           data-uid=\\"aaa~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2\\"
         >
           <div
             data-uid=\\"bbb~~~1\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~1\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~1\\"
           >
             8
           </div>
           <div
             data-uid=\\"bbb~~~2\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~2\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~2\\"
           >
             10
           </div>
           <div
             data-uid=\\"bbb~~~3\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~3\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~3\\"
           >
             12
           </div>
         </div>
         <div
           data-uid=\\"aaa~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3\\"
         >
           <div
             data-uid=\\"bbb~~~1\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~1\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~1\\"
           >
             12
           </div>
           <div
             data-uid=\\"bbb~~~2\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~2\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~2\\"
           >
             15
           </div>
           <div
             data-uid=\\"bbb~~~3\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~3\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~3\\"
           >
             18
           </div>
@@ -3303,7 +3303,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -3428,7 +3428,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -3804,7 +3804,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -4058,7 +4058,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1",
       "data-uid": "aaa~~~1",
       "skipDeepFreeze": true,
     },
@@ -4215,7 +4215,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~1",
       "data-uid": "bbb~~~1",
       "skipDeepFreeze": true,
     },
@@ -4372,7 +4372,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~2",
       "data-uid": "bbb~~~2",
       "skipDeepFreeze": true,
     },
@@ -4529,7 +4529,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~3",
       "data-uid": "bbb~~~3",
       "skipDeepFreeze": true,
     },
@@ -4783,7 +4783,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2",
       "data-uid": "aaa~~~2",
       "skipDeepFreeze": true,
     },
@@ -4940,7 +4940,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~1",
       "data-uid": "bbb~~~1",
       "skipDeepFreeze": true,
     },
@@ -5097,7 +5097,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~2",
       "data-uid": "bbb~~~2",
       "skipDeepFreeze": true,
     },
@@ -5254,7 +5254,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~3",
       "data-uid": "bbb~~~3",
       "skipDeepFreeze": true,
     },
@@ -5508,7 +5508,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3",
       "data-uid": "aaa~~~3",
       "skipDeepFreeze": true,
     },
@@ -5665,7 +5665,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~1",
       "data-uid": "bbb~~~1",
       "skipDeepFreeze": true,
     },
@@ -5822,7 +5822,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~2",
       "data-uid": "bbb~~~2",
       "skipDeepFreeze": true,
     },
@@ -5979,7 +5979,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~3",
       "data-uid": "bbb~~~3",
       "skipDeepFreeze": true,
     },
@@ -6032,7 +6032,7 @@ exports[`UiJsxCanvas render class component is available from arbitrary block in
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -6046,17 +6046,17 @@ exports[`UiJsxCanvas render class component is available from arbitrary block in
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"ccc-unparsed-no-template-path aaa\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa\\"
         >
           Thing
         </div>
         <div
           data-uid=\\"ccc-unparsed-no-template-path bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb\\"
         >
           Thing
         </div>
@@ -6201,7 +6201,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -6326,7 +6326,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -6500,7 +6500,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -6599,7 +6599,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa",
       "data-uid": "aaa",
       "skipDeepFreeze": true,
     },
@@ -6698,7 +6698,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb",
       "data-uid": "bbb",
       "skipDeepFreeze": true,
     },
@@ -6751,7 +6751,7 @@ exports[`UiJsxCanvas render console logging does not do anything bizarre 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -6766,7 +6766,7 @@ exports[`UiJsxCanvas render console logging does not do anything bizarre 1`] = `
       <div
         style=\\"position: absolute; bottom: 0; left: 0; right: 0; top: 0;\\"
         data-uid=\\"aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       ></div>
     </div>
   </div>
@@ -6908,7 +6908,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -7033,7 +7033,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -7220,7 +7220,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -7280,7 +7280,7 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are not the ap
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -7293,24 +7293,24 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are not the ap
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"xxx bbb~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
           data-uid=\\"xxx bbb~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
           data-uid=\\"xxx bbb~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
         </div>
@@ -7455,7 +7455,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -7580,7 +7580,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -7850,7 +7850,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -8009,7 +8009,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
       "data-uid": "bbb~~~1",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -8183,7 +8183,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
       "data-uid": "bbb~~~2",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -8357,7 +8357,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
       "data-uid": "bbb~~~3",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -8425,7 +8425,7 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are undefined 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -8438,24 +8438,24 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are undefined 
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"xxx bbb~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
           data-uid=\\"xxx bbb~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
           data-uid=\\"xxx bbb~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
         </div>
@@ -8600,7 +8600,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -8725,7 +8725,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -8995,7 +8995,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -9154,7 +9154,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
       "data-uid": "bbb~~~1",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -9328,7 +9328,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
       "data-uid": "bbb~~~2",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -9502,7 +9502,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
       "data-uid": "bbb~~~3",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -9570,7 +9570,7 @@ exports[`UiJsxCanvas render function component is available from arbitrary block
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -9584,17 +9584,17 @@ exports[`UiJsxCanvas render function component is available from arbitrary block
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"ccc aaa\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa:ccc\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa:ccc\\"
         >
           Thing
         </div>
         <div
           data-uid=\\"ccc bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb:ccc\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb:ccc\\"
         >
           Thing
         </div>
@@ -9739,7 +9739,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -9864,7 +9864,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -10038,7 +10038,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -10137,7 +10137,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa",
       "data-uid": "aaa",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -10250,7 +10250,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb",
       "data-uid": "bbb",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -10317,7 +10317,7 @@ exports[`UiJsxCanvas render function component works inside a map 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -10331,17 +10331,17 @@ exports[`UiJsxCanvas render function component works inside a map 1`] = `
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"ccc aaa~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1:ccc\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1:ccc\\"
         >
           Thing
         </div>
         <div
           data-uid=\\"ccc aaa~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2:ccc\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2:ccc\\"
         >
           Thing
         </div>
@@ -10486,7 +10486,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -10611,7 +10611,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -10818,7 +10818,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -10917,7 +10917,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1",
       "data-uid": "aaa~~~1",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -11030,7 +11030,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2",
       "data-uid": "aaa~~~2",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -11097,7 +11097,7 @@ exports[`UiJsxCanvas render handles a component that destructures its props obje
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -11116,13 +11116,13 @@ exports[`UiJsxCanvas render handles a component that destructures its props obje
           width: 100%;
           background-color: #ffffff;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           style=\\"position: absolute; background-color: #000000;\\"
           data-uid=\\"xxx bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
         >
           Hi there!
         </div>
@@ -11281,7 +11281,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -11420,7 +11420,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -11751,7 +11751,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -11939,7 +11939,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
       "data-uid": "bbb",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -12011,7 +12011,7 @@ exports[`UiJsxCanvas render handles a component that renames its props object 1`
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -12030,12 +12030,12 @@ exports[`UiJsxCanvas render handles a component that renames its props object 1`
           width: 100%;
           background-color: #ffffff;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"xxx bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
         >
           Hi there!
         </div>
@@ -12194,7 +12194,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -12333,7 +12333,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -12664,7 +12664,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -12852,7 +12852,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
       "data-uid": "bbb",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -12924,7 +12924,7 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -12943,13 +12943,13 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
           width: 100%;
           background-color: #ffffff;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           style=\\"position: absolute; background-color: #000000;\\"
           data-uid=\\"xxx bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
         >
           Hi there! - and hello!
         </div>
@@ -13108,7 +13108,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -13247,7 +13247,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -13626,7 +13626,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -13862,7 +13862,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
       "data-uid": "bbb",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -13940,7 +13940,7 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -13959,13 +13959,13 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
           width: 100%;
           background-color: #ffffff;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           style=\\"position: absolute; background-color: #000000;\\"
           data-uid=\\"xxx bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
         >
           Hi there! - and hello! - Now begone!
         </div>
@@ -14124,7 +14124,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -14263,7 +14263,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -14642,7 +14642,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -14878,7 +14878,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
       "data-uid": "bbb",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -14956,7 +14956,7 @@ exports[`UiJsxCanvas render handles chaining dependencies into the appropriate o
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -14969,7 +14969,7 @@ exports[`UiJsxCanvas render handles chaining dependencies into the appropriate o
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:bbb:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:bbb:aaa\\"
         data-uid=\\"aaa bbb app-entity\\"
       ></div>
     </div>
@@ -15112,7 +15112,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -15237,7 +15237,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -15352,7 +15352,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:bbb",
       "data-uid": "bbb app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -15418,7 +15418,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -15444,7 +15444,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
           height: 812px;
           background-color: #171111;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
@@ -15454,37 +15454,37 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
             grid-auto-rows: 31px;
           \\"
           data-uid=\\"eb1 03a\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a:eb1\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a:eb1\\"
         >
           <div
             data-uid=\\"834~~~1\\"
             data-label=\\"Copy\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~1\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~1\\"
           >
             Copy
           </div>
           <div
             data-uid=\\"999~~~2\\"
             data-label=\\"⌘,⎇,C\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2\\"
           >
             <span
               data-uid=\\"6a8 000\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000:6a8\\"
+              data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000:6a8\\"
               ><span
                 style=\\"padding: 6px;\\"
                 data-uid=\\"726~~~1\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000:6a8/726~~~1\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000:6a8/726~~~1\\"
                 >⌘</span
               ><span
                 style=\\"padding: 6px;\\"
                 data-uid=\\"726~~~2\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000:6a8/726~~~2\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000:6a8/726~~~2\\"
                 >⎇</span
               ><span
                 style=\\"padding: 6px;\\"
                 data-uid=\\"726~~~3\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000:6a8/726~~~3\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000:6a8/726~~~3\\"
                 >C</span
               ></span
             >
@@ -15492,32 +15492,32 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
           <div
             data-uid=\\"834~~~3\\"
             data-label=\\"Paste\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~3\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~3\\"
           >
             Paste
           </div>
           <div
             data-uid=\\"999~~~4\\"
             data-label=\\"⌘⎇V\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4\\"
           >
             <span
               data-uid=\\"6a8 000\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000:6a8\\"
+              data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000:6a8\\"
               ><span
                 style=\\"padding: 6px;\\"
                 data-uid=\\"726~~~1\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000:6a8/726~~~1\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000:6a8/726~~~1\\"
                 >⌘</span
               ><span
                 style=\\"padding: 6px;\\"
                 data-uid=\\"726~~~2\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000:6a8/726~~~2\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000:6a8/726~~~2\\"
                 >⎇</span
               ><span
                 style=\\"padding: 6px;\\"
                 data-uid=\\"726~~~3\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000:6a8/726~~~3\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000:6a8/726~~~3\\"
                 >V</span
               ></span
             >
@@ -15525,32 +15525,32 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
           <div
             data-uid=\\"834~~~5\\"
             data-label=\\"Cut\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~5\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~5\\"
           >
             Cut
           </div>
           <div
             data-uid=\\"999~~~6\\"
             data-label=\\"⌘⎇C\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6\\"
           >
             <span
               data-uid=\\"6a8 000\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000:6a8\\"
+              data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000:6a8\\"
               ><span
                 style=\\"padding: 6px;\\"
                 data-uid=\\"726~~~1\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000:6a8/726~~~1\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000:6a8/726~~~1\\"
                 >⌘</span
               ><span
                 style=\\"padding: 6px;\\"
                 data-uid=\\"726~~~2\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000:6a8/726~~~2\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000:6a8/726~~~2\\"
                 >⎇</span
               ><span
                 style=\\"padding: 6px;\\"
                 data-uid=\\"726~~~3\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000:6a8/726~~~3\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000:6a8/726~~~3\\"
                 >C</span
               ></span
             >
@@ -15697,7 +15697,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -15822,7 +15822,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -17015,7 +17015,7 @@ export var storyboard = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -17868,7 +17868,7 @@ export var storyboard = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a",
       "data-uid": "03a",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -18231,7 +18231,7 @@ export var storyboard = (props) => {
     "localFrame": null,
     "props": Object {
       "data-label": "Copy",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~1",
       "data-uid": "834~~~1",
       "skipDeepFreeze": true,
     },
@@ -18580,7 +18580,7 @@ export var storyboard = (props) => {
     "localFrame": null,
     "props": Object {
       "data-label": "Paste",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~3",
       "data-uid": "834~~~3",
       "skipDeepFreeze": true,
     },
@@ -18929,7 +18929,7 @@ export var storyboard = (props) => {
     "localFrame": null,
     "props": Object {
       "data-label": "Cut",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~5",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~5",
       "data-uid": "834~~~5",
       "skipDeepFreeze": true,
     },
@@ -19318,7 +19318,7 @@ export var storyboard = (props) => {
         "⎇",
         "C",
       ],
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2",
       "data-uid": "999~~~2",
       "skipDeepFreeze": true,
     },
@@ -19546,7 +19546,7 @@ export var storyboard = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000",
       "data-uid": "000",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -19952,7 +19952,7 @@ export var storyboard = (props) => {
     "localFrame": null,
     "props": Object {
       "data-label": "⌘⎇V",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4",
       "data-uid": "999~~~4",
       "skipDeepFreeze": true,
     },
@@ -20180,7 +20180,7 @@ export var storyboard = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000",
       "data-uid": "000",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -20582,7 +20582,7 @@ export var storyboard = (props) => {
     "localFrame": null,
     "props": Object {
       "data-label": "⌘⎇C",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6",
       "data-uid": "999~~~6",
       "skipDeepFreeze": true,
     },
@@ -20810,7 +20810,7 @@ export var storyboard = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000",
       "data-uid": "000",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -20890,7 +20890,7 @@ exports[`UiJsxCanvas render props can be accessed inside the arbitrary js block 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -20904,17 +20904,17 @@ exports[`UiJsxCanvas render props can be accessed inside the arbitrary js block 
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"ccc aaa\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa:ccc\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa:ccc\\"
         >
           Hello World!!
         </div>
         <div
           data-uid=\\"ddd bbb\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb:ddd\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb:ddd\\"
         >
           Hello Dolly!!
         </div>
@@ -21059,7 +21059,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -21184,7 +21184,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -21390,7 +21390,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -21505,7 +21505,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa",
       "data-uid": "aaa",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -21635,7 +21635,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb",
       "data-uid": "bbb",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -21703,7 +21703,7 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a class 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -21717,7 +21717,7 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a class 
     >
       <div
         data-uid=\\"ccc-unparsed-no-template-path aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       >
         Thing
       </div>
@@ -21861,7 +21861,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -21986,7 +21986,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -22165,7 +22165,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "ref": [Function],
       "skipDeepFreeze": true,
@@ -22219,7 +22219,7 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a functi
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -22234,7 +22234,7 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a functi
       <div
         style=\\"position: absolute; bottom: 0; left: 0; right: 0; top: 0;\\"
         data-uid=\\"aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       ></div>
     </div>
   </div>
@@ -22376,7 +22376,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -22501,7 +22501,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -22745,7 +22745,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "ref": [Function],
       "skipDeepFreeze": true,
@@ -22806,7 +22806,7 @@ exports[`UiJsxCanvas render renderrs correctly when a component is passed in via
   >
     <div
       data-utopia-scene-id=\\"eee/fff\\"
-      data-paths=\\"eee/fff\\"
+      data-path=\\"eee/fff\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -22821,15 +22821,15 @@ exports[`UiJsxCanvas render renderrs correctly when a component is passed in via
       <div
         data-uid=\\"aaa app-entity\\"
         style=\\"width: 100%; height: 100%; background-color: #ffffff;\\"
-        data-paths=\\"eee/fff/app-entity:aaa\\"
+        data-path=\\"eee/fff/app-entity:aaa\\"
       >
         Test
         <div
           data-uid=\\"ddd bbb\\"
           style=\\"background-color: pink; width: 100%; height: 20px;\\"
-          data-paths=\\"eee/fff/app-entity:aaa/bbb:ddd\\"
+          data-path=\\"eee/fff/app-entity:aaa/bbb:ddd\\"
         >
-          <div data-uid=\\"ccc~~~1\\" data-paths=\\"eee/fff/app-entity:aaa/ccc~~~1\\">
+          <div data-uid=\\"ccc~~~1\\" data-path=\\"eee/fff/app-entity:aaa/ccc~~~1\\">
             test
           </div>
         </div>
@@ -22952,7 +22952,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "eee/fff",
+      "data-path": "eee/fff",
       "data-uid": "fff eee",
       "data-utopia-scene-id": "eee/fff",
       "skipDeepFreeze": true,
@@ -23055,7 +23055,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "eee/fff/app-entity",
+      "data-path": "eee/fff/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -23324,7 +23324,7 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "eee/fff/app-entity:aaa",
+      "data-path": "eee/fff/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -23532,7 +23532,7 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "eee/fff/app-entity:aaa/bbb",
+      "data-path": "eee/fff/app-entity:aaa/bbb",
       "data-uid": "bbb",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -23550,7 +23550,7 @@ export var storyboard = (
       },
       "skipDeepFreeze": true,
       "thing": <div
-        data-paths="eee/fff/app-entity:aaa/ccc~~~1"
+        data-path="eee/fff/app-entity:aaa/ccc~~~1"
         data-uid="ccc~~~1"
       >
         test
@@ -23605,7 +23605,7 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -23619,7 +23619,7 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
     >
       <div
         style=\\"position: absolute; background-color: lightgrey;\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
@@ -23630,7 +23630,7 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
             height: 348px;
             background-color: #dddddd;
           \\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59:6be\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59:6be\\"
           data-uid=\\"6be d59\\"
         >
           <div
@@ -23641,7 +23641,7 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
               right: 10px;
               height: 30px;
             \\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59:6be/d03\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59:6be/d03\\"
             data-uid=\\"d03\\"
           ></div>
           <div
@@ -23652,7 +23652,7 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
               width: 193px;
               height: 244px;
             \\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59/dd5\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59/dd5\\"
             data-uid=\\"dd5\\"
           ></div>
           <div
@@ -23663,7 +23663,7 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
               right: 10px;
               height: 30px;
             \\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59:6be/41e\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59:6be/41e\\"
             data-uid=\\"41e\\"
           ></div>
         </div>
@@ -23808,7 +23808,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -23933,7 +23933,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -24174,7 +24174,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -24350,7 +24350,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59",
       "data-uid": "d59",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -24496,7 +24496,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59/dd5",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59/dd5",
       "data-uid": "dd5",
       "skipDeepFreeze": true,
       "style": Object {
@@ -24556,7 +24556,7 @@ exports[`UiJsxCanvas render renders a canvas defined by a utopia storyboard comp
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -24575,12 +24575,12 @@ exports[`UiJsxCanvas render renders a canvas defined by a utopia storyboard comp
           width: 100%;
           background-color: #ffffff;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           style=\\"position: absolute;\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
           data-uid=\\"bbb\\"
         >
           hi
@@ -24740,7 +24740,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -24879,7 +24879,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -25150,7 +25150,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -25283,7 +25283,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
       "data-uid": "bbb",
       "skipDeepFreeze": true,
       "style": Object {
@@ -25339,7 +25339,7 @@ exports[`UiJsxCanvas render renders a canvas reliant on another file that uses m
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -25358,12 +25358,12 @@ exports[`UiJsxCanvas render renders a canvas reliant on another file that uses m
           width: 100%;
           background-color: #ffffff;
         \\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           style=\\"position: absolute;\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
           data-uid=\\"bbb\\"
         >
           hi
@@ -25667,7 +25667,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -25806,7 +25806,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -26078,7 +26078,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -26211,7 +26211,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
       "data-uid": "bbb",
       "skipDeepFreeze": true,
       "style": Object {
@@ -26267,7 +26267,7 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -26281,119 +26281,119 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
     >
       <div
         data-uid=\\"b93 app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93\\"
       >
         <div
           data-uid=\\"2f0\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/2f0\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/2f0\\"
         >
           Originally Unassigned
         </div>
         <div
           data-uid=\\"4cf 59c\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/59c:4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/59c:4cf\\"
         >
           Originally Assigned
         </div>
         <div
           data-uid=\\"4cf 54b\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/54b:4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/54b:4cf\\"
         >
           Named Function
         </div>
         <div
           data-uid=\\"d18\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/d18\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/d18\\"
         >
           Named Class
         </div>
         <div
           data-uid=\\"4cf 995\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/995:4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/995:4cf\\"
         >
           Named Export
         </div>
         <div
           data-uid=\\"b93 0cf\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf:b93\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf:b93\\"
         >
           Renamed Export
         </div>
         <div
           data-uid=\\"d00\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/d00\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/d00\\"
         >
           First In Structure
         </div>
         <div
           data-uid=\\"7d0\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/7d0\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/7d0\\"
         >
           Second In Structure
         </div>
         <div
           data-uid=\\"4cf\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/4cf\\"
         >
           The Number Is 4
         </div>
         <div
           data-uid=\\"4cf d7f\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f:4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f:4cf\\"
         >
           Default Function
         </div>
         <div
           data-uid=\\"315\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/315\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/315\\"
         >
           Export Default Class
         </div>
         <div
           data-uid=\\"4cf 5b9\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9:4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9:4cf\\"
         >
           Default Named Function
         </div>
         <div
           data-uid=\\"4cf 1a1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1:4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1:4cf\\"
         >
           Defined Then Default Exported
         </div>
         <div
           data-uid=\\"4cf 301\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/301:4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/301:4cf\\"
         >
           Named As Default
         </div>
         <div
           data-uid=\\"4cf 8ce\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce:4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce:4cf\\"
         >
           Originally Assigned
         </div>
         <div
           data-uid=\\"4cf f77\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/f77:4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/f77:4cf\\"
         >
           Originally Assigned
         </div>
         <div
           data-uid=\\"4cf 218\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/218:4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/218:4cf\\"
         >
           Originally Assigned
         </div>
         <div
           data-uid=\\"4cf a17\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/a17:4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/a17:4cf\\"
         >
           Originally Assigned
         </div>
         <div
           data-uid=\\"4cf 8aa\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa:4cf\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa:4cf\\"
         >
           Default Function
         </div>
@@ -26536,7 +26536,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -26663,7 +26663,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -27406,7 +27406,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93",
       "data-uid": "b93 app-entity",
       "skipDeepFreeze": true,
     },
@@ -27509,7 +27509,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf",
       "data-uid": "0cf",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -27626,7 +27626,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1",
       "data-uid": "1a1",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -27743,7 +27743,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/218",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/218",
       "data-uid": "218",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -27860,7 +27860,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/2f0",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/2f0",
       "data-uid": "2f0",
       "skipDeepFreeze": true,
     },
@@ -27963,7 +27963,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/301",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/301",
       "data-uid": "301",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -28080,7 +28080,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/315",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/315",
       "data-uid": "315",
       "skipDeepFreeze": true,
     },
@@ -28253,7 +28253,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/4cf",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/4cf",
       "data-uid": "4cf",
       "skipDeepFreeze": true,
     },
@@ -28356,7 +28356,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/54b",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/54b",
       "data-uid": "54b",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -28473,7 +28473,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/59c",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/59c",
       "data-uid": "59c",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -28590,7 +28590,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9",
       "data-uid": "5b9",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -28707,7 +28707,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/7d0",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/7d0",
       "data-uid": "7d0",
       "skipDeepFreeze": true,
     },
@@ -28810,7 +28810,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa",
       "data-uid": "8aa",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -28929,7 +28929,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce",
       "data-uid": "8ce",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -29046,7 +29046,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/995",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/995",
       "data-uid": "995",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -29163,7 +29163,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/a17",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/a17",
       "data-uid": "a17",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -29280,7 +29280,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/d00",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/d00",
       "data-uid": "d00",
       "skipDeepFreeze": true,
     },
@@ -29383,7 +29383,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/d18",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/d18",
       "data-uid": "d18",
       "skipDeepFreeze": true,
     },
@@ -29486,7 +29486,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f",
       "data-uid": "d7f",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -29605,7 +29605,7 @@ export var App = (props) => {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:b93/f77",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/f77",
       "data-uid": "f77",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -29672,7 +29672,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -29685,24 +29685,24 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"xxx bbb~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
           data-uid=\\"xxx bbb~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
           data-uid=\\"xxx bbb~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
         </div>
@@ -29847,7 +29847,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -29972,7 +29972,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -30242,7 +30242,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -30401,7 +30401,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
       "data-uid": "bbb~~~1",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -30575,7 +30575,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
       "data-uid": "bbb~~~2",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -30749,7 +30749,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
       "data-uid": "bbb~~~3",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -30817,7 +30817,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -30830,24 +30830,24 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"xxx bbb~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
           data-uid=\\"xxx bbb~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
           data-uid=\\"xxx bbb~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
         </div>
@@ -30992,7 +30992,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -31117,7 +31117,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -31388,7 +31388,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -31548,7 +31548,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
       "data-uid": "bbb~~~1",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -31723,7 +31723,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
       "data-uid": "bbb~~~2",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -31898,7 +31898,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
       "data-uid": "bbb~~~3",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -31966,7 +31966,7 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block with 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -31979,24 +31979,24 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block with 
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"xxx bbb~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
           data-uid=\\"xxx bbb~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
           data-uid=\\"xxx bbb~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
         </div>
@@ -32141,7 +32141,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -32266,7 +32266,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -32543,7 +32543,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -32702,7 +32702,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
       "data-uid": "bbb~~~1",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -32876,7 +32876,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
       "data-uid": "bbb~~~2",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -33050,7 +33050,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
       "data-uid": "bbb~~~3",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -33118,7 +33118,7 @@ exports[`UiJsxCanvas render renders a component using the spread operator 1`] = 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -33133,12 +33133,12 @@ exports[`UiJsxCanvas render renders a component using the spread operator 1`] = 
       <div
         style=\\"position: absolute; height: 99.9; width: 77.7;\\"
         title=\\"Hi there!\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           style=\\"position: absolute;\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
           data-uid=\\"bbb\\"
         >
           hi
@@ -33298,7 +33298,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -33437,7 +33437,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -33670,7 +33670,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -33803,7 +33803,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
       "data-uid": "bbb",
       "skipDeepFreeze": true,
       "style": Object {
@@ -33859,7 +33859,7 @@ exports[`UiJsxCanvas render renders a component with a fragment at the root 1`] 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -33874,13 +33874,13 @@ exports[`UiJsxCanvas render renders a component with a fragment at the root 1`] 
     >
       <div
         data-uid=\\"aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       >
         hello
       </div>
       <div
         data-uid=\\"bbb app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:bbb\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:bbb\\"
       >
         bello
       </div>
@@ -34019,7 +34019,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-label": "Scene 2",
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -34122,7 +34122,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -34236,7 +34236,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -34340,7 +34340,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:bbb",
       "data-uid": "bbb app-entity",
       "skipDeepFreeze": true,
     },
@@ -34393,7 +34393,7 @@ exports[`UiJsxCanvas render renders correctly with a context 1`] = `
   >
     <div
       data-utopia-scene-id=\\"ccc/ddd\\"
-      data-paths=\\"ccc/ddd\\"
+      data-path=\\"ccc/ddd\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -34408,7 +34408,7 @@ exports[`UiJsxCanvas render renders correctly with a context 1`] = `
       <div
         data-uid=\\"bbb aaa app-entity\\"
         style=\\"width: 100%; height: 100%; background-color: #eb1010;\\"
-        data-paths=\\"ccc/ddd/app-entity:aaa/bbb\\"
+        data-path=\\"ccc/ddd/app-entity:aaa/bbb\\"
       ></div>
     </div>
   </div>
@@ -34528,7 +34528,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd",
+      "data-path": "ccc/ddd",
       "data-uid": "ddd ccc",
       "data-utopia-scene-id": "ccc/ddd",
       "skipDeepFreeze": true,
@@ -34631,7 +34631,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd/app-entity",
+      "data-path": "ccc/ddd/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -34855,7 +34855,7 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd/app-entity:aaa",
+      "data-path": "ccc/ddd/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "value": Object {
@@ -34977,7 +34977,7 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd/app-entity:aaa/bbb",
+      "data-path": "ccc/ddd/app-entity:aaa/bbb",
       "data-uid": "bbb aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -35035,7 +35035,7 @@ exports[`UiJsxCanvas render renders correctly with a nested context in another c
   >
     <div
       data-utopia-scene-id=\\"ccc/ddd\\"
-      data-paths=\\"ccc/ddd\\"
+      data-path=\\"ccc/ddd\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -35050,7 +35050,7 @@ exports[`UiJsxCanvas render renders correctly with a nested context in another c
       <div
         data-uid=\\"bbb inner aaa card app-entity\\"
         style=\\"width: 100%; height: 100%; background-color: #eb1010;\\"
-        data-paths=\\"ccc/ddd/app-entity:card:aaa/inner/bbb\\"
+        data-path=\\"ccc/ddd/app-entity:card:aaa/inner/bbb\\"
       ></div>
     </div>
   </div>
@@ -35170,7 +35170,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd",
+      "data-path": "ccc/ddd",
       "data-uid": "ddd ccc",
       "data-utopia-scene-id": "ccc/ddd",
       "skipDeepFreeze": true,
@@ -35273,7 +35273,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd/app-entity",
+      "data-path": "ccc/ddd/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -35381,7 +35381,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "ccc/ddd/app-entity:card",
+      "data-path": "ccc/ddd/app-entity:card",
       "data-uid": "card app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -35447,7 +35447,7 @@ exports[`UiJsxCanvas render renders fine with a valid registerModule call 1`] = 
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -35461,12 +35461,12 @@ exports[`UiJsxCanvas render renders fine with a valid registerModule call 1`] = 
     >
       <div
         style=\\"position: absolute; height: 99.9; width: 77.7;\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           style=\\"position: absolute;\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
           data-uid=\\"bbb\\"
         >
           hi
@@ -35590,7 +35590,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -35693,7 +35693,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -35879,7 +35879,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -36011,7 +36011,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
       "data-uid": "bbb",
       "skipDeepFreeze": true,
       "style": Object {
@@ -36067,7 +36067,7 @@ exports[`UiJsxCanvas render renders fine with two circularly referencing arbitra
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene\\"
-      data-paths=\\"utopia-storyboard-uid/scene\\"
+      data-path=\\"utopia-storyboard-uid/scene\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -36082,7 +36082,7 @@ exports[`UiJsxCanvas render renders fine with two circularly referencing arbitra
       <div
         data-uid=\\"aaa app-entity\\"
         style=\\"width: 100%; height: 100%; background-color: #ffffff;\\"
-        data-paths=\\"utopia-storyboard-uid/scene/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene/app-entity:aaa\\"
       >
         0 - 0
       </div>
@@ -36204,7 +36204,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene",
+      "data-path": "utopia-storyboard-uid/scene",
       "data-uid": "scene utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene",
       "skipDeepFreeze": true,
@@ -36307,7 +36307,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene/app-entity",
+      "data-path": "utopia-storyboard-uid/scene/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -36575,7 +36575,7 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
       "style": Object {
@@ -36633,7 +36633,7 @@ exports[`UiJsxCanvas render renders fine with two components that reference each
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene\\"
-      data-paths=\\"utopia-storyboard-uid/scene\\"
+      data-path=\\"utopia-storyboard-uid/scene\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -36647,7 +36647,7 @@ exports[`UiJsxCanvas render renders fine with two components that reference each
     >
       <div
         data-uid=\\"1a9~~~1 aaa-unparsed-no-template-path bbb-unparsed-no-template-path BBB app-entity\\"
-        data-paths=\\"1a9~~~1\\"
+        data-path=\\"1a9~~~1\\"
       >
         great
       </div>
@@ -36769,7 +36769,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene",
+      "data-path": "utopia-storyboard-uid/scene",
       "data-uid": "scene utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene",
       "skipDeepFreeze": true,
@@ -36872,7 +36872,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene/app-entity",
+      "data-path": "utopia-storyboard-uid/scene/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -36996,7 +36996,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene/app-entity:BBB",
+      "data-path": "utopia-storyboard-uid/scene/app-entity:BBB",
       "data-uid": "BBB app-entity",
       "skipDeepFreeze": true,
       "x": 5,
@@ -37050,7 +37050,7 @@ exports[`UiJsxCanvas render renders fragments correctly 1`] = `
   >
     <div
       data-utopia-scene-id=\\"eee/fff\\"
-      data-paths=\\"eee/fff\\"
+      data-path=\\"eee/fff\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -37071,24 +37071,24 @@ exports[`UiJsxCanvas render renders fragments correctly 1`] = `
           top: 0;
           background-color: #ffffff;
         \\"
-        data-paths=\\"eee/fff/app:aaa\\"
+        data-path=\\"eee/fff/app:aaa\\"
         data-uid=\\"aaa app\\"
       >
         <div
           data-label=\\"random-div\\"
           style=\\"width: 100px; height: 100px;\\"
           data-uid=\\"bbb\\"
-          data-paths=\\"eee/fff/app:aaa/bbb\\"
+          data-path=\\"eee/fff/app:aaa/bbb\\"
         >
           Hello
           <div
             data-label=\\"some-other-div\\"
             style=\\"width: 100px; height: 100px;\\"
             data-uid=\\"ccc\\"
-            data-paths=\\"eee/fff/app:aaa/bbb/ccc\\"
+            data-path=\\"eee/fff/app:aaa/bbb/ccc\\"
           ></div>
         </div>
-        <div data-uid=\\"ddd\\" data-paths=\\"eee/fff/app:aaa/ddd\\">World</div>
+        <div data-uid=\\"ddd\\" data-path=\\"eee/fff/app:aaa/ddd\\">World</div>
       </div>
     </div>
   </div>
@@ -37230,7 +37230,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "eee/fff",
+      "data-path": "eee/fff",
       "data-uid": "fff eee",
       "data-utopia-scene-id": "eee/fff",
       "skipDeepFreeze": true,
@@ -37355,7 +37355,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "eee/fff/app",
+      "data-path": "eee/fff/app",
       "data-uid": "app",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -37787,7 +37787,7 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "eee/fff/app:aaa",
+      "data-path": "eee/fff/app:aaa",
       "data-uid": "aaa app",
       "skipDeepFreeze": true,
       "style": Object {
@@ -38007,7 +38007,7 @@ export var storyboard = (
     "localFrame": null,
     "props": Object {
       "data-label": "random-div",
-      "data-paths": "eee/fff/app:aaa/bbb",
+      "data-path": "eee/fff/app:aaa/bbb",
       "data-uid": "bbb",
       "skipDeepFreeze": true,
       "style": Object {
@@ -38147,7 +38147,7 @@ export var storyboard = (
     "localFrame": null,
     "props": Object {
       "data-label": "some-other-div",
-      "data-paths": "eee/fff/app:aaa/bbb/ccc",
+      "data-path": "eee/fff/app:aaa/bbb/ccc",
       "data-uid": "ccc",
       "skipDeepFreeze": true,
       "style": Object {
@@ -38256,7 +38256,7 @@ export var storyboard = (
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "eee/fff/app:aaa/ddd",
+      "data-path": "eee/fff/app:aaa/ddd",
       "data-uid": "ddd",
       "skipDeepFreeze": true,
     },
@@ -38309,7 +38309,7 @@ exports[`UiJsxCanvas render renders img tag 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -38322,13 +38322,13 @@ exports[`UiJsxCanvas render renders img tag 1`] = `
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <img
           data-uid=\\"bbb\\"
           src=\\"data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb\\"
         />
       </div>
     </div>
@@ -38471,7 +38471,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -38596,7 +38596,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -38761,7 +38761,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -38876,7 +38876,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
       "data-uid": "bbb",
       "skipDeepFreeze": true,
       "src": "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=",
@@ -38930,7 +38930,7 @@ exports[`UiJsxCanvas render respects a jsx pragma 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       data-factory-function-works=\\"true\\"
       style=\\"
         position: absolute;
@@ -38945,7 +38945,7 @@ exports[`UiJsxCanvas render respects a jsx pragma 1`] = `
     >
       <div
         data-uid=\\"4cf aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:4cf\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:4cf\\"
         data-factory-function-works=\\"true\\"
       >
         Utopia
@@ -39091,7 +39091,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-factory-function-works": "true",
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -39217,7 +39217,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-factory-function-works": "true",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -39333,7 +39333,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-factory-function-works": "true",
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -39399,7 +39399,7 @@ exports[`UiJsxCanvas render supports passing down the scope to children of compo
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -39412,38 +39412,38 @@ exports[`UiJsxCanvas render supports passing down the scope to children of compo
       data-uid=\\"scene-aaa utopia-storyboard-uid\\"
     >
       <div
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
         data-uid=\\"aaa app-entity\\"
       >
         <div
           data-uid=\\"bbb~~~1\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1\\"
         >
           <div
             data-uid=\\"ccc\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1/ccc\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1/ccc\\"
           >
             1
           </div>
         </div>
         <div
           data-uid=\\"bbb~~~2\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2\\"
         >
           <div
             data-uid=\\"ccc\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2/ccc\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2/ccc\\"
           >
             2
           </div>
         </div>
         <div
           data-uid=\\"bbb~~~3\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3\\"
         >
           <div
             data-uid=\\"ccc\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3/ccc\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3/ccc\\"
           >
             3
           </div>
@@ -39589,7 +39589,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -39714,7 +39714,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -40013,7 +40013,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "skipDeepFreeze": true,
     },
@@ -40196,7 +40196,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
       "data-uid": "bbb~~~1",
       "skipDeepFreeze": true,
     },
@@ -40350,7 +40350,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1/ccc",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1/ccc",
       "data-uid": "ccc",
       "skipDeepFreeze": true,
     },
@@ -40533,7 +40533,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
       "data-uid": "bbb~~~2",
       "skipDeepFreeze": true,
     },
@@ -40687,7 +40687,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2/ccc",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2/ccc",
       "data-uid": "ccc",
       "skipDeepFreeze": true,
     },
@@ -40870,7 +40870,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
       "data-uid": "bbb~~~3",
       "skipDeepFreeze": true,
     },
@@ -41024,7 +41024,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3/ccc",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3/ccc",
       "data-uid": "ccc",
       "skipDeepFreeze": true,
     },
@@ -41077,7 +41077,7 @@ exports[`UiJsxCanvas render the canvas supports emotion CSS prop 1`] = `
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -41091,7 +41091,7 @@ exports[`UiJsxCanvas render the canvas supports emotion CSS prop 1`] = `
     >
       <div
         data-uid=\\"ba3 aaa app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:ba3\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:ba3\\"
         class=\\"css-16au7uv\\"
       >
         Utopia
@@ -41236,7 +41236,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -41361,7 +41361,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -41476,7 +41476,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
       "data-uid": "aaa app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -41542,7 +41542,7 @@ exports[`UiJsxCanvas render the spy wrapper is compatible with React.cloneElemen
   >
     <div
       data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-      data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+      data-path=\\"utopia-storyboard-uid/scene-aaa\\"
       style=\\"
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
@@ -41556,15 +41556,15 @@ exports[`UiJsxCanvas render the spy wrapper is compatible with React.cloneElemen
     >
       <div
         data-uid=\\"zzz app-entity\\"
-        data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
+        data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
           data-uid=\\"cloner-root cloner\\"
-          data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner:cloner-root\\"
+          data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner:cloner-root\\"
         >
           <div
             data-uid=\\"cloned\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner/cloned\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner/cloned\\"
             style=\\"color: red; font-weight: 800;\\"
           >
             ha
@@ -41711,7 +41711,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa",
+      "data-path": "utopia-storyboard-uid/scene-aaa",
       "data-uid": "scene-aaa utopia-storyboard-uid",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
@@ -41836,7 +41836,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
       "data-uid": "app-entity",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -42017,7 +42017,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
       "data-uid": "zzz app-entity",
       "skipDeepFreeze": true,
     },
@@ -42152,7 +42152,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner",
       "data-uid": "cloner",
       "data-utopia-instance-path": Object {
         "parts": Array [
@@ -42272,7 +42272,7 @@ Object {
     "label": null,
     "localFrame": null,
     "props": Object {
-      "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner/cloned",
+      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner/cloned",
       "data-uid": "cloned",
       "skipDeepFreeze": true,
       "style": Object {

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -476,7 +476,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c utopia-storyboard-uid/scene-aaa/app-entity",
+          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
           "data-uid": "05c app-entity",
           "skipDeepFreeze": true,
           "style": Object {
@@ -1112,7 +1112,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c utopia-storyboard-uid/scene-aaa/app-entity",
+          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
           "data-uid": "05c app-entity",
           "skipDeepFreeze": true,
           "style": Object {
@@ -1736,7 +1736,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c utopia-storyboard-uid/scene-aaa/app-entity",
+          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
           "data-uid": "05c app-entity",
           "skipDeepFreeze": true,
           "style": Object {
@@ -2350,7 +2350,7 @@ describe('DOM Walker tests', () => {
         },
         "props": Object {
           "data-label": "Hat",
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
           "data-uid": "aaa app-entity",
           "skipDeepFreeze": true,
           "style": Object {
@@ -2770,7 +2770,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity",
+          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
           "data-uid": "aaa app-entity",
           "skipDeepFreeze": true,
           "style": Object {

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -190,7 +190,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid",
+          "data-path": "utopia-storyboard-uid",
           "data-uid": "utopia-storyboard-uid",
           "skipDeepFreeze": true,
         },
@@ -270,7 +270,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa",
+          "data-path": "utopia-storyboard-uid/scene-aaa",
           "data-uid": "scene-aaa",
           "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
           "skipDeepFreeze": true,
@@ -365,7 +365,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
           "data-uid": "app-entity",
           "data-utopia-instance-path": Object {
             "parts": Array [
@@ -476,7 +476,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
           "data-uid": "05c app-entity",
           "skipDeepFreeze": true,
           "style": Object {
@@ -579,7 +579,7 @@ describe('DOM Walker tests', () => {
           "y": 98,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0",
           "data-uid": "ef0",
           "skipDeepFreeze": true,
           "style": Object {
@@ -683,7 +683,7 @@ describe('DOM Walker tests', () => {
           "y": 27,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0/488",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0/488",
           "data-uid": "488",
           "skipDeepFreeze": true,
           "style": Object {
@@ -830,7 +830,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid",
+          "data-path": "utopia-storyboard-uid",
           "data-uid": "utopia-storyboard-uid",
           "skipDeepFreeze": true,
         },
@@ -910,7 +910,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa",
+          "data-path": "utopia-storyboard-uid/scene-aaa",
           "data-uid": "scene-aaa",
           "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
           "skipDeepFreeze": true,
@@ -1005,7 +1005,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
           "data-uid": "app-entity",
           "data-utopia-instance-path": Object {
             "parts": Array [
@@ -1112,7 +1112,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
           "data-uid": "05c app-entity",
           "skipDeepFreeze": true,
           "style": Object {
@@ -1211,7 +1211,7 @@ describe('DOM Walker tests', () => {
           "y": 98,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0",
           "data-uid": "ef0",
           "skipDeepFreeze": true,
           "style": Object {
@@ -1307,7 +1307,7 @@ describe('DOM Walker tests', () => {
           "y": 27,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0/488",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0/488",
           "data-uid": "488",
           "skipDeepFreeze": true,
           "style": Object {
@@ -1454,7 +1454,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid",
+          "data-path": "utopia-storyboard-uid",
           "data-uid": "utopia-storyboard-uid",
           "skipDeepFreeze": true,
         },
@@ -1534,7 +1534,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa",
+          "data-path": "utopia-storyboard-uid/scene-aaa",
           "data-uid": "scene-aaa",
           "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
           "skipDeepFreeze": true,
@@ -1629,7 +1629,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
           "data-uid": "app-entity",
           "data-utopia-instance-path": Object {
             "parts": Array [
@@ -1736,7 +1736,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
           "data-uid": "05c app-entity",
           "skipDeepFreeze": true,
           "style": Object {
@@ -1836,7 +1836,7 @@ describe('DOM Walker tests', () => {
           "y": 98,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0",
           "data-uid": "ef0",
           "skipDeepFreeze": true,
           "style": Object {
@@ -1932,7 +1932,7 @@ describe('DOM Walker tests', () => {
           "y": 27,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0/488",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0/488",
           "data-uid": "488",
           "skipDeepFreeze": true,
           "style": Object {
@@ -2067,7 +2067,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid",
+          "data-path": "utopia-storyboard-uid",
           "data-uid": "utopia-storyboard-uid",
           "skipDeepFreeze": true,
         },
@@ -2147,7 +2147,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa",
+          "data-path": "utopia-storyboard-uid/scene-aaa",
           "data-uid": "scene-aaa",
           "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
           "skipDeepFreeze": true,
@@ -2242,7 +2242,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
           "data-uid": "app-entity",
           "data-utopia-instance-path": Object {
             "parts": Array [
@@ -2350,7 +2350,7 @@ describe('DOM Walker tests', () => {
         },
         "props": Object {
           "data-label": "Hat",
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
           "data-uid": "aaa app-entity",
           "skipDeepFreeze": true,
           "style": Object {
@@ -2488,7 +2488,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid",
+          "data-path": "utopia-storyboard-uid",
           "data-uid": "utopia-storyboard-uid",
           "skipDeepFreeze": true,
         },
@@ -2568,7 +2568,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa",
+          "data-path": "utopia-storyboard-uid/scene-aaa",
           "data-uid": "scene-aaa",
           "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
           "skipDeepFreeze": true,
@@ -2663,7 +2663,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
           "data-uid": "app-entity",
           "data-utopia-instance-path": Object {
             "parts": Array [
@@ -2770,7 +2770,7 @@ describe('DOM Walker tests', () => {
           "y": 0,
         },
         "props": Object {
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
           "data-uid": "aaa app-entity",
           "skipDeepFreeze": true,
           "style": Object {
@@ -2869,7 +2869,7 @@ describe('DOM Walker tests', () => {
         },
         "props": Object {
           "data-label": "Plane",
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
           "data-uid": "bbb~~~1",
           "skipDeepFreeze": true,
         },
@@ -2961,7 +2961,7 @@ describe('DOM Walker tests', () => {
         },
         "props": Object {
           "data-label": "Plane",
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
           "data-uid": "bbb~~~2",
           "skipDeepFreeze": true,
         },
@@ -3053,7 +3053,7 @@ describe('DOM Walker tests', () => {
         },
         "props": Object {
           "data-label": "Plane",
-          "data-paths": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
+          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
           "data-uid": "bbb~~~3",
           "skipDeepFreeze": true,
         },

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -47,7 +47,7 @@ import {
 } from '../editor/store/store-hook'
 import {
   UTOPIA_DO_NOT_TRAVERSE_KEY,
-  UTOPIA_PATHS_KEY,
+  UTOPIA_PATH_KEY,
   UTOPIA_SCENE_ID_KEY,
 } from '../../core/model/utopia-constants'
 

--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -81,7 +81,7 @@ export var storyboard = (
         >
           <div
             data-utopia-scene-id=\\"sb/scene\\"
-            data-paths=\\"sb/scene\\"
+            data-path=\\"sb/scene\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -93,7 +93,7 @@ export var storyboard = (
             \\"
             data-uid=\\"scene sb\\"
           >
-            <div data-uid=\\"app-root app\\" data-paths=\\"sb/scene/app:app-root\\"></div>
+            <div data-uid=\\"app-root app\\" data-path=\\"sb/scene/app:app-root\\"></div>
           </div>
         </div>
       </div>
@@ -145,7 +145,7 @@ export default function App(props) {
         >
           <div
             data-utopia-scene-id=\\"sb/scene\\"
-            data-paths=\\"sb/scene\\"
+            data-path=\\"sb/scene\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -157,7 +157,7 @@ export default function App(props) {
             \\"
             data-uid=\\"scene sb\\"
           >
-            <div data-uid=\\"app-outer-div app\\" data-paths=\\"sb/scene/app\\">
+            <div data-uid=\\"app-outer-div app\\" data-path=\\"sb/scene/app\\">
               <div data-uid=\\"inner-div\\">hello</div>
             </div>
           </div>
@@ -242,7 +242,7 @@ export default function App(props) {
         >
           <div
             data-utopia-scene-id=\\"storyboard-entity/scene-1-entity\\"
-            data-paths=\\"storyboard-entity/scene-1-entity\\"
+            data-path=\\"storyboard-entity/scene-1-entity\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -257,14 +257,14 @@ export default function App(props) {
           >
             <div
               data-uid=\\"app-outer-div app-entity\\"
-              data-paths=\\"storyboard-entity/scene-1-entity/app-entity\\"
+              data-path=\\"storyboard-entity/scene-1-entity/app-entity\\"
             >
               <div data-uid=\\"inner-div\\">hello</div>
             </div>
           </div>
           <div
             data-utopia-scene-id=\\"storyboard-entity/scene-2-entity\\"
-            data-paths=\\"storyboard-entity/scene-2-entity\\"
+            data-path=\\"storyboard-entity/scene-2-entity\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -286,7 +286,7 @@ export default function App(props) {
                 height: 100%;
                 background-color: blue;
               \\"
-              data-paths=\\"storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div\\"
+              data-path=\\"storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div\\"
             ></div>
           </div>
         </div>
@@ -396,7 +396,7 @@ export default function () {
         >
           <div
             data-utopia-scene-id=\\"storyboard-entity/scene-1-entity\\"
-            data-paths=\\"storyboard-entity/scene-1-entity\\"
+            data-path=\\"storyboard-entity/scene-1-entity\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -417,7 +417,7 @@ export default function () {
                 height: 100%;
                 background-color: #ffffff;
               \\"
-              data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div\\"
+              data-path=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div\\"
             >
               <div
                 data-uid=\\"card-outer-div card-instance\\"
@@ -428,7 +428,7 @@ export default function () {
                   width: 133px;
                   height: 300px;
                 \\"
-                data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div\\"
+                data-path=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div\\"
               >
                 <div
                   data-uid=\\"card-inner-div\\"
@@ -440,7 +440,7 @@ export default function () {
                     height: 50px;
                     background-color: red;
                   \\"
-                  data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-div\\"
+                  data-path=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-div\\"
                 ></div>
                 <div
                   style=\\"
@@ -451,7 +451,7 @@ export default function () {
                     height: 50px;
                     background-color: blue;
                   \\"
-                  data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle\\"
+                  data-path=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle\\"
                   data-uid=\\"card-inner-rectangle\\"
                   data-utopia-do-not-traverse=\\"true\\"
                 ></div>
@@ -459,7 +459,7 @@ export default function () {
               hello
               <div
                 data-uid=\\"4cf d7f\\"
-                data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/d7f:4cf\\"
+                data-path=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/d7f:4cf\\"
               >
                 Default Function Time
               </div>

--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -81,7 +81,7 @@ export var storyboard = (
         >
           <div
             data-utopia-scene-id=\\"sb/scene\\"
-            data-paths=\\"sb/scene sb\\"
+            data-paths=\\"sb/scene\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -93,10 +93,7 @@ export var storyboard = (
             \\"
             data-uid=\\"scene sb\\"
           >
-            <div
-              data-uid=\\"app-root app\\"
-              data-paths=\\"sb/scene/app:app-root sb/scene/app\\"
-            ></div>
+            <div data-uid=\\"app-root app\\" data-paths=\\"sb/scene/app:app-root\\"></div>
           </div>
         </div>
       </div>
@@ -148,7 +145,7 @@ export default function App(props) {
         >
           <div
             data-utopia-scene-id=\\"sb/scene\\"
-            data-paths=\\"sb/scene sb\\"
+            data-paths=\\"sb/scene\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -245,7 +242,7 @@ export default function App(props) {
         >
           <div
             data-utopia-scene-id=\\"storyboard-entity/scene-1-entity\\"
-            data-paths=\\"storyboard-entity/scene-1-entity storyboard-entity\\"
+            data-paths=\\"storyboard-entity/scene-1-entity\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -267,7 +264,7 @@ export default function App(props) {
           </div>
           <div
             data-utopia-scene-id=\\"storyboard-entity/scene-2-entity\\"
-            data-paths=\\"storyboard-entity/scene-2-entity storyboard-entity\\"
+            data-paths=\\"storyboard-entity/scene-2-entity\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -289,7 +286,7 @@ export default function App(props) {
                 height: 100%;
                 background-color: blue;
               \\"
-              data-paths=\\"storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div storyboard-entity/scene-2-entity/same-file-app-entity\\"
+              data-paths=\\"storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div\\"
             ></div>
           </div>
         </div>
@@ -399,7 +396,7 @@ export default function () {
         >
           <div
             data-utopia-scene-id=\\"storyboard-entity/scene-1-entity\\"
-            data-paths=\\"storyboard-entity/scene-1-entity storyboard-entity\\"
+            data-paths=\\"storyboard-entity/scene-1-entity\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -420,7 +417,7 @@ export default function () {
                 height: 100%;
                 background-color: #ffffff;
               \\"
-              data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div storyboard-entity/scene-1-entity/app-entity\\"
+              data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div\\"
             >
               <div
                 data-uid=\\"card-outer-div card-instance\\"
@@ -431,7 +428,7 @@ export default function () {
                   width: 133px;
                   height: 300px;
                 \\"
-                data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance\\"
+                data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div\\"
               >
                 <div
                   data-uid=\\"card-inner-div\\"
@@ -462,7 +459,7 @@ export default function () {
               hello
               <div
                 data-uid=\\"4cf d7f\\"
-                data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/d7f:4cf storyboard-entity/scene-1-entity/app-entity:app-outer-div/d7f\\"
+                data-paths=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/d7f:4cf\\"
               >
                 Default Function Time
               </div>

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -30,7 +30,7 @@ import {
 } from './ui-jsx-canvas-element-renderer-utils'
 import { useContextSelector } from 'use-context-selector'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import { UTOPIA_INSTANCE_PATH, UTOPIA_PATHS_KEY } from '../../../core/model/utopia-constants'
+import { UTOPIA_INSTANCE_PATH, UTOPIA_PATH_KEY } from '../../../core/model/utopia-constants'
 import { getPathsFromString } from '../../../core/shared/uid-utils'
 import { useGetTopLevelElementsAndImports } from './ui-jsx-canvas-top-level-elements'
 import { useGetCodeAndHighlightBounds } from './ui-jsx-canvas-execution-scope'
@@ -39,7 +39,7 @@ import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/shared/dom-utils'
 
 export type ComponentRendererComponent = React.ComponentType<{
   [UTOPIA_INSTANCE_PATH]: ElementPath
-  [UTOPIA_PATHS_KEY]?: string
+  [UTOPIA_PATH_KEY]?: string
 }> & {
   topLevelElementName: string | null
   propertyControls?: PropertyControls
@@ -78,7 +78,7 @@ export function createComponentRendererComponent(params: {
   const Component = (realPassedPropsIncludingUtopiaSpecialStuff: any) => {
     const {
       [UTOPIA_INSTANCE_PATH]: instancePathAny, // TODO types?
-      [UTOPIA_PATHS_KEY]: pathsString, // TODO types?
+      [UTOPIA_PATH_KEY]: pathsString, // TODO types?
       ...realPassedProps
     } = realPassedPropsIncludingUtopiaSpecialStuff
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { MapLike } from 'typescript'
 import { getUtopiaID } from '../../../core/model/element-template-utils'
 import {
-  UTOPIA_PATHS_KEY,
+  UTOPIA_PATH_KEY,
   UTOPIA_SCENE_ID_KEY,
   UTOPIA_INSTANCE_PATH,
   UTOPIA_UIDS_KEY,
@@ -400,7 +400,7 @@ function renderJSXElement(
 
   const finalPropsIcludingElementPath = {
     ...finalProps,
-    [UTOPIA_PATHS_KEY]: optionalMap(EP.toString, elementPath),
+    [UTOPIA_PATH_KEY]: optionalMap(EP.toString, elementPath),
   }
 
   const staticElementPathForGeneratedElement = optionalMap(EP.makeLastPartOfPathStatic, elementPath)

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1275,7 +1275,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -1289,7 +1289,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
           >
             <div
               data-uid=\\"ccc-unparsed-no-template-path aaa app-entity\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
+              data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
             >
               hello
             </div>
@@ -1373,7 +1373,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -1388,7 +1388,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
             <div
               id=\\"nasty-div\\"
               data-uid=\\"77f~~~1 833~~~2 65e~~~1 aaa app-entity\\"
-              data-paths=\\"833~~~2/77f~~~1\\"
+              data-path=\\"833~~~2/77f~~~1\\"
             >
               huhahuha
             </div>
@@ -1884,7 +1884,7 @@ describe('UiJsxCanvas render multifile projects', () => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -1898,11 +1898,11 @@ describe('UiJsxCanvas render multifile projects', () => {
           >
             <div
               data-uid=\\"app-outer-div app-entity\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div\\"
+              data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div\\"
             >
               <div
                 data-uid=\\"inner-div\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/inner-div\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/inner-div\\"
               >
                 hello
               </div>
@@ -1968,7 +1968,7 @@ describe('UiJsxCanvas render multifile projects', () => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -1982,21 +1982,21 @@ describe('UiJsxCanvas render multifile projects', () => {
           >
             <div
               data-uid=\\"app-outer-div app-entity\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div\\"
+              data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div\\"
             >
               <div
                 data-uid=\\"card-outer-div card-instance\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/card-instance:card-outer-div\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/card-instance:card-outer-div\\"
               >
                 <div
                   data-uid=\\"card-header\\"
-                  data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/card-instance:card-outer-div/card-header\\"
+                  data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/card-instance:card-outer-div/card-header\\"
                 >
                   Card
                 </div>
                 <span
                   data-uid=\\"card-content\\"
-                  data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/card-instance/card-content\\"
+                  data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/card-instance/card-content\\"
                   >hello</span
                 >
               </div>
@@ -2054,7 +2054,7 @@ describe('UiJsxCanvas render multifile projects', () => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -2068,7 +2068,7 @@ describe('UiJsxCanvas render multifile projects', () => {
           >
             <div
               data-uid=\\"app-outer-div app-entity\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity\\"
+              data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity\\"
             >
               <div data-uid=\\"inner-div\\">Hi there!</div>
             </div>
@@ -2125,7 +2125,7 @@ describe('UiJsxCanvas render multifile projects', () => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -2139,7 +2139,7 @@ describe('UiJsxCanvas render multifile projects', () => {
           >
             <div
               data-uid=\\"app-outer-div app-entity\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity\\"
+              data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity\\"
             >
               <div data-uid=\\"inner-div\\">Hi there!</div>
             </div>
@@ -2209,7 +2209,7 @@ describe('UiJsxCanvas render multifile projects', () => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
+            data-path=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -2223,28 +2223,28 @@ describe('UiJsxCanvas render multifile projects', () => {
           >
             <div
               data-uid=\\"outer-div app-entity\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div\\"
+              data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div\\"
             >
               <div
                 data-uid=\\"aaa\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/aaa\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/aaa\\"
               >
                 <div
                   data-uid=\\"bbb~~~1\\"
-                  data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/bbb~~~1\\"
+                  data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/bbb~~~1\\"
                 ></div>
               </div>
               <div
                 data-uid=\\"ccc\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/ccc\\"
+                data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/ccc\\"
               >
                 <div
                   data-uid=\\"ddd~~~1\\"
-                  data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/ddd~~~1\\"
+                  data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/ddd~~~1\\"
                 ></div>
                 <div
                   data-uid=\\"eee~~~2\\"
-                  data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/eee~~~2\\"
+                  data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div/eee~~~2\\"
                 ></div>
               </div>
             </div>

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1275,7 +1275,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -1289,7 +1289,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
           >
             <div
               data-uid=\\"ccc-unparsed-no-template-path aaa app-entity\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
             >
               hello
             </div>
@@ -1373,7 +1373,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -1388,7 +1388,7 @@ export var ${BakedInStoryboardVariableName} = (props) => {
             <div
               id=\\"nasty-div\\"
               data-uid=\\"77f~~~1 833~~~2 65e~~~1 aaa app-entity\\"
-              data-paths=\\"833~~~2/77f~~~1 833~~~2 65e~~~1 utopia-storyboard-uid/scene-aaa/app-entity:aaa utopia-storyboard-uid/scene-aaa/app-entity\\"
+              data-paths=\\"833~~~2/77f~~~1\\"
             >
               huhahuha
             </div>
@@ -1884,7 +1884,7 @@ describe('UiJsxCanvas render multifile projects', () => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -1898,7 +1898,7 @@ describe('UiJsxCanvas render multifile projects', () => {
           >
             <div
               data-uid=\\"app-outer-div app-entity\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div utopia-storyboard-uid/scene-aaa/app-entity\\"
+              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div\\"
             >
               <div
                 data-uid=\\"inner-div\\"
@@ -1968,7 +1968,7 @@ describe('UiJsxCanvas render multifile projects', () => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -1982,11 +1982,11 @@ describe('UiJsxCanvas render multifile projects', () => {
           >
             <div
               data-uid=\\"app-outer-div app-entity\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div utopia-storyboard-uid/scene-aaa/app-entity\\"
+              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div\\"
             >
               <div
                 data-uid=\\"card-outer-div card-instance\\"
-                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/card-instance:card-outer-div utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/card-instance\\"
+                data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/card-instance:card-outer-div\\"
               >
                 <div
                   data-uid=\\"card-header\\"
@@ -2054,7 +2054,7 @@ describe('UiJsxCanvas render multifile projects', () => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -2125,7 +2125,7 @@ describe('UiJsxCanvas render multifile projects', () => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -2209,7 +2209,7 @@ describe('UiJsxCanvas render multifile projects', () => {
         >
           <div
             data-utopia-scene-id=\\"utopia-storyboard-uid/scene-aaa\\"
-            data-paths=\\"utopia-storyboard-uid/scene-aaa utopia-storyboard-uid\\"
+            data-paths=\\"utopia-storyboard-uid/scene-aaa\\"
             style=\\"
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
@@ -2223,7 +2223,7 @@ describe('UiJsxCanvas render multifile projects', () => {
           >
             <div
               data-uid=\\"outer-div app-entity\\"
-              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div utopia-storyboard-uid/scene-aaa/app-entity\\"
+              data-paths=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div\\"
             >
               <div
                 data-uid=\\"aaa\\"

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -76,7 +76,7 @@ import {
 } from '../../utils/react-performance'
 import { unimportAllButTheseCSSFiles } from '../../core/webpack-loaders/css-loader'
 import { useSelectAndHover } from './controls/select-mode/select-mode-hooks'
-import { UTOPIA_INSTANCE_PATH, UTOPIA_PATHS_KEY } from '../../core/model/utopia-constants'
+import { UTOPIA_INSTANCE_PATH, UTOPIA_PATH_KEY } from '../../core/model/utopia-constants'
 import {
   createLookupRender,
   utopiaCanvasJSXLookup,

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -179,7 +179,7 @@ function useTriggerHighlightPerformanceTest(key: 'regular' | 'all-elements'): ()
 
     const targetPath = allPaths.current[0]
 
-    const htmlElement = document.querySelector(`*[data-path~="${EP.toString(targetPath)}"]`)
+    const htmlElement = document.querySelector(`*[data-path*="${EP.toString(targetPath)}"]`)
     if (htmlElement == null) {
       console.info(`HIGHLIGHT_${allCapsKey}_TEST_ERROR_NO_ELEMENT`)
       return
@@ -252,7 +252,7 @@ export function useTriggerSelectionPerformanceTest(): () => void {
 
     const targetElement = forceNotNull(
       'Target element should exist.',
-      document.querySelector(`*[data-path~="${EP.toString(targetPath)}"]`),
+      document.querySelector(`*[data-path*="${EP.toString(targetPath)}"]`),
     )
     const originalTargetBounds = targetElement.getBoundingClientRect()
     const leftToTarget =
@@ -421,7 +421,7 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
 
     const targetElement = forceNotNull(
       'Target element should exist.',
-      document.querySelector(`*[data-path~="${EP.toString(childTargetPath)}"]`),
+      document.querySelector(`*[data-path*="${EP.toString(childTargetPath)}"]`),
     )
     const originalTargetBounds = targetElement.getBoundingClientRect()
     const leftToTarget =

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -179,7 +179,7 @@ function useTriggerHighlightPerformanceTest(key: 'regular' | 'all-elements'): ()
 
     const targetPath = allPaths.current[0]
 
-    const htmlElement = document.querySelector(`*[data-paths~="${EP.toString(targetPath)}"]`)
+    const htmlElement = document.querySelector(`*[data-path~="${EP.toString(targetPath)}"]`)
     if (htmlElement == null) {
       console.info(`HIGHLIGHT_${allCapsKey}_TEST_ERROR_NO_ELEMENT`)
       return
@@ -252,7 +252,7 @@ export function useTriggerSelectionPerformanceTest(): () => void {
 
     const targetElement = forceNotNull(
       'Target element should exist.',
-      document.querySelector(`*[data-paths~="${EP.toString(targetPath)}"]`),
+      document.querySelector(`*[data-path~="${EP.toString(targetPath)}"]`),
     )
     const originalTargetBounds = targetElement.getBoundingClientRect()
     const leftToTarget =
@@ -421,7 +421,7 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
 
     const targetElement = forceNotNull(
       'Target element should exist.',
-      document.querySelector(`*[data-paths~="${EP.toString(childTargetPath)}"]`),
+      document.querySelector(`*[data-path~="${EP.toString(childTargetPath)}"]`),
     )
     const originalTargetBounds = targetElement.getBoundingClientRect()
     const leftToTarget =

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -179,7 +179,7 @@ function useTriggerHighlightPerformanceTest(key: 'regular' | 'all-elements'): ()
 
     const targetPath = allPaths.current[0]
 
-    const htmlElement = document.querySelector(`*[data-path*="${EP.toString(targetPath)}"]`)
+    const htmlElement = document.querySelector(`*[data-path^="${EP.toString(targetPath)}"]`)
     if (htmlElement == null) {
       console.info(`HIGHLIGHT_${allCapsKey}_TEST_ERROR_NO_ELEMENT`)
       return
@@ -252,7 +252,7 @@ export function useTriggerSelectionPerformanceTest(): () => void {
 
     const targetElement = forceNotNull(
       'Target element should exist.',
-      document.querySelector(`*[data-path*="${EP.toString(targetPath)}"]`),
+      document.querySelector(`*[data-path^="${EP.toString(targetPath)}"]`),
     )
     const originalTargetBounds = targetElement.getBoundingClientRect()
     const leftToTarget =
@@ -421,7 +421,7 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
 
     const targetElement = forceNotNull(
       'Target element should exist.',
-      document.querySelector(`*[data-path*="${EP.toString(childTargetPath)}"]`),
+      document.querySelector(`*[data-path^="${EP.toString(childTargetPath)}"]`),
     )
     const originalTargetBounds = targetElement.getBoundingClientRect()
     const leftToTarget =

--- a/editor/src/core/model/utopia-constants.ts
+++ b/editor/src/core/model/utopia-constants.ts
@@ -1,5 +1,5 @@
 export const UTOPIA_UIDS_KEY = 'data-uid'
-export const UTOPIA_PATHS_KEY = 'data-paths'
+export const UTOPIA_PATH_KEY = 'data-paths'
 export const UTOPIA_LABEL_KEY = 'data-label'
 export const UTOPIA_DO_NOT_TRAVERSE_KEY = 'data-utopia-do-not-traverse'
 export const UTOPIA_SCENE_ID_KEY = 'data-utopia-scene-id'
@@ -9,7 +9,7 @@ export const UTOPIA_INSTANCE_PATH = 'data-utopia-instance-path'
 
 export const UtopiaKeys: Array<string> = [
   UTOPIA_UIDS_KEY,
-  UTOPIA_PATHS_KEY,
+  UTOPIA_PATH_KEY,
   UTOPIA_LABEL_KEY,
   UTOPIA_DO_NOT_TRAVERSE_KEY,
   UTOPIA_SCENE_ID_KEY,

--- a/editor/src/core/model/utopia-constants.ts
+++ b/editor/src/core/model/utopia-constants.ts
@@ -1,5 +1,5 @@
 export const UTOPIA_UIDS_KEY = 'data-uid'
-export const UTOPIA_PATH_KEY = 'data-paths'
+export const UTOPIA_PATH_KEY = 'data-path'
 export const UTOPIA_LABEL_KEY = 'data-label'
 export const UTOPIA_DO_NOT_TRAVERSE_KEY = 'data-utopia-do-not-traverse'
 export const UTOPIA_SCENE_ID_KEY = 'data-utopia-scene-id'

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -73,6 +73,28 @@ function getElementPathCache(fullElementPath: ElementPathPart[]): ElementPathCac
 const SceneSeparator = ':'
 const ElementSeparator = '/'
 
+function getComponentPathStringForPathString(path: string): string | null {
+  const indexOfLastSceneSeparator = path.lastIndexOf(SceneSeparator)
+  const indexOfLastElementSeparator = path.lastIndexOf(ElementSeparator)
+  if (indexOfLastSceneSeparator > indexOfLastElementSeparator) {
+    return path.slice(0, indexOfLastSceneSeparator)
+  } else {
+    return null
+  }
+}
+
+export function getAllElementPathStringsForPathString(path: string): Array<string> {
+  let allElementPathStrings: Array<string> = []
+  let workingPath: string | null = path
+
+  while (workingPath != null) {
+    allElementPathStrings.push(workingPath)
+    workingPath = getComponentPathStringForPathString(workingPath)
+  }
+
+  return allElementPathStrings
+}
+
 export function elementPathPartToString(path: ElementPathPart): string {
   let result: string = ''
   const elementsLength = path.length

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -238,7 +238,8 @@ function getSplitPathsStrings(pathsString: string | null): Array<string> {
   if (pathsString == null) {
     return []
   } else {
-    return pathsString.split(' ')
+    const firstPath = pathsString.split(' ')[0]
+    return firstPath == null ? [] : EP.getAllElementPathStringsForPathString(firstPath)
   }
 }
 

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -24,7 +24,7 @@ import * as PP from './property-path'
 import * as EP from './element-path'
 import { objectMap, objectValues } from './object-utils'
 import { getDOMAttribute } from './dom-utils'
-import { UTOPIA_PATHS_KEY, UTOPIA_UIDS_KEY } from '../model/utopia-constants'
+import { UTOPIA_PATH_KEY, UTOPIA_UIDS_KEY } from '../model/utopia-constants'
 import { addAllUniquely, mapDropNulls } from './array-utils'
 import { ElementPath } from './project-file-types'
 
@@ -257,7 +257,7 @@ export interface PathWithString {
 }
 
 export function getPathWithStringsOnDomElement(element: Element): Array<PathWithString> {
-  const pathsAttribute = getDOMAttribute(element, UTOPIA_PATHS_KEY)
+  const pathsAttribute = getDOMAttribute(element, UTOPIA_PATH_KEY)
   return mapDropNulls((pathString) => {
     const parsedPath = EP.fromString(pathString)
     if (EP.isElementPath(parsedPath)) {
@@ -272,7 +272,7 @@ export function getPathWithStringsOnDomElement(element: Element): Array<PathWith
 }
 
 export function getPathsOnDomElement(element: Element): Array<ElementPath> {
-  const pathsAttribute = getDOMAttribute(element, UTOPIA_PATHS_KEY)
+  const pathsAttribute = getDOMAttribute(element, UTOPIA_PATH_KEY)
   return getPathsFromString(pathsAttribute)
 }
 

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -235,12 +235,7 @@ export function appendToUidString(
 }
 
 function getSplitPathsStrings(pathsString: string | null): Array<string> {
-  if (pathsString == null) {
-    return []
-  } else {
-    const firstPath = pathsString.split(' ')[0]
-    return firstPath == null ? [] : EP.getAllElementPathStringsForPathString(firstPath)
-  }
+  return pathsString == null ? [] : EP.getAllElementPathStringsForPathString(pathsString)
 }
 
 function getPathsFromSplitString(splitPaths: Array<string>): Array<ElementPath> {

--- a/editor/src/utils/canvas-react-utils.spec.tsx
+++ b/editor/src/utils/canvas-react-utils.spec.tsx
@@ -40,11 +40,11 @@ describe('Monkey Function', () => {
     class TestClass extends React.Component {
       render() {
         return (
-          <div data-uid='cica' data-paths='cica'>
-            <div data-uid='kutya' data-paths='kutya'>
+          <div data-uid='cica' data-path='cica'>
+            <div data-uid='kutya' data-path='kutya'>
               Hello!
             </div>
-            <div data-uid='majom' data-paths='majom'>
+            <div data-uid='majom' data-path='majom'>
               Hello!
             </div>
           </div>
@@ -52,11 +52,11 @@ describe('Monkey Function', () => {
       }
     }
 
-    expect(renderToFormattedString(<TestClass data-uid={'test1'} data-paths='test1' />))
+    expect(renderToFormattedString(<TestClass data-uid={'test1'} data-path='test1' />))
       .toMatchInlineSnapshot(`
-      "<div data-uid=\\"cica test1\\" data-paths=\\"cica\\">
-        <div data-uid=\\"kutya\\" data-paths=\\"kutya\\">Hello!</div>
-        <div data-uid=\\"majom\\" data-paths=\\"majom\\">Hello!</div>
+      "<div data-uid=\\"cica test1\\" data-path=\\"cica\\">
+        <div data-uid=\\"kutya\\" data-path=\\"kutya\\">Hello!</div>
+        <div data-uid=\\"majom\\" data-path=\\"majom\\">Hello!</div>
       </div>
       "
     `)
@@ -67,7 +67,7 @@ describe('Monkey Function', () => {
     class TestClass extends React.Component {
       render() {
         return (
-          <div data-uid='inner-div' data-paths='inner-div'>
+          <div data-uid='inner-div' data-path='inner-div'>
             {this.context.value}
           </div>
         )
@@ -77,14 +77,12 @@ describe('Monkey Function', () => {
 
     expect(
       renderToFormattedString(
-        <MyContext.Provider value={{ value: 'hello!' }} data-uid='provider' data-paths='provider'>
-          <TestClass data-uid={'test-class'} data-paths='test-class' />
+        <MyContext.Provider value={{ value: 'hello!' }} data-uid='provider' data-path='provider'>
+          <TestClass data-uid={'test-class'} data-path='test-class' />
         </MyContext.Provider>,
       ),
     ).toMatchInlineSnapshot(`
-      "<div data-uid=\\"inner-div test-class provider\\" data-paths=\\"inner-div\\">
-        hello!
-      </div>
+      "<div data-uid=\\"inner-div test-class provider\\" data-path=\\"inner-div\\">hello!</div>
       "
     `)
   })
@@ -94,7 +92,7 @@ describe('Monkey Function', () => {
     class TestClass extends React.Component {
       render() {
         return (
-          <div data-uid='inner-div' data-paths='inner-div'>
+          <div data-uid='inner-div' data-path='inner-div'>
             {this.context.value}
           </div>
         )
@@ -104,15 +102,15 @@ describe('Monkey Function', () => {
 
     const Renderer = () => {
       return (
-        <MyContext.Provider value={{ value: 'hello!' }} data-uid='provider' data-paths='provider'>
-          <TestClass data-uid='test-class' data-paths='test-class' />
+        <MyContext.Provider value={{ value: 'hello!' }} data-uid='provider' data-path='provider'>
+          <TestClass data-uid='test-class' data-path='test-class' />
         </MyContext.Provider>
       )
     }
 
-    expect(renderToFormattedString(<Renderer data-uid={'renderer'} data-paths={'renderer'} />))
+    expect(renderToFormattedString(<Renderer data-uid={'renderer'} data-path={'renderer'} />))
       .toMatchInlineSnapshot(`
-      "<div data-uid=\\"inner-div test-class provider renderer\\" data-paths=\\"inner-div\\">
+      "<div data-uid=\\"inner-div test-class provider renderer\\" data-path=\\"inner-div\\">
         hello!
       </div>
       "

--- a/editor/src/utils/canvas-react-utils.spec.tsx
+++ b/editor/src/utils/canvas-react-utils.spec.tsx
@@ -54,7 +54,7 @@ describe('Monkey Function', () => {
 
     expect(renderToFormattedString(<TestClass data-uid={'test1'} data-paths='test1' />))
       .toMatchInlineSnapshot(`
-      "<div data-uid=\\"cica test1\\" data-paths=\\"cica test1\\">
+      "<div data-uid=\\"cica test1\\" data-paths=\\"cica\\">
         <div data-uid=\\"kutya\\" data-paths=\\"kutya\\">Hello!</div>
         <div data-uid=\\"majom\\" data-paths=\\"majom\\">Hello!</div>
       </div>
@@ -82,10 +82,7 @@ describe('Monkey Function', () => {
         </MyContext.Provider>,
       ),
     ).toMatchInlineSnapshot(`
-      "<div
-        data-uid=\\"inner-div test-class provider\\"
-        data-paths=\\"inner-div test-class provider\\"
-      >
+      "<div data-uid=\\"inner-div test-class provider\\" data-paths=\\"inner-div\\">
         hello!
       </div>
       "
@@ -115,10 +112,7 @@ describe('Monkey Function', () => {
 
     expect(renderToFormattedString(<Renderer data-uid={'renderer'} data-paths={'renderer'} />))
       .toMatchInlineSnapshot(`
-      "<div
-        data-uid=\\"inner-div test-class provider renderer\\"
-        data-paths=\\"inner-div test-class provider renderer\\"
-      >
+      "<div data-uid=\\"inner-div test-class provider renderer\\" data-paths=\\"inner-div\\">
         hello!
       </div>
       "

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -113,9 +113,10 @@ function attachDataUidToRoot(
     return originalResponse
   } else {
     if (shouldIncludeDataUID(originalResponse.type)) {
+      const newPaths = originalResponse.props[UTOPIA_PATHS_KEY] ?? paths
       return React.cloneElement(originalResponse, {
         [UTOPIA_UIDS_KEY]: appendToUidString(originalResponse.props[UTOPIA_UIDS_KEY], dataUids),
-        [UTOPIA_PATHS_KEY]: appendToUidString(originalResponse.props[UTOPIA_PATHS_KEY], paths),
+        [UTOPIA_PATHS_KEY]: newPaths, //appendToUidString(originalResponse.props[UTOPIA_PATHS_KEY], paths),
       })
     } else {
       return originalResponse
@@ -212,7 +213,7 @@ const mangleExoticType = Utils.memoize(
       const existingChildUIDs = child.props?.[UTOPIA_UIDS_KEY]
       const existingChildPaths = child.props?.[UTOPIA_PATHS_KEY]
       const appendedUIDString = appendToUidString(existingChildUIDs, dataUids)
-      const appendedPathsString = appendToUidString(existingChildPaths, paths)
+      const appendedPathsString = existingChildPaths ?? paths //appendToUidString(existingChildPaths, paths)
       if ((!React.isValidElement(child) as boolean) || child == null) {
         return child
       } else {


### PR DESCRIPTION
This PR is a pre-cursor to the solution to #2059 

**Problem:**
We print all paths for an element onto the rendered dom element via the `data-paths` attribute. The reason for this is so that we can tie that rendered element to all of the components in the React tree that actually directly resulted in that dom element (for the sake of metadata, and selection following). This approach was fine so far, but the solution to the above ticket makes that approach a lot trickier, and we realised that we only need the final path, since we can extrapolate the other paths via that.

**Fix:**
Only print the final (full) path to the dom element, and then use a function in `element-path.ts` to provide the extrapolation algorithm.

The core changes exist in `element-path.ts` and `canvas-react-utils.ts`.

**Commit Details:**
- Created a function for extrapolating the paths of all elements directly result in the dom element rendered at a given path in `element-path.ts`
- Only attach the resultant path to the element in `canvas-react-utils.ts` rather than appending them all
- Renamed `DATA_UTOPIA_PATHS` to `DATA_UTOPIA_PATH`, and `data-paths` to `data-path`
- Updated all of the test snapshots broken by this, ensuring that only the printed paths had been updated and nothing more. 
