### PR TITLE
Run the performance and screenshot tests without using headless.

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -134,7 +134,6 @@ jobs:
         id: run-performance-test
         env:
           BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
-          HEADLESS: 'true'
           AWS_S3_BUCKET: ${{secrets.PERFORMANCE_GRAPHS_BUCKET}}
           AWS_ACCESS_KEY_ID: ${{ secrets.PERFORMANCE_GRAPHS_ACCESS_KEY}}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.PERFORMANCE_GRAPHS_SECRET_KEY }}
@@ -142,7 +141,7 @@ jobs:
           PERFORMANCE_GRAPHS_PLOTLY_USERNAME: ${{ secrets.PERFORMANCE_GRAPHS_PLOTLY_USERNAME}}
           PERFORMANCE_GRAPHS_PLOTLY_API_KEY: ${{secrets.PERFORMANCE_GRAPHS_PLOTLY_API_KEY}}
         run: |
-          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "run-puppeteer-test"
+          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "xvfb-run --server-args='-screen 0 1920x1080x24' run-puppeteer-test"
       - name: Find Comment
         uses: peter-evans/find-comment@v1
         id: fc

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -141,7 +141,7 @@ jobs:
           PERFORMANCE_GRAPHS_PLOTLY_USERNAME: ${{ secrets.PERFORMANCE_GRAPHS_PLOTLY_USERNAME}}
           PERFORMANCE_GRAPHS_PLOTLY_API_KEY: ${{secrets.PERFORMANCE_GRAPHS_PLOTLY_API_KEY}}
         run: |
-          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "xvfb-run --server-args='-screen 0 1920x1080x24' run-puppeteer-test"
+          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "xvfb-run --server-args='-screen 0 1920x1080x24 -ac -nolisten tcp -dpi 96 +extension RANDR' run-puppeteer-test"
       - name: Find Comment
         uses: peter-evans/find-comment@v1
         id: fc

--- a/.github/workflows/screenshot-production.yml
+++ b/.github/workflows/screenshot-production.yml
@@ -38,7 +38,7 @@ jobs:
           BASE_EDITOR_URL: 'https://utopia.app'
           PROJECT_ID: '9f8c4564'
         run: |
-          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; pnpm run screenshot-test"
+          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; xvfb-run --server-args='-screen 0 1920x1080x24' pnpm run screenshot-test"
       - name: Build Discord Message
         env:
           TEMPLATE: >-

--- a/.github/workflows/screenshot-staging.yml
+++ b/.github/workflows/screenshot-staging.yml
@@ -36,7 +36,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.PERFORMANCE_GRAPHS_SECRET_KEY }}
           AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
         run: |
-          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; pnpm run screenshot-test"
+          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; xvfb-run --server-args='-screen 0 1920x1080x24' pnpm run screenshot-test"
       - name: Build Discord Message
         env:
           TEMPLATE: >-

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -530,7 +530,6 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
     const targetPath = forceNotNull('Invalid array.', last(grandChildrenPaths))
 
     // Switch Canvas Strategies on.
-    const strategiesCurrentlyEnabled = isFeatureEnabled('Canvas Strategies')
     setFeatureEnabled('Canvas Strategies', true)
     // Delete the other children that just get in the way.
     const parentPath = EP.parentPath(targetPath)
@@ -670,14 +669,6 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
         framesPassed++
         requestAnimationFrame(step)
       } else {
-        // Potentially turn off Canvas Strategies.
-        setFeatureEnabled('Canvas Strategies', strategiesCurrentlyEnabled)
-        // Reset the position.
-        await dispatch([unsetProperty(childTargetPath!, PP.create(['style']))], 'everyone')
-          .entireUpdateFinished
-        // Unfocus the target.
-        await dispatch([setFocusedElement(null)], 'everyone').entireUpdateFinished
-
         console.info('ABSOLUTE_MOVE_TEST_FINISHED')
       }
     }

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -114,10 +114,7 @@ async function loadProject(
   // Wait for the editor to stabilise, ensuring that the canvas can render for example.
   const startWaitingTime = Date.now()
   let editorReady: boolean = false
-  let itemSelected: boolean = false
   let canvasPopulated: boolean = false
-  let codeEditorPopulated: boolean = false
-  let codeEditorLoaded: boolean = false
   while (startWaitingTime + CANVAS_POPULATE_WAIT_TIME_MS > Date.now() && !editorReady) {
     // Check canvas has been populated.
     if (!canvasPopulated) {
@@ -134,36 +131,14 @@ async function loadProject(
     const itemLabelContainer = document.querySelector(`div[class~="item-label-container"]`)
     if (itemLabelContainer != null) {
       if (itemLabelContainer instanceof HTMLElement) {
-        itemSelected = true
         itemLabelContainer.click()
       }
     }
     //}
 
-    // Wait for the code to appear in the code editor.
-    if (!codeEditorPopulated) {
-      const loadingScreenElement = document.querySelector(`div#${VSCodeLoadingScreenID}`)
-      const vscodeEditorElement = document.querySelector(`iframe#vscode-editor`)
-      if (vscodeEditorElement != null && loadingScreenElement == null) {
-        // Drill down inside the outer iframe.
-        const vscodeOuterElement = (vscodeEditorElement as any).contentWindow?.document.body.querySelector(
-          `iframe#vscode-outer`,
-        )
-        if (vscodeOuterElement != null) {
-          codeEditorLoaded = true
-          const firstViewLine = (vscodeOuterElement as any).contentWindow?.document.body.querySelector(
-            `div.view-line`,
-          )
-          if (firstViewLine != null) {
-            codeEditorPopulated = true
-          }
-        }
-      }
-    }
-
     // Appears the code editor can't be relied on to load enough of the time for
     // this check to not break everything.
-    editorReady = canvasPopulated // && codeEditorPopulated
+    editorReady = canvasPopulated
 
     if (!editorReady) {
       await wait(500)

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -49,6 +49,7 @@ import { CURRENT_PROJECT_VERSION } from '../../components/editor/actions/migrati
 import { BuiltInDependencies } from '../es-modules/package-manager/built-in-dependencies-list'
 import { LargeProjectContents } from '../../test-cases/large-project'
 import { VSCodeLoadingScreenID } from '../../components/code-editor/vscode-editor-loading-screen'
+import { v4 as UUID } from 'uuid'
 
 export function wait(timeout: number): Promise<void> {
   return new Promise((resolve) => {
@@ -76,9 +77,7 @@ function measureStep(prefix: string, framesPassed: number): void {
 
 const CANVAS_POPULATE_WAIT_TIME_MS = 20 * 1000
 
-let testProjectID: number = 999000
-
-async function loadProjectInner(
+async function loadProject(
   dispatch: DebugDispatch,
   builtInDependencies: BuiltInDependencies,
   projectContents: ProjectContentTreeRoot,
@@ -110,8 +109,7 @@ async function loadProjectInner(
   }
 
   // Load the project itself.
-  const newProjectID = testProjectID++
-  await load(dispatch, persistentModel, 'Test', `${newProjectID}`, builtInDependencies, false)
+  await load(dispatch, persistentModel, 'Test', UUID(), builtInDependencies, false)
 
   // Wait for the editor to stabilise, ensuring that the canvas can render for example.
   const startWaitingTime = Date.now()
@@ -177,22 +175,6 @@ async function loadProjectInner(
     await wait(2000)
   }
   return editorReady
-}
-
-const LOAD_PROJECT_MAX_ATTEMPTS = 3
-
-async function loadProject(
-  dispatch: DebugDispatch,
-  builtInDependencies: BuiltInDependencies,
-  projectContents: ProjectContentTreeRoot,
-): Promise<boolean> {
-  for (let attempt = 1; attempt <= LOAD_PROJECT_MAX_ATTEMPTS; attempt++) {
-    const result = await loadProjectInner(dispatch, builtInDependencies, projectContents)
-    if (result) {
-      return true
-    }
-  }
-  return false
 }
 
 export function useTriggerScrollPerformanceTest(): () => void {

--- a/puppeteer-tests/README.md
+++ b/puppeteer-tests/README.md
@@ -3,10 +3,9 @@
 1. npm install
 2. Create a project on localhost and copy its URL.
 3. run the performance test like this in the terminal: `EDITOR_URL=<project-url-you-just-copied> npm run start`
-4. can provide an env var HEADLESS=false to see what the editor is doing: `HEADLESS=false EDITOR_URL=<project-url-you-just-copied> npm run start`
-5. It's possible to provide a browser path if the bundled one is no use: `BROWSER='google-chrome' EDITOR_URL=<project-url-you-just-copied> npm run start`
-6. you will see console output with the frame numbers.
-7. That's all you need for debugging existing tests!
+4. It's possible to provide a browser path if the bundled one is no use: `BROWSER='google-chrome' EDITOR_URL=<project-url-you-just-copied> npm run start`
+5. you will see console output with the frame numbers.
+6. That's all you need for debugging existing tests!
 
 To debug plotly graphs, you also need a Plotly account username and password, please provide these env vars to the script `PERFORMANCE_GRAPHS_PLOTLY_USERNAME` and `PERFORMANCE_GRAPHS_PLOTLY_API_KEY`
 

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -189,7 +189,6 @@ async function retryPageCalls<T>(
     const { page, browser } = await setupBrowser(url, 120000)
     await page.waitForXPath(`//div[contains(@id, "canvas-container")]`)
     await page.waitForXPath('//div[contains(@class, "item-label-container")]')
-    await wait(10000)
     try {
       const result = await call(page)
       // Check the result.
@@ -203,7 +202,7 @@ async function retryPageCalls<T>(
         throw new Error(`Error during measurements ${e}`)
       }
     } finally {
-      await page.close({ runBeforeUnload: true })
+      await page.close()
       await browser.close()
     }
   }

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -12,7 +12,7 @@ const BRANCH_NAME = process.env.BRANCH_NAME ? `?branch_name=${process.env.BRANCH
 const STAGING_EDITOR_URL = process.env.EDITOR_URL ?? `https://utopia.pizza/p${BRANCH_NAME}`
 const MASTER_EDITOR_URL = process.env.MASTER_EDITOR_URL ?? `https://utopia.pizza/p`
 
-type FrameResult = {
+interface FrameResult {
   title: string
   timeSeries: Array<number>
   analytics: {
@@ -23,6 +23,7 @@ type FrameResult = {
     percentile50: number | undefined
     percentile75: number | undefined
   }
+  succeeded: boolean
 }
 
 const EmptyResult: FrameResult = {
@@ -36,6 +37,7 @@ const EmptyResult: FrameResult = {
     percentile50: undefined,
     percentile75: undefined,
   },
+  succeeded: true,
 }
 
 function loadTraceEventsJSON(): Promise<any> {
@@ -123,17 +125,23 @@ function timeBasicCalc(): FrameResult {
     title: 'Calc Pi',
     analytics: analytics,
     timeSeries: sortedTimes,
+    succeeded: true,
   }
 }
 
 async function testEmptyDispatch(page: puppeteer.Page): Promise<FrameResult> {
   console.log('Test Baseline Performance')
   await page.tracing.start({ path: 'trace.json' })
-  await clickOnce(page, "//a[contains(., 'B L')]", 'BASELINE_TEST_FINISHED', 'BASELINE_TEST_ERROR')
+  const succeeded = await clickOnce(
+    page,
+    "//a[contains(., 'B L')]",
+    'BASELINE_TEST_FINISHED',
+    'BASELINE_TEST_ERROR',
+  )
   await page.tracing.stop()
 
   const traceJson = await loadTraceEventsJSON()
-  return getFrameData(traceJson, 'baseline', 'Empty Dispatch')
+  return getFrameData(traceJson, 'baseline', 'Empty Dispatch', succeeded)
 }
 
 function consoleMessageForResult(result: FrameResult): string {
@@ -163,30 +171,85 @@ export const testPerformance = async function () {
   console.info(`::set-output name=perf-chart-master:: ${masterResult.summaryImageUrl}`)
 }
 
-export const testPerformanceInner = async function (url: string): Promise<PerformanceResult> {
-  let scrollResult = EmptyResult
-  let resizeResult = EmptyResult
-  let highlightRegularResult = EmptyResult
-  let highlightAllElementsResult = EmptyResult
-  let selectionResult: Array<FrameResult> = []
-  let basicCalc = EmptyResult
-  let simpleDispatch = EmptyResult
-  let absoluteMoveResult: Array<FrameResult> = []
-  const { page, browser } = await setupBrowser(url, 120000)
-  try {
-    simpleDispatch = await testEmptyDispatch(page)
-    basicCalc = timeBasicCalc()
-    highlightRegularResult = await testHighlightRegularPerformance(page)
-    highlightAllElementsResult = await testHighlightAllElementsPerformance(page)
-    selectionResult = await testSelectionPerformance(page)
-    resizeResult = await testResizePerformance(page)
-    scrollResult = await testScrollingPerformance(page)
-    absoluteMoveResult = await testAbsoluteMovePerformance(page)
-  } catch (e) {
-    throw new Error(`Error during measurements ${e}`)
-  } finally {
-    browser.close()
+type PageToPromiseResult<T> = (page: puppeteer.Page) => Promise<T>
+
+async function retryPageCalls<T>(
+  url: string,
+  call: PageToPromiseResult<T>,
+  checkSucceeded: (value: T) => boolean,
+  defaultResult: T,
+): Promise<T> {
+  for (let retryCount: number = 1; retryCount <= 3; retryCount++) {
+    const { page, browser } = await setupBrowser(url, 120000)
+    await page.waitForXPath(`//div[contains(@id, "canvas-container")]`)
+    await page.waitForXPath('//div[contains(@class, "item-label-container")]')
+    try {
+      const result = await call(page)
+      // Check the result.
+      const success: boolean = checkSucceeded(result)
+      if (success || retryCount === 3) {
+        return result
+      }
+    } catch (e) {
+      if (retryCount >= 3) {
+        console.error(e)
+        throw new Error(`Error during measurements ${e}`)
+      }
+    } finally {
+      await page.close({ runBeforeUnload: true })
+      await browser.close()
+    }
   }
+  return defaultResult
+}
+
+function frameResultSuccess(frameResult: FrameResult): boolean {
+  return frameResult.succeeded
+}
+
+function frameArraySuccess(frameArray: Array<FrameResult>): boolean {
+  return frameArray.every(frameResultSuccess)
+}
+
+export const testPerformanceInner = async function (url: string): Promise<PerformanceResult> {
+  const simpleDispatch = await retryPageCalls(
+    url,
+    testEmptyDispatch,
+    frameResultSuccess,
+    EmptyResult,
+  )
+  const basicCalc = timeBasicCalc()
+  const highlightRegularResult = await retryPageCalls(
+    url,
+    testHighlightRegularPerformance,
+    frameResultSuccess,
+    EmptyResult,
+  )
+  const highlightAllElementsResult = await retryPageCalls(
+    url,
+    testHighlightAllElementsPerformance,
+    frameResultSuccess,
+    EmptyResult,
+  )
+  const selectionResult = await retryPageCalls(url, testSelectionPerformance, frameArraySuccess, [])
+  const resizeResult = await retryPageCalls(
+    url,
+    testResizePerformance,
+    frameResultSuccess,
+    EmptyResult,
+  )
+  const scrollResult = await retryPageCalls(
+    url,
+    testScrollingPerformance,
+    frameResultSuccess,
+    EmptyResult,
+  )
+  const absoluteMoveResult = await retryPageCalls(
+    url,
+    testAbsoluteMovePerformance,
+    frameArraySuccess,
+    [],
+  )
   const messageParts = [
     highlightRegularResult,
     highlightAllElementsResult,
@@ -212,11 +275,11 @@ async function clickOnce(
   xpath: string,
   expectedConsoleMessage: string,
   errorMessage?: string,
-): Promise<void> {
+): Promise<boolean> {
   await page.waitForXPath(xpath)
   const [button] = await page.$x(xpath)
   await button!.click()
-  await consoleDoneMessage(page, expectedConsoleMessage, errorMessage)
+  return consoleDoneMessage(page, expectedConsoleMessage, errorMessage)
 }
 
 export const testScrollingPerformance = async function (
@@ -229,10 +292,15 @@ export const testScrollingPerformance = async function (
 
   // and then we run the test for a third time, this time running tracing
   await page.tracing.start({ path: 'trace.json' })
-  await clickOnce(page, "//a[contains(., 'P S')]", 'SCROLL_TEST_FINISHED', 'SCROLL_TEST_ERROR')
+  const succeeded = await clickOnce(
+    page,
+    "//a[contains(., 'P S')]",
+    'SCROLL_TEST_FINISHED',
+    'SCROLL_TEST_ERROR',
+  )
   await page.tracing.stop()
   const traceJson = await loadTraceEventsJSON()
-  return getFrameData(traceJson, 'scroll', 'Scroll Canvas')
+  return getFrameData(traceJson, 'scroll', 'Scroll Canvas', succeeded)
 }
 
 export const testResizePerformance = async function (page: puppeteer.Page): Promise<FrameResult> {
@@ -240,34 +308,26 @@ export const testResizePerformance = async function (page: puppeteer.Page): Prom
   await page.waitForXPath(ResizeButtonXPath)
 
   // select element using the navigator
-  const navigatorElement = await page.$('[class^="item-label-container"]')
+  const navigatorElement = await page.waitForXPath(
+    '//div[contains(@class, "item-label-container")]',
+  )
   await navigatorElement!.click()
 
   // we run it twice without measurements to warm up the environment
-  await clickOnce(
-    page,
-    ResizeButtonXPath,
-    'RESIZE_TEST_FINISHED',
-    'RESIZE_TEST_MISSING_SELECTEDVIEW',
-  )
-  await clickOnce(
-    page,
-    ResizeButtonXPath,
-    'RESIZE_TEST_FINISHED',
-    'RESIZE_TEST_MISSING_SELECTEDVIEW',
-  )
+  await clickOnce(page, ResizeButtonXPath, 'RESIZE_TEST_FINISHED', 'RESIZE_TEST_ERROR')
+  await clickOnce(page, ResizeButtonXPath, 'RESIZE_TEST_FINISHED', 'RESIZE_TEST_ERROR')
 
   // and then we run the test for a third time, this time running tracing
   await page.tracing.start({ path: 'trace.json' })
-  await clickOnce(
+  const succeeded = await clickOnce(
     page,
     ResizeButtonXPath,
     'RESIZE_TEST_FINISHED',
-    'RESIZE_TEST_MISSING_SELECTEDVIEW',
+    'RESIZE_TEST_ERROR',
   )
   await page.tracing.stop()
   const traceJson = await loadTraceEventsJSON()
-  return getFrameData(traceJson, 'resize', 'Resize')
+  return getFrameData(traceJson, 'resize', 'Resize', succeeded)
 }
 
 export const testHighlightRegularPerformance = async function (
@@ -291,7 +351,7 @@ export const testHighlightRegularPerformance = async function (
 
   // and then we run the test for a third time, this time running tracing
   await page.tracing.start({ path: 'trace.json' })
-  await clickOnce(
+  const succeeded = await clickOnce(
     page,
     "//a[contains(., 'PRH')]",
     'HIGHLIGHT_REGULAR_TEST_FINISHED',
@@ -299,7 +359,7 @@ export const testHighlightRegularPerformance = async function (
   )
   await page.tracing.stop()
   const traceJson = await loadTraceEventsJSON()
-  return getFrameData(traceJson, 'highlight_regular', 'Highlight Regular')
+  return getFrameData(traceJson, 'highlight_regular', 'Highlight Regular', succeeded)
 }
 
 export const testHighlightAllElementsPerformance = async function (
@@ -323,7 +383,7 @@ export const testHighlightAllElementsPerformance = async function (
 
   // and then we run the test for a third time, this time running tracing
   await page.tracing.start({ path: 'trace.json' })
-  await clickOnce(
+  const succeeded = await clickOnce(
     page,
     "//a[contains(., 'PAH')]",
     'HIGHLIGHT_ALL-ELEMENTS_TEST_FINISHED',
@@ -331,7 +391,7 @@ export const testHighlightAllElementsPerformance = async function (
   )
   await page.tracing.stop()
   const traceJson = await loadTraceEventsJSON()
-  return getFrameData(traceJson, 'highlight_all-elements', 'Highlight All Elements')
+  return getFrameData(traceJson, 'highlight_all-elements', 'Highlight All Elements', succeeded)
 }
 
 export const testSelectionPerformance = async function (
@@ -345,12 +405,17 @@ export const testSelectionPerformance = async function (
 
   // and then we run the test for a third time, this time running tracing
   await page.tracing.start({ path: 'trace.json' })
-  await clickOnce(page, "//a[contains(., 'P E')]", 'SELECT_TEST_FINISHED', 'SELECT_TEST_ERROR')
+  const succeeded = await clickOnce(
+    page,
+    "//a[contains(., 'P E')]",
+    'SELECT_TEST_FINISHED',
+    'SELECT_TEST_ERROR',
+  )
   await page.tracing.stop()
   const traceJson = await loadTraceEventsJSON()
   return [
-    getFrameData(traceJson, 'select', 'Selection'),
-    getFrameData(traceJson, 'select_deselect', 'De-Selection'),
+    getFrameData(traceJson, 'select', 'Selection', succeeded),
+    getFrameData(traceJson, 'select_deselect', 'De-Selection', succeeded),
   ]
 }
 
@@ -375,7 +440,7 @@ export const testAbsoluteMovePerformance = async function (
 
   // and then we run the test for a third time, this time running tracing
   await page.tracing.start({ path: 'trace.json' })
-  await clickOnce(
+  const succeeded = await clickOnce(
     page,
     "//a[contains(., 'PAM')]",
     'ABSOLUTE_MOVE_TEST_FINISHED',
@@ -384,12 +449,17 @@ export const testAbsoluteMovePerformance = async function (
   await page.tracing.stop()
   const traceJson = await loadTraceEventsJSON()
   return [
-    getFrameData(traceJson, 'absolute_move_interaction', 'Absolute Move (Interaction)'),
-    getFrameData(traceJson, 'absolute_move_move', 'Absolute Move (Just Move)'),
+    getFrameData(traceJson, 'absolute_move_interaction', 'Absolute Move (Interaction)', succeeded),
+    getFrameData(traceJson, 'absolute_move_move', 'Absolute Move (Just Move)', succeeded),
   ]
 }
 
-const getFrameData = (traceEventsJson: any, markNamePrefix: string, title: string): FrameResult => {
+const getFrameData = (
+  traceEventsJson: any,
+  markNamePrefix: string,
+  title: string,
+  succeeded: boolean,
+): FrameResult => {
   const relevantEvents: any[] = traceEventsJson.filter((e: any) => {
     return e.cat === 'blink.user_timing' && e.name.startsWith(`${markNamePrefix}_`)
   })
@@ -435,6 +505,7 @@ const getFrameData = (traceEventsJson: any, markNamePrefix: string, title: strin
     title: title,
     analytics: analytics,
     timeSeries: sortedFrameTimes,
+    succeeded: succeeded,
   }
 }
 
@@ -563,6 +634,7 @@ async function createSummaryPng(
 }
 
 testPerformance().catch((e) => {
+  console.error(e)
   const errorMessage = `"There was an error with Puppeteer: ${e.name} – ${e.message}"`
   console.info(`::set-output name=perf-result::${errorMessage}`)
 

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -12,6 +12,12 @@ const BRANCH_NAME = process.env.BRANCH_NAME ? `?branch_name=${process.env.BRANCH
 const STAGING_EDITOR_URL = process.env.EDITOR_URL ?? `https://utopia.pizza/p${BRANCH_NAME}`
 const MASTER_EDITOR_URL = process.env.MASTER_EDITOR_URL ?? `https://utopia.pizza/p`
 
+export function wait(timeout: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeout)
+  })
+}
+
 interface FrameResult {
   title: string
   timeSeries: Array<number>
@@ -183,6 +189,7 @@ async function retryPageCalls<T>(
     const { page, browser } = await setupBrowser(url, 120000)
     await page.waitForXPath(`//div[contains(@id, "canvas-container")]`)
     await page.waitForXPath('//div[contains(@class, "item-label-container")]')
+    await wait(10000)
     try {
       const result = await call(page)
       // Check the result.

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -87,7 +87,7 @@ export function consoleDoneMessage(
   })
   return timeLimitPromise(
     consoleDonePromise,
-    10 * ONE_MINUTE_IN_MS, // 10 minutes.
+    1 * ONE_MINUTE_IN_MS, // 10 minutes.
     `Missing console message ${expectedConsoleMessage} in test browser.`,
   ).finally(() => {
     // Ensure we remove the handler afterwards.

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -18,6 +18,9 @@ export const setupBrowser = async (
     executablePath: process.env.BROWSER,
   })
   const page = await browser.newPage()
+  page.on('dialog', async (dialog) => {
+    await dialog.dismiss()
+  })
   page.setDefaultNavigationTimeout(120000)
   page.setDefaultTimeout(defaultTimeout)
   await page.setViewport({ width: 1500, height: 768 })

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -87,7 +87,7 @@ export function consoleDoneMessage(
   })
   return timeLimitPromise(
     consoleDonePromise,
-    1 * ONE_MINUTE_IN_MS, // 10 minutes.
+    10 * ONE_MINUTE_IN_MS, // 10 minutes.
     `Missing console message ${expectedConsoleMessage} in test browser.`,
   ).finally(() => {
     // Ensure we remove the handler afterwards.

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -62,11 +62,11 @@ export function consoleDoneMessage(
   page: puppeteer.Page,
   expectedConsoleMessage: string,
   errorMessage?: string,
-): Promise<void> {
+): Promise<boolean> {
   let handler: (message: PageEventObject['console']) => void = () => {
     console.info('Should not fire.')
   }
-  const consoleDonePromise = new Promise<void>((resolve, reject) => {
+  const consoleDonePromise = new Promise<boolean>((resolve, reject) => {
     handler = (message: PageEventObject['console']) => {
       const messageText = message.text()
       if (
@@ -75,7 +75,7 @@ export function consoleDoneMessage(
       ) {
         // the editor will console.info('SCROLL_TEST_FINISHED') when the scrolling test is complete.
         // we wait until we see this console log and then we resolve the Promise
-        resolve()
+        resolve(true)
       } else {
         console.info(`CONSOLE: ${messageText}`)
       }

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -4,7 +4,6 @@ import type { PageEventObject } from 'puppeteer'
 const fs = require('fs')
 const path = require('path')
 const AWS = require('aws-sdk')
-const yn = require('yn')
 
 export const setupBrowser = async (
   url: string,
@@ -15,7 +14,7 @@ export const setupBrowser = async (
 }> => {
   const browser = await puppeteer.launch({
     args: ['--no-sandbox', '--enable-thread-instruction-count'],
-    headless: yn(process.env.HEADLESS),
+    headless: false,
     executablePath: process.env.BROWSER,
   })
   const page = await browser.newPage()


### PR DESCRIPTION
**Problem:**
The baseline test appears to be flaky in relation to whether or not the tests are run headless. That is when running with the UI showing it appears to work flawlessly repeatedly, but in local testing switching `HEADLESS=true` on made it fail about 50% of the time.

**Fix:**
Completely disable the "headless" operation of Puppeteer as it seemingly works different somehow.

**Commit Details:**
- Put invocations of `xvfb-run` into the various calls that start any
  puppeteer tests.
- Disable the `HEADLESS` environment variable handling.
- Fix up the readme to represent that `HEADLESS` can't be used.
- Added a function `retryPageCalls` so that a specific failing performance test can be attempted more than once.
- Remove some unncessary cleanup logic from the absolute move test.
- Removed an unnecessary wait from `retryPageCalls`.
- Remove the `runBeforeUnload` option from `page.close` as it appears to do
  nothing.
- Added dialog dismissal callback so that any `beforeunload` handling is immediately
  dismissed so that the tests can continue.
- Use UUID V4 for project IDs to avoid possible collisions with using old ones.
- Removed some logic that would cause cross-origin errors as it was attempting to access the code editor iframe.