### PR TITLE
Always render the inspector contents.

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -316,12 +316,25 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
     dispatch(actions, 'everyone')
   }, [dispatch, selectedViews, aspectRatioLocked])
 
+  const shouldShowInspector = React.useMemo(() => {
+    return props.elementPath.length !== 0 && !anyUnknownElements
+  }, [props.elementPath, anyUnknownElements])
+
   function renderInspectorContents() {
-    if (props.elementPath.length == 0 || anyUnknownElements) {
-      return <SettingsPanel />
-    } else {
-      return (
-        <React.Fragment>
+    return (
+      <React.Fragment>
+        <div
+          style={{
+            display: shouldShowInspector ? 'none' : undefined,
+          }}
+        >
+          <SettingsPanel />
+        </div>
+        <div
+          style={{
+            display: shouldShowInspector ? undefined : 'none',
+          }}
+        >
           <AlignmentButtons numberOfTargets={selectedViews.length} />
           {when(isTwindEnabled(), <ClassNameSubsection />)}
           {anyComponents ? <ComponentSection isScene={false} /> : null}
@@ -342,9 +355,9 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
           <WarningSubsection />
           <ImgSection />
           <EventHandlersSection />
-        </React.Fragment>
-      )
-    }
+        </div>
+      </React.Fragment>
+    )
   }
 
   return (

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`570`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`572`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`642`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`644`)
   })
 })

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`572`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`573`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`644`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`645`)
   })
 })


### PR DESCRIPTION
**Problem:**
There's a sizeable cost we incur newly mounting the entire inspector contents each time we go from nothing selected to something selected.

**Fix:**
Instead of conditionally rendering the inspector, always render it and hide it with CSS instead.

**Commit Details:**
- The two panels of the inspector are now always rendered and hidden
  with the `display` property, instead of conditionally rendering
  one or the other.
