### PR TITLE
fix(inspector) fix highlight effect

### DIFF
--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -199,6 +199,24 @@ export class InspectorContextMenuWrapper<T> extends ReactComponent<ContextMenuWr
         css={{
           width: '100%',
           ...this.props.style,
+          '--control-styles-interactive-unset-main-color': UtopiaTheme.color.fg7.value,
+          '--control-styles-interactive-unset-secondary-color': UtopiaTheme.color.fg7.value,
+          '--control-styles-interactive-unset-track-color': UtopiaTheme.color.bg5.value,
+          '--control-styles-interactive-unset-rail-color': UtopiaTheme.color.bg3.value,
+          '&:hover': {
+            '--control-styles-interactive-unset-main-color': getControlStyles('simple').mainColor,
+            '--control-styles-interactive-unset-secondary-color': getControlStyles('simple')
+              .secondaryColor,
+            '--control-styles-interactive-unset-track-color': getControlStyles('simple').trackColor,
+            '--control-styles-interactive-unset-rail-color': getControlStyles('simple').railColor,
+          },
+          '&:focus-within': {
+            '--control-styles-interactive-unset-main-color': getControlStyles('simple').mainColor,
+            '--control-styles-interactive-unset-secondary-color': getControlStyles('simple')
+              .secondaryColor,
+            '--control-styles-interactive-unset-track-color': getControlStyles('simple').trackColor,
+            '--control-styles-interactive-unset-rail-color': getControlStyles('simple').railColor,
+          },
         }}
       >
         <React.Fragment>

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -1,6 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx jsx */
-import { css, jsx } from '@emotion/react'
 import * as ObjectPath from 'object-path'
 import React from 'react'
 import {
@@ -84,7 +81,6 @@ import { ElementPath, PropertyPath } from '../../core/shared/project-file-types'
 import { when } from '../../utils/react-conditionals'
 import { createSelector } from 'reselect'
 import { isTwindEnabled } from '../../core/tailwind/tailwind'
-import { getControlStyles } from './common/control-status'
 import { isStrategyActive } from '../canvas/canvas-strategies/canvas-strategies'
 
 export interface ElementPathElement {
@@ -352,26 +348,6 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
           width: '100%',
           position: 'relative',
           color: colorTheme.neutralForeground.value,
-        }}
-        css={{
-          '--control-styles-interactive-unset-main-color': UtopiaTheme.color.fg7.value,
-          '--control-styles-interactive-unset-secondary-color': UtopiaTheme.color.fg7.value,
-          '--control-styles-interactive-unset-track-color': UtopiaTheme.color.bg5.value,
-          '--control-styles-interactive-unset-rail-color': UtopiaTheme.color.bg3.value,
-          '&:hover': {
-            '--control-styles-interactive-unset-main-color': getControlStyles('simple').mainColor,
-            '--control-styles-interactive-unset-secondary-color': getControlStyles('simple')
-              .secondaryColor,
-            '--control-styles-interactive-unset-track-color': getControlStyles('simple').trackColor,
-            '--control-styles-interactive-unset-rail-color': getControlStyles('simple').railColor,
-          },
-          '&:focus-within': {
-            '--control-styles-interactive-unset-main-color': getControlStyles('simple').mainColor,
-            '--control-styles-interactive-unset-secondary-color': getControlStyles('simple')
-              .secondaryColor,
-            '--control-styles-interactive-unset-track-color': getControlStyles('simple').trackColor,
-            '--control-styles-interactive-unset-rail-color': getControlStyles('simple').railColor,
-          },
         }}
         onFocus={onFocus}
       >

--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/layout-system-controls.tsx
@@ -10,6 +10,7 @@ import {
   InspectorInfo,
   stylePropPathMappingFn,
   InspectorPropsContext,
+  useInspectorInfoSimpleUntyped,
 } from '../../../common/property-path-hooks'
 import { useEditorState } from '../../../../editor/store/store-hook'
 import { switchLayoutSystem } from '../../../../editor/actions/action-creators'
@@ -35,6 +36,10 @@ import {
 import { useInspectorInfoLonghandShorthand } from '../../../common/longhand-shorthand-hooks'
 import { PropertyPath } from '../../../../../core/shared/project-file-types'
 import { useContextSelector } from 'use-context-selector'
+import { UIGridRow } from '../../../widgets/ui-grid-row'
+import { PropertyLabel } from '../../../widgets/property-label'
+import { InspectorContextMenuWrapper } from '../../../../context-menu-wrapper'
+import { optionalAddOnUnsetValues } from '../../../common/context-menu-items'
 
 function useDefaultedLayoutSystemInfo(): {
   value: LayoutSystem | 'flow'
@@ -151,6 +156,50 @@ export function buildPaddingPropsToUnset(
     stylePropPathMappingFn('paddingBottom', propertyTarget),
   ]
 }
+
+export const PaddingRow = React.memo(() => {
+  const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
+    return contextData.targetPath
+  })
+  const paddingPropsToUnset = React.useMemo(() => {
+    return buildPaddingPropsToUnset(targetPath)
+  }, [targetPath])
+  const metadata = useInspectorInfoSimpleUntyped(
+    paddingPropsToUnset,
+    (v) => v,
+    (v) => v,
+  )
+
+  const contextMenuLabel = React.useMemo(() => ['all paddings'], [])
+  const contextMenuItems = React.useMemo(
+    () =>
+      optionalAddOnUnsetValues(
+        metadata.propertyStatus.set,
+        contextMenuLabel,
+        metadata.onUnsetValues,
+      ),
+    [contextMenuLabel, metadata.propertyStatus.set, metadata.onUnsetValues],
+  )
+
+  return (
+    <InspectorContextMenuWrapper
+      id='padding-subsection-context-menu'
+      items={contextMenuItems}
+      data={null}
+    >
+      <UIGridRow tall padded={true} variant='<---1fr--->|------172px-------|'>
+        <PropertyLabel
+          target={paddingPropsToUnset}
+          propNamesToUnset={contextMenuLabel}
+          style={{ paddingBottom: 12 }}
+        >
+          Padding
+        </PropertyLabel>
+        <PaddingControl />
+      </UIGridRow>
+    </InspectorContextMenuWrapper>
+  )
+})
 
 export const PaddingControl = React.memo(() => {
   const {

--- a/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/container-subsection.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { useContextSelector } from 'use-context-selector'
 import {
   FlexRow,
   H1,
@@ -8,14 +7,8 @@ import {
   InspectorSectionIcons,
   InspectorSubsectionHeader,
 } from '../../../../../uuiui'
-import { InspectorPropsContext } from '../../../common/property-path-hooks'
-import { PropertyLabel } from '../../../widgets/property-label'
 import { SeeMoreButton, SeeMoreHOC, useToggle } from '../../../widgets/see-more'
-import { UIGridRow } from '../../../widgets/ui-grid-row'
-import {
-  PaddingControl,
-  buildPaddingPropsToUnset,
-} from '../../layout-section/layout-system-subsection/layout-system-controls'
+import { PaddingRow } from '../../layout-section/layout-system-subsection/layout-system-controls'
 import { BlendModeRow } from './blendmode-row'
 import { OpacityRow } from './opacity-row'
 import { OverflowRow } from './overflow-row'
@@ -23,12 +16,7 @@ import { RadiusRow } from './radius-row'
 
 export const ContainerSubsection = React.memo(() => {
   const [seeMoreVisible, toggleSeeMoreVisible] = useToggle(false)
-  const targetPath = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
-  const paddingPropsToUnset = React.useMemo(() => {
-    return buildPaddingPropsToUnset(targetPath)
-  }, [targetPath])
+
   return (
     <>
       <InspectorSubsectionHeader>
@@ -50,16 +38,7 @@ export const ContainerSubsection = React.memo(() => {
       <OpacityRow />
       <OverflowRow />
       <RadiusRow />
-      <UIGridRow tall padded={true} variant='<---1fr--->|------172px-------|'>
-        <PropertyLabel
-          target={paddingPropsToUnset}
-          propNamesToUnset={['all paddings']}
-          style={{ paddingBottom: 12 }}
-        >
-          Padding
-        </PropertyLabel>
-        <PaddingControl />
-      </UIGridRow>
+      <PaddingRow />
       <SeeMoreHOC visible={seeMoreVisible}>
         <BlendModeRow />
       </SeeMoreHOC>

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2350`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2373`)
   })
 
   it('Changing the selected view with a less simple project', async () => {

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`357`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`361`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`417`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`421`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2503`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2526`)
   })
 })


### PR DESCRIPTION
**Problem:**
There is a bug in the inspector, all rows are highlighted when you mouseover. The editor should only highlight 1 row where your cursor is.

**Fix:**
Moving the control styles back to the contextmenu, and adding the missing contextmenu (and creating the mouseover effect) for padding row.

**Commit Details:**
- hover css for control styles moved to context-menu-wrapper
- added a padding row that can use the contextmenu with one item that deletes all paddings
- updated render count tests
