### PR TITLE
Remove redundant state patching

### DIFF
--- a/editor/src/components/canvas/commands/adjust-number-command.spec.tsx
+++ b/editor/src/components/canvas/commands/adjust-number-command.spec.tsx
@@ -1,3 +1,4 @@
+import update from 'immutability-helper'
 import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import * as EP from '../../../core/shared/element-path'
 import { getNumberPropertyFromProps } from '../../../core/shared/jsx-attributes'
@@ -6,7 +7,6 @@ import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-s
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import { adjustNumberProperty, runAdjustNumberProperty } from './adjust-number-command'
-import { applyStatePatches } from './commands'
 
 describe('adjustNumberProperty', () => {
   it('works for left style prop', async () => {
@@ -47,12 +47,7 @@ describe('adjustNumberProperty', () => {
       adjustNumberPropertyCommand,
     )
 
-    const patchedEditor = applyStatePatches(
-      renderResult.getEditorState().editor,
-      renderResult.getEditorState().editor,
-      [result.editorStatePatch],
-    )
-
+    const patchedEditor = update(renderResult.getEditorState().editor, result.editorStatePatch)
     const updatedLeftStyleProp = withUnderlyingTargetFromEditorState(
       cardInstancePath,
       patchedEditor,

--- a/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
@@ -1,9 +1,9 @@
+import update from 'immutability-helper'
 import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import * as EP from '../../../core/shared/element-path'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
 import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
-import { applyStatePatches } from './commands'
 import { reparentElement, runReparentElement } from './reparent-element-command'
 
 describe('runReparentElement', () => {
@@ -31,9 +31,7 @@ describe('runReparentElement', () => {
 
     const result = runReparentElement(originalEditorState, reparentCommand)
 
-    const patchedEditor = applyStatePatches(originalEditorState, originalEditorState, [
-      result.editorStatePatch,
-    ])
+    const patchedEditor = update(originalEditorState, result.editorStatePatch)
     const newPath = EP.appendToPath(newParentPath, EP.toUid(targetPath))
 
     const newElement = withUnderlyingTargetFromEditorState(

--- a/editor/src/components/canvas/commands/update-selected-views-command.spec.tsx
+++ b/editor/src/components/canvas/commands/update-selected-views-command.spec.tsx
@@ -1,8 +1,9 @@
+import update from 'immutability-helper'
 import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import * as EP from '../../../core/shared/element-path'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
-import { applyStatePatches } from './commands'
+import { foldAndApplyCommands } from './commands'
 import { runUpdateSelectedViews, updateSelectedViews } from './update-selected-views-command'
 
 describe('updateSelectedViews', () => {
@@ -25,9 +26,7 @@ describe('updateSelectedViews', () => {
 
     const result = runUpdateSelectedViews(originalEditorState, updateSelectedViewsCommand)
 
-    const patchedEditor = applyStatePatches(originalEditorState, originalEditorState, [
-      result.editorStatePatch,
-    ])
+    const patchedEditor = update(originalEditorState, result.editorStatePatch)
 
     expect(patchedEditor.selectedViews).toEqual([targetPath])
   })

--- a/editor/src/components/canvas/commands/wildcard-patch-command.spec.tsx
+++ b/editor/src/components/canvas/commands/wildcard-patch-command.spec.tsx
@@ -1,9 +1,9 @@
+import update from 'immutability-helper'
 import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import * as EP from '../../../core/shared/element-path'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
 import { selectComponents, setFocusedElement } from '../../editor/actions/action-creators'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
-import { applyStatePatches } from './commands'
 import { runWildcardPatch, wildcardPatch } from './wildcard-patch-command'
 
 describe('wildcardPatch', () => {
@@ -28,11 +28,7 @@ describe('wildcardPatch', () => {
 
     const result = runWildcardPatch(renderResult.getEditorState().editor, wildcardCommand)
 
-    const patchedEditor = applyStatePatches(
-      renderResult.getEditorState().editor,
-      renderResult.getEditorState().editor,
-      [result.editorStatePatch],
-    )
+    const patchedEditor = update(renderResult.getEditorState().editor, result.editorStatePatch)
     expect(patchedEditor.selectedViews).toEqual([])
   })
 })


### PR DESCRIPTION
# Problem

`foldCommands` calculates all the state patches, and to do that, it needs to update the state with all the patches. Then it throws away the patched state, and just returns the patches. `foldAndApplyCommands` uses these patches to recreate the same patched state.
This is confusing and also not ideal performancewise.

# Solution
`foldAndApplyCommands` just directly returns the patched editor state, instead of collecting the patches and reapplying them again.