### PR TITLE
Parametrized tests for bounding box resize

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -7,7 +7,13 @@ import {
 } from '../../../core/shared/element-template'
 import { CanvasPoint, canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import { altModifier, emptyModifiers, Modifiers, shiftModifier } from '../../../utils/modifiers'
+import {
+  altModifier,
+  altShiftModifier,
+  emptyModifiers,
+  Modifiers,
+  shiftModifier,
+} from '../../../utils/modifiers'
 import { EditorState } from '../../editor/store/editor-state'
 import { EdgePosition } from '../canvas-types'
 import { foldAndApplyCommands } from '../commands/commands'
@@ -77,18 +83,22 @@ const testMetadata: ElementInstanceMetadataMap = {
   } as ElementInstanceMetadata,
 }
 
+const testDrag = canvasPoint({
+  x: 15,
+  y: 25,
+})
+
+const testBounding = { left: 50, top: 50, width: 250, height: 300 }
+
 describe('Absolute Resize Bounding Box Strategy single select', () => {
   it.each([
     [
       'top left corner',
       {
         edgePosition: { x: 0, y: 0 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: emptyModifiers,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 65, top: 75, width: 235, height: 275 },
       },
     ],
@@ -96,12 +106,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'bottom left corner',
       {
         edgePosition: { x: 0, y: 1 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: emptyModifiers,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 65, top: 50, width: 235, height: 325 },
       },
     ],
@@ -109,12 +116,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'top right corner',
       {
         edgePosition: { x: 1, y: 0 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: emptyModifiers,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 50, top: 75, width: 265, height: 275 },
       },
     ],
@@ -122,12 +126,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'bottom right corner',
       {
         edgePosition: { x: 1, y: 1 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: emptyModifiers,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 50, top: 50, width: 265, height: 325 },
       },
     ],
@@ -135,12 +136,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'top side',
       {
         edgePosition: { x: 0.5, y: 0 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: emptyModifiers,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 50, top: 75, width: 250, height: 275 },
       },
     ],
@@ -148,12 +146,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'left side',
       {
         edgePosition: { x: 0, y: 0.5 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: emptyModifiers,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 65, top: 50, width: 235, height: 300 },
       },
     ],
@@ -161,12 +156,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'bottom side',
       {
         edgePosition: { x: 0.5, y: 1 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: emptyModifiers,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 50, top: 50, width: 250, height: 325 },
       },
     ],
@@ -174,12 +166,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'right side',
       {
         edgePosition: { x: 1, y: 0.5 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: emptyModifiers,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 50, top: 50, width: 265, height: 300 },
       },
     ],
@@ -187,12 +176,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'top left corner, center mode',
       {
         edgePosition: { x: 0, y: 0 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: altModifier,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 65, top: 75, width: 220, height: 250 },
       },
     ],
@@ -200,12 +186,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'bottom left corner, center mode',
       {
         edgePosition: { x: 0, y: 1 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: altModifier,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 65, top: 25, width: 220, height: 350 },
       },
     ],
@@ -213,12 +196,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'top right corner, center mode',
       {
         edgePosition: { x: 1, y: 0 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: altModifier,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 35, top: 75, width: 280, height: 250 },
       },
     ],
@@ -226,12 +206,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'bottom right corner, center mode',
       {
         edgePosition: { x: 1, y: 1 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: altModifier,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 35, top: 25, width: 280, height: 350 },
       },
     ],
@@ -239,12 +216,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'top side, center mode',
       {
         edgePosition: { x: 0.5, y: 0 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: altModifier,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 50, top: 75, width: 250, height: 250 },
       },
     ],
@@ -252,12 +226,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'left side, center mode',
       {
         edgePosition: { x: 0, y: 0.5 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: altModifier,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 65, top: 50, width: 220, height: 300 },
       },
     ],
@@ -265,12 +236,9 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'bottom side, center mode',
       {
         edgePosition: { x: 0.5, y: 1 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: altModifier,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 50, top: 25, width: 250, height: 350 },
       },
     ],
@@ -278,13 +246,170 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       'right side, center mode',
       {
         edgePosition: { x: 1, y: 0.5 } as EdgePosition,
-        drag: canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        drag: testDrag,
         modifiers: altModifier,
-        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        bounding: testBounding,
         draggedBounding: { left: 35, top: 50, width: 280, height: 300 },
+      },
+    ],
+    [
+      'top left corner, aspect ratio locked',
+      {
+        edgePosition: { x: 0, y: 0 } as EdgePosition,
+        drag: testDrag,
+        modifiers: shiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 65, top: 68, width: 235, height: 282 },
+      },
+    ],
+    [
+      'bottom left corner, aspect ratio locked',
+      {
+        edgePosition: { x: 0, y: 1 } as EdgePosition,
+        drag: testDrag,
+        modifiers: shiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 29, top: 50, width: 271, height: 325 },
+      },
+    ],
+    [
+      'top right corner, aspect ratio locked',
+      {
+        edgePosition: { x: 1, y: 0 } as EdgePosition,
+        drag: testDrag,
+        modifiers: shiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 50, top: 32, width: 265, height: 318 },
+      },
+    ],
+    [
+      'bottom right corner, aspect ratio locked',
+      {
+        edgePosition: { x: 1, y: 1 } as EdgePosition,
+        drag: testDrag,
+        modifiers: shiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 50, top: 50, width: 271, height: 325 },
+      },
+    ],
+    [
+      'top side, aspect ratio locked',
+      {
+        edgePosition: { x: 0.5, y: 0 } as EdgePosition,
+        drag: testDrag,
+        modifiers: shiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 60, top: 75, width: 229, height: 275 },
+      },
+    ],
+    [
+      'left side, aspect ratio locked',
+      {
+        edgePosition: { x: 0, y: 0.5 } as EdgePosition,
+        drag: testDrag,
+        modifiers: shiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 65, top: 59, width: 235, height: 282 },
+      },
+    ],
+    [
+      'bottom side, aspect ratio locked',
+      {
+        edgePosition: { x: 0.5, y: 1 } as EdgePosition,
+        drag: testDrag,
+        modifiers: shiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 40, top: 50, width: 271, height: 325 },
+      },
+    ],
+    [
+      'right side, aspect ratio locked',
+      {
+        edgePosition: { x: 1, y: 0.5 } as EdgePosition,
+        drag: testDrag,
+        modifiers: shiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 50, top: 41, width: 265, height: 318 },
+      },
+    ],
+    [
+      'top left corner, center mode, aspect ratio locked',
+      {
+        edgePosition: { x: 0, y: 0 } as EdgePosition,
+        drag: testDrag,
+        modifiers: altShiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 65, top: 68, width: 220, height: 264 },
+      },
+    ],
+    [
+      'bottom left corner, center mode, aspect ratio locked',
+      {
+        edgePosition: { x: 0, y: 1 } as EdgePosition,
+        drag: testDrag,
+        modifiers: altShiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 29, top: 25, width: 292, height: 350 },
+      },
+    ],
+    [
+      'top right corner, center mode, aspect ratio locked',
+      {
+        edgePosition: { x: 1, y: 0 } as EdgePosition,
+        drag: testDrag,
+        modifiers: altShiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 35, top: 32, width: 280, height: 336 },
+      },
+    ],
+    [
+      'bottom right corner, center mode, aspect ratio locked',
+      {
+        edgePosition: { x: 1, y: 1 } as EdgePosition,
+        drag: testDrag,
+        modifiers: altShiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 29, top: 25, width: 292, height: 350 },
+      },
+    ],
+    [
+      'top side, center mode, aspect ratio locked',
+      {
+        edgePosition: { x: 0.5, y: 0 } as EdgePosition,
+        drag: testDrag,
+        modifiers: altShiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 71, top: 75, width: 208, height: 250 },
+      },
+    ],
+    [
+      'left side, center mode, aspect ratio locked',
+      {
+        edgePosition: { x: 0, y: 0.5 } as EdgePosition,
+        drag: testDrag,
+        modifiers: altShiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 65, top: 68, width: 220, height: 264 },
+      },
+    ],
+    [
+      'bottom side, center mode, aspect ratio locked',
+      {
+        edgePosition: { x: 0.5, y: 1 } as EdgePosition,
+        drag: testDrag,
+        modifiers: altShiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 29, top: 25, width: 292, height: 350 },
+      },
+    ],
+    [
+      'right side, center mode, aspect ratio locked',
+      {
+        edgePosition: { x: 1, y: 0.5 } as EdgePosition,
+        drag: testDrag,
+        modifiers: altShiftModifier,
+        bounding: testBounding,
+        draggedBounding: { left: 35, top: 32, width: 280, height: 336 },
       },
     ],
   ])(
@@ -381,10 +506,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        testDrag,
         shiftModifier,
         testMetadata,
       )
@@ -459,10 +581,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        testDrag,
         emptyModifiers,
         testMetadata,
       )
@@ -537,10 +656,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        testDrag,
         shiftModifier,
         testMetadata,
       )
@@ -615,10 +731,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        testDrag,
         emptyModifiers,
         testMetadata,
       )
@@ -693,10 +806,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        testDrag,
         shiftModifier,
         testMetadata,
       )
@@ -771,10 +881,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        testDrag,
         emptyModifiers,
         testMetadata,
       )
@@ -849,10 +956,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        testDrag,
         shiftModifier,
         testMetadata,
       )
@@ -936,10 +1040,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        testDrag,
         modifiers,
         testMetadata,
       )
@@ -1020,10 +1121,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        canvasPoint({
-          x: 15,
-          y: 25,
-        }),
+        testDrag,
         modifiers,
         testMetadata,
       )

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -83,338 +83,427 @@ const testMetadata: ElementInstanceMetadataMap = {
   } as ElementInstanceMetadata,
 }
 
-const testDrag = canvasPoint({
-  x: 15,
-  y: 25,
-})
-
-const testBounding = { left: 50, top: 50, width: 250, height: 300 }
-
 describe('Absolute Resize Bounding Box Strategy single select', () => {
   it.each([
     [
       'top left corner',
       {
         edgePosition: { x: 0, y: 0 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: emptyModifiers,
-        bounding: testBounding,
-        draggedBounding: { left: 65, top: 75, width: 235, height: 275 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 65, top: 75, width: 235, height: 275 },
       },
     ],
     [
       'bottom left corner',
       {
         edgePosition: { x: 0, y: 1 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: emptyModifiers,
-        bounding: testBounding,
-        draggedBounding: { left: 65, top: 50, width: 235, height: 325 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 65, top: 50, width: 235, height: 325 },
       },
     ],
     [
       'top right corner',
       {
         edgePosition: { x: 1, y: 0 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: emptyModifiers,
-        bounding: testBounding,
-        draggedBounding: { left: 50, top: 75, width: 265, height: 275 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 50, top: 75, width: 265, height: 275 },
       },
     ],
     [
       'bottom right corner',
       {
         edgePosition: { x: 1, y: 1 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: emptyModifiers,
-        bounding: testBounding,
-        draggedBounding: { left: 50, top: 50, width: 265, height: 325 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 50, top: 50, width: 265, height: 325 },
       },
     ],
     [
       'top side',
       {
         edgePosition: { x: 0.5, y: 0 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: emptyModifiers,
-        bounding: testBounding,
-        draggedBounding: { left: 50, top: 75, width: 250, height: 275 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 50, top: 75, width: 250, height: 275 },
       },
     ],
     [
       'left side',
       {
         edgePosition: { x: 0, y: 0.5 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: emptyModifiers,
-        bounding: testBounding,
-        draggedBounding: { left: 65, top: 50, width: 235, height: 300 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 65, top: 50, width: 235, height: 300 },
       },
     ],
     [
       'bottom side',
       {
         edgePosition: { x: 0.5, y: 1 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: emptyModifiers,
-        bounding: testBounding,
-        draggedBounding: { left: 50, top: 50, width: 250, height: 325 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 50, top: 50, width: 250, height: 325 },
       },
     ],
     [
       'right side',
       {
         edgePosition: { x: 1, y: 0.5 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: emptyModifiers,
-        bounding: testBounding,
-        draggedBounding: { left: 50, top: 50, width: 265, height: 300 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 50, top: 50, width: 265, height: 300 },
       },
     ],
     [
       'top left corner, center mode',
       {
         edgePosition: { x: 0, y: 0 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 65, top: 75, width: 220, height: 250 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 65, top: 75, width: 220, height: 250 },
       },
     ],
     [
       'bottom left corner, center mode',
       {
         edgePosition: { x: 0, y: 1 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 65, top: 25, width: 220, height: 350 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 65, top: 25, width: 220, height: 350 },
       },
     ],
     [
       'top right corner, center mode',
       {
         edgePosition: { x: 1, y: 0 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 35, top: 75, width: 280, height: 250 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 35, top: 75, width: 280, height: 250 },
       },
     ],
     [
       'bottom right corner, center mode',
       {
         edgePosition: { x: 1, y: 1 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 35, top: 25, width: 280, height: 350 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 35, top: 25, width: 280, height: 350 },
       },
     ],
     [
       'top side, center mode',
       {
         edgePosition: { x: 0.5, y: 0 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 50, top: 75, width: 250, height: 250 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 50, top: 75, width: 250, height: 250 },
       },
     ],
     [
       'left side, center mode',
       {
         edgePosition: { x: 0, y: 0.5 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 65, top: 50, width: 220, height: 300 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 65, top: 50, width: 220, height: 300 },
       },
     ],
     [
       'bottom side, center mode',
       {
         edgePosition: { x: 0.5, y: 1 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 50, top: 25, width: 250, height: 350 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 50, top: 25, width: 250, height: 350 },
       },
     ],
     [
       'right side, center mode',
       {
         edgePosition: { x: 1, y: 0.5 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 35, top: 50, width: 280, height: 300 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 35, top: 50, width: 280, height: 300 },
       },
     ],
     [
       'top left corner, aspect ratio locked',
       {
         edgePosition: { x: 0, y: 0 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: shiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 65, top: 68, width: 235, height: 282 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 65, top: 68, width: 235, height: 282 },
       },
     ],
     [
       'bottom left corner, aspect ratio locked',
       {
         edgePosition: { x: 0, y: 1 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: shiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 29, top: 50, width: 271, height: 325 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 29, top: 50, width: 271, height: 325 },
       },
     ],
     [
       'top right corner, aspect ratio locked',
       {
         edgePosition: { x: 1, y: 0 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: shiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 50, top: 32, width: 265, height: 318 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 50, top: 32, width: 265, height: 318 },
       },
     ],
     [
       'bottom right corner, aspect ratio locked',
       {
         edgePosition: { x: 1, y: 1 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: shiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 50, top: 50, width: 271, height: 325 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 50, top: 50, width: 271, height: 325 },
       },
     ],
     [
       'top side, aspect ratio locked',
       {
         edgePosition: { x: 0.5, y: 0 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: shiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 60, top: 75, width: 229, height: 275 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 60, top: 75, width: 229, height: 275 },
       },
     ],
     [
       'left side, aspect ratio locked',
       {
         edgePosition: { x: 0, y: 0.5 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: shiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 65, top: 59, width: 235, height: 282 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 65, top: 59, width: 235, height: 282 },
       },
     ],
     [
       'bottom side, aspect ratio locked',
       {
         edgePosition: { x: 0.5, y: 1 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: shiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 40, top: 50, width: 271, height: 325 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 40, top: 50, width: 271, height: 325 },
       },
     ],
     [
       'right side, aspect ratio locked',
       {
         edgePosition: { x: 1, y: 0.5 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: shiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 50, top: 41, width: 265, height: 318 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 50, top: 41, width: 265, height: 318 },
       },
     ],
     [
       'top left corner, center mode, aspect ratio locked',
       {
         edgePosition: { x: 0, y: 0 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altShiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 65, top: 68, width: 220, height: 264 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 65, top: 68, width: 220, height: 264 },
       },
     ],
     [
       'bottom left corner, center mode, aspect ratio locked',
       {
         edgePosition: { x: 0, y: 1 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altShiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 29, top: 25, width: 292, height: 350 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 29, top: 25, width: 292, height: 350 },
       },
     ],
     [
       'top right corner, center mode, aspect ratio locked',
       {
         edgePosition: { x: 1, y: 0 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altShiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 35, top: 32, width: 280, height: 336 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 35, top: 32, width: 280, height: 336 },
       },
     ],
     [
       'bottom right corner, center mode, aspect ratio locked',
       {
         edgePosition: { x: 1, y: 1 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altShiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 29, top: 25, width: 292, height: 350 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 29, top: 25, width: 292, height: 350 },
       },
     ],
     [
       'top side, center mode, aspect ratio locked',
       {
         edgePosition: { x: 0.5, y: 0 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altShiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 71, top: 75, width: 208, height: 250 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 71, top: 75, width: 208, height: 250 },
       },
     ],
     [
       'left side, center mode, aspect ratio locked',
       {
         edgePosition: { x: 0, y: 0.5 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altShiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 65, top: 68, width: 220, height: 264 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 65, top: 68, width: 220, height: 264 },
       },
     ],
     [
       'bottom side, center mode, aspect ratio locked',
       {
         edgePosition: { x: 0.5, y: 1 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altShiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 29, top: 25, width: 292, height: 350 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 29, top: 25, width: 292, height: 350 },
       },
     ],
     [
       'right side, center mode, aspect ratio locked',
       {
         edgePosition: { x: 1, y: 0.5 } as EdgePosition,
-        drag: testDrag,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers: altShiftModifier,
-        bounding: testBounding,
-        draggedBounding: { left: 35, top: 32, width: 280, height: 336 },
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 35, top: 32, width: 280, height: 336 },
       },
     ],
   ])(
     `Single select absolute resize: %s`,
-    async (_, { edgePosition, drag, modifiers, bounding, draggedBounding }) => {
+    async (_, { edgePosition, drag, modifiers, bounding, expectedBounding }) => {
       const snippet = `
         <View style={{ ...(props.style || {}) }} data-uid='aaa'>
           <View
@@ -455,7 +544,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         makeTestProjectCodeWithSnippet(`
         <View style={{ ...(props.style || {}) }} data-uid='aaa'>
           <View
-            style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: ${draggedBounding.left}, top: ${draggedBounding.top}, width: ${draggedBounding.width}, height: ${draggedBounding.height} }}
+            style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: ${expectedBounding.left}, top: ${expectedBounding.top}, width: ${expectedBounding.width}, height: ${expectedBounding.height} }}
             data-uid='bbb'
           />
         </View>
@@ -506,7 +595,10 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        testDrag,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         emptyModifiers,
         testMetadata,
       )
@@ -581,7 +673,10 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        testDrag,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         shiftModifier,
         testMetadata,
       )
@@ -656,7 +751,10 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        testDrag,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         emptyModifiers,
         testMetadata,
       )
@@ -731,7 +829,10 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        testDrag,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         shiftModifier,
         testMetadata,
       )
@@ -806,7 +907,10 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        testDrag,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         emptyModifiers,
         testMetadata,
       )
@@ -881,7 +985,10 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        testDrag,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         shiftModifier,
         testMetadata,
       )
@@ -956,7 +1063,10 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        testDrag,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         emptyModifiers,
         testMetadata,
       )
@@ -1031,7 +1141,10 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        testDrag,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         shiftModifier,
         testMetadata,
       )
@@ -1115,7 +1228,10 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        testDrag,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers,
         testMetadata,
       )
@@ -1196,7 +1312,10 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         snippet,
         selectedElements,
         edgePosition,
-        testDrag,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
         modifiers,
         testMetadata,
       )

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -464,6 +464,81 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
     },
   )
   describe('Absolute Resize Bounding Box Strategy multi select', () => {
+    it('works with element resized from TL corner', async () => {
+      const edgePosition: EdgePosition = { x: 0, y: 0 }
+      const snippet = `
+    <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <div
+        style={{ 
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 50,
+          left: 30,
+          width: 100,
+          height: 120,
+         }}
+        data-uid='bbb'
+      />
+      <div
+        style={{ 
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 40,
+          left: 90,
+          bottom: 250,
+          right: 210
+         }}
+        data-uid='ccc'
+      />
+    </div>
+    `
+      const selectedElements = [
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'bbb'],
+        ]),
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'ccc'],
+        ]),
+      ]
+      const editorAfterStrategy = multiselectResizeElements(
+        snippet,
+        selectedElements,
+        edgePosition,
+        testDrag,
+        emptyModifiers,
+        testMetadata,
+      )
+      expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+            <div
+              style={{ 
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 73,
+                left: 45,
+                width: 91,
+                height: 97,
+              }}
+              data-uid='bbb'
+            />
+            <div
+              style={{ 
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 65,
+                left: 99,
+                bottom: 246,
+                right: 210
+              }}
+              data-uid='ccc'
+            />
+          </div>`,
+        ),
+      )
+    })
     it('works with element aspect ratio locked resized from TL corner', async () => {
       const edgePosition: EdgePosition = { x: 0, y: 0 }
       const snippet = `

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -2,11 +2,12 @@ import { left } from '../../../core/shared/either'
 import { elementPath, fromString } from '../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
+  ElementInstanceMetadataMap,
   SpecialSizeMeasurements,
 } from '../../../core/shared/element-template'
-import { canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
+import { CanvasPoint, canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import { emptyModifiers, Modifiers, shiftModifier } from '../../../utils/modifiers'
+import { altModifier, emptyModifiers, Modifiers, shiftModifier } from '../../../utils/modifiers'
 import { EditorState } from '../../editor/store/editor-state'
 import { EdgePosition } from '../canvas-types'
 import { foldAndApplyCommands } from '../commands/commands'
@@ -24,7 +25,9 @@ function multiselectResizeElements(
   snippet: string,
   targetElements: Array<ElementPath>,
   edgePosition: EdgePosition,
-  modifiers: Modifiers = emptyModifiers,
+  drag: CanvasPoint,
+  modifiers: Modifiers,
+  metadata: ElementInstanceMetadataMap,
 ): EditorState {
   const initialEditor = getEditorStateWithSelectedViews(
     makeTestProjectCodeWithSnippet(snippet),
@@ -35,7 +38,7 @@ function multiselectResizeElements(
     null as any, // the strategy does not use this
     modifiers,
     { type: 'RESIZE_HANDLE', edgePosition: edgePosition },
-    canvasPoint({ x: 15, y: 25 }),
+    drag,
   )
 
   const strategyResult = absoluteResizeBoundingBoxStrategy.apply(
@@ -48,754 +51,1010 @@ function multiselectResizeElements(
       accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
-      startingMetadata: {
-        'scene-aaa/app-entity:aaa/bbb': {
-          elementPath: fromString('scene-aaa/app-entity:aaa/bbb'),
-          element: left('div'),
-          specialSizeMeasurements: {
-            immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
-          } as SpecialSizeMeasurements,
-          globalFrame: { height: 120, width: 100, x: 30, y: 50 },
-        } as ElementInstanceMetadata,
-        'scene-aaa/app-entity:aaa/ccc': {
-          elementPath: fromString('scene-aaa/app-entity:aaa/ccc'),
-          element: left('div'),
-          specialSizeMeasurements: {
-            immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
-          } as SpecialSizeMeasurements,
-          globalFrame: { height: 110, width: 100, x: 90, y: 40 },
-        } as ElementInstanceMetadata,
-      },
+      startingMetadata: metadata,
     } as StrategyState,
   )
   return foldAndApplyCommands(initialEditor, initialEditor, [], [], strategyResult, 'permanent')
     .editorState
 }
 
-describe('Absolute Resize Bounding Box Strategy', () => {
-  it('works with element resized from TL corner', async () => {
-    const edgePosition: EdgePosition = { x: 0, y: 0 }
-    const snippet = `
-  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 50,
-        left: 30,
-        width: 100,
-        height: 120,
-       }}
-      data-uid='bbb'
-    />
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 40,
-        left: 90,
-        bottom: 250,
-        right: 210
-       }}
-      data-uid='ccc'
-    />
-  </div>
-  `
-    const selectedElements = [
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'bbb'],
-      ]),
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'ccc'],
-      ]),
-    ]
-    const editorAfterStrategy = multiselectResizeElements(snippet, selectedElements, edgePosition)
-    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
-      makeTestProjectCodeWithSnippet(
-        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 73,
-              left: 45,
-              width: 91,
-              height: 97,
-            }}
-            data-uid='bbb'
-          />
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 65,
-              left: 99,
-              bottom: 246,
-              right: 210
-            }}
-            data-uid='ccc'
-          />
-        </div>`,
-      ),
-    )
-  })
-  it('works with element aspect ratio locked resized from TL corner', async () => {
-    const edgePosition: EdgePosition = { x: 0, y: 0 }
-    const snippet = `
-  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 50,
-        left: 30,
-        width: 100,
-        height: 120,
-       }}
-      data-uid='bbb'
-    />
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 40,
-        left: 90,
-        bottom: 250,
-        right: 210
-       }}
-      data-uid='ccc'
-    />
-  </div>
-  `
-    const selectedElements = [
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'bbb'],
-      ]),
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'ccc'],
-      ]),
-    ]
-    const editorAfterStrategy = multiselectResizeElements(
-      snippet,
-      selectedElements,
-      edgePosition,
-      shiftModifier,
-    )
-    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
-      makeTestProjectCodeWithSnippet(
-        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 61,
-              left: 45,
-              width: 91,
-              height: 109,
-            }}
-            data-uid='bbb'
-          />
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 52,
-              left: 99,
-              bottom: 248,
-              right: 210
-            }}
-            data-uid='ccc'
-          />
-        </div>`,
-      ),
-    )
-  })
-  it('works with element resized from BR corner', async () => {
-    const edgePosition: EdgePosition = { x: 1, y: 1 }
-    const snippet = `
-  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 50,
-        left: 30,
-        width: 100,
-        height: 120,
-       }}
-      data-uid='bbb'
-    />
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 40,
-        left: 90,
-        bottom: 250,
-        right: 210
-       }}
-      data-uid='ccc'
-    />
-  </div>
-  `
-    const selectedElements = [
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'bbb'],
-      ]),
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'ccc'],
-      ]),
-    ]
-    const editorAfterStrategy = multiselectResizeElements(snippet, selectedElements, edgePosition)
-    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
-      makeTestProjectCodeWithSnippet(
-        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 52,
-              left: 30,
-              width: 109,
-              height: 143,
-            }}
-            data-uid='bbb'
-          />
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 40,
-              left: 96,
-              bottom: 229,
-              right: 195
-            }}
-            data-uid='ccc'
-          />
-        </div>`,
-      ),
-    )
-  })
-  it('works with element aspect ratio locked resized from BR corner', async () => {
-    const edgePosition: EdgePosition = { x: 1, y: 1 }
-    const snippet = `
-  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 50,
-        left: 30,
-        width: 100,
-        height: 120,
-       }}
-      data-uid='bbb'
-    />
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 40,
-        left: 90,
-        bottom: 250,
-        right: 210
-       }}
-      data-uid='ccc'
-    />
-  </div>
-  `
-    const selectedElements = [
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'bbb'],
-      ]),
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'ccc'],
-      ]),
-    ]
-    const editorAfterStrategy = multiselectResizeElements(
-      snippet,
-      selectedElements,
-      edgePosition,
-      shiftModifier,
-    )
-    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
-      makeTestProjectCodeWithSnippet(
-        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 52,
-              left: 30,
-              width: 119,
-              height: 143,
-            }}
-            data-uid='bbb'
-          />
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 40,
-              left: 102,
-              bottom: 229,
-              right: 179
-            }}
-            data-uid='ccc'
-          />
-        </div>`,
-      ),
-    )
-  })
-  it('works with element resized from RIGHT edge', async () => {
-    const edgePosition: EdgePosition = { x: 1, y: 0.5 }
-    const snippet = `
-  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 50,
-        left: 30,
-        width: 100,
-        height: 120,
-       }}
-      data-uid='bbb'
-    />
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 40,
-        left: 90,
-        bottom: 250,
-        right: 210
-       }}
-      data-uid='ccc'
-    />
-  </div>
-  `
-    const selectedElements = [
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'bbb'],
-      ]),
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'ccc'],
-      ]),
-    ]
-    const editorAfterStrategy = multiselectResizeElements(snippet, selectedElements, edgePosition)
-    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
-      makeTestProjectCodeWithSnippet(
-        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 50,
-              left: 30,
-              width: 109,
-              height: 120,
-            }}
-            data-uid='bbb'
-          />
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 40,
-              left: 96,
-              bottom: 250,
-              right: 195
-            }}
-            data-uid='ccc'
-          />
-        </div>`,
-      ),
-    )
-  })
-  it('works with element aspect ratio locked resized from RIGHT edge', async () => {
-    const edgePosition: EdgePosition = { x: 1, y: 0.5 }
-    const snippet = `
-  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 50,
-        left: 30,
-        width: 100,
-        height: 120,
-       }}
-      data-uid='bbb'
-    />
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 40,
-        left: 90,
-        bottom: 250,
-        right: 210
-       }}
-      data-uid='ccc'
-    />
-  </div>
-  `
-    const selectedElements = [
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'bbb'],
-      ]),
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'ccc'],
-      ]),
-    ]
-    const editorAfterStrategy = multiselectResizeElements(
-      snippet,
-      selectedElements,
-      edgePosition,
-      shiftModifier,
-    )
-    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
-      makeTestProjectCodeWithSnippet(
-        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 45,
-              left: 30,
-              width: 109,
-              height: 131,
-            }}
-            data-uid='bbb'
-          />
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 34,
-              left: 96,
-              bottom: 246,
-              right: 195
-            }}
-            data-uid='ccc'
-          />
-        </div>`,
-      ),
-    )
-  })
-  it('works with element resized from TOP edge', async () => {
-    const edgePosition: EdgePosition = { x: 0.5, y: 0 }
-    const snippet = `
-  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 50,
-        left: 30,
-        width: 100,
-        height: 120,
-       }}
-      data-uid='bbb'
-    />
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 40,
-        left: 90,
-        bottom: 250,
-        right: 210
-       }}
-      data-uid='ccc'
-    />
-  </div>
-  `
-    const selectedElements = [
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'bbb'],
-      ]),
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'ccc'],
-      ]),
-    ]
-    const editorAfterStrategy = multiselectResizeElements(snippet, selectedElements, edgePosition)
-    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
-      makeTestProjectCodeWithSnippet(
-        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 73,
-              left: 30,
-              width: 100,
-              height: 97,
-            }}
-            data-uid='bbb'
-          />
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 65,
-              left: 90,
-              bottom: 246,
-              right: 210
-            }}
-            data-uid='ccc'
-          />
-        </div>`,
-      ),
-    )
-  })
-  it('works with element aspect ratio locked resized from TOP edge', async () => {
-    const edgePosition: EdgePosition = { x: 0.5, y: 0 }
-    const snippet = `
-  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 50,
-        left: 30,
-        width: 100,
-        height: 120,
-       }}
-      data-uid='bbb'
-    />
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 40,
-        left: 90,
-        bottom: 250,
-        right: 210
-       }}
-      data-uid='ccc'
-    />
-  </div>
-  `
-    const selectedElements = [
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'bbb'],
-      ]),
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'ccc'],
-      ]),
-    ]
-    const editorAfterStrategy = multiselectResizeElements(
-      snippet,
-      selectedElements,
-      edgePosition,
-      shiftModifier,
-    )
-    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
-      makeTestProjectCodeWithSnippet(
-        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 73,
-              left: 45,
-              width: 81,
-              height: 97,
-            }}
-            data-uid='bbb'
-          />
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 65,
-              left: 94,
-              bottom: 246,
-              right: 225
-            }}
-            data-uid='ccc'
-          />
-        </div>`,
-      ),
-    )
-  })
-})
+const testMetadata: ElementInstanceMetadataMap = {
+  'scene-aaa/app-entity:aaa/bbb': {
+    elementPath: fromString('scene-aaa/app-entity:aaa/bbb'),
+    element: left('div'),
+    specialSizeMeasurements: {
+      immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+    } as SpecialSizeMeasurements,
+    globalFrame: { height: 120, width: 100, x: 30, y: 50 },
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity:aaa/ccc': {
+    elementPath: fromString('scene-aaa/app-entity:aaa/ccc'),
+    element: left('div'),
+    specialSizeMeasurements: {
+      immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+    } as SpecialSizeMeasurements,
+    globalFrame: { height: 110, width: 100, x: 90, y: 40 },
+  } as ElementInstanceMetadata,
+}
 
-describe('Center based resize strategy', () => {
-  it('works with element resized from TL corner', async () => {
-    const edgePosition: EdgePosition = { x: 0, y: 0 }
-    const snippet = `
-  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 50,
-        left: 30,
-        width: 100,
-        height: 120,
-       }}
-      data-uid='bbb'
-    />
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 40,
-        left: 90,
-        bottom: 250,
-        right: 210
-       }}
-      data-uid='ccc'
-    />
-  </div>
-  `
-    const selectedElements = [
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'bbb'],
-      ]),
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'ccc'],
-      ]),
-    ]
-    const modifiers: Modifiers = {
-      alt: true,
-      cmd: false,
-      ctrl: false,
-      shift: false,
-    }
-    const editorAfterStrategy = multiselectResizeElements(
-      snippet,
-      selectedElements,
-      edgePosition,
-      modifiers,
-    )
-    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
-      makeTestProjectCodeWithSnippet(
-        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 71,
-              left: 45,
-              width: 81,
-              height: 74,
-            }}
+describe('Absolute Resize Bounding Box Strategy single select', () => {
+  it.each([
+    [
+      'top left corner',
+      {
+        edgePosition: { x: 0, y: 0 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: emptyModifiers,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 65, top: 75, width: 235, height: 275 },
+      },
+    ],
+    [
+      'bottom left corner',
+      {
+        edgePosition: { x: 0, y: 1 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: emptyModifiers,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 65, top: 50, width: 235, height: 325 },
+      },
+    ],
+    [
+      'top right corner',
+      {
+        edgePosition: { x: 1, y: 0 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: emptyModifiers,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 50, top: 75, width: 265, height: 275 },
+      },
+    ],
+    [
+      'bottom right corner',
+      {
+        edgePosition: { x: 1, y: 1 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: emptyModifiers,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 50, top: 50, width: 265, height: 325 },
+      },
+    ],
+    [
+      'top side',
+      {
+        edgePosition: { x: 0.5, y: 0 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: emptyModifiers,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 50, top: 75, width: 250, height: 275 },
+      },
+    ],
+    [
+      'left side',
+      {
+        edgePosition: { x: 0, y: 0.5 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: emptyModifiers,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 65, top: 50, width: 235, height: 300 },
+      },
+    ],
+    [
+      'bottom side',
+      {
+        edgePosition: { x: 0.5, y: 1 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: emptyModifiers,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 50, top: 50, width: 250, height: 325 },
+      },
+    ],
+    [
+      'right side',
+      {
+        edgePosition: { x: 1, y: 0.5 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: emptyModifiers,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 50, top: 50, width: 265, height: 300 },
+      },
+    ],
+    [
+      'top left corner, center mode',
+      {
+        edgePosition: { x: 0, y: 0 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: altModifier,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 65, top: 75, width: 220, height: 250 },
+      },
+    ],
+    [
+      'bottom left corner, center mode',
+      {
+        edgePosition: { x: 0, y: 1 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: altModifier,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 65, top: 25, width: 220, height: 350 },
+      },
+    ],
+    [
+      'top right corner, center mode',
+      {
+        edgePosition: { x: 1, y: 0 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: altModifier,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 35, top: 75, width: 280, height: 250 },
+      },
+    ],
+    [
+      'bottom right corner, center mode',
+      {
+        edgePosition: { x: 1, y: 1 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: altModifier,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 35, top: 25, width: 280, height: 350 },
+      },
+    ],
+    [
+      'top side, center mode',
+      {
+        edgePosition: { x: 0.5, y: 0 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: altModifier,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 50, top: 75, width: 250, height: 250 },
+      },
+    ],
+    [
+      'left side, center mode',
+      {
+        edgePosition: { x: 0, y: 0.5 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: altModifier,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 65, top: 50, width: 220, height: 300 },
+      },
+    ],
+    [
+      'bottom side, center mode',
+      {
+        edgePosition: { x: 0.5, y: 1 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: altModifier,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 50, top: 25, width: 250, height: 350 },
+      },
+    ],
+    [
+      'right side, center mode',
+      {
+        edgePosition: { x: 1, y: 0.5 } as EdgePosition,
+        drag: canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers: altModifier,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        draggedBounding: { left: 35, top: 50, width: 280, height: 300 },
+      },
+    ],
+  ])(
+    `Single select absolute resize: %s`,
+    async (_, { edgePosition, drag, modifiers, bounding, draggedBounding }) => {
+      const snippet = `
+        <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+          <View
+            style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: ${bounding.left}, top: ${bounding.top}, width: ${bounding.width}, height: ${bounding.height} }}
             data-uid='bbb'
           />
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 65,
-              left: 94,
-              bottom: 267,
-              right: 225
-            }}
-            data-uid='ccc'
+        </View>
+      `
+      const selectedElements = [
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'bbb'],
+        ]),
+      ]
+      const editorAfterStrategy = multiselectResizeElements(
+        snippet,
+        selectedElements,
+        edgePosition,
+        drag,
+        modifiers,
+        {
+          'scene-aaa/app-entity:aaa/bbb': {
+            elementPath: fromString('scene-aaa/app-entity:aaa/bbb'),
+            element: left('div'),
+            specialSizeMeasurements: {
+              immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            } as SpecialSizeMeasurements,
+            globalFrame: {
+              height: bounding.height,
+              width: bounding.width,
+              x: bounding.left,
+              y: bounding.top,
+            },
+          } as ElementInstanceMetadata,
+        },
+      )
+      expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+        makeTestProjectCodeWithSnippet(`
+        <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+          <View
+            style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: ${draggedBounding.left}, top: ${draggedBounding.top}, width: ${draggedBounding.width}, height: ${draggedBounding.height} }}
+            data-uid='bbb'
           />
-        </div>`,
-      ),
-    )
+        </View>
+      `),
+      )
+    },
+  )
+  describe('Absolute Resize Bounding Box Strategy multi select', () => {
+    it('works with element aspect ratio locked resized from TL corner', async () => {
+      const edgePosition: EdgePosition = { x: 0, y: 0 }
+      const snippet = `
+    <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 50,
+          left: 30,
+          width: 100,
+          height: 120,
+         }}
+        data-uid='bbb'
+      />
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 40,
+          left: 90,
+          bottom: 250,
+          right: 210
+         }}
+        data-uid='ccc'
+      />
+    </div>
+    `
+      const selectedElements = [
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'bbb'],
+        ]),
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'ccc'],
+        ]),
+      ]
+      const editorAfterStrategy = multiselectResizeElements(
+        snippet,
+        selectedElements,
+        edgePosition,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        shiftModifier,
+        testMetadata,
+      )
+      expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 61,
+                left: 45,
+                width: 91,
+                height: 109,
+              }}
+              data-uid='bbb'
+            />
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 52,
+                left: 99,
+                bottom: 248,
+                right: 210
+              }}
+              data-uid='ccc'
+            />
+          </div>`,
+        ),
+      )
+    })
+    it('works with element resized from BR corner', async () => {
+      const edgePosition: EdgePosition = { x: 1, y: 1 }
+      const snippet = `
+    <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 50,
+          left: 30,
+          width: 100,
+          height: 120,
+         }}
+        data-uid='bbb'
+      />
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 40,
+          left: 90,
+          bottom: 250,
+          right: 210
+         }}
+        data-uid='ccc'
+      />
+    </div>
+    `
+      const selectedElements = [
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'bbb'],
+        ]),
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'ccc'],
+        ]),
+      ]
+      const editorAfterStrategy = multiselectResizeElements(
+        snippet,
+        selectedElements,
+        edgePosition,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        emptyModifiers,
+        testMetadata,
+      )
+      expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 52,
+                left: 30,
+                width: 109,
+                height: 143,
+              }}
+              data-uid='bbb'
+            />
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 40,
+                left: 96,
+                bottom: 229,
+                right: 195
+              }}
+              data-uid='ccc'
+            />
+          </div>`,
+        ),
+      )
+    })
+    it('works with element aspect ratio locked resized from BR corner', async () => {
+      const edgePosition: EdgePosition = { x: 1, y: 1 }
+      const snippet = `
+    <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 50,
+          left: 30,
+          width: 100,
+          height: 120,
+         }}
+        data-uid='bbb'
+      />
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 40,
+          left: 90,
+          bottom: 250,
+          right: 210
+         }}
+        data-uid='ccc'
+      />
+    </div>
+    `
+      const selectedElements = [
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'bbb'],
+        ]),
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'ccc'],
+        ]),
+      ]
+      const editorAfterStrategy = multiselectResizeElements(
+        snippet,
+        selectedElements,
+        edgePosition,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        shiftModifier,
+        testMetadata,
+      )
+      expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 52,
+                left: 30,
+                width: 119,
+                height: 143,
+              }}
+              data-uid='bbb'
+            />
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 40,
+                left: 102,
+                bottom: 229,
+                right: 179
+              }}
+              data-uid='ccc'
+            />
+          </div>`,
+        ),
+      )
+    })
+    it('works with element resized from RIGHT edge', async () => {
+      const edgePosition: EdgePosition = { x: 1, y: 0.5 }
+      const snippet = `
+    <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 50,
+          left: 30,
+          width: 100,
+          height: 120,
+         }}
+        data-uid='bbb'
+      />
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 40,
+          left: 90,
+          bottom: 250,
+          right: 210
+         }}
+        data-uid='ccc'
+      />
+    </div>
+    `
+      const selectedElements = [
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'bbb'],
+        ]),
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'ccc'],
+        ]),
+      ]
+      const editorAfterStrategy = multiselectResizeElements(
+        snippet,
+        selectedElements,
+        edgePosition,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        emptyModifiers,
+        testMetadata,
+      )
+      expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 50,
+                left: 30,
+                width: 109,
+                height: 120,
+              }}
+              data-uid='bbb'
+            />
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 40,
+                left: 96,
+                bottom: 250,
+                right: 195
+              }}
+              data-uid='ccc'
+            />
+          </div>`,
+        ),
+      )
+    })
+    it('works with element aspect ratio locked resized from RIGHT edge', async () => {
+      const edgePosition: EdgePosition = { x: 1, y: 0.5 }
+      const snippet = `
+    <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 50,
+          left: 30,
+          width: 100,
+          height: 120,
+         }}
+        data-uid='bbb'
+      />
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 40,
+          left: 90,
+          bottom: 250,
+          right: 210
+         }}
+        data-uid='ccc'
+      />
+    </div>
+    `
+      const selectedElements = [
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'bbb'],
+        ]),
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'ccc'],
+        ]),
+      ]
+      const editorAfterStrategy = multiselectResizeElements(
+        snippet,
+        selectedElements,
+        edgePosition,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        shiftModifier,
+        testMetadata,
+      )
+      expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 45,
+                left: 30,
+                width: 109,
+                height: 131,
+              }}
+              data-uid='bbb'
+            />
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 34,
+                left: 96,
+                bottom: 246,
+                right: 195
+              }}
+              data-uid='ccc'
+            />
+          </div>`,
+        ),
+      )
+    })
+    it('works with element resized from TOP edge', async () => {
+      const edgePosition: EdgePosition = { x: 0.5, y: 0 }
+      const snippet = `
+    <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 50,
+          left: 30,
+          width: 100,
+          height: 120,
+         }}
+        data-uid='bbb'
+      />
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 40,
+          left: 90,
+          bottom: 250,
+          right: 210
+         }}
+        data-uid='ccc'
+      />
+    </div>
+    `
+      const selectedElements = [
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'bbb'],
+        ]),
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'ccc'],
+        ]),
+      ]
+      const editorAfterStrategy = multiselectResizeElements(
+        snippet,
+        selectedElements,
+        edgePosition,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        emptyModifiers,
+        testMetadata,
+      )
+      expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 73,
+                left: 30,
+                width: 100,
+                height: 97,
+              }}
+              data-uid='bbb'
+            />
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 65,
+                left: 90,
+                bottom: 246,
+                right: 210
+              }}
+              data-uid='ccc'
+            />
+          </div>`,
+        ),
+      )
+    })
+    it('works with element aspect ratio locked resized from TOP edge', async () => {
+      const edgePosition: EdgePosition = { x: 0.5, y: 0 }
+      const snippet = `
+    <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 50,
+          left: 30,
+          width: 100,
+          height: 120,
+         }}
+        data-uid='bbb'
+      />
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 40,
+          left: 90,
+          bottom: 250,
+          right: 210
+         }}
+        data-uid='ccc'
+      />
+    </div>
+    `
+      const selectedElements = [
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'bbb'],
+        ]),
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'ccc'],
+        ]),
+      ]
+      const editorAfterStrategy = multiselectResizeElements(
+        snippet,
+        selectedElements,
+        edgePosition,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        shiftModifier,
+        testMetadata,
+      )
+      expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 73,
+                left: 45,
+                width: 81,
+                height: 97,
+              }}
+              data-uid='bbb'
+            />
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 65,
+                left: 94,
+                bottom: 246,
+                right: 225
+              }}
+              data-uid='ccc'
+            />
+          </div>`,
+        ),
+      )
+    })
   })
-  it('works with element resized from Bottom edge', async () => {
-    const edgePosition: EdgePosition = { x: 0.5, y: 1 }
-    const snippet = `
-  <div style={{ ...(props.style || {}) }} data-uid='aaa'>
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 50,
-        left: 30,
-        width: 100,
-        height: 120,
-       }}
-      data-uid='bbb'
-    />
-    <div
-      style={{ 
-        backgroundColor: '#0091FFAA',
-        position: 'absolute',
-        top: 40,
-        left: 90,
-        bottom: 250,
-        right: 210
-       }}
-      data-uid='ccc'
-    />
-  </div>
-  `
-    const selectedElements = [
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'bbb'],
-      ]),
-      elementPath([
-        ['scene-aaa', 'app-entity'],
-        ['aaa', 'ccc'],
-      ]),
-    ]
-    const modifiers: Modifiers = {
-      alt: true,
-      cmd: false,
-      ctrl: false,
-      shift: false,
-    }
-    const editorAfterStrategy = multiselectResizeElements(
-      snippet,
-      selectedElements,
-      edgePosition,
-      modifiers,
-    )
-    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
-      makeTestProjectCodeWithSnippet(
-        `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 29,
-              left: 30,
-              width: 100,
-              height: 166,
-            }}
-            data-uid='bbb'
-          />
-          <div
-            style={{ 
-              backgroundColor: '#0091FFAA',
-              position: 'absolute',
-              top: 15,
-              left: 90,
-              bottom: 233,
-              right: 210
-            }}
-            data-uid='ccc'
-          />
-        </div>`,
-      ),
-    )
+
+  describe('Center based resize strategy', () => {
+    it('works with element resized from TL corner', async () => {
+      const edgePosition: EdgePosition = { x: 0, y: 0 }
+      const snippet = `
+    <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 50,
+          left: 30,
+          width: 100,
+          height: 120,
+         }}
+        data-uid='bbb'
+      />
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 40,
+          left: 90,
+          bottom: 250,
+          right: 210
+         }}
+        data-uid='ccc'
+      />
+    </div>
+    `
+      const selectedElements = [
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'bbb'],
+        ]),
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'ccc'],
+        ]),
+      ]
+      const modifiers: Modifiers = {
+        alt: true,
+        cmd: false,
+        ctrl: false,
+        shift: false,
+      }
+      const editorAfterStrategy = multiselectResizeElements(
+        snippet,
+        selectedElements,
+        edgePosition,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers,
+        testMetadata,
+      )
+      expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 71,
+                left: 45,
+                width: 81,
+                height: 74,
+              }}
+              data-uid='bbb'
+            />
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 65,
+                left: 94,
+                bottom: 267,
+                right: 225
+              }}
+              data-uid='ccc'
+            />
+          </div>`,
+        ),
+      )
+    })
+    it('works with element resized from Bottom edge', async () => {
+      const edgePosition: EdgePosition = { x: 0.5, y: 1 }
+      const snippet = `
+    <div style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 50,
+          left: 30,
+          width: 100,
+          height: 120,
+         }}
+        data-uid='bbb'
+      />
+      <div
+        style={{
+          backgroundColor: '#0091FFAA',
+          position: 'absolute',
+          top: 40,
+          left: 90,
+          bottom: 250,
+          right: 210
+         }}
+        data-uid='ccc'
+      />
+    </div>
+    `
+      const selectedElements = [
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'bbb'],
+        ]),
+        elementPath([
+          ['scene-aaa', 'app-entity'],
+          ['aaa', 'ccc'],
+        ]),
+      ]
+      const modifiers: Modifiers = {
+        alt: true,
+        cmd: false,
+        ctrl: false,
+        shift: false,
+      }
+      const editorAfterStrategy = multiselectResizeElements(
+        snippet,
+        selectedElements,
+        edgePosition,
+        canvasPoint({
+          x: 15,
+          y: 25,
+        }),
+        modifiers,
+        testMetadata,
+      )
+      expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+        makeTestProjectCodeWithSnippet(
+          `<div style={{ ...(props.style || {}) }} data-uid='aaa'>
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 29,
+                left: 30,
+                width: 100,
+                height: 166,
+              }}
+              data-uid='bbb'
+            />
+            <div
+              style={{
+                backgroundColor: '#0091FFAA',
+                position: 'absolute',
+                top: 15,
+                left: 90,
+                bottom: 233,
+                right: 210
+              }}
+              data-uid='ccc'
+            />
+          </div>`,
+        ),
+      )
+    })
   })
 })

--- a/editor/src/utils/modifiers.ts
+++ b/editor/src/utils/modifiers.ts
@@ -42,6 +42,13 @@ export const shiftCmdModifier: Modifiers = {
   shift: true,
 }
 
+export const altShiftModifier: Modifiers = {
+  alt: true,
+  cmd: false,
+  ctrl: false,
+  shift: true,
+}
+
 export const Modifier = {
   modifiersForKeyboardEvent: function (event: KeyboardEvent): Modifiers {
     let result: Modifiers = { ...Modifier.modifiersForEvent(event) }

--- a/editor/src/utils/modifiers.ts
+++ b/editor/src/utils/modifiers.ts
@@ -28,6 +28,13 @@ export const cmdModifier: Modifiers = {
   shift: false,
 }
 
+export const altModifier: Modifiers = {
+  alt: true,
+  cmd: false,
+  ctrl: false,
+  shift: false,
+}
+
 export const shiftCmdModifier: Modifiers = {
   alt: false,
   cmd: true,


### PR DESCRIPTION
I added parametrized tests for single select bounding box resize.

In my opinion these are more compact and way easier to read, they also cover the full functionality (all corners and sides with all modifier combinations).