### PR TITLE
Better and simpler flex reorder

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -8,11 +8,13 @@ import { InteractionSession, StrategyState } from './interaction-state'
 // TODO: fill this in, maybe make it an ADT for different strategies
 export interface CustomStrategyState {
   escapeHatchActivated: boolean
+  lastReorderIdx: number | null
 }
 
 export function defaultCustomStrategyState(): CustomStrategyState {
   return {
     escapeHatchActivated: false,
+    lastReorderIdx: null,
   }
 }
 

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -101,6 +101,7 @@ export const escapeHatchStrategy: CanvasStrategy = {
         return {
           commands: [...moveAndPositionCommands, ...siblingCommands],
           customState: {
+            ...strategyState.customStrategyState,
             escapeHatchActivated,
           },
         }

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -210,6 +210,7 @@ describe('interactionStart', () => {
         "currentStrategyFitness": 10,
         "customStrategyState": Object {
           "escapeHatchActivated": false,
+          "lastReorderIdx": null,
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -267,6 +268,7 @@ describe('interactionStart', () => {
         "currentStrategyFitness": 0,
         "customStrategyState": Object {
           "escapeHatchActivated": false,
+          "lastReorderIdx": null,
         },
         "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},
@@ -328,6 +330,7 @@ describe('interactionUpdatex', () => {
         "currentStrategyFitness": 10,
         "customStrategyState": Object {
           "escapeHatchActivated": false,
+          "lastReorderIdx": null,
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -386,6 +389,7 @@ describe('interactionUpdatex', () => {
         "currentStrategyFitness": 0,
         "customStrategyState": Object {
           "escapeHatchActivated": false,
+          "lastReorderIdx": null,
         },
         "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},
@@ -474,6 +478,7 @@ describe('interactionHardReset', () => {
         "currentStrategyFitness": 10,
         "customStrategyState": Object {
           "escapeHatchActivated": false,
+          "lastReorderIdx": null,
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -537,6 +542,7 @@ describe('interactionHardReset', () => {
         "currentStrategyFitness": 0,
         "customStrategyState": Object {
           "escapeHatchActivated": false,
+          "lastReorderIdx": null,
         },
         "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},
@@ -687,6 +693,7 @@ describe('interactionUpdate with user changed strategy', () => {
         "currentStrategyFitness": 10,
         "customStrategyState": Object {
           "escapeHatchActivated": false,
+          "lastReorderIdx": null,
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -751,6 +758,7 @@ describe('interactionUpdate with user changed strategy', () => {
         "currentStrategyFitness": 0,
         "customStrategyState": Object {
           "escapeHatchActivated": false,
+          "lastReorderIdx": null,
         },
         "sortedApplicableStrategies": Array [],
         "startingMetadata": Object {},


### PR DESCRIPTION
The original flex reorder was quite complicated, because I had to split the canvas territory into drop target areas, which were associated to new indexes in the flex order.
See https://github.com/concrete-utopia/utopia/pull/2227

In this PR I changed this to how figma works: you can reorder to a specific index if you the mouse over the element at that index. That did not work well previously, because during dragging, when the mouse was in between two siblings, the target element always jumped back to the original position. This resulted in weird blinking back and forth:

![doesnotwork](https://user-images.githubusercontent.com/127662/168858817-a2073d9e-03be-46e7-9b3b-a8ab0666869f.gif)

What I needed to implement is the following:
- if you drag over a sibling, reorder to that index
- when you are not over a sibling, keep the element at the previous position where it was dragged to.

Now it was possible to implement this, because I could save the last reorder index into the new custom strategy state! This way I could remove the way more complicated and more error-prone algorithm from the original flex reorder PR.

![works](https://user-images.githubusercontent.com/127662/168858800-cf40eec9-6e8c-4f6c-a312-33cec39b9576.gif)
