### PR TITLE
Improvements for inspector first load/remount.

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2865,8 +2865,7 @@ export function getValidElementPathsFromElement(
 
     const isFocused = parentIsScene || matchingFocusedPathPart != null
     if (isFocused) {
-      paths = [
-        ...paths,
+      paths.push(
         ...getValidElementPaths(
           focusedElementPath,
           name,
@@ -2876,7 +2875,7 @@ export function getValidElementPathsFromElement(
           transientFilesState,
           resolve,
         ),
-      ]
+      )
     }
 
     return paths

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -85,6 +85,8 @@ import {
   DestructuredArray,
   DestructuredArrayPart,
   functionParam,
+  StyleAttributeMetadata,
+  StyleAttributeMetadataEntry,
 } from '../../../core/shared/element-template'
 import { CanvasRectangle, LocalPoint, LocalRectangle } from '../../../core/shared/math-utils'
 import { RawSourceMap } from '../../../core/workers/ts/ts-typings/RawSourceMap'
@@ -859,6 +861,21 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
   }
 }
 
+export const StyleAttributeMetadataEntryKeepDeepEquality: KeepDeepEqualityCall<StyleAttributeMetadataEntry> = (
+  oldValue: StyleAttributeMetadataEntry,
+  newValue: StyleAttributeMetadataEntry,
+) => {
+  if (oldValue.fromStyleSheet === newValue.fromStyleSheet) {
+    return keepDeepEqualityResult(oldValue, true)
+  } else {
+    return keepDeepEqualityResult(newValue, false)
+  }
+}
+
+export const StyleAttributeMetadataKeepDeepEquality: KeepDeepEqualityCall<StyleAttributeMetadata> = objectDeepEquality(
+  undefinableDeepEquality(StyleAttributeMetadataEntryKeepDeepEquality),
+)
+
 export function ElementInstanceMetadataKeepDeepEquality(): KeepDeepEqualityCall<
   ElementInstanceMetadata
 > {
@@ -868,7 +885,7 @@ export function ElementInstanceMetadataKeepDeepEquality(): KeepDeepEqualityCall<
     (metadata) => metadata.element,
     EitherKeepDeepEquality(createCallWithTripleEquals(), JSXElementChildKeepDeepEquality()),
     (metadata) => metadata.props,
-    createCallFromIntrospectiveKeepDeep(),
+    objectDeepEquality(createCallFromIntrospectiveKeepDeep()),
     (metadata) => metadata.globalFrame,
     nullableDeepEquality(CanvasRectangleKeepDeepEquality),
     (metadata) => metadata.localFrame,
@@ -882,7 +899,7 @@ export function ElementInstanceMetadataKeepDeepEquality(): KeepDeepEqualityCall<
     (metadata) => metadata.computedStyle,
     nullableDeepEquality(objectDeepEquality(createCallWithTripleEquals())),
     (metadata) => metadata.attributeMetadatada,
-    createCallFromIntrospectiveKeepDeep(),
+    nullableDeepEquality(StyleAttributeMetadataKeepDeepEquality),
     (metadata) => metadata.label,
     nullableDeepEquality(createCallWithTripleEquals()),
     (metadata) => metadata.importInfo,

--- a/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-element-subsection/flex-element-subsection.tsx
@@ -23,6 +23,7 @@ import {
   InspectorCallbackContext,
   InspectorPropsContext,
   stylePropPathMappingFn,
+  useGetLayoutControlStatus,
   useInspectorLayoutInfo,
 } from '../../../common/property-path-hooks'
 import { isNotUnsetDefaultOrDetected } from '../../../common/control-status'
@@ -80,35 +81,35 @@ export const FlexElementSubsectionExperiment = React.memo((props: FlexElementSub
 export function useInitialFixedSectionState(parentFlexDirection: string | null): boolean {
   const isRowLayouted = parentFlexDirection === 'row' || parentFlexDirection === 'row-reverse'
 
-  const width = useInspectorLayoutInfo('width')
-  const minWidth = useInspectorLayoutInfo('minWidth')
-  const maxWidth = useInspectorLayoutInfo('maxWidth')
-  const height = useInspectorLayoutInfo('height')
-  const minHeight = useInspectorLayoutInfo('minHeight')
-  const maxHeight = useInspectorLayoutInfo('maxHeight')
+  const width = useGetLayoutControlStatus('width')
+  const minWidth = useGetLayoutControlStatus('minWidth')
+  const maxWidth = useGetLayoutControlStatus('maxWidth')
+  const height = useGetLayoutControlStatus('height')
+  const minHeight = useGetLayoutControlStatus('minHeight')
+  const maxHeight = useGetLayoutControlStatus('maxHeight')
 
   return isRowLayouted
-    ? isNotUnsetDefaultOrDetected(width.controlStatus) ||
-        isNotUnsetDefaultOrDetected(minWidth.controlStatus) ||
-        isNotUnsetDefaultOrDetected(maxWidth.controlStatus)
-    : isNotUnsetDefaultOrDetected(height.controlStatus) ||
-        isNotUnsetDefaultOrDetected(minHeight.controlStatus) ||
-        isNotUnsetDefaultOrDetected(maxHeight.controlStatus)
+    ? isNotUnsetDefaultOrDetected(width) ||
+        isNotUnsetDefaultOrDetected(minWidth) ||
+        isNotUnsetDefaultOrDetected(maxWidth)
+    : isNotUnsetDefaultOrDetected(height) ||
+        isNotUnsetDefaultOrDetected(minHeight) ||
+        isNotUnsetDefaultOrDetected(maxHeight)
 }
 
 export function useInitialAdvancedSectionState(): boolean {
-  const alignSelf = useInspectorLayoutInfo('alignSelf')
-  return isNotUnsetDefaultOrDetected(alignSelf.controlStatus)
+  const alignSelf = useGetLayoutControlStatus('alignSelf')
+  return isNotUnsetDefaultOrDetected(alignSelf)
 }
 
 export function useInitialSizeSectionState(): boolean {
-  const flexBasis = useInspectorLayoutInfo('flexBasis')
-  const flexGrow = useInspectorLayoutInfo('flexGrow')
-  const flexShrink = useInspectorLayoutInfo('flexShrink')
+  const flexBasis = useGetLayoutControlStatus('flexBasis')
+  const flexGrow = useGetLayoutControlStatus('flexGrow')
+  const flexShrink = useGetLayoutControlStatus('flexShrink')
   return (
-    isNotUnsetDefaultOrDetected(flexBasis.controlStatus) ||
-    isNotUnsetDefaultOrDetected(flexGrow.controlStatus) ||
-    isNotUnsetDefaultOrDetected(flexShrink.controlStatus)
+    isNotUnsetDefaultOrDetected(flexBasis) ||
+    isNotUnsetDefaultOrDetected(flexGrow) ||
+    isNotUnsetDefaultOrDetected(flexShrink)
   )
 }
 
@@ -253,20 +254,20 @@ export function useInitialCrossSectionState(parentFlexDirection: string | null):
   const isColumnLayouted =
     parentFlexDirection === 'column' || parentFlexDirection === 'column-reverse'
 
-  const width = useInspectorLayoutInfo('width')
-  const minWidth = useInspectorLayoutInfo('minWidth')
-  const maxWidth = useInspectorLayoutInfo('maxWidth')
-  const height = useInspectorLayoutInfo('height')
-  const minHeight = useInspectorLayoutInfo('minHeight')
-  const maxHeight = useInspectorLayoutInfo('maxHeight')
+  const width = useGetLayoutControlStatus('width')
+  const minWidth = useGetLayoutControlStatus('minWidth')
+  const maxWidth = useGetLayoutControlStatus('maxWidth')
+  const height = useGetLayoutControlStatus('height')
+  const minHeight = useGetLayoutControlStatus('minHeight')
+  const maxHeight = useGetLayoutControlStatus('maxHeight')
 
   return isColumnLayouted
-    ? isNotUnsetDefaultOrDetected(width.controlStatus) ||
-        isNotUnsetDefaultOrDetected(minWidth.controlStatus) ||
-        isNotUnsetDefaultOrDetected(maxWidth.controlStatus)
-    : isNotUnsetDefaultOrDetected(height.controlStatus) ||
-        isNotUnsetDefaultOrDetected(minHeight.controlStatus) ||
-        isNotUnsetDefaultOrDetected(maxHeight.controlStatus)
+    ? isNotUnsetDefaultOrDetected(width) ||
+        isNotUnsetDefaultOrDetected(minWidth) ||
+        isNotUnsetDefaultOrDetected(maxWidth)
+    : isNotUnsetDefaultOrDetected(height) ||
+        isNotUnsetDefaultOrDetected(minHeight) ||
+        isNotUnsetDefaultOrDetected(maxHeight)
 }
 
 const CrossAxisControls = React.memo((props: FlexElementSubsectionProps) => {

--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/gigantic-size-pins-subsection.tsx
@@ -22,6 +22,7 @@ import {
   InspectorInfo,
   InspectorPropsContext,
   stylePropPathMappingFn,
+  useGetLayoutControlStatus,
   useInspectorLayoutInfo,
 } from '../../../common/property-path-hooks'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
@@ -574,16 +575,16 @@ interface GiganticSizePinsSubsectionProps {
 export const GiganticSizePinsSubsection = React.memo((props: GiganticSizePinsSubsectionProps) => {
   const { layoutType, parentFlexDirection, aspectRatioLocked, toggleAspectRatioLock } = props
 
-  const minWidth = useInspectorLayoutInfo('minWidth')
-  const maxWidth = useInspectorLayoutInfo('maxWidth')
-  const minHeight = useInspectorLayoutInfo('minHeight')
-  const maxHeight = useInspectorLayoutInfo('maxHeight')
+  const minWidth = useGetLayoutControlStatus('minWidth')
+  const maxWidth = useGetLayoutControlStatus('maxWidth')
+  const minHeight = useGetLayoutControlStatus('minHeight')
+  const maxHeight = useGetLayoutControlStatus('maxHeight')
 
   const hasMinMaxValues =
-    isNotUnsetOrDefault(minWidth.controlStatus) ||
-    isNotUnsetOrDefault(maxWidth.controlStatus) ||
-    isNotUnsetOrDefault(minHeight.controlStatus) ||
-    isNotUnsetOrDefault(maxHeight.controlStatus)
+    isNotUnsetOrDefault(minWidth) ||
+    isNotUnsetOrDefault(maxWidth) ||
+    isNotUnsetOrDefault(minHeight) ||
+    isNotUnsetOrDefault(maxHeight)
   const [minMaxToggled, setMinMaxToggled] = usePropControlledStateV2(hasMinMaxValues)
   const toggleMinMax = React.useCallback(() => {
     setMinMaxToggled(!minMaxToggled)

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -391,11 +391,7 @@ export function notNullPathsEqual(l: ElementPath, r: ElementPath): boolean {
 }
 
 function elementPathPartsEqual(l: ElementPathPart, r: ElementPathPart): boolean {
-  if (l === r) {
-    return true
-  } else {
-    return arrayEquals(l, r)
-  }
+  return arrayEquals(l, r)
 }
 
 export function fullElementPathsEqual(l: ElementPathPart[], r: ElementPathPart[]): boolean {


### PR DESCRIPTION
**Problem:**
The inspector is quite costly to remount currently because of the creation of new elements as well as some complicated inspector specific hooks. This impacts on selection performance as it is either updated on a change or created anew if nothing is currently selected. As selection changes also include some expensive work like the DOM walker, any time saved in either of these hotspots would be beneficial to the user experience.

**Fix:**
The primary fix in this PR is that of the introduction of `useGetLayoutControlStatus`, which can be used instead of `useInspectorLayoutInfo` if it can suffice because the latter is quite expensive to use/run. This provides an approximately 15% improvement to the runtime of the selection change, taking it from around 120ms to a shade under 100ms.

The improvement to `ElementInstanceMetadataKeepDeepEquality` reduces the introspection.

The rest are mostly minor tweaks that were just spotted in the process of prodding at the performance.

**Commit Details:**
- `getValidElementPathsFromElement` now pushes to the `paths` mutable
  array rather than reassigning it to a newly constructed array.
- Slight improvement to `ElementInstanceMetadataKeepDeepEquality`, where
  `props` is known to be an `object` of some kind and `attributeMetadata`
  actually has a known structure.
- New hook `useGetLayoutControlStatus` for when only the `ControlStatus`
  is needed for a given property instead of using the more heavyweight
  `useInspectorLayoutInfo`.
- Updated some inspector components to use `useGetLayoutControlStatus`.
- Removed an unnecessary identity check from `elementPathPartsEqual` as
  `arrayEquals` does the same check itself.
