### PR TITLE
Fixed test debugging on pnpm using NODE_OPTIONS

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -19,7 +19,7 @@
     "check-dependency-cruiser": "depcruise --config .dependency-cruiser.js src",
     "test": "jest --config ./jest.config.js",
     "test-ci": "NODE_OPTIONS=--max_old_space_size=6656 xvfb-run -a pnpm run test -- --maxWorkers=1",
-    "test-debug": "node --inspect-brk node_modules/.bin/jest --config ./jest.config.js --runInBand",
+    "test-debug": "NODE_OPTIONS='--inspect-brk' jest --config ./jest.config.js --runInBand",
     "test-watch": "pnpm run test -- --watch",
     "test-update-snapshot": "pnpm run test -- --updateSnapshot",
     "test-browser": "karma start --single-run",


### PR DESCRIPTION
Fixes #2274

**Problem:**
pnpm generates bash scripts, which don't play ball with `node --inspect-brk`

**Fix:**
Following a work around described [here](https://github.com/pnpm/pnpm/issues/2097), we can instead initiate the tests with breakpoints by setting the `NODE_OPTIONS`.