### PR TITLE
Minor improvement to `getElementWarningsInner`.

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1803,35 +1803,30 @@ function getElementWarningsInner(
   rootMetadata: ElementInstanceMetadataMap,
 ): ComplexMap<ElementPath, ElementWarnings> {
   let result: ComplexMap<ElementPath, ElementWarnings> = emptyComplexMap()
-  MetadataUtils.walkMetadata(
-    rootMetadata,
-    (elementMetadata: ElementInstanceMetadata, parentMetadata: ElementInstanceMetadata | null) => {
-      // Check to see if this element is collapsed in one dimension.
-      const globalFrame = elementMetadata.globalFrame
-      const widthOrHeightZero =
-        globalFrame != null ? globalFrame.width === 0 || globalFrame.height === 0 : false
+  Object.values(rootMetadata).forEach((elementMetadata) => {
+    // Check to see if this element is collapsed in one dimension.
+    const globalFrame = elementMetadata.globalFrame
+    const widthOrHeightZero =
+      globalFrame != null ? globalFrame.width === 0 || globalFrame.height === 0 : false
 
-      // Identify if this element looks to be trying to position itself with "pins", but
-      // the parent element isn't appropriately configured.
-      let absoluteWithUnpositionedParent: boolean = false
-      if (parentMetadata != null) {
-        if (
-          elementMetadata.specialSizeMeasurements.position === 'absolute' &&
-          !elementMetadata.specialSizeMeasurements.immediateParentProvidesLayout
-        ) {
-          absoluteWithUnpositionedParent = true
-        }
-      }
+    // Identify if this element looks to be trying to position itself with "pins", but
+    // the parent element isn't appropriately configured.
+    let absoluteWithUnpositionedParent: boolean = false
+    if (
+      elementMetadata.specialSizeMeasurements.position === 'absolute' &&
+      !elementMetadata.specialSizeMeasurements.immediateParentProvidesLayout
+    ) {
+      absoluteWithUnpositionedParent = true
+    }
 
-      // Build the warnings object and add it to the map.
-      const warnings: ElementWarnings = {
-        widthOrHeightZero: widthOrHeightZero,
-        absoluteWithUnpositionedParent: absoluteWithUnpositionedParent,
-        dynamicSceneChildWidthHeightPercentage: false,
-      }
-      result = addToComplexMap(toString, result, elementMetadata.elementPath, warnings)
-    },
-  )
+    // Build the warnings object and add it to the map.
+    const warnings: ElementWarnings = {
+      widthOrHeightZero: widthOrHeightZero,
+      absoluteWithUnpositionedParent: absoluteWithUnpositionedParent,
+      dynamicSceneChildWidthHeightPercentage: false,
+    }
+    result = addToComplexMap(toString, result, elementMetadata.elementPath, warnings)
+  })
   return result
 }
 


### PR DESCRIPTION
**Problem:**
`getElementWarningsInner` is a little costly because it walks the metadata, but it appears that is not necessary now.

**Fix:**
Instead of walking the hierarchy, the code has been changed to loop over every element instead.

**Commit Details:**
- As the parent metadata isn't actively accessed, the cost of walking
  the metadata isn't actually necessary, so this changes that to loop
  over each value instead.
