### PR TITLE
Restored initialiseTests for screenshot test

### DIFF
--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -139,3 +139,17 @@ export async function uploadPNGtoAWS(testFile: string): Promise<string | null> {
     })
   })
 }
+
+export function initialiseTests(page: puppeteer.Page): Promise<void> {
+  console.log('Initialising the project')
+  await page.waitForXPath('//div[contains(@class, "item-label-container")]')
+
+  // Select something
+  const navigatorElement = await page.$('[class^="item-label-container"]')
+  await navigatorElement!.click()
+
+  // First selection will open the file in VS Code, triggering a bunch of downloads, so we pause briefly
+  await page.waitForTimeout(15000)
+
+  console.log('Finished initialising')
+}


### PR DESCRIPTION
**Problem:**
The screenshot test was broken in #2172 by the removal of the `initialiseTests` function.

**Fix:**
Restore the function.