### PR TITLE
Remove the now redundant appending of UIDs

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -20,11 +20,9 @@ exports[`UiJsxCanvas #747 - DOM object constructor cannot be called as a functio
         width: 375px;
         height: 812px;
       \\"
-      data-uid=\\"scene sb\\"
+      data-uid=\\"scene\\"
     >
-      <div data-uid=\\"comment-root 5c5~~~1 app\\" data-path=\\"5c5~~~1:comment-root\\">
-        hat
-      </div>
+      <div data-uid=\\"comment-root\\" data-path=\\"5c5~~~1:comment-root\\">hat</div>
     </div>
   </div>
 </div>
@@ -144,7 +142,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "sb/scene",
-      "data-uid": "scene sb",
+      "data-uid": "scene",
       "data-utopia-scene-id": "sb/scene",
       "skipDeepFreeze": true,
       "style": Object {

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -20,11 +20,11 @@ exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"position: absolute; bottom: 0; left: 0; right: 0; top: 0;\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       >
         <div
@@ -184,7 +184,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -604,7 +604,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "bottom": 0,
@@ -1025,11 +1025,11 @@ exports[`UiJsxCanvas render Label carried through for normal elements 1`] = `
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"position: absolute; bottom: 0; left: 0; right: 0; top: 0;\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
         data-label=\\"Hat\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       ></div>
@@ -1174,7 +1174,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -1503,7 +1503,7 @@ Object {
     "props": Object {
       "data-label": "Hat",
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "bottom": 0,
@@ -1573,10 +1573,10 @@ exports[`UiJsxCanvas render Renders input tag without errors 1`] = `
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <input
-        data-uid=\\"00f 567 app-entity\\"
+        data-uid=\\"00f\\"
         style=\\"top: 10px;\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:567:00f\\"
       />
@@ -1721,7 +1721,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -1963,7 +1963,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:567",
-      "data-uid": "567 app-entity",
+      "data-uid": "567",
       "data-utopia-instance-path": Object {
         "parts": Array [
           Array [
@@ -2039,10 +2039,10 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
-        data-uid=\\"zzz app-entity\\"
+        data-uid=\\"zzz\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
@@ -2205,7 +2205,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -2589,7 +2589,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz app-entity",
+      "data-uid": "zzz",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -3105,10 +3105,10 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
-        data-uid=\\"zzz app-entity\\"
+        data-uid=\\"zzz\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
@@ -3322,7 +3322,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -3825,7 +3825,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz app-entity",
+      "data-uid": "zzz",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -6075,20 +6075,20 @@ exports[`UiJsxCanvas render class component is available from arbitrary block in
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
-        data-uid=\\"zzz app-entity\\"
+        data-uid=\\"zzz\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
-          data-uid=\\"ccc-unparsed-no-template-path aaa\\"
+          data-uid=\\"ccc-unparsed-no-template-path\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa\\"
         >
           Thing
         </div>
         <div
-          data-uid=\\"ccc-unparsed-no-template-path bbb\\"
+          data-uid=\\"ccc-unparsed-no-template-path\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb\\"
         >
           Thing
@@ -6235,7 +6235,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -6536,7 +6536,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz app-entity",
+      "data-uid": "zzz",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -6799,11 +6799,11 @@ exports[`UiJsxCanvas render console logging does not do anything bizarre 1`] = `
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"position: absolute; bottom: 0; left: 0; right: 0; top: 0;\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       ></div>
     </div>
@@ -6947,7 +6947,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -7261,7 +7261,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "bottom": 0,
@@ -7331,26 +7331,26 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are not the ap
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
-          data-uid=\\"xxx bbb~~~1\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
-          data-uid=\\"xxx bbb~~~2\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
-          data-uid=\\"xxx bbb~~~3\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
@@ -7497,7 +7497,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -7894,7 +7894,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -8482,26 +8482,26 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are undefined 
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
-          data-uid=\\"xxx bbb~~~1\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
-          data-uid=\\"xxx bbb~~~2\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
-          data-uid=\\"xxx bbb~~~3\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
@@ -8648,7 +8648,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -9045,7 +9045,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -9633,20 +9633,20 @@ exports[`UiJsxCanvas render function component is available from arbitrary block
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
-        data-uid=\\"zzz app-entity\\"
+        data-uid=\\"zzz\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
-          data-uid=\\"ccc aaa\\"
+          data-uid=\\"ccc\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa:ccc\\"
         >
           Thing
         </div>
         <div
-          data-uid=\\"ccc bbb\\"
+          data-uid=\\"ccc\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb:ccc\\"
         >
           Thing
@@ -9793,7 +9793,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -10094,7 +10094,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz app-entity",
+      "data-uid": "zzz",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -10385,20 +10385,20 @@ exports[`UiJsxCanvas render function component works inside a map 1`] = `
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
-        data-uid=\\"zzz app-entity\\"
+        data-uid=\\"zzz\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
-          data-uid=\\"ccc aaa~~~1\\"
+          data-uid=\\"ccc\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1:ccc\\"
         >
           Thing
         </div>
         <div
-          data-uid=\\"ccc aaa~~~2\\"
+          data-uid=\\"ccc\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2:ccc\\"
         >
           Thing
@@ -10545,7 +10545,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -10879,7 +10879,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz app-entity",
+      "data-uid": "zzz",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -11170,7 +11170,7 @@ exports[`UiJsxCanvas render handles a component that destructures its props obje
         width: 200px;
         top: 79px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"
@@ -11180,11 +11180,11 @@ exports[`UiJsxCanvas render handles a component that destructures its props obje
           background-color: #ffffff;
         \\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
           style=\\"position: absolute; background-color: #000000;\\"
-          data-uid=\\"xxx bbb\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
         >
           Hi there!
@@ -11345,7 +11345,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -11817,7 +11817,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "#FFFFFF",
@@ -12088,7 +12088,7 @@ exports[`UiJsxCanvas render handles a component that renames its props object 1`
         width: 200px;
         top: 79px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"
@@ -12098,10 +12098,10 @@ exports[`UiJsxCanvas render handles a component that renames its props object 1`
           background-color: #ffffff;
         \\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
-          data-uid=\\"xxx bbb\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
         >
           Hi there!
@@ -12262,7 +12262,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -12734,7 +12734,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "#FFFFFF",
@@ -13005,7 +13005,7 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
         width: 200px;
         top: 79px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"
@@ -13015,11 +13015,11 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
           background-color: #ffffff;
         \\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
           style=\\"position: absolute; background-color: #000000;\\"
-          data-uid=\\"xxx bbb\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
         >
           Hi there! - and hello!
@@ -13180,7 +13180,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -13700,7 +13700,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "#FFFFFF",
@@ -14025,7 +14025,7 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
         width: 200px;
         top: 79px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"
@@ -14035,11 +14035,11 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
           background-color: #ffffff;
         \\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
           style=\\"position: absolute; background-color: #000000;\\"
-          data-uid=\\"xxx bbb\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb:xxx\\"
         >
           Hi there! - and hello! - Now begone!
@@ -14200,7 +14200,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -14720,7 +14720,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "#FFFFFF",
@@ -15045,11 +15045,11 @@ exports[`UiJsxCanvas render handles chaining dependencies into the appropriate o
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:bbb:aaa\\"
-        data-uid=\\"aaa bbb app-entity\\"
+        data-uid=\\"aaa\\"
       ></div>
     </div>
   </div>
@@ -15192,7 +15192,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -15434,7 +15434,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:bbb",
-      "data-uid": "bbb app-entity",
+      "data-uid": "bbb",
       "data-utopia-instance-path": Object {
         "parts": Array [
           Array [
@@ -15510,7 +15510,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
         width: 375px;
         height: 812px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"
@@ -15527,7 +15527,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
           background-color: #171111;
         \\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
           style=\\"
@@ -15535,7 +15535,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
             grid-template-columns: 2fr 1fr;
             grid-auto-rows: 31px;
           \\"
-          data-uid=\\"eb1 03a\\"
+          data-uid=\\"eb1\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a:eb1\\"
         >
           <div
@@ -15551,7 +15551,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
             data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2\\"
           >
             <span
-              data-uid=\\"6a8 000\\"
+              data-uid=\\"6a8\\"
               data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000:6a8\\"
               ><span
                 style=\\"padding: 6px;\\"
@@ -15584,7 +15584,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
             data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4\\"
           >
             <span
-              data-uid=\\"6a8 000\\"
+              data-uid=\\"6a8\\"
               data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000:6a8\\"
               ><span
                 style=\\"padding: 6px;\\"
@@ -15617,7 +15617,7 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
             data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6\\"
           >
             <span
-              data-uid=\\"6a8 000\\"
+              data-uid=\\"6a8\\"
               data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000:6a8\\"
               ><span
                 style=\\"padding: 6px;\\"
@@ -15780,7 +15780,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -17100,7 +17100,7 @@ export var storyboard = (props) => {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "#171111",
@@ -20995,20 +20995,20 @@ exports[`UiJsxCanvas render props can be accessed inside the arbitrary js block 
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
-        data-uid=\\"zzz app-entity\\"
+        data-uid=\\"zzz\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
-          data-uid=\\"ccc aaa\\"
+          data-uid=\\"ccc\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa:ccc\\"
         >
           Hello World!!
         </div>
         <div
-          data-uid=\\"ddd bbb\\"
+          data-uid=\\"ddd\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb:ddd\\"
         >
           Hello Dolly!!
@@ -21155,7 +21155,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -21488,7 +21488,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz app-entity",
+      "data-uid": "zzz",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -21813,10 +21813,10 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a class 
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
-        data-uid=\\"ccc-unparsed-no-template-path aaa app-entity\\"
+        data-uid=\\"ccc-unparsed-no-template-path\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       >
         Thing
@@ -21962,7 +21962,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -22268,7 +22268,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "ref": [Function],
       "skipDeepFreeze": true,
     },
@@ -22332,11 +22332,11 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a functi
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"position: absolute; bottom: 0; left: 0; right: 0; top: 0;\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       ></div>
     </div>
@@ -22480,7 +22480,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -22851,7 +22851,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "ref": [Function],
       "skipDeepFreeze": true,
       "style": Object {
@@ -22922,16 +22922,16 @@ exports[`UiJsxCanvas render renderrs correctly when a component is passed in via
         width: 375px;
         height: 812px;
       \\"
-      data-uid=\\"fff eee\\"
+      data-uid=\\"fff\\"
     >
       <div
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
         style=\\"width: 100%; height: 100%; background-color: #ffffff;\\"
         data-path=\\"eee/fff/app-entity:aaa\\"
       >
         Test
         <div
-          data-uid=\\"ddd bbb\\"
+          data-uid=\\"ddd\\"
           style=\\"background-color: pink; width: 100%; height: 20px;\\"
           data-path=\\"eee/fff/app-entity:aaa/bbb:ddd\\"
         >
@@ -23059,7 +23059,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "eee/fff",
-      "data-uid": "fff eee",
+      "data-uid": "fff",
       "data-utopia-scene-id": "eee/fff",
       "skipDeepFreeze": true,
       "style": Object {
@@ -23433,7 +23433,7 @@ export var storyboard = (
     "localFrame": null,
     "props": Object {
       "data-path": "eee/fff/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "#FFFFFF",
@@ -23725,12 +23725,12 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"position: absolute; background-color: lightgrey;\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
           style=\\"
@@ -23741,7 +23741,7 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
             background-color: #dddddd;
           \\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59:6be\\"
-          data-uid=\\"6be d59\\"
+          data-uid=\\"6be\\"
         >
           <div
             style=\\"
@@ -23919,7 +23919,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -24287,7 +24287,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "lightgrey",
@@ -24681,7 +24681,7 @@ exports[`UiJsxCanvas render renders a canvas defined by a utopia storyboard comp
         width: 200px;
         top: 79px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"
@@ -24691,7 +24691,7 @@ exports[`UiJsxCanvas render renders a canvas defined by a utopia storyboard comp
           background-color: #ffffff;
         \\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
           style=\\"position: absolute;\\"
@@ -24856,7 +24856,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -25268,7 +25268,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "#FFFFFF",
@@ -25468,7 +25468,7 @@ exports[`UiJsxCanvas render renders a canvas reliant on another file that uses m
         width: 200px;
         top: 79px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"
@@ -25478,7 +25478,7 @@ exports[`UiJsxCanvas render renders a canvas reliant on another file that uses m
           background-color: #ffffff;
         \\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
           style=\\"position: absolute;\\"
@@ -25787,7 +25787,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -26200,7 +26200,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "#FFFFFF",
@@ -26400,10 +26400,10 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
         width: 600px;
         top: 0;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
-        data-uid=\\"b93 app-entity\\"
+        data-uid=\\"b93\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93\\"
       >
         <div
@@ -26413,13 +26413,13 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
           Originally Unassigned
         </div>
         <div
-          data-uid=\\"4cf 59c\\"
+          data-uid=\\"4cf\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/59c:4cf\\"
         >
           Originally Assigned
         </div>
         <div
-          data-uid=\\"4cf 54b\\"
+          data-uid=\\"4cf\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/54b:4cf\\"
         >
           Named Function
@@ -26431,13 +26431,13 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
           Named Class
         </div>
         <div
-          data-uid=\\"4cf 995\\"
+          data-uid=\\"4cf\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/995:4cf\\"
         >
           Named Export
         </div>
         <div
-          data-uid=\\"b93 0cf\\"
+          data-uid=\\"b93\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf:b93\\"
         >
           Renamed Export
@@ -26461,7 +26461,7 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
           The Number Is 4
         </div>
         <div
-          data-uid=\\"4cf d7f\\"
+          data-uid=\\"4cf\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f:4cf\\"
         >
           Default Function
@@ -26473,49 +26473,49 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
           Export Default Class
         </div>
         <div
-          data-uid=\\"4cf 5b9\\"
+          data-uid=\\"4cf\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9:4cf\\"
         >
           Default Named Function
         </div>
         <div
-          data-uid=\\"4cf 1a1\\"
+          data-uid=\\"4cf\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1:4cf\\"
         >
           Defined Then Default Exported
         </div>
         <div
-          data-uid=\\"4cf 301\\"
+          data-uid=\\"4cf\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/301:4cf\\"
         >
           Named As Default
         </div>
         <div
-          data-uid=\\"4cf 8ce\\"
+          data-uid=\\"4cf\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce:4cf\\"
         >
           Originally Assigned
         </div>
         <div
-          data-uid=\\"4cf f77\\"
+          data-uid=\\"4cf\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/f77:4cf\\"
         >
           Originally Assigned
         </div>
         <div
-          data-uid=\\"4cf 218\\"
+          data-uid=\\"4cf\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/218:4cf\\"
         >
           Originally Assigned
         </div>
         <div
-          data-uid=\\"4cf a17\\"
+          data-uid=\\"4cf\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/a17:4cf\\"
         >
           Originally Assigned
         </div>
         <div
-          data-uid=\\"4cf 8aa\\"
+          data-uid=\\"4cf\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa:4cf\\"
         >
           Default Function
@@ -26660,7 +26660,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -27532,7 +27532,7 @@ export var App = (props) => {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93",
-      "data-uid": "b93 app-entity",
+      "data-uid": "b93",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -29827,26 +29827,26 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
-          data-uid=\\"xxx bbb~~~1\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
-          data-uid=\\"xxx bbb~~~2\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
-          data-uid=\\"xxx bbb~~~3\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
@@ -29993,7 +29993,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -30390,7 +30390,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -30978,26 +30978,26 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
-          data-uid=\\"xxx bbb~~~1\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
-          data-uid=\\"xxx bbb~~~2\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
-          data-uid=\\"xxx bbb~~~3\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
@@ -31144,7 +31144,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -31542,7 +31542,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -32133,26 +32133,26 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block with 
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
-          data-uid=\\"xxx bbb~~~1\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1:xxx\\"
         >
           n1
         </div>
         <div
-          data-uid=\\"xxx bbb~~~2\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2:xxx\\"
         >
           n2
         </div>
         <div
-          data-uid=\\"xxx bbb~~~3\\"
+          data-uid=\\"xxx\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3:xxx\\"
         >
           n3
@@ -32299,7 +32299,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -32703,7 +32703,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -33291,13 +33291,13 @@ exports[`UiJsxCanvas render renders a component using the spread operator 1`] = 
         width: 200px;
         top: 79px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"position: absolute; height: 99.9; width: 77.7;\\"
         title=\\"Hi there!\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
           style=\\"position: absolute;\\"
@@ -33462,7 +33462,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -33836,7 +33836,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "height": "99.9",
@@ -34036,17 +34036,17 @@ exports[`UiJsxCanvas render renders a component with a fragment at the root 1`] 
         width: 212px;
         height: 188px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
       data-label=\\"Scene 2\\"
     >
       <div
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
       >
         hello
       </div>
       <div
-        data-uid=\\"bbb app-entity\\"
+        data-uid=\\"bbb\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:bbb\\"
       >
         bello
@@ -34187,7 +34187,7 @@ Object {
     "props": Object {
       "data-label": "Scene 2",
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -34406,7 +34406,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -34511,7 +34511,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:bbb",
-      "data-uid": "bbb app-entity",
+      "data-uid": "bbb",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -34574,10 +34574,10 @@ exports[`UiJsxCanvas render renders correctly with a context 1`] = `
         width: 375px;
         height: 812px;
       \\"
-      data-uid=\\"ddd ccc\\"
+      data-uid=\\"ddd\\"
     >
       <div
-        data-uid=\\"bbb aaa app-entity\\"
+        data-uid=\\"bbb\\"
         style=\\"width: 100%; height: 100%; background-color: #eb1010;\\"
         data-path=\\"ccc/ddd/app-entity:aaa/bbb\\"
       ></div>
@@ -34700,7 +34700,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "ccc/ddd",
-      "data-uid": "ddd ccc",
+      "data-uid": "ddd",
       "data-utopia-scene-id": "ccc/ddd",
       "skipDeepFreeze": true,
       "style": Object {
@@ -35029,7 +35029,7 @@ export var storyboard = (
     "localFrame": null,
     "props": Object {
       "data-path": "ccc/ddd/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "value": Object {
         "current": Object {},
@@ -35152,7 +35152,7 @@ export var storyboard = (
     "localFrame": null,
     "props": Object {
       "data-path": "ccc/ddd/app-entity:aaa/bbb",
-      "data-uid": "bbb aaa app-entity",
+      "data-uid": "bbb",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "#EB1010",
@@ -35220,10 +35220,10 @@ exports[`UiJsxCanvas render renders correctly with a nested context in another c
         width: 375px;
         height: 812px;
       \\"
-      data-uid=\\"ddd ccc\\"
+      data-uid=\\"ddd\\"
     >
       <div
-        data-uid=\\"bbb inner aaa card app-entity\\"
+        data-uid=\\"bbb\\"
         style=\\"width: 100%; height: 100%; background-color: #eb1010;\\"
         data-path=\\"ccc/ddd/app-entity:card:aaa/inner/bbb\\"
       ></div>
@@ -35346,7 +35346,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "ccc/ddd",
-      "data-uid": "ddd ccc",
+      "data-uid": "ddd",
       "data-utopia-scene-id": "ccc/ddd",
       "skipDeepFreeze": true,
       "style": Object {
@@ -35559,7 +35559,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "ccc/ddd/app-entity:card",
-      "data-uid": "card app-entity",
+      "data-uid": "card",
       "data-utopia-instance-path": Object {
         "parts": Array [
           Array [
@@ -35635,12 +35635,12 @@ exports[`UiJsxCanvas render renders fine with a valid registerModule call 1`] = 
         width: 200px;
         top: 79px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         style=\\"position: absolute; height: 99.9; width: 77.7;\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
           style=\\"position: absolute;\\"
@@ -35769,7 +35769,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -36060,7 +36060,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "height": "99.9",
@@ -36259,10 +36259,10 @@ exports[`UiJsxCanvas render renders fine with two circularly referencing arbitra
         width: 375px;
         height: 812px;
       \\"
-      data-uid=\\"scene utopia-storyboard-uid\\"
+      data-uid=\\"scene\\"
     >
       <div
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
         style=\\"width: 100%; height: 100%; background-color: #ffffff;\\"
         data-path=\\"utopia-storyboard-uid/scene/app-entity:aaa\\"
       >
@@ -36387,7 +36387,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene",
-      "data-uid": "scene utopia-storyboard-uid",
+      "data-uid": "scene",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene",
       "skipDeepFreeze": true,
       "style": Object {
@@ -36760,7 +36760,7 @@ export var storyboard = (
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "#FFFFFF",
@@ -36828,14 +36828,9 @@ exports[`UiJsxCanvas render renders fine with two components that reference each
         width: 375px;
         height: 812px;
       \\"
-      data-uid=\\"scene utopia-storyboard-uid\\"
+      data-uid=\\"scene\\"
     >
-      <div
-        data-uid=\\"1a9~~~1 aaa-unparsed-no-template-path bbb-unparsed-no-template-path BBB app-entity\\"
-        data-path=\\"1a9~~~1\\"
-      >
-        great
-      </div>
+      <div data-uid=\\"1a9~~~1\\" data-path=\\"1a9~~~1\\">great</div>
     </div>
   </div>
 </div>
@@ -36955,7 +36950,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene",
-      "data-uid": "scene utopia-storyboard-uid",
+      "data-uid": "scene",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene",
       "skipDeepFreeze": true,
       "style": Object {
@@ -37184,7 +37179,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene/app-entity:BBB",
-      "data-uid": "BBB app-entity",
+      "data-uid": "BBB",
       "skipDeepFreeze": true,
       "x": 5,
     },
@@ -37248,7 +37243,7 @@ exports[`UiJsxCanvas render renders fragments correctly 1`] = `
         width: 375px;
         top: 0;
       \\"
-      data-uid=\\"fff eee\\"
+      data-uid=\\"fff\\"
     >
       <div
         style=\\"
@@ -37260,7 +37255,7 @@ exports[`UiJsxCanvas render renders fragments correctly 1`] = `
           background-color: #ffffff;
         \\"
         data-path=\\"eee/fff/app:aaa\\"
-        data-uid=\\"aaa app\\"
+        data-uid=\\"aaa\\"
       >
         <div
           data-label=\\"random-div\\"
@@ -37419,7 +37414,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "eee/fff",
-      "data-uid": "fff eee",
+      "data-uid": "fff",
       "data-utopia-scene-id": "eee/fff",
       "skipDeepFreeze": true,
       "style": Object {
@@ -37978,7 +37973,7 @@ export var storyboard = (
     "localFrame": null,
     "props": Object {
       "data-path": "eee/fff/app:aaa",
-      "data-uid": "aaa app",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
       "style": Object {
         "backgroundColor": "#FFFFFF",
@@ -38513,11 +38508,11 @@ exports[`UiJsxCanvas render renders img tag 1`] = `
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <img
           data-uid=\\"bbb\\"
@@ -38666,7 +38661,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -38958,7 +38953,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -39139,10 +39134,10 @@ exports[`UiJsxCanvas render respects a jsx pragma 1`] = `
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
-        data-uid=\\"4cf aaa app-entity\\"
+        data-uid=\\"4cf\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:4cf\\"
         data-factory-function-works=\\"true\\"
       >
@@ -39290,7 +39285,7 @@ Object {
     "props": Object {
       "data-factory-function-works": "true",
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -39534,7 +39529,7 @@ Object {
     "props": Object {
       "data-factory-function-works": "true",
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "data-utopia-instance-path": Object {
         "parts": Array [
           Array [
@@ -39610,11 +39605,11 @@ exports[`UiJsxCanvas render supports passing down the scope to children of compo
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
-        data-uid=\\"aaa app-entity\\"
+        data-uid=\\"aaa\\"
       >
         <div
           data-uid=\\"bbb~~~1\\"
@@ -39791,7 +39786,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -40217,7 +40212,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {
@@ -41297,10 +41292,10 @@ exports[`UiJsxCanvas render the canvas supports emotion CSS prop 1`] = `
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
-        data-uid=\\"ba3 aaa app-entity\\"
+        data-uid=\\"ba3\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa:ba3\\"
         class=\\"css-16au7uv\\"
       >
@@ -41447,7 +41442,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -41689,7 +41684,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa app-entity",
+      "data-uid": "aaa",
       "data-utopia-instance-path": Object {
         "parts": Array [
           Array [
@@ -41765,14 +41760,14 @@ exports[`UiJsxCanvas render the spy wrapper is compatible with React.cloneElemen
         width: 400px;
         height: 400px;
       \\"
-      data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+      data-uid=\\"scene-aaa\\"
     >
       <div
-        data-uid=\\"zzz app-entity\\"
+        data-uid=\\"zzz\\"
         data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz\\"
       >
         <div
-          data-uid=\\"cloner-root cloner\\"
+          data-uid=\\"cloner-root\\"
           data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner:cloner-root\\"
         >
           <div
@@ -41925,7 +41920,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa utopia-storyboard-uid",
+      "data-uid": "scene-aaa",
       "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
       "skipDeepFreeze": true,
       "style": Object {
@@ -42233,7 +42228,7 @@ Object {
     "localFrame": null,
     "props": Object {
       "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz app-entity",
+      "data-uid": "zzz",
       "skipDeepFreeze": true,
     },
     "specialSizeMeasurements": Object {

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -496,7 +496,7 @@ describe('DOM Walker tests', () => {
         },
         "props": Object {
           "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
-          "data-uid": "05c app-entity",
+          "data-uid": "05c",
           "skipDeepFreeze": true,
           "style": Object {
             "backgroundColor": "#FFFFFF",
@@ -1163,7 +1163,7 @@ describe('DOM Walker tests', () => {
         },
         "props": Object {
           "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
-          "data-uid": "05c app-entity",
+          "data-uid": "05c",
           "skipDeepFreeze": true,
           "style": Object {
             "backgroundColor": "#FFFFFF",
@@ -1818,7 +1818,7 @@ describe('DOM Walker tests', () => {
         },
         "props": Object {
           "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
-          "data-uid": "05c app-entity",
+          "data-uid": "05c",
           "skipDeepFreeze": true,
           "style": Object {
             "backgroundColor": "#FFFFFF",
@@ -2463,7 +2463,7 @@ describe('DOM Walker tests', () => {
         "props": Object {
           "data-label": "Hat",
           "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-          "data-uid": "aaa app-entity",
+          "data-uid": "aaa",
           "skipDeepFreeze": true,
           "style": Object {
             "bottom": 0,
@@ -2902,7 +2902,7 @@ describe('DOM Walker tests', () => {
         },
         "props": Object {
           "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-          "data-uid": "aaa app-entity",
+          "data-uid": "aaa",
           "skipDeepFreeze": true,
           "style": Object {
             "bottom": 0,

--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -91,9 +91,9 @@ export var storyboard = (
               width: 375px;
               height: 812px;
             \\"
-            data-uid=\\"scene sb\\"
+            data-uid=\\"scene\\"
           >
-            <div data-uid=\\"app-root app\\" data-path=\\"sb/scene/app:app-root\\"></div>
+            <div data-uid=\\"app-root\\" data-path=\\"sb/scene/app:app-root\\"></div>
           </div>
         </div>
       </div>
@@ -155,9 +155,9 @@ export default function App(props) {
               width: 375px;
               height: 812px;
             \\"
-            data-uid=\\"scene sb\\"
+            data-uid=\\"scene\\"
           >
-            <div data-uid=\\"app-outer-div app\\" data-path=\\"sb/scene/app\\">
+            <div data-uid=\\"app-outer-div\\" data-path=\\"sb/scene/app\\">
               <div data-uid=\\"inner-div\\">hello</div>
             </div>
           </div>
@@ -252,11 +252,11 @@ export default function App(props) {
               width: 375px;
               height: 812px;
             \\"
-            data-uid=\\"scene-1-entity storyboard-entity\\"
+            data-uid=\\"scene-1-entity\\"
             data-label=\\"Imported App\\"
           >
             <div
-              data-uid=\\"app-outer-div app-entity\\"
+              data-uid=\\"app-outer-div\\"
               data-path=\\"storyboard-entity/scene-1-entity/app-entity\\"
             >
               <div data-uid=\\"inner-div\\">hello</div>
@@ -274,11 +274,11 @@ export default function App(props) {
               width: 375px;
               height: 812px;
             \\"
-            data-uid=\\"scene-2-entity storyboard-entity\\"
+            data-uid=\\"scene-2-entity\\"
             data-label=\\"Same File App\\"
           >
             <div
-              data-uid=\\"same-file-app-div same-file-app-entity\\"
+              data-uid=\\"same-file-app-div\\"
               data-label=\\"Scene Thing\\"
               style=\\"
                 position: relative;
@@ -406,11 +406,11 @@ export default function () {
               width: 375px;
               height: 812px;
             \\"
-            data-uid=\\"scene-1-entity storyboard-entity\\"
+            data-uid=\\"scene-1-entity\\"
             data-label=\\"Imported App\\"
           >
             <div
-              data-uid=\\"app-outer-div app-entity\\"
+              data-uid=\\"app-outer-div\\"
               style=\\"
                 position: relative;
                 width: 100%;
@@ -420,7 +420,7 @@ export default function () {
               data-path=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div\\"
             >
               <div
-                data-uid=\\"card-outer-div card-instance\\"
+                data-uid=\\"card-outer-div\\"
                 style=\\"
                   position: absolute;
                   left: 67px;
@@ -458,7 +458,7 @@ export default function () {
               </div>
               hello
               <div
-                data-uid=\\"4cf d7f\\"
+                data-uid=\\"4cf\\"
                 data-path=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/d7f:4cf\\"
               >
                 Default Function Time

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -5,7 +5,7 @@ import {
   UTOPIA_PATH_KEY,
   UTOPIA_SCENE_ID_KEY,
   UTOPIA_INSTANCE_PATH,
-  UTOPIA_UIDS_KEY,
+  UTOPIA_UID_KEY,
   UTOPIA_UID_ORIGINAL_PARENTS_KEY,
 } from '../../../core/model/utopia-constants'
 import { flatMapEither, forEachRight } from '../../../core/shared/either'
@@ -128,9 +128,9 @@ function monkeyUidProp(uid: string | undefined, propsToUpdate: MapLike<any>): Ma
     ...propsToUpdate,
   }
 
-  const uidsFromProps = monkeyedProps[UTOPIA_UIDS_KEY]
-  const uidsToPass = uidsFromProps ?? uid
-  monkeyedProps[UTOPIA_UIDS_KEY] = uidsToPass
+  const uidFromProps = monkeyedProps[UTOPIA_UID_KEY]
+  const uidToPass = uidFromProps ?? uid
+  monkeyedProps[UTOPIA_UID_KEY] = uidToPass
 
   return monkeyedProps
 }
@@ -213,7 +213,7 @@ export function renderCoreElement(
 
       const passthroughProps = monkeyUidProp(uid, assembledProps)
 
-      const key = optionalMap(EP.toString, elementPath) ?? passthroughProps[UTOPIA_UIDS_KEY]
+      const key = optionalMap(EP.toString, elementPath) ?? passthroughProps[UTOPIA_UID_KEY]
 
       return renderJSXElement(
         key,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -43,7 +43,7 @@ import { objectMap } from '../../../core/shared/object-utils'
 import { cssValueOnlyContainsComments } from '../../../printer-parsers/css/css-parser-utils'
 import { filterDataProps } from '../../../utils/canvas-react-utils'
 import { buildSpyWrappedElement } from './ui-jsx-canvas-spy-wrapper'
-import { appendToUidString, createIndexedUid } from '../../../core/shared/uid-utils'
+import { createIndexedUid } from '../../../core/shared/uid-utils'
 import { isComponentRendererComponent } from './ui-jsx-canvas-component-renderer'
 import { optionalMap } from '../../../core/shared/optional-utils'
 import { canvasMissingJSXElementError } from './canvas-render-errors'
@@ -129,7 +129,7 @@ function monkeyUidProp(uid: string | undefined, propsToUpdate: MapLike<any>): Ma
   }
 
   const uidsFromProps = monkeyedProps[UTOPIA_UIDS_KEY]
-  const uidsToPass = appendToUidString(uidsFromProps, uid)
+  const uidsToPass = uidsFromProps ?? uid
   monkeyedProps[UTOPIA_UIDS_KEY] = uidsToPass
 
   return monkeyedProps

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1285,10 +1285,10 @@ export var ${BakedInStoryboardVariableName} = (props) => {
               width: 400px;
               height: 400px;
             \\"
-            data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+            data-uid=\\"scene-aaa\\"
           >
             <div
-              data-uid=\\"ccc-unparsed-no-template-path aaa app-entity\\"
+              data-uid=\\"ccc-unparsed-no-template-path\\"
               data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:aaa\\"
             >
               hello
@@ -1383,13 +1383,9 @@ export var ${BakedInStoryboardVariableName} = (props) => {
               width: 400px;
               height: 400px;
             \\"
-            data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+            data-uid=\\"scene-aaa\\"
           >
-            <div
-              id=\\"nasty-div\\"
-              data-uid=\\"77f~~~1 833~~~2 65e~~~1 aaa app-entity\\"
-              data-path=\\"833~~~2/77f~~~1\\"
-            >
+            <div id=\\"nasty-div\\" data-uid=\\"77f~~~1\\" data-path=\\"833~~~2/77f~~~1\\">
               huhahuha
             </div>
           </div>
@@ -1894,10 +1890,10 @@ describe('UiJsxCanvas render multifile projects', () => {
               width: 200px;
               top: 79px;
             \\"
-            data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+            data-uid=\\"scene-aaa\\"
           >
             <div
-              data-uid=\\"app-outer-div app-entity\\"
+              data-uid=\\"app-outer-div\\"
               data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div\\"
             >
               <div
@@ -1978,14 +1974,14 @@ describe('UiJsxCanvas render multifile projects', () => {
               width: 200px;
               top: 79px;
             \\"
-            data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+            data-uid=\\"scene-aaa\\"
           >
             <div
-              data-uid=\\"app-outer-div app-entity\\"
+              data-uid=\\"app-outer-div\\"
               data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div\\"
             >
               <div
-                data-uid=\\"card-outer-div card-instance\\"
+                data-uid=\\"card-outer-div\\"
                 data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:app-outer-div/card-instance:card-outer-div\\"
               >
                 <div
@@ -2064,10 +2060,10 @@ describe('UiJsxCanvas render multifile projects', () => {
               width: 200px;
               top: 79px;
             \\"
-            data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+            data-uid=\\"scene-aaa\\"
           >
             <div
-              data-uid=\\"app-outer-div app-entity\\"
+              data-uid=\\"app-outer-div\\"
               data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity\\"
             >
               <div data-uid=\\"inner-div\\">Hi there!</div>
@@ -2135,10 +2131,10 @@ describe('UiJsxCanvas render multifile projects', () => {
               width: 200px;
               top: 79px;
             \\"
-            data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+            data-uid=\\"scene-aaa\\"
           >
             <div
-              data-uid=\\"app-outer-div app-entity\\"
+              data-uid=\\"app-outer-div\\"
               data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity\\"
             >
               <div data-uid=\\"inner-div\\">Hi there!</div>
@@ -2219,10 +2215,10 @@ describe('UiJsxCanvas render multifile projects', () => {
               width: 400px;
               height: 400px;
             \\"
-            data-uid=\\"scene-aaa utopia-storyboard-uid\\"
+            data-uid=\\"scene-aaa\\"
           >
             <div
-              data-uid=\\"outer-div app-entity\\"
+              data-uid=\\"outer-div\\"
               data-path=\\"utopia-storyboard-uid/scene-aaa/app-entity:outer-div\\"
             >
               <div

--- a/editor/src/components/editor/actions/actions.ts
+++ b/editor/src/components/editor/actions/actions.ts
@@ -513,7 +513,7 @@ import { emptySet } from '../../../core/shared/set-utils'
 import { absolutePathFromRelativePath, stripLeadingSlash } from '../../../utils/path-utils'
 import { resolveModule } from '../../../core/es-modules/package-manager/module-resolution'
 import { reverse, uniqBy } from '../../../core/shared/array-utils'
-import { UTOPIA_UIDS_KEY } from '../../../core/model/utopia-constants'
+import { UTOPIA_UID_KEY } from '../../../core/model/utopia-constants'
 import {
   DefaultPostCSSConfig,
   DefaultTailwindConfig,
@@ -4601,7 +4601,7 @@ export const UPDATE_FNS = {
           const propsWithUid = forceRight(
             setJSXValueAtPath(
               action.toInsert.element.props,
-              PP.create([UTOPIA_UIDS_KEY]),
+              PP.create([UTOPIA_UID_KEY]),
               jsxAttributeValue(newUID, emptyComments),
             ),
             `Could not set data-uid on props of insertable element ${action.toInsert.element.name}`,

--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -76,7 +76,7 @@ import {
 } from '../shared/project-components'
 import { ProjectContentTreeRoot } from '../assets'
 import { generateUidWithExistingComponents } from '../../core/model/element-template-utils'
-import { UTOPIA_UIDS_KEY } from '../../core/model/utopia-constants'
+import { UTOPIA_UID_KEY } from '../../core/model/utopia-constants'
 
 interface InsertMenuProps {
   lastFontSettings: FontSettings | null
@@ -135,7 +135,7 @@ export function componentBeingInserted(
 }
 
 function isUidProp(prop: JSXAttributesPart): boolean {
-  return isJSXAttributesEntry(prop) && prop.key === UTOPIA_UIDS_KEY
+  return isJSXAttributesEntry(prop) && prop.key === UTOPIA_UID_KEY
 }
 
 const isNonUidProp = (prop: JSXAttributesPart) => !isUidProp(prop)

--- a/editor/src/core/model/scene-utils.ts
+++ b/editor/src/core/model/scene-utils.ts
@@ -42,7 +42,7 @@ import {
   jsxSimpleAttributeToValue,
 } from '../shared/jsx-attributes'
 import { stripNulls } from '../shared/array-utils'
-import { UTOPIA_UIDS_KEY } from './utopia-constants'
+import { UTOPIA_UID_KEY } from './utopia-constants'
 import { getUtopiaID } from './element-template-utils'
 import { getContentsTreeFileFromString, ProjectContentTreeRoot } from '../../components/assets'
 import { getUtopiaJSXComponentsFromSuccess } from './project-file-utils'
@@ -150,7 +150,7 @@ export function createSceneFromComponent(
   uid: string,
 ): JSXElement {
   const sceneProps = jsxAttributesFromMap({
-    [UTOPIA_UIDS_KEY]: jsxAttributeValue(uid, emptyComments),
+    [UTOPIA_UID_KEY]: jsxAttributeValue(uid, emptyComments),
     style: jsxAttributeValue(
       {
         position: 'absolute',
@@ -173,7 +173,7 @@ export function createSceneFromComponent(
       componentImportedAs,
       componentUID,
       jsxAttributesFromMap({
-        [UTOPIA_UIDS_KEY]: jsxAttributeValue(componentUID, emptyComments),
+        [UTOPIA_UID_KEY]: jsxAttributeValue(componentUID, emptyComments),
       }),
       [],
     ),
@@ -182,7 +182,7 @@ export function createSceneFromComponent(
 
 export function createStoryboardElement(scenes: Array<JSXElement>, uid: string): JSXElement {
   const storyboardProps = jsxAttributesFromMap({
-    [UTOPIA_UIDS_KEY]: jsxAttributeValue(uid, emptyComments),
+    [UTOPIA_UID_KEY]: jsxAttributeValue(uid, emptyComments),
   })
   return jsxElement('Storyboard', uid, storyboardProps, scenes)
 }

--- a/editor/src/core/model/utopia-constants.ts
+++ b/editor/src/core/model/utopia-constants.ts
@@ -1,4 +1,4 @@
-export const UTOPIA_UIDS_KEY = 'data-uid'
+export const UTOPIA_UID_KEY = 'data-uid'
 export const UTOPIA_PATH_KEY = 'data-path'
 export const UTOPIA_LABEL_KEY = 'data-label'
 export const UTOPIA_DO_NOT_TRAVERSE_KEY = 'data-utopia-do-not-traverse'
@@ -8,7 +8,7 @@ export const UTOPIA_UID_ORIGINAL_PARENTS_KEY = 'data-utopia-original-parents'
 export const UTOPIA_INSTANCE_PATH = 'data-utopia-instance-path'
 
 export const UtopiaKeys: Array<string> = [
-  UTOPIA_UIDS_KEY,
+  UTOPIA_UID_KEY,
   UTOPIA_PATH_KEY,
   UTOPIA_LABEL_KEY,
   UTOPIA_DO_NOT_TRAVERSE_KEY,

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -24,7 +24,7 @@ import * as PP from './property-path'
 import * as EP from './element-path'
 import { objectMap, objectValues } from './object-utils'
 import { getDOMAttribute } from './dom-utils'
-import { UTOPIA_PATH_KEY, UTOPIA_UIDS_KEY } from '../model/utopia-constants'
+import { UTOPIA_PATH_KEY, UTOPIA_UID_KEY } from '../model/utopia-constants'
 import { addAllUniquely, mapDropNulls } from './array-utils'
 import { ElementPath } from './project-file-types'
 
@@ -208,14 +208,6 @@ export function fixUtopiaElement(
   }
 
   return fixUtopiaElementInner(elementToFix)
-}
-
-export function uidsFromString(uidList: string = ''): Array<string> {
-  return uidList.split(' ')
-}
-
-export function uidsToString(uidList: Array<string>): string {
-  return uidList.join(' ')
 }
 
 function getSplitPathsStrings(pathsString: string | null): Array<string> {

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -218,22 +218,6 @@ export function uidsToString(uidList: Array<string>): string {
   return uidList.join(' ')
 }
 
-export function appendToUidString(
-  uidsString: string | null | undefined,
-  uidsToAppendString: string | null | undefined,
-): string | null {
-  if (uidsToAppendString == null) {
-    return uidsString ?? null
-  } else if (uidsString == null || uidsString.length === 0) {
-    return uidsToAppendString
-  } else {
-    const existingUIDs = uidsFromString(uidsString)
-    const uidsToAppend = uidsFromString(uidsToAppendString)
-    const updatedUIDs = addAllUniquely(existingUIDs, uidsToAppend)
-    return uidsToString(updatedUIDs)
-  }
-}
-
 function getSplitPathsStrings(pathsString: string | null): Array<string> {
   return pathsString == null ? [] : EP.getAllElementPathStringsForPathString(pathsString)
 }

--- a/editor/src/utils/canvas-react-utils.spec.tsx
+++ b/editor/src/utils/canvas-react-utils.spec.tsx
@@ -54,7 +54,7 @@ describe('Monkey Function', () => {
 
     expect(renderToFormattedString(<TestClass data-uid={'test1'} data-path='test1' />))
       .toMatchInlineSnapshot(`
-      "<div data-uid=\\"cica test1\\" data-path=\\"cica\\">
+      "<div data-uid=\\"cica\\" data-path=\\"cica\\">
         <div data-uid=\\"kutya\\" data-path=\\"kutya\\">Hello!</div>
         <div data-uid=\\"majom\\" data-path=\\"majom\\">Hello!</div>
       </div>
@@ -82,7 +82,7 @@ describe('Monkey Function', () => {
         </MyContext.Provider>,
       ),
     ).toMatchInlineSnapshot(`
-      "<div data-uid=\\"inner-div test-class provider\\" data-path=\\"inner-div\\">hello!</div>
+      "<div data-uid=\\"inner-div\\" data-path=\\"inner-div\\">hello!</div>
       "
     `)
   })
@@ -110,9 +110,7 @@ describe('Monkey Function', () => {
 
     expect(renderToFormattedString(<Renderer data-uid={'renderer'} data-path={'renderer'} />))
       .toMatchInlineSnapshot(`
-      "<div data-uid=\\"inner-div test-class provider renderer\\" data-path=\\"inner-div\\">
-        hello!
-      </div>
+      "<div data-uid=\\"inner-div\\" data-path=\\"inner-div\\">hello!</div>
       "
     `)
   })
@@ -129,7 +127,7 @@ describe('Monkey Function', () => {
 
     const TestStoryboard: React.FunctionComponent = (props) => {
       return (
-        <UtopiaStoryboard data-uid='scene sb test1'>
+        <UtopiaStoryboard data-uid='scene'>
           <UtopiaScene data-uid='scene'>
             <TestComponent data-uid='component-instance' />
           </UtopiaScene>
@@ -138,8 +136,8 @@ describe('Monkey Function', () => {
     }
 
     expect(renderToFormattedString(<TestStoryboard data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"scene sb test1\\">
-        <div data-uid=\\"component-root component-instance\\">
+      "<div data-uid=\\"scene\\">
+        <div data-uid=\\"component-root\\">
           <div data-uid=\\"kutya\\">Hello!</div>
           <div data-uid=\\"majom\\">Hello!</div>
         </div>
@@ -193,7 +191,7 @@ describe('Monkey Function', () => {
     }
 
     expect(renderToFormattedString(<TestComponent data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"root-div cica test1\\">Hello!</div>
+      "<div data-uid=\\"root-div\\">Hello!</div>
       "
     `)
   })
@@ -233,7 +231,7 @@ describe('Monkey Function', () => {
     }
 
     expect(renderToFormattedString(<TestComponent data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"cica test1\\"><div>Hello!</div></div>
+      "<div data-uid=\\"cica\\"><div>Hello!</div></div>
       "
     `)
   })
@@ -267,7 +265,7 @@ describe('Monkey Function', () => {
     }
 
     expect(renderToFormattedString(<TestClass data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"root-div test-class test1\\">Hello!</div>
+      "<div data-uid=\\"root-div\\">Hello!</div>
       "
     `)
   })
@@ -288,7 +286,7 @@ describe('Monkey Function', () => {
     }
 
     expect(renderToFormattedString(<Cica data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"root-div wrapper-component test1\\">Hello!</div>
+      "<div data-uid=\\"root-div\\">Hello!</div>
       "
     `)
   })
@@ -309,7 +307,7 @@ describe('Monkey Function', () => {
     }
 
     expect(renderToFormattedString(<TestClass data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"root-div cica test1\\">Hello!</div>
+      "<div data-uid=\\"root-div\\">Hello!</div>
       "
     `)
   })
@@ -360,7 +358,7 @@ describe('Monkey Function', () => {
     }
 
     expect(renderToFormattedString(<Component data-uid={'test1'} />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"root-div fragment test1\\">Hello!</div>
+      "<div data-uid=\\"root-div\\">Hello!</div>
       "
     `)
   })
@@ -409,8 +407,8 @@ describe('Monkey Function', () => {
 
     expect(renderToFormattedString(<Component />)).toMatchInlineSnapshot(`
       "<div data-uid=\\"cica\\">
-        <div data-uid=\\"hello-div kutya\\">Hello</div>
-        <div data-uid=\\"world-div kutya\\">world!</div>
+        <div data-uid=\\"hello-div\\">Hello</div>
+        <div data-uid=\\"world-div\\">world!</div>
       </div>
       "
     `)
@@ -426,9 +424,7 @@ describe('Monkey Function', () => {
         </Storyboard>,
       ),
     ).toMatchInlineSnapshot(`
-      "<div data-uid=\\"scene ignore\\">
-        <div data-uid=\\"cica scene-component\\">Hello!</div>
-      </div>
+      "<div data-uid=\\"scene\\"><div data-uid=\\"cica\\">Hello!</div></div>
       "
     `)
   })
@@ -534,7 +530,7 @@ describe('Monkey Function', () => {
       )
     }
     expect(renderToFormattedString(<App data-uid='cica' />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"zzz cica\\">
+      "<div data-uid=\\"zzz\\">
         <div data-uid=\\"aaa\\">
           <div data-uid=\\"bbb\\">4</div>
           <div data-uid=\\"bbb\\">5</div>
@@ -560,7 +556,7 @@ describe('Monkey Function', () => {
       return <div data-uid='zzz'>{[' ']}hello!</div>
     }
     expect(renderToFormattedString(<App data-uid='cica' />)).toMatchInlineSnapshot(`
-      "<div data-uid=\\"zzz cica\\">hello!</div>
+      "<div data-uid=\\"zzz\\">hello!</div>
       "
     `)
   })
@@ -585,13 +581,10 @@ describe('Monkey Function', () => {
       </Storyboard>
     )
     expect(renderToFormattedString(storyboard)).toMatchInlineSnapshot(`
-      "<div
-        data-uid=\\"scene-aaa utopia-storyboard-uid\\"
-        style=\\"left: 0; top: 0; width: 400px; height: 400px;\\"
-      >
-        <div data-uid=\\"zzz app\\">
-          <div data-uid=\\"ccc aaa\\">Hello World!!</div>
-          <div data-uid=\\"ddd bbb\\">Hello Dolly!!</div>
+      "<div data-uid=\\"scene-aaa\\" style=\\"left: 0; top: 0; width: 400px; height: 400px;\\">
+        <div data-uid=\\"zzz\\">
+          <div data-uid=\\"ccc\\">Hello World!!</div>
+          <div data-uid=\\"ddd\\">Hello Dolly!!</div>
         </div>
       </div>
       "

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -7,7 +7,6 @@ import { firstLetterIsLowerCase } from '../core/shared/string-utils'
 import { isIntrinsicHTMLElementString } from '../core/shared/element-template'
 import { UtopiaKeys, UTOPIA_UIDS_KEY, UTOPIA_PATH_KEY } from '../core/model/utopia-constants'
 import { v4 } from 'uuid'
-import { appendToUidString } from '../core/shared/uid-utils'
 import { isFeatureEnabled } from './feature-switches'
 import { PERFORMANCE_MARKS_ALLOWED } from '../common/env-vars'
 
@@ -109,7 +108,7 @@ function attachDataUidToRoot(
   } else {
     if (shouldIncludeDataUID(originalResponse.type)) {
       return React.cloneElement(originalResponse, {
-        [UTOPIA_UIDS_KEY]: appendToUidString(originalResponse.props[UTOPIA_UIDS_KEY], dataUids),
+        [UTOPIA_UIDS_KEY]: originalResponse.props[UTOPIA_UIDS_KEY] ?? dataUids,
         [UTOPIA_PATH_KEY]: originalResponse.props[UTOPIA_PATH_KEY] ?? path,
       })
     } else {
@@ -206,7 +205,7 @@ const mangleExoticType = Utils.memoize(
       }
       const existingChildUIDs = child.props?.[UTOPIA_UIDS_KEY]
       const existingChildPath = child.props?.[UTOPIA_PATH_KEY]
-      const appendedUIDString = appendToUidString(existingChildUIDs, dataUids)
+      const appendedUIDString = existingChildUIDs ?? dataUids
       const mangledChildPath = existingChildPath ?? path
       if ((!React.isValidElement(child) as boolean) || child == null) {
         return child


### PR DESCRIPTION
**Problem:**
We previously relied on all UIDs for an element being appended to the `data-uid` prop as a space separated string, as that was required for building all paths for the rendered DOM element. However, this became redundant with #2168 which removed the requirement for all paths to be included (since we can calculate them from the longest path). The fact this became redundant was overlooked at the time, but is now causing issues with dynamically building the paths (a piece of ongoing work), so now is the time to fix it.

**Fix:**
Remove the UID appending behaviour, switching back to the previous behaviour (which for a root element is to use its UID if one is provided, or fall back to the UID in the component's props if one exists there).

**Commit Details:**
- Remove UID appending in `canvas-react-utils.ts` and in `ui-jsx-canvas-element-renderer-utils.tsx`
- Rename constants and variables to reflect that there is now only a single UID in the `data-uid` attribute
- Updated all affected `data-uid` values in tests