### PR TITLE
feature(canvas) strategy parent outline

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -27,6 +27,7 @@ import { CanvasCommand } from '../commands/commands'
 import { convertToAbsolute } from '../commands/convert-to-absolute-command'
 import { setCssLengthProperty } from '../commands/set-css-length-command'
 import { showOutlineHighlight } from '../commands/show-outline-highlight-command'
+import { ParentOutlines } from '../controls/parent-outlines'
 import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
 import { AnimationTimer, PieTimerControl } from '../controls/select-mode/pie-timer'
 import { applyAbsoluteMoveCommon } from './absolute-move-strategy'
@@ -66,6 +67,11 @@ export const escapeHatchStrategy: CanvasStrategy = {
       control: PieTimerControl,
       key: 'pie-timer-control',
       show: 'visible-only-while-active',
+    },
+    {
+      control: ParentOutlines,
+      key: 'parent-outlines-control',
+      show: 'always-visible',
     },
   ],
   fitness: (canvasState, interactionState, strategyState) => {

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -13,6 +13,7 @@ import {
 import * as EP from '../../../core/shared/element-path'
 import { reverse, stripNulls } from '../../../core/shared/array-utils'
 import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
+import { ParentOutlines } from '../controls/parent-outlines'
 
 export const flexReorderStrategy: CanvasStrategy = {
   id: 'FLEX_REORDER',
@@ -32,6 +33,11 @@ export const flexReorderStrategy: CanvasStrategy = {
       control: DragOutlineControl,
       key: 'ghost-outline-control',
       show: 'visible-only-while-active',
+    },
+    {
+      control: ParentOutlines,
+      key: 'parent-outlines-control',
+      show: 'always-visible',
     },
   ],
   fitness: (canvasState, interactionState, strategyState) => {

--- a/editor/src/components/canvas/controls/parent-outlines.tsx
+++ b/editor/src/components/canvas/controls/parent-outlines.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { mapDropNulls, stripNulls, uniqBy } from '../../../core/shared/array-utils'
+import * as EP from '../../../core/shared/element-path'
+import { useColorTheme } from '../../../uuiui'
+import { useEditorState } from '../../editor/store/store-hook'
+import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
+
+export const ParentOutlines = React.memo(() => {
+  const colorTheme = useColorTheme()
+  const scale = useEditorState((store) => store.editor.canvas.scale, 'ParentOutlines canvas scale')
+  const parentFrames = useEditorState((store) => {
+    const targetParents = uniqBy(
+      stripNulls(store.editor.selectedViews.map((view) => EP.parentPath(view))),
+      EP.pathsEqual,
+    )
+    return mapDropNulls((parentPath) => {
+      const parentElement = MetadataUtils.findElementByElementPath(
+        store.editor.jsxMetadata,
+        parentPath,
+      )
+      if (
+        MetadataUtils.isFlexLayoutedContainer(parentElement) ||
+        MetadataUtils.isGridLayoutedContainer(parentElement)
+      ) {
+        return MetadataUtils.getFrameInCanvasCoords(parentPath, store.editor.jsxMetadata)
+      } else {
+        return null
+      }
+    }, targetParents)
+  }, 'ParentOutlines frames')
+
+  return (
+    <>
+      {parentFrames.map((frame, i) => {
+        return (
+          <CanvasOffsetWrapper key={`parent-outline-${i}`}>
+            <div
+              style={{
+                position: 'absolute',
+                left: frame.x,
+                top: frame.y,
+                width: frame.width,
+                height: frame.height,
+                outlineStyle: 'dotted',
+                outlineColor: colorTheme.primary.value,
+                outlineWidth: 1 / scale,
+              }}
+            />
+          </CanvasOffsetWrapper>
+        )
+      })}
+    </>
+  )
+})


### PR DESCRIPTION
**Problem:**
Parent outlines are missing for flex elements.

**Fix:**
Escape hatch and flex reorder strategies are showing parent outlines for flex and grid elements.

**Commit Details:**
- new component parent-outline
- parent outline is added to `controlsToRender`