### PR TITLE
Remove screen size restriction that broke screenshot tests

### DIFF
--- a/.github/workflows/screenshot-production.yml
+++ b/.github/workflows/screenshot-production.yml
@@ -38,7 +38,7 @@ jobs:
           BASE_EDITOR_URL: 'https://utopia.app'
           PROJECT_ID: '9f8c4564'
         run: |
-          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; xvfb-run --server-args='-screen 0 1920x1080x24' pnpm run screenshot-test"
+          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; pnpm run screenshot-test"
       - name: Build Discord Message
         env:
           TEMPLATE: >-

--- a/.github/workflows/screenshot-production.yml
+++ b/.github/workflows/screenshot-production.yml
@@ -36,6 +36,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.PERFORMANCE_GRAPHS_SECRET_KEY }}
           AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
           BASE_EDITOR_URL: 'https://utopia.app'
+          HEADLESS: 'true'
           PROJECT_ID: '9f8c4564'
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; pnpm run screenshot-test"

--- a/.github/workflows/screenshot-staging.yml
+++ b/.github/workflows/screenshot-staging.yml
@@ -3,7 +3,6 @@ on:
   repository_dispatch:
     types: [trigger-staging-screenshot]
   workflow_dispatch:
-  pull_request:
 
 jobs:
   take-screenshot:

--- a/.github/workflows/screenshot-staging.yml
+++ b/.github/workflows/screenshot-staging.yml
@@ -3,6 +3,7 @@ on:
   repository_dispatch:
     types: [trigger-staging-screenshot]
   workflow_dispatch:
+  pull_request:
 
 jobs:
   take-screenshot:
@@ -36,7 +37,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.PERFORMANCE_GRAPHS_SECRET_KEY }}
           AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
         run: |
-          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; xvfb-run --server-args='-screen 0 1920x1080x24' pnpm run screenshot-test"
+          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; pnpm run screenshot-test"
       - name: Build Discord Message
         env:
           TEMPLATE: >-

--- a/.github/workflows/screenshot-staging.yml
+++ b/.github/workflows/screenshot-staging.yml
@@ -36,6 +36,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.PERFORMANCE_GRAPHS_ACCESS_KEY}}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.PERFORMANCE_GRAPHS_SECRET_KEY }}
           AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
+          HEADLESS: 'true'
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run "cd puppeteer-tests; pnpm install --unsafe-perm; pnpm run screenshot-test"
       - name: Build Discord Message

--- a/puppeteer-tests/README.md
+++ b/puppeteer-tests/README.md
@@ -1,10 +1,10 @@
 ## How to run the performance tests locally
 
-1. npm install
+1. pnpm install
 2. Create a project on localhost and copy its URL.
-3. run the performance test like this in the terminal: `EDITOR_URL=<project-url-you-just-copied> npm run start`
-4. It's possible to provide a browser path if the bundled one is no use: `BROWSER='google-chrome' EDITOR_URL=<project-url-you-just-copied> npm run start`
-5. you will see console output with the frame numbers.
+3. Run the performance test like this in the terminal: `EDITOR_URL=<project-url-you-just-copied> pnpm run performance-test`
+4. It's possible to provide a browser path if the bundled one is no use: `BROWSER='google-chrome' EDITOR_URL=<project-url-you-just-copied> pnpm run performance-test`
+5. You will see console output with the frame numbers.
 6. That's all you need for debugging existing tests!
 
 To debug plotly graphs, you also need a Plotly account username and password, please provide these env vars to the script `PERFORMANCE_GRAPHS_PLOTLY_USERNAME` and `PERFORMANCE_GRAPHS_PLOTLY_API_KEY`

--- a/puppeteer-tests/src/utils.ts
+++ b/puppeteer-tests/src/utils.ts
@@ -4,6 +4,7 @@ import type { PageEventObject } from 'puppeteer'
 const fs = require('fs')
 const path = require('path')
 const AWS = require('aws-sdk')
+const yn = require('yn')
 
 export const setupBrowser = async (
   url: string,
@@ -14,7 +15,7 @@ export const setupBrowser = async (
 }> => {
   const browser = await puppeteer.launch({
     args: ['--no-sandbox', '--enable-thread-instruction-count'],
-    headless: false,
+    headless: yn(process.env.HEADLESS) ?? false,
     executablePath: process.env.BROWSER,
   })
   const page = await browser.newPage()


### PR DESCRIPTION
**Problem:**
Removing the headless option for some reason broke the screenshots around the code editor, truncating it.

**Fix:**
The fix was to restore the headless option, but only for the screenshot tests. It was previously completely removed, as removing the explicit env var wasn't enough to stop running the performance tests in headless mode. The reason for this was a combination of `yn(input)` returning `undefined` for unrecognised input (which is the case when no `HEADLESS` env var has been set), and puppeteer defaulting to `headless: true`.