### PR TITLE
Enable multiselection for keyboard move

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -10,13 +10,12 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
   id: 'KEYBOARD_ABSOLUTE_MOVE',
   name: 'Keyboard absolute Move',
   isApplicable: (canvasState, _interactionState, metadata) => {
-    if (canvasState.selectedElements.length === 1) {
-      const elementMetadata = MetadataUtils.findElementByElementPath(
-        metadata,
-        canvasState.selectedElements[0],
-      )
+    if (canvasState.selectedElements.length > 0) {
+      return canvasState.selectedElements.every((element) => {
+        const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
 
-      return elementMetadata?.specialSizeMeasurements.position === 'absolute'
+        return elementMetadata?.specialSizeMeasurements.position === 'absolute'
+      })
     } else {
       return false
     }


### PR DESCRIPTION
I enabled multiselection for keyboard move, it was accidentally filtered out in isApplicable