### PR TITLE
Refactored away parameter on useApplyCanvasOffsetToStyle.

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -26,6 +26,7 @@ import { ResolvingRemoteDependencyErrorName } from '../../core/es-modules/packag
 import { CanvasLoadingScreen } from './canvas-loading-screen'
 import { isHooksErrorMessage } from '../../utils/canvas-react-utils'
 import { useApplyCanvasOffsetToStyle } from './controls/canvas-offset-wrapper'
+import { when } from '../../utils/react-conditionals'
 
 interface CanvasComponentEntryProps {}
 
@@ -76,38 +77,39 @@ export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps
     clearRuntimeErrors()
   }, [clearRuntimeErrors])
 
-  const containerRef = useApplyCanvasOffsetToStyle(true, canvasProps != null)
+  const containerRef = useApplyCanvasOffsetToStyle(true)
 
-  if (canvasProps == null) {
-    return <CanvasLoadingScreen />
-  } else {
-    return (
+  return (
+    <>
+      {when(canvasProps == null, <CanvasLoadingScreen />)}
       <div
         id='canvas-container-outer'
         ref={containerRef}
         style={{
           position: 'absolute',
-          transition: canvasProps.scrollAnimation ? 'transform 0.3s ease-in-out' : 'initial',
+          transition: canvasProps?.scrollAnimation ? 'transform 0.3s ease-in-out' : 'initial',
           transform: 'translate3d(0px, 0px, 0px)',
         }}
       >
-        <CanvasErrorBoundary
-          filePath={canvasProps.uiFilePath}
-          projectContents={canvasProps.projectContents}
-          reportError={onRuntimeError}
-          requireFn={canvasProps.curriedRequireFn}
-          key={`canvas-error-boundary-${canvasProps.mountCount}`}
-        >
-          <RemoteDependencyBoundary
+        {canvasProps == null ? null : (
+          <CanvasErrorBoundary
+            filePath={canvasProps.uiFilePath}
             projectContents={canvasProps.projectContents}
+            reportError={onRuntimeError}
             requireFn={canvasProps.curriedRequireFn}
+            key={`canvas-error-boundary-${canvasProps.mountCount}`}
           >
-            <DomWalkerWrapper {...canvasProps} clearErrors={localClearRuntimeErrors} />
-          </RemoteDependencyBoundary>
-        </CanvasErrorBoundary>
+            <RemoteDependencyBoundary
+              projectContents={canvasProps.projectContents}
+              requireFn={canvasProps.curriedRequireFn}
+            >
+              <DomWalkerWrapper {...canvasProps} clearErrors={localClearRuntimeErrors} />
+            </RemoteDependencyBoundary>
+          </CanvasErrorBoundary>
+        )}
       </div>
-    )
-  }
+    </>
+  )
 })
 
 function DomWalkerWrapper(props: UiJsxCanvasPropsWithErrorCallback) {

--- a/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
+++ b/editor/src/components/canvas/controls/canvas-offset-wrapper.tsx
@@ -12,15 +12,12 @@ export const CanvasOffsetWrapper = React.memo((props) => {
   )
 })
 
-export function useApplyCanvasOffsetToStyle(
-  setScaleToo: boolean,
-  forceOffset?: boolean, // this is not so nice, but the element is optionally rendered in canvas-component-entry
-): React.RefObject<HTMLDivElement> {
+export function useApplyCanvasOffsetToStyle(setScaleToo: boolean): React.RefObject<HTMLDivElement> {
   const elementRef = React.useRef<HTMLDivElement>(null)
   const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
   const scaleRef = useRefEditorState((store) => store.editor.canvas.scale)
   const applyCanvasOffset = React.useCallback(
-    (roundedCanvasOffset: CanvasVector, _?: any) => {
+    (roundedCanvasOffset: CanvasVector) => {
       if (elementRef.current != null) {
         elementRef.current.style.setProperty(
           'transform',
@@ -39,8 +36,9 @@ export function useApplyCanvasOffsetToStyle(
   useSelectorWithCallback((store) => store.editor.canvas.roundedCanvasOffset, applyCanvasOffset)
 
   const applyCanvasOffsetEffect = React.useCallback(() => {
-    applyCanvasOffset(canvasOffsetRef.current, forceOffset)
-  }, [applyCanvasOffset, canvasOffsetRef, forceOffset])
+    applyCanvasOffset(canvasOffsetRef.current)
+  }, [applyCanvasOffset, canvasOffsetRef])
   React.useLayoutEffect(applyCanvasOffsetEffect, [applyCanvasOffsetEffect])
+
   return elementRef
 }

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`353`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`357`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`413`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`417`)
   })
 
   it('Changing the selected view with a simple project', async () => {


### PR DESCRIPTION
**Problem:**
`CanvasComponentEntry` conditionally renders either the loading screen or the canvas proper based on if the value for `canvasProps` is null or not. But this has necessitated a slight hack to `useApplyCanvasOffsetToStyle` to ensure that once it becomes non-null and the canvas is rendered that then the appropriate properties are applied to the div that wraps around the canvas content. This is an issue on first load as the canvas is not able to load immediately but once it is loaded the layout effect has already been triggered, the hack just causes that effect to fire another time.

**Fix:**
The fix is to always render the container div but conditionally render the canvas contents inside it instead, so that the properties can always be applied in the layout effect.

**Commit Details:**
- Modified `CanvasComponentEntry` to always render the `canvas-container-outer`
  div, so that the ref returned by `useApplyCanvasOffsetToStyle` is non-null and
  the canvas offset can always be applied to it.
- Used `when` to render `CanvasLoadingScreen` in the same fragment as the
  `canvas-container-outer` div rather than as an alternative to it.
- Removed the `forceOffset` parameter from `useApplyCanvasOffsetToStyle`.
