### PR TITLE
Minor performance improvement

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -38,6 +38,7 @@ import {
   parseCSSLength,
   CSSPosition,
   positionValues,
+  computedStyleKeys,
 } from '../inspector/common/css-utils'
 import { CanvasContainerProps, UiJsxCanvasCtxAtom } from './ui-jsx-canvas'
 import { camelCaseToDashed } from '../../core/shared/string-utils'
@@ -610,7 +611,7 @@ function getComputedStyle(
   let computedStyle: ComputedStyle = {}
   let attributeMetadata: StyleAttributeMetadata = {}
   if (elementStyle != null) {
-    Object.keys(elementStyle).forEach((key) => {
+    computedStyleKeys.forEach((key) => {
       // Accessing the value directly often doesn't work, and using `getPropertyValue` requires
       // using dashed case rather than camel case
       const caseCorrectedKey = camelCaseToDashed(key)

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4579,6 +4579,13 @@ export const DOMEventHandlerEmptyValues = DOMEventHandlerNames.reduce((current, 
   return current
 }, {} as DOMEventAttributeProperties)
 
+const elementPropertiesEmptyValuesExcludingEvents: UtopianElementProperties &
+  DOMIMGAttributeProperties = {
+  alt: '',
+  src: '/',
+  className: '',
+}
+
 const elementPropertiesEmptyValues: ParsedElementProperties = {
   alt: '',
   src: '/',
@@ -4741,6 +4748,12 @@ export const emptyValues: ParsedProperties = {
   ...layoutEmptyValues,
   ...layoutEmptyValuesNew,
 }
+
+export const computedStyleKeys: Array<string> = Object.keys({
+  ...elementPropertiesEmptyValuesExcludingEvents,
+  ...cssEmptyValues,
+  ...layoutEmptyValuesNew,
+})
 
 type Parser<T> = (simpleValue: unknown, rawValue: ModifiableAttribute | null) => Either<string, T>
 


### PR DESCRIPTION
This fix is cherry picked from https://github.com/concrete-utopia/utopia/pull/2130/

A really minor improvement, about 0.5-0.6 ms win in running this loop, but it also reduces the number of keys from nearly a thousand to 60, which can have other positive effects too.