### PR TITLE
Persist customStrategyState across strategies

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -49,6 +49,8 @@ function dragByPixels(
     metadata: null as any, // the strategy does not use this
   }
 
+  const customStrategyState = { foo: 'bar' }
+
   const strategyResult = absoluteMoveStrategy.apply(
     pickCanvasStateFromEditorState(editorState),
     interactionSession,
@@ -70,11 +72,11 @@ function dragByPixels(
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
       },
-      customStrategyState: { foo: 'bar' },
+      customStrategyState: customStrategyState,
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customState).toEqual(customStrategyState)
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -30,11 +30,11 @@ export const absoluteMoveStrategy: CanvasStrategy = {
     }
   },
   controlsToRender: [], // Uses existing hooks in select-mode-hooks.tsx
-  fitness: (canvasState, interactionState, sessionState) => {
+  fitness: (canvasState, interactionState, strategyState) => {
     return absoluteMoveStrategy.isApplicable(
       canvasState,
       interactionState,
-      sessionState.startingMetadata,
+      strategyState.startingMetadata,
     ) &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.activeControl.type === 'BOUNDING_AREA'
@@ -71,7 +71,7 @@ export const absoluteMoveStrategy: CanvasStrategy = {
           updateHighlightedViews('transient', []),
           setSnappingGuidelines('transient', guidelinesWithSnappingVector),
         ],
-        customState: null,
+        customState: sessionState.customStrategyState,
       }
     }
     // Fallback for when the checks above are not satisfied.

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -45,6 +45,8 @@ function reparentElement(
     metadata: null as any, // the strategy does not use this
   }
 
+  const customStrategyState = { foo: 'bar' }
+
   const strategyResult = absoluteReparentStrategy.apply(
     pickCanvasStateFromEditorState(editorState),
     interactionSession,
@@ -80,11 +82,11 @@ function reparentElement(
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
       },
-      customStrategyState: { foo: 'bar' },
+      customStrategyState: customStrategyState,
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customState).toEqual(customStrategyState)
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
@@ -87,10 +87,13 @@ export const absoluteReparentStrategy: CanvasStrategy = {
             commands.map((c) => c.newPath),
           ),
         ],
-        customState: null,
+        customState: strategyState.customStrategyState,
       }
     } else {
-      return emptyStrategyApplicationResult
+      return {
+        commands: [],
+        customState: strategyState.customStrategyState,
+      }
     }
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -47,6 +47,8 @@ function multiselectResizeElements(
     drag,
   )
 
+  const customStrategyState = { foo: 'bar' }
+
   const strategyResult = absoluteResizeBoundingBoxStrategy.apply(
     pickCanvasStateFromEditorState(initialEditor),
     { ...interactionSessionWithoutMetadata, metadata: {} },
@@ -58,11 +60,11 @@ function multiselectResizeElements(
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: metadata,
-      customStrategyState: { foo: 'bar' },
+      customStrategyState: customStrategyState,
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customState).toEqual(customStrategyState)
 
   return foldAndApplyCommands(
     initialEditor,

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -54,18 +54,18 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
   controlsToRender: [
     { control: AbsoluteResizeControl, key: 'absolute-resize-control', show: 'always-visible' },
   ],
-  fitness: (canvasState, interactionState, sessionState) => {
+  fitness: (canvasState, interactionState, strategyState) => {
     return absoluteResizeBoundingBoxStrategy.isApplicable(
       canvasState,
       interactionState,
-      sessionState.startingMetadata,
+      strategyState.startingMetadata,
     ) &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.activeControl.type === 'RESIZE_HANDLE'
       ? 1
       : 0
   },
-  apply: (canvasState, interactionState, sessionState) => {
+  apply: (canvasState, interactionState, strategyState) => {
     if (
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.interactionData.drag != null &&
@@ -75,7 +75,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
       const edgePosition = interactionState.activeControl.edgePosition
 
       const originalBoundingBox = getMultiselectBounds(
-        sessionState.startingMetadata,
+        strategyState.startingMetadata,
         canvasState.selectedElements,
       )
       if (originalBoundingBox != null) {
@@ -95,7 +95,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
         )
         const { snappedBoundingBox, guidelinesWithSnappingVector } = snapBoundingBox(
           canvasState.selectedElements,
-          sessionState.startingMetadata,
+          strategyState.startingMetadata,
           edgePosition,
           newBoundingBox,
           canvasState.scale,
@@ -111,7 +111,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
             )
             const originalFrame = MetadataUtils.getFrameInCanvasCoords(
               selectedElement,
-              sessionState.startingMetadata,
+              strategyState.startingMetadata,
             )
 
             if (element == null || originalFrame == null) {
@@ -124,8 +124,10 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
               originalFrame,
             )
             const elementParentBounds =
-              MetadataUtils.findElementByElementPath(sessionState.startingMetadata, selectedElement)
-                ?.specialSizeMeasurements.immediateParentBounds ?? null
+              MetadataUtils.findElementByElementPath(
+                strategyState.startingMetadata,
+                selectedElement,
+              )?.specialSizeMeasurements.immediateParentBounds ?? null
 
             return [
               ...createResizeCommandsFromFrame(
@@ -141,12 +143,15 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
         )
         return {
           commands: [...commandsForSelectedElements, updateHighlightedViews('transient', [])],
-          customState: null,
+          customState: strategyState.customStrategyState,
         }
       }
     }
     // Fallback for when the checks above are not satisfied.
-    return emptyStrategyApplicationResult
+    return {
+      commands: [],
+      customState: strategyState.customStrategyState,
+    }
   },
 }
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.spec.tsx
@@ -26,6 +26,8 @@ function resizeElement(editor: EditorState, edgePosition: EdgePosition): EditorS
     canvasPoint({ x: 15, y: 25 }),
   )
 
+  const customStrategyState = { foo: 'bar' }
+
   const strategyResult = absoluteResizeDeltaStrategy.apply(
     pickCanvasStateFromEditorState(editor),
     { ...interactionSessionWithoutMetadata, metadata: {} },
@@ -43,11 +45,11 @@ function resizeElement(editor: EditorState, edgePosition: EdgePosition): EditorS
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
       },
-      customStrategyState: { foo: 'bar' },
+      customStrategyState: customStrategyState,
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customState).toEqual(customStrategyState)
 
   return foldAndApplyCommands(editor, editor, [], [], strategyResult.commands, 'permanent')
     .editorState

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
@@ -37,18 +37,18 @@ export const absoluteResizeDeltaStrategy: CanvasStrategy = {
   controlsToRender: [
     { control: AbsoluteResizeControl, key: 'absolute-resize-control', show: 'always-visible' },
   ],
-  fitness: (canvasState, interactionState, sessionState) => {
+  fitness: (canvasState, interactionState, strategyState) => {
     return absoluteResizeDeltaStrategy.isApplicable(
       canvasState,
       interactionState,
-      sessionState.startingMetadata,
+      strategyState.startingMetadata,
     ) &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.activeControl.type === 'RESIZE_HANDLE'
       ? 1
       : 0
   },
-  apply: (canvasState, interactionState, sessionState) => {
+  apply: (canvasState, interactionState, strategyState) => {
     if (
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.interactionData.drag != null &&
@@ -58,7 +58,7 @@ export const absoluteResizeDeltaStrategy: CanvasStrategy = {
       const edgePosition = interactionState.activeControl.edgePosition
       const { snappedDragVector, guidelinesWithSnappingVector } = snapDrag(
         canvasState.selectedElements,
-        sessionState.startingMetadata,
+        strategyState.startingMetadata,
         drag,
         edgePosition,
         canvasState.scale,
@@ -76,7 +76,7 @@ export const absoluteResizeDeltaStrategy: CanvasStrategy = {
           )
           const elementParentBounds =
             MetadataUtils.findElementByElementPath(
-              sessionState.startingMetadata, // TODO should this be using the current metadata?
+              strategyState.startingMetadata, // TODO should this be using the current metadata?
               selectedElement,
             )?.specialSizeMeasurements.immediateParentBounds ?? null
 
@@ -99,11 +99,14 @@ export const absoluteResizeDeltaStrategy: CanvasStrategy = {
           updateHighlightedViews('transient', []),
           setSnappingGuidelines('transient', guidelinesWithSnappingVector),
         ],
-        customState: null,
+        customState: strategyState.customStrategyState,
       }
     }
     // Fallback for when the checks above are not satisfied.
-    return emptyStrategyApplicationResult
+    return {
+      commands: [],
+      customState: strategyState.customStrategyState,
+    }
   },
 }
 

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
@@ -151,6 +151,8 @@ function dragBy15Pixels(
     metadata: null as any, // the strategy does not use this
   }
 
+  const customStrategyState = { foo: 'bar' }
+
   const strategyResult = escapeHatchStrategy.apply(
     pickCanvasStateFromEditorState(editorState),
     interactionSession,
@@ -162,11 +164,11 @@ function dragBy15Pixels(
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: metadata,
-      customStrategyState: { foo: 'bar' },
+      customStrategyState: customStrategyState,
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customState).toEqual(customStrategyState)
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -71,11 +71,14 @@ export const escapeHatchStrategy: CanvasStrategy = {
       )
       return {
         commands: [...moveAndPositionCommands, ...siblingCommands],
-        customState: null,
+        customState: strategyState.customStrategyState,
       }
     }
     // Fallback for when the checks above are not satisfied.
-    return emptyStrategyApplicationResult
+    return {
+      commands: [],
+      customState: strategyState.customStrategyState,
+    }
   },
 }
 

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
@@ -128,6 +128,8 @@ function reorderElement(
     metadata: null as any, // the strategy does not use this
   }
 
+  const customStrategyState = { foo: 'bar' }
+
   const strategyResult = flexReorderStrategy.apply(
     pickCanvasStateFromEditorState(editorState),
     interactionSession,
@@ -139,11 +141,11 @@ function reorderElement(
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: metadata,
-      customStrategyState: { foo: 'bar' },
+      customStrategyState: customStrategyState,
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customState).toEqual(customStrategyState)
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -27,11 +27,11 @@ export const flexReorderStrategy: CanvasStrategy = {
     }
   },
   controlsToRender: [], // Uses existing hooks in select-mode-hooks.tsx
-  fitness: (canvasState, interactionState, sessionState) => {
+  fitness: (canvasState, interactionState, strategyState) => {
     return flexReorderStrategy.isApplicable(
       canvasState,
       interactionState,
-      sessionState.startingMetadata,
+      strategyState.startingMetadata,
     ) &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.activeControl.type === 'BOUNDING_AREA'
@@ -69,13 +69,13 @@ export const flexReorderStrategy: CanvasStrategy = {
     if (newIndex == null || newIndex === oldIndex) {
       return {
         commands: [],
-        customState: null,
+        customState: sessionState.customStrategyState,
       }
     }
 
     return {
       commands: [reorderElement('permanent', target, newIndex)],
-      customState: null,
+      customState: sessionState.customStrategyState,
     }
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -44,7 +44,7 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
     }
     return 0
   },
-  apply: (canvasState, interactionState, sessionState) => {
+  apply: (canvasState, interactionState, strategyState) => {
     if (interactionState.interactionData.type === 'KEYBOARD') {
       return {
         commands: interactionState.interactionData.keysPressed.flatMap<AdjustCssLengthProperty>(
@@ -59,7 +59,7 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
                   selectedElement,
                   drag,
                   canvasState,
-                  sessionState,
+                  strategyState,
                 ),
               )
             } else {
@@ -67,10 +67,13 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
             }
           },
         ),
-        customState: null,
+        customState: strategyState.customStrategyState,
       }
     }
-    return emptyStrategyApplicationResult
+    return {
+      commands: [],
+      customState: strategyState.customStrategyState,
+    }
   },
 }
 

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -26,12 +26,12 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
   controlsToRender: [
     { control: AbsoluteResizeControl, key: 'absolute-resize-control', show: 'always-visible' },
   ],
-  fitness: (canvasState, interactionState, sessionState) => {
+  fitness: (canvasState, interactionState, strategyState) => {
     if (
       keyboardAbsoluteResizeStrategy.isApplicable(
         canvasState,
         interactionState,
-        sessionState.startingMetadata,
+        strategyState.startingMetadata,
       ) &&
       interactionState.interactionData.type === 'KEYBOARD'
     ) {
@@ -49,7 +49,7 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
     }
     return 0
   },
-  apply: (canvasState, interactionState, sessionState) => {
+  apply: (canvasState, interactionState, strategyState) => {
     if (interactionState.interactionData.type === 'KEYBOARD') {
       return {
         commands: interactionState.interactionData.keysPressed.flatMap<AdjustCssLengthProperty>(
@@ -71,7 +71,7 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
                 )
                 const elementParentBounds =
                   MetadataUtils.findElementByElementPath(
-                    sessionState.startingMetadata,
+                    strategyState.startingMetadata,
                     selectedElement,
                   )?.specialSizeMeasurements.immediateParentBounds ?? null
 
@@ -91,10 +91,13 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
             }
           },
         ),
-        customState: null,
+        customState: strategyState.customStrategyState,
       }
     }
-    return emptyStrategyApplicationResult
+    return {
+      commands: [],
+      customState: strategyState.customStrategyState,
+    }
   },
 }
 

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -31,6 +31,8 @@ export function pressKeys(
     metadata: null as any, // the strategy does not use this
   }
 
+  const customStrategyState = { foo: 'bar' }
+
   const strategyResult = strategy.apply(
     pickCanvasStateFromEditorState(editorState),
     interactionSession,
@@ -52,11 +54,11 @@ export function pressKeys(
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
       },
-      customStrategyState: { foo: 'bar' },
+      customStrategyState: customStrategyState,
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customState).toEqual(customStrategyState)
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
@@ -33,7 +33,7 @@ export function getAbsoluteMoveCommandsForSelectedElement(
   selectedElement: ElementPath,
   drag: CanvasVector,
   canvasState: InteractionCanvasState,
-  sessionState: StrategyState,
+  strategyState: StrategyState,
 ): Array<AdjustCssLengthProperty> {
   const element: JSXElement | null = getElementFromProjectContents(
     selectedElement,
@@ -42,7 +42,7 @@ export function getAbsoluteMoveCommandsForSelectedElement(
   )
   const elementParentBounds =
     MetadataUtils.findElementByElementPath(
-      sessionState.startingMetadata, // TODO should this be using the current metadata?
+      strategyState.startingMetadata, // TODO should this be using the current metadata?
       selectedElement,
     )?.specialSizeMeasurements.immediateParentBounds ?? null // TODO this should probably be coordinateSystemBounds
 


### PR DESCRIPTION
Improvement over https://github.com/concrete-utopia/utopia/pull/2240

When I worked on `customStrategyState` I expected the state to be an internal concept to the specific strategies.
However, after some discussions it was clear that it also makes sense to treat this state as something which is persistent for the interaction, even if the winner strategy changes.

To make that work, I applied the following changes:
- Removed the nullability of `StrategyState.customStrategyState`
- Added a `defaultCustomStrategyState` constructor, so it is easy to create a new empty custom strategy state
- I kept the nullability in `StrategyApplicationResult`. When a strategy returns `null` as the new custom strategy state, that just means the strategy doesn't want to change the existing strategy.

I also renamed sessionState to strategyState, I think that was probably an earlier name for this concept.