### PR TITLE
Move props out of metatadata.

### DIFF
--- a/editor/src/components/aspect-ratio.ts
+++ b/editor/src/components/aspect-ratio.ts
@@ -6,6 +6,7 @@ import {
 } from '../core/shared/jsx-attributes'
 import * as PP from '../core/shared/property-path'
 import * as ObjectPath from 'object-path'
+import { ElementProps } from './editor/store/editor-state'
 
 export const AspectRatioPath = 'aspectRatio'
 export const AspectRatioEnabledPath = `${AspectRatioPath}.enabled`
@@ -14,7 +15,10 @@ export function isAspectRatioLockedFromProps(props: any): boolean {
   return ObjectPath.get(props, AspectRatioEnabledPath) ?? false
 }
 
-export function isAspectRatioLockedNew(component: ElementInstanceMetadata): boolean {
+export function isAspectRatioLockedNew(
+  component: ElementInstanceMetadata,
+  elementProps: ElementProps,
+): boolean {
   const element = component.element
   if (isRight(element) && isJSXElement(element.value)) {
     const props = element.value.props
@@ -32,6 +36,6 @@ export function isAspectRatioLockedNew(component: ElementInstanceMetadata): bool
       )
     }
   } else {
-    return isAspectRatioLockedFromProps(component.props)
+    return isAspectRatioLockedFromProps(elementProps)
   }
 }

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -140,19 +140,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "sb/scene",
-      "data-uid": "scene",
-      "data-utopia-scene-id": "sb/scene",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 812,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 375,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -244,11 +231,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "sb/scene/app",
-      "data-uid": "app",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -182,19 +182,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -308,28 +295,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -602,18 +567,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -725,12 +678,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": "Plane",
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
-      "data-uid": "bbb~~~1",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -842,12 +789,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": "Plane",
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
-      "data-uid": "bbb~~~2",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -959,12 +900,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": "Plane",
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
-      "data-uid": "bbb~~~3",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -1172,19 +1107,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -1298,28 +1220,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -1500,19 +1400,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": "Hat",
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -1719,19 +1606,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -1845,28 +1719,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -1961,24 +1813,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:567",
-      "data-uid": "567",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "567",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -2203,19 +2037,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -2329,28 +2150,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -2587,11 +2386,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -2738,11 +2532,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1",
-      "data-uid": "aaa~~~1",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -2889,11 +2678,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2",
-      "data-uid": "aaa~~~2",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -3040,11 +2824,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3",
-      "data-uid": "aaa~~~3",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -3320,19 +3099,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -3446,28 +3212,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -3823,11 +3567,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -4078,11 +3817,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1",
-      "data-uid": "aaa~~~1",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -4236,11 +3970,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~1",
-      "data-uid": "bbb~~~1",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -4394,11 +4123,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~2",
-      "data-uid": "bbb~~~2",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -4552,11 +4276,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1/bbb~~~3",
-      "data-uid": "bbb~~~3",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -4807,11 +4526,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2",
-      "data-uid": "aaa~~~2",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -4965,11 +4679,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~1",
-      "data-uid": "bbb~~~1",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -5123,11 +4832,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~2",
-      "data-uid": "bbb~~~2",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -5281,11 +4985,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2/bbb~~~3",
-      "data-uid": "bbb~~~3",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -5536,11 +5235,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3",
-      "data-uid": "aaa~~~3",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -5694,11 +5388,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~1",
-      "data-uid": "bbb~~~1",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -5852,11 +5541,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~2",
-      "data-uid": "bbb~~~2",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6010,11 +5694,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~3/bbb~~~3",
-      "data-uid": "bbb~~~3",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6233,19 +5912,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6359,28 +6025,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6534,11 +6178,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6634,11 +6273,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6734,11 +6368,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb",
-      "data-uid": "bbb",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -6945,19 +6574,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -7071,28 +6687,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -7259,18 +6853,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -7495,19 +7077,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -7621,28 +7190,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -7892,11 +7439,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -8052,26 +7594,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
-      "data-uid": "bbb~~~1",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~1",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n1",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -8227,26 +7749,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
-      "data-uid": "bbb~~~2",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~2",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n2",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -8402,26 +7904,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
-      "data-uid": "bbb~~~3",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~3",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n3",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -8646,19 +8128,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -8772,28 +8241,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -9043,11 +8490,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -9203,26 +8645,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
-      "data-uid": "bbb~~~1",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~1",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n1",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -9378,26 +8800,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
-      "data-uid": "bbb~~~2",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~2",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n2",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -9553,26 +8955,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
-      "data-uid": "bbb~~~3",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~3",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n3",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -9791,19 +9173,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -9917,28 +9286,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -10092,11 +9439,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -10192,25 +9534,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa",
-      "data-uid": "aaa",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "zzz",
-            "aaa",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -10306,25 +9629,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb",
-      "data-uid": "bbb",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "zzz",
-            "bbb",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -10543,19 +9847,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -10669,28 +9960,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -10877,11 +10146,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -10977,25 +10241,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~1",
-      "data-uid": "aaa~~~1",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "zzz",
-            "aaa~~~1",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -11091,25 +10336,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa~~~2",
-      "data-uid": "aaa~~~2",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "zzz",
-            "aaa~~~2",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -11343,19 +10569,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 200,
-        "left": 59,
-        "position": "absolute",
-        "top": 79,
-        "width": 200,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -11483,27 +10696,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-      "title": "Hi there!",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -11815,17 +11007,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#FFFFFF",
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -12004,30 +11185,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
-      "data-uid": "bbb",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#000000",
-        "position": "absolute",
-      },
-      "title": "Hi there!",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -12260,19 +11417,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 200,
-        "left": 59,
-        "position": "absolute",
-        "top": 79,
-        "width": 200,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -12400,27 +11544,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-      "title": "Hi there!",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -12732,17 +11855,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#FFFFFF",
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -12921,30 +12033,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
-      "data-uid": "bbb",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#000000",
-        "position": "absolute",
-      },
-      "title": "Hi there!",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -13178,19 +12266,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 200,
-        "left": 59,
-        "position": "absolute",
-        "top": 79,
-        "width": 200,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -13318,27 +12393,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-      "title": "Hi there!",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -13698,17 +12752,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#FFFFFF",
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -13935,36 +12978,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
-      "data-uid": "bbb",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#000000",
-        "position": "absolute",
-      },
-      "titles": Array [
-        "Hi there!",
-        "ignored",
-        Object {
-          "title": "and hello!",
-        },
-      ],
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -14198,19 +13211,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 200,
-        "left": 59,
-        "position": "absolute",
-        "top": 79,
-        "width": 200,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -14338,27 +13338,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-      "title": "Hi there!",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -14718,17 +13697,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#FFFFFF",
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -14955,36 +13923,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
-      "data-uid": "bbb",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#000000",
-        "position": "absolute",
-      },
-      "titles": Array [
-        "Hi there!",
-        "ignored",
-        Object {
-          "title": "and hello!",
-        },
-      ],
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -15190,19 +14128,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -15316,28 +14241,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -15432,24 +14335,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:bbb",
-      "data-uid": "bbb",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "bbb",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -15778,19 +14663,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 812,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 375,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -15904,28 +14776,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -17098,24 +15948,6 @@ export var storyboard = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#171111",
-        "bottom": 0,
-        "color": "#237AFF",
-        "fontFamily": "Inter",
-        "fontSize": "12px",
-        "height": 812,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-        "width": 376,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -17952,25 +16784,6 @@ export var storyboard = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a",
-      "data-uid": "03a",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "03a",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -18315,12 +17128,6 @@ export var storyboard = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": "Copy",
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~1",
-      "data-uid": "834~~~1",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -18665,12 +17472,6 @@ export var storyboard = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": "Paste",
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~3",
-      "data-uid": "834~~~3",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -19015,12 +17816,6 @@ export var storyboard = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": "Cut",
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/834~~~5",
-      "data-uid": "834~~~5",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -19401,16 +18196,6 @@ export var storyboard = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": Array [
-        "⌘",
-        "⎇",
-        "C",
-      ],
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2",
-      "data-uid": "999~~~2",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -19635,32 +18420,6 @@ export var storyboard = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~2/000",
-      "data-uid": "000",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "03a",
-            "999~~~2",
-            "000",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "shortcut": Array [
-        "⌘",
-        "⎇",
-        "C",
-      ],
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -20041,12 +18800,6 @@ export var storyboard = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": "⌘⎇V",
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4",
-      "data-uid": "999~~~4",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -20271,28 +19024,6 @@ export var storyboard = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~4/000",
-      "data-uid": "000",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "03a",
-            "999~~~4",
-            "000",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "shortcut": "⌘⎇V",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -20673,12 +19404,6 @@ export var storyboard = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": "⌘⎇C",
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6",
-      "data-uid": "999~~~6",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -20903,28 +19628,6 @@ export var storyboard = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/03a/999~~~6/000",
-      "data-uid": "000",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "03a",
-            "999~~~6",
-            "000",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "shortcut": "⌘⎇C",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -21153,19 +19856,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -21279,28 +19969,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -21486,11 +20154,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -21602,26 +20265,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/aaa",
-      "data-uid": "aaa",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "zzz",
-            "aaa",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "name": "World!",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -21733,26 +20376,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/bbb",
-      "data-uid": "bbb",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "zzz",
-            "bbb",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "name": "Dolly!",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -21960,19 +20583,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -22086,28 +20696,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -22266,12 +20854,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "ref": [Function],
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -22478,19 +21060,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -22604,28 +21173,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -22849,19 +21396,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "ref": [Function],
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -23057,19 +21591,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "eee/fff",
-      "data-uid": "fff",
-      "data-utopia-scene-id": "eee/fff",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 812,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 375,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -23161,21 +21682,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "eee/fff/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "eee",
-            "fff",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -23431,16 +21937,6 @@ export var storyboard = (
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "eee/fff/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#FFFFFF",
-        "height": "100%",
-        "width": "100%",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -23640,31 +22136,6 @@ export var storyboard = (
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "eee/fff/app-entity:aaa/bbb",
-      "data-uid": "bbb",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "eee",
-            "fff",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "thing": <div
-        data-path="eee/fff/app-entity:aaa/ccc~~~1"
-        data-uid="ccc~~~1"
-      >
-        test
-      </div>,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -23917,19 +22388,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -24043,28 +22501,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -24285,15 +22721,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "lightgrey",
-        "position": "absolute",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -24462,31 +22889,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59",
-      "data-uid": "d59",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "d59",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 348,
-        "left": 28,
-        "top": 27,
-        "width": 221,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -24609,18 +23011,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/d59/dd5",
-      "data-uid": "dd5",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#fff",
-        "height": 244,
-        "left": 14,
-        "top": 21,
-        "width": 193,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -24854,19 +23244,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 200,
-        "left": 59,
-        "position": "absolute",
-        "top": 79,
-        "width": 200,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -24994,27 +23371,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-      "title": "Hi there!",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -25266,17 +23622,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#FFFFFF",
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -25400,14 +23745,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
-      "data-uid": "bbb",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "position": "absolute",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -25785,19 +24122,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 200,
-        "left": 59,
-        "position": "absolute",
-        "top": 79,
-        "width": 200,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -25925,27 +24249,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-      "title": "Hi there!",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -26198,17 +24501,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#FFFFFF",
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -26332,14 +24624,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
-      "data-uid": "bbb",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "position": "absolute",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -26658,19 +24942,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 600,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 600,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -26786,26 +25057,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": "100%",
-        "position": "absolute",
-        "width": "100%",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -27530,11 +25781,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93",
-      "data-uid": "b93",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -27634,25 +25880,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/0cf",
-      "data-uid": "0cf",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "0cf",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -27752,25 +25979,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/1a1",
-      "data-uid": "1a1",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "1a1",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -27870,25 +26078,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/218",
-      "data-uid": "218",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "218",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -27988,11 +26177,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/2f0",
-      "data-uid": "2f0",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -28092,25 +26276,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/301",
-      "data-uid": "301",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "301",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -28210,11 +26375,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/315",
-      "data-uid": "315",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -28384,11 +26544,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/4cf",
-      "data-uid": "4cf",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -28488,25 +26643,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/54b",
-      "data-uid": "54b",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "54b",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -28606,25 +26742,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/59c",
-      "data-uid": "59c",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "59c",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -28724,25 +26841,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/5b9",
-      "data-uid": "5b9",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "5b9",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -28842,11 +26940,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/7d0",
-      "data-uid": "7d0",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -28946,25 +27039,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/8aa",
-      "data-uid": "8aa",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "8aa",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -29066,25 +27140,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/8ce",
-      "data-uid": "8ce",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "8ce",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -29184,25 +27239,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/995",
-      "data-uid": "995",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "995",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -29302,25 +27338,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/a17",
-      "data-uid": "a17",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "a17",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -29420,11 +27437,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/d00",
-      "data-uid": "d00",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -29524,11 +27536,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/d18",
-      "data-uid": "d18",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -29628,25 +27635,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/d7f",
-      "data-uid": "d7f",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "d7f",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -29748,25 +27736,6 @@ export var App = (props) => {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:b93/f77",
-      "data-uid": "f77",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "b93",
-            "f77",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -29991,19 +27960,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -30117,28 +28073,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -30388,11 +28322,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -30548,26 +28477,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
-      "data-uid": "bbb~~~1",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~1",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n1",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -30723,26 +28632,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
-      "data-uid": "bbb~~~2",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~2",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n2",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -30898,26 +28787,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
-      "data-uid": "bbb~~~3",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~3",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n3",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -31142,19 +29011,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -31268,28 +29124,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -31540,11 +29374,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -31701,26 +29530,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
-      "data-uid": "bbb~~~1",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~1",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n1",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -31877,26 +29686,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
-      "data-uid": "bbb~~~2",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~2",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n2",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -32053,26 +29842,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
-      "data-uid": "bbb~~~3",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~3",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n3",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -32297,19 +30066,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -32423,28 +30179,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -32701,11 +30435,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -32861,26 +30590,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
-      "data-uid": "bbb~~~1",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~1",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n1",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -33036,26 +30745,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
-      "data-uid": "bbb~~~2",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~2",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n2",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -33211,26 +30900,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
-      "data-uid": "bbb~~~3",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-            "bbb~~~3",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "title": "n3",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -33460,19 +31129,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 200,
-        "left": 59,
-        "position": "absolute",
-        "top": 79,
-        "width": 200,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -33600,27 +31256,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": "99.9",
-        "position": "absolute",
-        "width": "77.7",
-      },
-      "title": "Hi there!",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -33834,17 +31469,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": "99.9",
-        "position": "absolute",
-        "width": "77.7",
-      },
-      "title": "Hi there!",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -33968,14 +31592,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
-      "data-uid": "bbb",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "position": "absolute",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -34184,20 +31800,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": "Scene 2",
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 188,
-        "left": 406,
-        "position": "absolute",
-        "top": 62,
-        "width": 212,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -34289,21 +31891,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -34404,11 +31991,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -34509,11 +32091,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:bbb",
-      "data-uid": "bbb",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -34698,19 +32275,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "ccc/ddd",
-      "data-uid": "ddd",
-      "data-utopia-scene-id": "ccc/ddd",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 812,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 375,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -34802,21 +32366,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "ccc/ddd/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "ccc",
-            "ddd",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -35027,14 +32576,6 @@ export var storyboard = (
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "ccc/ddd/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "value": Object {
-        "current": Object {},
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -35150,16 +32691,6 @@ export var storyboard = (
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "ccc/ddd/app-entity:aaa/bbb",
-      "data-uid": "bbb",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#EB1010",
-        "height": "100%",
-        "width": "100%",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -35344,19 +32875,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "ccc/ddd",
-      "data-uid": "ddd",
-      "data-utopia-scene-id": "ccc/ddd",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 812,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 375,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -35448,21 +32966,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "ccc/ddd/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "ccc",
-            "ddd",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -35557,24 +33060,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "ccc/ddd/app-entity:card",
-      "data-uid": "card",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "ccc",
-            "ddd",
-            "app-entity",
-          ],
-          Array [
-            "card",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -35767,19 +33252,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 200,
-        "left": 59,
-        "position": "absolute",
-        "top": 79,
-        "width": 200,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -35871,21 +33343,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -36058,16 +33515,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": "99.9",
-        "position": "absolute",
-        "width": "77.7",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -36191,14 +33638,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
-      "data-uid": "bbb",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "position": "absolute",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -36385,19 +33824,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene",
-      "data-uid": "scene",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 812,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 375,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -36489,21 +33915,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -36758,16 +34169,6 @@ export var storyboard = (
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#FFFFFF",
-        "height": "100%",
-        "width": "100%",
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -36948,19 +34349,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene",
-      "data-uid": "scene",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 812,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 375,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -37052,21 +34440,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -37177,12 +34550,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene/app-entity:BBB",
-      "data-uid": "BBB",
-      "skipDeepFreeze": true,
-      "x": 5,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -37412,19 +34779,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "eee/fff",
-      "data-uid": "fff",
-      "data-utopia-scene-id": "eee/fff",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 812,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 375,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -37538,28 +34892,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "eee/fff/app",
-      "data-uid": "app",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "eee",
-            "fff",
-            "app",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -37971,19 +35303,6 @@ export var storyboard = (
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "eee/fff/app:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "backgroundColor": "#FFFFFF",
-        "bottom": 0,
-        "left": 0,
-        "position": "relative",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -38191,16 +35510,6 @@ export var storyboard = (
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": "random-div",
-      "data-path": "eee/fff/app:aaa/bbb",
-      "data-uid": "bbb",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 100,
-        "width": 100,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -38332,16 +35641,6 @@ export var storyboard = (
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-label": "some-other-div",
-      "data-path": "eee/fff/app:aaa/bbb/ccc",
-      "data-uid": "ccc",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 100,
-        "width": 100,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -38443,11 +35742,6 @@ export var storyboard = (
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "eee/fff/app:aaa/ddd",
-      "data-uid": "ddd",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -38659,19 +35953,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -38785,28 +36066,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -38951,11 +36210,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -39067,12 +36321,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb",
-      "data-uid": "bbb",
-      "skipDeepFreeze": true,
-      "src": "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=",
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -39282,20 +36530,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-factory-function-works": "true",
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -39409,29 +36643,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-factory-function-works": "true",
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -39526,25 +36737,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-factory-function-works": "true",
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -39784,19 +36976,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -39910,28 +37089,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -40210,11 +37367,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -40394,11 +37546,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
-      "data-uid": "bbb~~~1",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -40549,11 +37696,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1/ccc",
-      "data-uid": "ccc",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -40733,11 +37875,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
-      "data-uid": "bbb~~~2",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -40888,11 +38025,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2/ccc",
-      "data-uid": "ccc",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -41072,11 +38204,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
-      "data-uid": "bbb~~~3",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -41227,11 +38354,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3/ccc",
-      "data-uid": "ccc",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -41440,19 +38562,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -41566,28 +38675,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -41682,24 +38769,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-      "data-uid": "aaa",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "aaa",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -41918,19 +38987,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa",
-      "data-uid": "scene-aaa",
-      "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "height": 400,
-        "left": 0,
-        "position": "absolute",
-        "top": 0,
-        "width": 400,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -42044,28 +39100,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-      "data-uid": "app-entity",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-      "style": Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -42226,11 +39260,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz",
-      "data-uid": "zzz",
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -42362,25 +39391,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner",
-      "data-uid": "cloner",
-      "data-utopia-instance-path": Object {
-        "parts": Array [
-          Array [
-            "utopia-storyboard-uid",
-            "scene-aaa",
-            "app-entity",
-          ],
-          Array [
-            "zzz",
-            "cloner",
-          ],
-        ],
-        "type": "elementpath",
-      },
-      "skipDeepFreeze": true,
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,
@@ -42483,15 +39493,6 @@ Object {
     "isEmotionOrStyledComponent": false,
     "label": null,
     "localFrame": null,
-    "props": Object {
-      "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:zzz/cloner/cloned",
-      "data-uid": "cloned",
-      "skipDeepFreeze": true,
-      "style": Object {
-        "color": "red",
-        "fontWeight": 800,
-      },
-    },
     "specialSizeMeasurements": Object {
       "clientHeight": 0,
       "clientWidth": 0,

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -48,6 +48,7 @@ function dragByPixels(
       vector,
     ),
     metadata: null as any, // the strategy does not use this
+    allElementProps: null as any, // the strategy does not use this
   }
 
   const strategyResult = absoluteMoveStrategy.apply(
@@ -71,6 +72,7 @@ function dragByPixels(
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
       },
+      startingAllElementProps: {},
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
   )

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -44,6 +44,7 @@ export const absoluteMoveStrategy: CanvasStrategy = {
       canvasState,
       interactionState,
       sessionState.startingMetadata,
+      sessionState.startingAllElementProps,
     ) &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.activeControl.type === 'BOUNDING_AREA'

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -56,6 +56,7 @@ function dragByPixels(
       vector,
     ),
     metadata: null as any, // the strategy does not use this
+    allElementProps: null as any, // the strategy does not use this
   }
 
   const strategyResult = absoluteMoveStrategy.apply(
@@ -79,6 +80,7 @@ function dragByPixels(
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
       },
+      startingAllElementProps: {},
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
   )

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -44,6 +44,7 @@ function reparentElement(
       canvasPoint({ x: 0, y: 0 }),
     ),
     metadata: null as any, // the strategy does not use this
+    allElementProps: null as any, // the strategy does not use this
   }
 
   const strategyResult = absoluteReparentStrategy.apply(
@@ -81,6 +82,7 @@ function reparentElement(
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
       },
+      startingAllElementProps: {},
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
   )

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.ts
@@ -54,6 +54,7 @@ export const absoluteReparentStrategy: CanvasStrategy = {
       canvasOffset,
       projectContents,
       openFile,
+      strategyState.startingAllElementProps,
     )
     const newParent = reparentResult.newParent
     const moveCommands = absoluteMoveStrategy.apply(canvasState, interactionState, strategyState)

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -50,7 +50,7 @@ function multiselectResizeElements(
 
   const strategyResult = absoluteResizeBoundingBoxStrategy.apply(
     pickCanvasStateFromEditorState(initialEditor),
-    { ...interactionSessionWithoutMetadata, metadata: {} },
+    { ...interactionSessionWithoutMetadata, metadata: {}, allElementProps: {} },
     {
       currentStrategy: null as any, // the strategy does not use this
       currentStrategyFitness: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -50,7 +50,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
         const elementProps = allElementProps[EP.toString(element)] ?? {}
         return (
           elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
-          hasAtLeastTwoPinsPerSide(elementProps)
+          hasAtLeastTwoPinsPerSide(elementProps) // TODO should this use projectContents?
         )
       })
     } else {

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -12,7 +12,7 @@ import {
   transformFrameUsingBoundingBox,
 } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import { getElementFromProjectContents } from '../../editor/store/editor-state'
+import { AllElementProps, getElementFromProjectContents } from '../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { EdgePosition } from '../canvas-types'
 import {
@@ -31,11 +31,12 @@ import {
   resizeBoundingBox,
   runLegacyAbsoluteResizeSnapping,
 } from './shared-absolute-resize-strategy-helpers'
+import * as EP from '../../../core/shared/element-path'
 
 export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
   name: 'Absolute Resize',
-  isApplicable: (canvasState, interactionState, metadata) => {
+  isApplicable: (canvasState, interactionState, metadata, allElementProps) => {
     if (
       canvasState.selectedElements.length > 1 ||
       (canvasState.selectedElements.length >= 1 &&
@@ -44,9 +45,10 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
     ) {
       return canvasState.selectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
+        const elementProps = allElementProps[EP.toString(element)] ?? {}
         return (
           elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
-          hasAtLeastTwoPinsPerSide(elementMetadata.props)
+          hasAtLeastTwoPinsPerSide(elementProps)
         )
       })
     } else {
@@ -61,6 +63,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
       canvasState,
       interactionState,
       sessionState.startingMetadata,
+      sessionState.startingAllElementProps,
     ) &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.activeControl.type === 'RESIZE_HANDLE'
@@ -103,6 +106,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
           canvasState.scale,
           lockedAspectRatio,
           centerBased,
+          sessionState.startingAllElementProps,
         )
         const commandsForSelectedElements = canvasState.selectedElements.flatMap(
           (selectedElement) => {
@@ -208,6 +212,7 @@ function snapBoundingBox(
   canvasScale: number,
   lockedAspectRatio: number | null,
   centerBased: 'center-based' | 'non-center-based',
+  allElementProps: AllElementProps,
 ) {
   const { snappedBoundingBox, guidelinesWithSnappingVector } = runLegacyAbsoluteResizeSnapping(
     selectedElements,
@@ -217,6 +222,7 @@ function snapBoundingBox(
     canvasScale,
     lockedAspectRatio,
     centerBased,
+    allElementProps,
   )
 
   return {

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.spec.tsx
@@ -29,7 +29,7 @@ function resizeElement(editor: EditorState, edgePosition: EdgePosition): EditorS
 
   const strategyResult = absoluteResizeDeltaStrategy.apply(
     pickCanvasStateFromEditorState(editor),
-    { ...interactionSessionWithoutMetadata, metadata: {} },
+    { ...interactionSessionWithoutMetadata, metadata: {}, allElementProps: {} },
     {
       currentStrategy: null as any, // the strategy does not use this
       currentStrategyFitness: null as any, // the strategy does not use this
@@ -43,6 +43,9 @@ function resizeElement(editor: EditorState, edgePosition: EdgePosition): EditorS
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
+      },
+      startingAllElementProps: {
+        'scene-aaa/app-entity:aaa/bbb': {},
       },
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
@@ -2,7 +2,7 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementInstanceMetadataMap, JSXElement } from '../../../core/shared/element-template'
 import { CanvasVector, offsetPoint } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import { withUnderlyingTarget } from '../../editor/store/editor-state'
+import { AllElementProps, withUnderlyingTarget } from '../../editor/store/editor-state'
 import { EdgePosition } from '../canvas-types'
 import { setCursorCommand } from '../commands/set-cursor-command'
 import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
@@ -44,6 +44,7 @@ export const absoluteResizeDeltaStrategy: CanvasStrategy = {
       canvasState,
       interactionState,
       sessionState.startingMetadata,
+      sessionState.startingAllElementProps,
     ) &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.activeControl.type === 'RESIZE_HANDLE'
@@ -64,6 +65,7 @@ export const absoluteResizeDeltaStrategy: CanvasStrategy = {
         drag,
         edgePosition,
         canvasState.scale,
+        sessionState.startingAllElementProps,
       )
 
       const commandsForSelectedElements = canvasState.selectedElements.flatMap(
@@ -116,6 +118,7 @@ function snapDrag(
   drag: CanvasVector,
   edgePosition: EdgePosition,
   canvasScale: number,
+  allElementProps: AllElementProps,
 ): {
   snappedDragVector: CanvasVector
   guidelinesWithSnappingVector: Array<GuidelineWithSnappingVector>
@@ -141,6 +144,7 @@ function snapDrag(
     canvasScale,
     null,
     'non-center-based',
+    allElementProps,
   )
   const snappedDragVector = offsetPoint(drag, snapDelta)
 

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
@@ -61,6 +61,7 @@ describe('Strategy Fitness', () => {
         canvasPoint({ x: 15, y: 15 }),
       ),
       metadata: renderResult.getEditorState().editor.jsxMetadata,
+      allElementProps: renderResult.getEditorState().editor.allElementProps,
     }
 
     const canvasStrategy = findCanvasStrategy(
@@ -105,6 +106,7 @@ describe('Strategy Fitness', () => {
         canvasPoint({ x: 15, y: 15 }),
       ),
       metadata: renderResult.getEditorState().editor.jsxMetadata,
+      allElementProps: renderResult.getEditorState().editor.allElementProps,
     }
 
     const canvasStrategy = findCanvasStrategy(
@@ -153,6 +155,7 @@ describe('Strategy Fitness', () => {
         canvasPoint({ x: 15, y: 15 }),
       ),
       metadata: renderResult.getEditorState().editor.jsxMetadata,
+      allElementProps: renderResult.getEditorState().editor.allElementProps,
     }
 
     const canvasStrategy = findCanvasStrategy(
@@ -201,6 +204,7 @@ describe('Strategy Fitness', () => {
         canvasPoint({ x: -15, y: -15 }),
       ),
       metadata: renderResult.getEditorState().editor.jsxMetadata,
+      allElementProps: renderResult.getEditorState().editor.allElementProps,
     }
 
     const canvasStrategy = findCanvasStrategy(

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -4,7 +4,7 @@ import { addAllUniquelyBy, mapDropNulls, sortBy } from '../../../core/shared/arr
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import { arrayEquals } from '../../../core/shared/utils'
 import { InnerDispatchResult } from '../../editor/store/dispatch'
-import { EditorState, EditorStorePatched } from '../../editor/store/editor-state'
+import { AllElementProps, EditorState, EditorStorePatched } from '../../editor/store/editor-state'
 import { useEditorState } from '../../editor/store/store-hook'
 import { CanvasCommand } from '../commands/commands'
 import { absoluteMoveStrategy } from './absolute-move-strategy'
@@ -50,9 +50,10 @@ function getApplicableStrategies(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
   metadata: ElementInstanceMetadataMap,
+  allElementProps: AllElementProps,
 ): Array<CanvasStrategy> {
   return strategies.filter((strategy) => {
-    return strategy.isApplicable(canvasState, interactionSession, metadata)
+    return strategy.isApplicable(canvasState, interactionSession, metadata, allElementProps)
   })
 }
 
@@ -68,16 +69,19 @@ const getApplicableStrategiesSelector = createSelector(
   },
   (store: EditorStorePatched) => store.editor.canvas.interactionSession,
   (store: EditorStorePatched) => store.editor.jsxMetadata,
+  (store: EditorStorePatched) => store.editor.allElementProps,
   (
     canvasState: InteractionCanvasState,
     interactionSession: InteractionSession | null,
     metadata: ElementInstanceMetadataMap,
+    allElementProps: AllElementProps,
   ): Array<CanvasStrategy> => {
     return getApplicableStrategies(
       RegisteredCanvasStrategies,
       canvasState,
       interactionSession,
       metadata,
+      allElementProps,
     )
   },
 )
@@ -102,6 +106,7 @@ function getApplicableStrategiesOrderedByFitness(
     canvasState,
     interactionSession,
     strategyState.startingMetadata,
+    strategyState.startingAllElementProps,
   )
 
   // Compute the fitness results upfront.

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -1,3 +1,4 @@
+import { AllElementProps } from 'src/components/editor/store/editor-state'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import { CanvasVector } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
@@ -64,6 +65,7 @@ export interface CanvasStrategy {
     canvasState: InteractionCanvasState,
     interactionSession: InteractionSession | null,
     metadata: ElementInstanceMetadataMap,
+    allElementProps: AllElementProps,
   ) => boolean
 
   // The controls to render when this strategy is applicable, regardless of if it is currently active

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
@@ -149,6 +149,7 @@ function dragBy15Pixels(
       canvasPoint({ x: 15, y: 15 }),
     ),
     metadata: null as any, // the strategy does not use this
+    allElementProps: null as any, // the strategy does not use this
   }
 
   const strategyResult = escapeHatchStrategy.apply(

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -81,6 +81,7 @@ export const escapeHatchStrategy: CanvasStrategy = {
       canvasState,
       interactionState,
       strategyState.startingMetadata,
+      strategyState.startingAllElementProps,
     ) &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.activeControl.type === 'BOUNDING_AREA' &&

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
@@ -170,6 +170,7 @@ function reorderElement(
       drag,
     ),
     metadata: null as any, // the strategy does not use this
+    allElementProps: null as any, // the strategy does not use this
   }
 
   const strategyResult = flexReorderStrategy.apply(

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -48,6 +48,7 @@ export const flexReorderStrategy: CanvasStrategy = {
       canvasState,
       interactionState,
       strategyState.startingMetadata,
+      strategyState.startingAllElementProps,
     ) &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.activeControl.type === 'BOUNDING_AREA'

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -10,7 +10,7 @@ import {
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { KeyCharacter } from '../../../utils/keyboard'
 import { Modifiers } from '../../../utils/modifiers'
-import { EditorStatePatch } from '../../editor/store/editor-state'
+import { AllElementProps, EditorStatePatch } from '../../editor/store/editor-state'
 import { EdgePosition } from '../canvas-types'
 import { MoveIntoDragThreshold } from '../canvas-utils'
 import { CanvasCommand } from '../commands/commands'
@@ -59,6 +59,7 @@ export interface InteractionSession {
   sourceOfUpdate: CanvasControlType
   lastInteractionTime: number
   metadata: ElementInstanceMetadataMap
+  allElementProps: AllElementProps
 
   // To track if the user selected a strategy
   userPreferredStrategy: CanvasStrategyId | null
@@ -74,6 +75,7 @@ export function interactionSession(
   metadata: ElementInstanceMetadataMap,
   userPreferredStrategy: CanvasStrategyId | null,
   startedAt: number,
+  allElementProps: AllElementProps,
 ): InteractionSession {
   return {
     interactionData: interactionData,
@@ -83,10 +85,14 @@ export function interactionSession(
     metadata: metadata,
     userPreferredStrategy: userPreferredStrategy,
     startedAt: startedAt,
+    allElementProps: allElementProps,
   }
 }
 
-export type InteractionSessionWithoutMetadata = Omit<InteractionSession, 'metadata'>
+export type InteractionSessionWithoutMetadata = Omit<
+  InteractionSession,
+  'metadata' | 'allElementProps'
+>
 
 export interface CommandDescription {
   description: string
@@ -105,9 +111,13 @@ export interface StrategyState {
   // Checkpointed metadata at the point at which a strategy change has occurred.
   startingMetadata: ElementInstanceMetadataMap
   customStrategyState: CustomStrategyState
+  startingAllElementProps: AllElementProps
 }
 
-export function createEmptyStrategyState(metadata?: ElementInstanceMetadataMap): StrategyState {
+export function createEmptyStrategyState(
+  metadata: ElementInstanceMetadataMap,
+  allElementProps: AllElementProps,
+): StrategyState {
   return {
     currentStrategy: null,
     currentStrategyFitness: 0,
@@ -115,8 +125,9 @@ export function createEmptyStrategyState(metadata?: ElementInstanceMetadataMap):
     accumulatedPatches: [],
     commandDescriptions: [],
     sortedApplicableStrategies: [],
-    startingMetadata: metadata ?? {},
+    startingMetadata: metadata,
     customStrategyState: defaultCustomStrategyState(),
+    startingAllElementProps: allElementProps,
   }
 }
 

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -27,6 +27,7 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
         canvasState,
         interactionState,
         sessionState.startingMetadata,
+        sessionState.startingAllElementProps,
       ) &&
       interactionState.interactionData.type === 'KEYBOARD'
     ) {

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -32,6 +32,7 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
         canvasState,
         interactionState,
         sessionState.startingMetadata,
+        sessionState.startingAllElementProps,
       ) &&
       interactionState.interactionData.type === 'KEYBOARD'
     ) {

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -29,6 +29,7 @@ export function pressKeys(
       null as any, // the strategy does not use this
     ),
     metadata: null as any, // the strategy does not use this
+    allElementProps: null as any,
   }
 
   const strategyResult = strategy.apply(
@@ -52,6 +53,7 @@ export function pressKeys(
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
       },
+      startingAllElementProps: { 'scene-aaa/app-entity:aaa/bbb': {} },
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
   )

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
@@ -1,3 +1,4 @@
+import { AllElementProps } from 'src/components/editor/store/editor-state'
 import { isHorizontalPoint } from 'utopia-api/core'
 import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
 import { framePointForPinnedProp } from '../../../core/layout/layout-helpers-new'
@@ -337,6 +338,7 @@ export function runLegacyAbsoluteResizeSnapping(
   canvasScale: number,
   lockedAspectRatio: number | null,
   centerBased: IsCenterBased,
+  allElementProps: AllElementProps,
 ): {
   snapDelta: CanvasVector
   snappedBoundingBox: CanvasRectangle
@@ -363,6 +365,7 @@ export function runLegacyAbsoluteResizeSnapping(
     draggedPointMovedWithoutSnap,
     oppositePoint,
     draggedCorner,
+    allElementProps,
   )
 
   const snapDelta = pointDifference(draggedPointMovedWithoutSnap, snappedPointOnCanvas)

--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -14,7 +14,7 @@ import {
 } from '../../core/shared/math-utils'
 import { EditorAction } from '../editor/action-types'
 import * as EditorActions from '../editor/actions/action-creators'
-import { DerivedState, EditorState } from '../editor/store/editor-state'
+import { AllElementProps, DerivedState, EditorState } from '../editor/store/editor-state'
 import * as EP from '../../core/shared/element-path'
 import { buildTree, ElementPathTree, getSubTree } from '../../core/shared/element-path-tree'
 import { objectValues } from '../../core/shared/object-utils'
@@ -47,6 +47,7 @@ const Canvas = {
     TargetSearchType.ParentsOfSelected,
   ],
   getFramesInCanvasContext(
+    allElementProps: AllElementProps,
     metadata: ElementInstanceMetadataMap,
     useBoundingFrames: boolean,
   ): Array<FrameWithPath> {
@@ -73,7 +74,7 @@ const Canvas = {
         }
       }
 
-      const overflows = MetadataUtils.overflows(component)
+      const overflows = MetadataUtils.overflows(allElementProps, componentTree.path)
       const includeClippedNext = useBoundingFrames && overflows
 
       let children: Array<ElementPathTree> = []
@@ -271,10 +272,15 @@ const Canvas = {
     searchTypes: Array<TargetSearchType>,
     useBoundingFrames: boolean,
     looseTargetingForZeroSizedElements: 'strict' | 'loose',
+    allElementProps: AllElementProps,
   ): Array<{ elementPath: ElementPath; canBeFilteredOut: boolean }> {
     const looseReparentThreshold = 5
     const targetFilters = Canvas.targetFilter(selectedViews, searchTypes)
-    const framesWithPaths = Canvas.getFramesInCanvasContext(componentMetadata, useBoundingFrames)
+    const framesWithPaths = Canvas.getFramesInCanvasContext(
+      allElementProps,
+      componentMetadata,
+      useBoundingFrames,
+    )
     const filteredFrames = framesWithPaths.filter((frameWithPath) => {
       const shouldUseLooseTargeting =
         looseTargetingForZeroSizedElements === 'loose' &&

--- a/editor/src/components/canvas/controls/breadcrumb-trail.tsx
+++ b/editor/src/components/canvas/controls/breadcrumb-trail.tsx
@@ -14,11 +14,12 @@ interface ElementPathElement {
 }
 
 export const BreadcrumbTrail = React.memo(() => {
-  const { dispatch, jsxMetadata, selectedViews } = useEditorState((store) => {
+  const { dispatch, jsxMetadata, selectedViews, allElementProps } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
       jsxMetadata: store.editor.jsxMetadata,
       selectedViews: store.editor.selectedViews,
+      allElementProps: store.editor.allElementProps,
     }
   }, 'TopMenuContextProvider')
 
@@ -37,13 +38,13 @@ export const BreadcrumbTrail = React.memo(() => {
         const component = MetadataUtils.findElementByElementPath(jsxMetadata, path)
         if (component != null) {
           elements.push({
-            name: MetadataUtils.getElementLabel(path, jsxMetadata),
+            name: MetadataUtils.getElementLabel(allElementProps, path, jsxMetadata),
             path: path,
           })
         }
       })
       return elements
-    }, [selectedViews, jsxMetadata]),
+    }, [selectedViews, jsxMetadata, allElementProps]),
   )
 
   const lastElemIndex = elementPath.length - 1

--- a/editor/src/components/canvas/controls/component-area-control.tsx
+++ b/editor/src/components/canvas/controls/component-area-control.tsx
@@ -12,6 +12,7 @@ import { ControlFontSize } from '../canvas-controls-frame'
 import { CanvasPositions } from '../canvas-types'
 //TODO: switch to functional component and make use of 'useColorTheme':
 import { UtopiaTheme, colorTheme } from '../../../uuiui'
+import { AllElementProps } from 'src/components/editor/store/editor-state'
 
 interface ComponentAreaControlProps {
   mouseEnabled: boolean
@@ -39,6 +40,7 @@ interface ComponentAreaControlProps {
   selectedViews: ElementPath[]
   showAdditionalControls: boolean
   testID?: string
+  allElementProps: AllElementProps
 }
 
 // SelectModeControl is a transparent react component sitting on top of a utopia component.
@@ -129,7 +131,11 @@ class ComponentAreaControlInner extends React.Component<ComponentAreaControlProp
   }
 
   getComponentLabelControl = () => {
-    const label = MetadataUtils.getElementLabel(this.props.target, this.props.componentMetadata)
+    const label = MetadataUtils.getElementLabel(
+      this.props.allElementProps,
+      this.props.target,
+      this.props.componentMetadata,
+    )
     const scaledFontSize = ControlFontSize / this.props.scale
     const offsetY = -(scaledFontSize * 1.5)
     const offsetX = 3 / this.props.scale

--- a/editor/src/components/canvas/controls/insert-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/insert-mode-control-container.tsx
@@ -220,6 +220,7 @@ export class InsertModeControlContainer extends React.Component<
         windowToCanvasPosition={this.props.windowToCanvasPosition}
         selectedViews={this.props.selectedViews}
         showAdditionalControls={this.props.showAdditionalControls}
+        allElementProps={this.props.allElementProps}
       />
     )
   }

--- a/editor/src/components/canvas/controls/layout-parent-control.tsx
+++ b/editor/src/components/canvas/controls/layout-parent-control.tsx
@@ -51,15 +51,18 @@ export const LayoutParentControl = React.memo((): JSX.Element | null => {
           alignItems: null,
         }
       }
-      const element = MetadataUtils.getParent(
+      const parentElement = MetadataUtils.getParent(
         store.editor.jsxMetadata,
         store.editor.selectedViews[0],
       )
-      const elementProps = store.editor.allElementProps[EP.toString(store.editor.selectedViews[0])]
+      const elementProps =
+        parentElement == null
+          ? {}
+          : store.editor.allElementProps[EP.toString(parentElement.elementPath)]
       return {
-        parentTarget: element?.elementPath,
-        parentLayout: element?.specialSizeMeasurements.layoutSystemForChildren,
-        parentFrame: element?.globalFrame,
+        parentTarget: parentElement?.elementPath,
+        parentLayout: parentElement?.specialSizeMeasurements.layoutSystemForChildren,
+        parentFrame: parentElement?.globalFrame,
         flexWrap: elementProps?.style?.flexWrap ?? 'nowrap',
         flexDirection: elementProps?.style?.flexDirection ?? 'row',
         alignItems: elementProps?.style?.alignItems ?? 'flex-start',

--- a/editor/src/components/canvas/controls/layout-parent-control.tsx
+++ b/editor/src/components/canvas/controls/layout-parent-control.tsx
@@ -55,13 +55,14 @@ export const LayoutParentControl = React.memo((): JSX.Element | null => {
         store.editor.jsxMetadata,
         store.editor.selectedViews[0],
       )
+      const elementProps = store.editor.allElementProps[EP.toString(store.editor.selectedViews[0])]
       return {
         parentTarget: element?.elementPath,
         parentLayout: element?.specialSizeMeasurements.layoutSystemForChildren,
         parentFrame: element?.globalFrame,
-        flexWrap: element?.props?.style?.flexWrap ?? 'nowrap',
-        flexDirection: element?.props?.style?.flexDirection ?? 'row',
-        alignItems: element?.props?.style?.alignItems ?? 'flex-start',
+        flexWrap: elementProps?.style?.flexWrap ?? 'nowrap',
+        flexDirection: elementProps?.style?.flexDirection ?? 'row',
+        alignItems: elementProps?.style?.alignItems ?? 'flex-start',
       }
     }, 'LayoutParentControl')
 

--- a/editor/src/components/canvas/controls/multiselect-resize-control.tsx
+++ b/editor/src/components/canvas/controls/multiselect-resize-control.tsx
@@ -208,8 +208,7 @@ export class SingleSelectResizeControls extends React.Component<SingleSelectResi
     return this.props.selectedViews.map((view, index) => {
       const target = MetadataUtils.findElementByElementPath(this.props.componentMetadata, view)
       const frame = optionalMap((metadata) => metadata.globalFrame, target)
-      const targetProps =
-        target == null ? {} : this.props.allElementProps[EP.toString(target.elementPath)] ?? {}
+      const targetProps = target == null ? {} : this.props.allElementProps[EP.toString(view)] ?? {}
       if (frame == null) {
         return null
       } else {

--- a/editor/src/components/canvas/controls/multiselect-resize-control.tsx
+++ b/editor/src/components/canvas/controls/multiselect-resize-control.tsx
@@ -69,6 +69,7 @@ export class MultiselectResizeControl extends React.Component<
         this.props.scale,
         pickPointOnRect(boundingBox, this.state.guidelineStartPoint),
         resizingFromPosition,
+        this.props.allElementProps,
       )
     }
   }
@@ -176,6 +177,7 @@ export class MultiselectResizeControl extends React.Component<
               maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
               flexDirection={null}
               propertyTargetSelectedIndex={this.props.resizeOptions.propertyTargetSelectedIndex}
+              targetProps={null}
             />
             {guidelineElements}
           </>
@@ -206,6 +208,8 @@ export class SingleSelectResizeControls extends React.Component<SingleSelectResi
     return this.props.selectedViews.map((view, index) => {
       const target = MetadataUtils.findElementByElementPath(this.props.componentMetadata, view)
       const frame = optionalMap((metadata) => metadata.globalFrame, target)
+      const targetProps =
+        target == null ? {} : this.props.allElementProps[EP.toString(target.elementPath)] ?? {}
       if (frame == null) {
         return null
       } else {
@@ -236,6 +240,7 @@ export class SingleSelectResizeControls extends React.Component<SingleSelectResi
             maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
             flexDirection={null}
             propertyTargetSelectedIndex={this.props.resizeOptions.propertyTargetSelectedIndex}
+            targetProps={targetProps}
           />
         )
       }

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -15,6 +15,7 @@ import {
   TransientCanvasState,
   TransientFilesState,
   ResizeOptions,
+  AllElementProps,
 } from '../../editor/store/editor-state'
 import { ElementPath, NodeModules } from '../../../core/shared/project-file-types'
 import { CanvasPositions, CSSCursor } from '../canvas-types'
@@ -120,6 +121,7 @@ export interface ControlProps {
   transientState: TransientCanvasState
   resolve: ResolveFn
   resizeOptions: ResizeOptions
+  allElementProps: AllElementProps
 }
 
 interface NewCanvasControlsProps {
@@ -304,15 +306,17 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
   const renderModeControlContainer = () => {
     const elementAspectRatioLocked = localSelectedViews.every((target) => {
       const possibleElement = MetadataUtils.findElementByElementPath(componentMetadata, target)
-      if (possibleElement == null) {
+      const elementProps = props.editor.allElementProps[EP.toString(target)]
+      if (possibleElement == null || elementProps == null) {
         return false
       } else {
-        return isAspectRatioLockedNew(possibleElement)
+        return isAspectRatioLockedNew(possibleElement, elementProps)
       }
     })
     const imageMultiplier: number | null = MetadataUtils.getImageMultiplier(
       componentMetadata,
       localSelectedViews,
+      props.editor.allElementProps,
     )
     const resolveFn = props.editor.codeResultCache.curriedResolveFn(props.editor.projectContents)
     const controlProps: ControlProps = {
@@ -337,6 +341,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       transientState: props.transientState,
       resolve: resolveFn,
       resizeOptions: props.editor.canvas.resizeOptions,
+      allElementProps: props.editor.allElementProps,
     }
     const dragState = props.editor.canvas.dragState
     switch (props.editor.mode.type) {

--- a/editor/src/components/canvas/controls/position-outline.tsx
+++ b/editor/src/components/canvas/controls/position-outline.tsx
@@ -45,7 +45,8 @@ const usePropsOrJSXAttributes = (path: ElementPath): PropsOrJSXAttributes => {
     if (element != null && isRight(element.element) && isJSXElement(element.element.value)) {
       return right(element.element.value.props)
     } else {
-      return left(element?.props ?? {})
+      const elementProps = store.editor.allElementProps[EP.toString(path)]
+      return left(elementProps ?? {})
     }
   }, 'usePropsOrJSXAttributes')
 }

--- a/editor/src/components/canvas/controls/property-target-selector.tsx
+++ b/editor/src/components/canvas/controls/property-target-selector.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { ElementProps } from 'src/components/editor/store/editor-state'
 import { useContextSelector } from 'use-context-selector'
 import { LayoutTargetableProp, StyleLayoutProp } from '../../../core/layout/layout-helpers-new'
 import { getSimpleAttributeAtPath } from '../../../core/model/element-metadata-utils'
@@ -20,6 +21,7 @@ interface PropertyTargetSelectorProps {
   top: number
   left: number
   options: Array<LayoutTargetableProp>
+  targetProps: ElementProps | null
 }
 
 export const PropertyTargetSelector = React.memo(
@@ -57,12 +59,12 @@ export const PropertyTargetSelector = React.memo(
       return resizeOptions.propertyTargetOptions.map((option) =>
         eitherToMaybe(
           getSimpleAttributeAtPath(
-            left(props.targetComponentMetadata?.props ?? {}),
+            left(props.targetProps ?? {}),
             stylePropPathMappingFn(option, ['style']),
           ),
         ),
       )
-    }, [resizeOptions.propertyTargetOptions, props.targetComponentMetadata?.props])
+    }, [resizeOptions.propertyTargetOptions, props.targetProps])
 
     const defaultSelectedOptionIndex = React.useMemo(() => {
       const indexOfFirstWithValue = valuesForProp.findIndex((value) => value != null)

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -203,7 +203,7 @@ export class SelectModeControlContainer extends React.Component<
         if (currentInstance == null) {
           return frameIntersect
         } else {
-          if (MetadataUtils.overflows(currentInstance)) {
+          if (MetadataUtils.overflows(this.props.allElementProps, currentInstance.elementPath)) {
             return frameIntersect
           } else {
             const currentFrame = currentInstance.globalFrame
@@ -247,6 +247,7 @@ export class SelectModeControlContainer extends React.Component<
         windowToCanvasPosition={this.props.windowToCanvasPosition}
         selectedViews={this.props.selectedViews}
         showAdditionalControls={this.props.showAdditionalControls}
+        allElementProps={this.props.allElementProps}
       />
     )
   }

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -22,7 +22,11 @@ import {
   setFocusedElement,
   setHighlightedView,
 } from '../../../editor/actions/action-creators'
-import { EditorState, EditorStorePatched } from '../../../editor/store/editor-state'
+import {
+  AllElementProps,
+  EditorState,
+  EditorStorePatched,
+} from '../../../editor/store/editor-state'
 import { useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
 import { moveDragState } from '../../canvas-types'
@@ -141,6 +145,7 @@ export function getSelectableViews(
   hiddenInstances: Array<ElementPath>,
   allElementsDirectlySelectable: boolean,
   childrenSelectable: boolean,
+  allElementProps: AllElementProps,
 ): ElementPath[] {
   let candidateViews: Array<ElementPath>
 
@@ -154,7 +159,7 @@ export function getSelectableViews(
       const scene = MetadataUtils.findElementByElementPath(componentMetadata, path)
       const rootElements = MetadataUtils.getRootViewPaths(componentMetadata, path)
       if (
-        MetadataUtils.isSceneTreatedAsGroup(scene) &&
+        MetadataUtils.isSceneTreatedAsGroup(allElementProps, path) &&
         rootElements != null &&
         rootElements.length > 1
       ) {
@@ -205,13 +210,20 @@ function useFindValidTarget(): (
       canvasScale: store.editor.canvas.scale,
       canvasOffset: store.editor.canvas.realCanvasOffset,
       focusedElementPath: store.editor.focusedElementPath,
+      allElementProps: store.editor.allElementProps,
     }
   })
 
   return React.useCallback(
     (selectableViews: Array<ElementPath>, mousePoint: WindowPoint | null) => {
-      const { selectedViews, componentMetadata, hiddenInstances, canvasScale, canvasOffset } =
-        storeRef.current
+      const {
+        selectedViews,
+        componentMetadata,
+        hiddenInstances,
+        canvasScale,
+        canvasOffset,
+        allElementProps,
+      } = storeRef.current
       const validElementMouseOver: ElementPath | null = getValidTargetAtPoint(
         componentMetadata,
         selectedViews,
@@ -220,6 +232,7 @@ function useFindValidTarget(): (
         mousePoint,
         canvasScale,
         canvasOffset,
+        allElementProps,
       )
       const validElementPath: ElementPath | null =
         validElementMouseOver != null ? validElementMouseOver : null
@@ -387,18 +400,21 @@ export function useGetSelectableViewsForSelectMode() {
       selectedViews: store.editor.selectedViews,
       hiddenInstances: store.editor.hiddenInstances,
       focusedElementPath: store.editor.focusedElementPath,
+      allElementProps: store.editor.allElementProps,
     }
   })
 
   return React.useCallback(
     (allElementsDirectlySelectable: boolean, childrenSelectable: boolean) => {
-      const { componentMetadata, selectedViews, hiddenInstances } = storeRef.current
+      const { componentMetadata, selectedViews, hiddenInstances, allElementProps } =
+        storeRef.current
       const selectableViews = getSelectableViews(
         componentMetadata,
         selectedViews,
         hiddenInstances,
         allElementsDirectlySelectable,
         childrenSelectable,
+        allElementProps,
       )
       return selectableViews
     },

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -23,7 +23,11 @@ import {
 import { ResizeStatus } from './new-canvas-controls'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import CanvasActions from '../canvas-actions'
-import { OriginalCanvasAndLocalFrame, ResizeOptions } from '../../editor/store/editor-state'
+import {
+  ElementProps,
+  OriginalCanvasAndLocalFrame,
+  ResizeOptions,
+} from '../../editor/store/editor-state'
 import {
   DetectedLayoutSystem,
   ElementInstanceMetadata,
@@ -198,6 +202,7 @@ interface ResizeEdgeProps {
   resizeStatus: ResizeStatus
   targetComponentMetadata: ElementInstanceMetadata | null
   dragState: DragState | null
+  targetProps: ElementProps | null
 }
 
 interface ResizeEdgeState {}
@@ -305,6 +310,7 @@ class ResizeEdge extends React.Component<ResizeEdgeProps, ResizeEdgeState> {
             left={left + shiftPropertyTargetSelectorAxis('vertical', this.props.direction, edge)}
             options={getResizeOptions(layoutSystem, this.props.direction, edge)}
             targetComponentMetadata={this.props.targetComponentMetadata}
+            targetProps={this.props.targetProps}
             key={
               this.props.targetComponentMetadata != null
                 ? EP.toString(this.props.targetComponentMetadata.elementPath)
@@ -329,6 +335,7 @@ interface ResizeLinesProps {
   dragState: DragState | null
   color?: string
   flexDirection: 'horizontal' | 'vertical' | null
+  targetProps: ElementProps | null
 }
 
 const LineOffset = 6
@@ -399,6 +406,7 @@ const ResizeLines = React.memo((props: ResizeLinesProps) => {
           left={left + shiftPropertyTargetSelectorAxis('vertical', props.direction, edge)}
           options={getResizeOptions(layoutSystem, props.direction, edge)}
           targetComponentMetadata={props.targetComponentMetadata}
+          targetProps={props.targetProps}
           key={
             props.targetComponentMetadata != null
               ? EP.toString(props.targetComponentMetadata.elementPath)
@@ -573,6 +581,7 @@ interface ResizeRectangleProps {
   maybeClearHighlightsOnHoverEnd: () => void
   flexDirection: 'horizontal' | 'vertical' | null
   propertyTargetSelectedIndex: number
+  targetProps: ElementProps | null
 }
 
 export class ResizeRectangle extends React.Component<ResizeRectangleProps> {

--- a/editor/src/components/canvas/controls/yoga-control.tsx
+++ b/editor/src/components/canvas/controls/yoga-control.tsx
@@ -20,13 +20,14 @@ import { ControlProps } from './new-canvas-controls'
 import { getSelectionColor } from './outline-control'
 import { ResizeRectangle } from './size-box'
 import { useColorTheme } from '../../../uuiui'
-import { withUnderlyingTarget } from '../../editor/store/editor-state'
+import { ElementProps, withUnderlyingTarget } from '../../editor/store/editor-state'
 
 interface YogaResizeControlProps extends ControlProps {
   targetElement: ElementInstanceMetadata
   target: ElementPath
   color: string
   dragState: ResizeDragState | null
+  targetProps: ElementProps | null
 }
 
 class YogaResizeControl extends React.Component<YogaResizeControlProps> {
@@ -123,6 +124,7 @@ class YogaResizeControl extends React.Component<YogaResizeControlProps> {
         maybeClearHighlightsOnHoverEnd={this.props.maybeClearHighlightsOnHoverEnd}
         flexDirection={flexDirection}
         propertyTargetSelectedIndex={this.props.resizeOptions.propertyTargetSelectedIndex}
+        targetProps={this.props.targetProps}
       />
     )
   }
@@ -172,6 +174,7 @@ export const YogaControls = React.memo((props: YogaControlsProps) => {
           targetElement={
             MetadataUtils.findElementByElementPath(props.componentMetadata, targets[0])!
           }
+          targetProps={props.allElementProps[EP.toString(targets[0])] ?? null}
           color={color}
         />
       )}

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -17,6 +17,7 @@ import { getPathsOnDomElement } from '../../core/shared/uid-utils'
 import Canvas, { TargetSearchType } from './canvas'
 import { CanvasPositions } from './canvas-types'
 import { CanvasScale, CanvasScrollOffset } from '../../utils/global-positions'
+import { AllElementProps } from '../editor/store/editor-state'
 
 export function findParentSceneValidPaths(target: Element): Array<ElementPath> | null {
   const validPaths = getDOMAttribute(target, 'data-utopia-valid-paths')
@@ -90,6 +91,7 @@ export function getValidTargetAtPoint(
   point: WindowPoint | null,
   canvasScale: number,
   canvasOffset: CanvasVector,
+  allElementProps: AllElementProps,
 ): ElementPath | null {
   if (point == null) {
     return null
@@ -103,6 +105,7 @@ export function getValidTargetAtPoint(
       point,
       canvasScale,
       canvasOffset,
+      allElementProps,
     )[0] ?? null
   )
 }
@@ -115,6 +118,7 @@ export function getAllTargetsAtPoint(
   point: WindowPoint | null,
   canvasScale: number,
   canvasOffset: CanvasVector,
+  allElementProps: AllElementProps,
 ): Array<ElementPath> {
   if (point == null) {
     return []
@@ -128,6 +132,7 @@ export function getAllTargetsAtPoint(
     [TargetSearchType.All],
     true,
     'loose',
+    allElementProps,
   )
   const elementsUnderPoint = document.elementsFromPoint(point.x, point.y)
   const validPathsSet =

--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -12,7 +12,6 @@ import { matchInlineSnapshotBrowser } from '../../../test/karma-snapshots'
 disableStoredStateforTests()
 
 function sanitizeElementMetadata(element: ElementInstanceMetadata): ElementInstanceMetadata {
-  delete element.props['children']
   return {
     ...element,
     element: left('REMOVED_FROM_TEST'),
@@ -109,11 +108,6 @@ describe('DOM Walker tests', () => {
           "x": 0,
           "y": 0,
         },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid",
-          "data-uid": "utopia-storyboard-uid",
-          "skipDeepFreeze": true,
-        },
         "specialSizeMeasurements": Object {
           "clientHeight": 0,
           "clientWidth": 0,
@@ -189,19 +183,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa",
-          "data-uid": "scene-aaa",
-          "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "height": 812,
-            "left": 0,
-            "position": "relative",
-            "top": 0,
-            "width": 375,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -290,28 +271,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-          "data-uid": "app-entity",
-          "data-utopia-instance-path": Object {
-            "parts": Array [
-              Array [
-                "utopia-storyboard-uid",
-                "scene-aaa",
-                "app-entity",
-              ],
-            ],
-            "type": "elementpath",
-          },
-          "skipDeepFreeze": true,
-          "style": Object {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -407,19 +366,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
-          "data-uid": "05c",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "backgroundColor": "#FFFFFF",
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -517,19 +463,6 @@ describe('DOM Walker tests', () => {
           "x": 55,
           "y": 98,
         },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0",
-          "data-uid": "ef0",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "backgroundColor": "#DDDDDD",
-            "height": 124,
-            "left": 55,
-            "position": "absolute",
-            "top": 98,
-            "width": 266,
-          },
-        },
         "specialSizeMeasurements": Object {
           "clientHeight": 124,
           "clientWidth": 266,
@@ -626,19 +559,6 @@ describe('DOM Walker tests', () => {
           "width": 125,
           "x": 71,
           "y": 27,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0/488",
-          "data-uid": "488",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "backgroundColor": "#DDDDDD",
-            "height": 70,
-            "left": 71,
-            "position": "absolute",
-            "top": 27,
-            "width": 125,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 70,
@@ -782,11 +702,6 @@ describe('DOM Walker tests', () => {
           "x": 0,
           "y": 0,
         },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid",
-          "data-uid": "utopia-storyboard-uid",
-          "skipDeepFreeze": true,
-        },
         "specialSizeMeasurements": Object {
           "clientHeight": 0,
           "clientWidth": 0,
@@ -862,19 +777,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa",
-          "data-uid": "scene-aaa",
-          "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "height": 812,
-            "left": 0,
-            "position": "relative",
-            "top": 0,
-            "width": 375,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -963,28 +865,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-          "data-uid": "app-entity",
-          "data-utopia-instance-path": Object {
-            "parts": Array [
-              Array [
-                "utopia-storyboard-uid",
-                "scene-aaa",
-                "app-entity",
-              ],
-            ],
-            "type": "elementpath",
-          },
-          "skipDeepFreeze": true,
-          "style": Object {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -1076,19 +956,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
-          "data-uid": "05c",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "backgroundColor": "#FFFFFF",
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -1182,20 +1049,6 @@ describe('DOM Walker tests', () => {
           "x": 55,
           "y": 98,
         },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0",
-          "data-uid": "ef0",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "backgroundColor": "#DDDDDD",
-            "height": 124,
-            "left": 55,
-            "padding": 20,
-            "position": "fixed",
-            "top": 98,
-            "width": 266,
-          },
-        },
         "specialSizeMeasurements": Object {
           "clientHeight": 164,
           "clientWidth": 306,
@@ -1283,19 +1136,6 @@ describe('DOM Walker tests', () => {
           "width": 125,
           "x": 71,
           "y": 27,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0/488",
-          "data-uid": "488",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "backgroundColor": "#DDDDDD",
-            "height": 70,
-            "left": 71,
-            "position": "absolute",
-            "top": 27,
-            "width": 125,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 70,
@@ -1439,11 +1279,6 @@ describe('DOM Walker tests', () => {
           "x": 0,
           "y": 0,
         },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid",
-          "data-uid": "utopia-storyboard-uid",
-          "skipDeepFreeze": true,
-        },
         "specialSizeMeasurements": Object {
           "clientHeight": 0,
           "clientWidth": 0,
@@ -1519,19 +1354,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa",
-          "data-uid": "scene-aaa",
-          "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "height": 812,
-            "left": 0,
-            "position": "relative",
-            "top": 0,
-            "width": 375,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -1620,28 +1442,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-          "data-uid": "app-entity",
-          "data-utopia-instance-path": Object {
-            "parts": Array [
-              Array [
-                "utopia-storyboard-uid",
-                "scene-aaa",
-                "app-entity",
-              ],
-            ],
-            "type": "elementpath",
-          },
-          "skipDeepFreeze": true,
-          "style": Object {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -1733,20 +1533,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c",
-          "data-uid": "05c",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "backgroundColor": "#FFFFFF",
-            "bottom": 0,
-            "display": "flex",
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -1840,20 +1626,6 @@ describe('DOM Walker tests', () => {
           "x": 55,
           "y": 98,
         },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0",
-          "data-uid": "ef0",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "backgroundColor": "#DDDDDD",
-            "height": 124,
-            "left": 55,
-            "padding": 20,
-            "position": "fixed",
-            "top": 98,
-            "width": 266,
-          },
-        },
         "specialSizeMeasurements": Object {
           "clientHeight": 164,
           "clientWidth": 306,
@@ -1941,19 +1713,6 @@ describe('DOM Walker tests', () => {
           "width": 125,
           "x": 71,
           "y": 27,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:05c/ef0/488",
-          "data-uid": "488",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "backgroundColor": "#DDDDDD",
-            "height": 70,
-            "left": 71,
-            "position": "absolute",
-            "top": 27,
-            "width": 125,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 70,
@@ -2085,11 +1844,6 @@ describe('DOM Walker tests', () => {
           "x": 0,
           "y": 0,
         },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid",
-          "data-uid": "utopia-storyboard-uid",
-          "skipDeepFreeze": true,
-        },
         "specialSizeMeasurements": Object {
           "clientHeight": 0,
           "clientWidth": 0,
@@ -2165,19 +1919,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa",
-          "data-uid": "scene-aaa",
-          "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "height": 812,
-            "left": 0,
-            "position": "relative",
-            "top": 0,
-            "width": 375,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -2266,28 +2007,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-          "data-uid": "app-entity",
-          "data-utopia-instance-path": Object {
-            "parts": Array [
-              Array [
-                "utopia-storyboard-uid",
-                "scene-aaa",
-                "app-entity",
-              ],
-            ],
-            "type": "elementpath",
-          },
-          "skipDeepFreeze": true,
-          "style": Object {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -2379,19 +2098,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-label": "Hat",
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-          "data-uid": "aaa",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -2527,11 +2233,6 @@ describe('DOM Walker tests', () => {
           "x": 0,
           "y": 0,
         },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid",
-          "data-uid": "utopia-storyboard-uid",
-          "skipDeepFreeze": true,
-        },
         "specialSizeMeasurements": Object {
           "clientHeight": 0,
           "clientWidth": 0,
@@ -2607,19 +2308,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa",
-          "data-uid": "scene-aaa",
-          "data-utopia-scene-id": "utopia-storyboard-uid/scene-aaa",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "height": 812,
-            "left": 0,
-            "position": "relative",
-            "top": 0,
-            "width": 375,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -2708,28 +2396,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity",
-          "data-uid": "app-entity",
-          "data-utopia-instance-path": Object {
-            "parts": Array [
-              Array [
-                "utopia-storyboard-uid",
-                "scene-aaa",
-                "app-entity",
-              ],
-            ],
-            "type": "elementpath",
-          },
-          "skipDeepFreeze": true,
-          "style": Object {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -2821,18 +2487,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa",
-          "data-uid": "aaa",
-          "skipDeepFreeze": true,
-          "style": Object {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 812,
@@ -2926,12 +2580,6 @@ describe('DOM Walker tests', () => {
           "x": 0,
           "y": 0,
         },
-        "props": Object {
-          "data-label": "Plane",
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~1",
-          "data-uid": "bbb~~~1",
-          "skipDeepFreeze": true,
-        },
         "specialSizeMeasurements": Object {
           "clientHeight": 0,
           "clientWidth": 375,
@@ -3024,12 +2672,6 @@ describe('DOM Walker tests', () => {
           "x": 0,
           "y": 0,
         },
-        "props": Object {
-          "data-label": "Plane",
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~2",
-          "data-uid": "bbb~~~2",
-          "skipDeepFreeze": true,
-        },
         "specialSizeMeasurements": Object {
           "clientHeight": 0,
           "clientWidth": 375,
@@ -3121,12 +2763,6 @@ describe('DOM Walker tests', () => {
           "width": 375,
           "x": 0,
           "y": 0,
-        },
-        "props": Object {
-          "data-label": "Plane",
-          "data-path": "utopia-storyboard-uid/scene-aaa/app-entity:aaa/bbb~~~3",
-          "data-uid": "bbb~~~3",
-          "skipDeepFreeze": true,
         },
         "specialSizeMeasurements": Object {
           "clientHeight": 0,

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -226,7 +226,6 @@ function mergeFragmentMetadata(
       const merged = elementInstanceMetadata(
         elementMetadata.elementPath,
         left('fragment'),
-        {},
         boundingRectangle(
           existingMetadata.globalFrame ?? zeroCanvasRect,
           elementMetadata.globalFrame ?? zeroCanvasRect,
@@ -542,7 +541,6 @@ function collectMetadata(
       return elementInstanceMetadata(
         path,
         left(tagName),
-        {},
         globalFrame,
         localFrame,
         false,
@@ -815,7 +813,6 @@ function walkCanvasRootFragment(
     const metadata: ElementInstanceMetadata = elementInstanceMetadata(
       canvasRootPath,
       left('Storyboard'),
-      {},
       { x: 0, y: 0, width: 0, height: 0 } as CanvasRectangle,
       { x: 0, y: 0, width: 0, height: 0 } as LocalRectangle,
       false,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper.tsx
@@ -44,7 +44,6 @@ export function buildSpyWrappedElement(
     const instanceMetadata: ElementInstanceMetadata = {
       element: right(jsx),
       elementPath: elementPath,
-      props: makeCanvasElementPropsSafe(reportedProps),
       globalFrame: null,
       localFrame: null,
       componentInstance: false,
@@ -60,6 +59,8 @@ export function buildSpyWrappedElement(
       updateInvalidatedPaths((current) => current, 'invalidate')
       const elementPathString = EP.toComponentId(elementPath)
       metadataContext.current.spyValues.metadata[elementPathString] = instanceMetadata
+      metadataContext.current.spyValues.allElementProps[elementPathString] =
+        makeCanvasElementPropsSafe(reportedProps)
     }
   }
   const spyWrapperProps: SpyWrapperProps = {

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -103,7 +103,6 @@ function stripUidsFromMetadata(metadata: ElementInstanceMetadata): ElementInstan
 }
 
 function stripUnwantedDataFromMetadata(metadata: ElementInstanceMetadata): ElementInstanceMetadata {
-  delete metadata.props['children']
   return stripUidsFromMetadata(metadata)
 }
 

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -48,6 +48,7 @@ import {
   getIndexHtmlFileFromEditorState,
   CanvasBase64Blobs,
   TransientFilesState,
+  AllElementProps,
 } from '../editor/store/editor-state'
 import { proxyConsole } from './console-proxy'
 import type { UpdateMutableCallback } from './dom-walker'
@@ -101,6 +102,7 @@ const emptyFileBlobs: UIFileBase64Blobs = {}
 
 export type SpyValues = {
   metadata: ElementInstanceMetadataMap
+  allElementProps: AllElementProps
 }
 
 export interface UiJsxCanvasContextData {
@@ -114,6 +116,7 @@ export function emptyUiJsxCanvasContextData(): UiJsxCanvasContextData {
     current: {
       spyValues: {
         metadata: {},
+        allElementProps: {},
       },
     },
   }

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -263,7 +263,7 @@ export async function renderTestEditorWithModel(
       ? mockBuiltInDependencies
       : createBuiltInDependenciesList(workers)
   const initialEditorStore: EditorStoreFull = {
-    strategyState: createEmptyStrategyState(),
+    strategyState: createEmptyStrategyState({}, {}),
     unpatchedEditor: emptyEditorState,
     patchedEditor: emptyEditorState,
     unpatchedDerived: derivedState,

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -16,7 +16,7 @@ import {
   duplicateSelected,
   toggleHidden,
 } from './editor/actions/action-creators'
-import { TransientFilesState } from './editor/store/editor-state'
+import { AllElementProps, TransientFilesState } from './editor/store/editor-state'
 import {
   toggleBackgroundLayers,
   toggleBorder,
@@ -46,6 +46,7 @@ export interface CanvasData {
   hiddenInstances: ElementPath[]
   scale: number
   focusedElementPath: ElementPath | null
+  allElementProps: AllElementProps
 }
 
 export function requireDispatch(dispatch: EditorDispatch | null | undefined): EditorDispatch {

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -76,6 +76,7 @@ import {
   defaultUserState,
   editorModelFromPersistentModel,
   withUnderlyingTargetFromEditorState,
+  ElementProps,
 } from '../store/editor-state'
 import { editorMoveTemplate, UPDATE_FNS } from './actions'
 import {
@@ -827,12 +828,12 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     ['aaa', 'bbb'],
   ])
 
+  const rootElementProps: ElementProps = {
+    'data-uid': 'aaa',
+  }
   const rootElementMetadata: ElementInstanceMetadata = {
     elementPath: rootElementPath,
     element: right(firstTopLevelElement.rootElement),
-    props: {
-      'data-uid': 'aaa',
-    },
     globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
     localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
     componentInstance: false,
@@ -844,18 +845,18 @@ describe('SWITCH_LAYOUT_SYSTEM', () => {
     importInfo: null,
   }
 
+  const childElementProps: ElementProps = {
+    'data-uid': 'bbb',
+    style: {
+      left: 5,
+      top: 10,
+      width: 200,
+      height: 300,
+    },
+  }
   const childElementMetadata: ElementInstanceMetadata = {
     elementPath: childElementPath,
     element: right(childElement),
-    props: {
-      'data-uid': 'bbb',
-      style: {
-        left: 5,
-        top: 10,
-        width: 200,
-        height: 300,
-      },
-    },
     globalFrame: canvasRectangle({ x: 0, y: 0, width: 200, height: 300 }),
     localFrame: localRectangle({ x: 0, y: 0, width: 200, height: 300 }),
     componentInstance: false,
@@ -1489,7 +1490,6 @@ describe('SET_FOCUSED_ELEMENT', () => {
     const divElementMetadata = elementInstanceMetadata(
       pathToFocus,
       right(underlyingElement),
-      {},
       zeroRectangle as CanvasRectangle,
       zeroRectangle as LocalRectangle,
       false,
@@ -1524,7 +1524,6 @@ describe('SET_FOCUSED_ELEMENT', () => {
     const cardElementMetadata = elementInstanceMetadata(
       pathToFocus,
       right(underlyingElement),
-      {},
       zeroRectangle as CanvasRectangle,
       zeroRectangle as LocalRectangle,
       false,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -712,8 +712,8 @@ function switchAndUpdateFrames(
     case 'flex':
       withUpdatedLayoutSystem = {
         ...withUpdatedLayoutSystem,
-        jsxMetadata: MetadataUtils.setPropertyDirectlyIntoMetadata(
-          withUpdatedLayoutSystem.jsxMetadata,
+        allElementProps: MetadataUtils.setPropertyDirectlyIntoMetadata(
+          withUpdatedLayoutSystem.allElementProps,
           target,
           styleDisplayPath, // TODO LAYOUT investigate if we should use also update the DOM walker specialSizeMeasurements
           'flex',
@@ -721,8 +721,8 @@ function switchAndUpdateFrames(
       }
       withUpdatedLayoutSystem = {
         ...withUpdatedLayoutSystem,
-        jsxMetadata: MetadataUtils.setPropertyDirectlyIntoMetadata(
-          withUpdatedLayoutSystem.jsxMetadata,
+        allElementProps: MetadataUtils.setPropertyDirectlyIntoMetadata(
+          withUpdatedLayoutSystem.allElementProps,
           target,
           stylePropPathMappingFn('position', propertyTarget), // TODO LAYOUT investigate if we should use also update the DOM walker specialSizeMeasurements
           'relative',
@@ -732,8 +732,8 @@ function switchAndUpdateFrames(
     case LayoutSystem.PinSystem:
       withUpdatedLayoutSystem = {
         ...withUpdatedLayoutSystem,
-        jsxMetadata: MetadataUtils.setPropertyDirectlyIntoMetadata(
-          withUpdatedLayoutSystem.jsxMetadata,
+        allElementProps: MetadataUtils.setPropertyDirectlyIntoMetadata(
+          withUpdatedLayoutSystem.allElementProps,
           target,
           stylePropPathMappingFn('position', propertyTarget), // TODO LAYOUT investigate if we should use also update the DOM walker specialSizeMeasurements
           'absolute',
@@ -744,16 +744,16 @@ function switchAndUpdateFrames(
     default:
       withUpdatedLayoutSystem = {
         ...withUpdatedLayoutSystem,
-        jsxMetadata: MetadataUtils.unsetPropertyDirectlyIntoMetadata(
-          withUpdatedLayoutSystem.jsxMetadata,
+        allElementProps: MetadataUtils.unsetPropertyDirectlyIntoMetadata(
+          withUpdatedLayoutSystem.allElementProps,
           target,
           styleDisplayPath,
         ),
       }
       withUpdatedLayoutSystem = {
         ...withUpdatedLayoutSystem,
-        jsxMetadata: MetadataUtils.setPropertyDirectlyIntoMetadata(
-          withUpdatedLayoutSystem.jsxMetadata,
+        allElementProps: MetadataUtils.setPropertyDirectlyIntoMetadata(
+          withUpdatedLayoutSystem.allElementProps,
           target,
           styleDisplayPath, // TODO LAYOUT investigate if we should use also update the DOM walker specialSizeMeasurements
           layoutSystem,
@@ -800,6 +800,7 @@ function switchAndUpdateFrames(
         metadata,
         components,
         propertyTarget,
+        editor.allElementProps,
       )
     },
     target,
@@ -1046,6 +1047,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     vscodeLoadingScreenVisible: currentEditor.vscodeLoadingScreenVisible,
     indexedDBFailed: currentEditor.indexedDBFailed,
     forceParseFiles: currentEditor.forceParseFiles,
+    allElementProps: poppedEditor.allElementProps,
   }
 }
 
@@ -2799,6 +2801,7 @@ export const UPDATE_FNS = {
                 null,
                 null,
                 ['style'],
+                workingEditorState.allElementProps,
               )
               updatedComponents = maybeSwitchResult.components
               toastsAdded.push(...maybeSwitchResult.toast)
@@ -3083,12 +3086,13 @@ export const UPDATE_FNS = {
     } as LocalRectangle
 
     const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, action.element)
+    const elementProps = editor.allElementProps[EP.toString(action.element)] ?? {}
     if (
       element != null &&
       MetadataUtils.isTextAgainstImports(element) &&
-      element.props.textSizing == 'auto'
+      elementProps.textSizing == 'auto'
     ) {
-      const alignment = element.props.style.textAlign
+      const alignment = elementProps.style.textAlign
       if (alignment === 'center') {
         frame = Utils.setRectCenterX(frame, initialFrame.x + initialFrame.width / 2)
       } else if (alignment === 'right') {
@@ -4041,6 +4045,9 @@ export const UPDATE_FNS = {
         ...editor,
         domMetadata: finalDomMetadata,
         spyMetadata: finalSpyMetadata,
+        allElementProps: {
+          ...spyCollector.current.spyValues.allElementProps,
+        },
       }
     }
   },

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -475,6 +475,7 @@ export function handleKeyDown(
             WindowMousePositionRaw,
             editor.canvas.scale,
             editor.canvas.realCanvasOffset,
+            editor.allElementProps,
           )
           const nextTarget = Canvas.getNextTarget(editor.selectedViews, targetStack)
           if (targetStack.length === 0 || nextTarget === null) {

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -64,6 +64,7 @@ function createEditorStore(
     interactionSessionWithMetadata = {
       ...interactionSession,
       metadata: {},
+      allElementProps: {},
     }
   }
 
@@ -83,7 +84,7 @@ function createEditorStore(
     patchedEditor: emptyEditorState,
     unpatchedDerived: derivedState,
     patchedDerived: derivedState,
-    strategyState: strategyState ?? createEmptyStrategyState(),
+    strategyState: strategyState ?? createEmptyStrategyState({}, {}),
     history: history,
     userState: {
       loginState: notLoggedIn,
@@ -222,6 +223,7 @@ describe('interactionStart', () => {
             "name": "Test Strategy",
           },
         ],
+        "startingAllElementProps": Object {},
         "startingMetadata": Object {},
       }
     `)
@@ -271,6 +273,7 @@ describe('interactionStart', () => {
           "lastReorderIdx": null,
         },
         "sortedApplicableStrategies": Array [],
+        "startingAllElementProps": Object {},
         "startingMetadata": Object {},
       }
     `)
@@ -342,6 +345,7 @@ describe('interactionUpdatex', () => {
             "name": "Test Strategy",
           },
         ],
+        "startingAllElementProps": Object {},
         "startingMetadata": Object {},
       }
     `)
@@ -392,6 +396,7 @@ describe('interactionUpdatex', () => {
           "lastReorderIdx": null,
         },
         "sortedApplicableStrategies": Array [],
+        "startingAllElementProps": Object {},
         "startingMetadata": Object {},
       }
     `)
@@ -490,6 +495,7 @@ describe('interactionHardReset', () => {
             "name": "Test Strategy",
           },
         ],
+        "startingAllElementProps": Object {},
         "startingMetadata": Object {},
       }
     `)
@@ -545,6 +551,7 @@ describe('interactionHardReset', () => {
           "lastReorderIdx": null,
         },
         "sortedApplicableStrategies": Array [],
+        "startingAllElementProps": Object {},
         "startingMetadata": Object {},
       }
     `)
@@ -705,6 +712,7 @@ describe('interactionUpdate with user changed strategy', () => {
             "name": "Test Strategy",
           },
         ],
+        "startingAllElementProps": Object {},
         "startingMetadata": Object {},
       }
     `)
@@ -761,6 +769,7 @@ describe('interactionUpdate with user changed strategy', () => {
           "lastReorderIdx": null,
         },
         "sortedApplicableStrategies": Array [],
+        "startingAllElementProps": Object {},
         "startingMetadata": Object {},
       }
     `)

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -42,6 +42,7 @@ export function interactionFinished(
   const newEditorState = result.unpatchedEditor
   const withClearedSession = createEmptyStrategyState(
     newEditorState.canvas.interactionSession?.metadata ?? newEditorState.jsxMetadata,
+    newEditorState.canvas.interactionSession?.allElementProps ?? newEditorState.allElementProps,
   )
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
   const interactionSession = storedState.unpatchedEditor.canvas.interactionSession
@@ -152,6 +153,7 @@ export function interactionHardReset(
         sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: resetStrategyState.startingMetadata,
         customStrategyState: strategyResult.customState ?? result.strategyState.customStrategyState,
+        startingAllElementProps: resetStrategyState.startingAllElementProps,
       }
 
       return {
@@ -242,6 +244,7 @@ export function interactionStart(
   const newEditorState = result.unpatchedEditor
   const withClearedSession = createEmptyStrategyState(
     newEditorState.canvas.interactionSession?.metadata ?? newEditorState.jsxMetadata,
+    newEditorState.canvas.interactionSession?.allElementProps ?? newEditorState.allElementProps,
   )
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
   const interactionSession = newEditorState.canvas.interactionSession
@@ -287,6 +290,7 @@ export function interactionStart(
         sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: newEditorState.canvas.interactionSession.metadata,
         customStrategyState: strategyResult.customState ?? result.strategyState.customStrategyState,
+        startingAllElementProps: newEditorState.canvas.interactionSession.allElementProps,
       }
 
       return {
@@ -319,7 +323,7 @@ export function interactionCancel(
   return {
     unpatchedEditorState: updatedEditorState,
     patchedEditorState: updatedEditorState,
-    newStrategyState: createEmptyStrategyState(),
+    newStrategyState: createEmptyStrategyState({}, {}),
   }
 }
 
@@ -373,6 +377,7 @@ function handleUserChangedStrategy(
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
       customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
+      startingAllElementProps: strategyState.startingAllElementProps,
     }
 
     return {
@@ -429,6 +434,7 @@ function handleAccumulatingKeypresses(
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
       customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
+      startingAllElementProps: strategyState.startingAllElementProps,
     }
 
     return {
@@ -485,6 +491,7 @@ function handleUpdate(
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
       customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
+      startingAllElementProps: strategyState.startingAllElementProps,
     }
     return {
       unpatchedEditorState: newEditorState,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -809,6 +809,10 @@ export function editorStateCodeEditorErrors(
   }
 }
 
+export type ElementProps = { [key: string]: any }
+
+export type AllElementProps = { [path: string]: ElementProps }
+
 // FIXME We need to pull out ProjectState from here
 export interface EditorState {
   id: string | null
@@ -871,6 +875,7 @@ export interface EditorState {
   vscodeLoadingScreenVisible: boolean
   indexedDBFailed: boolean
   forceParseFiles: Array<string>
+  allElementProps: AllElementProps // the final, resolved, static props value for each element.
 }
 
 export function editorState(
@@ -934,6 +939,7 @@ export function editorState(
   vscodeLoadingScreenVisible: boolean,
   indexedDBFailed: boolean,
   forceParseFiles: Array<string>,
+  allElementProps: AllElementProps,
 ): EditorState {
   return {
     id: id,
@@ -996,6 +1002,7 @@ export function editorState(
     vscodeLoadingScreenVisible: vscodeLoadingScreenVisible,
     indexedDBFailed: indexedDBFailed,
     forceParseFiles: forceParseFiles,
+    allElementProps: allElementProps,
   }
 }
 
@@ -1782,6 +1789,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     vscodeLoadingScreenVisible: true,
     indexedDBFailed: false,
     forceParseFiles: [],
+    allElementProps: {},
   }
 }
 
@@ -2055,6 +2063,7 @@ export function editorModelFromPersistentModel(
     vscodeLoadingScreenVisible: true,
     indexedDBFailed: false,
     forceParseFiles: [],
+    allElementProps: {},
   }
   return editor
 }

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -218,7 +218,9 @@ describe('action RENAME_COMPONENT', () => {
       builtInDependencies,
     )
     const updatedMetadata = createFakeMetadataForEditor(updatedEditor)
-    chaiExpect(MetadataUtils.getElementLabel(target, updatedMetadata)).to.deep.equal(newName)
+    chaiExpect(
+      MetadataUtils.getElementLabel(editor.allElementProps, target, updatedMetadata),
+    ).to.deep.equal(newName)
 
     const clearNameAction = renameComponent(target, null)
     const clearedNameEditor = runLocalEditorAction(
@@ -233,9 +235,9 @@ describe('action RENAME_COMPONENT', () => {
       builtInDependencies,
     )
     const clearedNameMetadata = createFakeMetadataForEditor(clearedNameEditor)
-    chaiExpect(MetadataUtils.getElementLabel(target, clearedNameMetadata)).to.deep.equal(
-      expectedDefaultName,
-    )
+    chaiExpect(
+      MetadataUtils.getElementLabel(editor.allElementProps, target, clearedNameMetadata),
+    ).to.deep.equal(expectedDefaultName)
   }
 
   it('renames an existing scene', () => checkRename(ScenePathForTestUiJsFile, 'Test'))

--- a/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances-3.spec.ts
@@ -27,6 +27,7 @@ import {
   SpecialSizeMeasurementsKeepDeepEquality,
 } from './store-deep-equality-instances'
 import * as EP from '../../../core/shared/element-path'
+import { ElementProps } from './editor-state'
 
 describe('CanvasRectangleKeepDeepEquality', () => {
   const oldValue: CanvasRectangle = canvasRectangle({
@@ -358,11 +359,6 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
   const oldValue: ElementInstanceMetadata = {
     elementPath: EP.elementPath([['scene'], ['aaa', 'bbb']]),
     element: left('div'),
-    props: {
-      a: {
-        b: [],
-      },
-    },
     globalFrame: canvasRectangle({
       x: 10,
       y: 20,
@@ -443,11 +439,6 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
   const newDifferentValue: ElementInstanceMetadata = {
     elementPath: EP.elementPath([['scene'], ['aaa', 'bbb']]),
     element: left('div'),
-    props: {
-      a: {
-        b: [],
-      },
-    },
     globalFrame: canvasRectangle({
       x: 10,
       y: 20,
@@ -535,7 +526,6 @@ describe('ElementInstanceMetadataKeepDeepEquality', () => {
     const result = ElementInstanceMetadataKeepDeepEquality(oldValue, newDifferentValue)
     expect(result.value.elementPath).toBe(oldValue.elementPath)
     expect(result.value.element).toBe(oldValue.element)
-    expect(result.value.props).toEqual(oldValue.props)
     expect(result.value.globalFrame).toBe(oldValue.globalFrame)
     expect(result.value.localFrame).toBe(oldValue.localFrame)
     expect(result.value.componentInstance).toBe(oldValue.componentInstance)
@@ -555,11 +545,6 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
     elem: {
       elementPath: EP.elementPath([['scene'], ['aaa', 'bbb']]),
       element: left('div'),
-      props: {
-        a: {
-          b: [],
-        },
-      },
       globalFrame: canvasRectangle({
         x: 10,
         y: 20,
@@ -642,11 +627,6 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
     elem: {
       elementPath: EP.elementPath([['scene'], ['aaa', 'bbb']]),
       element: left('div'),
-      props: {
-        a: {
-          b: [],
-        },
-      },
       globalFrame: canvasRectangle({
         x: 10,
         y: 20,
@@ -729,11 +709,6 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
     elem: {
       elementPath: EP.elementPath([['scene'], ['aaa', 'bbb']]),
       element: left('div'),
-      props: {
-        a: {
-          b: [],
-        },
-      },
       globalFrame: canvasRectangle({
         x: 10,
         y: 20,
@@ -821,13 +796,12 @@ describe('ElementInstanceMetadataMapKeepDeepEquality', () => {
   it('same value returns the same reference', () => {
     const result = ElementInstanceMetadataMapKeepDeepEquality(oldValue, newSameValue)
     expect(result.value).toStrictEqual(oldValue)
-    expect(result.areEqual).toEqual(false)
+    expect(result.areEqual).toEqual(true)
   })
   it('different but similar value handled appropriately', () => {
     const result = ElementInstanceMetadataMapKeepDeepEquality(oldValue, newDifferentValue)
     expect(result.value.elem.elementPath).toBe(oldValue.elem.elementPath)
     expect(result.value.elem.element).toBe(oldValue.elem.element)
-    expect(result.value.elem.props).toEqual(oldValue.elem.props)
     expect(result.value.elem.globalFrame).toBe(oldValue.elem.globalFrame)
     expect(result.value.elem.localFrame).toBe(oldValue.elem.localFrame)
     expect(result.value.elem.componentInstance).toBe(oldValue.elem.componentInstance)

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -299,6 +299,7 @@ import {
   editorStateCodeEditorErrors,
   Theme,
   editorState,
+  AllElementProps,
 } from './editor-state'
 import {
   CornerGuideline,
@@ -1232,13 +1233,11 @@ export const ElementInstanceMetadataPropsKeepDeepEquality: KeepDeepEqualityCall<
   createCallWithShallowEquals()
 
 export const ElementInstanceMetadataKeepDeepEquality: KeepDeepEqualityCall<ElementInstanceMetadata> =
-  combine12EqualityCalls(
+  combine11EqualityCalls(
     (metadata) => metadata.elementPath,
     ElementPathKeepDeepEquality,
     (metadata) => metadata.element,
     EitherKeepDeepEquality(createCallWithTripleEquals(), JSXElementChildKeepDeepEquality()),
-    (metadata) => metadata.props,
-    objectDeepEquality(ElementInstanceMetadataPropsKeepDeepEquality),
     (metadata) => metadata.globalFrame,
     nullableDeepEquality(CanvasRectangleKeepDeepEquality),
     (metadata) => metadata.localFrame,
@@ -1647,7 +1646,7 @@ export const CanvasControlTypeKeepDeepEquality: KeepDeepEqualityCall<CanvasContr
 }
 
 export const InteractionSessionKeepDeepEquality: KeepDeepEqualityCall<InteractionSession> =
-  combine7EqualityCalls(
+  combine8EqualityCalls(
     (session) => session.interactionData,
     InputDataKeepDeepEquality,
     (session) => session.activeControl,
@@ -1662,6 +1661,8 @@ export const InteractionSessionKeepDeepEquality: KeepDeepEqualityCall<Interactio
     nullableDeepEquality(createCallWithTripleEquals()),
     (session) => session.startedAt,
     createCallWithTripleEquals(),
+    (session) => session.allElementProps,
+    createCallFromIntrospectiveKeepDeep(),
     interactionSession,
   )
 
@@ -3059,6 +3060,10 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     oldValue.forceParseFiles,
     newValue.forceParseFiles,
   )
+  const allElementPropsResults = createCallFromIntrospectiveKeepDeep<AllElementProps>()(
+    oldValue.allElementProps,
+    newValue.allElementProps,
+  )
 
   const areEqual =
     idResult.areEqual &&
@@ -3120,7 +3125,8 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     themeResults.areEqual &&
     vscodeLoadingScreenVisibleResults.areEqual &&
     indexedDBFailedResults.areEqual &&
-    forceParseFilesResults.areEqual
+    forceParseFilesResults.areEqual &&
+    allElementPropsResults.areEqual
 
   if (areEqual) {
     return keepDeepEqualityResult(oldValue, true)
@@ -3186,6 +3192,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       vscodeLoadingScreenVisibleResults.value,
       indexedDBFailedResults.value,
       forceParseFilesResults.value,
+      allElementPropsResults.value,
     )
 
     return keepDeepEqualityResult(newEditorState, false)

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -116,6 +116,7 @@ function useCanvasContextMenuItems(
                 WindowMousePositionRaw,
                 data.scale,
                 data.canvasOffset,
+                data.allElementProps,
               )
             }
             return !elementsUnderCursor.some((underCursor: ElementPath) =>
@@ -193,6 +194,7 @@ export const ElementContextMenu = React.memo(({ contextMenuInstance }: ElementCo
       hiddenInstances: store.editor.hiddenInstances,
       scale: store.editor.canvas.scale,
       focusedElementPath: store.editor.focusedElementPath,
+      allElementProps: store.editor.allElementProps,
     }
   })
 
@@ -209,6 +211,7 @@ export const ElementContextMenu = React.memo(({ contextMenuInstance }: ElementCo
       hiddenInstances: currentEditor.hiddenInstances,
       scale: currentEditor.scale,
       focusedElementPath: currentEditor.focusedElementPath,
+      allElementProps: currentEditor.allElementProps,
     }
   }, [editorSliceRef])
 

--- a/editor/src/components/images.ts
+++ b/editor/src/components/images.ts
@@ -14,6 +14,8 @@ import { Size, CanvasRectangle, CanvasPoint, canvasRectangle } from '../core/sha
 import { EditorAction } from './editor/action-types'
 import { insertJSXElement } from './editor/actions/action-creators'
 import { forceNotNull } from '../core/shared/optional-utils'
+import { AllElementProps } from './editor/store/editor-state'
+import * as EP from '../core/shared/element-path'
 
 export function getImageSrc(
   projectId: string | null,
@@ -136,12 +138,18 @@ export function getImageSizeFromProps(props: any): Size {
   }
 }
 
-export function getImageSize(component: ElementInstanceMetadata): Size {
-  return getImageSizeFromProps(component.props)
+export function getImageSize(
+  allElementProps: AllElementProps,
+  component: ElementInstanceMetadata,
+): Size {
+  return getImageSizeFromProps(allElementProps[EP.toString(component.elementPath)])
 }
 
-export function getImageSizeFromMetadata(instance: ElementInstanceMetadata): Size {
-  return getImageSizeFromProps(instance.props)
+export function getImageSizeFromMetadata(
+  allElementProps: AllElementProps,
+  instance: ElementInstanceMetadata,
+): Size {
+  return getImageSizeFromProps(allElementProps[EP.toString(instance.elementPath)])
 }
 
 export function getImageSizeMultiplierFromProps(props: any): number {

--- a/editor/src/components/inspector/common/name-and-icon-hook.ts
+++ b/editor/src/components/inspector/common/name-and-icon-hook.ts
@@ -13,7 +13,7 @@ import {
   NameAndIconResultKeepDeepEquality,
 } from '../../../utils/deep-equality-instances'
 import { createSelector } from 'reselect'
-import { EditorStorePatched } from '../../editor/store/editor-state'
+import { AllElementProps, EditorStorePatched } from '../../editor/store/editor-state'
 import React from 'react'
 import { objectValues } from '../../../core/shared/object-utils'
 import { eitherToMaybe } from '../../../core/shared/either'
@@ -31,10 +31,11 @@ export function useMetadata(): ElementInstanceMetadataMap {
 
 const namesAndIconsAllPathsResultSelector = createSelector(
   (store: EditorStorePatched) => store.editor.jsxMetadata,
-  (metadata) => {
+  (store: EditorStorePatched) => store.editor.allElementProps,
+  (metadata, allElementProps) => {
     let result: Array<NameAndIconResult> = []
     for (const metadataElement of objectValues(metadata)) {
-      const nameAndIconResult = getNameAndIconResult(metadataElement)
+      const nameAndIconResult = getNameAndIconResult(allElementProps, metadataElement)
       result.push(nameAndIconResult)
     }
     return result
@@ -48,12 +49,15 @@ export function useNamesAndIconsAllPaths(): NameAndIconResult[] {
   })
 }
 
-function getNameAndIconResult(metadata: ElementInstanceMetadata): NameAndIconResult {
+function getNameAndIconResult(
+  allElementProps: AllElementProps,
+  metadata: ElementInstanceMetadata,
+): NameAndIconResult {
   const elementName = MetadataUtils.getJSXElementName(eitherToMaybe(metadata.element))
   return {
     path: metadata.elementPath,
     name: elementName,
-    label: MetadataUtils.getElementLabelFromMetadata(metadata),
+    label: MetadataUtils.getElementLabelFromMetadata(allElementProps, metadata),
     iconProps: createComponentOrElementIconProps(metadata),
   }
 }

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -6,6 +6,7 @@ import { InspectorCallbackContext, InspectorCallbackContextData } from './proper
 import create, { GetState, Mutate, SetState, StoreApi } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import {
+  AllElementProps,
   editorModelFromPersistentModel,
   EditorState,
   EditorStorePatched,
@@ -97,7 +98,6 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
     [EP.toString(selectedViews[0])]: elementInstanceMetadata(
       selectedViews[0],
       null as any,
-      { testPropWithoutControl: 'yes' },
       null,
       null,
       true,
@@ -109,12 +109,14 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
       null,
     ),
   }
+  let allElementProps: AllElementProps = {
+    [EP.toString(selectedViews[0])]: { testPropWithoutControl: 'yes' },
+  }
 
   if (selectedViews.length > 1) {
     metadata[EP.toString(selectedViews[1])] = elementInstanceMetadata(
       selectedViews[1],
       null as any,
-      { propWithControlButNoValue: 'but there is a value!' },
       null,
       null,
       true,
@@ -125,12 +127,14 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
       null,
       null,
     )
+    allElementProps[EP.toString(selectedViews[1])] = {
+      propWithControlButNoValue: 'but there is a value!',
+    }
   }
   if (selectedViews.length > 2) {
     metadata[EP.toString(selectedViews[2])] = elementInstanceMetadata(
-      selectedViews[1],
+      selectedViews[2],
       null as any,
-      { propWithOtherKey: 10 },
       null,
       null,
       true,
@@ -141,6 +145,8 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
       null,
       null,
     )
+
+    allElementProps[EP.toString(selectedViews[2])] = { propWithOtherKey: 10 }
   }
 
   const initialEditorState = editorModelFromPersistentModel(persistentModel, NO_OP)
@@ -173,6 +179,7 @@ function callPropertyControlsHook(selectedViews: ElementPath[]) {
       },
     },
     jsxMetadata: metadata,
+    allElementProps: allElementProps,
   }
 
   const initialEditorStore: EditorStorePatched = {

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -266,10 +266,12 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
       anyComponentsInner =
         anyComponentsInner || MetadataUtils.isComponentInstance(view, rootComponents)
       const possibleElement = MetadataUtils.findElementByElementPath(rootMetadata, view)
-      if (possibleElement != null) {
+      const elementProps = store.editor.allElementProps[EP.toString(view)]
+      if (possibleElement != null && elementProps != null) {
         // Slightly coarse in definition, but element metadata is in a weird little world of
         // its own compared to the props.
-        aspectRatioLockedInner = aspectRatioLockedInner || isAspectRatioLockedNew(possibleElement)
+        aspectRatioLockedInner =
+          aspectRatioLockedInner || isAspectRatioLockedNew(possibleElement, elementProps)
 
         const elementOriginType = MetadataUtils.getElementOriginType(rootComponents, view)
         if (elementOriginType === 'unknown-element') {
@@ -432,11 +434,12 @@ export const SingleInspectorEntryPoint: React.FunctionComponent<
   }>
 > = React.memo((props) => {
   const { selectedViews } = props
-  const { dispatch, jsxMetadata, isUIJSFile } = useEditorState((store) => {
+  const { dispatch, jsxMetadata, isUIJSFile, allElementProps } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
       jsxMetadata: store.editor.jsxMetadata,
       isUIJSFile: isOpenFileUiJs(store.editor),
+      allElementProps: store.editor.allElementProps,
     }
   }, 'SingleInspectorEntryPoint')
 
@@ -472,13 +475,13 @@ export const SingleInspectorEntryPoint: React.FunctionComponent<
         const component = MetadataUtils.findElementByElementPath(jsxMetadata, path)
         if (component != null) {
           elements.push({
-            name: MetadataUtils.getElementLabel(path, jsxMetadata),
+            name: MetadataUtils.getElementLabel(allElementProps, path, jsxMetadata),
             path: path,
           })
         }
       })
       return elements
-    }, [selectedViews, jsxMetadata]),
+    }, [selectedViews, jsxMetadata, allElementProps]),
   )
 
   // Memoized Callbacks
@@ -568,10 +571,11 @@ export const InspectorContextProvider = React.memo<{
   children: React.ReactNode
 }>((props) => {
   const { selectedViews } = props
-  const { dispatch, jsxMetadata } = useEditorState((store) => {
+  const { dispatch, jsxMetadata, allElementProps } = useEditorState((store) => {
     return {
       dispatch: store.dispatch,
       jsxMetadata: store.editor.jsxMetadata,
+      allElementProps: store.editor.allElementProps,
     }
   }, 'InspectorContextProvider')
 
@@ -606,7 +610,7 @@ export const InspectorContextProvider = React.memo<{
 
       const jsxAttributes = isJSXElement(jsxElement) ? jsxElement.props : []
       newEditedMultiSelectedProps.push(jsxAttributes)
-      newSpiedProps.push(elementMetadata.props)
+      newSpiedProps.push(allElementProps[EP.toString(path)] ?? {})
       newComputedStyles.push(elementMetadata.computedStyle)
       newAttributeMetadatas.push(elementMetadata.attributeMetadatada)
     }

--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -13,6 +13,7 @@ import { useEditorState } from '../editor/store/store-hook'
 import { isRight, maybeEitherToMaybe } from '../../core/shared/either'
 import { IcnPropsBase } from '../../uuiui'
 import { shallowEqual } from '../../core/shared/equality-utils'
+import { AllElementProps } from '../editor/store/editor-state'
 
 interface LayoutIconResult {
   iconProps: IcnPropsBase
@@ -23,7 +24,7 @@ export function useLayoutOrElementIcon(path: ElementPath): LayoutIconResult {
   return useEditorState(
     (store) => {
       const metadata = store.editor.jsxMetadata
-      return createLayoutOrElementIconResult(path, metadata)
+      return createLayoutOrElementIconResult(path, metadata, store.editor.allElementProps)
     },
     'useLayoutOrElementIcon',
     (oldResult: LayoutIconResult, newResult: LayoutIconResult) => {
@@ -51,13 +52,15 @@ export function createComponentOrElementIconProps(element: ElementInstanceMetada
 export function createLayoutOrElementIconResult(
   path: ElementPath,
   metadata: ElementInstanceMetadataMap,
+  allElementProps: AllElementProps,
 ): LayoutIconResult {
   let isPositionAbsolute: boolean = false
 
   const element = MetadataUtils.findElementByElementPath(metadata, path)
+  const elementProps = allElementProps[EP.toString(path)]
 
-  if (element != null && element.props != null && element.props.style != null) {
-    isPositionAbsolute = element.props.style['position'] === 'absolute'
+  if (element != null && elementProps != null && elementProps.style != null) {
+    isPositionAbsolute = elementProps.style['position'] === 'absolute'
   }
 
   const layoutIcon = createLayoutIconProps(path, metadata)

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -57,6 +57,7 @@ const navigatorItemWrapperSelectorFactory = (elementPath: ElementPath) =>
     (store: EditorStorePatched) => store.editor.projectContents,
     (store: EditorStorePatched) => store.editor.nodeModules.files,
     (store: EditorStorePatched) => store.editor.canvas.openFile?.filename ?? null,
+    (store: EditorStorePatched) => store.editor.allElementProps,
     (
       jsxMetadata,
       selectedViews,
@@ -67,6 +68,7 @@ const navigatorItemWrapperSelectorFactory = (elementPath: ElementPath) =>
       projectContents,
       nodeModules,
       currentFilePath,
+      allElementProps,
     ) => {
       const underlying = normalisePathToUnderlyingTarget(
         projectContents,
@@ -96,7 +98,12 @@ const navigatorItemWrapperSelectorFactory = (elementPath: ElementPath) =>
         elementPath,
       )
       const staticName = MetadataUtils.getStaticElementName(elementPath, componentsIncludingScenes)
-      const labelInner = MetadataUtils.getElementLabel(elementPath, jsxMetadata, staticName)
+      const labelInner = MetadataUtils.getElementLabel(
+        allElementProps,
+        elementPath,
+        jsxMetadata,
+        staticName,
+      )
       // FIXME: This is a mitigation for a situation where somehow this component re-renders
       // when the navigatorTargets indicate it shouldn't exist...
       const isInNavigatorTargets = EP.containsPath(elementPath, navigatorTargets)

--- a/editor/src/components/text-utils.ts
+++ b/editor/src/components/text-utils.ts
@@ -8,7 +8,7 @@ import { NodeModules, PropertyPath, ElementPath } from '../core/shared/project-f
 import Utils from '../utils/utils'
 import { EditorAction, EditorDispatch, TextFormattingType } from './editor/action-types'
 import * as EditorActions from './editor/actions/action-creators'
-import { EditorState } from './editor/store/editor-state'
+import { EditorState, ElementProps } from './editor/store/editor-state'
 import * as PP from '../core/shared/property-path'
 
 export function italicStyleTransform(value: 'italic' | 'normal'): boolean {
@@ -22,8 +22,8 @@ export function italicStyleReverseTransform(value: boolean): string {
 const ItalicPropertyArray = ['style', 'fontStyle']
 export const ItalicProperty: PropertyPath = PP.create(ItalicPropertyArray)
 
-export function isItalicText(element: ElementInstanceMetadata): boolean {
-  return italicStyleTransform(Utils.pathOr('normal', ItalicPropertyArray, element.props))
+export function isItalicText(elementProps: ElementProps): boolean {
+  return italicStyleTransform(Utils.pathOr('normal', ItalicPropertyArray, elementProps))
 }
 
 const BoldWeight: number = 700
@@ -40,8 +40,8 @@ export function boldStyleReverseTransform(value: boolean): number {
 const BoldPropertyArray = ['style', 'fontWeight']
 export const BoldProperty: PropertyPath = PP.create(BoldPropertyArray)
 
-export function isBoldText(element: ElementInstanceMetadata): boolean {
-  return boldStyleTransform(Utils.pathOr(NormalWeight, BoldPropertyArray, element.props))
+export function isBoldText(elementProps: ElementProps): boolean {
+  return boldStyleTransform(Utils.pathOr(NormalWeight, BoldPropertyArray, elementProps))
 }
 
 export function decorationStyleTransform(value: 'underline' | 'none'): boolean {
@@ -55,8 +55,8 @@ export function decorationStyleReverseTransform(value: boolean): string {
 const UnderlinedPropertyArray = ['style', 'textDecoration']
 export const UnderlinedProperty: PropertyPath = PP.create(UnderlinedPropertyArray)
 
-export function isUnderlinedText(element: ElementInstanceMetadata): boolean {
-  return decorationStyleTransform(Utils.pathOr('none', UnderlinedPropertyArray, element.props))
+export function isUnderlinedText(elementProps: ElementProps): boolean {
+  return decorationStyleTransform(Utils.pathOr('none', UnderlinedPropertyArray, elementProps))
 }
 
 function propertyForTextFormatting(textFormatting: TextFormattingType): PropertyPath {

--- a/editor/src/core/layout/layout-utils.spec.browser2.tsx
+++ b/editor/src/core/layout/layout-utils.spec.browser2.tsx
@@ -73,17 +73,6 @@ describe('maybeSwitchLayoutProps', () => {
     )
     const elementPath = EP.appendNewElementPath(TestScenePath, [NewUID])
 
-    const testSceneProps: ElementProps = {
-      style: {
-        width: 375,
-        height: 812,
-      },
-    }
-
-    const elementProps: ElementProps = {
-      'data-uid': NewUID,
-    }
-
     const metadata: ElementInstanceMetadataMap = {
       [EP.toString(TestScenePath)]: {
         elementPath: TestScenePath,

--- a/editor/src/core/layout/layout-utils.spec.browser2.tsx
+++ b/editor/src/core/layout/layout-utils.spec.browser2.tsx
@@ -22,6 +22,7 @@ import {
 import { FOR_TESTS_setNextGeneratedUid } from '../model/element-template-utils'
 import { left, right } from '../shared/either'
 import { CanvasRectangle, LocalRectangle } from '../shared/math-utils'
+import { ElementProps } from 'src/components/editor/store/editor-state'
 
 const NewUID = 'catdog'
 
@@ -72,16 +73,21 @@ describe('maybeSwitchLayoutProps', () => {
     )
     const elementPath = EP.appendNewElementPath(TestScenePath, [NewUID])
 
+    const testSceneProps: ElementProps = {
+      style: {
+        width: 375,
+        height: 812,
+      },
+    }
+
+    const elementProps: ElementProps = {
+      'data-uid': NewUID,
+    }
+
     const metadata: ElementInstanceMetadataMap = {
       [EP.toString(TestScenePath)]: {
         elementPath: TestScenePath,
         element: left('Scene'),
-        props: {
-          style: {
-            width: 375,
-            height: 812,
-          },
-        },
         globalFrame: { x: 0, y: 0, width: 375, height: 812 } as CanvasRectangle,
         localFrame: { x: 0, y: 0, width: 375, height: 812 } as LocalRectangle,
         componentInstance: false,
@@ -95,9 +101,6 @@ describe('maybeSwitchLayoutProps', () => {
       [EP.toString(elementPath)]: {
         elementPath: elementPath,
         element: right(elementToPaste),
-        props: {
-          'data-uid': NewUID,
-        },
         globalFrame: { x: 0, y: 0, width: 375, height: 812 } as CanvasRectangle,
         localFrame: { x: 0, y: 0, width: 375, height: 812 } as LocalRectangle,
         componentInstance: true,

--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -27,6 +27,7 @@ import {
 import { sampleImportsForTests } from './test-ui-js-file.test-utils'
 import { BakedInStoryboardUID } from './scene-utils'
 import { ElementPath } from '../shared/project-file-types'
+import { AllElementProps, ElementProps } from 'src/components/editor/store/editor-state'
 
 const TestScenePath = 'scene-aaa'
 
@@ -37,7 +38,6 @@ const testComponentMetadataChild1: ElementInstanceMetadata = {
     [BakedInStoryboardUID, TestScenePath],
     ['View', 'View0'],
   ]),
-  props: {},
   element: right(jsxTestElement('View', [], [])),
   componentInstance: false,
   isEmotionOrStyledComponent: false,
@@ -54,7 +54,6 @@ const testComponentMetadataChild2: ElementInstanceMetadata = {
     [BakedInStoryboardUID, TestScenePath],
     ['View', 'View1'],
   ]),
-  props: {},
   element: right(jsxTestElement('View', [], [])),
   componentInstance: false,
   isEmotionOrStyledComponent: false,
@@ -72,9 +71,6 @@ const testComponentMetadataGrandchild: ElementInstanceMetadata = {
     [BakedInStoryboardUID, TestScenePath],
     ['View', 'View2', 'View0'],
   ]),
-  props: {
-    cica: 'hello',
-  },
   element: right(jsxTestElement('View', [], [])),
   componentInstance: false,
   isEmotionOrStyledComponent: false,
@@ -85,6 +81,10 @@ const testComponentMetadataGrandchild: ElementInstanceMetadata = {
   importInfo: null,
 }
 
+const testComponentPropsGrandchild: ElementProps = {
+  cica: 'hello',
+}
+
 const testComponentMetadataChild3: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
@@ -92,7 +92,6 @@ const testComponentMetadataChild3: ElementInstanceMetadata = {
     [BakedInStoryboardUID, TestScenePath],
     ['View', 'View2'],
   ]),
-  props: {},
   element: right(jsxTestElement('View', [], [])),
   componentInstance: false,
   isEmotionOrStyledComponent: false,
@@ -107,7 +106,6 @@ const testComponentRoot1: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   elementPath: EP.elementPath([[BakedInStoryboardUID, TestScenePath], ['View']]),
-  props: {},
   element: right(jsxTestElement('View', [], [])),
   componentInstance: false,
   isEmotionOrStyledComponent: false,
@@ -125,7 +123,6 @@ const testComponentSceneChildElementRootChild: ElementInstanceMetadata = {
     [BakedInStoryboardUID, TestScenePath, 'Scene-Child'],
     ['Scene-Child-Root', 'Child'],
   ]),
-  props: {},
   element: right(jsxTestElement('View', [], [])),
   componentInstance: false,
   isEmotionOrStyledComponent: false,
@@ -143,7 +140,6 @@ const testComponentSceneChildElementRoot: ElementInstanceMetadata = {
     [BakedInStoryboardUID, TestScenePath, 'Scene-Child'],
     ['Scene-Child-Root'],
   ]),
-  props: {},
   element: right(jsxTestElement('View', [], [])),
   componentInstance: false,
   isEmotionOrStyledComponent: false,
@@ -158,7 +154,6 @@ const testComponentSceneChildElement: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   elementPath: EP.elementPath([[BakedInStoryboardUID, TestScenePath, 'Scene-Child']]),
-  props: {},
   element: right(jsxTestElement('View', [], [])),
   componentInstance: false,
   isEmotionOrStyledComponent: false,
@@ -173,12 +168,6 @@ const testComponentSceneElement: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   elementPath: EP.elementPath([[BakedInStoryboardUID, TestScenePath]]),
-  props: {
-    style: {
-      width: 100,
-      height: 100,
-    },
-  },
   element: right(jsxTestElement('Scene', [], [])),
   componentInstance: false,
   isEmotionOrStyledComponent: false,
@@ -189,11 +178,17 @@ const testComponentSceneElement: ElementInstanceMetadata = {
   importInfo: null,
 }
 
+const testComponentSceneElementProps: ElementProps = {
+  style: {
+    width: 100,
+    height: 100,
+  },
+}
+
 const testStoryboardGrandChildElement: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   elementPath: EP.elementPath([[BakedInStoryboardUID, 'Child', 'GrandChild']]),
-  props: {},
   element: right(jsxTestElement('View', [], [])),
   componentInstance: false,
   isEmotionOrStyledComponent: false,
@@ -208,7 +203,6 @@ const testStoryboardChildElement: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 100, height: 100 }),
   elementPath: EP.elementPath([[BakedInStoryboardUID, 'Child']]),
-  props: {},
   element: right(jsxTestElement('View', [], [])),
   componentInstance: false,
   isEmotionOrStyledComponent: false,
@@ -223,7 +217,6 @@ const testStoryboardElement: ElementInstanceMetadata = {
   globalFrame: canvasRectangle({ x: 0, y: 0, width: 0, height: 0 }),
   localFrame: localRectangle({ x: 0, y: 0, width: 0, height: 0 }),
   elementPath: EP.elementPath([[BakedInStoryboardUID]]),
-  props: {},
   element: right(jsxTestElement('Storyboard', [], [])),
   componentInstance: true,
   isEmotionOrStyledComponent: false,
@@ -251,26 +244,6 @@ const testElementMetadataMap: ElementInstanceMetadataMap = {
 }
 
 const testJsxMetadata = testElementMetadataMap
-
-describe('findElements', () => {
-  it('Finds the element metadata', () => {
-    const foundViewsWithHelloProp = MetadataUtils.findElements(
-      testElementMetadataMap,
-      (element) => {
-        return element.props['cica'] != null
-      },
-    )
-
-    expect(foundViewsWithHelloProp).toHaveLength(1)
-    expect(foundViewsWithHelloProp[0].props.cica).toEqual('hello')
-
-    const notFoundViews = MetadataUtils.findElements(
-      testElementMetadataMap,
-      (element) => element.props.nonexistentProp != null,
-    )
-    expect(notFoundViews).toHaveLength(0)
-  })
-})
 
 describe('findElementByElementPath', () => {
   it('works with an empty object', () => {
@@ -333,7 +306,6 @@ describe('targetElementSupportsChildren', () => {
         [BakedInStoryboardUID, TestScenePath],
         ['Dummy', 'Element'],
       ]),
-      props: {},
       element: right(jsxTestElement(elementName, [], [])),
       componentInstance: false,
       isEmotionOrStyledComponent: false,
@@ -460,9 +432,6 @@ describe('getElementLabel', () => {
   const spanElementMetadata = elementInstanceMetadata(
     spanPath,
     right(spanElement),
-    {
-      'data-uid': 'span-1',
-    },
     zeroRectangle as CanvasRectangle,
     zeroRectangle as LocalRectangle,
     false,
@@ -473,6 +442,9 @@ describe('getElementLabel', () => {
     null,
     null,
   )
+  const spanElementProps: ElementProps = {
+    'data-uid': 'span-1',
+  }
   const divElement = jsxElement(
     'div',
     'div-1',
@@ -482,9 +454,6 @@ describe('getElementLabel', () => {
   const divElementMetadata = elementInstanceMetadata(
     divPath,
     right(divElement),
-    {
-      'data-uid': 'div-1',
-    },
     zeroRectangle as CanvasRectangle,
     zeroRectangle as LocalRectangle,
     false,
@@ -495,12 +464,19 @@ describe('getElementLabel', () => {
     null,
     null,
   )
+  const divElementProps: ElementProps = {
+    'data-uid': 'div-1',
+  }
   const metadata: ElementInstanceMetadataMap = {
     [EP.toString(spanElementMetadata.elementPath)]: spanElementMetadata,
     [EP.toString(divElementMetadata.elementPath)]: divElementMetadata,
   }
+  const allElementProps: AllElementProps = {
+    [EP.toString(spanElementMetadata.elementPath)]: spanElementProps,
+    [EP.toString(divElementMetadata.elementPath)]: divElementProps,
+  }
   it('the label of a spin containing text is that text', () => {
-    const actualResult = MetadataUtils.getElementLabel(spanPath, metadata)
+    const actualResult = MetadataUtils.getElementLabel(allElementProps, spanPath, metadata)
     expect(actualResult).toEqual('test text')
   })
 })

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1486,7 +1486,6 @@ export function createNotImported(): ImportInfo {
 export interface ElementInstanceMetadata {
   elementPath: ElementPath
   element: Either<string, JSXElementChild>
-  props: { [key: string]: any } // the final, resolved, static props value
   globalFrame: CanvasRectangle | null
   localFrame: LocalRectangle | null
   componentInstance: boolean
@@ -1501,7 +1500,6 @@ export interface ElementInstanceMetadata {
 export function elementInstanceMetadata(
   elementPath: ElementPath,
   element: Either<string, JSXElementChild>,
-  props: { [key: string]: any },
   globalFrame: CanvasRectangle | null,
   localFrame: LocalRectangle | null,
   componentInstance: boolean,
@@ -1515,7 +1513,6 @@ export function elementInstanceMetadata(
   return {
     elementPath: elementPath,
     element: element,
-    props: props,
     globalFrame: globalFrame,
     localFrame: localFrame,
     componentInstance: componentInstance,

--- a/editor/src/core/tailwind/tailwind-options.tsx
+++ b/editor/src/core/tailwind/tailwind-options.tsx
@@ -302,6 +302,7 @@ export function useGetSelectedClasses(): {
   const allElementProps = useEditorState(
     (store) => store.editor.allElementProps,
     'ClassNameSelect allElementProps',
+    (oldProps, newProps) => oldProps === newProps,
   )
 
   const classNamesFromAttributesOrProps = React.useMemo(

--- a/editor/src/core/tailwind/tailwind-options.tsx
+++ b/editor/src/core/tailwind/tailwind-options.tsx
@@ -27,6 +27,7 @@ import {
   jsxSimpleAttributeToValue,
 } from '../shared/jsx-attributes'
 import * as PP from '../shared/property-path'
+import * as EP from '../shared/element-path'
 import { isTwindEnabled } from './tailwind'
 import { AttributeCategories, AttributeCategory } from './attribute-categories'
 
@@ -298,6 +299,11 @@ export function useGetSelectedClasses(): {
     'ClassNameSelect elementPaths',
   )
 
+  const allElementProps = useEditorState(
+    (store) => store.editor.allElementProps,
+    'ClassNameSelect allElementProps',
+  )
+
   const classNamesFromAttributesOrProps = React.useMemo(
     () =>
       elements.map((element, index) => {
@@ -311,12 +317,12 @@ export function useGetSelectedClasses(): {
             elementPath,
           )
           return {
-            value: elementMetadata?.props['className'],
+            value: allElementProps[EP.toString(elementPath)]['className'],
             isSettable: fromAttributes.isSettable,
           }
         }
       }),
-    [elements, elementPaths, metadataRef],
+    [elements, elementPaths, metadataRef, allElementProps],
   )
 
   const isSettable =

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -378,6 +378,8 @@ export function runLocalCanvasAction(
           interactionSession: {
             ...action.interactionSession,
             metadata: model.canvas.interactionSession?.metadata ?? model.jsxMetadata,
+            allElementProps:
+              model.canvas.interactionSession?.allElementProps ?? model.allElementProps,
           },
         },
       }
@@ -914,10 +916,11 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         this.props.editor.jsxMetadata,
         target,
       )
-      if (possibleElement == null) {
+      const elementProps = this.props.editor.allElementProps[EP.toString(target)]
+      if (possibleElement == null || elementProps == null) {
         return false
       } else {
-        return isAspectRatioLockedNew(possibleElement)
+        return isAspectRatioLockedNew(possibleElement, elementProps)
       }
     })
   }

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -133,7 +133,7 @@ export class Editor {
     let emptyEditorState = createEditorState(this.boundDispatch)
     const derivedState = deriveState(emptyEditorState, null)
 
-    const strategyState = createEmptyStrategyState()
+    const strategyState = createEmptyStrategyState({}, {})
 
     const history = History.init(emptyEditorState, derivedState)
 

--- a/editor/src/utils/utils.test-utils.ts
+++ b/editor/src/utils/utils.test-utils.ts
@@ -149,7 +149,7 @@ export function createEditorStates(selectedViews: ElementPath[] = []): {
       jsxMetadata: componentMetadata,
     },
     derivedState: derivedState,
-    strategyState: createEmptyStrategyState(),
+    strategyState: createEmptyStrategyState({}, {}),
     dispatch: Utils.NO_OP,
   }
 }
@@ -329,7 +329,6 @@ function createFakeMetadataForJSXElement(
     elements.push({
       elementPath: elementPath,
       element: right(element),
-      props: props,
       globalFrame: canvasRectangle(frame),
       localFrame: localRectangle(frame),
       componentInstance: false,
@@ -365,7 +364,6 @@ function createFakeMetadataForStoryboard(elementPath: ElementPath): ElementInsta
     globalFrame: canvasRectangle({ x: 0, y: 0, width: 0, height: 0 }),
     localFrame: localRectangle({ x: 0, y: 0, width: 0, height: 0 }),
     elementPath: elementPath,
-    props: {},
     element: right(jsxTestElement('Storyboard', [], [])),
     componentInstance: true,
     isEmotionOrStyledComponent: false,


### PR DESCRIPTION
**Problem:**
The spy props have long been effectively embedded inside `ElementInstanceMetadata` which leads to a lot of issues with them changing and forcing a lot of the model to need updating as well as those needing introspective deep equality which is slow to use on lots of small cases.

**Fix:**
Removed the `ElementInstanceMetadata.props` property and put the props into one dictionary style object at the root of `EditorState`.

**Commit Details:**
- `props` removed from `ElementInstanceMetadata`.
- Added `ElementProps` type for the props of an element.
- Added `AllElementProps` type for the props of the entire project.
- Added `EditorState.allElementProps` property.
- Updated the `EditorState` and `ElementInstanceMetadata` deep
  equality functions.
- Added an `allElementProps` parameter to `CanvasStrategy.isApplicable`.
- In numerous functions either added an `AllElementProps` parameter
  alongside an `ElementInstanceMetadataMap` parameter or in a few cases
  replaced it.
- In `property-control-hooks.spec.tsx` fixed a bug with the wrong
  path being assigned to the metadata of an element.
