### PR TITLE
remove absolute resize control feature switch

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -317,7 +317,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       case 'select':
       case 'select-lite':
       case 'live': {
-        if (isFeatureEnabled('Canvas Absolute Resize Controls')) {
+        if (isFeatureEnabled('Canvas Strategies')) {
           return null
         } else {
           return (
@@ -411,16 +411,16 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       {renderHighlightControls()}
       <LayoutParentControl />
       {when(
-        isFeatureEnabled('Canvas Absolute Resize Controls'),
+        isFeatureEnabled('Canvas Strategies'),
         <MultiSelectOutlineControl localSelectedElements={localSelectedViews} />,
       )}
-      {when(isFeatureEnabled('Canvas Absolute Resize Controls'), <GuidelineControls />)}
+      {when(isFeatureEnabled('Canvas Strategies'), <GuidelineControls />)}
       {when(
         isFeatureEnabled('Canvas Strategies'),
         <>{strategyControls.map((c) => React.createElement(c.control, { key: c.key }))}</>,
       )}
       {when(
-        isFeatureEnabled('Canvas Absolute Resize Controls'),
+        isFeatureEnabled('Canvas Strategies'),
         <FlexResizeControl localSelectedElements={localSelectedViews} />,
       )}
     </div>

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -13,7 +13,6 @@ export type FeatureName =
   | 'Click on empty canvas unfocuses'
   | 'Insertion Plus Button'
   | 'Canvas Strategies'
-  | 'Canvas Absolute Resize Controls'
   | 'Keyboard up clears interaction'
 
 export const AllFeatureNames: FeatureName[] = [
@@ -27,7 +26,6 @@ export const AllFeatureNames: FeatureName[] = [
   'Click on empty canvas unfocuses',
   'Insertion Plus Button',
   'Canvas Strategies',
-  'Canvas Absolute Resize Controls',
   'Keyboard up clears interaction',
 ]
 
@@ -42,7 +40,6 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Click on empty canvas unfocuses': true,
   'Insertion Plus Button': true,
   'Canvas Strategies': false,
-  'Canvas Absolute Resize Controls': false,
   'Keyboard up clears interaction': false,
 }
 


### PR DESCRIPTION
**Fix:**
Cleaning up one of the experimental feature switches that shows the new canvas controls, they are part of the strategies feature flag instead.
The name was also very confusing as the new absolute Resize Control is already included in the strategy's `controlsToRender`.

**Commit Details:**
- removed feature flag `Canvas Absolute Resize Controls`
