### PR TITLE
test - adjusted margin size

### DIFF
--- a/website-next/components/projects/projects-page-component.tsx
+++ b/website-next/components/projects/projects-page-component.tsx
@@ -109,7 +109,7 @@ class ProjectCard extends React.Component<ProjectCardProps> {
                 fontSize: 11,
                 display: 'inline-block',
                 wordWrap: 'break-word',
-                marginTop: 8,
+                marginTop: 0,
               }}
             >
               <span className='timeago'>Last edited about {timeago.format(modifiedAt)}</span>


### PR DESCRIPTION
Project Cards had awkward space between the title and the last edited date.

To fix this, I removed the unnecessary marginTop on the last edited date.