### PR TITLE
Improve useCanvasContextMenuItems.

### DIFF
--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -84,6 +84,7 @@ function useCanvasContextMenuItems(
   const elementNamesAndIcons = useNamesAndIconsAllPaths()
 
   if (contextMenuInstance === 'context-menu-canvas') {
+    let elementsUnderCursor: Array<ElementPath> | null = null
     const elementListSubmenu: Array<ContextMenuItem<CanvasData>> = elementNamesAndIcons.map(
       ({ label, path, iconProps }) => {
         return {
@@ -102,22 +103,22 @@ function useCanvasContextMenuItems(
           enabled: true,
           action: () => dispatch([selectComponents([path], false)], 'canvas'),
           isHidden: (data: CanvasData) => {
-            const elementsUnderCursor = getAllTargetsAtPoint(
-              data.jsxMetadata,
-              data.selectedViews,
-              data.hiddenInstances,
-              'no-filter',
-              WindowMousePositionRaw,
-              data.scale,
-              data.canvasOffset,
-            )
-            if (elementsUnderCursor != null) {
-              return !elementsUnderCursor.some((underCursor: ElementPath) =>
-                EP.pathsEqual(underCursor, path),
+            // Only run this once as the values used are the same for each and every
+            // entry and `getAllTargetsAtPoint` is very expensive.
+            if (elementsUnderCursor == null) {
+              elementsUnderCursor = getAllTargetsAtPoint(
+                data.jsxMetadata,
+                data.selectedViews,
+                data.hiddenInstances,
+                'no-filter',
+                WindowMousePositionRaw,
+                data.scale,
+                data.canvasOffset,
               )
-            } else {
-              return true
             }
+            return !elementsUnderCursor.some((underCursor: ElementPath) =>
+              EP.pathsEqual(underCursor, path),
+            )
           },
         }
       },


### PR DESCRIPTION
**Problem:**
`useCanvasContextMenuItems` was running `getAllTargetsAtPoint` a number of times that is linear to the size of the project. Given that `getAllTargetsAtPoint` takes around 3ms per call it was causing a visible pause when right clicking on an element in our large reference project.

**Fix:**
Now `getAllTargetsAtPoint` is run just once when the context menu is triggered as all the values passed to it are common for each and every entriy.

**Commit Details:**
- Only run `getAllTargetsAtPoint` once during a call to the hook,
  instead of for each and every value returned from
  `useNamesAndIconsAllPaths`.
