### PR TITLE
Fix keyboard interaction timeout

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -643,31 +643,37 @@ export function useSelectAndHover(
   }
 }
 
-export function setupClearKeyboardInteraction(
-  editorStoreRef: { readonly current: EditorStorePatched },
-  keyboardTimeoutHandler: React.MutableRefObject<NodeJS.Timeout | null>,
-) {
-  if (!isFeatureEnabled('Keyboard up clears interaction')) {
-    if (keyboardTimeoutHandler.current != null) {
-      clearTimeout(keyboardTimeoutHandler.current)
-      keyboardTimeoutHandler.current = null
-    }
-
-    keyboardTimeoutHandler.current = setTimeout(clearHighlightedViews, KeyboardInteractionTimeout)
-
-    const clearKeyboardInteraction = () => {
-      window.removeEventListener('mousedown', clearKeyboardInteraction)
+export function useClearKeyboardInteraction(editorStoreRef: {
+  readonly current: EditorStorePatched
+}) {
+  const keyboardTimeoutHandler = React.useRef<NodeJS.Timeout | null>(null)
+  return () => {
+    if (!isFeatureEnabled('Keyboard up clears interaction')) {
       if (keyboardTimeoutHandler.current != null) {
         clearTimeout(keyboardTimeoutHandler.current)
         keyboardTimeoutHandler.current = null
       }
-      if (
-        editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type === 'KEYBOARD'
-      ) {
-        editorStoreRef.current.dispatch([CanvasActions.clearInteractionSession(true)], 'everyone')
-      }
-    }
 
-    window.addEventListener('mousedown', clearKeyboardInteraction, { once: true, capture: true })
+      const clearKeyboardInteraction = () => {
+        window.removeEventListener('mousedown', clearKeyboardInteraction)
+        if (keyboardTimeoutHandler.current != null) {
+          clearTimeout(keyboardTimeoutHandler.current)
+          keyboardTimeoutHandler.current = null
+        }
+        if (
+          editorStoreRef.current.editor.canvas.interactionSession?.interactionData.type ===
+          'KEYBOARD'
+        ) {
+          editorStoreRef.current.dispatch([CanvasActions.clearInteractionSession(true)], 'everyone')
+        }
+      }
+
+      keyboardTimeoutHandler.current = setTimeout(
+        clearKeyboardInteraction,
+        KeyboardInteractionTimeout,
+      )
+
+      window.addEventListener('mousedown', clearKeyboardInteraction, { once: true, capture: true })
+    }
   }
 }

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -60,7 +60,7 @@ import {
   createInteractionViaKeyboard,
   updateInteractionViaKeyboard,
 } from '../canvas/canvas-strategies/interaction-state'
-import { setupClearKeyboardInteraction } from '../canvas/controls/select-mode/select-mode-hooks'
+import { useClearKeyboardInteraction } from '../canvas/controls/select-mode/select-mode-hooks'
 
 function pushProjectURLToBrowserHistory(projectId: string, projectName: string): void {
   // Make sure we don't replace the query params
@@ -135,7 +135,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
     return applyShortcutConfigurationToDefaults(editorStoreRef.current.userState.shortcutConfig)
   }, [editorStoreRef])
 
-  const keyboardTimeoutHandler = React.useRef<NodeJS.Timeout | null>(null)
+  const setClearKeyboardInteraction = useClearKeyboardInteraction(editorStoreRef)
 
   const onWindowKeyDown = React.useCallback(
     (event: KeyboardEvent) => {
@@ -180,7 +180,8 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
                 )
 
           editorStoreRef.current.dispatch([action], 'everyone')
-          setupClearKeyboardInteraction(editorStoreRef, keyboardTimeoutHandler)
+
+          setClearKeyboardInteraction()
         }
       }
 
@@ -192,7 +193,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
         editorStoreRef.current.dispatch,
       )
     },
-    [editorStoreRef, namesByKey],
+    [editorStoreRef, namesByKey, setClearKeyboardInteraction],
   )
 
   const onWindowKeyUp = React.useCallback(


### PR DESCRIPTION
# Bug

Keyboard interaction timeout was never triggered

# Root cause

Probably a buggy code completion, we just called a completely different clear function than what was needed.....

If I was there, I also converted the function to a hook, so the keyboard timeout handler ref can be created inside the hook. Because the function had to be called conditionally, I created a hook, which returns a function, which can be called inside the conditional