### PR TITLE
Improve canvas valid path handling.

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { emptySet } from '../../../core/shared/set-utils'
 import type { MapLike } from 'typescript'
 import { atomWithPubSub } from '../../../core/shared/atom-with-pub-sub'
 import { Either, left } from '../../../core/shared/either'
@@ -60,12 +61,12 @@ export const UtopiaProjectCtxAtom = atomWithPubSub<UtopiaProjectCtxProps>({
 })
 
 interface SceneLevelContextProps {
-  validPaths: Array<ElementPath>
+  validPaths: Set<ElementPath>
 }
 
 export const SceneLevelUtopiaCtxAtom = atomWithPubSub<SceneLevelContextProps>({
   key: 'SceneLevelUtopiaCtxAtom',
   defaultValue: {
-    validPaths: [],
+    validPaths: new Set(),
   },
 })

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -57,7 +57,7 @@ export function createLookupRender(
   requireResult: MapLike<any>,
   hiddenInstances: Array<ElementPath>,
   fileBlobs: UIFileBase64Blobs,
-  validPaths: Array<ElementPath>,
+  validPaths: Set<ElementPath>,
   reactChildren: React.ReactNode | undefined,
   metadataContext: UiJsxCanvasContextData,
   updateInvalidatedPaths: DomWalkerInvalidatePathsCtxData,
@@ -150,7 +150,7 @@ export function renderCoreElement(
   requireResult: MapLike<any>,
   hiddenInstances: Array<ElementPath>,
   fileBlobs: UIFileBase64Blobs,
-  validPaths: Array<ElementPath>,
+  validPaths: Set<ElementPath>,
   uid: string | undefined,
   reactChildren: React.ReactNode | undefined,
   metadataContext: UiJsxCanvasContextData,
@@ -320,7 +320,7 @@ function renderJSXElement(
   inScope: MapLike<any>,
   hiddenInstances: Array<ElementPath>,
   fileBlobs: UIFileBase64Blobs,
-  validPaths: Array<ElementPath>,
+  validPaths: Set<ElementPath>,
   passthroughProps: MapLike<any>,
   metadataContext: UiJsxCanvasContextData,
   updateInvalidatedPaths: DomWalkerInvalidatePathsCtxData,
@@ -403,19 +403,11 @@ function renderJSXElement(
     [UTOPIA_PATH_KEY]: optionalMap(EP.toString, elementPath),
   }
 
-  const staticElementPathForGeneratedElement = optionalMap(EP.makeLastPartOfPathStatic, elementPath)
-
-  const staticValidPaths = validPaths.map(EP.makeLastPartOfPathStatic)
-
   if (FinalElement == null) {
     throw canvasMissingJSXElementError(jsxFactoryFunctionName, code, jsx, filePath, highlightBounds)
   }
 
-  if (
-    elementPath != null &&
-    staticElementPathForGeneratedElement != null &&
-    EP.containsPath(staticElementPathForGeneratedElement, staticValidPaths)
-  ) {
+  if (elementPath != null && validPaths.has(EP.makeLastPartOfPathStatic(elementPath))) {
     return buildSpyWrappedElement(
       jsx,
       finalPropsIcludingElementPath,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope.tsx
@@ -43,6 +43,7 @@ import { useContextSelector } from 'use-context-selector'
 import { shallowEqual } from '../../../core/shared/equality-utils'
 import { usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
 import { JSX_CANVAS_LOOKUP_FUNCTION_NAME } from '../../../core/shared/dom-utils'
+import { emptySet } from '../../../core/shared/set-utils'
 
 const emptyFileBlobs: UIFileBase64Blobs = {}
 
@@ -134,7 +135,7 @@ export function createExecutionScope(
       requireResult,
       hiddenInstances,
       fileBlobsForFile,
-      [],
+      new Set(),
       undefined,
       metadataContext,
       updateInvalidatedPaths,

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -445,7 +445,7 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
   clearSpyCollectorInvalidPaths(rootValidPaths, metadataContext)
 
   const sceneLevelUtopiaContextValue = useKeepReferenceEqualityIfPossible({
-    validPaths: rootValidPaths,
+    validPaths: new Set(rootValidPaths.map((path) => EP.makeLastPartOfPathStatic(path))),
   })
 
   const rerenderUtopiaContextValue = useKeepShallowReferenceEquality({


### PR DESCRIPTION
**Problem:**
The `renderJSXElement` function is transforming the valid paths each and every time it is called.

**Fix:**
Perform the transformation on the valid paths when the scene context that holds them is created.

**Commit Details:**
- Change `validPaths` to be a `Set` instead of an `Array`.
- Apply `makeLastPartOfPathStatic` to the `validPaths` scene
  context value on creation.
- In `renderJSXElement` don't apply `makeLastPartOfPathStatic`
  as it has been done on creation.
