### PR TITLE
Use DOM query to trigger code editor loading screen removal

### DIFF
--- a/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
+++ b/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
@@ -278,17 +278,3 @@ export const VSCodeLoadingScreen = React.memo((): React.ReactElement | null => {
     </div>
   )
 })
-
-export function checkVSCodeRendered(desiredFile: string | null): boolean {
-  const vscodeEditorElement = document.querySelector<HTMLIFrameElement>(`iframe#vscode-editor`)
-  const vscodeOuterElement = vscodeEditorElement?.contentWindow?.document.body.querySelector<
-    HTMLIFrameElement
-  >(`iframe#vscode-outer`)
-
-  const editorSelector = desiredFile == null ? `div[data-uri]` : `div[data-uri$='${desiredFile}']`
-  const codeEditorElement = vscodeOuterElement?.contentWindow?.document.body.querySelector(
-    editorSelector,
-  )
-
-  return codeEditorElement != null
-}

--- a/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
+++ b/editor/src/components/code-editor/vscode-editor-loading-screen.tsx
@@ -278,3 +278,17 @@ export const VSCodeLoadingScreen = React.memo((): React.ReactElement | null => {
     </div>
   )
 })
+
+export function checkVSCodeRendered(desiredFile: string | null): boolean {
+  const vscodeEditorElement = document.querySelector<HTMLIFrameElement>(`iframe#vscode-editor`)
+  const vscodeOuterElement = vscodeEditorElement?.contentWindow?.document.body.querySelector<
+    HTMLIFrameElement
+  >(`iframe#vscode-outer`)
+
+  const editorSelector = desiredFile == null ? `div[data-uri]` : `div[data-uri$='${desiredFile}']`
+  const codeEditorElement = vscodeOuterElement?.contentWindow?.document.body.querySelector(
+    editorSelector,
+  )
+
+  return codeEditorElement != null
+}

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -63,7 +63,6 @@ import {
   getOpenTextFileKey,
 } from '../../components/editor/store/editor-state'
 import { ProjectFileChange } from '../../components/editor/store/vscode-changes'
-import { checkVSCodeRendered } from '../../components/code-editor/vscode-editor-loading-screen'
 
 const Scheme = 'utopia'
 const RootDir = `/${Scheme}`
@@ -161,6 +160,20 @@ function watchForChanges(dispatch: EditorDispatch): void {
   }
 
   watch(toFSPath('/'), true, onCreated, onModified, onDeleted, onIndexedDBFailure)
+}
+
+function checkVSCodeRendered(desiredFile: string | null): boolean {
+  const vscodeEditorElement = document.querySelector<HTMLIFrameElement>(`iframe#vscode-editor`)
+  const vscodeOuterElement = vscodeEditorElement?.contentWindow?.document.body.querySelector<
+    HTMLIFrameElement
+  >(`iframe#vscode-outer`)
+
+  const editorSelector = desiredFile == null ? `div[data-uri]` : `div[data-uri$='${desiredFile}']`
+  const codeEditorElement = vscodeOuterElement?.contentWindow?.document.body.querySelector(
+    editorSelector,
+  )
+
+  return codeEditorElement != null
 }
 
 let currentInit: Promise<void> = Promise.resolve()

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -173,6 +173,7 @@ export async function initVSCodeBridge(
   openFilePath: string | null,
 ): Promise<void> {
   let loadingScreenHidden = false
+  let loadingScreenPollCount = 0
   function hideLoadingScreen() {
     if (polledClearLoadingScreenTimeout != null) {
       clearTimeout(polledClearLoadingScreenTimeout)
@@ -182,7 +183,10 @@ export async function initVSCodeBridge(
     dispatch([hideVSCodeLoadingScreen()], 'everyone')
   }
   function polledClearLoadingScreen() {
-    const codeEditorLoaded = checkVSCodeRendered(openFilePath)
+    loadingScreenPollCount++
+    // Fallback incase the file just doesn't load for some reason
+    const desiredFile = loadingScreenPollCount >= 10 ? null : openFilePath
+    const codeEditorLoaded = checkVSCodeRendered(desiredFile)
     if (codeEditorLoaded) {
       hideLoadingScreen()
     } else {


### PR DESCRIPTION
**Problem:**
We have recently been seeing an issue whereby the code editor's loading screen isn't being removed, despite the code editor rendering.

**Fix:**
Inspired by some work in #2172 I decided to check for the existence of VS Code's DOM elements to remove the loading screen, but that alone isn't enough because we attempt to restore the previously open file, so removing the loading screen to then immediately switch out the open file results in a particularly jarring experience. Fortunately, VS Code has an element specifically for the editor which includes a `data-uri` attribute for the open file, so we can simply check for the existence of that element for the matching file (falling back to any open file after 10 seconds).
