### PR TITLE
Fix: Using zustand subscribeWithSelector middleware

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -1,18 +1,9 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { toString } from '../../../core/shared/element-path'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
-import {
-  canvasPoint,
-  CanvasPoint,
-  canvasRectangle,
-  offsetPoint,
-  offsetRect,
-  zeroCanvasRect,
-} from '../../../core/shared/math-utils'
+import { CanvasPoint, offsetPoint } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
-import { wildcardPatch } from '../commands/wildcard-patch-command'
 import { runLegacyAbsoluteMoveSnapping } from '../controls/guideline-helpers'
 import { determineConstrainedDragAxis } from '../controls/select-mode/move-utils'
 import { ConstrainedDragAxis, GuidelineWithSnappingVector } from '../guideline'

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -1,9 +1,18 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { toString } from '../../../core/shared/element-path'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
-import { CanvasPoint, offsetPoint } from '../../../core/shared/math-utils'
+import {
+  canvasPoint,
+  CanvasPoint,
+  canvasRectangle,
+  offsetPoint,
+  offsetRect,
+  zeroCanvasRect,
+} from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
+import { wildcardPatch } from '../commands/wildcard-patch-command'
 import { runLegacyAbsoluteMoveSnapping } from '../controls/guideline-helpers'
 import { determineConstrainedDragAxis } from '../controls/select-mode/move-utils'
 import { ConstrainedDragAxis, GuidelineWithSnappingVector } from '../guideline'

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -1,6 +1,6 @@
 import { act, render } from '@testing-library/react'
 import React from 'react'
-import create from 'zustand'
+import create, { GetState, Mutate, SetState, StoreApi } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import { notLoggedIn } from '../../common/user'
 import {
@@ -88,9 +88,12 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
     builtInDependencies: createBuiltInDependenciesList(null),
   }
 
-  const storeHook = create<EditorStorePatched>(
-    subscribeWithSelector((set) => patchedStoreFromFullStore(editorStore)),
-  )
+  const storeHook = create<
+    EditorStorePatched,
+    SetState<EditorStorePatched>,
+    GetState<EditorStorePatched>,
+    Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
+  >(subscribeWithSelector((set) => patchedStoreFromFullStore(editorStore)))
 
   render(<EditorRoot api={storeHook} useStore={storeHook} spyCollector={spyCollector} />)
 

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -1,6 +1,7 @@
 import { act, render } from '@testing-library/react'
 import React from 'react'
 import create from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
 import { notLoggedIn } from '../../common/user'
 import {
   ElementInstanceMetadata,
@@ -87,7 +88,9 @@ async function renderTestEditorWithCode(appUiJsFileCode: string) {
     builtInDependencies: createBuiltInDependenciesList(null),
   }
 
-  const storeHook = create<EditorStorePatched>((set) => patchedStoreFromFullStore(editorStore))
+  const storeHook = create<EditorStorePatched>(
+    subscribeWithSelector((set) => patchedStoreFromFullStore(editorStore)),
+  )
 
   render(<EditorRoot api={storeHook} useStore={storeHook} spyCollector={spyCollector} />)
 

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -32,6 +32,7 @@ try {
 import { act, render, RenderResult } from '@testing-library/react'
 import * as Prettier from 'prettier/standalone'
 import create from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
 import {
   ElementPath,
   foldParsedTextFile,
@@ -240,8 +241,8 @@ export async function renderTestEditorWithModel(
     builtInDependencies: builtInDependencies,
   }
 
-  const storeHook = create<EditorStorePatched>((set) =>
-    patchedStoreFromFullStore(initialEditorStore),
+  const storeHook = create<EditorStorePatched>(
+    subscribeWithSelector((set) => patchedStoreFromFullStore(initialEditorStore)),
   )
 
   // initializing the local editor state

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -31,7 +31,7 @@ try {
 
 import { act, render, RenderResult } from '@testing-library/react'
 import * as Prettier from 'prettier/standalone'
-import create from 'zustand'
+import create, { GetState, Mutate, SetState, StoreApi } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import {
   ElementPath,
@@ -241,9 +241,12 @@ export async function renderTestEditorWithModel(
     builtInDependencies: builtInDependencies,
   }
 
-  const storeHook = create<EditorStorePatched>(
-    subscribeWithSelector((set) => patchedStoreFromFullStore(initialEditorStore)),
-  )
+  const storeHook = create<
+    EditorStorePatched,
+    SetState<EditorStorePatched>,
+    GetState<EditorStorePatched>,
+    Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
+  >(subscribeWithSelector((set) => patchedStoreFromFullStore(initialEditorStore)))
 
   // initializing the local editor state
   workingEditorState = initialEditorStore

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -1,4 +1,5 @@
 import create from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
 import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { NO_OP } from '../../../core/shared/utils'
 import {
@@ -90,7 +91,7 @@ function createEditorStore(
     builtInDependencies: createBuiltInDependenciesList(null),
   }
 
-  const storeHook = create<EditorStoreFull>((set) => initialEditorStore)
+  const storeHook = create<EditorStoreFull>(subscribeWithSelector((set) => initialEditorStore))
 
   return initialEditorStore
 }

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -117,6 +117,7 @@ describe('useSelectorWithCallback', () => {
     let rerenderTestHook: () => void
 
     storeHook.subscribe(
+      (store) => store.editor.selectedViews,
       (newSelectedViews) => {
         if (newSelectedViews != null) {
           rerenderTestHook()
@@ -125,7 +126,6 @@ describe('useSelectorWithCallback', () => {
           // TODO this is super-baffling. turning this test async and putting done() here and expect()-ing values did not work for some reason
         }
       },
-      (store) => store.editor.selectedViews,
     )
 
     const { result, rerender } = renderHook<{ storeHook: UseStore<EditorStorePatched> }, void>(

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import create, { UseStore } from 'zustand'
+import create, { GetState, Mutate, SetState, StoreApi, UseStore } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import { renderHook } from '@testing-library/react-hooks'
 import { EditorStateContext, useSelectorWithCallback } from './store-hook'
@@ -25,7 +25,12 @@ function createEmptyEditorStoreHook() {
     builtInDependencies: createBuiltInDependenciesList(null),
   }
 
-  const storeHook = create<EditorStorePatched>(subscribeWithSelector((set) => initialEditorStore))
+  const storeHook = create<
+    EditorStorePatched,
+    SetState<EditorStorePatched>,
+    GetState<EditorStorePatched>,
+    Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
+  >(subscribeWithSelector((set) => initialEditorStore))
 
   return storeHook
 }

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import create, { UseStore } from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
 import { renderHook } from '@testing-library/react-hooks'
 import { EditorStateContext, useSelectorWithCallback } from './store-hook'
 import { createEditorState, EditorState, EditorStorePatched } from './editor-state'
@@ -24,7 +25,7 @@ function createEmptyEditorStoreHook() {
     builtInDependencies: createBuiltInDependenciesList(null),
   }
 
-  const storeHook = create<EditorStorePatched>((set) => initialEditorStore)
+  const storeHook = create<EditorStorePatched>(subscribeWithSelector((set) => initialEditorStore))
 
   return storeHook
 }

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -193,7 +193,7 @@ export function useSelectorWithCallback<U>(
   if (explainMe) {
     console.info('useSelectorWithCallback was executed so we call the callback ourselves')
   }
-  innerCallback(selectorRef.current(api.getState()))
+  innerCallback(selectorRef.current(api.getState())) // TODO investigate if we can use subscribeWithSelector's fireImmediately instead of this hack here
 
   React.useEffect(() => {
     if (explainMe) {

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -127,6 +127,8 @@ export const useRefEditorState = <U>(
 }
 
 export type UtopiaStoreHook = UseBoundStore<EditorStorePatched>
+
+// This is how to officially type the store with a subscribeWithSelector middleware as of Zustand 3.6.0 https://github.com/pmndrs/zustand#using-subscribe-with-selector
 export type UtopiaStoreAPI = Mutate<
   StoreApi<EditorStorePatched>,
   [['zustand/subscribeWithSelector', never]]

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -1,6 +1,6 @@
 import { produce } from 'immer'
 import React from 'react'
-import create, { StoreApi, UseBoundStore } from 'zustand'
+import create, { GetState, Mutate, SetState, StoreApi, UseBoundStore } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import { emptyComments, jsxAttributeValue, JSXElement } from '../../../core/shared/element-template'
 import { setJSXValueAtPath } from '../../../core/shared/jsx-attributes'
@@ -62,7 +62,12 @@ export function getStoreHook(
     builtInDependencies: createBuiltInDependenciesList(null),
   }
 
-  const storeHook = create<EditorStorePatched>(subscribeWithSelector((set) => defaultState))
+  const storeHook = create<
+    EditorStorePatched,
+    SetState<EditorStorePatched>,
+    GetState<EditorStorePatched>,
+    Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
+  >(subscribeWithSelector((set) => defaultState))
   const updateStoreWithImmer = (fn: (store: EditorStorePatched) => void) =>
     storeHook.setState(produce(fn))
   const updateStore = (fn: (store: EditorStorePatched) => EditorStorePatched) =>

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -1,6 +1,7 @@
 import { produce } from 'immer'
 import React from 'react'
 import create, { StoreApi, UseBoundStore } from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
 import { emptyComments, jsxAttributeValue, JSXElement } from '../../../core/shared/element-template'
 import { setJSXValueAtPath } from '../../../core/shared/jsx-attributes'
 import { isRight } from '../../../core/shared/either'
@@ -61,7 +62,7 @@ export function getStoreHook(
     builtInDependencies: createBuiltInDependenciesList(null),
   }
 
-  const storeHook = create<EditorStorePatched>((set) => defaultState)
+  const storeHook = create<EditorStorePatched>(subscribeWithSelector((set) => defaultState))
   const updateStoreWithImmer = (fn: (store: EditorStorePatched) => void) =>
     storeHook.setState(produce(fn))
   const updateStore = (fn: (store: EditorStorePatched) => EditorStorePatched) =>

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -14,7 +14,7 @@ import {
   makeInspectorHookContextProvider,
 } from './property-path-hooks.test-utils'
 import { EditorStorePatched } from '../../editor/store/editor-state'
-import create from 'zustand'
+import create, { GetState, Mutate, SetState, StoreApi } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import { EditorStateContext } from '../../editor/store/store-hook'
 import * as EP from '../../../core/shared/element-path'
@@ -61,7 +61,12 @@ function getPaddingHookResult<P extends ParsedPropertiesKeys, S extends ParsedPr
       builtInDependencies: [],
     }
 
-    const storeHook = create<EditorStorePatched>(subscribeWithSelector(() => initialEditorStore))
+    const storeHook = create<
+      EditorStorePatched,
+      SetState<EditorStorePatched>,
+      GetState<EditorStorePatched>,
+      Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
+    >(subscribeWithSelector(() => initialEditorStore))
 
     return (
       <EditorStateContext.Provider value={{ api: storeHook, useStore: storeHook }}>

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -15,6 +15,7 @@ import {
 } from './property-path-hooks.test-utils'
 import { EditorStorePatched } from '../../editor/store/editor-state'
 import create from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
 import { EditorStateContext } from '../../editor/store/store-hook'
 import * as EP from '../../../core/shared/element-path'
 import * as PP from '../../../core/shared/property-path'
@@ -60,7 +61,7 @@ function getPaddingHookResult<P extends ParsedPropertiesKeys, S extends ParsedPr
       builtInDependencies: [],
     }
 
-    const storeHook = create<EditorStorePatched>(() => initialEditorStore)
+    const storeHook = create<EditorStorePatched>(subscribeWithSelector(() => initialEditorStore))
 
     return (
       <EditorStateContext.Provider value={{ api: storeHook, useStore: storeHook }}>

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -3,7 +3,7 @@ import { renderHook } from '@testing-library/react-hooks'
 import { EditorStateContext } from '../../editor/store/store-hook'
 import { useGetPropertyControlsForSelectedComponents } from './property-controls-hooks'
 import { InspectorCallbackContext, InspectorCallbackContextData } from './property-path-hooks'
-import create from 'zustand'
+import create, { GetState, Mutate, SetState, StoreApi } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import {
   editorModelFromPersistentModel,
@@ -188,7 +188,12 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
     builtInDependencies: [],
   }
 
-  const storeHook = create<EditorStorePatched>(subscribeWithSelector((set) => initialEditorStore))
+  const storeHook = create<
+    EditorStorePatched,
+    SetState<EditorStorePatched>,
+    GetState<EditorStorePatched>,
+    Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
+  >(subscribeWithSelector((set) => initialEditorStore))
 
   const inspectorCallbackContext: InspectorCallbackContextData = {
     selectedViewsRef: { current: selectedViews },

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -4,6 +4,7 @@ import { EditorStateContext } from '../../editor/store/store-hook'
 import { useGetPropertyControlsForSelectedComponents } from './property-controls-hooks'
 import { InspectorCallbackContext, InspectorCallbackContextData } from './property-path-hooks'
 import create from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
 import {
   editorModelFromPersistentModel,
   EditorState,
@@ -187,7 +188,7 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
     builtInDependencies: [],
   }
 
-  const storeHook = create<EditorStorePatched>((set) => initialEditorStore)
+  const storeHook = create<EditorStorePatched>(subscribeWithSelector((set) => initialEditorStore))
 
   const inspectorCallbackContext: InspectorCallbackContextData = {
     selectedViewsRef: { current: selectedViews },

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`375`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`353`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`446`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`413`)
   })
 
   it('Changing the selected view with a simple project', async () => {

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -6,6 +6,7 @@ import * as ReactDOM from 'react-dom'
 import { hot } from 'react-hot-loader/root'
 import { unstable_trace as trace } from 'scheduler/tracing'
 import create from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
 import '../utils/vite-hmr-config'
 import {
   getProjectID,
@@ -160,8 +161,8 @@ export class Editor {
       alreadySaved: false,
     }
 
-    const storeHook = create<EditorStorePatched>((set) =>
-      patchedStoreFromFullStore(this.storedState),
+    const storeHook = create<EditorStorePatched>(
+      subscribeWithSelector((set) => patchedStoreFromFullStore(this.storedState)),
     )
 
     this.utopiaStoreHook = storeHook

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import * as ReactDOM from 'react-dom'
 import { hot } from 'react-hot-loader/root'
 import { unstable_trace as trace } from 'scheduler/tracing'
-import create from 'zustand'
+import create, { GetState, Mutate, SetState, StoreApi } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import '../utils/vite-hmr-config'
 import {
@@ -161,9 +161,12 @@ export class Editor {
       alreadySaved: false,
     }
 
-    const storeHook = create<EditorStorePatched>(
-      subscribeWithSelector((set) => patchedStoreFromFullStore(this.storedState)),
-    )
+    const storeHook = create<
+      EditorStorePatched,
+      SetState<EditorStorePatched>,
+      GetState<EditorStorePatched>,
+      Mutate<StoreApi<EditorStorePatched>, [['zustand/subscribeWithSelector', never]]>
+    >(subscribeWithSelector((set) => patchedStoreFromFullStore(this.storedState)))
 
     this.utopiaStoreHook = storeHook
     this.updateStore = storeHook.setState


### PR DESCRIPTION
**Problem:**
Ever since we updated Zustand, it'd print a thousand warnings that api.subscribe is deprecated and we should use the subscribeWithSelector middleware.

**Fix:**
Adopting the subscribeWithSelector middleware

**Commit Details:**
- Using subscribeWithSelector in editor.tsx
- Updating the type of `UtopiaStoreAPI`
- Updating all tests to use the subscribeWithSelector middleware
