### PR TITLE
Improve performance of `createOrderedElementPathsFromElement`.

### DIFF
--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -75,6 +75,18 @@ export function forEachChildOfTarget(
   target: ElementPath,
   handler: (elementPath: ElementPath) => void,
 ): void {
+  const foundTree = getSubTree(treeRoot, target)
+  if (foundTree != null) {
+    fastForEach(foundTree.children, (subTree) => {
+      handler(subTree.path)
+    })
+  }
+}
+
+export function getSubTree(
+  treeRoot: ElementPathTreeRoot,
+  target: ElementPath,
+): ElementPathTree | null {
   let workingRoot: ElementPathTreeRoot = treeRoot
   const totalParts = target.parts.reduce((workingCount, elem) => {
     return workingCount + elem.length
@@ -97,17 +109,17 @@ export function forEachChildOfTarget(
     const foundTree = workingRoot.find((elem) => EP.pathsEqual(elem.path, subElementPath))
     // Should there not be something at this point of the tree, bail out.
     if (foundTree == null) {
-      return
+      return null
     } else {
       if (pathSize === totalParts) {
         // When this is true, we're at the target element.
-        fastForEach(foundTree.children, (subTree) => {
-          handler(subTree.path)
-        })
+        return foundTree
       } else {
         // Otherwise continue working down the tree.
         workingRoot = foundTree.children
       }
     }
   }
+
+  return null
 }


### PR DESCRIPTION
**Problem:**
`createOrderedElementPathsFromElement` is a little slow.

**Fix:**
Reworked the function to walk down the tree from the roots and not to find each child in turn.

This was observed to take the runtime of the call from 2.13ms to 0.16ms.

**Commit Details:**
- Added `getSubTree` which subsumes most of the original implementation of
 `forEachChildOfTarget`.
- Reworked `createOrderedElementPathsFromElement` to use the new
  `getSubTree`.
- `getFramesInCanvasContext` now rewritten to use `getSubTree`.
- `getAllPaths` now rewritten to use `getSubTree`.