### PR TITLE
Multiselection for move and reparent strategies

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -352,4 +352,133 @@ describe('Axis locked move', () => {
       ),
     )
   })
+  it('works with a TL pinned absolute element with child', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50, top: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      >
+        <View
+          style={{ backgroundColor: '#0091FFAB', position: 'absolute', left: 100, top: 100, width: 250, height: 300 }}
+          data-uid='ccc'
+        />
+      </View>
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = dragBy15Pixels(initialEditor)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 65, top: 65, width: 250, height: 300 }}
+          data-uid='bbb'
+        >
+          <View
+            style={{ backgroundColor: '#0091FFAB', position: 'absolute', left: 100, top: 100, width: 250, height: 300 }}
+            data-uid='ccc'
+          />
+        </View>
+      </View>`,
+      ),
+    )
+  })
+  it('works with TL pinned absolute elements in multiselection', async () => {
+    const targetElement1 = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+    const targetElement2 = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'ccc'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50, top: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+      <View
+        style={{ backgroundColor: '#0091FFAB', position: 'absolute', left: 100, top: 100, width: 250, height: 300 }}
+        data-uid='ccc'
+      />
+    </View>
+    `,
+      [targetElement1, targetElement2],
+    )
+
+    const finalEditor = dragBy15Pixels(initialEditor)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 65, top: 65, width: 250, height: 300 }}
+          data-uid='bbb'
+        />
+        <View
+          style={{ backgroundColor: '#0091FFAB', position: 'absolute', left: 115, top: 115, width: 250, height: 300 }}
+          data-uid='ccc'
+        />
+      </View>`,
+      ),
+    )
+  })
+  it('works with TL pinned absolute elements in multiselection with descendant', async () => {
+    const targetElement1 = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+    const targetElement2 = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb', 'ccc'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50, top: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      >
+        <View
+          style={{ backgroundColor: '#0091FFAB', position: 'absolute', left: 100, top: 100, width: 250, height: 300 }}
+          data-uid='ccc'
+        />
+      </View>
+    </View>
+    `,
+      [targetElement1, targetElement2],
+    )
+
+    const finalEditor = dragBy15Pixels(initialEditor)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 65, top: 65, width: 250, height: 300 }}
+          data-uid='bbb'
+        >
+          <View
+            style={{ backgroundColor: '#0091FFAB', position: 'absolute', left: 100, top: 100, width: 250, height: 300 }}
+            data-uid='ccc'
+          />
+        </View>
+      </View>`,
+      ),
+    )
+  })
 })

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -10,6 +10,7 @@ import { ConstrainedDragAxis, GuidelineWithSnappingVector } from '../guideline'
 import { CanvasStrategy } from './canvas-strategy-types'
 import {
   getAbsoluteMoveCommandsForSelectedElement,
+  getDragTargets,
   getMultiselectBounds,
 } from './shared-absolute-move-strategy-helpers'
 
@@ -18,7 +19,8 @@ export const absoluteMoveStrategy: CanvasStrategy = {
   name: 'Absolute Move',
   isApplicable: (canvasState, _interactionState, metadata) => {
     if (canvasState.selectedElements.length > 0) {
-      return canvasState.selectedElements.every((element) => {
+      const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
+      return filteredSelectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
 
         return elementMetadata?.specialSizeMeasurements.position === 'absolute'
@@ -44,6 +46,7 @@ export const absoluteMoveStrategy: CanvasStrategy = {
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.interactionData.drag != null
     ) {
+      const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
       const drag = interactionState.interactionData.drag
       const shiftKeyPressed = interactionState.interactionData.modifiers.shift
       const constrainedDragAxis = shiftKeyPressed ? determineConstrainedDragAxis(drag) : null
@@ -54,7 +57,7 @@ export const absoluteMoveStrategy: CanvasStrategy = {
         canvasState.selectedElements,
         canvasState.scale,
       )
-      const commandsForSelectedElements = canvasState.selectedElements.flatMap((selectedElement) =>
+      const commandsForSelectedElements = filteredSelectedElements.flatMap((selectedElement) =>
         getAbsoluteMoveCommandsForSelectedElement(
           selectedElement,
           snappedDragVector,

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -95,7 +95,7 @@ function reparentElement(
   return finalEditor
 }
 
-describe('Absolute Rerarent Strategy', () => {
+describe('Absolute Reparent Strategy', () => {
   it('works with a TL pinned absolute element', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],
@@ -339,6 +339,328 @@ describe('Absolute Rerarent Strategy', () => {
           </div>
         </div>
         `),
+    )
+  })
+
+  it('works with a TL pinned absolute element with child', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'ccc'],
+    ])
+
+    const initialEditor = getEditorStateWithSelectedViews(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+        }}
+      >
+        <div
+          data-uid='bbb'
+          style={{
+            position: 'absolute',
+            width: 250,
+            height: 200,
+            top: 60,
+            left: 50,
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={{
+            position: 'absolute',
+            width: 20,
+            height: 30,
+            top: 75,
+            left: 90,
+          }}
+        >
+          <div
+            data-uid='ddd'
+            style={{
+              position: 'absolute',
+              width: 10,
+              height: 10,
+              top: 30,
+              left: 40,
+            }}
+          />
+        </div>
+      </div>
+      `),
+      [targetElement],
+    )
+
+    const finalEditor = reparentElement(initialEditor, false)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `
+        <div
+        data-uid='aaa'
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+        }}
+        >
+          <div
+            data-uid='bbb'
+            style={{
+              position: 'absolute',
+              width: 250,
+              height: 200,
+              top: 60,
+              left: 50,
+            }}
+          >
+            <div
+              data-uid='ccc'
+              style={{
+                position: 'absolute',
+                width: 20,
+                height: 30,
+                top: 15,
+                left: 40,
+              }}
+            >
+              <div
+                data-uid='ddd'
+                style={{
+                  position: 'absolute',
+                  width: 10,
+                  height: 10,
+                  top: 30,
+                  left: 40,
+                }}
+              />
+            </div>
+          </div>
+        </div>
+        `,
+      ),
+    )
+  })
+
+  it('works with TL pinned absolute elements in multiselection', async () => {
+    const targetElement1 = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'ccc'],
+    ])
+
+    const targetElement2 = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'ddd'],
+    ])
+
+    const initialEditor = getEditorStateWithSelectedViews(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+        }}
+      >
+        <div
+          data-uid='bbb'
+          style={{
+            position: 'absolute',
+            width: 250,
+            height: 200,
+            top: 60,
+            left: 50,
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={{
+            position: 'absolute',
+            width: 20,
+            height: 30,
+            top: 75,
+            left: 90,
+          }}
+        />
+        <div
+          data-uid='ddd'
+          style={{
+            position: 'absolute',
+            width: 10,
+            height: 10,
+            top: 30,
+            left: 40,
+          }}
+        />
+      </div>
+      `),
+      [targetElement1, targetElement2],
+    )
+
+    const finalEditor = reparentElement(initialEditor, false)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `
+        <div
+        data-uid='aaa'
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+        }}
+        >
+          <div
+            data-uid='bbb'
+            style={{
+              position: 'absolute',
+              width: 250,
+              height: 200,
+              top: 60,
+              left: 50,
+            }}
+          >
+            <div
+              data-uid='ccc'
+              style={{
+                position: 'absolute',
+                width: 20,
+                height: 30,
+                top: 15,
+                left: 40,
+              }}
+            />
+            <div
+              data-uid='ddd'
+              style={{
+                position: 'absolute',
+                width: 10,
+                height: 10,
+                top: -30,
+                left: -10,
+              }}
+            />
+          </div>
+        </div>
+        `,
+      ),
+    )
+  })
+
+  it('works with a TL pinned absolute elements in multiselection with descendant', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'ccc'],
+    ])
+    const targetElement2 = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'ccc', 'ddd'],
+    ])
+
+    const initialEditor = getEditorStateWithSelectedViews(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+        }}
+      >
+        <div
+          data-uid='bbb'
+          style={{
+            position: 'absolute',
+            width: 250,
+            height: 200,
+            top: 60,
+            left: 50,
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={{
+            position: 'absolute',
+            width: 20,
+            height: 30,
+            top: 75,
+            left: 90,
+          }}
+        >
+          <div
+            data-uid='ddd'
+            style={{
+              position: 'absolute',
+              width: 10,
+              height: 10,
+              top: 30,
+              left: 40,
+            }}
+          />
+        </div>
+      </div>
+      `),
+      [targetElement],
+    )
+
+    const finalEditor = reparentElement(initialEditor, false)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `
+        <div
+        data-uid='aaa'
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+        }}
+        >
+          <div
+            data-uid='bbb'
+            style={{
+              position: 'absolute',
+              width: 250,
+              height: 200,
+              top: 60,
+              left: 50,
+            }}
+          >
+            <div
+              data-uid='ccc'
+              style={{
+                position: 'absolute',
+                width: 20,
+                height: 30,
+                top: 15,
+                left: 40,
+              }}
+            >
+              <div
+                data-uid='ddd'
+                style={{
+                  position: 'absolute',
+                  width: 10,
+                  height: 10,
+                  top: 30,
+                  left: 40,
+                }}
+              />
+            </div>
+          </div>
+        </div>
+        `,
+      ),
     )
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
@@ -7,6 +7,7 @@ import { absoluteMoveStrategy } from './absolute-move-strategy'
 import { CanvasStrategy } from './canvas-strategy-types'
 import {
   getAbsoluteOffsetCommandsForSelectedElement,
+  getDragTargets,
   getFileOfElement,
 } from './shared-absolute-move-strategy-helpers'
 
@@ -15,36 +16,38 @@ export const absoluteReparentStrategy: CanvasStrategy = {
   name: 'Reparent Absolute Elements',
   isApplicable: (canvasState, interactionState, metadata) => {
     if (
-      canvasState.selectedElements.length === 1 &&
+      canvasState.selectedElements.length > 0 &&
       interactionState != null &&
       interactionState.interactionData.modifiers.cmd
     ) {
-      const selectedMetadata = MetadataUtils.findElementByElementPath(
-        metadata,
-        canvasState.selectedElements[0],
-      )
-      return selectedMetadata?.specialSizeMeasurements.position === 'absolute'
+      const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
+      return filteredSelectedElements.every((element) => {
+        const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
+
+        return elementMetadata?.specialSizeMeasurements.position === 'absolute'
+      })
     }
     return false
   },
   controlsToRender: [],
   fitness: (canvasState, interactionState) => {
     if (
-      canvasState.selectedElements.length === 1 &&
+      canvasState.selectedElements.length > 0 &&
       interactionState.interactionData.modifiers.cmd &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.interactionData.dragThresholdPassed
     ) {
-      return 999
+      return 2
     }
     return 0
   },
   apply: (canvasState, interactionState, strategyState) => {
     const { selectedElements, scale, canvasOffset, projectContents, openFile } = canvasState
+    const filteredSelectedElements = getDragTargets(selectedElements)
 
     const reparentResult = getReparentTarget(
-      selectedElements,
-      selectedElements,
+      filteredSelectedElements,
+      filteredSelectedElements,
       strategyState.startingMetadata,
       [],
       scale,
@@ -59,14 +62,14 @@ export const absoluteReparentStrategy: CanvasStrategy = {
       newParent,
     )?.specialSizeMeasurements.providesBoundsForChildren
 
-    const target = selectedElements[0]
-
-    const targetElementFile = getFileOfElement(target, projectContents, openFile)
+    const selectedElementFiles = filteredSelectedElements.map((element) =>
+      getFileOfElement(element, projectContents, openFile),
+    )
 
     const newParentFile = getFileOfElement(newParent, projectContents, openFile)
 
     // Currently we only support reparenting into the same file
-    const reparentingToSameFile = targetElementFile === newParentFile
+    const reparentingToSameFile = selectedElementFiles.every((file) => file === newParentFile)
 
     if (
       reparentResult.shouldReparent &&
@@ -74,20 +77,28 @@ export const absoluteReparentStrategy: CanvasStrategy = {
       providesBoundsForChildren &&
       reparentingToSameFile
     ) {
-      const newPath = EP.appendToPath(newParent, EP.toUid(target))
+      const commands = filteredSelectedElements.map((selectedElement) => {
+        const offsetCommands = getAbsoluteOffsetCommandsForSelectedElement(
+          selectedElement,
+          newParent,
+          strategyState,
+          canvasState,
+        )
 
-      const offsetCommands = getAbsoluteOffsetCommandsForSelectedElement(
-        target,
-        newParent,
-        strategyState,
-        canvasState,
-      )
+        const newPath = EP.appendToPath(newParent, EP.toUid(selectedElement))
+        return {
+          newPath: newPath,
+          commands: [...offsetCommands, reparentElement('permanent', selectedElement, newParent)],
+        }
+      })
 
       return [
         ...moveCommands,
-        ...offsetCommands,
-        reparentElement('permanent', target, newParent),
-        updateSelectedViews('permanent', [newPath]),
+        ...commands.flatMap((c) => c.commands),
+        updateSelectedViews(
+          'permanent',
+          commands.map((c) => c.newPath),
+        ),
       ]
     } else {
       return moveCommands

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
@@ -198,3 +198,10 @@ export function getFileOfElement(
     (_success, _element, _underlyingTarget, underlyingFilePath) => underlyingFilePath,
   )
 }
+
+// No need to include descendants in multiselection when dragging
+export function getDragTargets(selectedViews: Array<ElementPath>): Array<ElementPath> {
+  return selectedViews.filter((view) =>
+    selectedViews.every((otherView) => !EP.isDescendantOf(view, otherView)),
+  )
+}


### PR DESCRIPTION
# Issue

## Reparenting
Multiselection handling was not implemented in the absolute reparenting strategy.

## Moving
Multiselection was implemented in the absolute move strategy, but it did not filter out descendants, which caused them to move twice (their moved with their parent and also locally in the parent)

# Solution

I implemented multiselection in the reparenting strategy.
Filter out the descendants from the selection, they move with their parent anyway.
I added multiselection tests for both strategies