### PR TITLE
Fix useDomWalkerInvalidateCallbacks

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -192,10 +192,7 @@ function getCachedAttributesComingFromStyleSheets(
 }
 
 // todo move to file
-export type UpdateMutableCallback<S> = (
-  updater: (mutableState: S) => void,
-  invalidate: 'invalidate' | 'do-not-invalidate',
-) => void
+export type UpdateMutableCallback<S> = (updater: (mutableState: S) => void) => void
 
 export interface DomWalkerProps {
   selectedViews: Array<ElementPath>

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
@@ -27,7 +27,7 @@ export const SceneComponent = React.memo(
       ...style,
     }
 
-    updateInvalidatedPaths((current) => current.add(props[UTOPIA_SCENE_ID_KEY]), 'invalidate')
+    updateInvalidatedPaths((current) => current.add(props[UTOPIA_SCENE_ID_KEY]))
 
     return (
       <Scene {...remainingProps} style={sceneStyle}>

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
@@ -28,7 +28,7 @@ export const SceneComponent = React.memo(
     }
 
     // TODO right now we don't actually change the invalidated paths, just let the dom-walker know it should walk again
-    updateInvalidatedPaths((current) => current, 'invalidate')
+    updateInvalidatedPaths((current) => current.add(props[UTOPIA_SCENE_ID_KEY]), 'invalidate')
 
     return (
       <Scene {...remainingProps} style={sceneStyle}>

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
@@ -27,7 +27,6 @@ export const SceneComponent = React.memo(
       ...style,
     }
 
-    // TODO right now we don't actually change the invalidated paths, just let the dom-walker know it should walk again
     updateInvalidatedPaths((current) => current.add(props[UTOPIA_SCENE_ID_KEY]), 'invalidate')
 
     return (

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -57,7 +57,7 @@ export function buildSpyWrappedElement(
     }
     if (!EP.isStoryboardPath(elementPath) || shouldIncludeCanvasRootInTheSpy) {
       const elementPathString = EP.toComponentId(elementPath)
-      updateInvalidatedPaths((current) => current.add(elementPathString), 'invalidate')
+      updateInvalidatedPaths((current) => current.add(elementPathString))
       metadataContext.current.spyValues.metadata[elementPathString] = instanceMetadata
     }
   }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -57,8 +57,8 @@ export function buildSpyWrappedElement(
     }
     if (!EP.isStoryboardPath(elementPath) || shouldIncludeCanvasRootInTheSpy) {
       // TODO right now we don't actually invalidate the path, just let the dom-walker know it should walk again
-      updateInvalidatedPaths((current) => current, 'invalidate')
       const elementPathString = EP.toComponentId(elementPath)
+      updateInvalidatedPaths((current) => current.add(elementPathString), 'invalidate')
       metadataContext.current.spyValues.metadata[elementPathString] = instanceMetadata
     }
   }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -56,7 +56,6 @@ export function buildSpyWrappedElement(
       importInfo: importInfoFromImportDetails(jsx.name, imports),
     }
     if (!EP.isStoryboardPath(elementPath) || shouldIncludeCanvasRootInTheSpy) {
-      // TODO right now we don't actually invalidate the path, just let the dom-walker know it should walk again
       const elementPathString = EP.toComponentId(elementPath)
       updateInvalidatedPaths((current) => current.add(elementPathString), 'invalidate')
       metadataContext.current.spyValues.metadata[elementPathString] = instanceMetadata

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`721`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`422`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`795`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`485`)
   })
 
   it('Changing the selected view with a simple project', async () => {


### PR DESCRIPTION
useDomWalkerInvalidateCallbacks did not do anything, which broke the react-three-fiber test project, which draws content on canvas.

I fixed this and removed the unnecessary `invalidate` parameter.