### PR TITLE
Use a better version of Python to avoid rebuilds.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -539,7 +539,7 @@ let
     pkgs.heroku
   ];
 
-  pythonAndPackages = pkgs.python37.withPackages(ps: with ps; [ pyusb tkinter pkgconfig ]);
+  pythonAndPackages = pkgs.python3.withPackages(ps: with ps; [ pyusb tkinter pkgconfig ]);
 
   basePackages = [ node pkgs.libsecret pythonAndPackages pkgs.pkg-config pkgs.tmux pkgs.git pkgs.wget ] ++ linuxOnlyPackages ++ macOSOnlyPackages;
   withServerBasePackages = basePackages ++ (lib.optionals includeServerBuildSupport baseServerPackages);


### PR DESCRIPTION
**Problem:**
Every test run on the CI infrastructure is building the Python derivation each and every time which eats a lot of time for no benefit.

**Fix:**
Use a definition of Python that should be built and cached by Hydra so that the CI boxes don't have to do that build.

**Commit Details:**
- When declaring Python and it's packages use `pkgs.python3` instead
  of `pkgs.python37` so that we can take advantage of built derivations
  of Python 3.9 from Hydra instead of having to build the
  Python 3.7 package.
