### PR TITLE
Feature/canvas controls select mode

### DIFF
--- a/editor/src/components/canvas/controls/distance-guideline.tsx
+++ b/editor/src/components/canvas/controls/distance-guideline.tsx
@@ -90,8 +90,6 @@ function guidelinesClosestToDragOrFrame(
 interface DistanceGuidelineProps {
   canvasOffset: CanvasVector
   scale: number
-  selectedViews: Array<ElementPath>
-  highlightedViews: Array<ElementPath>
   boundingBox: CanvasRectangle
   guidelines: Array<Guideline>
 }

--- a/editor/src/components/canvas/controls/insertion-plus-button.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.tsx
@@ -1,4 +1,3 @@
-import { ControlProps } from './new-canvas-controls'
 import React from 'react'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { useEditorState } from '../../editor/store/store-hook'
@@ -23,26 +22,34 @@ interface ButtonControlProps {
   indexPosition: IndexPosition
 }
 
-export const InsertionControls: React.FunctionComponent<React.PropsWithChildren<ControlProps>> =
-  React.memo((props: ControlProps): React.ReactElement | null => {
-    if (props.selectedViews.length !== 1) {
+export const InsertionControls: React.FunctionComponent = React.memo(
+  (): React.ReactElement | null => {
+    const selectedViews = useEditorState(
+      (store) => store.editor.selectedViews,
+      'InsertionControls selectedViews',
+    )
+    const jsxMetadata = useEditorState(
+      (store) => store.editor.jsxMetadata,
+      'InsertionControls jsxMetadata',
+    )
+    const canvasOffset = useEditorState(
+      (store) => store.editor.canvas.realCanvasOffset,
+      'InsertionControls canvasOffset',
+    )
+    const scale = useEditorState((store) => store.editor.canvas.scale, 'InsertionControls scale')
+    if (selectedViews.length !== 1) {
       return null
     }
-    const selectedView = props.selectedViews[0]
+    const selectedView = selectedViews[0]
     const parentPath = selectedView
     const parentFrame =
-      parentPath != null
-        ? MetadataUtils.getFrameInCanvasCoords(parentPath, props.componentMetadata)
-        : null
+      parentPath != null ? MetadataUtils.getFrameInCanvasCoords(parentPath, jsxMetadata) : null
 
-    const parentElement = MetadataUtils.findElementByElementPath(
-      props.componentMetadata,
-      selectedView,
-    )
+    const parentElement = MetadataUtils.findElementByElementPath(jsxMetadata, selectedView)
     if (parentPath == null || parentFrame == null || parentElement == null) {
       return null
     }
-    const children = MetadataUtils.getChildren(props.componentMetadata, parentPath)
+    const children = MetadataUtils.getChildren(jsxMetadata, parentPath)
     let controlProps: ButtonControlProps[] = []
 
     if (
@@ -62,25 +69,25 @@ export const InsertionControls: React.FunctionComponent<React.PropsWithChildren<
 
       const beforeX =
         direction == 'column'
-          ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
-          : parentFrame.x + props.canvasOffset.x
+          ? parentFrame.x - InsertionButtonOffset + canvasOffset.x
+          : parentFrame.x + canvasOffset.x
       const beforeY =
         direction == 'column'
-          ? parentFrame.y + props.canvasOffset.y
-          : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
+          ? parentFrame.y + canvasOffset.y
+          : parentFrame.y - InsertionButtonOffset + canvasOffset.y
       const beforeLineEndX =
         direction == 'column'
-          ? parentFrame.x + parentFrame.width + props.canvasOffset.x
-          : parentFrame.x + props.canvasOffset.x
+          ? parentFrame.x + parentFrame.width + canvasOffset.x
+          : parentFrame.x + canvasOffset.x
       const beforeLineEndY =
         direction == 'column'
-          ? parentFrame.y + props.canvasOffset.y
-          : parentFrame.y + parentFrame.height + props.canvasOffset.y
+          ? parentFrame.y + canvasOffset.y
+          : parentFrame.y + parentFrame.height + canvasOffset.y
 
       if (direction != null) {
         controlProps.push({
           key: 'parent-0',
-          scale: props.scale,
+          scale: scale,
           positionX: beforeX,
           positionY: beforeY,
           lineEndX: beforeLineEndX,
@@ -96,10 +103,7 @@ export const InsertionControls: React.FunctionComponent<React.PropsWithChildren<
     }
 
     children.forEach((child, index) => {
-      const childFrame = MetadataUtils.getFrameInCanvasCoords(
-        child.elementPath,
-        props.componentMetadata,
-      )
+      const childFrame = MetadataUtils.getFrameInCanvasCoords(child.elementPath, jsxMetadata)
       if (child.specialSizeMeasurements.position !== 'absolute' && childFrame != null) {
         let direction: 'row' | 'column' | null = null
         if (child.specialSizeMeasurements.parentLayoutSystem === 'flex') {
@@ -115,24 +119,24 @@ export const InsertionControls: React.FunctionComponent<React.PropsWithChildren<
         if (direction != null) {
           const positionX =
             direction == 'column'
-              ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
-              : childFrame.x + childFrame.width + props.canvasOffset.x
+              ? parentFrame.x - InsertionButtonOffset + canvasOffset.x
+              : childFrame.x + childFrame.width + canvasOffset.x
           const positionY =
             direction == 'column'
-              ? childFrame.y + childFrame.height + props.canvasOffset.y
-              : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
+              ? childFrame.y + childFrame.height + canvasOffset.y
+              : parentFrame.y - InsertionButtonOffset + canvasOffset.y
 
           const lineEndX =
             direction == 'column'
-              ? parentFrame.x + parentFrame.width + props.canvasOffset.x
-              : childFrame.x + childFrame.width + props.canvasOffset.x
+              ? parentFrame.x + parentFrame.width + canvasOffset.x
+              : childFrame.x + childFrame.width + canvasOffset.x
           const lineEndY =
             direction == 'column'
-              ? childFrame.y + childFrame.height + props.canvasOffset.y
-              : parentFrame.y + parentFrame.height + props.canvasOffset.y
+              ? childFrame.y + childFrame.height + canvasOffset.y
+              : parentFrame.y + parentFrame.height + canvasOffset.y
           controlProps.push({
             key: EP.toString(child.elementPath),
-            scale: props.scale,
+            scale: scale,
             positionX: positionX,
             positionY: positionY,
             lineEndX: lineEndX,
@@ -148,23 +152,23 @@ export const InsertionControls: React.FunctionComponent<React.PropsWithChildren<
           if (index === 0) {
             const beforeX =
               direction == 'column'
-                ? parentFrame.x - InsertionButtonOffset + props.canvasOffset.x
-                : childFrame.x + props.canvasOffset.x
+                ? parentFrame.x - InsertionButtonOffset + canvasOffset.x
+                : childFrame.x + canvasOffset.x
             const beforeY =
               direction == 'column'
-                ? childFrame.y + props.canvasOffset.y
-                : parentFrame.y - InsertionButtonOffset + props.canvasOffset.y
+                ? childFrame.y + canvasOffset.y
+                : parentFrame.y - InsertionButtonOffset + canvasOffset.y
             const beforeLineEndX =
               direction == 'column'
-                ? parentFrame.x + parentFrame.width + props.canvasOffset.x
-                : childFrame.x + props.canvasOffset.x
+                ? parentFrame.x + parentFrame.width + canvasOffset.x
+                : childFrame.x + canvasOffset.x
             const beforeLineEndY =
               direction == 'column'
-                ? childFrame.y + props.canvasOffset.y
-                : parentFrame.y + parentFrame.height + props.canvasOffset.y
+                ? childFrame.y + canvasOffset.y
+                : parentFrame.y + parentFrame.height + canvasOffset.y
             controlProps.push({
               key: EP.toString(child.elementPath) + '0',
-              scale: props.scale,
+              scale: scale,
               positionX: beforeX,
               positionY: beforeY,
               lineEndX: beforeLineEndX,
@@ -187,7 +191,8 @@ export const InsertionControls: React.FunctionComponent<React.PropsWithChildren<
         ))}
       </>
     )
-  })
+  },
+)
 
 const InsertionButtonContainer = React.memo((props: ButtonControlProps) => {
   const [plusVisible, setPlusVisible] = React.useState(false)

--- a/editor/src/components/canvas/controls/insertion-plus-button.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.tsx
@@ -7,6 +7,7 @@ import { ElementPath } from '../../../core/shared/project-file-types'
 import * as EP from '../../../core/shared/element-path'
 import { openFloatingInsertMenu } from '../../editor/actions/action-creators'
 import { useColorTheme } from '../../../uuiui/styles/theme'
+import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 
 const InsertionButtonOffset = 10
 
@@ -24,6 +25,10 @@ interface ButtonControlProps {
 
 export const InsertionControls: React.FunctionComponent = React.memo(
   (): React.ReactElement | null => {
+    const isInteractionActive = useEditorState(
+      (store) => store.editor.canvas.interactionSession != null,
+      'DistanceGuidelineControl isInteractionActive',
+    )
     const selectedViews = useEditorState(
       (store) => store.editor.selectedViews,
       'InsertionControls selectedViews',
@@ -32,12 +37,8 @@ export const InsertionControls: React.FunctionComponent = React.memo(
       (store) => store.editor.jsxMetadata,
       'InsertionControls jsxMetadata',
     )
-    const canvasOffset = useEditorState(
-      (store) => store.editor.canvas.realCanvasOffset,
-      'InsertionControls canvasOffset',
-    )
     const scale = useEditorState((store) => store.editor.canvas.scale, 'InsertionControls scale')
-    if (selectedViews.length !== 1) {
+    if (selectedViews.length !== 1 || isInteractionActive) {
       return null
     }
     const selectedView = selectedViews[0]
@@ -67,22 +68,12 @@ export const InsertionControls: React.FunctionComponent = React.memo(
         // Ignore any other values.
       }
 
-      const beforeX =
-        direction == 'column'
-          ? parentFrame.x - InsertionButtonOffset + canvasOffset.x
-          : parentFrame.x + canvasOffset.x
-      const beforeY =
-        direction == 'column'
-          ? parentFrame.y + canvasOffset.y
-          : parentFrame.y - InsertionButtonOffset + canvasOffset.y
+      const beforeX = direction == 'column' ? parentFrame.x - InsertionButtonOffset : parentFrame.x
+      const beforeY = direction == 'column' ? parentFrame.y : parentFrame.y - InsertionButtonOffset
       const beforeLineEndX =
-        direction == 'column'
-          ? parentFrame.x + parentFrame.width + canvasOffset.x
-          : parentFrame.x + canvasOffset.x
+        direction == 'column' ? parentFrame.x + parentFrame.width : parentFrame.x
       const beforeLineEndY =
-        direction == 'column'
-          ? parentFrame.y + canvasOffset.y
-          : parentFrame.y + parentFrame.height + canvasOffset.y
+        direction == 'column' ? parentFrame.y : parentFrame.y + parentFrame.height
 
       if (direction != null) {
         controlProps.push({
@@ -119,21 +110,21 @@ export const InsertionControls: React.FunctionComponent = React.memo(
         if (direction != null) {
           const positionX =
             direction == 'column'
-              ? parentFrame.x - InsertionButtonOffset + canvasOffset.x
-              : childFrame.x + childFrame.width + canvasOffset.x
+              ? parentFrame.x - InsertionButtonOffset
+              : childFrame.x + childFrame.width
           const positionY =
             direction == 'column'
-              ? childFrame.y + childFrame.height + canvasOffset.y
-              : parentFrame.y - InsertionButtonOffset + canvasOffset.y
+              ? childFrame.y + childFrame.height
+              : parentFrame.y - InsertionButtonOffset
 
           const lineEndX =
             direction == 'column'
-              ? parentFrame.x + parentFrame.width + canvasOffset.x
-              : childFrame.x + childFrame.width + canvasOffset.x
+              ? parentFrame.x + parentFrame.width
+              : childFrame.x + childFrame.width
           const lineEndY =
             direction == 'column'
-              ? childFrame.y + childFrame.height + canvasOffset.y
-              : parentFrame.y + parentFrame.height + canvasOffset.y
+              ? childFrame.y + childFrame.height
+              : parentFrame.y + parentFrame.height
           controlProps.push({
             key: EP.toString(child.elementPath),
             scale: scale,
@@ -151,21 +142,13 @@ export const InsertionControls: React.FunctionComponent = React.memo(
           // first element has a plus button before the element too
           if (index === 0) {
             const beforeX =
-              direction == 'column'
-                ? parentFrame.x - InsertionButtonOffset + canvasOffset.x
-                : childFrame.x + canvasOffset.x
+              direction == 'column' ? parentFrame.x - InsertionButtonOffset : childFrame.x
             const beforeY =
-              direction == 'column'
-                ? childFrame.y + canvasOffset.y
-                : parentFrame.y - InsertionButtonOffset + canvasOffset.y
+              direction == 'column' ? childFrame.y : parentFrame.y - InsertionButtonOffset
             const beforeLineEndX =
-              direction == 'column'
-                ? parentFrame.x + parentFrame.width + canvasOffset.x
-                : childFrame.x + canvasOffset.x
+              direction == 'column' ? parentFrame.x + parentFrame.width : childFrame.x
             const beforeLineEndY =
-              direction == 'column'
-                ? childFrame.y + canvasOffset.y
-                : parentFrame.y + parentFrame.height + canvasOffset.y
+              direction == 'column' ? childFrame.y : parentFrame.y + parentFrame.height
             controlProps.push({
               key: EP.toString(child.elementPath) + '0',
               scale: scale,
@@ -185,11 +168,11 @@ export const InsertionControls: React.FunctionComponent = React.memo(
       }
     })
     return (
-      <>
+      <CanvasOffsetWrapper>
         {controlProps.map((control) => (
           <InsertionButtonContainer {...control} key={control.key} />
         ))}
-      </>
+      </CanvasOffsetWrapper>
     )
   },
 )

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -69,6 +69,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend'
 import { OutlineHighlightControl } from './select-mode/outline-highlight-control'
 import { InsertionControls } from './insertion-plus-button'
 import { DistanceGuidelineControl } from './select-mode/distance-guideline-control'
+import { SceneLabelControl } from './select-mode/scene-label'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -437,7 +438,14 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       onMouseMove={onMouseMove}
     >
       {renderModeControlContainer()}
-      {renderHighlightControls()}
+      {when(
+        (isFeatureEnabled('Canvas Strategies') && props.editor.mode.type === 'select') ||
+          props.editor.mode.type === 'select-lite',
+        <SceneLabelControl
+          maybeHighlightOnHover={maybeHighlightOnHover}
+          maybeClearHighlightsOnHoverEnd={maybeClearHighlightsOnHoverEnd}
+        />,
+      )}
       {when(
         (isFeatureEnabled('Canvas Strategies') && props.editor.mode.type === 'select') ||
           props.editor.mode.type === 'select-lite',
@@ -450,6 +458,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           props.editor.mode.type === 'select-lite',
         <InsertionControls />,
       )}
+      {renderHighlightControls()}
       <LayoutParentControl />
       {when(
         isFeatureEnabled('Canvas Strategies'),

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -67,6 +67,7 @@ import { GuidelineControls } from './guideline-controls'
 import { showContextMenu } from '../../editor/actions/action-creators'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import { OutlineHighlightControl } from './select-mode/outline-highlight-control'
+import { InsertionControls } from './insertion-plus-button'
 import { DistanceGuidelineControl } from './select-mode/distance-guideline-control'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
@@ -441,6 +442,13 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
         (isFeatureEnabled('Canvas Strategies') && props.editor.mode.type === 'select') ||
           props.editor.mode.type === 'select-lite',
         <DistanceGuidelineControl />,
+      )}
+      {when(
+        (isFeatureEnabled('Canvas Strategies') &&
+          isFeatureEnabled('Insertion Plus Button') &&
+          props.editor.mode.type === 'select') ||
+          props.editor.mode.type === 'select-lite',
+        <InsertionControls />,
       )}
       <LayoutParentControl />
       {when(

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -67,6 +67,7 @@ import { GuidelineControls } from './guideline-controls'
 import { showContextMenu } from '../../editor/actions/action-creators'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import { OutlineHighlightControl } from './select-mode/outline-highlight-control'
+import { DistanceGuidelineControl } from './select-mode/distance-guideline-control'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -436,6 +437,11 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
     >
       {renderModeControlContainer()}
       {renderHighlightControls()}
+      {when(
+        (isFeatureEnabled('Canvas Strategies') && props.editor.mode.type === 'select') ||
+          props.editor.mode.type === 'select-lite',
+        <DistanceGuidelineControl />,
+      )}
       <LayoutParentControl />
       {when(
         isFeatureEnabled('Canvas Strategies'),

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -515,7 +515,7 @@ export class SelectModeControlContainer extends React.Component<
                 />
               </>
             ) : null}
-            <ZeroSizedElementControls {...this.props} />
+            <ZeroSizedElementControls />
           </>
         ) : null}
         {when(isFeatureEnabled('Insertion Plus Button'), <InsertionControls />)}

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -390,8 +390,6 @@ export class SelectModeControlContainer extends React.Component<
               canvasOffset={this.props.canvasOffset}
               scale={this.props.scale}
               guidelines={distanceGuidelines}
-              selectedViews={this.props.selectedViews}
-              highlightedViews={this.props.highlightedViews}
               boundingBox={boundingBox}
             />,
           )

--- a/editor/src/components/canvas/controls/select-mode-control-container.tsx
+++ b/editor/src/components/canvas/controls/select-mode-control-container.tsx
@@ -518,7 +518,7 @@ export class SelectModeControlContainer extends React.Component<
             <ZeroSizedElementControls {...this.props} />
           </>
         ) : null}
-        {when(isFeatureEnabled('Insertion Plus Button'), <InsertionControls {...this.props} />)}
+        {when(isFeatureEnabled('Insertion Plus Button'), <InsertionControls />)}
         {this.getMoveGuidelines()}
         {this.getDistanceGuidelines()}
         {this.getBoundingMarks()}

--- a/editor/src/components/canvas/controls/select-mode/distance-guideline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/distance-guideline-control.tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import { flatMapArray, mapDropNulls } from '../../../../core/shared/array-utils'
+import * as EP from '../../../../core/shared/element-path'
+import { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
+import { CanvasRectangle } from '../../../../core/shared/math-utils'
+import { ElementPath } from '../../../../core/shared/project-file-types'
+import { fastForEach } from '../../../../core/shared/utils'
+import { useEditorState } from '../../../editor/store/store-hook'
+import { getMultiselectBounds } from '../../canvas-strategies/shared-absolute-move-strategy-helpers'
+import { Guideline, Guidelines } from '../../guideline'
+import { DistanceGuideline } from '../distance-guideline'
+
+function getDistanceGuidelines(
+  highlightedView: ElementPath,
+  componentMetadata: ElementInstanceMetadataMap,
+): Array<Guideline> {
+  const frame = MetadataUtils.getFrameInCanvasCoords(highlightedView, componentMetadata)
+  if (frame == null) {
+    return []
+  } else {
+    return Guidelines.guidelinesForFrame(frame, false)
+  }
+}
+
+export const DistanceGuidelineControl = React.memo(() => {
+  const selectedElements = useEditorState(
+    (store) => store.editor.selectedViews,
+    'DistanceGuidelineControl selectedElements',
+  )
+  const isInteractionActive = useEditorState(
+    (store) => store.editor.canvas.interactionSession != null,
+    'DistanceGuidelineControl isInteractionActive',
+  )
+
+  const altKeyPressed = useEditorState(
+    (store) => store.editor.keysPressed['alt'],
+    'DistanceGuidelineControl altKeyPressed',
+  )
+  const highlightedViews = useEditorState(
+    (store) => store.editor.highlightedViews,
+    'DistanceGuidelineControl highlightedViews',
+  )
+
+  const scale = useEditorState(
+    (store) => store.editor.canvas.scale,
+    'DistanceGuidelineControl scale',
+  )
+  const canvasOffset = useEditorState(
+    (store) => store.editor.canvas.realCanvasOffset,
+    'DistanceGuidelineControl canvasOffset',
+  )
+  const jsxMetadata = useEditorState(
+    (store) => store.editor.jsxMetadata,
+    'DistanceGuidelineControl jsxMetadata',
+  )
+
+  if (selectedElements.length > 0 && !isInteractionActive && altKeyPressed) {
+    let boundingBoxes: CanvasRectangle[] = []
+    if (EP.areAllElementsInSameInstance(selectedElements)) {
+      const multiSelectBounds = getMultiselectBounds(jsxMetadata, selectedElements)
+      if (multiSelectBounds != null) {
+        boundingBoxes = [multiSelectBounds]
+      }
+    } else {
+      boundingBoxes = mapDropNulls((element) => {
+        return MetadataUtils.getFrameInCanvasCoords(element, jsxMetadata)
+      }, selectedElements)
+    }
+
+    if (boundingBoxes.length === 0) {
+      return null
+    }
+
+    let guideLineElements: Array<JSX.Element> = []
+    fastForEach(boundingBoxes, (boundingBox, index) => {
+      let distanceGuidelines: Array<Guideline> = []
+      if (highlightedViews.length !== 0) {
+        distanceGuidelines = flatMapArray((highlightedView) => {
+          const highlightedViewIsSelected = selectedElements.some((selectedElement) =>
+            EP.pathsEqual(selectedElement, highlightedView),
+          )
+          if (highlightedViewIsSelected) {
+            return []
+          } else {
+            if (EP.isFromSameInstanceAs(highlightedView, selectedElements[index])) {
+              return getDistanceGuidelines(highlightedView, jsxMetadata)
+            } else {
+              return []
+            }
+          }
+        }, highlightedViews)
+      } else {
+        const parentPath = EP.parentPath(selectedElements[0])
+        if (parentPath != null) {
+          if (EP.isFromSameInstanceAs(parentPath, selectedElements[index])) {
+            distanceGuidelines = getDistanceGuidelines(parentPath, jsxMetadata)
+          }
+        }
+      }
+      guideLineElements.push(
+        <DistanceGuideline
+          key={`${EP.toComponentId(selectedElements[index])}-distance-guidelines`}
+          canvasOffset={canvasOffset}
+          scale={scale}
+          guidelines={distanceGuidelines}
+          selectedViews={selectedElements}
+          highlightedViews={highlightedViews}
+          boundingBox={boundingBox}
+        />,
+      )
+    })
+
+    return <>{guideLineElements}</>
+  } else {
+    return null
+  }
+})

--- a/editor/src/components/canvas/controls/select-mode/distance-guideline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/distance-guideline-control.tsx
@@ -44,15 +44,6 @@ export const DistanceGuidelineControl = React.memo(() => {
 })
 
 const DistanceGuidelineControlInner = React.memo(() => {
-  const highlightedViews = useEditorState(
-    (store) => store.editor.highlightedViews,
-    'DistanceGuidelineControl highlightedViews',
-  )
-  const selectedElements = useEditorState(
-    (store) => store.editor.selectedViews,
-    'DistanceGuidelineControl selectedElements',
-  )
-
   const scale = useEditorState(
     (store) => store.editor.canvas.scale,
     'DistanceGuidelineControl scale',
@@ -60,10 +51,6 @@ const DistanceGuidelineControlInner = React.memo(() => {
   const canvasOffset = useEditorState(
     (store) => store.editor.canvas.realCanvasOffset,
     'DistanceGuidelineControl canvasOffset',
-  )
-  const jsxMetadata = useEditorState(
-    (store) => store.editor.jsxMetadata,
-    'DistanceGuidelineControl jsxMetadata',
   )
   const boundingBoxes = useEditorState((store) => {
     if (EP.areAllElementsInSameInstance(store.editor.selectedViews)) {
@@ -86,30 +73,30 @@ const DistanceGuidelineControlInner = React.memo(() => {
   const distanceGuidelines = useEditorState((store) => {
     let guidelineInfo: Array<{ guidelines: Array<Guideline>; boundingBox: CanvasRectangle }> = []
     fastForEach(boundingBoxes, (boundingBox, index) => {
-      if (highlightedViews.length !== 0) {
+      if (store.editor.highlightedViews.length !== 0) {
         const guidelinesForHighlightedViews = flatMapArray((highlightedView) => {
-          const highlightedViewIsSelected = selectedElements.some((selectedElement) =>
+          const highlightedViewIsSelected = store.editor.selectedViews.some((selectedElement) =>
             EP.pathsEqual(selectedElement, highlightedView),
           )
           if (highlightedViewIsSelected) {
             return []
           } else {
-            if (EP.isFromSameInstanceAs(highlightedView, selectedElements[index])) {
-              return getDistanceGuidelines(highlightedView, jsxMetadata)
+            if (EP.isFromSameInstanceAs(highlightedView, store.editor.selectedViews[index])) {
+              return getDistanceGuidelines(highlightedView, store.editor.jsxMetadata)
             } else {
               return []
             }
           }
-        }, highlightedViews)
+        }, store.editor.highlightedViews)
         guidelineInfo.push({
           guidelines: guidelinesForHighlightedViews,
           boundingBox: boundingBox,
         })
       } else {
-        const parentPath = EP.parentPath(selectedElements[0])
+        const parentPath = EP.parentPath(store.editor.selectedViews[0])
         if (parentPath != null) {
-          if (EP.isFromSameInstanceAs(parentPath, selectedElements[index])) {
-            const guidelinesForParent = getDistanceGuidelines(parentPath, jsxMetadata)
+          if (EP.isFromSameInstanceAs(parentPath, store.editor.selectedViews[index])) {
+            const guidelinesForParent = getDistanceGuidelines(parentPath, store.editor.jsxMetadata)
             guidelineInfo.push({
               guidelines: guidelinesForParent,
               boundingBox: boundingBox,
@@ -126,12 +113,10 @@ const DistanceGuidelineControlInner = React.memo(() => {
       <>
         {distanceGuidelines.map((guidelineInfo, index) => (
           <DistanceGuideline
-            key={`${EP.toComponentId(selectedElements[index])}-distance-guidelines`}
+            key={`${index}-distance-guidelines`}
             canvasOffset={canvasOffset}
             scale={scale}
             guidelines={guidelineInfo.guidelines}
-            selectedViews={selectedElements}
-            highlightedViews={highlightedViews}
             boundingBox={guidelineInfo.boundingBox}
           />
         ))}

--- a/editor/src/components/canvas/controls/select-mode/distance-guideline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/distance-guideline-control.tsx
@@ -28,11 +28,22 @@ export const DistanceGuidelineControl = React.memo(() => {
     (store) => store.editor.canvas.interactionSession != null,
     'DistanceGuidelineControl isInteractionActive',
   )
-
   const altKeyPressed = useEditorState(
     (store) => store.editor.keysPressed['alt'],
     'DistanceGuidelineControl altKeyPressed',
   )
+  const selectedElements = useEditorState(
+    (store) => store.editor.selectedViews,
+    'DistanceGuidelineControl selectedElements',
+  )
+  if (selectedElements.length > 0 && !isInteractionActive && altKeyPressed) {
+    return <DistanceGuidelineControlInner />
+  } else {
+    return null
+  }
+})
+
+const DistanceGuidelineControlInner = React.memo(() => {
   const highlightedViews = useEditorState(
     (store) => store.editor.highlightedViews,
     'DistanceGuidelineControl highlightedViews',
@@ -110,12 +121,7 @@ export const DistanceGuidelineControl = React.memo(() => {
     return guidelineInfo
   }, 'DistanceGuidelineControl distanceGuidelines')
 
-  if (
-    selectedElements.length > 0 &&
-    !isInteractionActive &&
-    altKeyPressed &&
-    boundingBoxes.length !== 0
-  ) {
+  if (boundingBoxes.length !== 0) {
     return (
       <>
         {distanceGuidelines.map((guidelineInfo, index) => (

--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -54,7 +54,12 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
     'SceneLabel Z key pressed',
   )
   const label = useEditorState(
-    (store) => MetadataUtils.getElementLabel(props.target, store.editor.jsxMetadata),
+    (store) =>
+      MetadataUtils.getElementLabel(
+        store.editor.allElementProps,
+        props.target,
+        store.editor.jsxMetadata,
+      ),
     'SceneLabel label',
   )
   const frame = useEditorState(

--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -1,0 +1,163 @@
+import React from 'react'
+import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
+import * as EP from '../../../../core/shared/element-path'
+import { windowPoint } from '../../../../core/shared/math-utils'
+import { ElementPath } from '../../../../core/shared/project-file-types'
+import { NO_OP } from '../../../../core/shared/utils'
+import { Modifier } from '../../../../utils/modifiers'
+import { useColorTheme } from '../../../../uuiui'
+import { clearHighlightedViews, selectComponents } from '../../../editor/actions/action-creators'
+import { useEditorState } from '../../../editor/store/store-hook'
+import CanvasActions from '../../canvas-actions'
+import { ControlFontSize } from '../../canvas-controls-frame'
+import { boundingArea, createInteractionViaMouse } from '../../canvas-strategies/interaction-state'
+import { windowToCanvasCoordinates } from '../../dom-lookup'
+import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
+
+interface SceneLabelControlProps {
+  maybeHighlightOnHover: (target: ElementPath) => void
+  maybeClearHighlightsOnHoverEnd: () => void
+}
+
+interface SceneLabelProps extends SceneLabelControlProps {
+  target: ElementPath
+}
+
+export const SceneLabelControl = React.memo<SceneLabelControlProps>((props) => {
+  const sceneTargets = useEditorState(
+    (store) =>
+      Object.values(store.editor.jsxMetadata).filter((element) =>
+        MetadataUtils.isProbablyScene(store.editor.jsxMetadata, element.elementPath),
+      ),
+    'SceneLabelControl',
+  )
+  return (
+    <>
+      {sceneTargets.map((element) => (
+        <SceneLabel
+          key={EP.toString(element.elementPath)}
+          target={element.elementPath}
+          maybeHighlightOnHover={props.maybeHighlightOnHover}
+          maybeClearHighlightsOnHoverEnd={props.maybeClearHighlightsOnHoverEnd}
+        />
+      ))}
+    </>
+  )
+})
+
+const SceneLabel = React.memo<SceneLabelProps>((props) => {
+  const colorTheme = useColorTheme()
+  const dispatch = useEditorState((store) => store.dispatch, 'SceneLabel dispatch')
+
+  const labelSelectable = useEditorState(
+    (store) => !store.editor.keysPressed['z'],
+    'SceneLabel Z key pressed',
+  )
+  const label = useEditorState(
+    (store) => MetadataUtils.getElementLabel(props.target, store.editor.jsxMetadata),
+    'SceneLabel label',
+  )
+  const frame = useEditorState(
+    (store) => MetadataUtils.getFrameInCanvasCoords(props.target, store.editor.jsxMetadata),
+    'SceneLabel frame',
+  )
+
+  const canvasOffset = useEditorState(
+    (store) => store.editor.canvas.realCanvasOffset,
+    'SceneLabel canvasOffset',
+  )
+  const scale = useEditorState((store) => store.editor.canvas.scale, 'SceneLabel scale')
+  const scaledFontSize = ControlFontSize / scale
+  const offsetY = -(scaledFontSize * 1.5)
+  const offsetX = 3 / scale
+
+  const isSelected = useEditorState(
+    (store) => store.editor.selectedViews.some((view) => EP.pathsEqual(props.target, view)),
+    'SceneLabel isSelected',
+  )
+  const isHighlighted = useEditorState(
+    (store) => store.editor.selectedViews.some((view) => EP.pathsEqual(props.target, view)),
+    'SceneLabel isHighlighted',
+  )
+
+  const onMouseMove = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => event.stopPropagation(),
+    [],
+  )
+  const onMouseOver = React.useCallback(() => {
+    if (!isHighlighted) {
+      if (isSelected) {
+        props.maybeClearHighlightsOnHoverEnd()
+      } else {
+        props.maybeHighlightOnHover(props.target)
+      }
+    }
+  }, [isHighlighted, isSelected, props])
+
+  const onMouseLeave = React.useCallback(() => {
+    if (isHighlighted) {
+      dispatch([clearHighlightedViews()], 'canvas')
+    }
+  }, [dispatch, isHighlighted])
+
+  const onMouseDown = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.buttons === 1 && event.button !== 2) {
+        event.stopPropagation()
+
+        const isMultiselect = event.shiftKey
+        const selectAction = selectComponents([props.target], isMultiselect)
+        const canvasPositions = windowToCanvasCoordinates(
+          scale,
+          canvasOffset,
+          windowPoint({ x: event.nativeEvent.x, y: event.nativeEvent.y }),
+        )
+
+        const dragAction = CanvasActions.createInteractionSession(
+          createInteractionViaMouse(
+            canvasPositions.canvasPositionRaw,
+            Modifier.modifiersForEvent(event),
+            boundingArea(props.target),
+          ),
+        )
+        dispatch([selectAction, dragAction], 'canvas')
+      }
+    },
+    [dispatch, scale, canvasOffset, props.target],
+  )
+
+  if (frame != null) {
+    return (
+      <CanvasOffsetWrapper>
+        <div
+          onMouseOver={labelSelectable ? onMouseOver : NO_OP}
+          onMouseOut={labelSelectable ? onMouseLeave : NO_OP}
+          onMouseDown={labelSelectable ? onMouseDown : NO_OP}
+          onMouseMove={labelSelectable ? onMouseMove : NO_OP}
+          className='roleComponentName'
+          style={{
+            pointerEvents: labelSelectable ? 'initial' : 'none',
+            color: colorTheme.subduedForeground.value,
+            position: 'absolute',
+            fontWeight: 500,
+            left: frame.x + offsetX,
+            top: frame.y + offsetY,
+            maxWidth: frame.width,
+            paddingBottom: '0px',
+            fontFamily:
+              '-apple-system, BlinkMacSystemFont, Helvetica, "Segoe UI", Roboto,  Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+            fontSize: scaledFontSize,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            textDecoration: isSelected || isHighlighted ? 'underline' : undefined,
+          }}
+        >
+          {label}
+        </div>
+      </CanvasOffsetWrapper>
+    )
+  } else {
+    return null
+  }
+})

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -5,7 +5,6 @@ import { jsx, css } from '@emotion/react'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
 import { useColorTheme } from '../../../uuiui'
-import { ControlProps } from './new-canvas-controls'
 import {
   ElementInstanceMetadata,
   emptyComments,
@@ -22,35 +21,53 @@ import { EditorDispatch } from '../../editor/action-types'
 import { isZeroSizedElement, ZeroControlSize } from './outline-utils'
 import { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
+import { useEditorState } from '../../editor/store/store-hook'
 
 const EmptyChildren: ElementInstanceMetadata[] = []
-export const ZeroSizedElementControls = React.memo((props: ControlProps) => {
-  let zeroSizeChildren = EmptyChildren
-  if (props.cmdKeyPressed) {
-    zeroSizeChildren = props.selectedViews.flatMap((view) => {
-      const children = MetadataUtils.getChildren(props.componentMetadata, view)
-      return children.filter((child) => {
-        if (child.globalFrame == null) {
-          return false
-        } else {
-          return isZeroSizedElement(child.globalFrame)
-        }
+export const ZeroSizedElementControls = React.memo(() => {
+  const highlightedViews = useEditorState(
+    (store) => store.editor.highlightedViews,
+    'ZeroSizedElementControls highlightedViews',
+  )
+  const canvasOffset = useEditorState(
+    (store) => store.editor.canvas.realCanvasOffset,
+    'ZeroSizedElementControls canvasOffset',
+  )
+  const scale = useEditorState(
+    (store) => store.editor.canvas.scale,
+    'ZeroSizedElementControls scale',
+  )
+  const dispatch = useEditorState((store) => store.dispatch, 'ZeroSizedElementControls dispatch')
+
+  const zeroSizeChildren = useEditorState((store) => {
+    if (store.editor.keysPressed['cmd']) {
+      return store.editor.selectedViews.flatMap((view) => {
+        const children = MetadataUtils.getChildren(store.editor.jsxMetadata, view)
+        return children.filter((child) => {
+          if (child.globalFrame == null) {
+            return false
+          } else {
+            return isZeroSizedElement(child.globalFrame)
+          }
+        })
       })
-    })
-  }
+    } else {
+      return EmptyChildren
+    }
+  }, 'ZeroSizedElementControls selectedViews')
 
   return (
     <React.Fragment>
       {zeroSizeChildren.map((element) => {
         let isHighlighted =
-          props.highlightedViews.find((view) => EP.pathsEqual(element.elementPath, view)) != null
+          highlightedViews.find((view) => EP.pathsEqual(element.elementPath, view)) != null
         return (
           <ZeroSizeSelectControl
             key={`zero-size-element-${EP.toString(element.elementPath)}`}
             element={element}
-            dispatch={props.dispatch}
-            canvasOffset={props.canvasOffset}
-            scale={props.scale}
+            dispatch={dispatch}
+            canvasOffset={canvasOffset}
+            scale={scale}
             isHighlighted={isHighlighted}
           />
         )

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`421`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`424`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`484`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`487`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`573`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`576`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`645`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`648`)
   })
 })


### PR DESCRIPTION
**Problem:**
Some select mode controls are not visible during strategies. 

**Fix:**
Collected these controls and moved the guidelines to a new component and cleaned up the props for the others to use hooks, plus changed them to use `CanvasOffsetWrapper` to keep them from rerendering during canvas scroll. With this the SelectModeControlContainer can be deleted when we remove the feature flag for the strategies.
Zero size control only has the highlight the resize part of the control is still a TODO.

This PR adds these controls:
- distance guidelines which are visible between the selected and highlighted (or parent) element when pressing the alt key
- zero size highlight (can be seen on navigator mouseover)
- scene label which highlights and allows dragging
- for flex children the insertion plus button

Still missing (until the next PR):
- margin and padding controls
- zero size resize control
