### PR TITLE
Implement deep equality for `EditorState`.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -32,7 +32,7 @@ export interface DragInteractionData {
   globalTime: number
 }
 
-interface KeyboardInteractionData {
+export interface KeyboardInteractionData {
   type: 'KEYBOARD'
   keysPressed: Array<KeyCharacter>
   // keysPressed also includes modifiers, but we want the separate modifiers array since they are captured and mapped to a specific
@@ -64,6 +64,26 @@ export interface InteractionSession {
   userPreferredStrategy: CanvasStrategyId | null
 
   startedAt: number
+}
+
+export function interactionSession(
+  interactionData: InputData,
+  activeControl: CanvasControlType,
+  sourceOfUpdate: CanvasControlType,
+  lastInteractionTime: number,
+  metadata: ElementInstanceMetadataMap,
+  userPreferredStrategy: CanvasStrategyId | null,
+  startedAt: number,
+): InteractionSession {
+  return {
+    interactionData: interactionData,
+    activeControl: activeControl,
+    sourceOfUpdate: sourceOfUpdate,
+    lastInteractionTime: lastInteractionTime,
+    metadata: metadata,
+    userPreferredStrategy: userPreferredStrategy,
+    startedAt: startedAt,
+  }
 }
 
 export type InteractionSessionWithoutMetadata = Omit<InteractionSession, 'metadata'>
@@ -279,21 +299,21 @@ export function interactionDataHardReset(interactionData: InputData): InputData 
 }
 
 export function strategySwitchInteractionSessionReset(
-  interactionSession: InteractionSession,
+  interactionSessionToReset: InteractionSession,
 ): InteractionSession {
   return {
-    ...interactionSession,
-    interactionData: strategySwitchInteractionDataReset(interactionSession.interactionData),
+    ...interactionSessionToReset,
+    interactionData: strategySwitchInteractionDataReset(interactionSessionToReset.interactionData),
   }
 }
 
 // Hard reset means we need to ignore everything happening in the interaction until now, and replay all the dragging
 export function interactionSessionHardReset(
-  interactionSession: InteractionSession,
+  interactionSessionToReset: InteractionSession,
 ): InteractionSession {
   return {
-    ...interactionSession,
-    interactionData: interactionDataHardReset(interactionSession.interactionData),
+    ...interactionSessionToReset,
+    interactionData: interactionDataHardReset(interactionSessionToReset.interactionData),
   }
 }
 
@@ -313,22 +333,48 @@ export function hasDragModifiersChanged(
   )
 }
 
-interface BoundingArea {
+export interface BoundingArea {
   type: 'BOUNDING_AREA'
   target: ElementPath
 }
 
-interface ResizeHandle {
+export function boundingArea(target: ElementPath): BoundingArea {
+  return {
+    type: 'BOUNDING_AREA',
+    target: target,
+  }
+}
+
+export interface ResizeHandle {
   type: 'RESIZE_HANDLE'
   edgePosition: EdgePosition
 }
 
-interface FlexGapHandle {
+export function resizeHandle(edgePosition: EdgePosition): ResizeHandle {
+  return {
+    type: 'RESIZE_HANDLE',
+    edgePosition: edgePosition,
+  }
+}
+
+export interface FlexGapHandle {
   type: 'FLEX_GAP_HANDLE'
 }
 
-interface KeyboardCatcherControl {
+export function flexGapHandle(): FlexGapHandle {
+  return {
+    type: 'FLEX_GAP_HANDLE',
+  }
+}
+
+export interface KeyboardCatcherControl {
   type: 'KEYBOARD_CATCHER_CONTROL'
+}
+
+export function keyboardCatcherControl(): KeyboardCatcherControl {
+  return {
+    type: 'KEYBOARD_CATCHER_CONTROL',
+  }
 }
 
 export type CanvasControlType = BoundingArea | ResizeHandle | FlexGapHandle | KeyboardCatcherControl

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -242,26 +242,26 @@ export type PinOrFlexFrameChange =
 export function pinFrameChange(
   target: ElementPath,
   frame: CanvasRectangle,
-  edgePosition: EdgePosition | null = null,
+  edgePos: EdgePosition | null = null,
 ): PinFrameChange {
   return {
     type: 'PIN_FRAME_CHANGE',
     target: target,
     frame: frame,
-    edgePosition: edgePosition,
+    edgePosition: edgePos,
   }
 }
 
 export function pinSizeChange(
   target: ElementPath,
   frame: CanvasRectangle,
-  edgePosition: EdgePosition | null = null,
+  edgePos: EdgePosition | null = null,
 ): PinSizeChange {
   return {
     type: 'PIN_SIZE_CHANGE',
     target: target,
     frame: frame,
-    edgePosition: edgePosition,
+    edgePosition: edgePos,
   }
 }
 
@@ -296,13 +296,13 @@ export function flexResizeChange(
 
 export function singleResizeChange(
   target: ElementPath,
-  edgePosition: EdgePosition,
+  edgePos: EdgePosition,
   sizeDelta: CanvasVector,
 ): SingleResizeChange {
   return {
     type: 'SINGLE_RESIZE',
     target: target,
-    edgePosition: edgePosition,
+    edgePosition: edgePos,
     sizeDelta: sizeDelta,
   }
 }
@@ -487,7 +487,7 @@ export interface ResizeDragState {
 export function resizeDragState(
   originalSize: CanvasRectangle,
   originalFrames: Array<OriginalCanvasAndLocalFrame>,
-  edgePosition: EdgePosition,
+  edgePos: EdgePosition,
   enabledDirection: EnabledDirection,
   metadata: ElementInstanceMetadataMap,
   draggedElements: ElementPath[],
@@ -498,7 +498,7 @@ export function resizeDragState(
     type: 'RESIZE_DRAG_STATE',
     originalSize: originalSize,
     originalFrames: originalFrames,
-    edgePosition: edgePosition,
+    edgePosition: edgePos,
     enabledDirection: enabledDirection,
     metadata: metadata,
     draggedElements: draggedElements,
@@ -717,6 +717,13 @@ export type EdgePositionPart = 0 | 0.5 | 1
 
 export type EdgePosition = { x: EdgePositionPart; y: EdgePositionPart }
 
+export function edgePosition(x: EdgePositionPart, y: EdgePositionPart): EdgePosition {
+  return {
+    x: x,
+    y: y,
+  }
+}
+
 export function oppositeEdgePositionPart(part: EdgePositionPart): EdgePositionPart {
   switch (part) {
     case 0:
@@ -731,10 +738,10 @@ export function oppositeEdgePositionPart(part: EdgePositionPart): EdgePositionPa
   }
 }
 
-export function oppositeEdgePosition(edgePosition: EdgePosition): EdgePosition {
+export function oppositeEdgePosition(edgePos: EdgePosition): EdgePosition {
   return {
-    x: oppositeEdgePositionPart(edgePosition.x),
-    y: oppositeEdgePositionPart(edgePosition.y),
+    x: oppositeEdgePositionPart(edgePos.x),
+    y: oppositeEdgePositionPart(edgePos.y),
   }
 }
 

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -27,6 +27,7 @@ import {
 import { runUpdateSelectedViews, UpdateSelectedViews } from './update-selected-views-command'
 import { runWildcardPatch, WildcardPatch } from './wildcard-patch-command'
 import { runSetCssLengthProperty, SetCssLengthProperty } from './set-css-length-command'
+import { EditorStateKeepDeepEquality } from '../../editor/store/store-deep-equality-instances'
 
 export interface CommandFunctionResult {
   editorStatePatches: Array<EditorStatePatch>
@@ -144,7 +145,7 @@ export function foldAndApplyCommands(
   if (statePatches.length === 0) {
     workingEditorState = editorState
   } else {
-    workingEditorState = keepDeepReferenceEqualityIfPossible(priorPatchedState, workingEditorState)
+    workingEditorState = EditorStateKeepDeepEquality(priorPatchedState, workingEditorState).value
   }
 
   return {

--- a/editor/src/components/canvas/guideline.ts
+++ b/editor/src/components/canvas/guideline.ts
@@ -72,10 +72,22 @@ type GuidelineWithDistance = {
   distance: number
 }
 
-export type GuidelineWithSnappingVector = {
+export interface GuidelineWithSnappingVector {
   guideline: Guideline
   snappingVector: CanvasVector
   activateSnap: boolean
+}
+
+export function guidelineWithSnappingVector(
+  guideline: Guideline,
+  snappingVector: CanvasVector,
+  activateSnap: boolean,
+): GuidelineWithSnappingVector {
+  return {
+    guideline: guideline,
+    snappingVector: snappingVector,
+    activateSnap: activateSnap,
+  }
 }
 
 export type ConstrainedDragAxis = Axis | DiagonalAxis

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -65,6 +65,18 @@ export interface CodeResult {
   sourceMap: RawSourceMap | null
 }
 
+export function codeResult(
+  exports: ModuleExportTypes,
+  transpiledCode: string | null,
+  sourceMap: RawSourceMap | null,
+): CodeResult {
+  return {
+    exports: exports,
+    transpiledCode: transpiledCode,
+    sourceMap: sourceMap,
+  }
+}
+
 // UtopiaRequireFn is a special require function, where you can control whether the evaluation of the code should happen only once or more.
 // Standard JS behavior is to evaluate modules once lazily (the first time an import is processed), then cache
 // the value of the exports, and then use these values later. However, in our system this is not the desired behavior, because we need to evaluate the imports
@@ -80,18 +92,40 @@ export type UtopiaRequireFn = (
 
 export type CurriedUtopiaRequireFn = (projectContents: ProjectContentTreeRoot) => UtopiaRequireFn
 
-export type ComponentInfo = {
+export interface ComponentInfo {
   insertMenuLabel: string
   elementToInsert: JSXElementWithoutUID
   importsToAdd: Imports
 }
 
-export type ComponentDescriptor = {
+export function componentInfo(
+  insertMenuLabel: string,
+  elementToInsert: JSXElementWithoutUID,
+  importsToAdd: Imports,
+): ComponentInfo {
+  return {
+    insertMenuLabel: insertMenuLabel,
+    elementToInsert: elementToInsert,
+    importsToAdd: importsToAdd,
+  }
+}
+
+export interface ComponentDescriptor {
   properties: PropertyControls
   variants: ComponentInfo[]
 }
 
-export type ComponentDescriptorWithName = ComponentDescriptor & {
+export function componentDescriptor(
+  properties: PropertyControls,
+  variants: Array<ComponentInfo>,
+): ComponentDescriptor {
+  return {
+    properties: properties,
+    variants: variants,
+  }
+}
+
+export interface ComponentDescriptorWithName extends ComponentDescriptor {
   componentName: string
 }
 
@@ -106,15 +140,36 @@ export type PropertyControlsInfo = {
 export type ResolveFn = (importOrigin: string, toImport: string) => Either<string, string>
 export type CurriedResolveFn = (projectContents: ProjectContentTreeRoot) => ResolveFn
 
-export type CodeResultCache = {
+export interface CodeResultCache {
   skipDeepFreeze: true
   cache: { [filename: string]: CodeResult }
-  exportsInfo: ReadonlyArray<ExportsInfo>
+  exportsInfo: Array<ExportsInfo>
   error: Error | null
   curriedRequireFn: CurriedUtopiaRequireFn
   curriedResolveFn: CurriedResolveFn
   projectModules: MultiFileBuildResult
   evaluationCache: EvaluationCache
+}
+
+export function codeResultCache(
+  cache: { [filename: string]: CodeResult },
+  exportsInfo: Array<ExportsInfo>,
+  error: Error | null,
+  curriedRequireFn: CurriedUtopiaRequireFn,
+  curriedResolveFn: CurriedResolveFn,
+  projectModules: MultiFileBuildResult,
+  evaluationCache: EvaluationCache,
+): CodeResultCache {
+  return {
+    skipDeepFreeze: true,
+    cache: cache,
+    exportsInfo: exportsInfo,
+    error: error,
+    curriedRequireFn: curriedRequireFn,
+    curriedResolveFn: curriedResolveFn,
+    projectModules: projectModules,
+    evaluationCache: evaluationCache,
+  }
 }
 
 export function incorporateBuildResult(
@@ -156,7 +211,7 @@ const getCurriedEditorResolveFunction =
 export function generateCodeResultCache(
   projectContents: ProjectContentTreeRoot,
   updatedModules: MultiFileBuildResult,
-  exportsInfo: ReadonlyArray<ExportsInfo>,
+  exportsInfo: Array<ExportsInfo>,
   nodeModules: NodeModules,
   dispatch: EditorDispatch,
   evaluationCache: EvaluationCache,

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -72,6 +72,22 @@ export interface ProjectListing {
   thumbnail: string
 }
 
+export function projectListing(
+  id: string,
+  title: string,
+  createdAt: string,
+  modifiedAt: string,
+  thumbnail: string,
+): ProjectListing {
+  return {
+    id: id,
+    title: title,
+    createdAt: createdAt,
+    modifiedAt: modifiedAt,
+    thumbnail: thumbnail,
+  }
+}
+
 export type EditorModel = EditorState
 
 export type MoveRowBefore = {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -209,7 +209,13 @@ import type {
   RemoveFromNodeModulesContents,
   RunEscapeHatch,
 } from '../action-types'
-import { EditorModes, elementInsertionSubject, Mode, SceneInsertionSubject } from '../editor-modes'
+import {
+  EditorModes,
+  elementInsertionSubject,
+  Mode,
+  sceneInsertionSubject,
+  SceneInsertionSubject,
+} from '../editor-modes'
 import type {
   DuplicationState,
   ErrorMessages,
@@ -434,7 +440,7 @@ export function enableInsertModeForJSXElement(
 }
 
 export function enableInsertModeForScene(name: JSXElementName | 'scene'): SwitchEditorMode {
-  return switchEditorMode(EditorModes.insertMode(false, SceneInsertionSubject()))
+  return switchEditorMode(EditorModes.insertMode(false, sceneInsertionSubject()))
 }
 
 export function addToast(toastContent: Notice): AddToast {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4015,11 +4015,11 @@ export const UPDATE_FNS = {
     // Calculate the spy metadata given what has been collected.
     const spyResult = spyCollector.current.spyValues.metadata
 
-    const finalDomMetadata = arrayDeepEquality(ElementInstanceMetadataKeepDeepEquality())(
+    const finalDomMetadata = arrayDeepEquality(ElementInstanceMetadataKeepDeepEquality)(
       editor.domMetadata,
       action.elementMetadata as Array<ElementInstanceMetadata>, // we convert a ReadonlyArray to a regular array – it'd be nice to make more arrays readonly in the future
     ).value
-    const finalSpyMetadata = ElementInstanceMetadataMapKeepDeepEquality()(
+    const finalSpyMetadata = ElementInstanceMetadataMapKeepDeepEquality(
       editor.spyMetadata,
       spyResult,
     ).value

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -42,7 +42,7 @@ export function elementInsertionSubject(
   }
 }
 
-export function SceneInsertionSubject(): SceneInsertionSubject {
+export function sceneInsertionSubject(): SceneInsertionSubject {
   return {
     type: 'Scene',
   }
@@ -80,10 +80,22 @@ export function insertionSubjectIsDragAndDrop(
   return insertionSubject.type === 'DragAndDrop'
 }
 
-type InsertionParent = null | {
+export interface TargetedInsertionParent {
   target: ElementPath
   staticTarget: StaticElementPath
 }
+
+export function targetedInsertionParent(
+  target: ElementPath,
+  staticTarget: StaticElementPath,
+): TargetedInsertionParent {
+  return {
+    target: target,
+    staticTarget: staticTarget,
+  }
+}
+
+export type InsertionParent = null | TargetedInsertionParent
 
 export function insertionParent(
   target: ElementPath | null,
@@ -99,22 +111,22 @@ export function insertionParent(
   }
 }
 
-export type InsertMode = {
+export interface InsertMode {
   type: 'insert'
   subject: InsertionSubject
   insertionStarted: boolean
 }
 
-export type SelectMode = {
+export interface SelectMode {
   type: 'select'
   controlId: string | null
 }
 
-export type SelectLiteMode = {
+export interface SelectLiteMode {
   type: 'select-lite'
 }
 
-export type LiveCanvasMode = {
+export interface LiveCanvasMode {
   type: 'live'
   controlId: string | null
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -220,6 +220,13 @@ export interface OriginalPath {
   currentTP: ElementPath
 }
 
+export function originalPath(originalTP: ElementPath, currentTP: ElementPath): OriginalPath {
+  return {
+    originalTP: originalTP,
+    currentTP: currentTP,
+  }
+}
+
 export interface UserConfiguration {
   shortcutConfig: ShortcutConfiguration | null
 }
@@ -275,26 +282,63 @@ export interface FileDeleteModal {
   filePath: string
 }
 
+export function fileDeleteModal(filePath: string): FileDeleteModal {
+  return {
+    type: 'file-delete',
+    filePath: filePath,
+  }
+}
+
 export type ModalDialog = FileDeleteModal
 
 export type CursorImportanceLevel = 'fixed' | 'mouseOver' // only one fixed cursor can exist, mouseover is a bit less important
-export type CursorStackItem = {
+export interface CursorStackItem {
   id: string
   importance: CursorImportanceLevel
   cursor: CSSCursor
 }
+
+export function cursorStackItem(
+  id: string,
+  importance: CursorImportanceLevel,
+  cursor: CSSCursor,
+): CursorStackItem {
+  return {
+    id: id,
+    importance: importance,
+    cursor: cursor,
+  }
+}
+
 export type CursorStack = Array<CursorStackItem>
-export type CanvasCursor = {
+export interface CanvasCursor {
   fixed: CursorStackItem | null
   mouseOver: CursorStack
+}
+
+export function canvasCursor(fixed: CursorStackItem | null, mouseOver: CursorStack): CanvasCursor {
+  return {
+    fixed: fixed,
+    mouseOver: mouseOver,
+  }
 }
 
 export interface DuplicationState {
   duplicateRoots: Array<OriginalPath>
 }
 
+export function duplicationState(duplicateRoots: Array<OriginalPath>): DuplicationState {
+  return {
+    duplicateRoots: duplicateRoots,
+  }
+}
+
 export interface ImageBlob {
   base64: string
+}
+
+export function imageBlob(base64: string): ImageBlob {
+  return { base64: base64 }
 }
 
 export type UIFileBase64Blobs = { [key: string]: ImageBlob }
@@ -310,6 +354,12 @@ export interface ConsoleLog {
 
 export interface DesignerFile {
   filename: string
+}
+
+export function designerFile(filename: string): DesignerFile {
+  return {
+    filename: filename,
+  }
 }
 
 export type Theme = 'light' | 'dark'
@@ -332,18 +382,47 @@ export interface FloatingInsertMenuStateClosed {
   insertMenuMode: 'closed'
 }
 
+export function floatingInsertMenuStateClosed(): FloatingInsertMenuStateClosed {
+  return {
+    insertMenuMode: 'closed',
+  }
+}
+
 export interface FloatingInsertMenuStateInsert {
   insertMenuMode: 'insert'
   parentPath: ElementPath | null
   indexPosition: IndexPosition | null
 }
 
+export function floatingInsertMenuStateInsert(
+  parentPath: ElementPath | null,
+  indexPosition: IndexPosition | null,
+): FloatingInsertMenuStateInsert {
+  return {
+    insertMenuMode: 'insert',
+    parentPath: parentPath,
+    indexPosition: indexPosition,
+  }
+}
+
 export interface FloatingInsertMenuStateConvert {
   insertMenuMode: 'convert'
 }
 
+export function floatingInsertMenuStateConvert(): FloatingInsertMenuStateConvert {
+  return {
+    insertMenuMode: 'convert',
+  }
+}
+
 export interface FloatingInsertMenuStateWrap {
   insertMenuMode: 'wrap'
+}
+
+export function floatingInsertMenuStateWrap(): FloatingInsertMenuStateWrap {
+  return {
+    insertMenuMode: 'wrap',
+  }
 }
 
 export type FloatingInsertMenuState =
@@ -355,6 +434,16 @@ export type FloatingInsertMenuState =
 export interface ResizeOptions {
   propertyTargetOptions: Array<LayoutTargetableProp>
   propertyTargetSelectedIndex: number
+}
+
+export function resizeOptions(
+  propertyTargetOptions: Array<LayoutTargetableProp>,
+  propertyTargetSelectedIndex: number,
+): ResizeOptions {
+  return {
+    propertyTargetOptions: propertyTargetOptions,
+    propertyTargetSelectedIndex: propertyTargetSelectedIndex,
+  }
 }
 
 export interface VSCodeBridgeIdDefault {
@@ -395,6 +484,328 @@ export function getUnderlyingVSCodeBridgeID(bridgeId: VSCodeBridgeId): string {
   }
 }
 
+export interface EditorStateNodeModules {
+  skipDeepFreeze: true // when we evaluate the code files we plan to mutate the content with the eval result
+  files: NodeModules
+  projectFilesBuildResults: MultiFileBuildResult
+  packageStatus: PackageStatusMap
+}
+
+export function editorStateNodeModules(
+  skipDeepFreeze: true,
+  files: NodeModules,
+  projectFilesBuildResults: MultiFileBuildResult,
+  packageStatus: PackageStatusMap,
+): EditorStateNodeModules {
+  return {
+    skipDeepFreeze: skipDeepFreeze,
+    files: files,
+    projectFilesBuildResults: projectFilesBuildResults,
+    packageStatus: packageStatus,
+  }
+}
+
+export interface EditorStateLeftMenu {
+  selectedTab: LeftMenuTab
+  expanded: boolean
+  paneWidth: number
+}
+
+export function editorStateLeftMenu(
+  selectedTab: LeftMenuTab,
+  expanded: boolean,
+  paneWidth: number,
+): EditorStateLeftMenu {
+  return {
+    selectedTab: selectedTab,
+    expanded: expanded,
+    paneWidth: paneWidth,
+  }
+}
+
+export interface EditorStateRightMenu {
+  selectedTab: RightMenuTab
+  expanded: boolean
+}
+
+export function editorStateRightMenu(
+  selectedTab: RightMenuTab,
+  expanded: boolean,
+): EditorStateRightMenu {
+  return {
+    selectedTab: selectedTab,
+    expanded: expanded,
+  }
+}
+
+export interface EditorStateInterfaceDesigner {
+  codePaneWidth: number
+  codePaneVisible: boolean
+  restorableCodePaneWidth: number
+  additionalControls: boolean
+}
+
+export function editorStateInterfaceDesigner(
+  codePaneWidth: number,
+  codePaneVisible: boolean,
+  restorableCodePaneWidth: number,
+  additionalControls: boolean,
+): EditorStateInterfaceDesigner {
+  return {
+    codePaneWidth: codePaneWidth,
+    codePaneVisible: codePaneVisible,
+    restorableCodePaneWidth: restorableCodePaneWidth,
+    additionalControls: additionalControls,
+  }
+}
+
+export interface EditorStateCanvasTextEditor {
+  elementPath: ElementPath
+  triggerMousePosition: WindowPoint | null
+}
+
+export function editorStateCanvasTextEditor(
+  elementPath: ElementPath,
+  triggerMousePosition: WindowPoint | null,
+): EditorStateCanvasTextEditor {
+  return {
+    elementPath: elementPath,
+    triggerMousePosition: triggerMousePosition,
+  }
+}
+
+export interface EditorStateCanvasTransientProperty {
+  elementPath: ElementPath
+  attributesToUpdate: { [key: string]: JSXAttribute }
+}
+
+export function editorStateCanvasTransientProperty(
+  elementPath: ElementPath,
+  attributesToUpdate: { [key: string]: JSXAttribute },
+): EditorStateCanvasTransientProperty {
+  return {
+    elementPath: elementPath,
+    attributesToUpdate: attributesToUpdate,
+  }
+}
+
+export interface EditorStateCanvasControls {
+  // this is where we can put props for the strategy controls
+  snappingGuidelines: Array<GuidelineWithSnappingVector>
+}
+
+export function editorStateCanvasControls(
+  snappingGuidelines: Array<GuidelineWithSnappingVector>,
+): EditorStateCanvasControls {
+  return {
+    snappingGuidelines: snappingGuidelines,
+  }
+}
+
+export interface EditorStateCanvas {
+  visible: boolean
+  dragState: DragState | null
+  interactionSession: InteractionSession | null
+  scale: number
+  snappingThreshold: number
+  realCanvasOffset: CanvasVector
+  roundedCanvasOffset: CanvasVector
+  textEditor: EditorStateCanvasTextEditor | null
+  selectionControlsVisible: boolean
+  cursor: CSSCursor | null
+  duplicationState: DuplicationState | null
+  base64Blobs: CanvasBase64Blobs
+  mountCount: number
+  canvasContentInvalidateCount: number
+  domWalkerInvalidateCount: number
+  openFile: DesignerFile | null
+  scrollAnimation: boolean
+  transientProperties: { [key: string]: EditorStateCanvasTransientProperty } | null
+  resizeOptions: ResizeOptions
+  domWalkerAdditionalElementsToUpdate: Array<ElementPath>
+  controls: EditorStateCanvasControls
+}
+
+export function editorStateCanvas(
+  visible: boolean,
+  dragState: DragState | null,
+  interactionSession: InteractionSession | null,
+  scale: number,
+  snappingThreshold: number,
+  realCanvasOffset: CanvasVector,
+  roundedCanvasOffset: CanvasVector,
+  textEditor: EditorStateCanvasTextEditor | null,
+  selectionControlsVisible: boolean,
+  cursor: CSSCursor | null,
+  dupeState: DuplicationState | null,
+  base64Blobs: CanvasBase64Blobs,
+  mountCount: number,
+  canvasContentInvalidateCount: number,
+  domWalkerInvalidateCount: number,
+  openFile: DesignerFile | null,
+  scrollAnimation: boolean,
+  transientProperties: MapLike<EditorStateCanvasTransientProperty> | null,
+  resizeOpts: ResizeOptions,
+  domWalkerAdditionalElementsToUpdate: Array<ElementPath>,
+  controls: EditorStateCanvasControls,
+): EditorStateCanvas {
+  return {
+    visible: visible,
+    dragState: dragState,
+    interactionSession: interactionSession,
+    scale: scale,
+    snappingThreshold: snappingThreshold,
+    realCanvasOffset: realCanvasOffset,
+    roundedCanvasOffset: roundedCanvasOffset,
+    textEditor: textEditor,
+    selectionControlsVisible: selectionControlsVisible,
+    cursor: cursor,
+    duplicationState: dupeState,
+    base64Blobs: base64Blobs,
+    mountCount: mountCount,
+    canvasContentInvalidateCount: canvasContentInvalidateCount,
+    domWalkerInvalidateCount: domWalkerInvalidateCount,
+    openFile: openFile,
+    scrollAnimation: scrollAnimation,
+    transientProperties: transientProperties,
+    resizeOptions: resizeOpts,
+    domWalkerAdditionalElementsToUpdate: domWalkerAdditionalElementsToUpdate,
+    controls: controls,
+  }
+}
+
+export interface EditorStateInspector {
+  visible: boolean
+  classnameFocusCounter: number
+  layoutSectionHovered: boolean
+}
+
+export function editorStateInspector(
+  visible: boolean,
+  classnameFocusCounter: number,
+  layoutSectionHovered: boolean,
+): EditorStateInspector {
+  return {
+    visible: visible,
+    classnameFocusCounter: classnameFocusCounter,
+    layoutSectionHovered: layoutSectionHovered,
+  }
+}
+
+export interface EditorStateFileBrowser {
+  minimised: boolean
+  renamingTarget: string | null
+  dropTarget: string | null
+}
+
+export function editorStateFileBrowser(
+  minimised: boolean,
+  renamingTarget: string | null,
+  dropTarget: string | null,
+): EditorStateFileBrowser {
+  return {
+    minimised: minimised,
+    renamingTarget: renamingTarget,
+    dropTarget: dropTarget,
+  }
+}
+
+export interface EditorStateDependencyList {
+  minimised: boolean
+}
+
+export function editorStateDependencyList(minimised: boolean): EditorStateDependencyList {
+  return {
+    minimised: minimised,
+  }
+}
+
+export interface EditorStateGenericExternalResources {
+  minimised: boolean
+}
+
+export function editorStateGenericExternalResources(
+  minimised: boolean,
+): EditorStateGenericExternalResources {
+  return {
+    minimised: minimised,
+  }
+}
+
+export interface EditorStateGoogleFontsResources {
+  minimised: boolean
+}
+
+export function editorStateGoogleFontsResources(
+  minimised: boolean,
+): EditorStateGoogleFontsResources {
+  return {
+    minimised: minimised,
+  }
+}
+
+export interface EditorStateProjectSettings {
+  minimised: boolean
+}
+
+export function editorStateProjectSettings(minimised: boolean): EditorStateProjectSettings {
+  return {
+    minimised: minimised,
+  }
+}
+
+export interface EditorStateTopMenu {
+  formulaBarMode: 'css' | 'content'
+  formulaBarFocusCounter: number
+}
+
+export function editorStateTopMenu(
+  formulaBarMode: 'css' | 'content',
+  formulaBarFocusCounter: number,
+): EditorStateTopMenu {
+  return {
+    formulaBarMode: formulaBarMode,
+    formulaBarFocusCounter: formulaBarFocusCounter,
+  }
+}
+
+export interface EditorStatePreview {
+  visible: boolean
+  connected: boolean
+}
+
+export function editorStatePreview(visible: boolean, connected: boolean): EditorStatePreview {
+  return {
+    visible: visible,
+    connected: connected,
+  }
+}
+
+export interface EditorStateHome {
+  visible: boolean
+}
+
+export function editorStateHome(visible: boolean): EditorStateHome {
+  return {
+    visible: visible,
+  }
+}
+
+export interface EditorStateCodeEditorErrors {
+  buildErrors: ErrorMessages
+  lintErrors: ErrorMessages
+}
+
+export function editorStateCodeEditorErrors(
+  buildErrors: ErrorMessages,
+  lintErrors: ErrorMessages,
+): EditorStateCodeEditorErrors {
+  return {
+    buildErrors: buildErrors,
+    lintErrors: lintErrors,
+  }
+}
+
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
   id: string | null
@@ -411,12 +822,7 @@ export interface EditorState {
   projectContents: ProjectContentTreeRoot
   codeResultCache: CodeResultCache
   propertyControlsInfo: PropertyControlsInfo
-  nodeModules: {
-    skipDeepFreeze: true // when we evaluate the code files we plan to mutate the content with the eval result
-    files: NodeModules
-    projectFilesBuildResults: MultiFileBuildResult
-    packageStatus: PackageStatusMap
-  }
+  nodeModules: EditorStateNodeModules
   selectedViews: Array<ElementPath>
   highlightedViews: Array<ElementPath>
   hiddenInstances: Array<ElementPath>
@@ -427,98 +833,28 @@ export interface EditorState {
   openPopupId: string | null
   toasts: ReadonlyArray<Notice>
   cursorStack: CanvasCursor
-  leftMenu: {
-    selectedTab: LeftMenuTab
-    expanded: boolean
-    paneWidth: number
-  }
-  rightMenu: {
-    selectedTab: RightMenuTab
-    expanded: boolean
-  }
-  interfaceDesigner: {
-    codePaneWidth: number
-    codePaneVisible: boolean
-    restorableCodePaneWidth: number
-    additionalControls: boolean
-  }
-  canvas: {
-    visible: boolean
-    dragState: DragState | null
-    interactionSession: InteractionSession | null
-    scale: number
-    snappingThreshold: number
-    realCanvasOffset: CanvasVector
-    roundedCanvasOffset: CanvasVector
-    textEditor: {
-      elementPath: ElementPath
-      triggerMousePosition: WindowPoint | null
-    } | null
-    selectionControlsVisible: boolean
-    cursor: CSSCursor | null
-    duplicationState: DuplicationState | null
-    base64Blobs: CanvasBase64Blobs
-    mountCount: number
-    canvasContentInvalidateCount: number
-    domWalkerInvalidateCount: number
-    openFile: DesignerFile | null
-    scrollAnimation: boolean
-    transientProperties: MapLike<{
-      elementPath: ElementPath
-      attributesToUpdate: MapLike<JSXAttribute>
-    }> | null
-    resizeOptions: ResizeOptions
-    domWalkerAdditionalElementsToUpdate: Array<ElementPath>
-    controls: {
-      // this is where we can put props for the strategy controls
-      snappingGuidelines: Array<GuidelineWithSnappingVector>
-    }
-  }
+  leftMenu: EditorStateLeftMenu
+  rightMenu: EditorStateRightMenu
+  interfaceDesigner: EditorStateInterfaceDesigner
+  canvas: EditorStateCanvas
   floatingInsertMenu: FloatingInsertMenuState
-  inspector: {
-    visible: boolean
-    classnameFocusCounter: number
-    layoutSectionHovered: boolean
-  }
-  fileBrowser: {
-    minimised: boolean
-    renamingTarget: string | null
-    dropTarget: string | null
-  }
-  dependencyList: {
-    minimised: boolean
-  }
-  genericExternalResources: {
-    minimised: boolean
-  }
-  googleFontsResources: {
-    minimised: boolean
-  }
-  projectSettings: {
-    minimised: boolean
-  }
+  inspector: EditorStateInspector
+  fileBrowser: EditorStateFileBrowser
+  dependencyList: EditorStateDependencyList
+  genericExternalResources: EditorStateGenericExternalResources
+  googleFontsResources: EditorStateGoogleFontsResources
+  projectSettings: EditorStateProjectSettings
   navigator: NavigatorState
-  topmenu: {
-    formulaBarMode: 'css' | 'content'
-    formulaBarFocusCounter: number
-  }
-  preview: {
-    visible: boolean
-    connected: boolean
-  }
-  home: {
-    visible: boolean
-  }
+  topmenu: EditorStateTopMenu
+  preview: EditorStatePreview
+  home: EditorStateHome
   lastUsedFont: FontSettings | null
   modal: ModalDialog | null
   localProjectList: Array<ProjectListing>
   projectList: Array<ProjectListing>
   showcaseProjects: Array<ProjectListing>
   codeEditingEnabled: boolean
-  codeEditorErrors: {
-    buildErrors: ErrorMessages
-    lintErrors: ErrorMessages
-  }
+  codeEditorErrors: EditorStateCodeEditorErrors
   thumbnailLastGenerated: number
   pasteTargetsToIgnore: ElementPath[]
   parseOrPrintInFlight: boolean
@@ -534,27 +870,153 @@ export interface EditorState {
   forceParseFiles: Array<string>
 }
 
+export function editorState(
+  id: string | null,
+  vscodeBridgeId: VSCodeBridgeId,
+  forkedFromProjectId: string | null,
+  appID: string | null,
+  projectName: string,
+  projectDescription: string,
+  projectVersion: number,
+  isLoaded: boolean,
+  spyMetadata: ElementInstanceMetadataMap,
+  domMetadata: ElementInstanceMetadata[],
+  jsxMetadata: ElementInstanceMetadataMap,
+  projectContents: ProjectContentTreeRoot,
+  codeResultCache: CodeResultCache,
+  propertyControlsInfo: PropertyControlsInfo,
+  nodeModules: EditorStateNodeModules,
+  selectedViews: Array<ElementPath>,
+  highlightedViews: Array<ElementPath>,
+  hiddenInstances: Array<ElementPath>,
+  warnedInstances: Array<ElementPath>,
+  mode: Mode,
+  focusedPanel: EditorPanel | null,
+  keysPressed: KeysPressed,
+  openPopupId: string | null,
+  toasts: ReadonlyArray<Notice>,
+  cursorStack: CanvasCursor,
+  leftMenu: EditorStateLeftMenu,
+  rightMenu: EditorStateRightMenu,
+  interfaceDesigner: EditorStateInterfaceDesigner,
+  canvas: EditorStateCanvas,
+  floatingInsertMenu: FloatingInsertMenuState,
+  inspector: EditorStateInspector,
+  fileBrowser: EditorStateFileBrowser,
+  dependencyList: EditorStateDependencyList,
+  genericExternalResources: EditorStateGenericExternalResources,
+  googleFontsResources: EditorStateGoogleFontsResources,
+  projectSettings: EditorStateProjectSettings,
+  editorStateNavigator: NavigatorState,
+  topmenu: EditorStateTopMenu,
+  preview: EditorStatePreview,
+  home: EditorStateHome,
+  lastUsedFont: FontSettings | null,
+  modal: ModalDialog | null,
+  localProjectList: Array<ProjectListing>,
+  projectList: Array<ProjectListing>,
+  showcaseProjects: Array<ProjectListing>,
+  codeEditingEnabled: boolean,
+  codeEditorErrors: EditorStateCodeEditorErrors,
+  thumbnailLastGenerated: number,
+  pasteTargetsToIgnore: ElementPath[],
+  parseOrPrintInFlight: boolean,
+  safeMode: boolean,
+  saveError: boolean,
+  vscodeBridgeReady: boolean,
+  vscodeReady: boolean,
+  focusedElementPath: ElementPath | null,
+  config: UtopiaVSCodeConfig,
+  theme: Theme,
+  vscodeLoadingScreenVisible: boolean,
+  indexedDBFailed: boolean,
+  forceParseFiles: Array<string>,
+): EditorState {
+  return {
+    id: id,
+    vscodeBridgeId: vscodeBridgeId,
+    forkedFromProjectId: forkedFromProjectId,
+    appID: appID,
+    projectName: projectName,
+    projectDescription: projectDescription,
+    projectVersion: projectVersion,
+    isLoaded: isLoaded,
+    spyMetadata: spyMetadata,
+    domMetadata: domMetadata,
+    jsxMetadata: jsxMetadata,
+    projectContents: projectContents,
+    codeResultCache: codeResultCache,
+    propertyControlsInfo: propertyControlsInfo,
+    nodeModules: nodeModules,
+    selectedViews: selectedViews,
+    highlightedViews: highlightedViews,
+    hiddenInstances: hiddenInstances,
+    warnedInstances: warnedInstances,
+    mode: mode,
+    focusedPanel: focusedPanel,
+    keysPressed: keysPressed,
+    openPopupId: openPopupId,
+    toasts: toasts,
+    cursorStack: cursorStack,
+    leftMenu: leftMenu,
+    rightMenu: rightMenu,
+    interfaceDesigner: interfaceDesigner,
+    canvas: canvas,
+    floatingInsertMenu: floatingInsertMenu,
+    inspector: inspector,
+    fileBrowser: fileBrowser,
+    dependencyList: dependencyList,
+    genericExternalResources: genericExternalResources,
+    googleFontsResources: googleFontsResources,
+    projectSettings: projectSettings,
+    navigator: editorStateNavigator,
+    topmenu: topmenu,
+    preview: preview,
+    home: home,
+    lastUsedFont: lastUsedFont,
+    modal: modal,
+    localProjectList: localProjectList,
+    projectList: projectList,
+    showcaseProjects: showcaseProjects,
+    codeEditingEnabled: codeEditingEnabled,
+    codeEditorErrors: codeEditorErrors,
+    thumbnailLastGenerated: thumbnailLastGenerated,
+    pasteTargetsToIgnore: pasteTargetsToIgnore,
+    parseOrPrintInFlight: parseOrPrintInFlight,
+    safeMode: safeMode,
+    saveError: saveError,
+    vscodeBridgeReady: vscodeBridgeReady,
+    vscodeReady: vscodeReady,
+    focusedElementPath: focusedElementPath,
+    config: config,
+    theme: theme,
+    vscodeLoadingScreenVisible: vscodeLoadingScreenVisible,
+    indexedDBFailed: indexedDBFailed,
+    forceParseFiles: forceParseFiles,
+  }
+}
+
 export interface StoredEditorState {
   selectedViews: Array<ElementPath>
   mode: PersistedMode | null
 }
 
-export function storedEditorStateFromEditorState(editorState: EditorState): StoredEditorState {
+export function storedEditorStateFromEditorState(editor: EditorState): StoredEditorState {
   return {
-    selectedViews: editorState.selectedViews,
-    mode: convertModeToSavedMode(editorState.mode),
+    selectedViews: editor.selectedViews,
+    mode: convertModeToSavedMode(editor.mode),
   }
 }
 
 export function mergeStoredEditorStateIntoEditorState(
   storedEditorState: StoredEditorState | null,
-  editorState: EditorState,
+  editor: EditorState,
 ): EditorState {
   if (storedEditorState == null) {
-    return editorState
+    return editor
   } else {
     return {
-      ...editorState,
+      ...editor,
       selectedViews: storedEditorState.selectedViews,
       mode: storedEditorState.mode ?? EditorModes.selectLiteMode(),
     }
@@ -1079,14 +1541,14 @@ export interface DerivedState {
   elementWarnings: ComplexMap<ElementPath, ElementWarnings>
 }
 
-function emptyDerivedState(editorState: EditorState): DerivedState {
+function emptyDerivedState(editor: EditorState): DerivedState {
   return {
     navigatorTargets: [],
     visibleNavigatorTargets: [],
     canvas: {
       descendantsOfHiddenInstances: [],
       controls: [],
-      transientState: produceCanvasTransientState(editorState.selectedViews, editorState, false),
+      transientState: produceCanvasTransientState(editor.selectedViews, editor, false),
     },
     elementWarnings: emptyComplexMap(),
   }
@@ -1098,7 +1560,7 @@ export interface PersistentModel {
   projectVersion: number
   projectDescription: string
   projectContents: ProjectContentTreeRoot
-  exportsInfo: ReadonlyArray<ExportsInfo>
+  exportsInfo: Array<ExportsInfo>
   lastUsedFont: FontSettings | null
   hiddenInstances: Array<ElementPath>
   codeEditorErrors: {
@@ -1433,20 +1895,20 @@ export function deriveState(
 }
 
 export function createCanvasModelKILLME(
-  editorState: EditorState,
+  editor: EditorState,
   derivedState: DerivedState,
 ): CanvasModel {
   return {
     controls: derivedState.canvas.controls,
-    dragState: editorState.canvas.dragState,
-    keysPressed: editorState.keysPressed,
-    mode: editorState.mode,
-    scale: editorState.canvas.scale,
-    highlightedviews: editorState.highlightedViews,
-    selectedViews: editorState.selectedViews,
-    canvasOffset: editorState.canvas.roundedCanvasOffset,
-    focusedPanel: editorState.focusedPanel,
-    editorState: editorState,
+    dragState: editor.canvas.dragState,
+    keysPressed: editor.keysPressed,
+    mode: editor.mode,
+    scale: editor.canvas.scale,
+    highlightedviews: editor.highlightedViews,
+    selectedViews: editor.selectedViews,
+    canvasOffset: editor.canvas.roundedCanvasOffset,
+    focusedPanel: editor.focusedPanel,
+    editorState: editor,
   }
 }
 
@@ -1920,8 +2382,7 @@ export function reconstructJSXMetadata(editor: EditorState): ElementInstanceMeta
           editor.spyMetadata,
           editor.domMetadata,
         )
-        return ElementInstanceMetadataMapKeepDeepEquality()(editor.jsxMetadata, mergedMetadata)
-          .value
+        return ElementInstanceMetadataMapKeepDeepEquality(editor.jsxMetadata, mergedMetadata).value
       },
       (_) => editor.jsxMetadata,
       uiFile.fileContents.parsed,
@@ -1930,19 +2391,16 @@ export function reconstructJSXMetadata(editor: EditorState): ElementInstanceMeta
 }
 
 export function getStoryboardElementPathFromEditorState(
-  editorState: EditorState,
+  editor: EditorState,
 ): StaticElementPath | null {
-  return getStoryboardElementPath(
-    editorState.projectContents,
-    editorState.canvas.openFile?.filename ?? null,
-  )
+  return getStoryboardElementPath(editor.projectContents, editor.canvas.openFile?.filename ?? null)
 }
 
 export function getHighlightBoundsForFile(
-  editorState: EditorState,
+  editor: EditorState,
   fullPath: string,
 ): HighlightBoundsForUids | null {
-  const file = getContentsTreeFileFromString(editorState.projectContents, fullPath)
+  const file = getContentsTreeFileFromString(editor.projectContents, fullPath)
   if (isTextFile(file)) {
     if (isParseSuccess(file.fileContents.parsed)) {
       return getHighlightBoundsFromParseResult(file.fileContents.parsed)
@@ -1956,11 +2414,11 @@ export function getHighlightBoundsForFile(
 
 export function getHighlightBoundsForElementPath(
   path: ElementPath,
-  editorState: EditorState,
+  editor: EditorState,
 ): HighlightBoundsWithFile | null {
   const staticPath = EP.dynamicPathToStaticPath(path)
   if (staticPath != null) {
-    const highlightBounds = getHighlightBoundsForProject(editorState.projectContents)
+    const highlightBounds = getHighlightBoundsForProject(editor.projectContents)
     if (highlightBounds != null) {
       const highlightedUID = toUid(staticPath)
       return highlightBounds[highlightedUID]
@@ -1972,10 +2430,10 @@ export function getHighlightBoundsForElementPath(
 
 export function getHighlightBoundsForElementPaths(
   paths: Array<ElementPath>,
-  editorState: EditorState,
+  editor: EditorState,
 ): HighlightBoundsWithFileForUids {
   const targetUIDs = paths.map((path) => toUid(EP.dynamicPathToStaticPath(path)))
-  const projectHighlightBounds = getHighlightBoundsForProject(editorState.projectContents)
+  const projectHighlightBounds = getHighlightBoundsForProject(editor.projectContents)
   return pick(targetUIDs, projectHighlightBounds)
 }
 
@@ -2009,17 +2467,17 @@ export function getElementPathsInBounds(
 
 export function modifyParseSuccessAtPath(
   filePath: string,
-  editorState: EditorState,
+  editor: EditorState,
   modifyParseSuccess: (parseSuccess: ParseSuccess) => ParseSuccess,
 ): EditorState {
-  const projectFile = getContentsTreeFileFromString(editorState.projectContents, filePath)
+  const projectFile = getContentsTreeFileFromString(editor.projectContents, filePath)
   if (isTextFile(projectFile)) {
     const parsedFileContents = projectFile.fileContents.parsed
     if (isParseSuccess(parsedFileContents)) {
       const updatedParseSuccess = modifyParseSuccess(parsedFileContents)
       // Try to keep referential equality as much as possible.
       if (updatedParseSuccess === parsedFileContents) {
-        return editorState
+        return editor
       } else {
         const updatedFile = saveTextFileContents(
           projectFile,
@@ -2031,12 +2489,8 @@ export function modifyParseSuccessAtPath(
           false,
         )
         return {
-          ...editorState,
-          projectContents: addFileToProjectContents(
-            editorState.projectContents,
-            filePath,
-            updatedFile,
-          ),
+          ...editor,
+          projectContents: addFileToProjectContents(editor.projectContents, filePath, updatedFile),
         }
       }
     } else {
@@ -2050,7 +2504,7 @@ export function modifyParseSuccessAtPath(
 export function modifyUnderlyingTarget(
   target: ElementPath | null,
   currentFilePath: string,
-  editorState: EditorState,
+  editor: EditorState,
   modifyElement: (
     element: JSXElement,
     underlying: ElementPath,
@@ -2063,8 +2517,8 @@ export function modifyUnderlyingTarget(
   ) => ParseSuccess = (success) => success,
 ): EditorState {
   const underlyingTarget = normalisePathToUnderlyingTarget(
-    editorState.projectContents,
-    editorState.nodeModules.files,
+    editor.projectContents,
+    editor.nodeModules.files,
     currentFilePath,
     target,
   )
@@ -2113,12 +2567,12 @@ export function modifyUnderlyingTarget(
     }
   }
 
-  return modifyParseSuccessAtPath(targetSuccess.filePath, editorState, innerModifyParseSuccess)
+  return modifyParseSuccessAtPath(targetSuccess.filePath, editor, innerModifyParseSuccess)
 }
 
 export function modifyUnderlyingForOpenFile(
   target: ElementPath | null,
-  editorState: EditorState,
+  editor: EditorState,
   modifyElement: (
     element: JSXElement,
     underlying: ElementPath,
@@ -2132,8 +2586,8 @@ export function modifyUnderlyingForOpenFile(
 ): EditorState {
   return modifyUnderlyingTarget(
     target,
-    forceNotNull('Designer file should be open.', editorState.canvas.openFile?.filename),
-    editorState,
+    forceNotNull('Designer file should be open.', editor.canvas.openFile?.filename),
+    editor,
     modifyElement,
     modifyParseSuccess,
   )
@@ -2185,7 +2639,7 @@ export function withUnderlyingTarget<T>(
 
 export function withUnderlyingTargetFromEditorState<T>(
   target: ElementPath | null,
-  editorState: EditorState,
+  editor: EditorState,
   defaultValue: T,
   withTarget: (
     success: ParseSuccess,
@@ -2196,9 +2650,9 @@ export function withUnderlyingTargetFromEditorState<T>(
 ): T {
   return withUnderlyingTarget(
     target,
-    editorState.projectContents,
-    editorState.nodeModules.files,
-    editorState.canvas.openFile?.filename ?? null,
+    editor.projectContents,
+    editor.nodeModules.files,
+    editor.canvas.openFile?.filename ?? null,
     defaultValue,
     withTarget,
   )
@@ -2206,7 +2660,7 @@ export function withUnderlyingTargetFromEditorState<T>(
 
 export function forUnderlyingTargetFromEditorState(
   target: ElementPath | null,
-  editorState: EditorState,
+  editor: EditorState,
   withTarget: (
     success: ParseSuccess,
     element: JSXElement,
@@ -2214,7 +2668,7 @@ export function forUnderlyingTargetFromEditorState(
     underlyingFilePath: string,
   ) => void,
 ): void {
-  withUnderlyingTargetFromEditorState<any>(target, editorState, {}, withTarget)
+  withUnderlyingTargetFromEditorState<any>(target, editor, {}, withTarget)
 }
 
 export function forUnderlyingTarget(
@@ -2244,8 +2698,8 @@ export function getCurrentTheme(editor: EditorState): Theme {
   return editor.theme
 }
 
-export function getNewSceneName(editorState: EditorState): string {
-  const openFile = getOpenUIJSFile(editorState)
+export function getNewSceneName(editor: EditorState): string {
+  const openFile = getOpenUIJSFile(editor)
   if (openFile != null) {
     if (isParseSuccess(openFile.fileContents.parsed)) {
       const success = openFile.fileContents.parsed

--- a/editor/src/components/editor/store/store-deep-equality-instances-2.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances-2.spec.ts
@@ -18,7 +18,7 @@ import {
   UtopiaJSXComponent,
 } from '../../../core/shared/element-template'
 import {
-  ArbitraryJsBlockKeepDeepEquality,
+  ArbitraryJSBlockKeepDeepEquality,
   BoundParamKeepDeepEquality,
   DestructuredArrayKeepDeepEquality,
   DestructuredArrayPartKeepDeepEquality,
@@ -194,17 +194,17 @@ describe('JSXArbitraryBlockKeepDeepEquality', () => {
   }
 
   it('same reference returns the same reference', () => {
-    const result = JSXArbitraryBlockKeepDeepEquality()(oldValue, oldValue)
+    const result = JSXArbitraryBlockKeepDeepEquality(oldValue, oldValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const result = JSXArbitraryBlockKeepDeepEquality()(oldValue, newSameValue)
+    const result = JSXArbitraryBlockKeepDeepEquality(oldValue, newSameValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const result = JSXArbitraryBlockKeepDeepEquality()(oldValue, newDifferentValue)
+    const result = JSXArbitraryBlockKeepDeepEquality(oldValue, newDifferentValue)
     expect(result.value.type).toBe(oldValue.type)
     expect(result.value.originalJavascript).toBe(newDifferentValue.originalJavascript)
     expect(result.value.javascript).toBe(oldValue.javascript)
@@ -251,17 +251,17 @@ describe('ArbitraryJsBlockKeepDeepEquality', () => {
   }
 
   it('same reference returns the same reference', () => {
-    const result = ArbitraryJsBlockKeepDeepEquality()(oldValue, oldValue)
+    const result = ArbitraryJSBlockKeepDeepEquality()(oldValue, oldValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const result = ArbitraryJsBlockKeepDeepEquality()(oldValue, newSameValue)
+    const result = ArbitraryJSBlockKeepDeepEquality()(oldValue, newSameValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const result = ArbitraryJsBlockKeepDeepEquality()(oldValue, newDifferentValue)
+    const result = ArbitraryJSBlockKeepDeepEquality()(oldValue, newDifferentValue)
     expect(result.value.type).toBe(oldValue.type)
     expect(result.value.javascript).toBe(newDifferentValue.javascript)
     expect(result.value.transpiledJavascript).toBe(oldValue.transpiledJavascript)
@@ -293,17 +293,17 @@ describe('JSXTextBlockKeepDeepEquality', () => {
   }
 
   it('same reference returns the same reference', () => {
-    const result = JSXTextBlockKeepDeepEquality()(oldValue, oldValue)
+    const result = JSXTextBlockKeepDeepEquality(oldValue, oldValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const result = JSXTextBlockKeepDeepEquality()(oldValue, newSameValue)
+    const result = JSXTextBlockKeepDeepEquality(oldValue, newSameValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const result = JSXTextBlockKeepDeepEquality()(oldValue, newDifferentValue)
+    const result = JSXTextBlockKeepDeepEquality(oldValue, newDifferentValue)
     expect(result.value.type).toBe(oldValue.type)
     expect(result.value.text).toBe(newDifferentValue.text)
     expect(result.value.uniqueID).toBe(oldValue.uniqueID)
@@ -351,17 +351,17 @@ describe('JSXFragmentKeepDeepEquality', () => {
   }
 
   it('same reference returns the same reference', () => {
-    const result = JSXFragmentKeepDeepEquality()(oldValue, oldValue)
+    const result = JSXFragmentKeepDeepEquality(oldValue, oldValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const result = JSXFragmentKeepDeepEquality()(oldValue, newSameValue)
+    const result = JSXFragmentKeepDeepEquality(oldValue, newSameValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const result = JSXFragmentKeepDeepEquality()(oldValue, newDifferentValue)
+    const result = JSXFragmentKeepDeepEquality(oldValue, newDifferentValue)
     expect(result.value.type).toBe(oldValue.type)
     expect(result.value.children).toBe(oldValue.children)
     expect(result.value.uniqueID).toBe(newDifferentValue.uniqueID)

--- a/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
@@ -668,17 +668,17 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
   }
 
   it('same reference returns the same reference', () => {
-    const result = ElementInstanceMetadataKeepDeepEquality()(oldValue, oldValue)
+    const result = ElementInstanceMetadataKeepDeepEquality(oldValue, oldValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const result = ElementInstanceMetadataKeepDeepEquality()(oldValue, newSameValue)
+    const result = ElementInstanceMetadataKeepDeepEquality(oldValue, newSameValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const result = ElementInstanceMetadataKeepDeepEquality()(oldValue, newDifferentValue)
+    const result = ElementInstanceMetadataKeepDeepEquality(oldValue, newDifferentValue)
     expect(result.value.elementPath).toBe(oldValue.elementPath)
     expect(result.value.element).toBe(oldValue.element)
     expect(result.value.props).toBe(oldValue.props)
@@ -960,17 +960,17 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
   }
 
   it('same reference returns the same reference', () => {
-    const result = ElementInstanceMetadataMapKeepDeepEquality()(oldValue, oldValue)
+    const result = ElementInstanceMetadataMapKeepDeepEquality(oldValue, oldValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const result = ElementInstanceMetadataMapKeepDeepEquality()(oldValue, newSameValue)
+    const result = ElementInstanceMetadataMapKeepDeepEquality(oldValue, newSameValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const result = ElementInstanceMetadataMapKeepDeepEquality()(oldValue, newDifferentValue)
+    const result = ElementInstanceMetadataMapKeepDeepEquality(oldValue, newDifferentValue)
     expect(result.value.elem.elementPath).toBe(oldValue.elem.elementPath)
     expect(result.value.elem.element).toBe(oldValue.elem.element)
     expect(result.value.elem.props).toBe(oldValue.elem.props)

--- a/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
@@ -312,17 +312,17 @@ describe('MultiLineCommentKeepDeepEqualityCall', () => {
   }
 
   it('same reference returns the same reference', () => {
-    const result = MultiLineCommentKeepDeepEqualityCall()(oldValue, oldValue)
+    const result = MultiLineCommentKeepDeepEqualityCall(oldValue, oldValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const result = MultiLineCommentKeepDeepEqualityCall()(oldValue, newSameValue)
+    const result = MultiLineCommentKeepDeepEqualityCall(oldValue, newSameValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const result = MultiLineCommentKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    const result = MultiLineCommentKeepDeepEqualityCall(oldValue, newDifferentValue)
     expect(result.value.type).toBe(oldValue.type)
     expect(result.value.comment).toBe(oldValue.comment)
     expect(result.value.rawText).toBe(oldValue.rawText)
@@ -357,17 +357,17 @@ describe('SingleLineCommentKeepDeepEqualityCall', () => {
   }
 
   it('same reference returns the same reference', () => {
-    const result = SingleLineCommentKeepDeepEqualityCall()(oldValue, oldValue)
+    const result = SingleLineCommentKeepDeepEqualityCall(oldValue, oldValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const result = SingleLineCommentKeepDeepEqualityCall()(oldValue, newSameValue)
+    const result = SingleLineCommentKeepDeepEqualityCall(oldValue, newSameValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const result = SingleLineCommentKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    const result = SingleLineCommentKeepDeepEqualityCall(oldValue, newDifferentValue)
     expect(result.value.type).toBe(oldValue.type)
     expect(result.value.comment).toBe(oldValue.comment)
     expect(result.value.rawText).toBe(oldValue.rawText)
@@ -424,25 +424,25 @@ describe('CommentKeepDeepEqualityCall', () => {
   }
 
   it('same reference returns the same reference', () => {
-    const resultSingle = CommentKeepDeepEqualityCall()(oldSingleValue, oldSingleValue)
+    const resultSingle = CommentKeepDeepEqualityCall(oldSingleValue, oldSingleValue)
     expect(resultSingle.value).toBe(oldSingleValue)
     expect(resultSingle.areEqual).toEqual(true)
 
-    const resultMulti = CommentKeepDeepEqualityCall()(oldMultiValue, oldMultiValue)
+    const resultMulti = CommentKeepDeepEqualityCall(oldMultiValue, oldMultiValue)
     expect(resultMulti.value).toBe(oldMultiValue)
     expect(resultMulti.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const resultSingle = CommentKeepDeepEqualityCall()(oldSingleValue, newSameSingleValue)
+    const resultSingle = CommentKeepDeepEqualityCall(oldSingleValue, newSameSingleValue)
     expect(resultSingle.value).toBe(oldSingleValue)
     expect(resultSingle.areEqual).toEqual(true)
 
-    const resultMulti = CommentKeepDeepEqualityCall()(oldMultiValue, newSameMultiValue)
+    const resultMulti = CommentKeepDeepEqualityCall(oldMultiValue, newSameMultiValue)
     expect(resultMulti.value).toBe(oldMultiValue)
     expect(resultMulti.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const resultSingle = CommentKeepDeepEqualityCall()(oldSingleValue, newDifferentSingleValue)
+    const resultSingle = CommentKeepDeepEqualityCall(oldSingleValue, newDifferentSingleValue)
     expect(resultSingle.value.type).toBe(oldSingleValue.type)
     expect(resultSingle.value.comment).toBe(oldSingleValue.comment)
     expect(resultSingle.value.rawText).toBe(oldSingleValue.rawText)
@@ -451,7 +451,7 @@ describe('CommentKeepDeepEqualityCall', () => {
     expect(resultSingle.value).toEqual(newDifferentSingleValue)
     expect(resultSingle.areEqual).toEqual(false)
 
-    const resultMulti = CommentKeepDeepEqualityCall()(oldMultiValue, newDifferentMultiValue)
+    const resultMulti = CommentKeepDeepEqualityCall(oldMultiValue, newDifferentMultiValue)
     expect(resultMulti.value.type).toBe(oldMultiValue.type)
     expect(resultMulti.value.comment).toBe(oldMultiValue.comment)
     expect(resultMulti.value.rawText).toBe(oldMultiValue.rawText)
@@ -525,17 +525,17 @@ describe('ParsedCommentsKeepDeepEqualityCall', () => {
   }
 
   it('same reference returns the same reference', () => {
-    const result = ParsedCommentsKeepDeepEqualityCall()(oldValue, oldValue)
+    const result = ParsedCommentsKeepDeepEqualityCall(oldValue, oldValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const result = ParsedCommentsKeepDeepEqualityCall()(oldValue, newSameValue)
+    const result = ParsedCommentsKeepDeepEqualityCall(oldValue, newSameValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const result = ParsedCommentsKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    const result = ParsedCommentsKeepDeepEqualityCall(oldValue, newDifferentValue)
     expect(result.value.leadingComments).toBe(oldValue.leadingComments)
     expect(result.value.trailingComments[0].type).toBe(oldValue.trailingComments[0].type)
     expect(result.value.trailingComments[0].comment).toBe(oldValue.trailingComments[0].comment)
@@ -555,17 +555,17 @@ describe('JSXAttributeValueKeepDeepEqualityCall', () => {
   const newDifferentValue = jsxAttributeValue('new', emptyComments)
 
   it('same reference returns the same reference', () => {
-    const result = JSXAttributeValueKeepDeepEqualityCall()(oldValue, oldValue)
+    const result = JSXAttributeValueKeepDeepEqualityCall(oldValue, oldValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const result = JSXAttributeValueKeepDeepEqualityCall()(oldValue, newSameValue)
+    const result = JSXAttributeValueKeepDeepEqualityCall(oldValue, newSameValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const result = JSXAttributeValueKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    const result = JSXAttributeValueKeepDeepEqualityCall(oldValue, newDifferentValue)
     expect(result.value.type).toBe(oldValue.type)
     expect(result.value.comments).toBe(oldValue.comments)
     expect(result.value.value).toBe(newDifferentValue.value)
@@ -949,17 +949,17 @@ describe('JSXAttributeKeepDeepEqualityCall', () => {
   const newDifferentValue = jsxAttributeValue('new', emptyComments)
 
   it('same reference returns the same reference', () => {
-    const result = JSXAttributeKeepDeepEqualityCall()(oldValue, oldValue)
+    const result = JSXAttributeKeepDeepEqualityCall(oldValue, oldValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('same value returns the same reference', () => {
-    const result = JSXAttributeKeepDeepEqualityCall()(oldValue, newSameValue)
+    const result = JSXAttributeKeepDeepEqualityCall(oldValue, newSameValue)
     expect(result.value).toBe(oldValue)
     expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
-    const result = JSXAttributeKeepDeepEqualityCall()(oldValue, newDifferentValue)
+    const result = JSXAttributeKeepDeepEqualityCall(oldValue, newDifferentValue)
     expect(result.value.type).toBe(oldValue.type)
     expect((result.value as JSXAttributeValue<string>).value).toBe(
       (newDifferentValue as JSXAttributeValue<string>).value,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1,4 +1,76 @@
-import { Sides } from 'utopia-api/core'
+import { errorMessage, ErrorMessage } from '../../../core/shared/error-messages'
+import {
+  packageDetails,
+  PackageDetails,
+  PackageStatus,
+  PackageStatusMap,
+} from '../../../core/shared/npm-dependency-types'
+import {
+  assetFile,
+  AssetFile,
+  Directory,
+  esCodeFile,
+  ESCodeFile,
+  esRemoteDependencyPlaceholder,
+  ESRemoteDependencyPlaceholder,
+  ExportClass,
+  exportClass,
+  ExportDefaultFunctionOrClass,
+  exportDefaultFunctionOrClass,
+  ExportDestructuredAssignment,
+  exportDestructuredAssignment,
+  ExportDetail,
+  ExportFunction,
+  exportFunction,
+  ExportIdentifier,
+  exportIdentifier,
+  ExportVariable,
+  exportVariable,
+  ExportVariables,
+  exportVariables,
+  ExportVariablesWithModifier,
+  exportVariablesWithModifier,
+  highlightBounds,
+  HighlightBounds,
+  HighlightBoundsForUids,
+  imageFile,
+  ImageFile,
+  ImportAlias,
+  importAlias,
+  ImportDetails,
+  importDetails,
+  NodeModuleFile,
+  ParsedJSONFailure,
+  ParsedTextFile,
+  ParseFailure,
+  parseFailure,
+  parseSuccess,
+  ParseSuccess,
+  ReexportVariables,
+  reexportVariables,
+  ReexportWildcard,
+  reexportWildcard,
+  RevisionsState,
+  textFile,
+  TextFile,
+  TextFileContents,
+  textFileContents,
+  Unparsed,
+} from '../../../core/shared/project-file-types'
+import {
+  detailedTypeInfo,
+  DetailedTypeInfo,
+  detailedTypeInfoMemberInfo,
+  DetailedTypeInfoMemberInfo,
+  exportsInfo,
+  ExportsInfo,
+  exportType,
+  ExportType,
+  MultiFileBuildResult,
+  singleFileBuildResult,
+  SingleFileBuildResult,
+} from '../../../core/workers/common/worker-types'
+import { PropertyControls, Sides } from 'utopia-api/core'
 import {
   ElementInstanceMetadata,
   elementInstanceMetadata,
@@ -87,8 +159,21 @@ import {
   functionParam,
   StyleAttributeMetadata,
   StyleAttributeMetadataEntry,
+  TopLevelElement,
+  ImportStatement,
+  importStatement,
+  UnparsedCode,
+  unparsedCode,
+  JSXElementWithoutUID,
+  jsxElementWithoutUID,
 } from '../../../core/shared/element-template'
-import { CanvasRectangle, LocalPoint, LocalRectangle } from '../../../core/shared/math-utils'
+import {
+  CanvasRectangle,
+  LocalPoint,
+  LocalRectangle,
+  size,
+  Size,
+} from '../../../core/shared/math-utils'
 import { RawSourceMap } from '../../../core/workers/ts/ts-typings/RawSourceMap'
 import {
   KeepDeepEqualityResult,
@@ -113,6 +198,13 @@ import {
   createCallWithShallowEquals,
   combine10EqualityCalls,
   ComplexMapKeepDeepEquality,
+  createCallWithDeepEquals,
+  readOnlyArrayDeepEquality,
+  StringKeepDeepEquality,
+  BooleanKeepDeepEquality,
+  NullableStringKeepDeepEquality,
+  NumberKeepDeepEquality,
+  NullableNumberKeepDeepEquality,
 } from '../../../utils/deep-equality'
 import {
   ElementPathArrayKeepDeepEquality,
@@ -121,6 +213,10 @@ import {
   EitherKeepDeepEquality,
   JSXElementNameKeepDeepEqualityCall,
   ElementWarningsKeepDeepEquality,
+  WindowPointKeepDeepEquality,
+  CanvasPointKeepDeepEquality,
+  StaticElementPathKeepDeepEquality,
+  NavigatorStateKeepDeepEquality,
 } from '../../../utils/deep-equality-instances'
 import { createCallFromIntrospectiveKeepDeep } from '../../../utils/react-performance'
 import {
@@ -129,7 +225,195 @@ import {
   transientCanvasState,
   DerivedState,
   EditorStatePatch,
+  EditorStateNodeModules,
+  editorStateNodeModules,
+  EditorStateLeftMenu,
+  editorStateLeftMenu,
+  EditorStateRightMenu,
+  editorStateRightMenu,
+  EditorStateInterfaceDesigner,
+  editorStateInterfaceDesigner,
+  EditorStateCanvasTextEditor,
+  editorStateCanvasTextEditor,
+  EditorStateCanvasTransientProperty,
+  editorStateCanvasTransientProperty,
+  EditorStateCanvasControls,
+  editorStateCanvasControls,
+  EditorStateCanvas,
+  DuplicationState,
+  duplicationState,
+  OriginalPath,
+  originalPath,
+  ImageBlob,
+  imageBlob,
+  UIFileBase64Blobs,
+  CanvasBase64Blobs,
+  DesignerFile,
+  designerFile,
+  ResizeOptions,
+  resizeOptions,
+  editorStateCanvas,
+  EditorState,
+  VSCodeBridgeIdDefault,
+  vsCodeBridgeIdDefault,
+  VSCodeBridgeIdProjectId,
+  vsCodeBridgeIdProjectId,
+  VSCodeBridgeId,
+  CanvasCursor,
+  CursorStackItem,
+  CursorImportanceLevel,
+  cursorStackItem,
+  canvasCursor,
+  floatingInsertMenuStateClosed,
+  FloatingInsertMenuStateClosed,
+  floatingInsertMenuStateConvert,
+  FloatingInsertMenuStateConvert,
+  floatingInsertMenuStateWrap,
+  FloatingInsertMenuStateWrap,
+  floatingInsertMenuStateInsert,
+  FloatingInsertMenuStateInsert,
+  FloatingInsertMenuState,
+  EditorStateInspector,
+  editorStateInspector,
+  EditorStateFileBrowser,
+  editorStateFileBrowser,
+  EditorStateDependencyList,
+  editorStateDependencyList,
+  EditorStateGenericExternalResources,
+  editorStateGenericExternalResources,
+  editorStateGoogleFontsResources,
+  EditorStateGoogleFontsResources,
+  EditorStateProjectSettings,
+  editorStateProjectSettings,
+  EditorStateTopMenu,
+  editorStateTopMenu,
+  EditorStatePreview,
+  editorStatePreview,
+  editorStateHome,
+  EditorStateHome,
+  FileDeleteModal,
+  fileDeleteModal,
+  ModalDialog,
+  EditorStateCodeEditorErrors,
+  ErrorMessages,
+  editorStateCodeEditorErrors,
+  Theme,
+  editorState,
 } from './editor-state'
+import {
+  CornerGuideline,
+  xAxisGuideline,
+  XAxisGuideline,
+  yAxisGuideline,
+  YAxisGuideline,
+  cornerGuideline,
+  Guideline,
+  GuidelineWithSnappingVector,
+  guidelineWithSnappingVector,
+} from '../../canvas/guideline'
+import {
+  boundingArea,
+  BoundingArea,
+  CanvasControlType,
+  DragInteractionData,
+  flexGapHandle,
+  FlexGapHandle,
+  InputData,
+  interactionSession,
+  InteractionSession,
+  keyboardCatcherControl,
+  KeyboardCatcherControl,
+  KeyboardInteractionData,
+  resizeHandle,
+  ResizeHandle,
+} from '../../canvas/canvas-strategies/interaction-state'
+import { Modifiers } from '../../../utils/modifiers'
+import { CSSCursor, DragState, edgePosition, EdgePosition } from '../../canvas/canvas-types'
+import {
+  projectContentDirectory,
+  ProjectContentDirectory,
+  projectContentFile,
+  ProjectContentFile,
+  ProjectContentsTree,
+  ProjectContentTreeRoot,
+} from '../../assets'
+import { directory } from '../../../core/model/project-file-utils'
+import { parsedJSONFailure } from '../../../core/workers/common/project-file-utils'
+import {
+  codeResult,
+  CodeResult,
+  codeResultCache,
+  CodeResultCache,
+  componentDescriptor,
+  ComponentDescriptor,
+  ComponentDescriptorsForFile,
+  componentInfo,
+  ComponentInfo,
+  CurriedResolveFn,
+  CurriedUtopiaRequireFn,
+  PropertyControlsInfo,
+} from '../../custom-code/code-file'
+import {
+  EvaluationCache,
+  EvaluationCacheForPath,
+  evaluationCacheForPath,
+  fileEvaluationCache,
+  FileEvaluationCache,
+} from '../../../core/es-modules/package-manager/package-manager'
+import {
+  dragAndDropInsertionSubject,
+  DragAndDropInsertionSubject,
+  EditorModes,
+  elementInsertionSubject,
+  ElementInsertionSubject,
+  insertionParent,
+  InsertionSubject,
+  InsertMode,
+  LiveCanvasMode,
+  Mode,
+  sceneInsertionSubject,
+  SceneInsertionSubject,
+  SelectLiteMode,
+  SelectMode,
+  targetedInsertionParent,
+  TargetedInsertionParent,
+} from '../editor-modes'
+import { EditorPanel } from '../../common/actions'
+import { notice, Notice, NoticeLevel } from '../../common/notice'
+import {
+  absolute,
+  Absolute,
+  After,
+  back,
+  Back,
+  Before,
+  front,
+  Front,
+  after,
+  before,
+  IndexPosition,
+} from '../../../utils/utils'
+import {
+  CSSColor,
+  CSSFontFamily,
+  CSSFontSize,
+  CSSFontWeightAndStyle,
+  CSSLetterSpacing,
+  CSSLineHeight,
+  CSSTextAlign,
+  CSSTextDecorationLine,
+  fontSettings,
+  FontSettings,
+} from '../../inspector/common/css-utils'
+import { projectListing, ProjectListing } from '../action-types'
+import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
+
+export function TransientCanvasStateFilesStateKeepDeepEquality(
+  oldValue: TransientFilesState,
+  newValue: TransientFilesState,
+): KeepDeepEqualityResult<TransientFilesState> {
+  return createCallFromIntrospectiveKeepDeep<TransientFilesState>()(oldValue, newValue)
+}
 
 export function TransientCanvasStateKeepDeepEquality(): KeepDeepEqualityCall<TransientCanvasState> {
   return combine4EqualityCalls(
@@ -138,7 +422,7 @@ export function TransientCanvasStateKeepDeepEquality(): KeepDeepEqualityCall<Tra
     (state) => state.highlightedViews,
     ElementPathArrayKeepDeepEquality,
     (state) => state.filesState,
-    createCallFromIntrospectiveKeepDeep<TransientFilesState | null>(),
+    nullableDeepEquality(TransientCanvasStateFilesStateKeepDeepEquality),
     (state) => state.toastsToApply,
     createCallWithShallowEquals(),
     transientCanvasState,
@@ -181,67 +465,110 @@ export function DerivedStateKeepDeepEquality(): KeepDeepEqualityCall<DerivedStat
   )
 }
 
-export function MultiLineCommentKeepDeepEqualityCall(): KeepDeepEqualityCall<MultiLineComment> {
-  return combine4EqualityCalls(
+export const MultiLineCommentKeepDeepEqualityCall: KeepDeepEqualityCall<MultiLineComment> =
+  combine4EqualityCalls(
     (comment) => comment.comment,
-    createCallWithTripleEquals(),
+    StringKeepDeepEquality,
     (comment) => comment.rawText,
-    createCallWithTripleEquals(),
+    StringKeepDeepEquality,
     (comment) => comment.trailingNewLine,
-    createCallWithTripleEquals(),
+    BooleanKeepDeepEquality,
     (comment) => comment.pos,
-    createCallWithTripleEquals(),
+    NullableNumberKeepDeepEquality,
     multiLineComment,
   )
-}
 
-export function SingleLineCommentKeepDeepEqualityCall(): KeepDeepEqualityCall<SingleLineComment> {
-  return combine4EqualityCalls(
+export const SingleLineCommentKeepDeepEqualityCall: KeepDeepEqualityCall<SingleLineComment> =
+  combine4EqualityCalls(
     (comment) => comment.comment,
-    createCallWithTripleEquals(),
+    StringKeepDeepEquality,
     (comment) => comment.rawText,
-    createCallWithTripleEquals(),
+    StringKeepDeepEquality,
     (comment) => comment.trailingNewLine,
-    createCallWithTripleEquals(),
+    BooleanKeepDeepEquality,
     (comment) => comment.pos,
-    createCallWithTripleEquals(),
+    NullableNumberKeepDeepEquality,
     singleLineComment,
   )
-}
 
-export function CommentKeepDeepEqualityCall(): KeepDeepEqualityCall<Comment> {
-  return (oldComment, newComment) => {
-    if (isMultiLineComment(oldComment) && isMultiLineComment(newComment)) {
-      return MultiLineCommentKeepDeepEqualityCall()(oldComment, newComment)
-    } else if (isSingleLineComment(oldComment) && isSingleLineComment(newComment)) {
-      return SingleLineCommentKeepDeepEqualityCall()(oldComment, newComment)
-    } else {
-      return keepDeepEqualityResult(newComment, false)
-    }
+export const CommentKeepDeepEqualityCall: KeepDeepEqualityCall<Comment> = (
+  oldComment,
+  newComment,
+) => {
+  if (isMultiLineComment(oldComment) && isMultiLineComment(newComment)) {
+    return MultiLineCommentKeepDeepEqualityCall(oldComment, newComment)
+  } else if (isSingleLineComment(oldComment) && isSingleLineComment(newComment)) {
+    return SingleLineCommentKeepDeepEqualityCall(oldComment, newComment)
+  } else {
+    return keepDeepEqualityResult(newComment, false)
   }
 }
 
-export function ParsedCommentsKeepDeepEqualityCall(): KeepDeepEqualityCall<ParsedComments> {
-  return combine2EqualityCalls(
+export const ParsedCommentsKeepDeepEqualityCall: KeepDeepEqualityCall<ParsedComments> =
+  combine2EqualityCalls(
     (comments) => comments.leadingComments,
-    arrayDeepEquality(CommentKeepDeepEqualityCall()),
+    arrayDeepEquality(CommentKeepDeepEqualityCall),
     (comments) => comments.trailingComments,
-    arrayDeepEquality(CommentKeepDeepEqualityCall()),
+    arrayDeepEquality(CommentKeepDeepEqualityCall),
     parsedComments,
   )
+
+export function JSXAttributeValueValueKeepDeepEqualityCall(
+  oldValue: any,
+  newValue: any,
+): KeepDeepEqualityResult<any> {
+  return createCallFromIntrospectiveKeepDeep<any>()(oldValue, newValue)
 }
 
-export function JSXAttributeValueKeepDeepEqualityCall<T>(): KeepDeepEqualityCall<
-  JSXAttributeValue<T>
-> {
-  return combine2EqualityCalls(
+export const JSXAttributeValueKeepDeepEqualityCall: KeepDeepEqualityCall<JSXAttributeValue<any>> =
+  combine2EqualityCalls(
     (attribute) => attribute.value,
-    createCallFromIntrospectiveKeepDeep<T>(),
+    JSXAttributeValueValueKeepDeepEqualityCall,
     (attribute) => attribute.comments,
-    ParsedCommentsKeepDeepEqualityCall(),
+    ParsedCommentsKeepDeepEqualityCall,
     jsxAttributeValue,
   )
-}
+
+export const RawSourceMapKeepDeepEquality: KeepDeepEqualityCall<RawSourceMap> =
+  combine8EqualityCalls(
+    (map) => map.version,
+    NumberKeepDeepEquality,
+    (map) => map.sources,
+    arrayDeepEquality(StringKeepDeepEquality),
+    (map) => map.names,
+    arrayDeepEquality(StringKeepDeepEquality),
+    (map) => map.sourceRoot,
+    undefinableDeepEquality(StringKeepDeepEquality),
+    (map) => map.sourcesContent,
+    undefinableDeepEquality(arrayDeepEquality(StringKeepDeepEquality)),
+    (map) => map.transpiledContentUtopia,
+    undefinableDeepEquality(StringKeepDeepEquality),
+    (map) => map.mappings,
+    StringKeepDeepEquality,
+    (map) => map.file,
+    StringKeepDeepEquality,
+    (
+      version,
+      sources,
+      names,
+      sourceRoot,
+      sourcesContent,
+      transpiledContentUtopia,
+      mappings,
+      file,
+    ) => {
+      return {
+        version: version,
+        sources: sources,
+        names: names,
+        sourceRoot: sourceRoot,
+        sourcesContent: sourcesContent,
+        transpiledContentUtopia: transpiledContentUtopia,
+        mappings: mappings,
+        file: file,
+      }
+    },
+  )
 
 export function JSXAttributeOtherJavaScriptKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXAttributeOtherJavaScript> {
   return combine6EqualityCalls(
@@ -252,7 +579,7 @@ export function JSXAttributeOtherJavaScriptKeepDeepEqualityCall(): KeepDeepEqual
     (attribute) => attribute.definedElsewhere,
     arrayDeepEquality(createCallWithTripleEquals()),
     (attribute) => attribute.sourceMap,
-    createCallFromIntrospectiveKeepDeep(),
+    nullableDeepEquality(RawSourceMapKeepDeepEquality),
     (attribute) => attribute.uniqueID,
     createCallWithTripleEquals(),
     (block) => block.elementsWithin,
@@ -274,9 +601,9 @@ export function JSXAttributeOtherJavaScriptKeepDeepEqualityCall(): KeepDeepEqual
 export function JSXArrayValueKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXArrayValue> {
   return combine2EqualityCalls(
     (value) => value.value,
-    JSXAttributeKeepDeepEqualityCall(),
+    JSXAttributeKeepDeepEqualityCall,
     (value) => value.comments,
-    ParsedCommentsKeepDeepEqualityCall(),
+    ParsedCommentsKeepDeepEqualityCall,
     jsxArrayValue,
   )
 }
@@ -284,9 +611,9 @@ export function JSXArrayValueKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXArr
 export function JSXArraySpreadKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXArraySpread> {
   return combine2EqualityCalls(
     (value) => value.value,
-    JSXAttributeKeepDeepEqualityCall(),
+    JSXAttributeKeepDeepEqualityCall,
     (value) => value.comments,
-    ParsedCommentsKeepDeepEqualityCall(),
+    ParsedCommentsKeepDeepEqualityCall,
     jsxArraySpread,
   )
 }
@@ -308,7 +635,7 @@ export function JSXAttributeNestedArrayKeepDeepEqualityCall(): KeepDeepEqualityC
     (attribute) => attribute.content,
     arrayDeepEquality(JSXArrayElementKeepDeepEqualityCall()),
     (value) => value.comments,
-    ParsedCommentsKeepDeepEqualityCall(),
+    ParsedCommentsKeepDeepEqualityCall,
     jsxAttributeNestedArray,
   )
 }
@@ -316,9 +643,9 @@ export function JSXAttributeNestedArrayKeepDeepEqualityCall(): KeepDeepEqualityC
 export function JSXSpreadAssignmentKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXSpreadAssignment> {
   return combine2EqualityCalls(
     (value) => value.value,
-    JSXAttributeKeepDeepEqualityCall(),
+    JSXAttributeKeepDeepEqualityCall,
     (value) => value.comments,
-    ParsedCommentsKeepDeepEqualityCall(),
+    ParsedCommentsKeepDeepEqualityCall,
     jsxSpreadAssignment,
   )
 }
@@ -328,11 +655,11 @@ export function JSXPropertyAssignmentKeepDeepEqualityCall(): KeepDeepEqualityCal
     (value) => value.key,
     createCallWithTripleEquals(),
     (value) => value.value,
-    JSXAttributeKeepDeepEqualityCall(),
+    JSXAttributeKeepDeepEqualityCall,
     (value) => value.comments,
-    ParsedCommentsKeepDeepEqualityCall(),
+    ParsedCommentsKeepDeepEqualityCall,
     (value) => value.keyComments,
-    ParsedCommentsKeepDeepEqualityCall(),
+    ParsedCommentsKeepDeepEqualityCall,
     jsxPropertyAssignment,
   )
 }
@@ -354,7 +681,7 @@ export function JSXAttributeNestedObjectKeepDeepEqualityCall(): KeepDeepEquality
     (attribute) => attribute.content,
     arrayDeepEquality(JSXPropertyKeepDeepEqualityCall()),
     (value) => value.comments,
-    ParsedCommentsKeepDeepEqualityCall(),
+    ParsedCommentsKeepDeepEqualityCall,
     jsxAttributeNestedObject,
   )
 }
@@ -364,35 +691,30 @@ export function JSXAttributeFunctionCallKeepDeepEqualityCall(): KeepDeepEquality
     (value) => value.functionName,
     createCallWithTripleEquals(),
     (value) => value.parameters,
-    arrayDeepEquality(JSXAttributeKeepDeepEqualityCall()),
+    arrayDeepEquality(JSXAttributeKeepDeepEqualityCall),
     jsxAttributeFunctionCall,
   )
 }
 
-export function JSXAttributeKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXAttribute> {
-  return (oldAttribute, newAttribute) => {
-    if (isJSXAttributeValue(oldAttribute) && isJSXAttributeValue(newAttribute)) {
-      return JSXAttributeValueKeepDeepEqualityCall()(oldAttribute, newAttribute)
-    } else if (
-      isJSXAttributeOtherJavaScript(oldAttribute) &&
-      isJSXAttributeOtherJavaScript(newAttribute)
-    ) {
-      return JSXAttributeOtherJavaScriptKeepDeepEqualityCall()(oldAttribute, newAttribute)
-    } else if (isJSXAttributeNestedArray(oldAttribute) && isJSXAttributeNestedArray(newAttribute)) {
-      return JSXAttributeNestedArrayKeepDeepEqualityCall()(oldAttribute, newAttribute)
-    } else if (
-      isJSXAttributeNestedObject(oldAttribute) &&
-      isJSXAttributeNestedObject(newAttribute)
-    ) {
-      return JSXAttributeNestedObjectKeepDeepEqualityCall()(oldAttribute, newAttribute)
-    } else if (
-      isJSXAttributeFunctionCall(oldAttribute) &&
-      isJSXAttributeFunctionCall(newAttribute)
-    ) {
-      return JSXAttributeFunctionCallKeepDeepEqualityCall()(oldAttribute, newAttribute)
-    } else {
-      return keepDeepEqualityResult(newAttribute, false)
-    }
+export const JSXAttributeKeepDeepEqualityCall: KeepDeepEqualityCall<JSXAttribute> = (
+  oldAttribute,
+  newAttribute,
+) => {
+  if (isJSXAttributeValue(oldAttribute) && isJSXAttributeValue(newAttribute)) {
+    return JSXAttributeValueKeepDeepEqualityCall(oldAttribute, newAttribute)
+  } else if (
+    isJSXAttributeOtherJavaScript(oldAttribute) &&
+    isJSXAttributeOtherJavaScript(newAttribute)
+  ) {
+    return JSXAttributeOtherJavaScriptKeepDeepEqualityCall()(oldAttribute, newAttribute)
+  } else if (isJSXAttributeNestedArray(oldAttribute) && isJSXAttributeNestedArray(newAttribute)) {
+    return JSXAttributeNestedArrayKeepDeepEqualityCall()(oldAttribute, newAttribute)
+  } else if (isJSXAttributeNestedObject(oldAttribute) && isJSXAttributeNestedObject(newAttribute)) {
+    return JSXAttributeNestedObjectKeepDeepEqualityCall()(oldAttribute, newAttribute)
+  } else if (isJSXAttributeFunctionCall(oldAttribute) && isJSXAttributeFunctionCall(newAttribute)) {
+    return JSXAttributeFunctionCallKeepDeepEqualityCall()(oldAttribute, newAttribute)
+  } else {
+    return keepDeepEqualityResult(newAttribute, false)
   }
 }
 
@@ -401,9 +723,9 @@ export function JSXAttributesEntryDeepEqualityCall(): KeepDeepEqualityCall<JSXAt
     (entry) => entry.key,
     createCallWithTripleEquals(),
     (entry) => entry.value,
-    JSXAttributeKeepDeepEqualityCall(),
+    JSXAttributeKeepDeepEqualityCall,
     (entry) => entry.comments,
-    ParsedCommentsKeepDeepEqualityCall(),
+    ParsedCommentsKeepDeepEqualityCall,
     jsxAttributesEntry,
   )
 }
@@ -411,9 +733,9 @@ export function JSXAttributesEntryDeepEqualityCall(): KeepDeepEqualityCall<JSXAt
 export function JSXAttributesSpreadDeepEqualityCall(): KeepDeepEqualityCall<JSXAttributesSpread> {
   return combine2EqualityCalls(
     (entry) => entry.spreadValue,
-    JSXAttributeKeepDeepEqualityCall(),
+    JSXAttributeKeepDeepEqualityCall,
     (entry) => entry.comments,
-    ParsedCommentsKeepDeepEqualityCall(),
+    ParsedCommentsKeepDeepEqualityCall,
     jsxAttributesSpread,
   )
 }
@@ -448,12 +770,24 @@ export function JSXElementKeepDeepEquality(): KeepDeepEqualityCall<JSXElement> {
   )
 }
 
+export function JSXElementWithoutUIDKeepDeepEquality(): KeepDeepEqualityCall<JSXElementWithoutUID> {
+  return combine3EqualityCalls(
+    (element) => element.name,
+    JSXElementNameKeepDeepEqualityCall(),
+    (element) => element.props,
+    JSXAttributesKeepDeepEqualityCall(),
+    (element) => element.children,
+    JSXElementChildArrayKeepDeepEquality(),
+    jsxElementWithoutUID,
+  )
+}
+
 export function ElementsWithinKeepDeepEqualityCall(): KeepDeepEqualityCall<ElementsWithin> {
   return objectDeepEquality(JSXElementKeepDeepEquality())
 }
 
-export function JSXArbitraryBlockKeepDeepEquality(): KeepDeepEqualityCall<JSXArbitraryBlock> {
-  return combine7EqualityCalls(
+export const JSXArbitraryBlockKeepDeepEquality: KeepDeepEqualityCall<JSXArbitraryBlock> =
+  combine7EqualityCalls(
     (block) => block.originalJavascript,
     createCallWithTripleEquals(),
     (block) => block.javascript,
@@ -463,7 +797,7 @@ export function JSXArbitraryBlockKeepDeepEquality(): KeepDeepEqualityCall<JSXArb
     (block) => block.definedElsewhere,
     arrayDeepEquality(createCallWithTripleEquals()),
     (block) => block.sourceMap,
-    createCallFromIntrospectiveKeepDeep(),
+    nullableDeepEquality(RawSourceMapKeepDeepEquality),
     (block) => block.uniqueID,
     createCallWithTripleEquals(),
     (block) => block.elementsWithin,
@@ -489,9 +823,8 @@ export function JSXArbitraryBlockKeepDeepEquality(): KeepDeepEqualityCall<JSXArb
       }
     },
   )
-}
 
-export function ArbitraryJsBlockKeepDeepEquality(): KeepDeepEqualityCall<ArbitraryJSBlock> {
+export function ArbitraryJSBlockKeepDeepEquality(): KeepDeepEqualityCall<ArbitraryJSBlock> {
   return combine7EqualityCalls(
     (block) => block.javascript,
     createCallWithTripleEquals(),
@@ -502,7 +835,7 @@ export function ArbitraryJsBlockKeepDeepEquality(): KeepDeepEqualityCall<Arbitra
     (block) => block.definedElsewhere,
     arrayDeepEquality(createCallWithTripleEquals()),
     (block) => block.sourceMap,
-    createCallFromIntrospectiveKeepDeep(),
+    nullableDeepEquality(RawSourceMapKeepDeepEquality),
     (block) => block.uniqueID,
     createCallWithTripleEquals(),
     (block) => block.elementsWithin,
@@ -530,8 +863,99 @@ export function ArbitraryJsBlockKeepDeepEquality(): KeepDeepEqualityCall<Arbitra
   )
 }
 
-export function JSXTextBlockKeepDeepEquality(): KeepDeepEqualityCall<JSXTextBlock> {
-  return combine2EqualityCalls(
+export function JSXElementChildKeepDeepEquality(): KeepDeepEqualityCall<JSXElementChild> {
+  return (oldElement, newElement) => {
+    if (isJSXElement(oldElement) && isJSXElement(newElement)) {
+      return JSXElementKeepDeepEquality()(oldElement, newElement)
+    } else if (isJSXArbitraryBlock(oldElement) && isJSXArbitraryBlock(newElement)) {
+      return JSXArbitraryBlockKeepDeepEquality(oldElement, newElement)
+    } else if (isJSXTextBlock(oldElement) && isJSXTextBlock(newElement)) {
+      return JSXTextBlockKeepDeepEquality(oldElement, newElement)
+    } else if (isJSXFragment(oldElement) && isJSXFragment(newElement)) {
+      return JSXFragmentKeepDeepEquality(oldElement, newElement)
+    } else {
+      return keepDeepEqualityResult(newElement, false)
+    }
+  }
+}
+
+export const UtopiaJSXComponentKeepDeepEquality: KeepDeepEqualityCall<UtopiaJSXComponent> =
+  combine10EqualityCalls(
+    (component) => component.name,
+    createCallWithTripleEquals(),
+    (component) => component.isFunction,
+    createCallWithTripleEquals(),
+    (component) => component.declarationSyntax,
+    createCallWithTripleEquals(),
+    (component) => component.blockOrExpression,
+    createCallWithTripleEquals(),
+    (component) => component.param,
+    nullableDeepEquality(ParamKeepDeepEquality()),
+    (component) => component.propsUsed,
+    arrayDeepEquality(createCallWithTripleEquals()),
+    (component) => component.rootElement,
+    JSXElementChildKeepDeepEquality(),
+    (component) => component.arbitraryJSBlock,
+    nullableDeepEquality(ArbitraryJSBlockKeepDeepEquality()),
+    (component) => component.usedInReactDOMRender,
+    createCallWithTripleEquals(),
+    (component) => component.returnStatementComments,
+    ParsedCommentsKeepDeepEqualityCall,
+    utopiaJSXComponent,
+  )
+
+export const ImportStatementKeepDeepEquality: KeepDeepEqualityCall<ImportStatement> =
+  combine5EqualityCalls(
+    (statement) => statement.rawCode,
+    StringKeepDeepEquality,
+    (statement) => statement.importStarAs,
+    BooleanKeepDeepEquality,
+    (statement) => statement.importWithName,
+    BooleanKeepDeepEquality,
+    (statement) => statement.imports,
+    arrayDeepEquality(StringKeepDeepEquality),
+    (statement) => statement.module,
+    StringKeepDeepEquality,
+    importStatement,
+  )
+
+export const UnparsedCodeKeepDeepEquality: KeepDeepEqualityCall<UnparsedCode> =
+  combine1EqualityCall((unparsed) => unparsed.rawCode, StringKeepDeepEquality, unparsedCode)
+
+export const TopLevelElementKeepDeepEquality: KeepDeepEqualityCall<TopLevelElement> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'UTOPIA_JSX_COMPONENT':
+      if (newValue.type === oldValue.type) {
+        return UtopiaJSXComponentKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'ARBITRARY_JS_BLOCK':
+      if (newValue.type === oldValue.type) {
+        return ArbitraryJSBlockKeepDeepEquality()(oldValue, newValue)
+      }
+      break
+    case 'IMPORT_STATEMENT':
+      if (newValue.type === oldValue.type) {
+        return ImportStatementKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'UNPARSED_CODE':
+      if (newValue.type === oldValue.type) {
+        return UnparsedCodeKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+export const JSXTextBlockKeepDeepEquality: KeepDeepEqualityCall<JSXTextBlock> =
+  combine2EqualityCalls(
     (block) => block.text,
     createCallWithTripleEquals(),
     (block) => block.uniqueID,
@@ -544,42 +968,23 @@ export function JSXTextBlockKeepDeepEquality(): KeepDeepEqualityCall<JSXTextBloc
       }
     },
   )
-}
 
-export function JSXFragmentKeepDeepEquality(): KeepDeepEqualityCall<JSXFragment> {
-  return combine3EqualityCalls(
-    (fragment) => fragment.children,
-    JSXElementChildArrayKeepDeepEquality(),
-    (fragment) => fragment.uniqueID,
-    createCallWithTripleEquals(),
-    (fragment) => fragment.longForm,
-    createCallWithTripleEquals(),
-    (children, uniqueID, longForm) => {
-      return {
-        type: 'JSX_FRAGMENT',
-        children: children,
-        uniqueID: uniqueID,
-        longForm: longForm,
-      }
-    },
-  )
-}
-
-export function JSXElementChildKeepDeepEquality(): KeepDeepEqualityCall<JSXElementChild> {
-  return (oldElement, newElement) => {
-    if (isJSXElement(oldElement) && isJSXElement(newElement)) {
-      return JSXElementKeepDeepEquality()(oldElement, newElement)
-    } else if (isJSXArbitraryBlock(oldElement) && isJSXArbitraryBlock(newElement)) {
-      return JSXArbitraryBlockKeepDeepEquality()(oldElement, newElement)
-    } else if (isJSXTextBlock(oldElement) && isJSXTextBlock(newElement)) {
-      return JSXTextBlockKeepDeepEquality()(oldElement, newElement)
-    } else if (isJSXFragment(oldElement) && isJSXFragment(newElement)) {
-      return JSXFragmentKeepDeepEquality()(oldElement, newElement)
-    } else {
-      return keepDeepEqualityResult(newElement, false)
+export const JSXFragmentKeepDeepEquality: KeepDeepEqualityCall<JSXFragment> = combine3EqualityCalls(
+  (fragment) => fragment.children,
+  JSXElementChildArrayKeepDeepEquality(),
+  (fragment) => fragment.uniqueID,
+  createCallWithTripleEquals(),
+  (fragment) => fragment.longForm,
+  createCallWithTripleEquals(),
+  (children, uniqueID, longForm) => {
+    return {
+      type: 'JSX_FRAGMENT',
+      children: children,
+      uniqueID: uniqueID,
+      longForm: longForm,
     }
-  }
-}
+  },
+)
 
 export function JSXElementChildArrayKeepDeepEquality(): KeepDeepEqualityCall<
   Array<JSXElementChild>
@@ -657,31 +1062,6 @@ export function ParamKeepDeepEquality(): KeepDeepEqualityCall<Param> {
     functionParam,
   )
 }
-
-export const UtopiaJSXComponentKeepDeepEquality: KeepDeepEqualityCall<UtopiaJSXComponent> =
-  combine10EqualityCalls(
-    (component) => component.name,
-    createCallWithTripleEquals(),
-    (component) => component.isFunction,
-    createCallWithTripleEquals(),
-    (component) => component.declarationSyntax,
-    createCallWithTripleEquals(),
-    (component) => component.blockOrExpression,
-    createCallWithTripleEquals(),
-    (component) => component.param,
-    nullableDeepEquality(ParamKeepDeepEquality()),
-    (component) => component.propsUsed,
-    arrayDeepEquality(createCallWithTripleEquals()),
-    (component) => component.rootElement,
-    JSXElementChildKeepDeepEquality(),
-    (component) => component.arbitraryJSBlock,
-    nullableDeepEquality(ArbitraryJsBlockKeepDeepEquality()),
-    (component) => component.usedInReactDOMRender,
-    createCallWithTripleEquals(),
-    (component) => component.returnStatementComments,
-    ParsedCommentsKeepDeepEqualityCall(),
-    utopiaJSXComponent,
-  )
 
 export function CanvasRectangleKeepDeepEquality(
   oldRect: CanvasRectangle,
@@ -865,14 +1245,17 @@ export const StyleAttributeMetadataEntryKeepDeepEquality: KeepDeepEqualityCall<
 export const StyleAttributeMetadataKeepDeepEquality: KeepDeepEqualityCall<StyleAttributeMetadata> =
   objectDeepEquality(undefinableDeepEquality(StyleAttributeMetadataEntryKeepDeepEquality))
 
-export function ElementInstanceMetadataKeepDeepEquality(): KeepDeepEqualityCall<ElementInstanceMetadata> {
-  return combine12EqualityCalls(
+export const ElementInstanceMetadataPropsKeepDeepEquality: KeepDeepEqualityCall<any> =
+  createCallWithShallowEquals()
+
+export const ElementInstanceMetadataKeepDeepEquality: KeepDeepEqualityCall<ElementInstanceMetadata> =
+  combine12EqualityCalls(
     (metadata) => metadata.elementPath,
     ElementPathKeepDeepEquality,
     (metadata) => metadata.element,
     EitherKeepDeepEquality(createCallWithTripleEquals(), JSXElementChildKeepDeepEquality()),
     (metadata) => metadata.props,
-    objectDeepEquality(createCallFromIntrospectiveKeepDeep()),
+    objectDeepEquality(ElementInstanceMetadataPropsKeepDeepEquality),
     (metadata) => metadata.globalFrame,
     nullableDeepEquality(CanvasRectangleKeepDeepEquality),
     (metadata) => metadata.localFrame,
@@ -893,8 +1276,1925 @@ export function ElementInstanceMetadataKeepDeepEquality(): KeepDeepEqualityCall<
     nullableDeepEquality(ImportInfoKeepDeepEquality),
     elementInstanceMetadata,
   )
+
+export const ESCodeFileKeepDeepEquality: KeepDeepEqualityCall<ESCodeFile> = combine3EqualityCalls(
+  (codeFile) => codeFile.fileContents,
+  createCallWithTripleEquals(),
+  (codeFile) => codeFile.origin,
+  createCallWithTripleEquals(),
+  (codeFile) => codeFile.fullPath,
+  createCallWithTripleEquals(),
+  esCodeFile,
+)
+
+export const ESRemoteDependencyPlaceholderKeepDeepEquality: KeepDeepEqualityCall<ESRemoteDependencyPlaceholder> =
+  combine2EqualityCalls(
+    (remoteDependencyPlaceholder) => remoteDependencyPlaceholder.url,
+    createCallWithTripleEquals(),
+    (remoteDependencyPlaceholder) => remoteDependencyPlaceholder.downloadStarted,
+    createCallWithTripleEquals(),
+    esRemoteDependencyPlaceholder,
+  )
+
+export const NodeModuleFileKeepDeepEquality: KeepDeepEqualityCall<NodeModuleFile> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'ES_CODE_FILE':
+      if (newValue.type === oldValue.type) {
+        return ESCodeFileKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'ES_REMOTE_DEPENDENCY_PLACEHOLDER':
+      if (newValue.type === oldValue.type) {
+        return ESRemoteDependencyPlaceholderKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
 }
 
-export function ElementInstanceMetadataMapKeepDeepEquality(): KeepDeepEqualityCall<ElementInstanceMetadataMap> {
-  return objectDeepEquality(ElementInstanceMetadataKeepDeepEquality())
+export const ElementInstanceMetadataMapKeepDeepEquality: KeepDeepEqualityCall<ElementInstanceMetadataMap> =
+  objectDeepEquality(ElementInstanceMetadataKeepDeepEquality)
+
+export const ErrorMessageKeepDeepEquality: KeepDeepEqualityCall<ErrorMessage> =
+  combine12EqualityCalls(
+    (message) => message.fileName,
+    createCallWithTripleEquals(),
+    (message) => message.startLine,
+    createCallWithTripleEquals(),
+    (message) => message.startColumn,
+    createCallWithTripleEquals(),
+    (message) => message.endLine,
+    createCallWithTripleEquals(),
+    (message) => message.endColumn,
+    createCallWithTripleEquals(),
+    (message) => message.codeSnippet,
+    createCallWithTripleEquals(),
+    (message) => message.severity,
+    createCallWithTripleEquals(),
+    (message) => message.type,
+    createCallWithTripleEquals(),
+    (message) => message.message,
+    createCallWithTripleEquals(),
+    (message) => message.errorCode,
+    createCallWithTripleEquals(),
+    (message) => message.source,
+    createCallWithTripleEquals(),
+    (message) => message.passTime,
+    createCallWithTripleEquals(),
+    errorMessage,
+  )
+
+export const SingleFileBuildResultKeepDeepEquality: KeepDeepEqualityCall<SingleFileBuildResult> =
+  combine3EqualityCalls(
+    (buildResult) => buildResult.transpiledCode,
+    nullableDeepEquality(createCallWithTripleEquals()),
+    (buildResult) => buildResult.sourceMap,
+    nullableDeepEquality(RawSourceMapKeepDeepEquality),
+    (buildResult) => buildResult.errors,
+    arrayDeepEquality(ErrorMessageKeepDeepEquality),
+    singleFileBuildResult,
+  )
+
+export const MultiFileBuildResultKeepDeepEquality: KeepDeepEqualityCall<MultiFileBuildResult> =
+  objectDeepEquality(SingleFileBuildResultKeepDeepEquality)
+
+export const PackageStatusKeepDeepEquality: KeepDeepEqualityCall<PackageStatus> =
+  createCallWithTripleEquals()
+
+export const PackageDetailsKeepDeepEquality: KeepDeepEqualityCall<PackageDetails> =
+  combine1EqualityCall((details) => details.status, PackageStatusKeepDeepEquality, packageDetails)
+
+export const PackageStatusMapKeepDeepEquality: KeepDeepEqualityCall<PackageStatusMap> =
+  objectDeepEquality(PackageDetailsKeepDeepEquality)
+
+export const EditorStateNodeModulesKeepDeepEquality: KeepDeepEqualityCall<EditorStateNodeModules> =
+  combine4EqualityCalls(
+    (nodeModules) => nodeModules.skipDeepFreeze,
+    createCallWithTripleEquals(),
+    (nodeModules) => nodeModules.files,
+    objectDeepEquality(NodeModuleFileKeepDeepEquality),
+    (nodeModules) => nodeModules.projectFilesBuildResults,
+    MultiFileBuildResultKeepDeepEquality,
+    (nodeModules) => nodeModules.packageStatus,
+    PackageStatusMapKeepDeepEquality,
+    editorStateNodeModules,
+  )
+
+export const EditorStateLeftMenuKeepDeepEquality: KeepDeepEqualityCall<EditorStateLeftMenu> =
+  combine3EqualityCalls(
+    (esLeftMenu) => esLeftMenu.selectedTab,
+    createCallWithTripleEquals(),
+    (esLeftMenu) => esLeftMenu.expanded,
+    createCallWithTripleEquals(),
+    (esLeftMenu) => esLeftMenu.paneWidth,
+    createCallWithTripleEquals(),
+    editorStateLeftMenu,
+  )
+
+export const EditorStateRightMenuKeepDeepEquality: KeepDeepEqualityCall<EditorStateRightMenu> =
+  combine2EqualityCalls(
+    (esRightMenu) => esRightMenu.selectedTab,
+    createCallWithTripleEquals(),
+    (esRightMenu) => esRightMenu.expanded,
+    createCallWithTripleEquals(),
+    editorStateRightMenu,
+  )
+
+export const EditorStateInterfaceDesignerKeepDeepEquality: KeepDeepEqualityCall<EditorStateInterfaceDesigner> =
+  combine4EqualityCalls(
+    (designer) => designer.codePaneWidth,
+    createCallWithTripleEquals(),
+    (designer) => designer.codePaneVisible,
+    createCallWithTripleEquals(),
+    (designer) => designer.restorableCodePaneWidth,
+    createCallWithTripleEquals(),
+    (designer) => designer.additionalControls,
+    createCallWithTripleEquals(),
+    editorStateInterfaceDesigner,
+  )
+
+export const EditorStateCanvasTextEditorKeepDeepEquality: KeepDeepEqualityCall<EditorStateCanvasTextEditor> =
+  combine2EqualityCalls(
+    (editor) => editor.elementPath,
+    ElementPathKeepDeepEquality,
+    (editor) => editor.triggerMousePosition,
+    nullableDeepEquality(WindowPointKeepDeepEquality),
+    editorStateCanvasTextEditor,
+  )
+
+export const EditorStateCanvasTransientPropertyKeepDeepEquality: KeepDeepEqualityCall<EditorStateCanvasTransientProperty> =
+  combine2EqualityCalls(
+    (property) => property.elementPath,
+    ElementPathKeepDeepEquality,
+    (property) => property.attributesToUpdate,
+    objectDeepEquality(JSXAttributeKeepDeepEqualityCall),
+    editorStateCanvasTransientProperty,
+  )
+
+export const XAxisGuidelineKeepDeepEquality: KeepDeepEqualityCall<XAxisGuideline> =
+  combine3EqualityCalls(
+    (guideline) => guideline.x,
+    createCallWithTripleEquals(),
+    (guideline) => guideline.yTop,
+    createCallWithTripleEquals(),
+    (guideline) => guideline.yBottom,
+    createCallWithTripleEquals(),
+    xAxisGuideline,
+  )
+
+export const YAxisGuidelineKeepDeepEquality: KeepDeepEqualityCall<YAxisGuideline> =
+  combine3EqualityCalls(
+    (guideline) => guideline.y,
+    createCallWithTripleEquals(),
+    (guideline) => guideline.xLeft,
+    createCallWithTripleEquals(),
+    (guideline) => guideline.xRight,
+    createCallWithTripleEquals(),
+    yAxisGuideline,
+  )
+
+export const CornerGuidelineKeepDeepEquality: KeepDeepEqualityCall<CornerGuideline> =
+  combine4EqualityCalls(
+    (guideline) => guideline.x,
+    createCallWithTripleEquals(),
+    (guideline) => guideline.y,
+    createCallWithTripleEquals(),
+    (guideline) => guideline.xMovement,
+    createCallWithTripleEquals(),
+    (guideline) => guideline.yMovement,
+    createCallWithTripleEquals(),
+    cornerGuideline,
+  )
+
+export const GuidelineKeepDeepEquality: KeepDeepEqualityCall<Guideline> = (oldValue, newValue) => {
+  switch (oldValue.type) {
+    case 'XAxisGuideline':
+      if (newValue.type === oldValue.type) {
+        return XAxisGuidelineKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'YAxisGuideline':
+      if (newValue.type === oldValue.type) {
+        return YAxisGuidelineKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'CornerGuideline':
+      if (newValue.type === oldValue.type) {
+        return CornerGuidelineKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+export const GuidelineWithSnappingVectorKeepDeepEquality: KeepDeepEqualityCall<GuidelineWithSnappingVector> =
+  combine3EqualityCalls(
+    (guideline) => guideline.guideline,
+    GuidelineKeepDeepEquality,
+    (guideline) => guideline.snappingVector,
+    CanvasPointKeepDeepEquality,
+    (guideline) => guideline.activateSnap,
+    createCallWithTripleEquals(),
+    guidelineWithSnappingVector,
+  )
+
+export const EditorStateCanvasControlsKeepDeepEquality: KeepDeepEqualityCall<EditorStateCanvasControls> =
+  combine1EqualityCall(
+    (controls) => controls.snappingGuidelines,
+    arrayDeepEquality(GuidelineWithSnappingVectorKeepDeepEquality),
+    editorStateCanvasControls,
+  )
+
+export const ModifiersKeepDeepEquality: KeepDeepEqualityCall<Modifiers> = combine4EqualityCalls(
+  (modifiers) => modifiers.alt,
+  createCallWithTripleEquals(),
+  (modifiers) => modifiers.cmd,
+  createCallWithTripleEquals(),
+  (modifiers) => modifiers.ctrl,
+  createCallWithTripleEquals(),
+  (modifiers) => modifiers.shift,
+  createCallWithTripleEquals(),
+  (alt, cmd, ctrl, shift) => {
+    return {
+      alt: alt,
+      cmd: cmd,
+      ctrl: ctrl,
+      shift: shift,
+    }
+  },
+)
+
+export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInteractionData> =
+  combine7EqualityCalls(
+    (data) => data.dragStart,
+    CanvasPointKeepDeepEquality,
+    (data) => data.drag,
+    nullableDeepEquality(CanvasPointKeepDeepEquality),
+    (data) => data.prevDrag,
+    nullableDeepEquality(CanvasPointKeepDeepEquality),
+    (data) => data.dragThresholdPassed,
+    createCallWithTripleEquals(),
+    (data) => data.originalDragStart,
+    CanvasPointKeepDeepEquality,
+    (data) => data.modifiers,
+    ModifiersKeepDeepEquality,
+    (data) => data.globalTime,
+    createCallWithTripleEquals(),
+    (dragStart, drag, prevDrag, dragThresholdPassed, originalDragStart, modifiers, globalTime) => {
+      return {
+        type: 'DRAG',
+        dragStart: dragStart,
+        drag: drag,
+        prevDrag: prevDrag,
+        dragThresholdPassed: dragThresholdPassed,
+        originalDragStart: originalDragStart,
+        modifiers: modifiers,
+        globalTime: globalTime,
+      }
+    },
+  )
+
+export const KeyboardInteractionDataKeepDeepEquality: KeepDeepEqualityCall<KeyboardInteractionData> =
+  combine2EqualityCalls(
+    (data) => data.keysPressed,
+    arrayDeepEquality(createCallWithTripleEquals()),
+    (data) => data.modifiers,
+    ModifiersKeepDeepEquality,
+    (keysPressed, modifiers) => {
+      return {
+        type: 'KEYBOARD',
+        keysPressed: keysPressed,
+        modifiers: modifiers,
+      }
+    },
+  )
+
+export const InputDataKeepDeepEquality: KeepDeepEqualityCall<InputData> = (oldValue, newValue) => {
+  switch (oldValue.type) {
+    case 'DRAG':
+      if (newValue.type === oldValue.type) {
+        return DragInteractionDataKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'KEYBOARD':
+      if (newValue.type === oldValue.type) {
+        return KeyboardInteractionDataKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+export const EdgePositionKeepDeepEquality: KeepDeepEqualityCall<EdgePosition> =
+  combine2EqualityCalls(
+    (edge) => edge.x,
+    createCallWithTripleEquals(),
+    (edge) => edge.y,
+    createCallWithTripleEquals(),
+    edgePosition,
+  )
+
+export const BoundingAreaKeepDeepEquality: KeepDeepEqualityCall<BoundingArea> =
+  combine1EqualityCall((area) => area.target, ElementPathKeepDeepEquality, boundingArea)
+
+export const ResizeHandleKeepDeepEquality: KeepDeepEqualityCall<ResizeHandle> =
+  combine1EqualityCall((handle) => handle.edgePosition, EdgePositionKeepDeepEquality, resizeHandle)
+
+export const FlexGapHandleKeepDeepEquality: KeepDeepEqualityCall<FlexGapHandle> = (
+  oldValue,
+  newValue,
+) => {
+  // This will break should the definition of `FlexGapHandle` change.
+  flexGapHandle()
+  return keepDeepEqualityResult(oldValue, true)
+}
+
+export const KeyboardCatcherControlKeepDeepEquality: KeepDeepEqualityCall<
+  KeyboardCatcherControl
+> = (oldValue, newValue) => {
+  // This will break should the definition of `KeyboardCatcherControl` change.
+  keyboardCatcherControl()
+  return keepDeepEqualityResult(oldValue, true)
+}
+
+export const CanvasControlTypeKeepDeepEquality: KeepDeepEqualityCall<CanvasControlType> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'BOUNDING_AREA':
+      if (newValue.type === oldValue.type) {
+        return BoundingAreaKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'RESIZE_HANDLE':
+      if (newValue.type === oldValue.type) {
+        return ResizeHandleKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'FLEX_GAP_HANDLE':
+      if (newValue.type === oldValue.type) {
+        return FlexGapHandleKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'KEYBOARD_CATCHER_CONTROL':
+      if (newValue.type === oldValue.type) {
+        return KeyboardCatcherControlKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+export const InteractionSessionKeepDeepEquality: KeepDeepEqualityCall<InteractionSession> =
+  combine7EqualityCalls(
+    (session) => session.interactionData,
+    InputDataKeepDeepEquality,
+    (session) => session.activeControl,
+    CanvasControlTypeKeepDeepEquality,
+    (session) => session.sourceOfUpdate,
+    CanvasControlTypeKeepDeepEquality,
+    (session) => session.lastInteractionTime,
+    createCallWithTripleEquals(),
+    (session) => session.metadata,
+    ElementInstanceMetadataMapKeepDeepEquality,
+    (sesssion) => sesssion.userPreferredStrategy,
+    nullableDeepEquality(createCallWithTripleEquals()),
+    (session) => session.startedAt,
+    createCallWithTripleEquals(),
+    interactionSession,
+  )
+
+export const OriginalPathKeepDeepEquality: KeepDeepEqualityCall<OriginalPath> =
+  combine2EqualityCalls(
+    (original) => original.originalTP,
+    ElementPathKeepDeepEquality,
+    (original) => original.currentTP,
+    ElementPathKeepDeepEquality,
+    originalPath,
+  )
+
+export const DuplicationStateKeepDeepEquality: KeepDeepEqualityCall<DuplicationState> =
+  combine1EqualityCall(
+    (state) => state.duplicateRoots,
+    arrayDeepEquality(OriginalPathKeepDeepEquality),
+    duplicationState,
+  )
+
+export const ImageBlogKeepDeepEquality: KeepDeepEqualityCall<ImageBlob> = combine1EqualityCall(
+  (blob) => blob.base64,
+  createCallWithTripleEquals(),
+  imageBlob,
+)
+
+export const UIFileBase64BlobsKeepDeepEquality: KeepDeepEqualityCall<UIFileBase64Blobs> =
+  objectDeepEquality(ImageBlogKeepDeepEquality)
+
+export const CanvasBase64BlobsKeepDeepEquality: KeepDeepEqualityCall<CanvasBase64Blobs> =
+  objectDeepEquality(UIFileBase64BlobsKeepDeepEquality)
+
+export const DesignerFileKeepDeepEquality: KeepDeepEqualityCall<DesignerFile> =
+  combine1EqualityCall((file) => file.filename, createCallWithTripleEquals(), designerFile)
+
+export const ResizeOptionsKeepDeepEquality: KeepDeepEqualityCall<ResizeOptions> =
+  combine2EqualityCalls(
+    (options) => options.propertyTargetOptions,
+    arrayDeepEquality(createCallWithTripleEquals()),
+    (options) => options.propertyTargetSelectedIndex,
+    createCallWithTripleEquals(),
+    resizeOptions,
+  )
+
+export const EditorStateCanvasKeepDeepEquality: KeepDeepEqualityCall<EditorStateCanvas> = (
+  oldValue,
+  newValue,
+) => {
+  const visibleResult = BooleanKeepDeepEquality(oldValue.visible, newValue.visible)
+  // `dragState` likely going away, so a suboptimal way of handling this seems fine for now.
+  const dragStateResult = nullableDeepEquality(createCallWithDeepEquals<DragState>())(
+    oldValue.dragState,
+    newValue.dragState,
+  )
+  const interactionSessionResult = nullableDeepEquality(InteractionSessionKeepDeepEquality)(
+    oldValue.interactionSession,
+    newValue.interactionSession,
+  )
+  const scaleResult = NumberKeepDeepEquality(oldValue.scale, newValue.scale)
+  const snappingThresholdResult = NumberKeepDeepEquality(
+    oldValue.snappingThreshold,
+    newValue.snappingThreshold,
+  )
+  const realCanvasOffsetResult = CanvasPointKeepDeepEquality(
+    oldValue.realCanvasOffset,
+    newValue.realCanvasOffset,
+  )
+  const roundedCanvasOffsetResult = CanvasPointKeepDeepEquality(
+    oldValue.roundedCanvasOffset,
+    newValue.roundedCanvasOffset,
+  )
+  const textEditorResult = nullableDeepEquality(EditorStateCanvasTextEditorKeepDeepEquality)(
+    oldValue.textEditor,
+    newValue.textEditor,
+  )
+  const selectionControlsVisibleResult = BooleanKeepDeepEquality(
+    oldValue.selectionControlsVisible,
+    newValue.selectionControlsVisible,
+  )
+  const cursorResult = nullableDeepEquality(createCallWithTripleEquals<CSSCursor>())(
+    oldValue.cursor,
+    newValue.cursor,
+  )
+  const duplicationStateResult = nullableDeepEquality(DuplicationStateKeepDeepEquality)(
+    oldValue.duplicationState,
+    newValue.duplicationState,
+  )
+  const base64BlobsResult = CanvasBase64BlobsKeepDeepEquality(
+    oldValue.base64Blobs,
+    newValue.base64Blobs,
+  )
+  const mountCountResult = NumberKeepDeepEquality(oldValue.mountCount, newValue.mountCount)
+  const canvasContentInvalidateCountResult = NumberKeepDeepEquality(
+    oldValue.canvasContentInvalidateCount,
+    newValue.canvasContentInvalidateCount,
+  )
+  const domWalkerInvalidateCountResult = NumberKeepDeepEquality(
+    oldValue.domWalkerInvalidateCount,
+    newValue.domWalkerInvalidateCount,
+  )
+  const openFileResult = nullableDeepEquality(DesignerFileKeepDeepEquality)(
+    oldValue.openFile,
+    newValue.openFile,
+  )
+  const scrollAnimationResult = BooleanKeepDeepEquality(
+    oldValue.scrollAnimation,
+    newValue.scrollAnimation,
+  )
+  const transientPropertiesResult = nullableDeepEquality(
+    objectDeepEquality(EditorStateCanvasTransientPropertyKeepDeepEquality),
+  )(oldValue.transientProperties, newValue.transientProperties)
+  const resizeOptionsResult = ResizeOptionsKeepDeepEquality(
+    oldValue.resizeOptions,
+    newValue.resizeOptions,
+  )
+  const domWalkerAdditionalElementsToUpdateResult = arrayDeepEquality(ElementPathKeepDeepEquality)(
+    oldValue.domWalkerAdditionalElementsToUpdate,
+    newValue.domWalkerAdditionalElementsToUpdate,
+  )
+  const controlsResult = EditorStateCanvasControlsKeepDeepEquality(
+    oldValue.controls,
+    newValue.controls,
+  )
+
+  const areEqual =
+    visibleResult.areEqual &&
+    dragStateResult.areEqual &&
+    interactionSessionResult.areEqual &&
+    scaleResult.areEqual &&
+    snappingThresholdResult.areEqual &&
+    realCanvasOffsetResult.areEqual &&
+    roundedCanvasOffsetResult.areEqual &&
+    textEditorResult.areEqual &&
+    selectionControlsVisibleResult.areEqual &&
+    cursorResult.areEqual &&
+    duplicationStateResult.areEqual &&
+    base64BlobsResult.areEqual &&
+    mountCountResult.areEqual &&
+    canvasContentInvalidateCountResult.areEqual &&
+    domWalkerInvalidateCountResult.areEqual &&
+    openFileResult.areEqual &&
+    scrollAnimationResult.areEqual &&
+    transientPropertiesResult.areEqual &&
+    resizeOptionsResult.areEqual &&
+    domWalkerAdditionalElementsToUpdateResult.areEqual &&
+    controlsResult.areEqual
+  if (areEqual) {
+    return keepDeepEqualityResult(oldValue, true)
+  } else {
+    const newDeepValue = editorStateCanvas(
+      visibleResult.value,
+      dragStateResult.value,
+      interactionSessionResult.value,
+      scaleResult.value,
+      snappingThresholdResult.value,
+      realCanvasOffsetResult.value,
+      roundedCanvasOffsetResult.value,
+      textEditorResult.value,
+      selectionControlsVisibleResult.value,
+      cursorResult.value,
+      duplicationStateResult.value,
+      base64BlobsResult.value,
+      mountCountResult.value,
+      canvasContentInvalidateCountResult.value,
+      domWalkerInvalidateCountResult.value,
+      openFileResult.value,
+      scrollAnimationResult.value,
+      transientPropertiesResult.value,
+      resizeOptionsResult.value,
+      domWalkerAdditionalElementsToUpdateResult.value,
+      controlsResult.value,
+    )
+    return keepDeepEqualityResult(newDeepValue, false)
+  }
+}
+
+export const VSCodeBridgeIdDefaultKeepDeepEquality: KeepDeepEqualityCall<VSCodeBridgeIdDefault> =
+  combine1EqualityCall((value) => value.defaultID, StringKeepDeepEquality, vsCodeBridgeIdDefault)
+
+export const VSCodeBridgeIdProjectIdKeepDeepEquality: KeepDeepEqualityCall<VSCodeBridgeIdProjectId> =
+  combine1EqualityCall((value) => value.projectID, StringKeepDeepEquality, vsCodeBridgeIdProjectId)
+
+export const VSCodeBridgeIdKeepDeepEquality: KeepDeepEqualityCall<VSCodeBridgeId> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'VSCODE_BRIDGE_ID_DEFAULT':
+      if (newValue.type === oldValue.type) {
+        return VSCodeBridgeIdDefaultKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'VSCODE_BRIDGE_ID_PROJECT_ID':
+      if (newValue.type === oldValue.type) {
+        return VSCodeBridgeIdProjectIdKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+export const ExportVariablesWithModifierKeepDeepEquality: KeepDeepEqualityCall<ExportVariablesWithModifier> =
+  combine1EqualityCall(
+    (exportVars) => exportVars.variables,
+    arrayDeepEquality(StringKeepDeepEquality),
+    exportVariablesWithModifier,
+  )
+
+export const ExportFunctionKeepDeepEquality: KeepDeepEqualityCall<ExportFunction> =
+  combine1EqualityCall((expFn) => expFn.functionName, StringKeepDeepEquality, exportFunction)
+
+export const ExportClassKeepDeepEquality: KeepDeepEqualityCall<ExportClass> = combine1EqualityCall(
+  (expClass) => expClass.className,
+  StringKeepDeepEquality,
+  exportClass,
+)
+
+export const ExportVariableKeepDeepEquality: KeepDeepEqualityCall<ExportVariable> =
+  combine2EqualityCalls(
+    (expVar) => expVar.variableName,
+    StringKeepDeepEquality,
+    (expVar) => expVar.variableAlias,
+    NullableStringKeepDeepEquality,
+    exportVariable,
+  )
+
+export const ExportVariablesKeepDeepEquality: KeepDeepEqualityCall<ExportVariables> =
+  combine1EqualityCall(
+    (expVars) => expVars.variables,
+    arrayDeepEquality(ExportVariableKeepDeepEquality),
+    exportVariables,
+  )
+
+export const ExportDestructuredAssignmentKeepDeepEquality: KeepDeepEqualityCall<ExportDestructuredAssignment> =
+  combine1EqualityCall(
+    (expAssign) => expAssign.variables,
+    arrayDeepEquality(ExportVariableKeepDeepEquality),
+    exportDestructuredAssignment,
+  )
+
+export const ExportDefaultFunctionOrClassKeepDeepEquality: KeepDeepEqualityCall<ExportDefaultFunctionOrClass> =
+  combine1EqualityCall(
+    (expFnOrClass) => expFnOrClass.name,
+    NullableStringKeepDeepEquality,
+    exportDefaultFunctionOrClass,
+  )
+
+export const ExportIdentifierKeepDeepEquality: KeepDeepEqualityCall<ExportIdentifier> =
+  combine1EqualityCall((expIdent) => expIdent.name, StringKeepDeepEquality, exportIdentifier)
+
+export const ReexportWildcardKeepDeepEquality: KeepDeepEqualityCall<ReexportWildcard> =
+  combine2EqualityCalls(
+    (reex) => reex.reexportedModule,
+    StringKeepDeepEquality,
+    (reex) => reex.namespacedVariable,
+    NullableStringKeepDeepEquality,
+    reexportWildcard,
+  )
+
+export const ReexportVariablesKeepDeepEquality: KeepDeepEqualityCall<ReexportVariables> =
+  combine2EqualityCalls(
+    (reex) => reex.reexportedModule,
+    StringKeepDeepEquality,
+    (reex) => reex.variables,
+    arrayDeepEquality(ExportVariableKeepDeepEquality),
+    reexportVariables,
+  )
+
+export const ExportDetailKeepDeepEquality: KeepDeepEqualityCall<ExportDetail> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'EXPORT_VARIABLES_WITH_MODIFIER':
+      if (newValue.type === oldValue.type) {
+        return ExportVariablesWithModifierKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'EXPORT_FUNCTION':
+      if (newValue.type === oldValue.type) {
+        return ExportFunctionKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'EXPORT_CLASS':
+      if (newValue.type === oldValue.type) {
+        return ExportClassKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'EXPORT_VARIABLES':
+      if (newValue.type === oldValue.type) {
+        return ExportVariablesKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'EXPORT_DESTRUCTURED_ASSIGNMENT':
+      if (newValue.type === oldValue.type) {
+        return ExportDestructuredAssignmentKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'EXPORT_DEFAULT_FUNCTION_OR_CLASS':
+      if (newValue.type === oldValue.type) {
+        return ExportDefaultFunctionOrClassKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'EXPORT_IDENTIFIER':
+      if (newValue.type === oldValue.type) {
+        return ExportIdentifierKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'REEXPORT_WILDCARD':
+      if (newValue.type === oldValue.type) {
+        return ReexportWildcardKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'REEXPORT_VARIABLES':
+      if (newValue.type === oldValue.type) {
+        return ReexportVariablesKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+export const ImportAliasKeepDeepEquality: KeepDeepEqualityCall<ImportAlias> = combine2EqualityCalls(
+  (alias) => alias.name,
+  StringKeepDeepEquality,
+  (alias) => alias.alias,
+  StringKeepDeepEquality,
+  importAlias,
+)
+
+export const ImportDetailsKeepDeepEquality: KeepDeepEqualityCall<ImportDetails> =
+  combine3EqualityCalls(
+    (details) => details.importedWithName,
+    NullableStringKeepDeepEquality,
+    (details) => details.importedFromWithin,
+    arrayDeepEquality(ImportAliasKeepDeepEquality),
+    (details) => details.importedAs,
+    NullableStringKeepDeepEquality,
+    importDetails,
+  )
+
+export const ParsedJSONFailureKeepDeepEquality: KeepDeepEqualityCall<ParsedJSONFailure> =
+  combine6EqualityCalls(
+    (failure) => failure.codeSnippet,
+    StringKeepDeepEquality,
+    (failure) => failure.reason,
+    StringKeepDeepEquality,
+    (failure) => failure.startLine,
+    NumberKeepDeepEquality,
+    (failure) => failure.startCol,
+    NumberKeepDeepEquality,
+    (failure) => failure.endLine,
+    NumberKeepDeepEquality,
+    (failure) => failure.endCol,
+    NumberKeepDeepEquality,
+    parsedJSONFailure,
+  )
+
+export const ParseFailureKeepDeepEquality: KeepDeepEqualityCall<ParseFailure> =
+  combine4EqualityCalls(
+    (failure) => failure.diagnostics,
+    nullableDeepEquality(arrayDeepEquality(ErrorMessageKeepDeepEquality)),
+    (failure) => failure.parsedJSONFailure,
+    nullableDeepEquality(ParsedJSONFailureKeepDeepEquality),
+    (failure) => failure.errorMessage,
+    NullableStringKeepDeepEquality,
+    (failure) => failure.errorMessages,
+    arrayDeepEquality(ErrorMessageKeepDeepEquality),
+    parseFailure,
+  )
+
+export const HighlightBoundsKeepDeepEquality: KeepDeepEqualityCall<HighlightBounds> =
+  combine5EqualityCalls(
+    (bounds) => bounds.startLine,
+    NumberKeepDeepEquality,
+    (bounds) => bounds.startCol,
+    NumberKeepDeepEquality,
+    (bounds) => bounds.endLine,
+    NumberKeepDeepEquality,
+    (bounds) => bounds.endCol,
+    NumberKeepDeepEquality,
+    (bounds) => bounds.uid,
+    StringKeepDeepEquality,
+    highlightBounds,
+  )
+
+export const HighlightBoundsForUidsKeepDeepEquality: KeepDeepEqualityCall<HighlightBoundsForUids> =
+  objectDeepEquality(HighlightBoundsKeepDeepEquality)
+
+export const ParseSuccessKeepDeepEquality: KeepDeepEqualityCall<ParseSuccess> =
+  combine6EqualityCalls(
+    (success) => success.imports,
+    objectDeepEquality(ImportDetailsKeepDeepEquality),
+    (success) => success.topLevelElements,
+    arrayDeepEquality(TopLevelElementKeepDeepEquality),
+    (success) => success.highlightBounds,
+    HighlightBoundsForUidsKeepDeepEquality,
+    (success) => success.jsxFactoryFunction,
+    NullableStringKeepDeepEquality,
+    (success) => success.combinedTopLevelArbitraryBlock,
+    nullableDeepEquality(ArbitraryJSBlockKeepDeepEquality()),
+    (success) => success.exportsDetail,
+    arrayDeepEquality(ExportDetailKeepDeepEquality),
+    parseSuccess,
+  )
+
+export const UnparsedKeepDeepEquality: KeepDeepEqualityCall<Unparsed> = (oldValue, newValue) => {
+  // This may not trip if the definition of `Unparsed` changes.
+  return keepDeepEqualityResult(oldValue, true)
+}
+
+export const ParsedTextFileKeepDeepEquality: KeepDeepEqualityCall<ParsedTextFile> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'PARSE_FAILURE':
+      if (newValue.type === oldValue.type) {
+        return ParseFailureKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'PARSE_SUCCESS':
+      if (newValue.type === oldValue.type) {
+        return ParseSuccessKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'UNPARSED':
+      if (newValue.type === oldValue.type) {
+        return UnparsedKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+export const DirectoryKeepDeepEquality: KeepDeepEqualityCall<Directory> = (oldValue, newValue) => {
+  // Here so that this breaks the build if the definition of `Directory` changes.
+  directory()
+  return keepDeepEqualityResult(oldValue, true)
+}
+
+export const TextFileContentsKeepDeepEquality: KeepDeepEqualityCall<TextFileContents> =
+  combine3EqualityCalls(
+    (contents) => contents.code,
+    StringKeepDeepEquality,
+    (contents) => contents.parsed,
+    ParsedTextFileKeepDeepEquality,
+    (contents) => contents.revisionsState,
+    createCallWithTripleEquals<RevisionsState>(),
+    textFileContents,
+  )
+
+export const TextFileKeepDeepEquality: KeepDeepEqualityCall<TextFile> = combine4EqualityCalls(
+  (file) => file.fileContents,
+  TextFileContentsKeepDeepEquality,
+  (file) => file.lastSavedContents,
+  nullableDeepEquality(TextFileContentsKeepDeepEquality),
+  (file) => file.lastParseSuccess,
+  nullableDeepEquality(ParseSuccessKeepDeepEquality),
+  (file) => file.lastRevisedTime,
+  NumberKeepDeepEquality,
+  textFile,
+)
+
+export const ImageFileKeepDeepEquality: KeepDeepEqualityCall<ImageFile> = combine5EqualityCalls(
+  (file) => file.imageType,
+  undefinableDeepEquality(StringKeepDeepEquality),
+  (file) => file.base64,
+  undefinableDeepEquality(StringKeepDeepEquality),
+  (file) => file.width,
+  undefinableDeepEquality(NumberKeepDeepEquality),
+  (file) => file.height,
+  undefinableDeepEquality(NumberKeepDeepEquality),
+  (file) => file.hash,
+  NumberKeepDeepEquality,
+  imageFile,
+)
+
+export const AssetFileKeepDeepEquality: KeepDeepEqualityCall<AssetFile> = combine1EqualityCall(
+  (file) => file.base64,
+  undefinableDeepEquality(StringKeepDeepEquality),
+  assetFile,
+)
+
+export const TextOrImageOrAssetKeepDeepEquality: KeepDeepEqualityCall<
+  TextFile | ImageFile | AssetFile
+> = (oldValue, newValue) => {
+  switch (oldValue.type) {
+    case 'TEXT_FILE':
+      if (newValue.type === oldValue.type) {
+        return TextFileKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'IMAGE_FILE':
+      if (newValue.type === oldValue.type) {
+        return ImageFileKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'ASSET_FILE':
+      if (newValue.type === oldValue.type) {
+        return AssetFileKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+export const ProjectContentDirectoryKeepDeepEquality: KeepDeepEqualityCall<ProjectContentDirectory> =
+  combine3EqualityCalls(
+    (dir) => dir.fullPath,
+    StringKeepDeepEquality,
+    (dir) => dir.directory,
+    DirectoryKeepDeepEquality,
+    (dir) => dir.children,
+    ProjectContentTreeRootKeepDeepEquality(),
+    projectContentDirectory,
+  )
+
+export const ProjectContentFileKeepDeepEquality: KeepDeepEqualityCall<ProjectContentFile> =
+  combine2EqualityCalls(
+    (file) => file.fullPath,
+    StringKeepDeepEquality,
+    (file) => file.content,
+    TextOrImageOrAssetKeepDeepEquality,
+    projectContentFile,
+  )
+
+export function ProjectContentsTreeKeepDeepEquality(): KeepDeepEqualityCall<ProjectContentsTree> {
+  return (oldValue, newValue) => {
+    switch (oldValue.type) {
+      case 'PROJECT_CONTENT_DIRECTORY':
+        if (newValue.type === oldValue.type) {
+          return ProjectContentDirectoryKeepDeepEquality(oldValue, newValue)
+        }
+        break
+      case 'PROJECT_CONTENT_FILE':
+        if (newValue.type === oldValue.type) {
+          return ProjectContentFileKeepDeepEquality(oldValue, newValue)
+        }
+        break
+      default:
+        const _exhaustiveCheck: never = oldValue
+        throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+    }
+    return keepDeepEqualityResult(newValue, false)
+  }
+}
+
+export function ProjectContentTreeRootKeepDeepEquality(): KeepDeepEqualityCall<ProjectContentTreeRoot> {
+  return objectDeepEquality(ProjectContentsTreeKeepDeepEquality())
+}
+
+export const DetailedTypeInfoMemberInfoKeepDeepEquality: KeepDeepEqualityCall<DetailedTypeInfoMemberInfo> =
+  combine2EqualityCalls(
+    (info) => info.type,
+    StringKeepDeepEquality,
+    (info) => info.members,
+    objectDeepEquality(StringKeepDeepEquality),
+    detailedTypeInfoMemberInfo,
+  )
+
+export const DetailedTypeInfoKeepDeepEquality: KeepDeepEqualityCall<DetailedTypeInfo> =
+  combine2EqualityCalls(
+    (info) => info.name,
+    StringKeepDeepEquality,
+    (info) => info.memberInfo,
+    DetailedTypeInfoMemberInfoKeepDeepEquality,
+    detailedTypeInfo,
+  )
+
+export const ExportTypeKeepDeepEquality: KeepDeepEqualityCall<ExportType> = combine3EqualityCalls(
+  (expType) => expType.type,
+  StringKeepDeepEquality,
+  (expType) => expType.functionInfo,
+  nullableDeepEquality(arrayDeepEquality(DetailedTypeInfoKeepDeepEquality)),
+  (expType) => expType.reactClassInfo,
+  nullableDeepEquality(DetailedTypeInfoKeepDeepEquality),
+  exportType,
+)
+
+export const CodeResultKeepDeepEquality: KeepDeepEqualityCall<CodeResult> = combine3EqualityCalls(
+  (result) => result.exports,
+  objectDeepEquality(ExportTypeKeepDeepEquality),
+  (result) => result.transpiledCode,
+  NullableStringKeepDeepEquality,
+  (result) => result.sourceMap,
+  nullableDeepEquality(RawSourceMapKeepDeepEquality),
+  codeResult,
+)
+
+export const ExportsInfoKeepDeepEquality: KeepDeepEqualityCall<ExportsInfo> = combine3EqualityCalls(
+  (info) => info.filename,
+  StringKeepDeepEquality,
+  (info) => info.code,
+  StringKeepDeepEquality,
+  (info) => info.exportTypes,
+  objectDeepEquality(ExportTypeKeepDeepEquality),
+  exportsInfo,
+)
+
+export function ErrorKeepDeepEquality(
+  oldValue: Error,
+  newValue: Error,
+): KeepDeepEqualityResult<Error> {
+  return createCallFromIntrospectiveKeepDeep<Error>()(oldValue, newValue)
+}
+
+export function FileEvaluationCacheExportsKeepDeepEquality(
+  oldValue: any,
+  newValue: any,
+): KeepDeepEqualityResult<any> {
+  return createCallFromIntrospectiveKeepDeep<any>()(oldValue, newValue)
+}
+
+export const FileEvaluationCacheKeepDeepEquality: KeepDeepEqualityCall<FileEvaluationCache> =
+  combine1EqualityCall(
+    (cache) => cache.exports,
+    FileEvaluationCacheExportsKeepDeepEquality,
+    fileEvaluationCache,
+  )
+
+export const EvaluationCacheForPathKeepDeepEquality: KeepDeepEqualityCall<EvaluationCacheForPath> =
+  combine2EqualityCalls(
+    (cache) => cache.module,
+    FileEvaluationCacheKeepDeepEquality,
+    (cache) => cache.lastEvaluatedContent,
+    StringKeepDeepEquality,
+    evaluationCacheForPath,
+  )
+
+export const EvaluationCacheKeepDeepEquality: KeepDeepEqualityCall<EvaluationCache> =
+  objectDeepEquality(EvaluationCacheForPathKeepDeepEquality)
+
+export const CodeResultCacheKeepDeepEquality: KeepDeepEqualityCall<CodeResultCache> =
+  combine7EqualityCalls(
+    (cache) => cache.cache,
+    objectDeepEquality(CodeResultKeepDeepEquality),
+    (cache) => cache.exportsInfo,
+    arrayDeepEquality(ExportsInfoKeepDeepEquality),
+    (cache) => cache.error,
+    nullableDeepEquality(ErrorKeepDeepEquality),
+    (cache) => cache.curriedRequireFn,
+    createCallWithTripleEquals<CurriedUtopiaRequireFn>(),
+    (cache) => cache.curriedResolveFn,
+    createCallWithTripleEquals<CurriedResolveFn>(),
+    (cache) => cache.projectModules,
+    MultiFileBuildResultKeepDeepEquality,
+    (cache) => cache.evaluationCache,
+    EvaluationCacheKeepDeepEquality,
+    codeResultCache,
+  )
+
+export const ComponentInfoKeepDeepEquality: KeepDeepEqualityCall<ComponentInfo> =
+  combine3EqualityCalls(
+    (info) => info.insertMenuLabel,
+    StringKeepDeepEquality,
+    (info) => info.elementToInsert,
+    JSXElementWithoutUIDKeepDeepEquality(),
+    (info) => info.importsToAdd,
+    objectDeepEquality(ImportDetailsKeepDeepEquality),
+    componentInfo,
+  )
+
+export function PropertyControlsKeepDeepEquality(
+  oldValue: PropertyControls,
+  newValue: PropertyControls,
+): KeepDeepEqualityResult<PropertyControls> {
+  return createCallFromIntrospectiveKeepDeep<PropertyControls>()(oldValue, newValue) // Do these lazily for now.
+}
+
+export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<ComponentDescriptor> =
+  combine2EqualityCalls(
+    (descriptor) => descriptor.properties,
+    PropertyControlsKeepDeepEquality,
+    (descriptor) => descriptor.variants,
+    arrayDeepEquality(ComponentInfoKeepDeepEquality),
+    componentDescriptor,
+  )
+
+export const ComponentDescriptorsForFileKeepDeepEquality: KeepDeepEqualityCall<ComponentDescriptorsForFile> =
+  objectDeepEquality(ComponentDescriptorKeepDeepEquality)
+
+export const PropertyControlsInfoKeepDeepEquality: KeepDeepEqualityCall<PropertyControlsInfo> =
+  objectDeepEquality(ComponentDescriptorsForFileKeepDeepEquality)
+
+export const TargetedInsertionParentKeepDeepEquality: KeepDeepEqualityCall<TargetedInsertionParent> =
+  combine2EqualityCalls(
+    (parent) => parent.target,
+    ElementPathKeepDeepEquality,
+    (parent) => parent.staticTarget,
+    StaticElementPathKeepDeepEquality,
+    targetedInsertionParent,
+  )
+
+export const SizeKeepDeepEquality: KeepDeepEqualityCall<Size> = combine2EqualityCalls(
+  (s) => s.width,
+  NumberKeepDeepEquality,
+  (s) => s.height,
+  NumberKeepDeepEquality,
+  size,
+)
+
+export const ElementInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<ElementInsertionSubject> =
+  combine5EqualityCalls(
+    (subject) => subject.uid,
+    StringKeepDeepEquality,
+    (subject) => subject.element,
+    JSXElementKeepDeepEquality(),
+    (subject) => subject.size,
+    nullableDeepEquality(SizeKeepDeepEquality),
+    (subject) => subject.importsToAdd,
+    objectDeepEquality(ImportDetailsKeepDeepEquality),
+    (subject) => subject.parent,
+    nullableDeepEquality(TargetedInsertionParentKeepDeepEquality),
+    elementInsertionSubject,
+  )
+
+// Here to trigger failure in the case of `SceneInsertionSubject` changing it's definition.
+sceneInsertionSubject()
+export const SceneInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<SceneInsertionSubject> = (
+  oldValue,
+  newValue,
+) => {
+  return keepDeepEqualityResult(oldValue, true)
+}
+
+export const DragAndDropInsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<DragAndDropInsertionSubject> =
+  combine1EqualityCall(
+    (subject) => subject.imageAssets,
+    nullableDeepEquality(arrayDeepEquality(StringKeepDeepEquality)),
+    dragAndDropInsertionSubject,
+  )
+
+export const InsertionSubjectKeepDeepEquality: KeepDeepEqualityCall<InsertionSubject> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'Element':
+      if (newValue.type === oldValue.type) {
+        return ElementInsertionSubjectKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'Scene':
+      if (newValue.type === oldValue.type) {
+        return SceneInsertionSubjectKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'DragAndDrop':
+      if (newValue.type === oldValue.type) {
+        return DragAndDropInsertionSubjectKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+export const InsertModeKeepDeepEquality: KeepDeepEqualityCall<InsertMode> = combine2EqualityCalls(
+  (mode) => mode.insertionStarted,
+  BooleanKeepDeepEquality,
+  (mode) => mode.subject,
+  InsertionSubjectKeepDeepEquality,
+  EditorModes.insertMode,
+)
+
+export const SelectModeKeepDeepEquality: KeepDeepEqualityCall<SelectMode> = combine1EqualityCall(
+  (mode) => mode.controlId,
+  NullableStringKeepDeepEquality,
+  EditorModes.selectMode,
+)
+
+// Here to trigger failure in the case of `SelectLiteMode` changing it's definition.
+EditorModes.selectLiteMode()
+export const SelectLiteModeKeepDeepEquality: KeepDeepEqualityCall<SelectLiteMode> = (
+  oldValue,
+  newValue,
+) => {
+  return keepDeepEqualityResult(oldValue, true)
+}
+
+export const LiveCanvasModeKeepDeepEquality: KeepDeepEqualityCall<LiveCanvasMode> =
+  combine1EqualityCall(
+    (mode) => mode.controlId,
+    NullableStringKeepDeepEquality,
+    EditorModes.liveMode,
+  )
+
+export const ModeKeepDeepEquality: KeepDeepEqualityCall<Mode> = (oldValue, newValue) => {
+  switch (oldValue.type) {
+    case 'insert':
+      if (newValue.type === oldValue.type) {
+        return InsertModeKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'select':
+      if (newValue.type === oldValue.type) {
+        return SelectModeKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'select-lite':
+      if (newValue.type === oldValue.type) {
+        return SelectLiteModeKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'live':
+      if (newValue.type === oldValue.type) {
+        return LiveCanvasModeKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+export const NoticeKeepDeepEquality: KeepDeepEqualityCall<Notice> = combine4EqualityCalls(
+  (note) => note.message,
+  createCallWithTripleEquals<React.ReactChild>(),
+  (note) => note.level,
+  createCallWithTripleEquals<NoticeLevel>(),
+  (note) => note.persistent,
+  BooleanKeepDeepEquality,
+  (note) => note.id,
+  StringKeepDeepEquality,
+  notice,
+)
+
+export const CursorStackItemKeepDeepEquality: KeepDeepEqualityCall<CursorStackItem> =
+  combine3EqualityCalls(
+    (item) => item.id,
+    StringKeepDeepEquality,
+    (item) => item.importance,
+    createCallWithTripleEquals<CursorImportanceLevel>(),
+    (item) => item.cursor,
+    createCallWithTripleEquals<CSSCursor>(),
+    cursorStackItem,
+  )
+
+export const CanvasCursorKeepDeepEquality: KeepDeepEqualityCall<CanvasCursor> =
+  combine2EqualityCalls(
+    (cursor) => cursor.fixed,
+    nullableDeepEquality(CursorStackItemKeepDeepEquality),
+    (cursor) => cursor.mouseOver,
+    arrayDeepEquality(CursorStackItemKeepDeepEquality),
+    canvasCursor,
+  )
+
+// Here to cause the build to break if `Front` is changed.
+front()
+export const FrontKeepDeepEquality: KeepDeepEqualityCall<Front> = (oldValue, newValue) => {
+  return keepDeepEqualityResult(oldValue, true)
+}
+
+// Here to cause the build to break if `Back` is changed.
+back()
+export const BackKeepDeepEquality: KeepDeepEqualityCall<Back> = (oldValue, newValue) => {
+  return keepDeepEqualityResult(oldValue, true)
+}
+
+export const AbsoluteKeepDeepEquality: KeepDeepEqualityCall<Absolute> = combine1EqualityCall(
+  (abs) => abs.index,
+  NumberKeepDeepEquality,
+  absolute,
+)
+
+export const AfterKeepDeepEquality: KeepDeepEqualityCall<After> = combine1EqualityCall(
+  (aft) => aft.index,
+  NumberKeepDeepEquality,
+  after,
+)
+
+export const BeforeKeepDeepEquality: KeepDeepEqualityCall<Before> = combine1EqualityCall(
+  (bef) => bef.index,
+  NumberKeepDeepEquality,
+  before,
+)
+
+export const IndexPositionKeepDeepEquality: KeepDeepEqualityCall<IndexPosition> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'front':
+      if (newValue.type === oldValue.type) {
+        return FrontKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'back':
+      if (newValue.type === oldValue.type) {
+        return BackKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'absolute':
+      if (newValue.type === oldValue.type) {
+        return AbsoluteKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'after':
+      if (newValue.type === oldValue.type) {
+        return AfterKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'before':
+      if (newValue.type === oldValue.type) {
+        return BeforeKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+// Here to cause the build to break if `FloatingInsertMenuStateClosed` is changed.
+floatingInsertMenuStateClosed()
+export const FloatingInsertMenuStateClosedKeepDeepEquality: KeepDeepEqualityCall<
+  FloatingInsertMenuStateClosed
+> = (oldValue, newValue) => {
+  return keepDeepEqualityResult(oldValue, true)
+}
+
+export const FloatingInsertMenuStateInsertKeepDeepEquality: KeepDeepEqualityCall<FloatingInsertMenuStateInsert> =
+  combine2EqualityCalls(
+    (menu) => menu.parentPath,
+    nullableDeepEquality(ElementPathKeepDeepEquality),
+    (menu) => menu.indexPosition,
+    nullableDeepEquality(IndexPositionKeepDeepEquality),
+    floatingInsertMenuStateInsert,
+  )
+
+// Here to cause the build to break if `FloatingInsertMenuStateConvert` is changed.
+floatingInsertMenuStateConvert()
+export const FloatingInsertMenuStateConvertKeepDeepEquality: KeepDeepEqualityCall<
+  FloatingInsertMenuStateConvert
+> = (oldValue, newValue) => {
+  return keepDeepEqualityResult(oldValue, true)
+}
+
+// Here to cause the build to break if `FloatingInsertMenuStateWrap` is changed.
+floatingInsertMenuStateWrap()
+export const FloatingInsertMenuStateWrapKeepDeepEquality: KeepDeepEqualityCall<
+  FloatingInsertMenuStateWrap
+> = (oldValue, newValue) => {
+  return keepDeepEqualityResult(oldValue, true)
+}
+
+export const FloatingInsertMenuStateKeepDeepEquality: KeepDeepEqualityCall<
+  FloatingInsertMenuState
+> = (oldValue, newValue) => {
+  switch (oldValue.insertMenuMode) {
+    case 'closed':
+      if (newValue.insertMenuMode === oldValue.insertMenuMode) {
+        return FloatingInsertMenuStateClosedKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'insert':
+      if (newValue.insertMenuMode === oldValue.insertMenuMode) {
+        return FloatingInsertMenuStateInsertKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'convert':
+      if (newValue.insertMenuMode === oldValue.insertMenuMode) {
+        return FloatingInsertMenuStateConvertKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'wrap':
+      if (newValue.insertMenuMode === oldValue.insertMenuMode) {
+        return FloatingInsertMenuStateWrapKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+export const EditorStateInspectorKeepDeepEquality: KeepDeepEqualityCall<EditorStateInspector> =
+  combine3EqualityCalls(
+    (inspector) => inspector.visible,
+    BooleanKeepDeepEquality,
+    (inspector) => inspector.classnameFocusCounter,
+    NumberKeepDeepEquality,
+    (inspector) => inspector.layoutSectionHovered,
+    BooleanKeepDeepEquality,
+    editorStateInspector,
+  )
+
+export const EditorStateFileBrowserKeepDeepEquality: KeepDeepEqualityCall<EditorStateFileBrowser> =
+  combine3EqualityCalls(
+    (fileBrowser) => fileBrowser.minimised,
+    BooleanKeepDeepEquality,
+    (fileBrowser) => fileBrowser.renamingTarget,
+    NullableStringKeepDeepEquality,
+    (fileBrowser) => fileBrowser.dropTarget,
+    NullableStringKeepDeepEquality,
+    editorStateFileBrowser,
+  )
+
+export const EditorStateDependencyListKeepDeepEquality: KeepDeepEqualityCall<EditorStateDependencyList> =
+  combine1EqualityCall(
+    (depList) => depList.minimised,
+    BooleanKeepDeepEquality,
+    editorStateDependencyList,
+  )
+
+export const EditorStateGenericExternalResourcesKeepDeepEquality: KeepDeepEqualityCall<EditorStateGenericExternalResources> =
+  combine1EqualityCall(
+    (resources) => resources.minimised,
+    BooleanKeepDeepEquality,
+    editorStateGenericExternalResources,
+  )
+
+export const EditorStateGoogleFontsResourcesKeepDeepEquality: KeepDeepEqualityCall<EditorStateGoogleFontsResources> =
+  combine1EqualityCall(
+    (resources) => resources.minimised,
+    BooleanKeepDeepEquality,
+    editorStateGoogleFontsResources,
+  )
+
+export const EditorStateProjectSettingsKeepDeepEquality: KeepDeepEqualityCall<EditorStateProjectSettings> =
+  combine1EqualityCall(
+    (settings) => settings.minimised,
+    BooleanKeepDeepEquality,
+    editorStateProjectSettings,
+  )
+
+export const EditorStateTopMenuKeepDeepEquality: KeepDeepEqualityCall<EditorStateTopMenu> =
+  combine2EqualityCalls(
+    (menu) => menu.formulaBarMode,
+    createCallWithTripleEquals<'css' | 'content'>(),
+    (menu) => menu.formulaBarFocusCounter,
+    NumberKeepDeepEquality,
+    editorStateTopMenu,
+  )
+
+export const EditorStatePreviewKeepDeepEquality: KeepDeepEqualityCall<EditorStatePreview> =
+  combine2EqualityCalls(
+    (preview) => preview.visible,
+    BooleanKeepDeepEquality,
+    (preview) => preview.connected,
+    BooleanKeepDeepEquality,
+    editorStatePreview,
+  )
+
+export const EditorStateHomeKeepDeepEquality: KeepDeepEqualityCall<EditorStateHome> =
+  combine1EqualityCall((preview) => preview.visible, BooleanKeepDeepEquality, editorStateHome)
+
+export function CSSColorKeepDeepEquality(
+  oldValue: CSSColor,
+  newValue: CSSColor,
+): KeepDeepEqualityResult<CSSColor> {
+  return createCallFromIntrospectiveKeepDeep<CSSColor>()(oldValue, newValue)
+}
+
+export function CSSFontFamilyKeepDeepEquality(
+  oldValue: CSSFontFamily,
+  newValue: CSSFontFamily,
+): KeepDeepEqualityResult<CSSFontFamily> {
+  return createCallFromIntrospectiveKeepDeep<CSSFontFamily>()(oldValue, newValue)
+}
+
+export function CSSFontWeightAndStyleKeepDeepEquality(
+  oldValue: CSSFontWeightAndStyle,
+  newValue: CSSFontWeightAndStyle,
+): KeepDeepEqualityResult<CSSFontWeightAndStyle> {
+  return createCallFromIntrospectiveKeepDeep<CSSFontWeightAndStyle>()(oldValue, newValue)
+}
+
+export function CSSFontSizeKeepDeepEquality(
+  oldValue: CSSFontSize,
+  newValue: CSSFontSize,
+): KeepDeepEqualityResult<CSSFontSize> {
+  return createCallFromIntrospectiveKeepDeep<CSSFontSize>()(oldValue, newValue)
+}
+
+export function CSSTextAlignKeepDeepEquality(
+  oldValue: CSSTextAlign,
+  newValue: CSSTextAlign,
+): KeepDeepEqualityResult<CSSTextAlign> {
+  return createCallFromIntrospectiveKeepDeep<CSSTextAlign>()(oldValue, newValue)
+}
+
+export function CSSTextDecorationLineKeepDeepEquality(
+  oldValue: CSSTextDecorationLine,
+  newValue: CSSTextDecorationLine,
+): KeepDeepEqualityResult<CSSTextDecorationLine> {
+  return createCallFromIntrospectiveKeepDeep<CSSTextDecorationLine>()(oldValue, newValue)
+}
+
+export function CSSLetterSpacingKeepDeepEquality(
+  oldValue: CSSLetterSpacing,
+  newValue: CSSLetterSpacing,
+): KeepDeepEqualityResult<CSSLetterSpacing> {
+  return createCallFromIntrospectiveKeepDeep<CSSLetterSpacing>()(oldValue, newValue)
+}
+
+export function CSSLineHeightKeepDeepEquality(
+  oldValue: CSSLineHeight,
+  newValue: CSSLineHeight,
+): KeepDeepEqualityResult<CSSLineHeight> {
+  return createCallFromIntrospectiveKeepDeep<CSSLineHeight>()(oldValue, newValue)
+}
+
+export const FontSettingsKeepDeepEquality: KeepDeepEqualityCall<FontSettings> =
+  combine8EqualityCalls(
+    (settings) => settings.color,
+    CSSColorKeepDeepEquality,
+    (settings) => settings.fontFamily,
+    CSSFontFamilyKeepDeepEquality,
+    (settings) => settings.fontWeightAndStyle,
+    CSSFontWeightAndStyleKeepDeepEquality,
+    (settings) => settings.fontSize,
+    CSSFontSizeKeepDeepEquality,
+    (settings) => settings.textAlign,
+    CSSTextAlignKeepDeepEquality,
+    (settings) => settings.textDecorationLine,
+    CSSTextDecorationLineKeepDeepEquality,
+    (settings) => settings.letterSpacing,
+    CSSLetterSpacingKeepDeepEquality,
+    (settings) => settings.lineHeight,
+    CSSLineHeightKeepDeepEquality,
+    fontSettings,
+  )
+
+export const FileDeleteModalKeepDeepEquality: KeepDeepEqualityCall<FileDeleteModal> =
+  combine1EqualityCall((modal) => modal.filePath, StringKeepDeepEquality, fileDeleteModal)
+
+export const ModalDialogKeepDeepEquality: KeepDeepEqualityCall<ModalDialog> =
+  FileDeleteModalKeepDeepEquality
+
+export const ProjectListingKeepDeepEquality: KeepDeepEqualityCall<ProjectListing> =
+  combine5EqualityCalls(
+    (listing) => listing.id,
+    StringKeepDeepEquality,
+    (listing) => listing.title,
+    StringKeepDeepEquality,
+    (listing) => listing.createdAt,
+    StringKeepDeepEquality,
+    (listing) => listing.modifiedAt,
+    StringKeepDeepEquality,
+    (listing) => listing.thumbnail,
+    StringKeepDeepEquality,
+    projectListing,
+  )
+
+export const ErrorMessagesKeepDeepEquality: KeepDeepEqualityCall<ErrorMessages> =
+  objectDeepEquality(arrayDeepEquality(ErrorMessageKeepDeepEquality))
+
+export const EditorStateCodeEditorErrorsKeepDeepEquality: KeepDeepEqualityCall<EditorStateCodeEditorErrors> =
+  combine2EqualityCalls(
+    (errors) => errors.buildErrors,
+    ErrorMessagesKeepDeepEquality,
+    (errors) => errors.lintErrors,
+    ErrorMessagesKeepDeepEquality,
+    editorStateCodeEditorErrors,
+  )
+
+export const UtopiaVSCodeConfigKeepDeepEquality: KeepDeepEqualityCall<UtopiaVSCodeConfig> =
+  combine1EqualityCall(
+    (config) => config.followSelection,
+    combine1EqualityCall(
+      (follow) => follow.enabled,
+      BooleanKeepDeepEquality,
+      (enabled) => {
+        return {
+          enabled: enabled,
+        }
+      },
+    ),
+    (followSelection) => {
+      return {
+        followSelection: followSelection,
+      }
+    },
+  )
+
+export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
+  oldValue,
+  newValue,
+) => {
+  const idResult = NullableStringKeepDeepEquality(oldValue.id, newValue.id)
+  const vscodeBridgeIdResult = VSCodeBridgeIdKeepDeepEquality(
+    oldValue.vscodeBridgeId,
+    newValue.vscodeBridgeId,
+  )
+  const forkedFromProjectIdResult = NullableStringKeepDeepEquality(
+    oldValue.forkedFromProjectId,
+    newValue.forkedFromProjectId,
+  )
+  const appIDResult = NullableStringKeepDeepEquality(oldValue.appID, newValue.appID)
+  const projectNameResult = StringKeepDeepEquality(oldValue.projectName, newValue.projectName)
+  const projectDescriptionResult = StringKeepDeepEquality(
+    oldValue.projectDescription,
+    newValue.projectDescription,
+  )
+  const projectVersionResult = NumberKeepDeepEquality(
+    oldValue.projectVersion,
+    newValue.projectVersion,
+  )
+  const isLoadedResult = BooleanKeepDeepEquality(oldValue.isLoaded, newValue.isLoaded)
+  const spyMetadataResult = ElementInstanceMetadataMapKeepDeepEquality(
+    oldValue.spyMetadata,
+    newValue.spyMetadata,
+  )
+  const domMetadataResult = arrayDeepEquality(ElementInstanceMetadataKeepDeepEquality)(
+    oldValue.domMetadata,
+    newValue.domMetadata,
+  )
+  const jsxMetadataResult = ElementInstanceMetadataMapKeepDeepEquality(
+    oldValue.jsxMetadata,
+    newValue.jsxMetadata,
+  )
+  const projectContentsResult = ProjectContentTreeRootKeepDeepEquality()(
+    oldValue.projectContents,
+    newValue.projectContents,
+  )
+  const codeResultCacheResult = CodeResultCacheKeepDeepEquality(
+    oldValue.codeResultCache,
+    newValue.codeResultCache,
+  )
+  const propertyControlsInfoResult = PropertyControlsInfoKeepDeepEquality(
+    oldValue.propertyControlsInfo,
+    newValue.propertyControlsInfo,
+  )
+  const nodeModulesResult = EditorStateNodeModulesKeepDeepEquality(
+    oldValue.nodeModules,
+    newValue.nodeModules,
+  )
+  const selectedViewsResult = ElementPathArrayKeepDeepEquality(
+    oldValue.selectedViews,
+    newValue.selectedViews,
+  )
+  const highlightedViewsResult = ElementPathArrayKeepDeepEquality(
+    oldValue.highlightedViews,
+    newValue.highlightedViews,
+  )
+  const hiddenInstancesResult = ElementPathArrayKeepDeepEquality(
+    oldValue.hiddenInstances,
+    newValue.hiddenInstances,
+  )
+  const warnedInstancesResult = ElementPathArrayKeepDeepEquality(
+    oldValue.warnedInstances,
+    newValue.warnedInstances,
+  )
+  const modeResult = ModeKeepDeepEquality(oldValue.mode, newValue.mode)
+  const focusedPanelResult = createCallWithTripleEquals<EditorPanel | null>()(
+    oldValue.focusedPanel,
+    newValue.focusedPanel,
+  )
+  const keysPressedResult = objectDeepEquality(BooleanKeepDeepEquality)(
+    oldValue.keysPressed,
+    newValue.keysPressed,
+  )
+  const openPopupIdResult = NullableStringKeepDeepEquality(
+    oldValue.openPopupId,
+    newValue.openPopupId,
+  )
+  const toastsResults = readOnlyArrayDeepEquality(NoticeKeepDeepEquality)(
+    oldValue.toasts,
+    newValue.toasts,
+  )
+  const canvasCursorResults = CanvasCursorKeepDeepEquality(
+    oldValue.cursorStack,
+    newValue.cursorStack,
+  )
+  const leftMenuResults = EditorStateLeftMenuKeepDeepEquality(oldValue.leftMenu, newValue.leftMenu)
+  const rightMenuResults = EditorStateRightMenuKeepDeepEquality(
+    oldValue.rightMenu,
+    newValue.rightMenu,
+  )
+  const interfaceDesignerResults = EditorStateInterfaceDesignerKeepDeepEquality(
+    oldValue.interfaceDesigner,
+    newValue.interfaceDesigner,
+  )
+  const canvasResults = EditorStateCanvasKeepDeepEquality(oldValue.canvas, newValue.canvas)
+  const floatingInsertMenuResults = FloatingInsertMenuStateKeepDeepEquality(
+    oldValue.floatingInsertMenu,
+    newValue.floatingInsertMenu,
+  )
+  const inspectorResults = EditorStateInspectorKeepDeepEquality(
+    oldValue.inspector,
+    newValue.inspector,
+  )
+  const fileBrowserResults = EditorStateFileBrowserKeepDeepEquality(
+    oldValue.fileBrowser,
+    newValue.fileBrowser,
+  )
+  const dependencyListResults = EditorStateDependencyListKeepDeepEquality(
+    oldValue.dependencyList,
+    newValue.dependencyList,
+  )
+  const genericExternalResourcesResults = EditorStateGenericExternalResourcesKeepDeepEquality(
+    oldValue.genericExternalResources,
+    newValue.genericExternalResources,
+  )
+  const googleFontsResourcesResults = EditorStateGoogleFontsResourcesKeepDeepEquality(
+    oldValue.googleFontsResources,
+    newValue.googleFontsResources,
+  )
+  const projectSettingsResults = EditorStateProjectSettingsKeepDeepEquality(
+    oldValue.projectSettings,
+    newValue.projectSettings,
+  )
+  const navigatorResults = NavigatorStateKeepDeepEquality(oldValue.navigator, newValue.navigator)
+  const topmenuResults = EditorStateTopMenuKeepDeepEquality(oldValue.topmenu, newValue.topmenu)
+  const previewResults = EditorStatePreviewKeepDeepEquality(oldValue.preview, newValue.preview)
+  const homeResults = EditorStateHomeKeepDeepEquality(oldValue.home, newValue.home)
+  const lastUsedFontResults = nullableDeepEquality(FontSettingsKeepDeepEquality)(
+    oldValue.lastUsedFont,
+    newValue.lastUsedFont,
+  )
+  const modalResults = nullableDeepEquality(ModalDialogKeepDeepEquality)(
+    oldValue.modal,
+    newValue.modal,
+  )
+  const localProjectListResults = arrayDeepEquality(ProjectListingKeepDeepEquality)(
+    oldValue.localProjectList,
+    newValue.localProjectList,
+  )
+  const projectListResults = arrayDeepEquality(ProjectListingKeepDeepEquality)(
+    oldValue.projectList,
+    newValue.projectList,
+  )
+  const showcaseProjectsResults = arrayDeepEquality(ProjectListingKeepDeepEquality)(
+    oldValue.showcaseProjects,
+    newValue.showcaseProjects,
+  )
+  const codeEditingEnabledResults = BooleanKeepDeepEquality(
+    oldValue.codeEditingEnabled,
+    newValue.codeEditingEnabled,
+  )
+  const codeEditorErrorsResults = EditorStateCodeEditorErrorsKeepDeepEquality(
+    oldValue.codeEditorErrors,
+    newValue.codeEditorErrors,
+  )
+  const thumbnailLastGeneratedResults = NumberKeepDeepEquality(
+    oldValue.thumbnailLastGenerated,
+    newValue.thumbnailLastGenerated,
+  )
+  const pasteTargetsToIgnoreResults = ElementPathArrayKeepDeepEquality(
+    oldValue.pasteTargetsToIgnore,
+    newValue.pasteTargetsToIgnore,
+  )
+  const parseOrPrintInFlightResults = BooleanKeepDeepEquality(
+    oldValue.parseOrPrintInFlight,
+    newValue.parseOrPrintInFlight,
+  )
+  const safeModeResults = BooleanKeepDeepEquality(oldValue.safeMode, newValue.safeMode)
+  const saveErrorResults = BooleanKeepDeepEquality(oldValue.saveError, newValue.saveError)
+  const vscodeBridgeReadyResults = BooleanKeepDeepEquality(
+    oldValue.vscodeBridgeReady,
+    newValue.vscodeBridgeReady,
+  )
+  const vscodeReadyResults = BooleanKeepDeepEquality(oldValue.vscodeReady, newValue.vscodeReady)
+  const focusedElementPathResults = nullableDeepEquality(ElementPathKeepDeepEquality)(
+    oldValue.focusedElementPath,
+    newValue.focusedElementPath,
+  )
+  const configResults = UtopiaVSCodeConfigKeepDeepEquality(oldValue.config, newValue.config)
+  const themeResults = createCallWithTripleEquals<Theme>()(oldValue.theme, newValue.theme)
+  const vscodeLoadingScreenVisibleResults = BooleanKeepDeepEquality(
+    oldValue.vscodeLoadingScreenVisible,
+    newValue.vscodeLoadingScreenVisible,
+  )
+  const indexedDBFailedResults = BooleanKeepDeepEquality(
+    oldValue.indexedDBFailed,
+    newValue.indexedDBFailed,
+  )
+  const forceParseFilesResults = arrayDeepEquality(StringKeepDeepEquality)(
+    oldValue.forceParseFiles,
+    newValue.forceParseFiles,
+  )
+
+  const areEqual =
+    idResult.areEqual &&
+    vscodeBridgeIdResult.areEqual &&
+    forkedFromProjectIdResult.areEqual &&
+    appIDResult.areEqual &&
+    projectNameResult.areEqual &&
+    projectDescriptionResult.areEqual &&
+    projectVersionResult.areEqual &&
+    isLoadedResult.areEqual &&
+    spyMetadataResult.areEqual &&
+    domMetadataResult.areEqual &&
+    jsxMetadataResult.areEqual &&
+    projectContentsResult.areEqual &&
+    codeResultCacheResult.areEqual &&
+    propertyControlsInfoResult.areEqual &&
+    nodeModulesResult.areEqual &&
+    selectedViewsResult.areEqual &&
+    highlightedViewsResult.areEqual &&
+    hiddenInstancesResult.areEqual &&
+    warnedInstancesResult.areEqual &&
+    modeResult.areEqual &&
+    focusedPanelResult.areEqual &&
+    keysPressedResult.areEqual &&
+    openPopupIdResult.areEqual &&
+    toastsResults.areEqual &&
+    canvasCursorResults.areEqual &&
+    leftMenuResults.areEqual &&
+    rightMenuResults.areEqual &&
+    interfaceDesignerResults.areEqual &&
+    canvasResults.areEqual &&
+    floatingInsertMenuResults.areEqual &&
+    inspectorResults.areEqual &&
+    fileBrowserResults.areEqual &&
+    dependencyListResults.areEqual &&
+    genericExternalResourcesResults.areEqual &&
+    googleFontsResourcesResults.areEqual &&
+    projectSettingsResults.areEqual &&
+    navigatorResults.areEqual &&
+    topmenuResults.areEqual &&
+    previewResults.areEqual &&
+    homeResults.areEqual &&
+    lastUsedFontResults.areEqual &&
+    modalResults.areEqual &&
+    localProjectListResults.areEqual &&
+    projectListResults.areEqual &&
+    showcaseProjectsResults.areEqual &&
+    codeEditingEnabledResults.areEqual &&
+    codeEditorErrorsResults.areEqual &&
+    thumbnailLastGeneratedResults.areEqual &&
+    pasteTargetsToIgnoreResults.areEqual &&
+    parseOrPrintInFlightResults.areEqual &&
+    safeModeResults.areEqual &&
+    saveErrorResults.areEqual &&
+    vscodeBridgeReadyResults.areEqual &&
+    vscodeReadyResults.areEqual &&
+    focusedElementPathResults.areEqual &&
+    configResults.areEqual &&
+    themeResults.areEqual &&
+    vscodeLoadingScreenVisibleResults.areEqual &&
+    indexedDBFailedResults.areEqual &&
+    forceParseFilesResults.areEqual
+
+  if (areEqual) {
+    return keepDeepEqualityResult(oldValue, true)
+  } else {
+    const newEditorState = editorState(
+      idResult.value,
+      vscodeBridgeIdResult.value,
+      forkedFromProjectIdResult.value,
+      appIDResult.value,
+      projectNameResult.value,
+      projectDescriptionResult.value,
+      projectVersionResult.value,
+      isLoadedResult.value,
+      spyMetadataResult.value,
+      domMetadataResult.value,
+      jsxMetadataResult.value,
+      projectContentsResult.value,
+      codeResultCacheResult.value,
+      propertyControlsInfoResult.value,
+      nodeModulesResult.value,
+      selectedViewsResult.value,
+      highlightedViewsResult.value,
+      hiddenInstancesResult.value,
+      warnedInstancesResult.value,
+      modeResult.value,
+      focusedPanelResult.value,
+      keysPressedResult.value,
+      openPopupIdResult.value,
+      toastsResults.value,
+      canvasCursorResults.value,
+      leftMenuResults.value,
+      rightMenuResults.value,
+      interfaceDesignerResults.value,
+      canvasResults.value,
+      floatingInsertMenuResults.value,
+      inspectorResults.value,
+      fileBrowserResults.value,
+      dependencyListResults.value,
+      genericExternalResourcesResults.value,
+      googleFontsResourcesResults.value,
+      projectSettingsResults.value,
+      navigatorResults.value,
+      topmenuResults.value,
+      previewResults.value,
+      homeResults.value,
+      lastUsedFontResults.value,
+      modalResults.value,
+      localProjectListResults.value,
+      projectListResults.value,
+      showcaseProjectsResults.value,
+      codeEditingEnabledResults.value,
+      codeEditorErrorsResults.value,
+      thumbnailLastGeneratedResults.value,
+      pasteTargetsToIgnoreResults.value,
+      parseOrPrintInFlightResults.value,
+      safeModeResults.value,
+      saveErrorResults.value,
+      vscodeBridgeReadyResults.value,
+      vscodeReadyResults.value,
+      focusedElementPathResults.value,
+      configResults.value,
+      themeResults.value,
+      vscodeLoadingScreenVisibleResults.value,
+      indexedDBFailedResults.value,
+      forceParseFilesResults.value,
+    )
+
+    return keepDeepEqualityResult(newEditorState, false)
+  }
 }

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -3454,7 +3454,7 @@ export type CSSFontProperty =
   | CSSLetterSpacing
   | CSSLineHeight
 
-export type FontSettings = {
+export interface FontSettings {
   color: CSSColor
   fontFamily: CSSFontFamily
   fontWeightAndStyle: CSSFontWeightAndStyle
@@ -3463,6 +3463,28 @@ export type FontSettings = {
   textDecorationLine: CSSTextDecorationLine
   letterSpacing: CSSLetterSpacing
   lineHeight: CSSLineHeight
+}
+
+export function fontSettings(
+  color: CSSColor,
+  fontFamily: CSSFontFamily,
+  fontWeightAndStyle: CSSFontWeightAndStyle,
+  fontSize: CSSFontSize,
+  textAlign: CSSTextAlign,
+  textDecorationLine: CSSTextDecorationLine,
+  letterSpacing: CSSLetterSpacing,
+  lineHeight: CSSLineHeight,
+): FontSettings {
+  return {
+    color: color,
+    fontFamily: fontFamily,
+    fontWeightAndStyle: fontWeightAndStyle,
+    fontSize: fontSize,
+    textAlign: textAlign,
+    textDecorationLine: textDecorationLine,
+    letterSpacing: letterSpacing,
+    lineHeight: lineHeight,
+  }
 }
 
 export interface CSSTextShadow {

--- a/editor/src/components/inspector/common/property-controls-hooks.ts
+++ b/editor/src/components/inspector/common/property-controls-hooks.ts
@@ -258,8 +258,7 @@ export function useGetPropertyControlsForSelectedComponents(): Array<FullPropert
     },
     'useGetPropertyControlsForSelectedComponents selectedElements',
     (a, b) =>
-      arrayDeepEquality(arrayDeepEquality(ElementInstanceMetadataKeepDeepEquality()))(a, b)
-        .areEqual,
+      arrayDeepEquality(arrayDeepEquality(ElementInstanceMetadataKeepDeepEquality))(a, b).areEqual,
   )
 
   const selectedComponentsFIXME = useEditorState(

--- a/editor/src/core/shared/error-messages.ts
+++ b/editor/src/core/shared/error-messages.ts
@@ -17,6 +17,36 @@ export interface ErrorMessage {
   passTime: number | null
 }
 
+export function errorMessage(
+  fileName: string,
+  startLine: number | null,
+  startColumn: number | null,
+  endLine: number | null,
+  endColumn: number | null,
+  codeSnippet: string,
+  severity: ErrorMessageSeverity,
+  messageType: string,
+  message: string,
+  errorCode: string,
+  source: ErrorMessageSource,
+  passTime: number | null,
+): ErrorMessage {
+  return {
+    fileName: fileName,
+    startLine: startLine,
+    startColumn: startColumn,
+    endLine: endLine,
+    endColumn: endColumn,
+    codeSnippet: codeSnippet,
+    severity: severity,
+    type: messageType,
+    message: message,
+    errorCode: errorCode,
+    source: source,
+    passTime: passTime,
+  }
+}
+
 export function messageisFatal(e: ErrorMessage): boolean {
   return e.severity === 'fatal'
 }

--- a/editor/src/core/shared/npm-dependency-types.ts
+++ b/editor/src/core/shared/npm-dependency-types.ts
@@ -15,7 +15,7 @@ export interface PackageDetails {
   status: PackageStatus
 }
 
-function packageDetails(status: PackageStatus): PackageDetails {
+export function packageDetails(status: PackageStatus): PackageDetails {
   return {
     status: status,
   }

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -353,6 +353,22 @@ export interface HighlightBounds {
   uid: string
 }
 
+export function highlightBounds(
+  startLine: number,
+  startCol: number,
+  endLine: number,
+  endCol: number,
+  uid: string,
+): HighlightBounds {
+  return {
+    startLine: startLine,
+    startCol: startCol,
+    endLine: endLine,
+    endCol: endCol,
+    uid: uid,
+  }
+}
+
 export type HighlightBoundsForUids = { [uid: string]: HighlightBounds }
 
 export interface HighlightBoundsWithFile extends HighlightBounds {
@@ -374,7 +390,7 @@ export interface ParseSuccess {
 export function parseSuccess(
   imports: Imports,
   topLevelElements: Array<TopLevelElement>,
-  highlightBounds: HighlightBoundsForUids,
+  bounds: HighlightBoundsForUids,
   jsxFactoryFunction: string | null,
   combinedTopLevelArbitraryBlock: ArbitraryJSBlock | null,
   exportsDetail: ExportsDetail,
@@ -383,7 +399,7 @@ export function parseSuccess(
     type: 'PARSE_SUCCESS',
     imports: imports,
     topLevelElements: topLevelElements,
-    highlightBounds: highlightBounds,
+    highlightBounds: bounds,
     jsxFactoryFunction: jsxFactoryFunction,
     combinedTopLevelArbitraryBlock: combinedTopLevelArbitraryBlock,
     exportsDetail: exportsDetail,
@@ -632,10 +648,34 @@ export interface ImageFile {
   hash: number
 }
 
+export function imageFile(
+  imageType: string | undefined,
+  base64: string | undefined,
+  width: number | undefined,
+  height: number | undefined,
+  hash: number,
+): ImageFile {
+  return {
+    type: 'IMAGE_FILE',
+    imageType: imageType,
+    base64: base64,
+    width: width,
+    height: height,
+    hash: hash,
+  }
+}
+
 // Ensure this is kept up to date with server/src/Utopia/Web/ClientModel.hs.
 export interface AssetFile {
   type: 'ASSET_FILE'
   base64?: string
+}
+
+export function assetFile(base64: string | undefined): AssetFile {
+  return {
+    type: 'ASSET_FILE',
+    base64: base64,
+  }
 }
 
 export function isAssetFile(projectFile: ProjectFile | null): projectFile is AssetFile {

--- a/editor/src/core/workers/common/worker-types.ts
+++ b/editor/src/core/workers/common/worker-types.ts
@@ -197,6 +197,18 @@ export interface SingleFileBuildResult {
   errors: Array<ErrorMessage>
 }
 
+export function singleFileBuildResult(
+  transpiledCode: string | null,
+  sourceMap: RawSourceMap | null,
+  errors: Array<ErrorMessage>,
+): SingleFileBuildResult {
+  return {
+    transpiledCode: transpiledCode,
+    sourceMap: sourceMap,
+    errors: errors,
+  }
+}
+
 export interface MultiFileBuildResult {
   [filename: string]: SingleFileBuildResult
 }
@@ -209,15 +221,64 @@ export interface ExportsInfo {
   exportTypes: { [name: string]: ExportType }
 }
 
-export interface DetailedTypeInfo {
-  name: string
-  memberInfo: { type: string; members: { [member: string]: string } }
+export function exportsInfo(
+  filename: string,
+  code: string,
+  exportTypes: { [name: string]: ExportType },
+): ExportsInfo {
+  return {
+    filename: filename,
+    code: code,
+    exportTypes: exportTypes,
+  }
 }
 
-export type ExportType = {
+export interface DetailedTypeInfoMemberInfo {
+  type: string
+  members: { [member: string]: string }
+}
+
+export function detailedTypeInfoMemberInfo(
+  type: string,
+  members: { [member: string]: string },
+): DetailedTypeInfoMemberInfo {
+  return {
+    type: type,
+    members: members,
+  }
+}
+
+export interface DetailedTypeInfo {
+  name: string
+  memberInfo: DetailedTypeInfoMemberInfo
+}
+
+export function detailedTypeInfo(
+  name: string,
+  memberInfo: DetailedTypeInfoMemberInfo,
+): DetailedTypeInfo {
+  return {
+    name: name,
+    memberInfo: memberInfo,
+  }
+}
+
+export interface ExportType {
   type: string
   functionInfo: Array<DetailedTypeInfo> | null
   reactClassInfo: DetailedTypeInfo | null
+}
+
+export function exportType(
+  type: string,
+  functionInfo: Array<DetailedTypeInfo> | null,
+  reactClassInfo: DetailedTypeInfo | null,
+): ExportType {
+  return {
+    type: type,
+    functionInfo: functionInfo,
+    reactClassInfo: reactClassInfo,
+  }
 }
 
 export interface BuildResultMessage {

--- a/editor/src/utils/deep-equality-instances.ts
+++ b/editor/src/utils/deep-equality-instances.ts
@@ -17,7 +17,7 @@ import * as EP from '../core/shared/element-path'
 import * as PP from '../core/shared/property-path'
 import { HigherOrderControl } from '../components/canvas/canvas-types'
 import { JSXElementName } from '../core/shared/element-template'
-import { ElementPath, PropertyPath } from '../core/shared/project-file-types'
+import { ElementPath, PropertyPath, StaticElementPath } from '../core/shared/project-file-types'
 import { createCallFromIntrospectiveKeepDeep } from './react-performance'
 import { Either, foldEither, isLeft, left, right } from '../core/shared/either'
 import { NameAndIconResult } from '../components/inspector/common/name-and-icon-hook'
@@ -28,9 +28,15 @@ import {
   NavigatorState,
 } from '../components/editor/store/editor-state'
 import { LayoutTargetableProp } from '../core/layout/layout-helpers-new'
+import { CanvasPoint, canvasPoint, windowPoint, WindowPoint } from '../core/shared/math-utils'
 
 export const ElementPathKeepDeepEquality: KeepDeepEqualityCall<ElementPath> =
   createCallFromEqualsFunction((oldPath: ElementPath, newPath: ElementPath) => {
+    return EP.pathsEqual(oldPath, newPath)
+  })
+
+export const StaticElementPathKeepDeepEquality: KeepDeepEqualityCall<StaticElementPath> =
+  createCallFromEqualsFunction((oldPath: StaticElementPath, newPath: StaticElementPath) => {
     return EP.pathsEqual(oldPath, newPath)
   })
 
@@ -43,9 +49,16 @@ export function PropertyPathKeepDeepEquality(): KeepDeepEqualityCall<PropertyPat
   })
 }
 
+export function HigherOrderControlKeepDeepEquality(
+  oldValue: HigherOrderControl,
+  newValue: HigherOrderControl,
+): KeepDeepEqualityResult<HigherOrderControl> {
+  return createCallFromIntrospectiveKeepDeep<HigherOrderControl>()(oldValue, newValue)
+}
+
 export const HigherOrderControlArrayKeepDeepEquality: KeepDeepEqualityCall<
   Array<HigherOrderControl>
-> = arrayDeepEquality(createCallFromIntrospectiveKeepDeep())
+> = arrayDeepEquality(HigherOrderControlKeepDeepEquality)
 
 export function JSXElementNameKeepDeepEqualityCall(): KeepDeepEqualityCall<JSXElementName> {
   return combine2EqualityCalls(
@@ -172,3 +185,19 @@ export const ElementWarningsKeepDeepEquality: KeepDeepEqualityCall<ElementWarnin
     createCallWithTripleEquals(),
     elementWarnings,
   )
+
+export const WindowPointKeepDeepEquality: KeepDeepEqualityCall<WindowPoint> = combine2EqualityCalls(
+  (point) => point.x,
+  createCallWithTripleEquals(),
+  (point) => point.y,
+  createCallWithTripleEquals(),
+  (x, y) => windowPoint({ x: x, y: y }),
+)
+
+export const CanvasPointKeepDeepEquality: KeepDeepEqualityCall<CanvasPoint> = combine2EqualityCalls(
+  (point) => point.x,
+  createCallWithTripleEquals(),
+  (point) => point.y,
+  createCallWithTripleEquals(),
+  (x, y) => canvasPoint({ x: x, y: y }),
+)

--- a/editor/src/utils/modifiers.ts
+++ b/editor/src/utils/modifiers.ts
@@ -1,6 +1,6 @@
 import { optionalDeepFreeze } from './deep-freeze'
 
-export type Modifiers = {
+export interface Modifiers {
   alt: boolean
   cmd: boolean
   ctrl: boolean

--- a/editor/src/utils/utils.ts
+++ b/editor/src/utils/utils.ts
@@ -150,23 +150,60 @@ export type FilteredFields<Base, T> = {
   [K in keyof Base]: Base[K] extends T ? K : never
 }[keyof Base]
 
-export type Front = {
+export interface Front {
   type: 'front'
 }
-export type Back = {
+
+export function front(): Front {
+  return {
+    type: 'front',
+  }
+}
+
+export interface Back {
   type: 'back'
 }
-export type Absolute = {
+
+export function back(): Back {
+  return {
+    type: 'back',
+  }
+}
+
+export interface Absolute {
   type: 'absolute'
   index: number
 }
-export type After = {
+
+export function absolute(index: number): Absolute {
+  return {
+    type: 'absolute',
+    index: index,
+  }
+}
+
+export interface After {
   type: 'after'
   index: number
 }
-export type Before = {
+
+export function after(index: number): After {
+  return {
+    type: 'after',
+    index: index,
+  }
+}
+
+export interface Before {
   type: 'before'
   index: number
+}
+
+export function before(index: number): Before {
+  return {
+    type: 'before',
+    index: index,
+  }
 }
 
 export type IndexPosition = Front | Back | Absolute | After | Before


### PR DESCRIPTION
**Problem:**
Currently after applying the commands from the strategies an introspective deep reference comparison is done to the entire `EditorState` which is _very_ costly.

**Fix:**
Switched the deep reference comparison to our `KeepDeepEqualityCall` utility code.

**Commit Details:**
- Added `EditorStateKeepDeepEquality` and a lot of supporting instances
  for that.
- Replaced `keepDeepReferenceEqualityIfPossible` in `foldAndApplyCommands`
  with `EditorStateKeepDeepEquality`.
- Added a lot of "constructor" functions for our types so that they can
  be used more easily in `KeepDeepEqualityCall` instances.
- Changed the names of some function parameters to avoid name shadowing
  with the new functions created.