### PR TITLE
Stop top menu from re-rendering unnecessarily.

### DIFF
--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`361`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`343`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`421`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`403`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2373`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2353`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2526`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2506`)
   })
 })


### PR DESCRIPTION
**Problem:**
While working on wider canvas improvements it was observed that some parts of the very top menu are rendering continuously.

**Fix:**
Eliminated some dependencies on values that change continuously like the entire editor metadata or the metadata for the currently selected element.

**Commit Details:**
- Reworked `FormulaBar` to not have a direct value to the element
  itself which constantly changes.
- Reworked `ComponentOrInstanceIndicator` to not have a direct value
  to the entirety of `jsxMetadata` as that changes continually during
  any change to the canvas.
- Fixed `toggleOpen` in `ComponentOrInstanceIndicator` to not rely
  on the current value.
- Reworked `getEditContextStyle` into a value `editContextStyle` which
  is memoised.
- Created a new value `flexRowTheme` which memoises the styling assigned
  to the `css` property.
