### PR TITLE
Fix: Reparent to different file

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
@@ -62,21 +62,7 @@ export const absoluteReparentStrategy: CanvasStrategy = {
       newParent,
     )?.specialSizeMeasurements.providesBoundsForChildren
 
-    const selectedElementFiles = filteredSelectedElements.map((element) =>
-      getFileOfElement(element, projectContents, openFile),
-    )
-
-    const newParentFile = getFileOfElement(newParent, projectContents, openFile)
-
-    // Currently we only support reparenting into the same file
-    const reparentingToSameFile = selectedElementFiles.every((file) => file === newParentFile)
-
-    if (
-      reparentResult.shouldReparent &&
-      newParent != null &&
-      providesBoundsForChildren &&
-      reparentingToSameFile
-    ) {
+    if (reparentResult.shouldReparent && newParent != null && providesBoundsForChildren) {
       const commands = filteredSelectedElements.map((selectedElement) => {
         const offsetCommands = getAbsoluteOffsetCommandsForSelectedElement(
           selectedElement,

--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -62,7 +62,7 @@ export const runAdjustCssLengthProperty: CommandFunction<AdjustCssLengthProperty
   )
   if (isLeft(currentValue)) {
     return {
-      editorStatePatch: {},
+      editorStatePatches: [],
       commandDescription: `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
         command.property,
       )} not applied as value is not writeable.`,
@@ -75,7 +75,7 @@ export const runAdjustCssLengthProperty: CommandFunction<AdjustCssLengthProperty
 
   if (targetPropertyNonExistant && !command.createIfNonExistant) {
     return {
-      editorStatePatch: {},
+      editorStatePatches: [],
       commandDescription: `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
         command.property,
       )} not applied as the property does not exist.`,
@@ -85,7 +85,7 @@ export const runAdjustCssLengthProperty: CommandFunction<AdjustCssLengthProperty
   if (valueProbablyExpression) {
     // TODO add option to override expressions!!!
     return {
-      editorStatePatch: {},
+      editorStatePatches: [],
       commandDescription: `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
         command.property,
       )} not applied as the property is an expression we did not want to override.`,
@@ -118,7 +118,7 @@ export const runAdjustCssLengthProperty: CommandFunction<AdjustCssLengthProperty
 
   // fallback return
   return {
-    editorStatePatch: {},
+    editorStatePatches: [],
     commandDescription: `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
       command.property,
     )} not applied as the property is in a CSS unit we do not support. (${
@@ -159,7 +159,7 @@ function updatePixelValueByPixel(
   )
 
   return {
-    editorStatePatch: propertyUpdatePatch,
+    editorStatePatches: [propertyUpdatePatch],
     commandDescription: `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
       targetProperty,
     )} by ${byValue}`,
@@ -179,7 +179,7 @@ function updatePercentageValueByPixel(
   }
   if (parentDimensionPx == null) {
     return {
-      editorStatePatch: {},
+      editorStatePatches: [],
       commandDescription: `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
         targetProperty,
       )} not applied because the parent dimensions are unknown for some reason.`,
@@ -187,7 +187,7 @@ function updatePercentageValueByPixel(
   }
   if (parentDimensionPx === 0) {
     return {
-      editorStatePatch: {},
+      editorStatePatches: [],
       commandDescription: `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
         targetProperty,
       )} not applied because the parent dimension is 0.`,
@@ -216,7 +216,7 @@ function updatePercentageValueByPixel(
   )
 
   return {
-    editorStatePatch: propertyUpdatePatch,
+    editorStatePatches: [propertyUpdatePatch],
     commandDescription: `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
       targetProperty,
     )} by ${byValue}`,

--- a/editor/src/components/canvas/commands/adjust-number-command.spec.tsx
+++ b/editor/src/components/canvas/commands/adjust-number-command.spec.tsx
@@ -7,6 +7,7 @@ import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-s
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import { adjustNumberProperty, runAdjustNumberProperty } from './adjust-number-command'
+import { updateEditorStateWithPatches } from './commands'
 
 describe('adjustNumberProperty', () => {
   it('works for left style prop', async () => {
@@ -47,7 +48,10 @@ describe('adjustNumberProperty', () => {
       adjustNumberPropertyCommand,
     )
 
-    const patchedEditor = update(renderResult.getEditorState().editor, result.editorStatePatch)
+    const patchedEditor = updateEditorStateWithPatches(
+      renderResult.getEditorState().editor,
+      result.editorStatePatches,
+    )
     const updatedLeftStyleProp = withUnderlyingTargetFromEditorState(
       cardInstancePath,
       patchedEditor,

--- a/editor/src/components/canvas/commands/adjust-number-command.ts
+++ b/editor/src/components/canvas/commands/adjust-number-command.ts
@@ -108,7 +108,7 @@ export const runAdjustNumberProperty: CommandFunction<AdjustNumberProperty> = (
 
   if (targetPropertyNonExistant && !command.createIfNonExistant) {
     return {
-      editorStatePatch: {},
+      editorStatePatches: [],
       commandDescription: `Adjust Number Prop: ${EP.toUid(command.target)}/${PP.toString(
         command.property,
       )} not applied as the property does not exist.`,
@@ -127,7 +127,7 @@ export const runAdjustNumberProperty: CommandFunction<AdjustNumberProperty> = (
           case 'less-than':
             if (inequalityValue <= currentValue) {
               return {
-                editorStatePatch: {},
+                editorStatePatches: [],
                 commandDescription: `Adjust Number Prop: ${EP.toUid(command.target)}/${PP.toString(
                   command.property,
                 )} not applied as value is large enough already.`,
@@ -139,7 +139,7 @@ export const runAdjustNumberProperty: CommandFunction<AdjustNumberProperty> = (
           case 'greater-than':
             if (inequalityValue >= currentValue) {
               return {
-                editorStatePatch: {},
+                editorStatePatches: [],
                 commandDescription: `Adjust Number Prop: ${EP.toUid(command.target)}/${PP.toString(
                   command.property,
                 )} not applied as value is small enough already.`,
@@ -170,7 +170,7 @@ export const runAdjustNumberProperty: CommandFunction<AdjustNumberProperty> = (
     )
 
     return {
-      editorStatePatch: propertyUpdatePatch,
+      editorStatePatches: [propertyUpdatePatch],
       commandDescription: `Adjust Number Prop: ${EP.toUid(command.target)}/${PP.toString(
         command.property,
       )} by ${command.value}`,

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -18,7 +18,7 @@ import { runUpdateSelectedViews, UpdateSelectedViews } from './update-selected-v
 import { runWildcardPatch, WildcardPatch } from './wildcard-patch-command'
 
 export interface CommandFunctionResult {
-  editorStatePatch: EditorStatePatch
+  editorStatePatches: Array<EditorStatePatch>
   commandDescription: string
 }
 
@@ -91,13 +91,13 @@ export function foldAndApplyCommands(
       // Run the command with our current states.
       const commandResult = runCanvasCommand(workingEditorState, command)
       // Capture values from the result.
-      const statePatch = commandResult.editorStatePatch
+      const statePatch = commandResult.editorStatePatches
       // Apply the update to the editor state.
-      workingEditorState = update(workingEditorState, statePatch)
+      workingEditorState = updateEditorStateWithPatches(workingEditorState, statePatch)
       // Collate the patches.
-      statePatches.push(statePatch)
+      statePatches.push(...statePatch)
       if (shouldAccumulatePatches) {
-        accumulatedPatches.push(statePatch)
+        accumulatedPatches.push(...statePatch)
       }
       workingCommandDescriptions.push({
         description: commandResult.commandDescription,
@@ -120,4 +120,13 @@ export function foldAndApplyCommands(
     accumulatedPatches: mergePatches(accumulatedPatches),
     commandDescriptions: workingCommandDescriptions,
   }
+}
+
+export function updateEditorStateWithPatches(
+  state: EditorState,
+  patches: Array<EditorStatePatch>,
+): EditorState {
+  return patches.reduce((acc, curr) => {
+    return update(acc, curr)
+  }, state)
 }

--- a/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
@@ -4,6 +4,7 @@ import * as EP from '../../../core/shared/element-path'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
 import { withUnderlyingTargetFromEditorState } from '../../editor/store/editor-state'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
+import { updateEditorStateWithPatches } from './commands'
 import { reparentElement, runReparentElement } from './reparent-element-command'
 
 describe('runReparentElement', () => {
@@ -31,7 +32,10 @@ describe('runReparentElement', () => {
 
     const result = runReparentElement(originalEditorState, reparentCommand)
 
-    const patchedEditor = update(originalEditorState, result.editorStatePatch)
+    const patchedEditor = updateEditorStateWithPatches(
+      originalEditorState,
+      result.editorStatePatches,
+    )
     const newPath = EP.appendToPath(newParentPath, EP.toUid(targetPath))
 
     const newElement = withUnderlyingTargetFromEditorState(

--- a/editor/src/components/canvas/commands/set-snapping-guidelines-command.ts
+++ b/editor/src/components/canvas/commands/set-snapping-guidelines-command.ts
@@ -32,7 +32,7 @@ export const runSetSnappingGuidelines: CommandFunction<SetSnappingGuidelines> = 
     },
   }
   return {
-    editorStatePatch: editorStatePatch,
+    editorStatePatches: [editorStatePatch],
     commandDescription: `Set Snapping Guidelines`,
   }
 }

--- a/editor/src/components/canvas/commands/strategy-switched-command.ts
+++ b/editor/src/components/canvas/commands/strategy-switched-command.ts
@@ -35,7 +35,7 @@ export function runStrategySwitchedCommand(command: StrategySwitched): CommandFu
   }. ${command.dataReset ? 'Interaction data reset.' : ''}`
 
   return {
-    editorStatePatch: {},
+    editorStatePatches: [],
     commandDescription: commandDescription,
   }
 }

--- a/editor/src/components/canvas/commands/update-highlighted-views-command.ts
+++ b/editor/src/components/canvas/commands/update-highlighted-views-command.ts
@@ -23,13 +23,13 @@ export const runUpdateHighlightedViews: CommandFunction<UpdateHighlightedViews> 
   _: EditorState,
   command: UpdateHighlightedViews,
 ) => {
-  const editorStatePatch: EditorStatePatch = {
+  const editorStatePatch = {
     highlightedViews: {
       $set: command.value,
     },
   }
   return {
-    editorStatePatch: editorStatePatch,
+    editorStatePatches: [editorStatePatch],
     commandDescription: `Update Highlighted Views: ${command.value.map(EP.toString).join(', ')}`,
   }
 }

--- a/editor/src/components/canvas/commands/update-selected-views-command.spec.tsx
+++ b/editor/src/components/canvas/commands/update-selected-views-command.spec.tsx
@@ -3,7 +3,7 @@ import { createBuiltInDependenciesList } from '../../../core/es-modules/package-
 import * as EP from '../../../core/shared/element-path'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
-import { foldAndApplyCommands } from './commands'
+import { foldAndApplyCommands, updateEditorStateWithPatches } from './commands'
 import { runUpdateSelectedViews, updateSelectedViews } from './update-selected-views-command'
 
 describe('updateSelectedViews', () => {
@@ -26,7 +26,10 @@ describe('updateSelectedViews', () => {
 
     const result = runUpdateSelectedViews(originalEditorState, updateSelectedViewsCommand)
 
-    const patchedEditor = update(originalEditorState, result.editorStatePatch)
+    const patchedEditor = updateEditorStateWithPatches(
+      originalEditorState,
+      result.editorStatePatches,
+    )
 
     expect(patchedEditor.selectedViews).toEqual([targetPath])
   })

--- a/editor/src/components/canvas/commands/update-selected-views-command.ts
+++ b/editor/src/components/canvas/commands/update-selected-views-command.ts
@@ -1,6 +1,6 @@
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type { EditorState } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type { BaseCommand, CommandFunction, TransientOrNot } from './commands'
 
 export interface UpdateSelectedViews extends BaseCommand {
@@ -23,13 +23,13 @@ export const runUpdateSelectedViews: CommandFunction<UpdateSelectedViews> = (
   _: EditorState,
   command: UpdateSelectedViews,
 ) => {
-  const editorStatePatch = {
+  const editorStatePatch: EditorStatePatch = {
     selectedViews: {
       $set: command.value,
     },
   }
   return {
-    editorStatePatch: editorStatePatch,
+    editorStatePatches: [editorStatePatch],
     commandDescription: `Update Selected Views: ${command.value.map(EP.toString).join(', ')}`,
   }
 }

--- a/editor/src/components/canvas/commands/wildcard-patch-command.spec.tsx
+++ b/editor/src/components/canvas/commands/wildcard-patch-command.spec.tsx
@@ -4,6 +4,7 @@ import * as EP from '../../../core/shared/element-path'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
 import { selectComponents, setFocusedElement } from '../../editor/actions/action-creators'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
+import { updateEditorStateWithPatches } from './commands'
 import { runWildcardPatch, wildcardPatch } from './wildcard-patch-command'
 
 describe('wildcardPatch', () => {
@@ -28,7 +29,10 @@ describe('wildcardPatch', () => {
 
     const result = runWildcardPatch(renderResult.getEditorState().editor, wildcardCommand)
 
-    const patchedEditor = update(renderResult.getEditorState().editor, result.editorStatePatch)
+    const patchedEditor = updateEditorStateWithPatches(
+      renderResult.getEditorState().editor,
+      result.editorStatePatches,
+    )
     expect(patchedEditor.selectedViews).toEqual([])
   })
 })

--- a/editor/src/components/canvas/commands/wildcard-patch-command.ts
+++ b/editor/src/components/canvas/commands/wildcard-patch-command.ts
@@ -19,7 +19,7 @@ export const runWildcardPatch: CommandFunction<WildcardPatch> = (
   command: WildcardPatch,
 ) => {
   return {
-    editorStatePatch: command.patch,
+    editorStatePatches: [command.patch],
     commandDescription: `Wildcard Patch: ${JSON.stringify(command.patch, null, 2)}`,
   }
 }

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -113,12 +113,10 @@ describe('interactionCancel', () => {
         { type: 'BOUNDING_AREA', target: EP.elementPath([['aaa']]) },
       ),
     )
-    editorStore.strategyState.accumulatedPatches = [
-      runCanvasCommand(
-        editorStore.unpatchedEditor,
-        wildcardPatch('permanent', { selectedViews: { $set: [] } }),
-      ).editorStatePatch,
-    ]
+    editorStore.strategyState.accumulatedPatches = runCanvasCommand(
+      editorStore.unpatchedEditor,
+      wildcardPatch('permanent', { selectedViews: { $set: [] } }),
+    ).editorStatePatches
     const actualResult = interactionCancel(editorStore, dispatchResultFromEditorStore(editorStore))
     expect(actualResult.newStrategyState.accumulatedPatches).toHaveLength(0)
     expect(actualResult.newStrategyState.commandDescriptions).toHaveLength(0)
@@ -385,12 +383,10 @@ describe('interactionUpdate without strategy', () => {
       ),
     )
     editorStore.strategyState.currentStrategy = null
-    editorStore.strategyState.accumulatedPatches = [
-      runCanvasCommand(
-        editorStore.unpatchedEditor,
-        wildcardPatch('permanent', { canvas: { scale: { $set: 100 } } }),
-      ).editorStatePatch,
-    ]
+    editorStore.strategyState.accumulatedPatches = runCanvasCommand(
+      editorStore.unpatchedEditor,
+      wildcardPatch('permanent', { canvas: { scale: { $set: 100 } } }),
+    ).editorStatePatches
     const actualResult = interactionUpdate(
       [],
       editorStore,
@@ -659,12 +655,10 @@ describe('interactionUpdate with accumulating keypresses', () => {
     editorStore.strategyState.currentStrategyCommands = [
       wildcardPatch('permanent', { selectedViews: { $set: [EP.elementPath([['aaa']])] } }),
     ]
-    editorStore.strategyState.accumulatedPatches = [
-      runCanvasCommand(
-        editorStore.unpatchedEditor,
-        wildcardPatch('permanent', { focusedPanel: { $set: 'codeEditor' } }),
-      ).editorStatePatch,
-    ]
+    editorStore.strategyState.accumulatedPatches = runCanvasCommand(
+      editorStore.unpatchedEditor,
+      wildcardPatch('permanent', { focusedPanel: { $set: 'codeEditor' } }),
+    ).editorStatePatches
 
     const actualResult = interactionUpdate(
       [testStrategy],


### PR DESCRIPTION
# Issue
You can not reparent from one file to another. (Exception is thrown and utopia crashes)

# Description

This is not really a bug, more like an unimplemented feature, the `runReparentElement` function is implemented in a way that it absolutely expects to target and the new parent element to be in the same file.

This PR just moves the target element to new file. That can easily cause problems if the element is dependent on variable from its source scope, or uses an import. (But this can cause problems even in a single file.) Full reparenting solution would mean we have to implement quite complex refactorings, so let's skip that for now.

One problem I needed to solve is that in case of multiple files we need to:
1. remove the target element from the old file
2. add the target element to the new file

Unfortunately, creating an editor patch is a quite manual effort (see https://github.com/concrete-utopia/utopia/blob/master/editor/src/components/canvas/commands/reparent-element-command.ts#L67-L104 )

I extracted this logic into a function `getPatchForComponentChange` (maybe this can be reused elsewhere in other commands?)
However, I still had the issue that I have a separate patch for 1. and 2.
Merging editor state patches is a quite complex task I struggled with for a while, but finally I decided to refactor our commands in a way that they can include an array of editor state patches.

# Problems:

- This solution can reparent into a user defined component which doesn't render its children. In this case the target element just disappears. If we could recognize this situation, we could move it inside the root component inside the render function of the user defined component.
- The reparenting itself can easily result in exceptions, e.g. if variables are missing from the new scope.