### PR TITLE
On deletion, select the parents of the deleted items.

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -513,7 +513,7 @@ import { getTargetParentForPaste } from '../../../utils/clipboard'
 import { emptySet } from '../../../core/shared/set-utils'
 import { absolutePathFromRelativePath, stripLeadingSlash } from '../../../utils/path-utils'
 import { resolveModule } from '../../../core/es-modules/package-manager/module-resolution'
-import { reverse, uniqBy } from '../../../core/shared/array-utils'
+import { mapDropNulls, reverse, uniqBy } from '../../../core/shared/array-utils'
 import { UTOPIA_UID_KEY } from '../../../core/model/utopia-constants'
 import {
   DefaultPostCSSConfig,
@@ -1726,7 +1726,7 @@ export const UPDATE_FNS = {
     dispatch: EditorDispatch,
   ): EditorModel => {
     return toastOnGeneratedElementsSelected(
-      'Generated elements can only be deleted in code. ',
+      'Generated elements can only be deleted in code.',
       editorForAction,
       true,
       (editor) => {
@@ -1738,7 +1738,17 @@ export const UPDATE_FNS = {
           )
           return MetadataUtils.isStaticElement(components, selectedView)
         })
-        return deleteElements(staticSelectedElements, editor)
+        const withElementDeleted = deleteElements(staticSelectedElements, editor)
+        const parentsToSelect = uniqBy(
+          mapDropNulls((view) => {
+            return EP.parentPath(view)
+          }, editor.selectedViews),
+          EP.pathsEqual,
+        )
+        return {
+          ...withElementDeleted,
+          selectedViews: parentsToSelect,
+        }
       },
       dispatch,
     )

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -68,6 +68,7 @@ import { getLayoutPropertyOr } from '../../../core/layout/getLayoutProperty'
 import {
   ScenePathForTestUiJsFile,
   ScenePath1ForTestUiJsFile,
+  Scene1UID,
 } from '../../../core/model/test-ui-js-file.test-utils'
 import { emptyUiJsxCanvasContextData } from '../../canvas/ui-jsx-canvas'
 import { requestedNpmDependency } from '../../../core/shared/npm-dependency-types'
@@ -91,6 +92,7 @@ import {
 } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { NO_OP } from '../../../core/shared/utils'
 import { cssNumber } from '../../inspector/common/css-utils'
+import { testStaticElementPath } from '../../../core/shared/element-path.test-utils'
 
 const chaiExpect = Chai.expect
 
@@ -541,6 +543,10 @@ describe('action DELETE_SELECTED', () => {
           secondTargetElementPath,
         ),
       ).toBeNull()
+      expect(updatedEditor.selectedViews).toEqual([
+        EP.appendNewElementPath(ScenePathForTestUiJsFile, EP.staticElementPath(['aaa'])),
+        testStaticElementPath([[BakedInStoryboardUID, Scene1UID]]),
+      ])
     } else {
       chaiExpect.fail('src/app.js file was the wrong type.')
     }

--- a/editor/src/core/model/test-ui-js-file.test-utils.ts
+++ b/editor/src/core/model/test-ui-js-file.test-utils.ts
@@ -335,11 +335,15 @@ const scene = utopiaJSXComponent(
 
 export const TestScene0UID = 'scene-0'
 export const TestMainComponentUID = 'main-component-0'
-const ElementPathForTestUiJsFile = [BakedInStoryboardUID, TestScene0UID, TestMainComponentUID]
+export const ElementPathForTestUiJsFile = [
+  BakedInStoryboardUID,
+  TestScene0UID,
+  TestMainComponentUID,
+]
 export const ScenePathForTestUiJsFile = testStaticElementPath([ElementPathForTestUiJsFile])
-const Scene1UID = 'scene-1'
-const TestMainComponent1UID = 'main-component-1'
-const ElementPath1ForTestUiJsFile = [BakedInStoryboardUID, Scene1UID, TestMainComponent1UID]
+export const Scene1UID = 'scene-1'
+export const TestMainComponent1UID = 'main-component-1'
+export const ElementPath1ForTestUiJsFile = [BakedInStoryboardUID, Scene1UID, TestMainComponent1UID]
 export const ScenePath1ForTestUiJsFile = testStaticElementPath([ElementPath1ForTestUiJsFile])
 
 const Scene1 = defaultSceneElement(


### PR DESCRIPTION
**Problem:**
When deleting items, the selection is cleared as a result of the action, which has a detriment to the performance as it causes the inspector to unmount when the user likely wants the parent to be selected so they can manipulate that instead.

**Fix:**
Now the unique parents (should there be any) are selected as part of the action, similarly to how it is done in the `DELETE_VIEW` action.

**Commit Details:**
- `DELETE_SELECTED` action now selects the unique parents of the items
  that get deleted.