### PR TITLE
Remove non-standard dom element props

### DIFF
--- a/editor/src/uuiui/inputs/string-input.tsx
+++ b/editor/src/uuiui/inputs/string-input.tsx
@@ -156,7 +156,8 @@ export type HeadlessStringInputProps = React.InputHTMLAttributes<HTMLInputElemen
 
 export const HeadlessStringInput = React.forwardRef<HTMLInputElement, HeadlessStringInputProps>(
   (props, propsRef) => {
-    const { disabled, onKeyDown, onFocus, onSubmitValue, onEscape } = props
+    const { onSubmitValue, onEscape, ...otherProps } = props
+    const { disabled, onKeyDown, onFocus } = otherProps
 
     const ref = React.useRef<HTMLInputElement>(null)
 
@@ -202,7 +203,7 @@ export const HeadlessStringInput = React.forwardRef<HTMLInputElement, HeadlessSt
     return (
       <input
         ref={composeRefs(ref, propsRef)}
-        {...props}
+        {...otherProps}
         onKeyDown={handleOnKeyDown}
         onFocus={handleOnFocus}
       />


### PR DESCRIPTION
# Issue

This error is visible regularly in the console:
![image](https://user-images.githubusercontent.com/127662/165977611-5ed1fbbb-a416-42ac-808c-fe896c4745eb.png)

# Fix

See https://reactjs.org/warnings/unknown-prop.html
`onSubmitValue` and `onEscape` are not standard props for input dom elements, we should remove them before passing to the `input` element