### PR TITLE
dom walker: log cached parts

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -353,7 +353,11 @@ export function runDomWalker({
     )
     if (LogDomWalkerPerformance) {
       performance.mark('DOM_WALKER_END')
-      performance.measure('DOM WALKER', 'DOM_WALKER_START', 'DOM_WALKER_END')
+      performance.measure(
+        `DOM WALKER - cached paths: [${cachedPaths.map(EP.toString).join(', ')}]`,
+        'DOM_WALKER_START',
+        'DOM_WALKER_END',
+      )
     }
     domWalkerMutableState.initComplete = true // Mutation!
 


### PR DESCRIPTION
This is a micro PR that puts the dom walker cached paths as a string into the performance mark.

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/2226774/169855806-a31e4d39-4470-4a98-927d-51f0711f3d4d.png">

this makes it way easier for me to debug the dom-walker, because it puts the logged value right in the context where you can also check what changed on the canvas, and what action were dispatched (the action name is performance.marked as `MOMENTUM_DISPATCH: [<action name>]`

the screenshot looks scary but most projects don't have a thousand elements :)