### PR TITLE
mini fix to canvasInteractionHappening

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -117,9 +117,13 @@ function DomWalkerWrapper(props: UiJsxCanvasPropsWithErrorCallback) {
     (store) => store.editor.selectedViews,
     'DomWalkerWrapper selectedViews',
   )
+  const interactionSessionActive = useEditorState(
+    (store) => store.editor.canvas.interactionSession != null,
+    'DomWalkerWrapper interactionSession',
+  )
   let [updateInvalidatedPaths, updateInvalidatedScenes, containerRef] = useDomWalker({
     selectedViews: selectedViews,
-    canvasInteractionHappening: props.transientFilesState != null,
+    canvasInteractionHappening: interactionSessionActive || props.transientFilesState != null,
     mountCount: props.mountCount,
     domWalkerInvalidateCount: props.domWalkerInvalidateCount,
     scale: props.scale,

--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -32,20 +32,10 @@ interface CanvasComponentEntryProps {}
 
 export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps) => {
   const dispatch = useEditorState((store) => store.dispatch, 'CanvasComponentEntry dispatch')
-  const onDomReport = React.useCallback(
-    // TODO move to DomWalkerWrapper
-    (elementMetadata: ReadonlyArray<ElementInstanceMetadata>, cachedPaths: Array<ElementPath>) => {
-      dispatch([saveDOMReport(elementMetadata, cachedPaths)])
-    },
-    [dispatch],
-  )
+
   const canvasScrollAnimation = useEditorState(
     (store) => store.editor.canvas.scrollAnimation,
     'CanvasComponentEntry scrollAnimation',
-  )
-  const canvasScale = useEditorState(
-    (store) => store.editor.canvas.scale,
-    'CanvasComponentEntry canvasScale',
   )
   const { addToRuntimeErrors, clearRuntimeErrors } = useWriteOnlyRuntimeErrors()
   const { addToConsoleLogs, clearConsoleLogs } = useWriteOnlyConsoleLogs()
@@ -110,12 +100,7 @@ export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps
               projectContents={canvasProps.projectContents}
               requireFn={canvasProps.curriedRequireFn}
             >
-              <DomWalkerWrapper
-                {...canvasProps}
-                onDomReport={onDomReport}
-                scale={canvasScale}
-                clearErrors={localClearRuntimeErrors}
-              />
+              <DomWalkerWrapper {...canvasProps} clearErrors={localClearRuntimeErrors} />
             </RemoteDependencyBoundary>
           </CanvasErrorBoundary>
         )}
@@ -124,15 +109,18 @@ export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps
   )
 })
 
-type DomWalkerWrapperProps = UiJsxCanvasPropsWithErrorCallback & {
-  scale: number
-  onDomReport: (
-    elementMetadata: ReadonlyArray<ElementInstanceMetadata>,
-    cachedPaths: Array<ElementPath>,
-  ) => void
-}
-
-function DomWalkerWrapper(props: DomWalkerWrapperProps) {
+function DomWalkerWrapper(props: UiJsxCanvasPropsWithErrorCallback) {
+  const dispatch = useEditorState((store) => store.dispatch, 'CanvasComponentEntry dispatch')
+  const onDomReport = React.useCallback(
+    (elementMetadata: ReadonlyArray<ElementInstanceMetadata>, cachedPaths: Array<ElementPath>) => {
+      dispatch([saveDOMReport(elementMetadata, cachedPaths)])
+    },
+    [dispatch],
+  )
+  const canvasScale = useEditorState(
+    (store) => store.editor.canvas.scale,
+    'CanvasComponentEntry canvasScale',
+  )
   const selectedViews = useEditorState(
     (store) => store.editor.selectedViews,
     'DomWalkerWrapper selectedViews',
@@ -146,8 +134,8 @@ function DomWalkerWrapper(props: DomWalkerWrapperProps) {
     canvasInteractionHappening: interactionSessionActive || props.transientFilesState != null,
     mountCount: props.mountCount,
     domWalkerInvalidateCount: props.domWalkerInvalidateCount,
-    scale: props.scale,
-    onDomReport: props.onDomReport,
+    scale: canvasScale,
+    onDomReport: onDomReport,
     additionalElementsToUpdate: props.domWalkerAdditionalElementsToUpdate,
   })
 

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -55,7 +55,6 @@ import type { CurriedResolveFn } from '../custom-code/code-file'
 import * as path from 'path'
 
 export interface PartialCanvasProps {
-  scale: UiJsxCanvasProps['scale']
   hiddenInstances: UiJsxCanvasProps['hiddenInstances']
   editedTextElement: UiJsxCanvasProps['editedTextElement']
   mountCount: UiJsxCanvasProps['mountCount']
@@ -206,14 +205,11 @@ export function renderCanvasReturnResultAndError(
       curriedRequireFn: curriedRequireFn,
       curriedResolveFn: dumbResolveFn(Object.keys(codeFilesString)),
       base64FileBlobs: {},
-      onDomReport: Utils.NO_OP,
       clearErrors: clearErrors,
-      scale: 1,
       hiddenInstances: [],
       editedTextElement: null,
       mountCount: 0,
       domWalkerInvalidateCount: 0,
-      walkDOM: false,
       imports_KILLME: imports,
       canvasIsLive: false,
       shouldIncludeCanvasRootInTheSpy: false,
@@ -223,7 +219,6 @@ export function renderCanvasReturnResultAndError(
       focusedElementPath: null,
       projectContents: storeHookForTest.api.getState().editor.projectContents,
       transientFilesState: storeHookForTest.api.getState().derived.canvas.transientState.filesState,
-      scrollAnimation: false,
       propertyControlsInfo: {},
       dispatch: NO_OP,
       domWalkerAdditionalElementsToUpdate: [],
@@ -235,10 +230,8 @@ export function renderCanvasReturnResultAndError(
       curriedRequireFn: curriedRequireFn,
       curriedResolveFn: dumbResolveFn(Object.keys(codeFilesString)),
       base64FileBlobs: {},
-      onDomReport: Utils.NO_OP,
       clearErrors: clearErrors,
       domWalkerInvalidateCount: 0,
-      walkDOM: false,
       imports_KILLME: imports,
       canvasIsLive: false,
       shouldIncludeCanvasRootInTheSpy: false,
@@ -248,7 +241,6 @@ export function renderCanvasReturnResultAndError(
       focusedElementPath: null,
       projectContents: storeHookForTest.api.getState().editor.projectContents,
       transientFilesState: storeHookForTest.api.getState().derived.canvas.transientState.filesState,
-      scrollAnimation: false,
       propertyControlsInfo: {},
       dispatch: NO_OP,
       domWalkerAdditionalElementsToUpdate: [],

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -136,7 +136,6 @@ export const DomWalkerInvalidatePathsCtxAtom = atomWithPubSub<DomWalkerInvalidat
 })
 
 export interface UiJsxCanvasProps {
-  scale: number
   uiFilePath: string
   curriedRequireFn: CurriedUtopiaRequireFn
   curriedResolveFn: CurriedResolveFn
@@ -145,11 +144,6 @@ export interface UiJsxCanvasProps {
   base64FileBlobs: CanvasBase64Blobs
   mountCount: number
   domWalkerInvalidateCount: number
-  onDomReport: (
-    elementMetadata: ReadonlyArray<ElementInstanceMetadata>,
-    cachedPaths: Array<ElementPath>,
-  ) => void
-  walkDOM: boolean
   imports_KILLME: Imports // FIXME this is the storyboard imports object used only for the cssimport
   canvasIsLive: boolean
   shouldIncludeCanvasRootInTheSpy: boolean // FOR ui-jsx-canvas.spec TESTS ONLY!!!! this prevents us from having to update the legacy test snapshots
@@ -159,7 +153,6 @@ export interface UiJsxCanvasProps {
   focusedElementPath: ElementPath | null
   projectContents: ProjectContentTreeRoot
   transientFilesState: TransientFilesState | null
-  scrollAnimation: boolean
   propertyControlsInfo: PropertyControlsInfo
   dispatch: EditorDispatch
   domWalkerAdditionalElementsToUpdate: Array<ElementPath>
@@ -182,11 +175,6 @@ export function pickUiJsxCanvasProps(
   editor: EditorState,
   derived: DerivedState,
   dispatch: EditorDispatch,
-  walkDOM: boolean,
-  onDomReport: (
-    elementMetadata: ReadonlyArray<ElementInstanceMetadata>,
-    cachedPaths: Array<ElementPath>,
-  ) => void,
   clearConsoleLogs: () => void,
   addToConsoleLogs: (log: ConsoleLog) => void,
 ): UiJsxCanvasProps | null {
@@ -220,7 +208,6 @@ export function pickUiJsxCanvasProps(
       hiddenInstances = [...hiddenInstances, editedTextElement]
     }
     return {
-      scale: editor.canvas.scale,
       uiFilePath: uiFilePath,
       curriedRequireFn: editor.codeResultCache.curriedRequireFn,
       curriedResolveFn: editor.codeResultCache.curriedResolveFn,
@@ -229,8 +216,6 @@ export function pickUiJsxCanvasProps(
       base64FileBlobs: editor.canvas.base64Blobs,
       mountCount: editor.canvas.mountCount,
       domWalkerInvalidateCount: editor.canvas.domWalkerInvalidateCount,
-      onDomReport: onDomReport,
-      walkDOM: walkDOM,
       imports_KILLME: imports_KILLME,
       clearConsoleLogs: clearConsoleLogs,
       addToConsoleLogs: addToConsoleLogs,
@@ -240,7 +225,6 @@ export function pickUiJsxCanvasProps(
       focusedElementPath: editor.focusedElementPath,
       projectContents: editor.projectContents,
       transientFilesState: derived.canvas.transientState.filesState,
-      scrollAnimation: editor.canvas.scrollAnimation,
       propertyControlsInfo: editor.propertyControlsInfo,
       dispatch: dispatch,
       domWalkerAdditionalElementsToUpdate: editor.canvas.domWalkerAdditionalElementsToUpdate,
@@ -297,13 +281,10 @@ function clearSpyCollectorInvalidPaths(
 export const UiJsxCanvas = React.memo(
   React.forwardRef<HTMLDivElement, UiJsxCanvasPropsWithErrorCallback>((props, ref) => {
     const {
-      scale,
       uiFilePath,
       curriedRequireFn,
       curriedResolveFn,
       hiddenInstances,
-      walkDOM,
-      onDomReport,
       imports_KILLME: imports, // FIXME this is the storyboard imports object used only for the cssimport
       clearErrors,
       clearConsoleLogs,
@@ -497,15 +478,8 @@ export const UiJsxCanvas = React.memo(
           <UtopiaProjectCtxAtom.Provider value={utopiaProjectContextValue}>
             <CanvasContainer
               ref={ref}
-              mountCount={props.mountCount}
-              domWalkerInvalidateCount={props.domWalkerInvalidateCount}
-              walkDOM={walkDOM}
-              scale={scale}
-              onDomReport={onDomReport}
               validRootPaths={rootValidPaths}
               canvasRootElementElementPath={storyboardRootElementPath}
-              scrollAnimation={props.scrollAnimation}
-              canvasInteractionHappening={props.transientFilesState != null}
             >
               <SceneLevelUtopiaCtxAtom.Provider value={sceneLevelUtopiaContextValue}>
                 {StoryboardRootComponent == null ? null : (
@@ -735,18 +709,8 @@ function useGetStoryboardRoot(
 }
 
 export interface CanvasContainerProps {
-  walkDOM: boolean
-  scale: number
-  onDomReport: (
-    elementMetadata: ReadonlyArray<ElementInstanceMetadata>,
-    cachedPaths: Array<ElementPath>,
-  ) => void
   canvasRootElementElementPath: ElementPath
   validRootPaths: Array<ElementPath>
-  mountCount: number
-  domWalkerInvalidateCount: number
-  scrollAnimation: boolean
-  canvasInteractionHappening: boolean
 }
 
 const CanvasContainer = React.forwardRef<


### PR DESCRIPTION
**Problem:**
canvasInteractionHappening was only checking for transientFileState, which means it was false during Strategy interactions.

**Fix:**
canvasInteractionHappening now also checks if `canvas.interactionSession != null`

**Commit Details:**
- canvasInteractionHappening now also checks if `canvas.interactionSession != null`
- While I was there, I removed some unused canvas props
- I removed unused props from `CanvasContainer` as well
- I moved onDomWalker to `DomWalkerWrapper`
