### PR TITLE
Add outline control for flex reorder

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../core/shared/math-utils'
 import * as EP from '../../../core/shared/element-path'
 import { reverse, stripNulls } from '../../../core/shared/array-utils'
+import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
 
 export const flexReorderStrategy: CanvasStrategy = {
   id: 'FLEX_REORDER',
@@ -26,7 +27,13 @@ export const flexReorderStrategy: CanvasStrategy = {
       return false
     }
   },
-  controlsToRender: [], // Uses existing hooks in select-mode-hooks.tsx
+  controlsToRender: [
+    {
+      control: DragOutlineControl,
+      key: 'ghost-outline-control',
+      show: 'visible-only-while-active',
+    },
+  ],
   fitness: (canvasState, interactionState, sessionState) => {
     return flexReorderStrategy.isApplicable(
       canvasState,

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -443,10 +443,6 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
         isFeatureEnabled('Canvas Strategies'),
         <>{strategyControls.map((c) => React.createElement(c.control, { key: c.key }))}</>,
       )}
-      {when(
-        isFeatureEnabled('Canvas Strategies'),
-        <FlexResizeControl localSelectedElements={localSelectedViews} />,
-      )}
     </div>
   )
 }

--- a/editor/src/components/canvas/controls/select-mode/drag-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/drag-outline-control.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { zeroCanvasPoint } from '../../../../core/shared/math-utils'
+import { useColorTheme } from '../../../../uuiui'
+import { useEditorState } from '../../../editor/store/store-hook'
+import { getMultiselectBounds } from '../../canvas-strategies/shared-absolute-move-strategy-helpers'
+import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
+
+export const DragOutlineControl = React.memo(() => {
+  const scale = useEditorState((store) => store.editor.canvas.scale, 'OutlineControl scale')
+  const frame = useEditorState((store) => {
+    return getMultiselectBounds(store.strategyState.startingMetadata, store.editor.selectedViews)
+  }, 'GhostOutline frame')
+  const dragVector = useEditorState((store) => {
+    if (store.editor.canvas.interactionSession?.interactionData.type === 'DRAG') {
+      return store.editor.canvas.interactionSession.interactionData.drag ?? zeroCanvasPoint
+    } else {
+      return zeroCanvasPoint
+    }
+  }, 'GhostOutline dragVector')
+
+  const colorTheme = useColorTheme()
+
+  if (frame == null) {
+    return null
+  } else {
+    return (
+      <CanvasOffsetWrapper>
+        <div
+          style={{
+            position: 'absolute',
+            top: frame.y + dragVector.y,
+            left: frame.x + dragVector.x,
+            width: frame.width,
+            height: frame.height,
+            boxSizing: 'border-box',
+            boxShadow: `0px 0px 0px ${1 / scale}px  ${colorTheme.canvasSelectionFocusable.value}`,
+            opacity: '50%',
+          }}
+        />
+      </CanvasOffsetWrapper>
+    )
+  }
+})

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`446`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`445`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`509`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`508`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2384`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2382`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2538`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`2536`)
   })
 })


### PR DESCRIPTION
Outline control for flex reorder:

- copied the new control from branch https://github.com/concrete-utopia/utopia/compare/feature/escape-hatch-timer?expand=1#diff-04867b594f3128b6ffc4db3dbef1025e9350aa5e9b7e41f2fc4f1631190ebc74R8 , and modified it to use the startingMetadata
- removed the old flex resize controls