### PR TITLE
Added a small project for the absolute move test.

### DIFF
--- a/editor/src/components/menubar/menubar.tsx
+++ b/editor/src/components/menubar/menubar.tsx
@@ -10,7 +10,8 @@ import {
   useTriggerSelectionPerformanceTest,
   useTriggerRegularHighlightPerformanceTest,
   useTriggerAllElementsHighlightPerformanceTest,
-  useTriggerAbsoluteMovePerformanceTest,
+  useTriggerAbsoluteMoveLargePerformanceTest,
+  useTriggerAbsoluteMoveSmallPerformanceTest,
 } from '../../core/model/performance-scripts'
 import { useReParseOpenProjectFile } from '../../core/model/project-file-helper-hooks'
 import { shareURLForProject } from '../../core/shared/utils'
@@ -192,7 +193,8 @@ export const Menubar = React.memo(() => {
   const onTriggerRegularHighlightTest = useTriggerRegularHighlightPerformanceTest()
   const onTriggerAllElementsHighlightTest = useTriggerAllElementsHighlightPerformanceTest()
   const onTriggerSelectionTest = useTriggerSelectionPerformanceTest()
-  const onTriggerAbsoluteMoveTest = useTriggerAbsoluteMovePerformanceTest()
+  const onTriggerAbsoluteMoveLargeTest = useTriggerAbsoluteMoveLargePerformanceTest()
+  const onTriggerAbsoluteMoveSmallTest = useTriggerAbsoluteMoveSmallPerformanceTest()
 
   const previewURL =
     projectId == null ? '' : shareURLForProject(FLOATING_PREVIEW_BASE_URL, projectId, projectName)
@@ -369,7 +371,10 @@ export const Menubar = React.memo(() => {
             <a onClick={onTriggerSelectionTest}>P E</a>
           </Tile>
           <Tile style={{ marginTop: 12, marginBottom: 12 }} size='large'>
-            <a onClick={onTriggerAbsoluteMoveTest}>PAM</a>
+            <a onClick={onTriggerAbsoluteMoveLargeTest}>PAML</a>
+          </Tile>
+          <Tile style={{ marginTop: 12, marginBottom: 12 }} size='large'>
+            <a onClick={onTriggerAbsoluteMoveSmallTest}>PAMS</a>
           </Tile>
         </React.Fragment>
       ) : null}

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -50,6 +50,7 @@ import { BuiltInDependencies } from '../es-modules/package-manager/built-in-depe
 import { LargeProjectContents } from '../../test-cases/large-project'
 import { VSCodeLoadingScreenID } from '../../components/code-editor/vscode-editor-loading-screen'
 import { v4 as UUID } from 'uuid'
+import { SmallSingleDivProjectContents } from '../../test-cases/simple-single-div-project'
 
 export function wait(timeout: number): Promise<void> {
   return new Promise((resolve) => {
@@ -466,7 +467,15 @@ export function useTriggerSelectionPerformanceTest(): () => void {
   return trigger
 }
 
-export function useTriggerAbsoluteMovePerformanceTest(): () => void {
+export const useTriggerAbsoluteMoveLargePerformanceTest = () =>
+  useTriggerAbsoluteMovePerformanceTest(LargeProjectContents)
+
+export const useTriggerAbsoluteMoveSmallPerformanceTest = () =>
+  useTriggerAbsoluteMovePerformanceTest(SmallSingleDivProjectContents)
+
+export function useTriggerAbsoluteMovePerformanceTest(
+  projectContents: ProjectContentTreeRoot,
+): () => void {
   const dispatch = useEditorState(
     React.useCallback((store) => store.dispatch as DebugDispatch, []),
     'useTriggerAbsoluteMovePerformanceTest dispatch',
@@ -475,15 +484,12 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
     React.useCallback((store) => store.derived.navigatorTargets, []),
   )
   const metadata = useRefEditorState(React.useCallback((store) => store.editor.jsxMetadata, []))
-  const selectedViews = useRefEditorState(
-    React.useCallback((store) => store.editor.selectedViews, []),
-  )
   const builtInDependencies = useEditorState(
     (store) => store.builtInDependencies,
     'useTriggerAbsoluteMovePerformanceTest builtInDependencies',
   )
   const trigger = React.useCallback(async () => {
-    const editorReady = await loadProject(dispatch, builtInDependencies, LargeProjectContents)
+    const editorReady = await loadProject(dispatch, builtInDependencies, projectContents)
     if (!editorReady) {
       console.info('ABSOLUTE_MOVE_TEST_ERROR')
       return
@@ -648,6 +654,6 @@ export function useTriggerAbsoluteMovePerformanceTest(): () => void {
       }
     }
     requestAnimationFrame(step)
-  }, [dispatch, allPaths, metadata, builtInDependencies])
+  }, [dispatch, allPaths, metadata, builtInDependencies, projectContents])
   return trigger
 }

--- a/editor/src/test-cases/simple-single-div-project.ts
+++ b/editor/src/test-cases/simple-single-div-project.ts
@@ -1,0 +1,165 @@
+// Extracted by querying https://SERVER/v1/project/PROJECT_ID/contents.json/projectContents
+// Once prettier formats the JSON to a JavaScript value then enums are replaced.
+
+import { ProjectContentTreeRoot } from '../components/assets'
+import { RevisionsState } from '../core/shared/project-file-types'
+
+export const SmallSingleDivProjectContents: ProjectContentTreeRoot = {
+  'package.json': {
+    content: {
+      fileContents: {
+        code:
+          '{\n  "name": "Utopia Project",\n  "version": "0.1.0",\n  "utopia": {\n    "main-ui": "utopia/storyboard.js",\n    "html": "public/index.html",\n    "js": "src/index.js"\n  },\n  "dependencies": {\n    "react": "16.13.1",\n    "react-dom": "16.13.1",\n    "utopia-api": "0.4.1"\n  }\n}',
+        revisionsState: RevisionsState.CodeAhead,
+        parsed: {
+          type: 'UNPARSED',
+        },
+      },
+      lastSavedContents: null,
+      lastRevisedTime: 0,
+      type: 'TEXT_FILE',
+      lastParseSuccess: null,
+    },
+    type: 'PROJECT_CONTENT_FILE',
+    fullPath: '/package.json',
+  },
+  utopia: {
+    children: {
+      'storyboard.js': {
+        content: {
+          fileContents: {
+            code:
+              "import * as React from 'react'\nimport Utopia, {\n  Scene,\n  Storyboard,\n  registerModule,\n} from 'utopia-api'\nimport { App } from '/src/app.js'\n\nexport var storyboard = (\n  <Storyboard data-uid='storyboard-entity'>\n    <Scene\n      data-label='Imported App'\n      data-uid='scene-1-entity'\n      style={{\n        position: 'absolute',\n        left: 0,\n        top: 0,\n        width: 375,\n        height: 812,\n      }}\n    >\n      <App data-uid='app-entity' />\n    </Scene>\n  </Storyboard>\n)\n",
+            revisionsState: RevisionsState.CodeAhead,
+            parsed: {
+              type: 'UNPARSED',
+            },
+          },
+          lastSavedContents: null,
+          lastRevisedTime: 0,
+          type: 'TEXT_FILE',
+          lastParseSuccess: null,
+        },
+        type: 'PROJECT_CONTENT_FILE',
+        fullPath: '/utopia/storyboard.js',
+      },
+    },
+    type: 'PROJECT_CONTENT_DIRECTORY',
+    directory: {
+      type: 'DIRECTORY',
+    },
+    fullPath: '/utopia',
+  },
+  src: {
+    children: {
+      'card.js': {
+        content: {
+          fileContents: {
+            code:
+              "import * as React from 'react'\n\nexport var Card = () => {\n  return (\n    <div\n      data-uid='inner-div'\n      style={{\n        position: 'absolute',\n        left: 50,\n        top: 50,\n        width: 40,\n        height: 40,\n        backgroundColor: 'red',\n      }}\n    />\n  )\n}\n",
+            revisionsState: RevisionsState.CodeAhead,
+            parsed: {
+              type: 'UNPARSED',
+            },
+          },
+          lastSavedContents: {
+            code:
+              "import * as React from 'react'\n\nexport var Card = () => {\n  return (\n    <div\n      data-uid='inner-div'\n      style={{\n        position: 'absolute',\n        left: 50,\n        top: 50,\n        width: 40,\n        height: 40,\n        backgroundColor: 'red',\n      }}\n    />\n  )\n}\n",
+            revisionsState: RevisionsState.CodeAhead,
+            parsed: {
+              type: 'UNPARSED',
+            },
+          },
+          lastRevisedTime: 0,
+          type: 'TEXT_FILE',
+          lastParseSuccess: null,
+        },
+        type: 'PROJECT_CONTENT_FILE',
+        fullPath: '/src/card.js',
+      },
+      'app.js': {
+        content: {
+          fileContents: {
+            code:
+              "import * as React from 'react'\nimport { Card } from '/src/card.js'\n\nexport var App = (props) => {\n  return (\n    <div\n      data-uid='app-outer-div'\n      style={{\n        position: 'relative',\n        width: '100%',\n        height: '100%',\n        backgroundColor: '#FFFFFF',\n      }}\n    >\n      <Card />\n    </div>\n  )\n}\n",
+            revisionsState: RevisionsState.CodeAhead,
+            parsed: {
+              type: 'UNPARSED',
+            },
+          },
+          lastSavedContents: {
+            code:
+              "import * as React from 'react'\nimport { Card } from '/src/card.js'\n\nexport var App = (props) => {\n  return (\n    <div\n      data-uid='app-outer-div'\n      style={{\n        position: 'relative',\n        width: '100%',\n        height: '100%',\n        backgroundColor: '#FFFFFF',\n      }}\n    >\n      <Card />\n    </div>\n  )\n}\n",
+            revisionsState: RevisionsState.CodeAhead,
+            parsed: {
+              type: 'UNPARSED',
+            },
+          },
+          lastRevisedTime: 0,
+          type: 'TEXT_FILE',
+          lastParseSuccess: null,
+        },
+        type: 'PROJECT_CONTENT_FILE',
+        fullPath: '/src/app.js',
+      },
+      'index.js': {
+        content: {
+          fileContents: {
+            code:
+              "import * as React from 'react'\nimport * as ReactDOM from 'react-dom'\nimport { App } from '../src/app'\n\nconst root = document.getElementById('root')\nif (root != null) {\n  ReactDOM.render(<App />, root)\n}\n",
+            revisionsState: RevisionsState.CodeAhead,
+            parsed: {
+              type: 'UNPARSED',
+            },
+          },
+          lastSavedContents: null,
+          lastRevisedTime: 0,
+          type: 'TEXT_FILE',
+          lastParseSuccess: null,
+        },
+        type: 'PROJECT_CONTENT_FILE',
+        fullPath: '/src/index.js',
+      },
+    },
+    type: 'PROJECT_CONTENT_DIRECTORY',
+    directory: {
+      type: 'DIRECTORY',
+    },
+    fullPath: '/src',
+  },
+  assets: {
+    children: {},
+    type: 'PROJECT_CONTENT_DIRECTORY',
+    directory: {
+      type: 'DIRECTORY',
+    },
+    fullPath: '/assets',
+  },
+  public: {
+    children: {
+      'index.html': {
+        content: {
+          fileContents: {
+            code:
+              '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <meta charset="utf-8">\n    <title>Utopia React App</title>\n    <!-- Begin Generated Utopia External Links -->\n    <!-- End Generated Utopia External Links -->\n  </head>\n  <body>\n    <div id="root"></div>\n  </body>\n</html>',
+            revisionsState: RevisionsState.CodeAhead,
+            parsed: {
+              type: 'UNPARSED',
+            },
+          },
+          lastSavedContents: null,
+          lastRevisedTime: 0,
+          type: 'TEXT_FILE',
+          lastParseSuccess: null,
+        },
+        type: 'PROJECT_CONTENT_FILE',
+        fullPath: '/public/index.html',
+      },
+    },
+    type: 'PROJECT_CONTENT_DIRECTORY',
+    directory: {
+      type: 'DIRECTORY',
+    },
+    fullPath: '/public',
+  },
+}

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -172,9 +172,15 @@ export const testPerformanceInner = async function (url: string): Promise<Perfor
     frameResultSuccess,
     EmptyResult,
   )
-  const absoluteMoveResult = await retryPageCalls(
+  const absoluteMoveLargeResult = await retryPageCalls(
     url,
-    testAbsoluteMovePerformance,
+    testAbsoluteMovePerformanceLarge,
+    frameArraySuccess,
+    [],
+  )
+  const absoluteMoveSmallResult = await retryPageCalls(
+    url,
+    testAbsoluteMovePerformanceSmall,
     frameArraySuccess,
     [],
   )
@@ -184,7 +190,8 @@ export const testPerformanceInner = async function (url: string): Promise<Perfor
     ...selectionResult,
     scrollResult,
     resizeResult,
-    ...absoluteMoveResult,
+    ...absoluteMoveLargeResult,
+    ...absoluteMoveSmallResult,
   ]
   const summaryImage = await uploadSummaryImage(messageParts)
 
@@ -345,21 +352,21 @@ export const testSelectionPerformance = async function (
   ]
 }
 
-export const testAbsoluteMovePerformance = async function (
+export const testAbsoluteMovePerformanceLarge = async function (
   page: puppeteer.Page,
 ): Promise<Array<FrameResult>> {
-  console.log('Test Absolute Move Performance')
-  await page.waitForXPath("//a[contains(., 'PAM')]")
+  console.log('Test Absolute Move Performance (Large)')
+  await page.waitForXPath("//a[contains(., 'PAML')]")
   // we run it twice without measurements to warm up the environment
   await clickOnce(
     page,
-    "//a[contains(., 'PAM')]",
+    "//a[contains(., 'PAML')]",
     'ABSOLUTE_MOVE_TEST_FINISHED',
     'ABSOLUTE_MOVE_TEST_ERROR',
   )
   await clickOnce(
     page,
-    "//a[contains(., 'PAM')]",
+    "//a[contains(., 'PAML')]",
     'ABSOLUTE_MOVE_TEST_FINISHED',
     'ABSOLUTE_MOVE_TEST_ERROR',
   )
@@ -368,15 +375,60 @@ export const testAbsoluteMovePerformance = async function (
   await page.tracing.start({ categories: ['blink.user_timing'], path: 'trace.json' })
   const succeeded = await clickOnce(
     page,
-    "//a[contains(., 'PAM')]",
+    "//a[contains(., 'PAML')]",
     'ABSOLUTE_MOVE_TEST_FINISHED',
     'ABSOLUTE_MOVE_TEST_ERROR',
   )
   await page.tracing.stop()
   const traceJson = await loadTraceEventsJSON()
   return [
-    getFrameData(traceJson, 'absolute_move_interaction', 'Absolute Move (Interaction)', succeeded),
-    getFrameData(traceJson, 'absolute_move_move', 'Absolute Move (Just Move)', succeeded),
+    getFrameData(
+      traceJson,
+      'absolute_move_interaction',
+      'Absolute Move (Interaction, Large)',
+      succeeded,
+    ),
+    getFrameData(traceJson, 'absolute_move_move', 'Absolute Move (Just Move, Large)', succeeded),
+  ]
+}
+
+export const testAbsoluteMovePerformanceSmall = async function (
+  page: puppeteer.Page,
+): Promise<Array<FrameResult>> {
+  console.log('Test Absolute Move Performance (Small)')
+  await page.waitForXPath("//a[contains(., 'PAMS')]")
+  // we run it twice without measurements to warm up the environment
+  await clickOnce(
+    page,
+    "//a[contains(., 'PAMS')]",
+    'ABSOLUTE_MOVE_TEST_FINISHED',
+    'ABSOLUTE_MOVE_TEST_ERROR',
+  )
+  await clickOnce(
+    page,
+    "//a[contains(., 'PAMS')]",
+    'ABSOLUTE_MOVE_TEST_FINISHED',
+    'ABSOLUTE_MOVE_TEST_ERROR',
+  )
+
+  // and then we run the test for a third time, this time running tracing
+  await page.tracing.start({ categories: ['blink.user_timing'], path: 'trace.json' })
+  const succeeded = await clickOnce(
+    page,
+    "//a[contains(., 'PAMS')]",
+    'ABSOLUTE_MOVE_TEST_FINISHED',
+    'ABSOLUTE_MOVE_TEST_ERROR',
+  )
+  await page.tracing.stop()
+  const traceJson = await loadTraceEventsJSON()
+  return [
+    getFrameData(
+      traceJson,
+      'absolute_move_interaction',
+      'Absolute Move (Interaction, Small)',
+      succeeded,
+    ),
+    getFrameData(traceJson, 'absolute_move_move', 'Absolute Move (Just Move, Small)', succeeded),
   ]
 }
 


### PR DESCRIPTION
**Problem:**
We want to see some performance results for smaller projects as well as larger projects.

**Fix:**
A smaller test case project has been added. A new variant of the absolute move performance test has been added alongside that which uses the smaller project.

**Commit Details:**
- Renamed `testAbsoluteMovePerformance` to `testAbsoluteMovePerformanceLarge`,
  and pointed it at the menubar button `PAML`.
- Created `testAbsoluteMovePerformanceSmall` to use the new smaller project
  and pointed it at the menubar button `PAMS`.
- Incorporated the two absolute move performance functions into the results.
- Added `simple-single-div-project.ts` with a very simple starting
  project in it.
- Made `useTriggerAbsoluteMovePerformanceTest` be parameterized by the
  project contents to use in the test.
- In the menubar `PAM` has become `PAML` for the large absolute move test
- Added `PAMS` for the small absolute move test.
