### PR TITLE
Stop VS Code from propagating code changes into selection changes.

### DIFF
--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -433,6 +433,7 @@ async function updateDirtyContent(resource: vscode.Uri): Promise<void> {
   const filePath = fromUtopiaURI(resource)
   const { unsavedContent } = await readFileAsUTF8(filePath)
   if (unsavedContent != null) {
+    squashNextSelectionChange = true
     incomingFileChanges.add(filePath)
     const workspaceEdit = new vscode.WorkspaceEdit()
     workspaceEdit.replace(resource, entireDocRange(), unsavedContent)
@@ -502,7 +503,7 @@ async function revealRangeIfPossible(
   }
 }
 
-async function revealRangeIfPossibleInVisibleEditor(boundsInFile: BoundsInFile): Promise<void> {
+function revealRangeIfPossibleInVisibleEditor(boundsInFile: BoundsInFile): void {
   const visibleEditor = vscode.window.visibleTextEditors.find(
     (editor) => editor.document.uri.path === boundsInFile.filePath,
   )


### PR DESCRIPTION
**Problem:**
When inserting an element, sometimes the selection gets changed to the parent (or at least seemingly so) of the element that was just inserted.

**Fix:**
Use some existing logic to try to prevent this selection update from being fired back from VS Code to the main editor.

**Commit Details:**
- Added an update to `squashNextSelectionChange` to `updateDirtyContent`.
- Removed `async` from `revealRangeIfPossibleInVisibleEditor`.