### PR TITLE
Fix/canvas escape hatch strategy

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.ts
@@ -25,7 +25,7 @@ import {
 
 export const absoluteMoveStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_MOVE',
-  name: 'Absolute Move',
+  name: 'Absolute Move (Delta-based)',
   isApplicable: (canvasState, _interactionState, metadata) => {
     if (canvasState.selectedElements.length > 0) {
       const filteredSelectedElements = getDragTargets(canvasState.selectedElements)

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
@@ -250,8 +250,47 @@ describe('Escape Hatch Strategy', () => {
       ),
     )
   })
+  it('works on a flow element with all pins', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
 
-  it('works on a flow element with lots of siblings', async () => {
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{
+          backgroundColor: '#0091FFAA',
+          width: '50%',
+          height: '20%',
+          right: 200,
+          bottom: 320,
+          top: 0,
+          left: 0
+        }}
+        data-uid='bbb'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = dragBy15Pixels(initialEditor, simpleMetadataPercentValue)
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', width: '50%', height: '20%', right: 185, bottom: 305, top: 15, left: 15, position: 'absolute', }}
+          data-uid='bbb'
+        />
+      </View>`,
+      ),
+    )
+  })
+
+  xit('works on a flow element with lots of siblings', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'bbb'],
@@ -320,7 +359,7 @@ describe('Escape Hatch Strategy', () => {
       ),
     )
   })
-  it('works on a flow element with lots of siblings and mixed frame pins', async () => {
+  xit('works on a flow element with lots of siblings and mixed frame pins', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'bbb'],

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -42,7 +42,7 @@ import { DragInteractionData, InteractionSession, StrategyState } from './intera
 
 export const escapeHatchStrategy: CanvasStrategy = {
   id: 'ESCAPE_HATCH_STRATEGY',
-  name: 'Escape Hatch',
+  name: 'Absolute Move',
   isApplicable: (canvasState, _interactionState, metadata) => {
     if (canvasState.selectedElements.length > 0) {
       return canvasState.selectedElements.every((element) => {

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -97,15 +97,21 @@ export const escapeHatchStrategy: CanvasStrategy = {
   },
   apply: (canvasState, interactionState, strategyState) => {
     if (interactionState.interactionData.type === 'DRAG') {
+      let shouldEscapeHatch = false
       let escapeHatchActivated = strategyState.customStrategyState.escapeHatchActivated ?? false
-      if (
-        interactionState.interactionData.globalTime - interactionState.lastInteractionTime >
-          AnimationTimer ||
-        interactionState.interactionData.modifiers.cmd
-      ) {
-        escapeHatchActivated = true
+      if (interactionState.interactionData.modifiers.cmd) {
+        shouldEscapeHatch = true
+      } else {
+        if (
+          interactionState.interactionData.globalTime - interactionState.lastInteractionTime >
+          AnimationTimer
+        ) {
+          shouldEscapeHatch = true
+          escapeHatchActivated = true
+        }
       }
-      if (escapeHatchActivated) {
+
+      if (shouldEscapeHatch) {
         const getConversionAndMoveCommands = (
           snappedDragVector: CanvasPoint,
         ): Array<CanvasCommand> => {

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -77,23 +77,31 @@ export const escapeHatchStrategy: CanvasStrategy = {
     },
   ],
   fitness: (canvasState, interactionState, strategyState) => {
-    return escapeHatchStrategy.isApplicable(
-      canvasState,
-      interactionState,
-      strategyState.startingMetadata,
-    ) &&
+    if (
+      escapeHatchStrategy.isApplicable(
+        canvasState,
+        interactionState,
+        strategyState.startingMetadata,
+      ) &&
       interactionState.interactionData.type === 'DRAG' &&
-      interactionState.activeControl.type === 'BOUNDING_AREA' &&
-      escapeHatchAllowed(canvasState, interactionState.interactionData, strategyState)
-      ? 2
-      : 0
+      interactionState.activeControl.type === 'BOUNDING_AREA'
+    ) {
+      if (escapeHatchAllowed(canvasState, interactionState.interactionData, strategyState)) {
+        return 2
+      } else {
+        return 0.5
+      }
+    } else {
+      return 0
+    }
   },
   apply: (canvasState, interactionState, strategyState) => {
     if (interactionState.interactionData.type === 'DRAG') {
       let escapeHatchActivated = strategyState.customStrategyState.escapeHatchActivated ?? false
       if (
         interactionState.interactionData.globalTime - interactionState.lastInteractionTime >
-        AnimationTimer
+          AnimationTimer ||
+        interactionState.interactionData.modifiers.cmd
       ) {
         escapeHatchActivated = true
       }
@@ -298,6 +306,9 @@ function escapeHatchAllowed(
   interactionData: DragInteractionData,
   strategyState: StrategyState,
 ): boolean {
+  if (interactionData.modifiers.cmd) {
+    return true
+  }
   // flex children with siblings switches to escape hatch when the cursor reaches the parent bounds
   // for flow elements and flex child without siblings the conversion automatically starts on drag
   if (strategyState.customStrategyState.escapeHatchActivated) {

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -151,8 +151,10 @@ export function getEscapeHatchCommands(
     canvasState,
     dragDelta,
   )
-  const siblingCommands = collectSiblingCommands(selectedElements, metadata, canvasState)
-  return [...moveAndPositionCommands, ...siblingCommands]
+  return moveAndPositionCommands
+  // TEMPORARILY REMOVING SIBLING CONVERSION FOR EXPERIMENTING
+  // const siblingCommands = collectSiblingCommands(selectedElements, metadata, canvasState)
+  // return [...moveAndPositionCommands, ...siblingCommands]
 }
 
 function collectMoveCommandsForSelectedElements(

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -115,13 +115,14 @@ export const escapeHatchStrategy: CanvasStrategy = {
           getConversionAndMoveCommands,
         )
 
-        const highlightCommand = collectHighlightCommand(
-          canvasState,
-          interactionState.interactionData,
-          strategyState,
-        )
+        // TEMPORARILY REMOVING SIBLING CONVERSION FOR EXPERIMENTING
+        // const highlightCommand = collectHighlightCommand(
+        //   canvasState,
+        //   interactionState.interactionData,
+        //   strategyState,
+        // )
         return {
-          commands: [...absoluteMoveApplyResult.commands, highlightCommand],
+          commands: absoluteMoveApplyResult.commands,
           customState: {
             ...strategyState.customStrategyState,
             escapeHatchActivated,

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -109,8 +109,9 @@ export const escapeHatchStrategy: CanvasStrategy = {
         shouldEscapeHatch = true
       } else {
         if (
+          escapeHatchActivated ||
           interactionState.interactionData.globalTime - interactionState.lastInteractionTime >
-          AnimationTimer
+            AnimationTimer
         ) {
           shouldEscapeHatch = true
           escapeHatchActivated = true


### PR DESCRIPTION
**Fix:**
Experimenting with a different variation of the escape hatch.
Pressing CMD triggers the escape hatch without a timer, releasing CMD is just the regular flex reorder. Moving the element out of the parent still triggers the timer and the conversion.
And removing the sibling conversion for now, they can keep their original frame props.

**Commit Details:**
- Renamed Escape Hatch to Absolute Move on the UI
- Renamed Absolute Move to Absolute Move (Delta-based) on the UI
- Removed the sibling commands for now and the highlight outline
