### PR TITLE
Improve the performance of path appending.

### DIFF
--- a/editor/src/core/shared/element-path.spec.ts
+++ b/editor/src/core/shared/element-path.spec.ts
@@ -123,8 +123,8 @@ describe('appending to a path', () => {
       ['C', 'D'],
     ])
     const singleElementAdded = EP.appendToPath(start, 'E')
-    const singleElementAddedViaArray = EP.appendToPath(start, ['E'])
-    const multipleElementsAdded = EP.appendToPath(start, ['E', 'F'])
+    const singleElementAddedViaArray = EP.appendPartToPath(start, ['E'])
+    const multipleElementsAdded = EP.appendPartToPath(start, ['E', 'F'])
 
     expect(singleElementAdded).toEqual(
       EP.elementPath([
@@ -149,8 +149,8 @@ describe('appending to a path', () => {
   it('appendToPath works with an empty path', () => {
     const start = EP.emptyElementPath
     const singleElementAdded = EP.appendToPath(start, 'E')
-    const singleElementAddedViaArray = EP.appendToPath(start, ['E'])
-    const multipleElementsAdded = EP.appendToPath(start, ['E', 'F'])
+    const singleElementAddedViaArray = EP.appendPartToPath(start, ['E'])
+    const multipleElementsAdded = EP.appendPartToPath(start, ['E', 'F'])
 
     expect(singleElementAdded).toEqual(EP.elementPath([['E']]))
     expect(singleElementAddedViaArray).toEqual(EP.elementPath([['E']]))

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -341,26 +341,49 @@ export function toStaticUid(path: ElementPath): id {
   return extractOriginalUidFromIndexedUid(toUid(path))
 }
 
-export function appendToElementPath(
+export function appendArrayToElementPath(
   path: StaticElementPathPart,
-  next: id | Array<id>,
+  next: Array<id>,
 ): StaticElementPathPart
-export function appendToElementPath(path: ElementPathPart, next: id | Array<id>): ElementPathPart
-export function appendToElementPath(path: ElementPathPart, next: id | Array<id>): ElementPathPart {
-  return path.concat(next)
+export function appendArrayToElementPath(path: ElementPathPart, next: Array<id>): ElementPathPart
+export function appendArrayToElementPath(path: ElementPathPart, next: Array<id>): ElementPathPart {
+  return [...path, ...next]
 }
 
-function appendToElementPathArray(
+export function appendToElementPath(path: StaticElementPathPart, next: id): StaticElementPathPart
+export function appendToElementPath(path: ElementPathPart, next: id): ElementPathPart
+export function appendToElementPath(path: ElementPathPart, next: id): ElementPathPart {
+  return [...path, next]
+}
+
+function appendToElementPathArray(pathArray: ElementPathPart[], next: id): ElementPathPart[] {
+  if (isEmptyElementPathsArray(pathArray)) {
+    return [[next]]
+  } else {
+    let result: Array<ElementPathPart> = []
+    const lengthMinusOne = pathArray.length - 1
+    for (let index = 0; index < lengthMinusOne; index++) {
+      result.push(pathArray[index])
+    }
+    result.push(appendToElementPath(pathArray[lengthMinusOne], next))
+    return result
+  }
+}
+
+function appendPartToElementPathArray(
   pathArray: ElementPathPart[],
-  next: id | ElementPathPart,
+  next: ElementPathPart,
 ): ElementPathPart[] {
   if (isEmptyElementPathsArray(pathArray)) {
-    return [Array.isArray(next) ? next : [next]]
+    return [next]
   } else {
-    const prefix = dropLast(pathArray)
-    const lastPart = last(pathArray)!
-    const updatedLastPart = appendToElementPath(lastPart, next)
-    return [...prefix, updatedLastPart]
+    let result: Array<ElementPathPart> = []
+    const lengthMinusOne = pathArray.length - 1
+    for (let index = 0; index < lengthMinusOne; index++) {
+      result.push(pathArray[index])
+    }
+    result.push(appendArrayToElementPath(pathArray[lengthMinusOne], next))
+    return result
   }
 }
 
@@ -374,13 +397,20 @@ export function appendNewElementPath(path: ElementPath, next: id | ElementPathPa
   return elementPath([...path.parts, toAppend])
 }
 
-export function appendToPath(
-  path: StaticElementPath,
-  next: id | StaticElementPathPart,
-): StaticElementPath
-export function appendToPath(path: ElementPath, next: id | ElementPathPart): ElementPath
-export function appendToPath(path: ElementPath, next: id | ElementPathPart): ElementPath {
+export function appendToPath(path: StaticElementPath, next: id): StaticElementPath
+export function appendToPath(path: ElementPath, next: id): ElementPath
+export function appendToPath(path: ElementPath, next: id): ElementPath {
   const updatedPathParts = appendToElementPathArray(path.parts, next)
+  return elementPath(updatedPathParts)
+}
+
+export function appendPartToPath(
+  path: StaticElementPath,
+  next: StaticElementPathPart,
+): StaticElementPath
+export function appendPartToPath(path: ElementPath, next: ElementPathPart): ElementPath
+export function appendPartToPath(path: ElementPath, next: ElementPathPart): ElementPath {
+  const updatedPathParts = appendPartToElementPathArray(path.parts, next)
   return elementPath(updatedPathParts)
 }
 
@@ -547,7 +577,7 @@ export function replaceIfAncestor(
     } else if (replaceWith == null) {
       prefix = [trimmedOverlappingPart]
     } else {
-      prefix = appendToElementPathArray(replaceWith.parts, trimmedOverlappingPart)
+      prefix = appendPartToElementPathArray(replaceWith.parts, trimmedOverlappingPart)
     }
 
     const updatedPathParts = [...prefix, ...suffix]


### PR DESCRIPTION
**Problem:**
Element paths are appended to often and in various parts of the editor, so any inefficiencies in that code affect everything.

**Fix:**
Split apart the single and multiple part appending functions and stopped using some utility functions which did a bit more work that necessary.

A microbenchmark shows this approach to be 4 times faster than the old code: https://jsbench.me/fgl3n8tsnk/1

**Commit Details:**
- Split the functions that append to paths into those that append
  a single value and those that append an array.
- Reworked those functions which inherited from `appendToElementPathArray`
  to not use `dropLast` and `last` utility functions.