### PR TITLE
feature(escape-hatch) use some of the absolute move strategy commands for snapping and guidelines

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -1,11 +1,6 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
-import {
-  CanvasPoint,
-  offsetPoint,
-  zeroCanvasPoint,
-  zeroPoint,
-} from '../../../core/shared/math-utils'
+import { CanvasPoint, offsetPoint, zeroCanvasPoint } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -12,6 +12,7 @@ import {
   CanvasStrategy,
   emptyStrategyApplicationResult,
   InteractionCanvasState,
+  StrategyApplicationResult,
 } from './canvas-strategy-types'
 import { DragInteractionData, InteractionSession, StrategyState } from './interaction-state'
 import {
@@ -80,7 +81,7 @@ export function applyAbsoluteMoveCommon(
   interactionState: InteractionSession,
   strategyState: StrategyState,
   getMoveCommands: (snappedDragVector: CanvasPoint) => Array<CanvasCommand>,
-) {
+): StrategyApplicationResult {
   if (interactionState.interactionData.type === 'DRAG') {
     const drag = interactionState.interactionData.drag
     const shiftKeyPressed = interactionState.interactionData.modifiers.shift

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -28,6 +28,7 @@ import { setCssLengthProperty } from '../commands/set-css-length-command'
 import { showOutlineHighlight } from '../commands/show-outline-highlight-command'
 import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
 import { AnimationTimer, PieTimerControl } from '../controls/select-mode/pie-timer'
+import { getTransientMoveCommands, snapDragAbsoluteMove } from './absolute-move-strategy'
 import {
   CanvasStrategy,
   emptyStrategyApplicationResult,
@@ -88,11 +89,17 @@ export const escapeHatchStrategy: CanvasStrategy = {
         escapeHatchActivated = true
       }
       if (escapeHatchActivated) {
-        const commands = getEscapeHatchCommands(
+        const { snappedDragVector, guidelinesWithSnappingVector } = snapDragAbsoluteMove(
+          canvasState,
+          interactionState.interactionData,
+          strategyState,
+        )
+
+        const conversionCommands = getEscapeHatchCommands(
           canvasState.selectedElements,
           strategyState.startingMetadata,
           canvasState,
-          interactionState.interactionData.drag,
+          snappedDragVector,
         )
 
         const highlightCommand = collectHighlightCommand(
@@ -100,8 +107,9 @@ export const escapeHatchStrategy: CanvasStrategy = {
           interactionState.interactionData,
           strategyState,
         )
+        const moveTransientCommands = getTransientMoveCommands(guidelinesWithSnappingVector)
         return {
-          commands: [...commands, highlightCommand],
+          commands: [...conversionCommands, highlightCommand, ...moveTransientCommands],
           customState: {
             ...strategyState.customStrategyState,
             escapeHatchActivated,

--- a/editor/src/components/canvas/commands/set-css-length-command.ts
+++ b/editor/src/components/canvas/commands/set-css-length-command.ts
@@ -110,7 +110,7 @@ export const runSetCssLengthProperty: CommandFunction<SetCssLengthProperty> = (
 
   return {
     editorStatePatches: [propertyUpdatePatch],
-    commandDescription: `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
+    commandDescription: `Set Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
       command.property,
     )} by ${command.valuePx}`,
   }


### PR DESCRIPTION
**Problem:**
After converting to absolute with the escape hatch the guidelines and snap points are missing.

**Fix:**
I can't directly use all the absolute move commands because escape hatch also creates these properties. Adding layout props and applying the drag is still part of the escape hatch. 

**Commit Details:**
- extending escape hatch with snapped drag delta and guidelines
- made common functions for escape hatch and absolute move strategies
