### PR TITLE
Fix: absolute move test

### DIFF
--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -623,11 +623,16 @@ export function useTriggerAbsoluteMovePerformanceTest(
             bubbles: true,
             cancelable: true,
             metaKey: false,
-            clientX: targetBounds.left + (20 + moveCount * 3),
-            clientY: targetBounds.top + (20 + moveCount * 4),
+            clientX: targetBounds.left + (20 + 10 + moveCount * 3),
+            clientY: targetBounds.top + (20 + 10 + moveCount * 4),
             buttons: 1,
           }),
         )
+        const newBounds = targetElement.getBoundingClientRect()
+        if (newBounds.left !== targetBounds.left + 10 + moveCount * 3) {
+          console.info('ABSOLUTE_MOVE_TEST_ERROR')
+          return
+        }
         await wait(0)
       }
       markEnd('absolute_move_move', framesPassed)


### PR DESCRIPTION
**Problem:**
The absolute move performance tests were not dragging the mouse enough, which means they didn't actually move the element. 

**Fix:**
I added an extra 10px to the drag vector. 
To avoid future regression and make sure it actually moves the element, the test now throws an error if the target element's bounds did not update.
