### PR TITLE
Aspect ratio locked resize 

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../../core/shared/element-template'
 import { canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import { emptyModifiers } from '../../../utils/modifiers'
+import { emptyModifiers, Modifiers, shiftModifier } from '../../../utils/modifiers'
 import { EditorState } from '../../editor/store/editor-state'
 import { EdgePosition } from '../canvas-types'
 import { foldAndApplyCommands } from '../commands/commands'
@@ -24,6 +24,7 @@ function multiselectResizeElements(
   snippet: string,
   targetElements: Array<ElementPath>,
   edgePosition: EdgePosition,
+  modifiers: Modifiers = emptyModifiers,
 ): EditorState {
   const initialEditor = getEditorStateWithSelectedViews(
     makeTestProjectCodeWithSnippet(snippet),
@@ -32,7 +33,7 @@ function multiselectResizeElements(
 
   const interactionSessionWithoutMetadata = createMouseInteractionForTests(
     null as any, // the strategy does not use this
-    emptyModifiers,
+    modifiers,
     { type: 'RESIZE_HANDLE', edgePosition: edgePosition },
     canvasPoint({ x: 15, y: 25 }),
   )
@@ -140,6 +141,79 @@ describe('Absolute Resize Bounding Box Strategy', () => {
       ),
     )
   })
+  it('works with element aspect ratio locked resized from TL corner', async () => {
+    const edgePosition: EdgePosition = { x: 0, y: 0 }
+    const snippet = `
+  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+    <div
+      style={{ 
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        top: 50,
+        left: 30,
+        width: 100,
+        height: 120,
+       }}
+      data-uid='bbb'
+    />
+    <div
+      style={{ 
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        top: 40,
+        left: 90,
+        bottom: 250,
+        right: 210
+       }}
+      data-uid='ccc'
+    />
+  </div>
+  `
+    const selectedElements = [
+      elementPath([
+        ['scene-aaa', 'app-entity'],
+        ['aaa', 'bbb'],
+      ]),
+      elementPath([
+        ['scene-aaa', 'app-entity'],
+        ['aaa', 'ccc'],
+      ]),
+    ]
+    const editorAfterStrategy = multiselectResizeElements(
+      snippet,
+      selectedElements,
+      edgePosition,
+      shiftModifier,
+    )
+    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+          <div
+            style={{ 
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              top: 66,
+              left: 51,
+              width: 87,
+              height: 104,
+            }}
+            data-uid='bbb'
+          />
+          <div
+            style={{ 
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              top: 57,
+              left: 103,
+              bottom: 247,
+              right: 210
+            }}
+            data-uid='ccc'
+          />
+        </div>`,
+      ),
+    )
+  })
   it('works with element resized from BR corner', async () => {
     const edgePosition: EdgePosition = { x: 1, y: 1 }
     const snippet = `
@@ -201,6 +275,79 @@ describe('Absolute Resize Bounding Box Strategy', () => {
               left: 96,
               bottom: 229,
               right: 195
+            }}
+            data-uid='ccc'
+          />
+        </div>`,
+      ),
+    )
+  })
+  it('works with element aspect ratio locked resized from BR corner', async () => {
+    const edgePosition: EdgePosition = { x: 1, y: 1 }
+    const snippet = `
+  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+    <div
+      style={{ 
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        top: 50,
+        left: 30,
+        width: 100,
+        height: 120,
+       }}
+      data-uid='bbb'
+    />
+    <div
+      style={{ 
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        top: 40,
+        left: 90,
+        bottom: 250,
+        right: 210
+       }}
+      data-uid='ccc'
+    />
+  </div>
+  `
+    const selectedElements = [
+      elementPath([
+        ['scene-aaa', 'app-entity'],
+        ['aaa', 'bbb'],
+      ]),
+      elementPath([
+        ['scene-aaa', 'app-entity'],
+        ['aaa', 'ccc'],
+      ]),
+    ]
+    const editorAfterStrategy = multiselectResizeElements(
+      snippet,
+      selectedElements,
+      edgePosition,
+      shiftModifier,
+    )
+    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+          <div
+            style={{ 
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              top: 51,
+              left: 30,
+              width: 113,
+              height: 136,
+            }}
+            data-uid='bbb'
+          />
+          <div
+            style={{ 
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              top: 40,
+              left: 98,
+              bottom: 235,
+              right: 189
             }}
             data-uid='ccc'
           />
@@ -276,6 +423,79 @@ describe('Absolute Resize Bounding Box Strategy', () => {
       ),
     )
   })
+  it('works with element aspect ratio locked resized from RIGHT edge', async () => {
+    const edgePosition: EdgePosition = { x: 1, y: 0.5 }
+    const snippet = `
+  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+    <div
+      style={{ 
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        top: 50,
+        left: 30,
+        width: 100,
+        height: 120,
+       }}
+      data-uid='bbb'
+    />
+    <div
+      style={{ 
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        top: 40,
+        left: 90,
+        bottom: 250,
+        right: 210
+       }}
+      data-uid='ccc'
+    />
+  </div>
+  `
+    const selectedElements = [
+      elementPath([
+        ['scene-aaa', 'app-entity'],
+        ['aaa', 'bbb'],
+      ]),
+      elementPath([
+        ['scene-aaa', 'app-entity'],
+        ['aaa', 'ccc'],
+      ]),
+    ]
+    const editorAfterStrategy = multiselectResizeElements(
+      snippet,
+      selectedElements,
+      edgePosition,
+      shiftModifier,
+    )
+    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+          <div
+            style={{ 
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              top: 51,
+              left: 30,
+              width: 106,
+              height: 127,
+            }}
+            data-uid='bbb'
+          />
+          <div
+            style={{ 
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              top: 40,
+              left: 93,
+              bottom: 244,
+              right: 201
+            }}
+            data-uid='ccc'
+          />
+        </div>`,
+      ),
+    )
+  })
   it('works with element resized from TOP edge', async () => {
     const edgePosition: EdgePosition = { x: 0.5, y: 0 }
     const snippet = `
@@ -337,6 +557,79 @@ describe('Absolute Resize Bounding Box Strategy', () => {
               left: 90,
               bottom: 246,
               right: 210
+            }}
+            data-uid='ccc'
+          />
+        </div>`,
+      ),
+    )
+  })
+  it('works with element aspect ratio locked resized from TOP edge', async () => {
+    const edgePosition: EdgePosition = { x: 0.5, y: 0 }
+    const snippet = `
+  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+    <div
+      style={{ 
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        top: 50,
+        left: 30,
+        width: 100,
+        height: 120,
+       }}
+      data-uid='bbb'
+    />
+    <div
+      style={{ 
+        backgroundColor: '#0091FFAA',
+        position: 'absolute',
+        top: 40,
+        left: 90,
+        bottom: 250,
+        right: 210
+       }}
+      data-uid='ccc'
+    />
+  </div>
+  `
+    const selectedElements = [
+      elementPath([
+        ['scene-aaa', 'app-entity'],
+        ['aaa', 'bbb'],
+      ]),
+      elementPath([
+        ['scene-aaa', 'app-entity'],
+        ['aaa', 'ccc'],
+      ]),
+    ]
+    const editorAfterStrategy = multiselectResizeElements(
+      snippet,
+      selectedElements,
+      edgePosition,
+      shiftModifier,
+    )
+    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+          <div
+            style={{ 
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              top: 59,
+              left: 30,
+              width: 92,
+              height: 111,
+            }}
+            data-uid='bbb'
+          />
+          <div
+            style={{ 
+              backgroundColor: '#0091FFAA',
+              position: 'absolute',
+              top: 50,
+              left: 85,
+              bottom: 248,
+              right: 222
             }}
             data-uid='ccc'
           />

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -192,10 +192,10 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 66,
-              left: 51,
-              width: 87,
-              height: 104,
+              top: 61,
+              left: 45,
+              width: 91,
+              height: 109,
             }}
             data-uid='bbb'
           />
@@ -203,9 +203,9 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 57,
-              left: 103,
-              bottom: 247,
+              top: 52,
+              left: 99,
+              bottom: 248,
               right: 210
             }}
             data-uid='ccc'
@@ -333,10 +333,10 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 51,
+              top: 52,
               left: 30,
-              width: 113,
-              height: 136,
+              width: 119,
+              height: 143,
             }}
             data-uid='bbb'
           />
@@ -345,9 +345,9 @@ describe('Absolute Resize Bounding Box Strategy', () => {
               backgroundColor: '#0091FFAA',
               position: 'absolute',
               top: 40,
-              left: 98,
-              bottom: 235,
-              right: 189
+              left: 102,
+              bottom: 229,
+              right: 179
             }}
             data-uid='ccc'
           />

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -333,10 +333,10 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 51,
+              top: 52,
               left: 30,
-              width: 109,
-              height: 131,
+              width: 119,
+              height: 143,
             }}
             data-uid='bbb'
           />
@@ -345,9 +345,9 @@ describe('Absolute Resize Bounding Box Strategy', () => {
               backgroundColor: '#0091FFAA',
               position: 'absolute',
               top: 40,
-              left: 96,
-              bottom: 240,
-              right: 195
+              left: 102,
+              bottom: 229,
+              right: 179
             }}
             data-uid='ccc'
           />
@@ -474,7 +474,7 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 11,
+              top: 45,
               left: 30,
               width: 109,
               height: 131,
@@ -485,9 +485,9 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 0,
+              top: 34,
               left: 96,
-              bottom: 280,
+              bottom: 246,
               right: 195
             }}
             data-uid='ccc'
@@ -627,9 +627,9 @@ describe('Absolute Resize Bounding Box Strategy', () => {
               backgroundColor: '#0091FFAA',
               position: 'absolute',
               top: 65,
-              left: 93,
+              left: 94,
               bottom: 246,
-              right: 226
+              right: 225
             }}
             data-uid='ccc'
           />

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -474,10 +474,10 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 44,
+              top: 45,
               left: 30,
-              width: 106,
-              height: 127,
+              width: 109,
+              height: 131,
             }}
             data-uid='bbb'
           />
@@ -485,10 +485,10 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 33,
-              left: 93,
-              bottom: 251,
-              right: 201
+              top: 34,
+              left: 96,
+              bottom: 246,
+              right: 195
             }}
             data-uid='ccc'
           />
@@ -615,10 +615,10 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 59,
-              left: 42,
-              width: 92,
-              height: 111,
+              top: 73,
+              left: 45,
+              width: 81,
+              height: 97,
             }}
             data-uid='bbb'
           />
@@ -626,10 +626,10 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 50,
-              left: 97,
-              bottom: 248,
-              right: 210
+              top: 65,
+              left: 93,
+              bottom: 246,
+              right: 226
             }}
             data-uid='ccc'
           />

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -474,7 +474,7 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 51,
+              top: 44,
               left: 30,
               width: 106,
               height: 127,
@@ -485,9 +485,9 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 40,
+              top: 33,
               left: 93,
-              bottom: 244,
+              bottom: 251,
               right: 201
             }}
             data-uid='ccc'
@@ -616,7 +616,7 @@ describe('Absolute Resize Bounding Box Strategy', () => {
               backgroundColor: '#0091FFAA',
               position: 'absolute',
               top: 59,
-              left: 30,
+              left: 42,
               width: 92,
               height: 111,
             }}
@@ -627,9 +627,9 @@ describe('Absolute Resize Bounding Box Strategy', () => {
               backgroundColor: '#0091FFAA',
               position: 'absolute',
               top: 50,
-              left: 85,
+              left: 97,
               bottom: 248,
-              right: 222
+              right: 210
             }}
             data-uid='ccc'
           />

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -333,10 +333,10 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 52,
+              top: 51,
               left: 30,
-              width: 119,
-              height: 143,
+              width: 109,
+              height: 131,
             }}
             data-uid='bbb'
           />
@@ -345,9 +345,9 @@ describe('Absolute Resize Bounding Box Strategy', () => {
               backgroundColor: '#0091FFAA',
               position: 'absolute',
               top: 40,
-              left: 102,
-              bottom: 229,
-              right: 179
+              left: 96,
+              bottom: 240,
+              right: 195
             }}
             data-uid='ccc'
           />
@@ -474,7 +474,7 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 45,
+              top: 11,
               left: 30,
               width: 109,
               height: 131,
@@ -485,9 +485,9 @@ describe('Absolute Resize Bounding Box Strategy', () => {
             style={{ 
               backgroundColor: '#0091FFAA',
               position: 'absolute',
-              top: 34,
+              top: 0,
               left: 96,
-              bottom: 246,
+              bottom: 280,
               right: 195
             }}
             data-uid='ccc'

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -36,7 +36,9 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
   isApplicable: (canvasState, interactionState, metadata) => {
     if (
       canvasState.selectedElements.length > 1 ||
-      (canvasState.selectedElements.length >= 1 && interactionState?.interactionData.modifiers.alt)
+      (canvasState.selectedElements.length >= 1 &&
+        (interactionState?.interactionData.modifiers.alt ||
+          interactionState?.interactionData.modifiers.shift))
     ) {
       return canvasState.selectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -24,11 +24,11 @@ import { updateHighlightedViews } from '../commands/update-highlighted-views-com
 import { AbsoluteResizeControl } from '../controls/select-mode/absolute-resize-control'
 import { AbsolutePin, hasAtLeastTwoPinsPerSide } from './absolute-resize-helpers'
 import { CanvasStrategy } from './canvas-strategy-types'
+import { getMultiselectBounds } from './shared-absolute-move-strategy-helpers'
 import {
-  getMultiselectBounds,
   resizeBoundingBox,
   runLegacyAbsoluteResizeSnapping,
-} from './shared-absolute-move-strategy-helpers'
+} from './shared-absolute-resize-strategy-helpers'
 
 export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
@@ -84,6 +84,8 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
           ? originalBoundingBox.width / originalBoundingBox.height
           : null
         const centerBased = interactionState.interactionData.modifiers.alt
+          ? 'center-based'
+          : 'non-center-based'
         const newBoundingBox = resizeBoundingBox(
           originalBoundingBox,
           drag,
@@ -196,7 +198,7 @@ function snapBoundingBox(
   resizedBounds: CanvasRectangle,
   canvasScale: number,
   lockedAspectRatio: number | null,
-  centerBased: boolean,
+  centerBased: 'center-based' | 'non-center-based',
 ) {
   const { snappedBoundingBox, guidelinesWithSnappingVector } = runLegacyAbsoluteResizeSnapping(
     selectedElements,

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -80,12 +80,15 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
       )
       if (originalBoundingBox != null) {
         const keepAspectRatio = interactionState.interactionData.modifiers.shift
+        const lockedAspectRatio = keepAspectRatio
+          ? originalBoundingBox.width / originalBoundingBox.height
+          : null
         const centerBased = interactionState.interactionData.modifiers.alt
         const newBoundingBox = resizeBoundingBox(
           originalBoundingBox,
           drag,
           edgePosition,
-          keepAspectRatio,
+          lockedAspectRatio,
           centerBased,
         )
         const { snappedBoundingBox, guidelinesWithSnappingVector } = snapBoundingBox(
@@ -94,7 +97,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
           edgePosition,
           newBoundingBox,
           canvasState.scale,
-          keepAspectRatio,
+          lockedAspectRatio,
           centerBased,
         )
         const commandsForSelectedElements = canvasState.selectedElements.flatMap(
@@ -192,7 +195,7 @@ function snapBoundingBox(
   edgePosition: EdgePosition,
   resizedBounds: CanvasRectangle,
   canvasScale: number,
-  keepAspectRatio: boolean,
+  lockedAspectRatio: number | null,
   centerBased: boolean,
 ) {
   const { snappedBoundingBox, guidelinesWithSnappingVector } = runLegacyAbsoluteResizeSnapping(
@@ -201,7 +204,7 @@ function snapBoundingBox(
     edgePosition,
     resizedBounds,
     canvasScale,
-    keepAspectRatio,
+    lockedAspectRatio,
     centerBased,
   )
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -77,11 +77,13 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
         canvasState.selectedElements,
       )
       if (originalBoundingBox != null) {
+        const keepAspectRatio = interactionState.interactionData.modifiers.shift
         const centerBased = interactionState.interactionData.modifiers.alt
         const newBoundingBox = resizeBoundingBox(
           originalBoundingBox,
           drag,
           edgePosition,
+          keepAspectRatio,
           centerBased,
         )
         const { snappedBoundingBox, guidelinesWithSnappingVector } = snapBoundingBox(
@@ -90,7 +92,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
           edgePosition,
           newBoundingBox,
           canvasState.scale,
-          false,
+          keepAspectRatio,
           centerBased,
         )
         const commandsForSelectedElements = canvasState.selectedElements.flatMap(

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
@@ -73,7 +73,7 @@ export const absoluteResizeDeltaStrategy: CanvasStrategy = {
         drag,
         edgePosition,
         canvasState.scale,
-        false,
+        null,
       )
 
       const commandsForSelectedElements = canvasState.selectedElements.flatMap(
@@ -122,7 +122,7 @@ function snapDrag(
   drag: CanvasVector,
   edgePosition: EdgePosition,
   canvasScale: number,
-  keepAspectRatio: boolean,
+  lockedAspectRatio: number | null,
 ): {
   snappedDragVector: CanvasVector
   guidelinesWithSnappingVector: Array<GuidelineWithSnappingVector>
@@ -137,7 +137,7 @@ function snapDrag(
     originalBoundingBox,
     drag,
     edgePosition,
-    false,
+    null,
     false,
   )
   const { snapDelta, guidelinesWithSnappingVector } = runLegacyAbsoluteResizeSnapping(
@@ -146,7 +146,7 @@ function snapDrag(
     edgePosition,
     resizedUnsnappedBounds,
     canvasScale,
-    keepAspectRatio,
+    lockedAspectRatio,
     false,
   )
   const snappedDragVector = offsetPoint(drag, snapDelta)

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
@@ -32,7 +32,8 @@ export const absoluteResizeDeltaStrategy: CanvasStrategy = {
   isApplicable: (canvasState, interactionState, metadata) => {
     if (
       canvasState.selectedElements.length === 1 &&
-      !interactionState?.interactionData.modifiers.alt
+      !interactionState?.interactionData.modifiers.alt &&
+      !interactionState?.interactionData.modifiers.shift // shift is aspect ratio locked resize implemented in absolute-resize-bounding-box-strategy.tsx
     ) {
       return canvasState.selectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
@@ -185,7 +185,13 @@ function snapDrag(
     return { snappedDragVector: drag, guidelinesWithSnappingVector: [] }
   }
 
-  const resizedUnsnappedBounds = resizeBoundingBox(originalBoundingBox, drag, edgePosition, false)
+  const resizedUnsnappedBounds = resizeBoundingBox(
+    originalBoundingBox,
+    drag,
+    edgePosition,
+    false,
+    false,
+  )
   const { snapDelta, guidelinesWithSnappingVector } = runLegacyAbsoluteResizeSnapping(
     selectedElements,
     startingMetadata,

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
@@ -62,7 +62,6 @@ export const absoluteResizeDeltaStrategy: CanvasStrategy = {
         drag,
         edgePosition,
         canvasState.scale,
-        null,
       )
 
       const commandsForSelectedElements = canvasState.selectedElements.flatMap(
@@ -111,7 +110,6 @@ function snapDrag(
   drag: CanvasVector,
   edgePosition: EdgePosition,
   canvasScale: number,
-  lockedAspectRatio: number | null,
 ): {
   snappedDragVector: CanvasVector
   guidelinesWithSnappingVector: Array<GuidelineWithSnappingVector>
@@ -135,7 +133,7 @@ function snapDrag(
     edgePosition,
     resizedUnsnappedBounds,
     canvasScale,
-    lockedAspectRatio,
+    null,
     'non-center-based',
   )
   const snappedDragVector = offsetPoint(drag, snapDelta)

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
@@ -1,30 +1,19 @@
-import { isHorizontalPoint } from 'utopia-api/core'
-import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
-import { framePointForPinnedProp } from '../../../core/layout/layout-helpers-new'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { mapDropNulls } from '../../../core/shared/array-utils'
-import { isRight, right } from '../../../core/shared/either'
 import { ElementInstanceMetadataMap, JSXElement } from '../../../core/shared/element-template'
-import { CanvasRectangle, CanvasVector, offsetPoint } from '../../../core/shared/math-utils'
+import { CanvasVector, offsetPoint } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { withUnderlyingTarget } from '../../editor/store/editor-state'
-import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { EdgePosition } from '../canvas-types'
-import {
-  AdjustCssLengthProperty,
-  adjustCssLengthProperty,
-} from '../commands/adjust-css-length-command'
 import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
 import { AbsoluteResizeControl } from '../controls/select-mode/absolute-resize-control'
-import { AbsolutePin } from './absolute-resize-helpers'
 import { GuidelineWithSnappingVector } from '../guideline'
 import { CanvasStrategy } from './canvas-strategy-types'
+import { getMultiselectBounds } from './shared-absolute-move-strategy-helpers'
 import {
-  getMultiselectBounds,
   resizeBoundingBox,
   runLegacyAbsoluteResizeSnapping,
-} from './shared-absolute-move-strategy-helpers'
+} from './shared-absolute-resize-strategy-helpers'
 import { createResizeCommands } from './shared-absolute-resize-strategy-helpers'
 
 export const absoluteResizeDeltaStrategy: CanvasStrategy = {
@@ -138,7 +127,7 @@ function snapDrag(
     drag,
     edgePosition,
     null,
-    false,
+    'non-center-based',
   )
   const { snapDelta, guidelinesWithSnappingVector } = runLegacyAbsoluteResizeSnapping(
     selectedElements,
@@ -147,7 +136,7 @@ function snapDrag(
     resizedUnsnappedBounds,
     canvasScale,
     lockedAspectRatio,
-    false,
+    'non-center-based',
   )
   const snappedDragVector = offsetPoint(drag, snapDelta)
 

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.spec.tsx
@@ -1,27 +1,15 @@
 import { elementPath } from '../../../core/shared/element-path'
-import {
-  ElementInstanceMetadata,
-  SpecialSizeMeasurements,
-} from '../../../core/shared/element-template'
-import { canvasRectangle } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { KeyCharacter } from '../../../utils/keyboard'
-import { emptyModifiers, Modifiers } from '../../../utils/modifiers'
+import { emptyModifiers, Modifiers, shiftModifier } from '../../../utils/modifiers'
 import { EditorState } from '../../editor/store/editor-state'
-import { foldAndApplyCommands } from '../commands/commands'
 import {
   getEditorState,
   makeTestProjectCodeWithSnippet,
   testPrintCodeFromEditorState,
 } from '../ui-jsx.test-utils'
-import { pickCanvasStateFromEditorState } from './canvas-strategies'
-import {
-  createInteractionViaKeyboard,
-  InteractionSession,
-  StrategyState,
-} from './interaction-state'
 import { keyboardAbsoluteMoveStrategy } from './keyboard-absolute-move-strategy'
-import { pressKeys, shiftModifier } from './keyboard-interaction.test-utils'
+import { pressKeys } from './keyboard-interaction.test-utils'
 
 function prepareEditorState(codeSnippet: string, selectedViews: Array<ElementPath>): EditorState {
   return {

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.spec.tsx
@@ -1,27 +1,15 @@
 import { elementPath } from '../../../core/shared/element-path'
-import {
-  ElementInstanceMetadata,
-  SpecialSizeMeasurements,
-} from '../../../core/shared/element-template'
-import { canvasRectangle } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { KeyCharacter } from '../../../utils/keyboard'
-import { Modifiers } from '../../../utils/modifiers'
+import { cmdModifier, Modifiers, shiftCmdModifier } from '../../../utils/modifiers'
 import { EditorState } from '../../editor/store/editor-state'
-import { foldAndApplyCommands } from '../commands/commands'
 import {
   getEditorState,
   makeTestProjectCodeWithSnippet,
   testPrintCodeFromEditorState,
 } from '../ui-jsx.test-utils'
-import { pickCanvasStateFromEditorState } from './canvas-strategies'
-import {
-  createInteractionViaKeyboard,
-  InteractionSession,
-  StrategyState,
-} from './interaction-state'
 import { keyboardAbsoluteResizeStrategy } from './keyboard-absolute-resize-strategy'
-import { cmdModifier, pressKeys, shiftCmdModifier } from './keyboard-interaction.test-utils'
+import { pressKeys } from './keyboard-interaction.test-utils'
 
 function prepareEditorState(codeSnippet: string, selectedViews: Array<ElementPath>): EditorState {
   return {

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -66,24 +66,3 @@ export function pressKeys(
 
   return finalEditor
 }
-
-export const shiftModifier: Modifiers = {
-  alt: false,
-  cmd: false,
-  ctrl: false,
-  shift: true,
-}
-
-export const cmdModifier: Modifiers = {
-  alt: false,
-  cmd: true,
-  ctrl: false,
-  shift: false,
-}
-
-export const shiftCmdModifier: Modifiers = {
-  alt: false,
-  cmd: true,
-  ctrl: false,
-  shift: true,
-}

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
@@ -9,37 +9,19 @@ import type { ElementInstanceMetadataMap, JSXElement } from '../../../core/share
 import {
   boundingRectangleArray,
   canvasPoint,
-  CanvasPoint,
   CanvasRectangle,
   CanvasVector,
-  closestPointOnLine,
-  lineIntersection,
-  offsetPoint,
   pointDifference,
-  pointsEqual,
-  rectFromTwoPoints,
-  sideOfLine,
-  zeroCanvasPoint,
   zeroCanvasRect,
 } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import Utils from '../../../utils/utils'
+
 import { getElementFromProjectContents } from '../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
-import { EdgePosition } from '../canvas-types'
-import {
-  isEdgePositionAHorizontalEdge,
-  isEdgePositionAVerticalEdge,
-  isEdgePositionOnSide,
-  pickPointOnRect,
-  snapPoint,
-} from '../canvas-utils'
 import {
   adjustCssLengthProperty,
   AdjustCssLengthProperty,
 } from '../commands/adjust-css-length-command'
-import { pointGuidelineToBoundsEdge } from '../controls/guideline-helpers'
-import { GuidelineWithSnappingVector } from '../guideline'
 import { InteractionCanvasState } from './canvas-strategy-types'
 import { StrategyState } from './interaction-state'
 
@@ -196,174 +178,4 @@ export function getMultiselectBounds(
   }, selectedElements)
 
   return boundingRectangleArray(frames)
-}
-
-export function resizeBoundingBox(
-  boundingBox: CanvasRectangle,
-  drag: CanvasPoint,
-  edgePosition: EdgePosition,
-  lockedAspectRatio: number | null,
-  centerBased: boolean,
-): CanvasRectangle {
-  let dragToUse = drag
-  let cornerEdgePosition = edgePosition
-  let startingCornerPosition = {
-    x: 1 - edgePosition.x,
-    y: 1 - edgePosition.y,
-  } as EdgePosition
-
-  const isEdgeHorizontalSide = isEdgePositionAHorizontalEdge(edgePosition)
-  const isEdgeVerticalSide = isEdgePositionAVerticalEdge(edgePosition)
-
-  if (isEdgeHorizontalSide) {
-    dragToUse = canvasPoint({ x: 0, y: drag.y })
-    startingCornerPosition = { x: 0, y: startingCornerPosition.y }
-    cornerEdgePosition = { x: 1, y: edgePosition.y }
-  } else if (isEdgeVerticalSide) {
-    dragToUse = canvasPoint({ x: drag.x, y: 0 })
-    startingCornerPosition = { x: startingCornerPosition.x, y: 0 }
-    cornerEdgePosition = { x: edgePosition.x, y: 1 }
-  }
-
-  const oppositeCornerPoint = pickPointOnRect(boundingBox, startingCornerPosition)
-  const draggedCorner = pickPointOnRect(boundingBox, cornerEdgePosition)
-  let newCorner = offsetPoint(draggedCorner, dragToUse)
-
-  if (lockedAspectRatio != null) {
-    const horizontalLineB = {
-      x: newCorner.x + 100,
-      y: newCorner.y,
-    } as CanvasPoint
-    const verticalLineB = {
-      x: newCorner.x,
-      y: newCorner.y + 100,
-    } as CanvasPoint
-    const diagonalA = getPointOnDiagonal(cornerEdgePosition, draggedCorner, lockedAspectRatio)
-    if (isEdgeHorizontalSide || isEdgeVerticalSide) {
-      newCorner =
-        lineIntersection(
-          diagonalA,
-          draggedCorner,
-          newCorner,
-          isEdgeHorizontalSide ? horizontalLineB : verticalLineB,
-        ) ?? closestPointOnLine(diagonalA, draggedCorner, newCorner)
-    } else {
-      const pointPosToAxis = sideOfLine(diagonalA, draggedCorner, newCorner)
-      const topLeftOrBottomRight = edgePosition.x === edgePosition.y
-      const horizontalMatching =
-        (topLeftOrBottomRight && pointPosToAxis === 'right') ||
-        (!topLeftOrBottomRight && pointPosToAxis === 'left')
-      newCorner =
-        lineIntersection(
-          diagonalA,
-          draggedCorner,
-          newCorner,
-          horizontalMatching ? horizontalLineB : verticalLineB,
-        ) ?? closestPointOnLine(diagonalA, draggedCorner, newCorner)
-    }
-  }
-
-  let newBoundingBox = boundingBox
-  if (centerBased) {
-    const oppositeCornerDragged = offsetPoint(
-      oppositeCornerPoint,
-      pointDifference(dragToUse, zeroCanvasPoint),
-    )
-    newBoundingBox = rectFromTwoPoints(oppositeCornerDragged, newCorner)
-  } else {
-    newBoundingBox = rectFromTwoPoints(oppositeCornerPoint, newCorner)
-  }
-
-  if (lockedAspectRatio != null) {
-    if (isEdgeHorizontalSide) {
-      newBoundingBox.x = Utils.roundTo(
-        boundingBox.x + (boundingBox.width - newBoundingBox.width) / 2,
-      )
-    } else if (isEdgeVerticalSide) {
-      newBoundingBox.y -= Utils.roundTo(
-        boundingBox.y + (boundingBox.height - newBoundingBox.height) / 2,
-      )
-    }
-  }
-
-  return newBoundingBox
-}
-
-export function runLegacyAbsoluteResizeSnapping(
-  selectedElements: Array<ElementPath>,
-  jsxMetadata: ElementInstanceMetadataMap,
-  draggedCorner: EdgePosition,
-  resizedBounds: CanvasRectangle,
-  canvasScale: number,
-  lockedAspectRatio: number | null,
-  centerBased: boolean,
-): {
-  snapDelta: CanvasVector
-  snappedBoundingBox: CanvasRectangle
-  guidelinesWithSnappingVector: Array<GuidelineWithSnappingVector>
-} {
-  const oppositeCorner: EdgePosition = {
-    x: 1 - draggedCorner.x,
-    y: 1 - draggedCorner.y,
-  } as EdgePosition
-
-  const draggedPointMovedWithoutSnap = pickPointOnRect(resizedBounds, draggedCorner)
-  const oppositePoint =
-    lockedAspectRatio == null
-      ? pickPointOnRect(resizedBounds, oppositeCorner)
-      : getPointOnDiagonal(draggedCorner, draggedPointMovedWithoutSnap, lockedAspectRatio)
-
-  const { snappedPointOnCanvas, guidelinesWithSnappingVector } = snapPoint(
-    selectedElements,
-    jsxMetadata,
-    canvasScale,
-    draggedPointMovedWithoutSnap,
-    true,
-    lockedAspectRatio != null,
-    draggedPointMovedWithoutSnap,
-    oppositePoint,
-    draggedCorner,
-  )
-
-  const snapDelta = pointDifference(draggedPointMovedWithoutSnap, snappedPointOnCanvas)
-  const snappedBounds = resizeBoundingBox(
-    resizedBounds,
-    snapDelta,
-    draggedCorner,
-    lockedAspectRatio,
-    centerBased,
-  )
-
-  const updatedGuidelinesWithSnapping = pointGuidelineToBoundsEdge(
-    guidelinesWithSnappingVector,
-    snappedBounds,
-  )
-
-  return {
-    snapDelta: snapDelta,
-    snappedBoundingBox: snappedBounds,
-    guidelinesWithSnappingVector: updatedGuidelinesWithSnapping,
-  }
-}
-
-function getPointOnDiagonal(
-  edgePosition: EdgePosition,
-  cornerPoint: CanvasPoint,
-  aspectRatio: number,
-) {
-  if (
-    (edgePosition.x === 0 && edgePosition.y === 0) ||
-    (edgePosition.x === 1 && edgePosition.y === 1) ||
-    (edgePosition.x === 0.5 && edgePosition.y === 1) ||
-    (edgePosition.x === 1 && edgePosition.y === 0.5)
-  ) {
-    return {
-      x: cornerPoint.x + 100 * aspectRatio,
-      y: cornerPoint.y + 100,
-    } as CanvasPoint
-  }
-  return {
-    x: cornerPoint.x + 100 * aspectRatio,
-    y: cornerPoint.y - 100,
-  } as CanvasPoint
 }

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
@@ -13,6 +13,7 @@ import {
   CanvasRectangle,
   CanvasVector,
   closestPointOnLine,
+  lineIntersection,
   offsetPoint,
   pointDifference,
   rectFromTwoPoints,
@@ -222,14 +223,24 @@ export function resizeBoundingBox(
   let newCorner = offsetPoint(draggedCorner, dragToUse)
 
   if (keepAspectRatio) {
-    newCorner = closestPointOnLine(oppositeCornerPoint, draggedCorner, newCorner)
-    dragToUse = pointDifference(draggedCorner, newCorner)
     if (isEdgeOnSide) {
-      if (edgePosition.x === 0.5) {
-        dragToUse.x *= 2
-      } else if (edgePosition.y === 0.5) {
-        dragToUse.y *= 2
-      }
+      const horizontalLineB = {
+        x: newCorner.x + 10,
+        y: newCorner.y,
+      } as CanvasPoint
+      const verticalLineB = {
+        x: newCorner.x,
+        y: newCorner.y + 10,
+      } as CanvasPoint
+      newCorner =
+        lineIntersection(
+          oppositeCornerPoint,
+          draggedCorner,
+          newCorner,
+          edgePosition.x === 0.5 ? horizontalLineB : verticalLineB,
+        ) ?? closestPointOnLine(oppositeCornerPoint, draggedCorner, newCorner)
+    } else {
+      newCorner = closestPointOnLine(oppositeCornerPoint, draggedCorner, newCorner)
     }
   }
 
@@ -246,9 +257,9 @@ export function resizeBoundingBox(
 
   if (keepAspectRatio && isEdgeOnSide) {
     if (edgePosition.x === 0.5) {
-      newBoundingBox.x -= Utils.roundTo(dragToUse.x / 2)
+      newBoundingBox.x -= Utils.roundTo((newBoundingBox.width - boundingBox.width) / 2)
     } else if (edgePosition.y === 0.5) {
-      newBoundingBox.y -= Utils.roundTo(dragToUse.y / 2)
+      newBoundingBox.y -= Utils.roundTo((newBoundingBox.height - boundingBox.height) / 2)
     }
   }
 

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
@@ -1,30 +1,18 @@
 import { isHorizontalPoint } from 'utopia-api/core'
 import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
 import { framePointForPinnedProp } from '../../../core/layout/layout-helpers-new'
-import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../core/shared/array-utils'
 import { isRight, right } from '../../../core/shared/either'
-import { ElementInstanceMetadataMap, JSXElement } from '../../../core/shared/element-template'
-import { CanvasRectangle, CanvasVector, offsetPoint } from '../../../core/shared/math-utils'
+import { JSXElement } from '../../../core/shared/element-template'
+import { CanvasRectangle, CanvasVector } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import { withUnderlyingTarget } from '../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { EdgePosition } from '../canvas-types'
 import {
   AdjustCssLengthProperty,
   adjustCssLengthProperty,
 } from '../commands/adjust-css-length-command'
-import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
-import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
-import { AbsoluteResizeControl } from '../controls/select-mode/absolute-resize-control'
 import { AbsolutePin } from './absolute-resize-helpers'
-import { GuidelineWithSnappingVector } from '../guideline'
-import { CanvasStrategy } from './canvas-strategy-types'
-import {
-  getMultiselectBounds,
-  resizeBoundingBox,
-  runLegacyAbsoluteResizeSnapping,
-} from './shared-absolute-move-strategy-helpers'
 
 export function createResizeCommands(
   element: JSXElement,

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
@@ -3,16 +3,37 @@ import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
 import { framePointForPinnedProp } from '../../../core/layout/layout-helpers-new'
 import { mapDropNulls } from '../../../core/shared/array-utils'
 import { isRight, right } from '../../../core/shared/either'
-import { JSXElement } from '../../../core/shared/element-template'
-import { CanvasRectangle, CanvasVector } from '../../../core/shared/math-utils'
+import { ElementInstanceMetadataMap, JSXElement } from '../../../core/shared/element-template'
+import {
+  canvasPoint,
+  CanvasPoint,
+  CanvasRectangle,
+  CanvasVector,
+  closestPointOnLine,
+  lineIntersection,
+  offsetPoint,
+  pointDifference,
+  rectFromTwoPoints,
+  sideOfLine,
+  zeroCanvasPoint,
+} from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { EdgePosition } from '../canvas-types'
 import {
+  isEdgePositionAHorizontalEdge,
+  isEdgePositionAVerticalEdge,
+  pickPointOnRect,
+  snapPoint,
+} from '../canvas-utils'
+import {
   AdjustCssLengthProperty,
   adjustCssLengthProperty,
 } from '../commands/adjust-css-length-command'
+import { pointGuidelineToBoundsEdge } from '../controls/guideline-helpers'
+import { GuidelineWithSnappingVector } from '../guideline'
 import { AbsolutePin } from './absolute-resize-helpers'
+import Utils from '../../../utils/utils'
 
 export function createResizeCommands(
   element: JSXElement,
@@ -66,4 +87,176 @@ function pinsForEdgePosition(edgePosition: EdgePosition): AbsolutePin[] {
   }
 
   return [...horizontalPins, ...verticalPins]
+}
+
+type IsCenterBased = 'center-based' | 'non-center-based'
+
+export function resizeBoundingBox(
+  boundingBox: CanvasRectangle,
+  drag: CanvasPoint,
+  edgePosition: EdgePosition,
+  lockedAspectRatio: number | null,
+  centerBased: IsCenterBased,
+): CanvasRectangle {
+  let dragToUse = drag
+  let cornerEdgePosition = edgePosition
+  let startingCornerPosition = {
+    x: 1 - edgePosition.x,
+    y: 1 - edgePosition.y,
+  } as EdgePosition
+
+  const isEdgeHorizontalSide = isEdgePositionAHorizontalEdge(edgePosition)
+  const isEdgeVerticalSide = isEdgePositionAVerticalEdge(edgePosition)
+
+  if (isEdgeHorizontalSide) {
+    dragToUse = canvasPoint({ x: 0, y: drag.y })
+    startingCornerPosition = { x: 0, y: startingCornerPosition.y }
+    cornerEdgePosition = { x: 1, y: edgePosition.y }
+  } else if (isEdgeVerticalSide) {
+    dragToUse = canvasPoint({ x: drag.x, y: 0 })
+    startingCornerPosition = { x: startingCornerPosition.x, y: 0 }
+    cornerEdgePosition = { x: edgePosition.x, y: 1 }
+  }
+
+  const oppositeCornerPoint = pickPointOnRect(boundingBox, startingCornerPosition)
+  const draggedCorner = pickPointOnRect(boundingBox, cornerEdgePosition)
+  let newCorner = offsetPoint(draggedCorner, dragToUse)
+
+  if (lockedAspectRatio != null) {
+    const horizontalLineB = canvasPoint({
+      x: newCorner.x + 100,
+      y: newCorner.y,
+    })
+    const verticalLineB = canvasPoint({
+      x: newCorner.x,
+      y: newCorner.y + 100,
+    })
+    const diagonalA = getPointOnDiagonal(cornerEdgePosition, draggedCorner, lockedAspectRatio)
+    if (isEdgeHorizontalSide || isEdgeVerticalSide) {
+      newCorner =
+        lineIntersection(
+          diagonalA,
+          draggedCorner,
+          newCorner,
+          isEdgeHorizontalSide ? horizontalLineB : verticalLineB,
+        ) ?? closestPointOnLine(diagonalA, draggedCorner, newCorner)
+    } else {
+      const pointPosToAxis = sideOfLine(diagonalA, draggedCorner, newCorner)
+      const topLeftOrBottomRight = edgePosition.x === edgePosition.y
+      const horizontalMatching =
+        (topLeftOrBottomRight && pointPosToAxis === 'right') ||
+        (!topLeftOrBottomRight && pointPosToAxis === 'left')
+      newCorner =
+        lineIntersection(
+          diagonalA,
+          draggedCorner,
+          newCorner,
+          horizontalMatching ? horizontalLineB : verticalLineB,
+        ) ?? closestPointOnLine(diagonalA, draggedCorner, newCorner)
+    }
+  }
+
+  let newBoundingBox = boundingBox
+  if (centerBased === 'center-based') {
+    const oppositeCornerDragged = offsetPoint(
+      oppositeCornerPoint,
+      pointDifference(dragToUse, zeroCanvasPoint),
+    )
+    newBoundingBox = rectFromTwoPoints(oppositeCornerDragged, newCorner)
+  } else {
+    newBoundingBox = rectFromTwoPoints(oppositeCornerPoint, newCorner)
+  }
+
+  if (lockedAspectRatio != null) {
+    if (isEdgeHorizontalSide) {
+      newBoundingBox.x = Utils.roundTo(
+        boundingBox.x + (boundingBox.width - newBoundingBox.width) / 2,
+      )
+    } else if (isEdgeVerticalSide) {
+      newBoundingBox.y -= Utils.roundTo(
+        boundingBox.y + (boundingBox.height - newBoundingBox.height) / 2,
+      )
+    }
+  }
+
+  return newBoundingBox
+}
+
+export function runLegacyAbsoluteResizeSnapping(
+  selectedElements: Array<ElementPath>,
+  jsxMetadata: ElementInstanceMetadataMap,
+  draggedCorner: EdgePosition,
+  resizedBounds: CanvasRectangle,
+  canvasScale: number,
+  lockedAspectRatio: number | null,
+  centerBased: IsCenterBased,
+): {
+  snapDelta: CanvasVector
+  snappedBoundingBox: CanvasRectangle
+  guidelinesWithSnappingVector: Array<GuidelineWithSnappingVector>
+} {
+  const oppositeCorner: EdgePosition = {
+    x: 1 - draggedCorner.x,
+    y: 1 - draggedCorner.y,
+  } as EdgePosition
+
+  const draggedPointMovedWithoutSnap = pickPointOnRect(resizedBounds, draggedCorner)
+  const oppositePoint =
+    lockedAspectRatio == null
+      ? pickPointOnRect(resizedBounds, oppositeCorner)
+      : getPointOnDiagonal(draggedCorner, draggedPointMovedWithoutSnap, lockedAspectRatio)
+
+  const { snappedPointOnCanvas, guidelinesWithSnappingVector } = snapPoint(
+    selectedElements,
+    jsxMetadata,
+    canvasScale,
+    draggedPointMovedWithoutSnap,
+    true,
+    lockedAspectRatio != null,
+    draggedPointMovedWithoutSnap,
+    oppositePoint,
+    draggedCorner,
+  )
+
+  const snapDelta = pointDifference(draggedPointMovedWithoutSnap, snappedPointOnCanvas)
+  const snappedBounds = resizeBoundingBox(
+    resizedBounds,
+    snapDelta,
+    draggedCorner,
+    lockedAspectRatio,
+    centerBased,
+  )
+
+  const updatedGuidelinesWithSnapping = pointGuidelineToBoundsEdge(
+    guidelinesWithSnappingVector,
+    snappedBounds,
+  )
+
+  return {
+    snapDelta: snapDelta,
+    snappedBoundingBox: snappedBounds,
+    guidelinesWithSnappingVector: updatedGuidelinesWithSnapping,
+  }
+}
+
+function getPointOnDiagonal(
+  edgePosition: EdgePosition,
+  cornerPoint: CanvasPoint,
+  aspectRatio: number,
+) {
+  if (
+    (edgePosition.x === 0 && edgePosition.y === 0) ||
+    (edgePosition.x === 1 && edgePosition.y === 1) ||
+    (edgePosition.x === 0.5 && edgePosition.y === 1) ||
+    (edgePosition.x === 1 && edgePosition.y === 0.5)
+  ) {
+    return canvasPoint({
+      x: cornerPoint.x + 100 * aspectRatio,
+      y: cornerPoint.y + 100,
+    })
+  }
+  return canvasPoint({
+    x: cornerPoint.x + 100 * aspectRatio,
+    y: cornerPoint.y - 100,
+  })
 }

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
@@ -195,7 +195,7 @@ export function resizeBoundingBoxFromCornerAspectRatioLocked(
   if (centerBased === 'center-based') {
     const oppositeCornerDragged = offsetPoint(
       oppositeCorner,
-      pointDifference(drag, zeroCanvasPoint),
+      pointDifference(aspectRatioFixedNewCorner, draggedCorner),
     )
     return rectFromTwoPoints(oppositeCornerDragged, aspectRatioFixedNewCorner)
   } else {

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -741,11 +741,13 @@ export function lineIntersection<C extends CoordinateMarker>(
   } as Point<C>
 }
 
+// Returns which side of the line is point b. If looking from lineA to lineB it is on the left, it returns the value 'left', etc.
 export function sideOfLine<C extends CoordinateMarker>(
   lineA: Point<C>,
   lineB: Point<C>,
   p: Point<C>,
 ): 'left' | 'right' | 'on-line' {
+  // For explanation see: https://math.stackexchange.com/questions/274712/calculate-on-which-side-of-a-straight-line-is-a-given-point-located
   const d = (p.x - lineA.x) * (lineB.y - lineA.y) - (p.y - lineA.y) * (lineB.x - lineA.x)
   if (d == 0) {
     return 'on-line'

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -741,6 +741,22 @@ export function lineIntersection<C extends CoordinateMarker>(
   } as Point<C>
 }
 
+export function sideOfLine<C extends CoordinateMarker>(
+  lineA: Point<C>,
+  lineB: Point<C>,
+  p: Point<C>,
+): 'left' | 'right' | 'on-line' {
+  const d = (p.x - lineA.x) * (lineB.y - lineA.y) - (p.y - lineA.y) * (lineB.x - lineA.x)
+  if (d == 0) {
+    return 'on-line'
+  } else if (d < 0) {
+    return 'right'
+  } else {
+    // d > 0
+    return 'left'
+  }
+}
+
 export function roundPointTo<C extends CoordinateMarker>(p: Point<C>, precision: number): Point<C> {
   return {
     x: roundTo(p.x, precision),

--- a/editor/src/utils/modifiers.ts
+++ b/editor/src/utils/modifiers.ts
@@ -14,6 +14,13 @@ export const emptyModifiers: Modifiers = optionalDeepFreeze({
   shift: false,
 })
 
+export const shiftModifier: Modifiers = optionalDeepFreeze({
+  alt: false,
+  cmd: false,
+  ctrl: false,
+  shift: true,
+})
+
 export const Modifier = {
   modifiersForKeyboardEvent: function (event: KeyboardEvent): Modifiers {
     let result: Modifiers = { ...Modifier.modifiersForEvent(event) }

--- a/editor/src/utils/modifiers.ts
+++ b/editor/src/utils/modifiers.ts
@@ -14,12 +14,26 @@ export const emptyModifiers: Modifiers = optionalDeepFreeze({
   shift: false,
 })
 
-export const shiftModifier: Modifiers = optionalDeepFreeze({
+export const shiftModifier: Modifiers = {
   alt: false,
   cmd: false,
   ctrl: false,
   shift: true,
-})
+}
+
+export const cmdModifier: Modifiers = {
+  alt: false,
+  cmd: true,
+  ctrl: false,
+  shift: false,
+}
+
+export const shiftCmdModifier: Modifiers = {
+  alt: false,
+  cmd: true,
+  ctrl: false,
+  shift: true,
+}
 
 export const Modifier = {
   modifiersForKeyboardEvent: function (event: KeyboardEvent): Modifiers {


### PR DESCRIPTION
This PR implements the aspect ratio locked resize (using the mouse)

Aspect ratio locked resize has 2 distinct cases:
- when you drag a corner we resize the element in a way that the mouse cursor stays on the sides of the bounding box
![Mar-31-2022 12-57-57](https://user-images.githubusercontent.com/127662/161040154-bd7c30fa-17de-4b28-858a-b27ce6b3c693.gif)

- when you drag a side we do the same, but we also keep the center of the rectangle in the same position, so it grows/shrinks in two ways to the two sides.
![Mar-31-2022 12-58-46](https://user-images.githubusercontent.com/127662/161040280-308af99d-9671-40a7-91e1-4cbfba85c350.gif)

