### PR TITLE
fix(components) disable focusing on utopia api components

### DIFF
--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1258,6 +1258,11 @@ export const MetadataUtils = {
     if (isImported) {
       return false
     }
+    const isImportedFromUtopiaApi =
+      element != null ? isUtopiaAPIComponentFromMetadata(element) : false
+    if (isImportedFromUtopiaApi) {
+      return false
+    }
     const isComponent = elementName != null && !isIntrinsicElement(elementName)
     if (isComponent) {
       return true

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1254,13 +1254,8 @@ export const MetadataUtils = {
     if (isAnimatedComponent) {
       return false
     }
-    const isImported = isImportedComponentNPM(element)
+    const isImported = isImportedComponent(element)
     if (isImported) {
-      return false
-    }
-    const isImportedFromUtopiaApi =
-      element != null ? isUtopiaAPIComponentFromMetadata(element) : false
-    if (isImportedFromUtopiaApi) {
       return false
     }
     const isComponent = elementName != null && !isIntrinsicElement(elementName)

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`743`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`731`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`817`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`805`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`582`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`570`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`654`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`642`)
   })
 })


### PR DESCRIPTION
**Problem:**
Double clicking on utopia-api components isolates them to component editing. 

**Fix:**
Changing `isFocusableComponentFromMetadata` to check if the element is imported from utopia-api

