### PR TITLE
Fix copy paste

### DIFF
--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -72,6 +72,8 @@ import {
   getZIndexOfElement,
   elementOnlyHasSingleTextChild,
   transformJSXComponentAtPath,
+  guaranteeUniqueUids,
+  getAllUniqueUids,
 } from '../../../core/model/element-template-utils'
 import {
   getJSXAttributeAtPath,
@@ -2742,7 +2744,11 @@ export const UPDATE_FNS = {
       }
     }
     if (insertionAllowed) {
-      return action.elements.reduce((workingEditorState, currentValue, index) => {
+      const elements = guaranteeUniqueUids(
+        action.elements,
+        getAllUniqueUids(editor.projectContents),
+      )
+      return elements.reduce((workingEditorState, currentValue, index) => {
         let toastsAdded: Array<Notice> = []
         const modifyResult = modifyUnderlyingForOpenFile(
           targetParent,


### PR DESCRIPTION
# Issues

## Metadata serialization

Copy paste did not work at all, because it tried to serialize the whole `editor.jsxMetadata` to the clipboard, which threw two kinds of exceptions:
1. The metadata contains circular references
2. The metadata contains the Window object, which throws a (mysterious) cross-origin DOMException when stringified.

## Duplicate ids

When you copy-pasted views with children, then only the top-level elements received new ids, the descendants just used their existing ones, which could result in duplicate ids if the original elements were still in the project.

# Solution

I think the main problem is that the `ElementInstanceMetadataMap` type contains all different kinds of things, e.g. 
- geometrical information
- static props
- imports
etc.

We have all different kinds of functions which depend on the metadata (e.g. `maybeSwitchLayoutProps`) which call different kinds of `MetadataUtils` functions inside. If you need to use a `MetadataUtils` function, you need to provide the metadata, even if it only uses a small part of it. Furthermore, it is not trivial to see what is needed from the metadata, sometimes, it just returns the metadata for a specific elementpath, and maybe it only uses the frame information from that.
I thought about splitting `ElementInstanceMetadata` type, to have a new type which only includes important information for the copy-paste functionality, but it would be a huge refactor, which would affect a lot of code, and it is not clear how beneficial would that be ourside of copy paste.

So I decided to not touch the types, but try to filter the metadata and only keep the necessary information for copy paste in there. Unfortunately, this is not reflected in the types.

I filtered the metadata in two ways:
- only kept the metadata of elements which are either descendants or ancestors of at least one selected view (even that is overkill now, but these are the ones which can theoretically affect copy paste)
- cleared the static props from the metadata, because this contained all the problematic parts for serialization, these are huge objects, and not used at all in the paste code.

I also fixed the duplicate ids by regenerating them when pasting.

# What is missing?

The most important missing feature is my opinion is that if you paste into a different file, the necessary imports will not be added automatically. So a simple copy paste can easily result in a canvas exception.