### PR TITLE
Feature/canvas strategy reparent element

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -169,6 +169,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -264,6 +265,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -206,6 +206,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -340,6 +341,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -623,6 +625,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -739,6 +742,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -855,6 +859,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -971,6 +976,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1190,6 +1196,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1324,6 +1331,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1516,6 +1524,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1734,6 +1743,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1868,6 +1878,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -1979,6 +1990,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2215,6 +2227,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2349,6 +2362,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2589,6 +2603,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2739,6 +2754,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -2889,6 +2905,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -3039,6 +3056,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -3326,6 +3344,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -3460,6 +3479,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -3819,6 +3839,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4073,6 +4094,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4230,6 +4252,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4387,6 +4410,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4544,6 +4568,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4798,6 +4823,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -4955,6 +4981,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5112,6 +5139,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5269,6 +5297,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5523,6 +5552,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5680,6 +5710,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5837,6 +5868,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -5994,6 +6026,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6224,6 +6257,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6358,6 +6392,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6515,6 +6550,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6614,6 +6650,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6713,6 +6750,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -6931,6 +6969,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7065,6 +7104,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7242,6 +7282,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7478,6 +7519,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7612,6 +7654,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -7865,6 +7908,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8039,6 +8083,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8213,6 +8258,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8387,6 +8433,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8623,6 +8670,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -8757,6 +8805,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9010,6 +9059,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9184,6 +9234,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9358,6 +9409,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9532,6 +9584,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9762,6 +9815,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -9896,6 +9950,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10053,6 +10108,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10166,6 +10222,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10279,6 +10336,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10509,6 +10567,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10643,6 +10702,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10833,6 +10893,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -10946,6 +11007,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11059,6 +11121,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11304,6 +11367,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11451,6 +11515,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11772,6 +11837,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -11973,6 +12039,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12217,6 +12284,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12364,6 +12432,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12685,6 +12754,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -12886,6 +12956,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13131,6 +13202,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13278,6 +13350,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13647,6 +13720,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -13902,6 +13976,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14147,6 +14222,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14294,6 +14370,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14663,6 +14740,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -14918,6 +14996,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -15135,6 +15214,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -15269,6 +15349,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -15380,6 +15461,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -15720,6 +15802,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -15854,6 +15937,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -17043,6 +17127,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -17897,6 +17982,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -18246,6 +18332,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -18595,6 +18682,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -18944,6 +19032,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -19333,6 +19422,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -19582,6 +19672,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -19967,6 +20058,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20212,6 +20304,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20597,6 +20690,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -20842,6 +20936,7 @@ export var storyboard = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21082,6 +21177,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21216,6 +21312,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21405,6 +21502,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21535,6 +21633,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21665,6 +21764,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -21884,6 +21984,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22018,6 +22119,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22181,6 +22283,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22399,6 +22502,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22533,6 +22637,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22768,6 +22873,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -22975,6 +23081,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23080,6 +23187,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23344,6 +23452,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23567,6 +23676,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23831,6 +23941,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -23965,6 +24076,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24193,6 +24305,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24385,6 +24498,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24518,6 +24632,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24763,6 +24878,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -24910,6 +25026,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25171,6 +25288,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25301,6 +25419,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25690,6 +25809,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -25837,6 +25957,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -26099,6 +26220,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -26229,6 +26351,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -26559,6 +26682,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -26693,6 +26817,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27421,6 +27546,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27538,6 +27664,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27655,6 +27782,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27772,6 +27900,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27875,6 +28004,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -27992,6 +28122,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28095,6 +28226,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28268,6 +28400,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28385,6 +28518,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28502,6 +28636,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28619,6 +28754,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28722,6 +28858,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28839,6 +28976,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -28958,6 +29096,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29075,6 +29214,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29192,6 +29332,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29295,6 +29436,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29398,6 +29540,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29515,6 +29658,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29634,6 +29778,7 @@ export var App = (props) => {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -29870,6 +30015,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30004,6 +30150,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30257,6 +30404,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30431,6 +30579,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30605,6 +30754,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -30779,6 +30929,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31015,6 +31166,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31149,6 +31301,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31403,6 +31556,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31578,6 +31732,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31753,6 +31908,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -31928,6 +32084,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32164,6 +32321,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32298,6 +32456,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32558,6 +32717,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32732,6 +32892,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -32906,6 +33067,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33080,6 +33242,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33321,6 +33484,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33468,6 +33632,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33691,6 +33856,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -33821,6 +33987,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34042,6 +34209,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34147,6 +34315,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34251,6 +34420,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34355,6 +34525,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34551,6 +34722,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34656,6 +34828,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34873,6 +35046,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -34997,6 +35171,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35193,6 +35368,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35298,6 +35474,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35409,6 +35586,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35613,6 +35791,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35718,6 +35897,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -35899,6 +36079,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36029,6 +36210,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36227,6 +36409,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36332,6 +36515,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36595,6 +36779,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36792,6 +36977,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -36897,6 +37083,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37012,6 +37199,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37253,6 +37441,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37387,6 +37576,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -37810,6 +38000,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38026,6 +38217,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38166,6 +38358,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38271,6 +38464,7 @@ export var storyboard = (
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38494,6 +38688,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38628,6 +38823,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38776,6 +38972,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -38892,6 +39089,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39114,6 +39312,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39249,6 +39448,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39361,6 +39561,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39612,6 +39813,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -39746,6 +39948,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40028,6 +40231,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40211,6 +40415,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40365,6 +40570,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40548,6 +40754,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40702,6 +40909,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -40885,6 +41093,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -41039,6 +41248,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -41259,6 +41469,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -41393,6 +41604,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -41504,6 +41716,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -41734,6 +41947,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -41868,6 +42082,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -42032,6 +42247,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -42181,6 +42397,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,
@@ -42291,6 +42508,7 @@ Object {
       },
       "display": "initial",
       "flexDirection": null,
+      "globalContentBox": null,
       "htmlElementName": "div",
       "immediateParentBounds": Object {
         "height": 0,

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -52,7 +52,7 @@ function reparentElement(
       currentStrategy: null as any, // the strategy does not use this
       currentStrategyFitness: null as any, // the strategy does not use this
       currentStrategyCommands: null as any, // the strategy does not use this
-      accumulatedCommands: null as any, // the strategy does not use this
+      accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: {

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -61,6 +61,7 @@ function reparentElement(
           globalFrame: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
           specialSizeMeasurements: {
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            providesBoundsForChildren: true,
             globalContentBox: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
@@ -72,6 +73,7 @@ function reparentElement(
           globalFrame: canvasRectangle({ x: 50, y: 60, width: 250, height: 200 }),
           specialSizeMeasurements: {
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            providesBoundsForChildren: true,
             globalContentBox: targetParentWithSpecialContentBox
               ? canvasRectangle({ x: 90, y: 100, width: 170, height: 120 })
               : canvasRectangle({ x: 50, y: 60, width: 250, height: 200 }),

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -73,7 +73,7 @@ function reparentElement(
           specialSizeMeasurements: {
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
             globalContentBox: targetParentWithSpecialContentBox
-              ? canvasRectangle({ x: 60, y: 70, width: 225, height: 180 })
+              ? canvasRectangle({ x: 90, y: 100, width: 170, height: 120 })
               : canvasRectangle({ x: 50, y: 60, width: 250, height: 200 }),
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
@@ -322,10 +322,10 @@ describe('Absolute Move Strategy', () => {
               data-uid='ccc'
               style={{
                 position: 'absolute',
-                top: 35,
-                left: 60,
-                bottom: 90,
-                right: 125,
+                top: 5,
+                left: 30,
+                bottom: 60,
+                right: 100,
               }}
             />
           </div>

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -83,13 +83,19 @@ function reparentElement(
     } as StrategyState,
   )
 
-  const finalEditor = foldAndApplyCommands(editorState, editorState, strategyResult, 'permanent')
-    .editorState
+  const finalEditor = foldAndApplyCommands(
+    editorState,
+    editorState,
+    [],
+    [],
+    strategyResult,
+    'permanent',
+  ).editorState
 
   return finalEditor
 }
 
-describe('Absolute Move Strategy', () => {
+describe('Absolute Rerarent Strategy', () => {
   it('works with a TL pinned absolute element', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -1,0 +1,336 @@
+import { elementPath } from '../../../core/shared/element-path'
+import {
+  ElementInstanceMetadata,
+  SpecialSizeMeasurements,
+} from '../../../core/shared/element-template'
+import { canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
+import { WindowMousePositionRaw } from '../../../utils/global-positions'
+import { EditorState } from '../../editor/store/editor-state'
+import { foldAndApplyCommands } from '../commands/commands'
+import {
+  getEditorStateWithSelectedViews,
+  makeTestProjectCodeWithSnippet,
+  testPrintCodeFromEditorState,
+} from '../ui-jsx.test-utils'
+import { absoluteReparentStrategy } from './absolute-reparent-strategy'
+import { pickCanvasStateFromEditorState } from './canvas-strategies'
+import { InteractionSession, StrategyState } from './interaction-state'
+import { createMouseInteractionForTests } from './interaction-state.test-utils'
+
+jest.mock('../canvas-utils', () => ({
+  ...jest.requireActual('../canvas-utils'),
+  getReparentTarget: () => ({
+    shouldReparent: true,
+    newParent: {
+      type: 'elementpath',
+      parts: [
+        ['scene-aaa', 'app-entity'],
+        ['aaa', 'bbb'],
+      ],
+    },
+  }),
+}))
+
+function reparentElement(
+  editorState: EditorState,
+  targetParentWithSpecialContentBox: boolean,
+): EditorState {
+  const interactionSession: InteractionSession = {
+    ...createMouseInteractionForTests(
+      null as any, // the strategy does not use this
+      { cmd: true, alt: false, shift: false, ctrl: false },
+      null as any, // the strategy does not use this
+      canvasPoint({ x: 0, y: 0 }),
+    ),
+    metadata: null as any, // the strategy does not use this
+  }
+
+  const strategyResult = absoluteReparentStrategy.apply(
+    pickCanvasStateFromEditorState(editorState),
+    interactionSession,
+    {
+      currentStrategy: null as any, // the strategy does not use this
+      currentStrategyFitness: null as any, // the strategy does not use this
+      currentStrategyCommands: null as any, // the strategy does not use this
+      accumulatedCommands: null as any, // the strategy does not use this
+      commandDescriptions: null as any, // the strategy does not use this
+      sortedApplicableStrategies: null as any, // the strategy does not use this
+      startingMetadata: {
+        'scene-aaa/app-entity:aaa': {
+          elementPath: elementPath([['scene-aaa', 'app-entity'], ['aaa']]),
+          globalFrame: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+          specialSizeMeasurements: {
+            immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            globalContentBox: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+          } as SpecialSizeMeasurements,
+        } as ElementInstanceMetadata,
+        'scene-aaa/app-entity:aaa/bbb': {
+          elementPath: elementPath([
+            ['scene-aaa', 'app-entity'],
+            ['aaa', 'bbb'],
+          ]),
+          globalFrame: canvasRectangle({ x: 50, y: 60, width: 250, height: 200 }),
+          specialSizeMeasurements: {
+            immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            globalContentBox: targetParentWithSpecialContentBox
+              ? canvasRectangle({ x: 60, y: 70, width: 225, height: 180 })
+              : canvasRectangle({ x: 50, y: 60, width: 250, height: 200 }),
+          } as SpecialSizeMeasurements,
+        } as ElementInstanceMetadata,
+      },
+    } as StrategyState,
+  )
+
+  const finalEditor = foldAndApplyCommands(editorState, editorState, strategyResult, 'permanent')
+    .editorState
+
+  return finalEditor
+}
+
+describe('Absolute Move Strategy', () => {
+  it('works with a TL pinned absolute element', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'ccc'],
+    ])
+
+    const initialEditor = getEditorStateWithSelectedViews(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+        }}
+      >
+        <div
+          data-uid='bbb'
+          style={{
+            position: 'absolute',
+            width: 250,
+            height: 200,
+            top: 60,
+            left: 50,
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={{
+            position: 'absolute',
+            width: 20,
+            height: 30,
+            top: 75,
+            left: 90,
+          }}
+        />
+      </div>
+      `),
+      [targetElement],
+    )
+
+    const finalEditor = reparentElement(initialEditor, false)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `
+        <div
+        data-uid='aaa'
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+        }}
+        >
+          <div
+            data-uid='bbb'
+            style={{
+              position: 'absolute',
+              width: 250,
+              height: 200,
+              top: 60,
+              left: 50,
+            }}
+          >
+            <div
+              data-uid='ccc'
+              style={{
+                position: 'absolute',
+                width: 20,
+                height: 30,
+                top: 15,
+                left: 40,
+              }}
+            />
+          </div>
+        </div>
+        `,
+      ),
+    )
+  })
+
+  it('works with a TLBR pinned absolute element', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'ccc'],
+    ])
+
+    const initialEditor = getEditorStateWithSelectedViews(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+        }}
+      >
+        <div
+          data-uid='bbb'
+          style={{
+            position: 'absolute',
+            width: 250,
+            height: 200,
+            top: 60,
+            left: 50,
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={{
+            position: 'absolute',
+            top: 75,
+            left: 90,
+            bottom: 295,
+            right: 290
+          }}
+        />
+      </div>
+      `),
+      [targetElement],
+    )
+
+    const finalEditor = reparentElement(initialEditor, false)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          data-uid='aaa'
+          style={{
+            position: 'relative',
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#FFFFFF',
+          }}
+        >
+          <div
+            data-uid='bbb'
+            style={{
+              position: 'absolute',
+              width: 250,
+              height: 200,
+              top: 60,
+              left: 50,
+            }}
+          >
+            <div
+              data-uid='ccc'
+              style={{
+                position: 'absolute',
+                top: 15,
+                left: 40,
+                bottom: 155,
+                right: 190
+              }}
+            />
+          </div>
+        </div>
+        `),
+    )
+  })
+  it('works with a TLBR pinned absolute element when the parent has padding and border', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'ccc'],
+    ])
+
+    const initialEditor = getEditorStateWithSelectedViews(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+        }}
+      >
+        <div
+          data-uid='bbb'
+          style={{
+            position: 'absolute',
+            border: '40px solid grey',
+            width: 250,
+            height: 200,
+            top: 60,
+            left: 50,
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={{
+            position: 'absolute',
+            top: 105,
+            left: 120,
+            bottom: 240,
+            right: 240,
+          }}
+        />
+      </div>
+      `),
+      [targetElement],
+    )
+
+    const finalEditor = reparentElement(initialEditor, true)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div
+          data-uid='aaa'
+          style={{
+            position: 'relative',
+            width: '100%',
+            height: '100%',
+            backgroundColor: '#FFFFFF',
+          }}
+        >
+          <div
+            data-uid='bbb'
+            style={{
+              position: 'absolute',
+              border: '40px solid grey',
+              width: 250,
+              height: 200,
+              top: 60,
+              left: 50,
+            }}
+          >
+            <div
+              data-uid='ccc'
+              style={{
+                position: 'absolute',
+                top: 35,
+                left: 60,
+                bottom: 90,
+                right: 125,
+              }}
+            />
+          </div>
+        </div>
+        `),
+    )
+  })
+})

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
@@ -50,7 +50,7 @@ export const absoluteReparentStrategy: CanvasStrategy = {
     const newParent = reparentResult.newParent
     const moveCommands = absoluteMoveStrategy.apply(canvasState, interactionState, strategyState)
 
-    if (newParent != null) {
+    if (reparentResult.shouldReparent && newParent != null) {
       const target = canvasState.selectedElements[0]
       const newPath = EP.appendToPath(newParent, EP.toUid(canvasState.selectedElements[0]))
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
@@ -1,7 +1,5 @@
-import { stylePropPathMappingFn } from '../../../components/inspector/common/property-path-hooks'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
-import { pointDifference, zeroCanvasRect } from '../../../core/shared/math-utils'
 import { getReparentTarget } from '../canvas-utils'
 import { reparentElement } from '../commands/reparent-element-command'
 import { updateSelectedViews } from '../commands/update-selected-views-command'

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
@@ -49,8 +49,12 @@ export const absoluteReparentStrategy: CanvasStrategy = {
     )
     const newParent = reparentResult.newParent
     const moveCommands = absoluteMoveStrategy.apply(canvasState, interactionState, strategyState)
+    const providesBoundsForChildren = MetadataUtils.findElementByElementPath(
+      strategyState.startingMetadata,
+      newParent,
+    )?.specialSizeMeasurements.providesBoundsForChildren
 
-    if (reparentResult.shouldReparent && newParent != null) {
+    if (reparentResult.shouldReparent && newParent != null && providesBoundsForChildren) {
       const target = canvasState.selectedElements[0]
       const newPath = EP.appendToPath(newParent, EP.toUid(canvasState.selectedElements[0]))
 

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -205,6 +205,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "initial",
           "flexDirection": null,
+          "globalContentBox": null,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -293,6 +294,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -397,6 +404,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -499,6 +512,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -602,6 +621,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 124,
+            "width": 266,
+            "x": 55,
+            "y": 98,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -706,6 +731,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 70,
+            "width": 125,
+            "x": 126,
+            "y": 125,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 124,
@@ -845,6 +876,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "initial",
           "flexDirection": null,
+          "globalContentBox": null,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -933,6 +965,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1037,6 +1075,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1135,6 +1179,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1230,6 +1280,12 @@ describe('DOM Walker tests', () => {
           "coordinateSystemBounds": null,
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 164,
+            "width": 306,
+            "x": 55,
+            "y": 98,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1330,6 +1386,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 70,
+            "width": 125,
+            "x": 126,
+            "y": 125,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 164,
@@ -1469,6 +1531,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "initial",
           "flexDirection": null,
+          "globalContentBox": null,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -1557,6 +1620,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1661,6 +1730,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "flex",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1760,6 +1835,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "flex",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1855,6 +1936,12 @@ describe('DOM Walker tests', () => {
           "coordinateSystemBounds": null,
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 164,
+            "width": 306,
+            "x": 55,
+            "y": 98,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -1955,6 +2042,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 70,
+            "width": 125,
+            "x": 126,
+            "y": 125,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 164,
@@ -2082,6 +2175,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "initial",
           "flexDirection": null,
+          "globalContentBox": null,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -2170,6 +2264,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2274,6 +2374,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2372,6 +2478,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2503,6 +2615,7 @@ describe('DOM Walker tests', () => {
           },
           "display": "initial",
           "flexDirection": null,
+          "globalContentBox": null,
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 0,
@@ -2591,6 +2704,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2695,6 +2814,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2792,6 +2917,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 812,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2884,6 +3015,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 0,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -2976,6 +3113,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 0,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,
@@ -3068,6 +3211,12 @@ describe('DOM Walker tests', () => {
           },
           "display": "block",
           "flexDirection": "row",
+          "globalContentBox": Object {
+            "height": 0,
+            "width": 375,
+            "x": 0,
+            "y": 0,
+          },
           "htmlElementName": "div",
           "immediateParentBounds": Object {
             "height": 812,

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -762,13 +762,6 @@ function getSpecialMeasurements(
     parseCSSLength(elementStyle.paddingBottom),
     parseCSSLength(elementStyle.paddingLeft),
   )
-  const border = applicative4Either(
-    applicativeSidesPxTransform,
-    parseCSSLength(elementStyle.borderTopWidth),
-    parseCSSLength(elementStyle.borderRightWidth),
-    parseCSSLength(elementStyle.borderBottomWidth),
-    parseCSSLength(elementStyle.borderLeftWidth),
-  )
 
   let naturalWidth: number | null = null
   let naturalHeight: number | null = null
@@ -782,29 +775,23 @@ function getSpecialMeasurements(
 
   const childrenCount = element.childElementCount
 
-  const paddingValues = isRight(padding)
-    ? padding.value
-    : sides(undefined, undefined, undefined, undefined)
-  const borderValues = isRight(border)
-    ? border.value
-    : sides(undefined, undefined, undefined, undefined)
+  const borderTopWidth = parseCSSLength(elementStyle.borderTopWidth)
+  const borderRightWidth = parseCSSLength(elementStyle.borderRightWidth)
+  const borderBottomWidth = parseCSSLength(elementStyle.borderBottomWidth)
+  const borderLeftWidth = parseCSSLength(elementStyle.borderLeftWidth)
+  const border = {
+    top: isRight(borderTopWidth) ? borderTopWidth.value.value : 0,
+    right: isRight(borderRightWidth) ? borderRightWidth.value.value : 0,
+    bottom: isRight(borderBottomWidth) ? borderBottomWidth.value.value : 0,
+    left: isRight(borderLeftWidth) ? borderLeftWidth.value.value : 0,
+  }
 
   const globalFrame = globalFrameForElement(element, scale, containerRectLazy)
   const globalContentBox = canvasRectangle({
-    x: globalFrame.x + (paddingValues.left ?? 0) + (borderValues.left ?? 0),
-    y: globalFrame.y + (paddingValues.top ?? 0) + (borderValues.top ?? 0),
-    width:
-      globalFrame.width -
-      (paddingValues.left ?? 0) -
-      (paddingValues.right ?? 0) -
-      (borderValues.left ?? 0) -
-      (borderValues.right ?? 0),
-    height:
-      globalFrame.height -
-      (paddingValues.top ?? 0) -
-      (paddingValues.bottom ?? 0) -
-      (borderValues.top ?? 0) -
-      (borderValues.bottom ?? 0),
+    x: globalFrame.x + border.left,
+    y: globalFrame.y + border.top,
+    width: globalFrame.width - border.left - border.right,
+    height: globalFrame.height - border.top - border.bottom,
   })
 
   return specialSizeMeasurements(
@@ -819,7 +806,7 @@ function getSpecialMeasurements(
     elementStyle.display,
     position,
     isRight(margin) ? margin.value : sides(undefined, undefined, undefined, undefined),
-    paddingValues,
+    isRight(padding) ? padding.value : sides(undefined, undefined, undefined, undefined),
     naturalWidth,
     naturalHeight,
     clientWidth,

--- a/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
@@ -260,6 +260,12 @@ describe('SpecialSizeMeasurementsKeepDeepEquality', () => {
     flexDirection: 'column',
     htmlElementName: 'div',
     renderedChildrenCount: 10,
+    globalContentBox: canvasRectangle({
+      x: 20,
+      y: 40,
+      width: 60,
+      height: 80,
+    }),
   }
 
   const newSameValue: SpecialSizeMeasurements = {
@@ -306,6 +312,12 @@ describe('SpecialSizeMeasurementsKeepDeepEquality', () => {
     flexDirection: 'column',
     htmlElementName: 'div',
     renderedChildrenCount: 10,
+    globalContentBox: canvasRectangle({
+      x: 20,
+      y: 40,
+      width: 60,
+      height: 80,
+    }),
   }
   const newDifferentValue: SpecialSizeMeasurements = {
     offset: {
@@ -351,6 +363,12 @@ describe('SpecialSizeMeasurementsKeepDeepEquality', () => {
     flexDirection: 'column',
     htmlElementName: 'div',
     renderedChildrenCount: 10,
+    globalContentBox: canvasRectangle({
+      x: 20,
+      y: 40,
+      width: 60,
+      height: 0,
+    }),
   }
 
   it('same reference returns the same reference', () => {
@@ -459,6 +477,12 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
       flexDirection: 'column',
       htmlElementName: 'div',
       renderedChildrenCount: 10,
+      globalContentBox: canvasRectangle({
+        x: 20,
+        y: 40,
+        width: 60,
+        height: 80,
+      }),
     },
     computedStyle: {
       a: 'a',
@@ -538,6 +562,12 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
       flexDirection: 'column',
       htmlElementName: 'div',
       renderedChildrenCount: 10,
+      globalContentBox: canvasRectangle({
+        x: 20,
+        y: 40,
+        width: 60,
+        height: 80,
+      }),
     },
     computedStyle: {
       a: 'a',
@@ -617,6 +647,12 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
       flexDirection: 'column',
       htmlElementName: 'div',
       renderedChildrenCount: 10,
+      globalContentBox: canvasRectangle({
+        x: 20,
+        y: 40,
+        width: 60,
+        height: 80,
+      }),
     },
     computedStyle: {
       a: 'a',
@@ -728,6 +764,12 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
         flexDirection: 'column',
         htmlElementName: 'div',
         renderedChildrenCount: 10,
+        globalContentBox: canvasRectangle({
+          x: 20,
+          y: 40,
+          width: 60,
+          height: 80,
+        }),
       },
       computedStyle: {
         a: 'a',
@@ -809,6 +851,12 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
         flexDirection: 'column',
         htmlElementName: 'div',
         renderedChildrenCount: 10,
+        globalContentBox: canvasRectangle({
+          x: 20,
+          y: 40,
+          width: 60,
+          height: 80,
+        }),
       },
       computedStyle: {
         a: 'a',
@@ -890,6 +938,12 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
         flexDirection: 'column',
         htmlElementName: 'div',
         renderedChildrenCount: 10,
+        globalContentBox: canvasRectangle({
+          x: 20,
+          y: 40,
+          width: 60,
+          height: 80,
+        }),
       },
       computedStyle: {
         a: 'a',

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -802,6 +802,10 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
     const displayEquals = oldSize.display === newSize.display
     const htmlElementNameEquals = oldSize.htmlElementName === newSize.htmlElementName
     const renderedChildrenCount = oldSize.renderedChildrenCount === newSize.renderedChildrenCount
+    const globalContentBoxEquals = nullableDeepEquality(CanvasRectangleKeepDeepEquality)(
+      oldSize.globalContentBox,
+      newSize.globalContentBox,
+    )
     const areEqual =
       offsetResult.areEqual &&
       coordinateSystemBoundsResult.areEqual &&
@@ -822,7 +826,8 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       flexDirectionResult &&
       displayEquals &&
       htmlElementNameEquals &&
-      renderedChildrenCount
+      renderedChildrenCount &&
+      globalContentBoxEquals
     if (areEqual) {
       return keepDeepEqualityResult(oldSize, true)
     } else {
@@ -847,6 +852,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
         newSize.flexDirection,
         newSize.htmlElementName,
         newSize.renderedChildrenCount,
+        newSize.globalContentBox,
       )
       return keepDeepEqualityResult(sizeMeasurements, false)
     }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -805,7 +805,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
     const globalContentBoxEquals = nullableDeepEquality(CanvasRectangleKeepDeepEquality)(
       oldSize.globalContentBox,
       newSize.globalContentBox,
-    )
+    ).areEqual
     const areEqual =
       offsetResult.areEqual &&
       coordinateSystemBoundsResult.areEqual &&

--- a/editor/src/core/layout/layout-utils.spec.browser2.tsx
+++ b/editor/src/core/layout/layout-utils.spec.browser2.tsx
@@ -123,6 +123,7 @@ describe('maybeSwitchLayoutProps', () => {
           null,
           'div',
           0,
+          null,
         ),
         computedStyle: emptyComputedStyle,
         attributeMetadatada: emptyAttributeMetadatada,

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1552,6 +1552,7 @@ export interface SpecialSizeMeasurements {
   flexDirection: string | null
   htmlElementName: string
   renderedChildrenCount: number
+  globalContentBox: CanvasRectangle | null
 }
 
 export function specialSizeMeasurements(
@@ -1575,6 +1576,7 @@ export function specialSizeMeasurements(
   flexDirection: string | null,
   htmlElementName: string,
   renderedChildrenCount: number,
+  globalContentBox: CanvasRectangle | null,
 ): SpecialSizeMeasurements {
   return {
     offset,
@@ -1597,6 +1599,7 @@ export function specialSizeMeasurements(
     flexDirection,
     htmlElementName,
     renderedChildrenCount,
+    globalContentBox,
   }
 }
 
@@ -1624,6 +1627,7 @@ export const emptySpecialSizeMeasurements = specialSizeMeasurements(
   null,
   'div',
   0,
+  null,
 )
 
 export const emptyComputedStyle: ComputedStyle = {}


### PR DESCRIPTION
This PR fixes the absolute reparent strategy and adds tests.
It was not far from complete as the reparent and move are already handled by this strategy, the missing feature is that only elements with top/left were offset for the new parent, it needs offset for the bottom/right style properties too.
The other issue I noticed is the result of calculating the offset deltas with elements with border, the borders are included in the canvas frame, but for pin positions the inner content frame is needed.

The new parent target is also restricted to elements that are not flow using the `providesBoundsForChildren` from the metadata.

**Commit Details:**
- fix the absolute reparent strategy offset
- extended metadata to calculate the inner content box, the default border-box box-sizing includes the borders in the frame too.
- tests
