### PR TITLE
Fix/flex canvas strategies

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -27,6 +27,7 @@ import { CanvasCommand } from '../commands/commands'
 import { convertToAbsolute } from '../commands/convert-to-absolute-command'
 import { setCssLengthProperty } from '../commands/set-css-length-command'
 import { showOutlineHighlight } from '../commands/show-outline-highlight-command'
+import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
 import { ParentOutlines } from '../controls/parent-outlines'
 import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
 import { AnimationTimer, PieTimerControl } from '../controls/select-mode/pie-timer'
@@ -127,7 +128,7 @@ export const escapeHatchStrategy: CanvasStrategy = {
         }
       } else {
         return {
-          commands: [],
+          commands: [updateHighlightedViews('transient', [])],
           customState: null,
         }
       }

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -14,6 +14,7 @@ import * as EP from '../../../core/shared/element-path'
 import { reverse, stripNulls } from '../../../core/shared/array-utils'
 import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
 import { ParentOutlines } from '../controls/parent-outlines'
+import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
 
 export const flexReorderStrategy: CanvasStrategy = {
   id: 'FLEX_REORDER',
@@ -87,7 +88,7 @@ export const flexReorderStrategy: CanvasStrategy = {
 
     if (realNewIndex === unpatchedIndex) {
       return {
-        commands: [],
+        commands: [updateHighlightedViews('transient', [])],
         customState: {
           ...strategyState.customStrategyState,
           lastReorderIdx: realNewIndex,
@@ -95,7 +96,10 @@ export const flexReorderStrategy: CanvasStrategy = {
       }
     } else {
       return {
-        commands: [reorderElement('permanent', target, realNewIndex)],
+        commands: [
+          reorderElement('permanent', target, realNewIndex),
+          updateHighlightedViews('transient', []),
+        ],
         customState: {
           ...strategyState.customStrategyState,
           lastReorderIdx: realNewIndex,

--- a/editor/src/components/canvas/controls/select-mode/drag-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/drag-outline-control.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { zeroCanvasPoint } from '../../../../core/shared/math-utils'
 import { useColorTheme } from '../../../../uuiui'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { getMultiselectBounds } from '../../canvas-strategies/shared-absolute-move-strategy-helpers'
@@ -12,15 +11,15 @@ export const DragOutlineControl = React.memo(() => {
   }, 'GhostOutline frame')
   const dragVector = useEditorState((store) => {
     if (store.editor.canvas.interactionSession?.interactionData.type === 'DRAG') {
-      return store.editor.canvas.interactionSession.interactionData.drag ?? zeroCanvasPoint
+      return store.editor.canvas.interactionSession.interactionData.drag
     } else {
-      return zeroCanvasPoint
+      return null
     }
   }, 'GhostOutline dragVector')
 
   const colorTheme = useColorTheme()
 
-  if (frame == null) {
+  if (frame == null || dragVector == null) {
     return null
   } else {
     return (


### PR DESCRIPTION
**Problem:**
Mousedown on a flex element immediately shows the dragged outline (or some kind of highlight?).

**Fix:**
I'm changing the dragged outline to be hidden when the drag delta is null. Also clearing highlighted views while the strategy is active to not have any accidental highlight.

**Commit Details:**
- fix drag outline control
- flex reorder strategy is applying the highlight clear command too
