### PR TITLE
Faster containsPath and related functions.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -413,6 +413,7 @@ function renderJSXElement(
 
   if (
     elementPath != null &&
+    staticElementPathForGeneratedElement != null &&
     EP.containsPath(staticElementPathForGeneratedElement, staticValidPaths)
   ) {
     return buildSpyWrappedElement(

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -385,7 +385,7 @@ export function appendToPath(path: ElementPath, next: id | ElementPathPart): Ele
 }
 
 export function notNullPathsEqual(l: ElementPath, r: ElementPath): boolean {
-  return pathsEqual(l, r)
+  return fullElementPathsEqual(l.parts, r.parts)
 }
 
 function elementPathPartsEqual(l: ElementPathPart, r: ElementPathPart): boolean {
@@ -408,9 +408,13 @@ export function pathsEqual(l: ElementPath | null, r: ElementPath | null): boolea
   }
 }
 
-export function containsPath(path: ElementPath | null, paths: Array<ElementPath>): boolean {
-  const matchesPath = (p: ElementPath) => pathsEqual(path, p)
-  return paths.some(matchesPath)
+export function containsPath(path: ElementPath, paths: Array<ElementPath>): boolean {
+  for (const toCheck of paths) {
+    if (notNullPathsEqual(toCheck, path)) {
+      return true
+    }
+  }
+  return false
 }
 
 export function filterPaths(paths: ElementPath[], pathsToFilter: ElementPath[]): ElementPath[] {


### PR DESCRIPTION
**Problem:**
It was observed that `containsPath` is quite a widely used function which appears to be doing a bunch of unnecessary work like checking for nulls and using a lambda with the higher order function `Array.some`.

**Fix:**
Reworked `containsPath` and did some small refactors using the types to guide what should be possible.

**Commit Details:**
- `notNullPathsEqual` now delegates to `fullElementPathsEqual` to
  avoid having to perform the null checks the former has, as the type
  specifies the values are already not null.
- `containsPath` now doesn't allow a `null` for the `path` parameter as
  that was only ever possibly passed in one place.
- Now that `null` is not permitted for `path`, `containsPath` can
  utilise `notNullPathsEqual` directly, the higher level function
  `Array.some` is ditched as that requires a lambda which we don't
  really need for something so simple.
