### PR TITLE
Persist customStrategyState across strategies

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -14,7 +14,7 @@ export function defaultCustomStrategyState() {
 
 export interface StrategyApplicationResult {
   commands: Array<CanvasCommand>
-  customState: CustomStrategyState | null
+  customState: CustomStrategyState | null // null means the previous custom strategy state should be kept
 }
 
 export const emptyStrategyApplicationResult = {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -8,7 +8,7 @@ import { InteractionSession, StrategyState } from './interaction-state'
 // TODO: fill this in, maybe make it an ADT for different strategies
 export interface CustomStrategyState {}
 
-export function defaultCustomStrategyState() {
+export function defaultCustomStrategyState(): CustomStrategyState {
   return {}
 }
 

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -8,6 +8,10 @@ import { InteractionSession, StrategyState } from './interaction-state'
 // TODO: fill this in, maybe make it an ADT for different strategies
 export interface CustomStrategyState {}
 
+export function defaultCustomStrategyState() {
+  return {}
+}
+
 export interface StrategyApplicationResult {
   commands: Array<CanvasCommand>
   customState: CustomStrategyState | null

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -14,7 +14,12 @@ import { EditorStatePatch } from '../../editor/store/editor-state'
 import { EdgePosition } from '../canvas-types'
 import { MoveIntoDragThreshold } from '../canvas-utils'
 import { CanvasCommand } from '../commands/commands'
-import { CanvasStrategy, CanvasStrategyId, CustomStrategyState } from './canvas-strategy-types'
+import {
+  CanvasStrategy,
+  CanvasStrategyId,
+  CustomStrategyState,
+  defaultCustomStrategyState,
+} from './canvas-strategy-types'
 
 export interface DragInteractionData {
   type: 'DRAG'
@@ -78,7 +83,7 @@ export interface StrategyState {
 
   // Checkpointed metadata at the point at which a strategy change has occurred.
   startingMetadata: ElementInstanceMetadataMap
-  customStrategyState: CustomStrategyState | null
+  customStrategyState: CustomStrategyState
 }
 
 export function createEmptyStrategyState(metadata?: ElementInstanceMetadataMap): StrategyState {
@@ -90,7 +95,7 @@ export function createEmptyStrategyState(metadata?: ElementInstanceMetadataMap):
     commandDescriptions: [],
     sortedApplicableStrategies: [],
     startingMetadata: metadata ?? {},
-    customStrategyState: null,
+    customStrategyState: defaultCustomStrategyState(),
   }
 }
 

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -9,7 +9,7 @@ import { Modifiers } from '../../../utils/modifiers'
 import { EditorState } from '../../editor/store/editor-state'
 import { foldAndApplyCommands } from '../commands/commands'
 import { pickCanvasStateFromEditorState } from './canvas-strategies'
-import { CanvasStrategy, CustomStrategyState } from './canvas-strategy-types'
+import { CanvasStrategy } from './canvas-strategy-types'
 import {
   createInteractionViaKeyboard,
   InteractionSession,

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -255,7 +255,7 @@ describe('interactionStart', () => {
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
         "currentStrategyFitness": 0,
-        "customStrategyState": null,
+        "customStrategyState": Object {},
         "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},
       }
@@ -371,7 +371,7 @@ describe('interactionUpdatex', () => {
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
         "currentStrategyFitness": 0,
-        "customStrategyState": null,
+        "customStrategyState": Object {},
         "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},
       }
@@ -519,7 +519,7 @@ describe('interactionHardReset', () => {
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
         "currentStrategyFitness": 0,
-        "customStrategyState": null,
+        "customStrategyState": Object {},
         "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},
       }
@@ -730,7 +730,7 @@ describe('interactionUpdate with user changed strategy', () => {
         "currentStrategy": null,
         "currentStrategyCommands": Array [],
         "currentStrategyFitness": 0,
-        "customStrategyState": null,
+        "customStrategyState": Object {},
         "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},
       }

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -151,7 +151,7 @@ export function interactionHardReset(
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: resetStrategyState.startingMetadata,
-        customStrategyState: strategyResult.customState,
+        customStrategyState: strategyResult.customState ?? result.strategyState.customStrategyState,
       }
 
       return {
@@ -286,7 +286,7 @@ export function interactionStart(
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: newEditorState.canvas.interactionSession.metadata,
-        customStrategyState: strategyResult.customState,
+        customStrategyState: strategyResult.customState ?? result.strategyState.customStrategyState,
       }
 
       return {
@@ -372,7 +372,7 @@ function handleUserChangedStrategy(
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
-      customStrategyState: strategyResult.customState,
+      customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
     }
 
     return {
@@ -428,7 +428,7 @@ function handleAccumulatingKeypresses(
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
-      customStrategyState: strategyResult.customState,
+      customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
     }
 
     return {
@@ -484,7 +484,7 @@ function handleUpdate(
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
-      customStrategyState: strategyResult.customState,
+      customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
     }
     return {
       unpatchedEditorState: newEditorState,


### PR DESCRIPTION
Improvement over https://github.com/concrete-utopia/utopia/pull/2240

When I worked on `customStrategyState` I expected the state to be an internal concept to the specific strategies.
However, after some discussions it was clear that it also makes sense to treat this state as something which is persistent for the interaction, even if the winner strategy changes.

To make that work, I applied the following changes:
- Removed the nullability of `StrategyState.customStrategyState`
- Added a `defaultCustomStrategyState` constructor, so it is easy to create a new empty custom strategy state
- I kept the nullability in `StrategyApplicationResult`. When a strategy returns `null` as the new custom strategy state, that just means the strategy doesn't want to change the existing strategy.

I also renamed sessionState to strategyState, I think that was probably an earlier name for this concept.