### PR TITLE
assert invalidatedPaths in dom-walker-caching.spec

### DIFF
--- a/editor/src/components/canvas/dom-walker-caching.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker-caching.spec.browser2.tsx
@@ -77,7 +77,7 @@ describe('Dom-walker Caching', () => {
             ],
           },
         ],
-        false,
+        true,
       )
     })
 
@@ -98,21 +98,45 @@ describe('Dom-walker Caching', () => {
       await dispatchDone
     })
 
+    expect(renderResult.getRecordedActions().map((a) => a.action)).toEqual([
+      'SET_ELEMENTS_TO_RERENDER',
+      'SET_CANVAS_FRAMES',
+      'UPDATE_FROM_WORKER',
+      'SAVE_DOM_REPORT',
+      'SAVE_DOM_REPORT',
+      'SET_CANVAS_FRAMES',
+      'UPDATE_FROM_WORKER',
+      'SAVE_DOM_REPORT',
+      'SAVE_DOM_REPORT',
+    ])
+
     const saveDomReportActions = renderResult
       .getRecordedActions()
       .filter((action): action is SaveDOMReport => action.action === 'SAVE_DOM_REPORT')
 
     expect(saveDomReportActions.length).toBe(4)
+
+    expect(saveDomReportActions[1].invalidatedPaths).toEqual(['storyboard-entity/scene-1-entity'])
     expect(saveDomReportActions[1].cachedPaths).toEqual([
       EP.fromString(':storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div'),
       EP.fromString(':storyboard-entity/scene-2-entity/same-file-app-entity'),
       EP.fromString(':storyboard-entity/scene-2-entity'),
+    ])
+
+    expect(saveDomReportActions[2].invalidatedPaths).toEqual([
+      'storyboard-entity/scene-1-entity',
+      'storyboard-entity',
+      'storyboard-entity/scene-1-entity/app-entity:app-outer-div',
+      'storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div',
+      'storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div',
     ])
     expect(saveDomReportActions[2].cachedPaths).toEqual([
       EP.fromString(':storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div'),
       EP.fromString(':storyboard-entity/scene-2-entity/same-file-app-entity'),
       EP.fromString(':storyboard-entity/scene-2-entity'),
     ])
+
+    expect(saveDomReportActions[3].invalidatedPaths).toEqual(['storyboard-entity/scene-1-entity'])
     expect(saveDomReportActions[3].cachedPaths).toEqual([
       EP.fromString(':storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div'),
       EP.fromString(':storyboard-entity/scene-2-entity/same-file-app-entity'),
@@ -172,12 +196,34 @@ describe('Dom-walker Caching', () => {
       .getRecordedActions()
       .filter((action): action is SaveDOMReport => action.action === 'SAVE_DOM_REPORT')
 
+    expect(renderResult.getRecordedActions().map((a) => a.action)).toEqual([
+      'SET_ELEMENTS_TO_RERENDER',
+      'SET_CANVAS_FRAMES',
+      'UPDATE_FROM_WORKER',
+      'SAVE_DOM_REPORT',
+      'SAVE_DOM_REPORT',
+      'SET_CANVAS_FRAMES',
+      'UPDATE_FROM_WORKER',
+      'SAVE_DOM_REPORT',
+      'SAVE_DOM_REPORT',
+    ])
+
     expect(saveDomReportActions.length).toBe(4)
+
+    expect(saveDomReportActions[1].invalidatedPaths).toEqual(['storyboard-entity/scene-2-entity'])
     expect(saveDomReportActions[1].cachedPaths).toEqual([
       EP.fromString(':storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance'),
       EP.fromString(':storyboard-entity/scene-1-entity/app-entity:app-outer-div'),
       EP.fromString(':storyboard-entity/scene-1-entity/app-entity'),
       EP.fromString(':storyboard-entity/scene-1-entity'),
+    ])
+
+    expect(saveDomReportActions[2].invalidatedPaths).toEqual([
+      'storyboard-entity/scene-2-entity',
+      'storyboard-entity',
+      'storyboard-entity/scene-1-entity/app-entity:app-outer-div',
+      'storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div',
+      'storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div',
     ])
     expect(saveDomReportActions[2].cachedPaths).toEqual([
       EP.fromString(':storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance'),
@@ -185,6 +231,8 @@ describe('Dom-walker Caching', () => {
       EP.fromString(':storyboard-entity/scene-1-entity/app-entity'),
       EP.fromString(':storyboard-entity/scene-1-entity'),
     ])
+
+    expect(saveDomReportActions[3].invalidatedPaths).toEqual(['storyboard-entity/scene-2-entity'])
     expect(saveDomReportActions[3].cachedPaths).toEqual([
       EP.fromString(':storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance'),
       EP.fromString(':storyboard-entity/scene-1-entity/app-entity:app-outer-div'),

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -302,7 +302,11 @@ export function runDomWalker({
   scale,
   additionalElementsToUpdate,
   rootMetadataInStateRef,
-}: RunDomWalkerParams): { metadata: ElementInstanceMetadata[]; cachedPaths: ElementPath[] } | null {
+}: RunDomWalkerParams): {
+  metadata: ElementInstanceMetadata[]
+  cachedPaths: ElementPath[]
+  invalidatedPaths: string[]
+} | null {
   const needsWalk =
     !domWalkerMutableState.initComplete || domWalkerMutableState.invalidatedPaths.size > 0
 
@@ -319,6 +323,9 @@ export function runDomWalker({
     if (LogDomWalkerPerformance) {
       performance.mark('DOM_WALKER_START')
     }
+
+    const invalidatedPaths = Array.from(domWalkerMutableState.invalidatedPaths)
+
     // Get some base values relating to the div this component creates.
     if (
       ObserversAvailable &&
@@ -363,7 +370,7 @@ export function runDomWalker({
     // Fragments will appear as multiple separate entries with duplicate UIDs, so we need to handle those
     const fixedMetadata = mergeFragmentMetadata(metadata)
 
-    return { metadata: fixedMetadata, cachedPaths: cachedPaths }
+    return { metadata: fixedMetadata, cachedPaths: cachedPaths, invalidatedPaths: invalidatedPaths }
   } else {
     // TODO flip if-else
     return null

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -231,6 +231,7 @@ export async function renderTestEditorWithModel(
       const saveDomReportAction = saveDOMReport(
         domWalkerResult.metadata,
         domWalkerResult.cachedPaths,
+        domWalkerResult.invalidatedPaths,
       )
       recordedActions.push(saveDomReportAction)
       const editorWithNewMetadata = editorDispatch(

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -655,6 +655,7 @@ export interface SaveDOMReport {
   action: 'SAVE_DOM_REPORT'
   elementMetadata: ReadonlyArray<ElementInstanceMetadata>
   cachedPaths: Array<ElementPath>
+  invalidatedPaths: Array<string>
 }
 
 export interface SetProp {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1017,11 +1017,13 @@ export function setMainUIFile(uiFile: string): SetMainUIFile {
 export function saveDOMReport(
   elementMetadata: ReadonlyArray<ElementInstanceMetadata>,
   cachedPaths: Array<ElementPath>,
+  invalidatedPaths: Array<string>,
 ): SaveDOMReport {
   return {
     action: 'SAVE_DOM_REPORT',
     elementMetadata: elementMetadata,
     cachedPaths: cachedPaths,
+    invalidatedPaths: invalidatedPaths,
   }
 }
 

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -400,7 +400,13 @@ export class Editor {
         if (domWalkerResult != null) {
           dispatchResultWithMetadata = editorDispatch(
             this.boundDispatch,
-            [EditorActions.saveDOMReport(domWalkerResult.metadata, domWalkerResult.cachedPaths)],
+            [
+              EditorActions.saveDOMReport(
+                domWalkerResult.metadata,
+                domWalkerResult.cachedPaths,
+                domWalkerResult.invalidatedPaths,
+              ),
+            ],
             dispatchResult,
             this.spyCollector,
           )


### PR DESCRIPTION
**Problem:**
The set of invalidatedPaths holds crucial insight into how the dom walker caching works. Recently Balint and I were also making changes to it, and we had trouble with visibility into how / what we actually changed.

**Fix:**
The dom walker result now contains the invalidatedPaths as it were when the walker started walking.
Assert on the invalidatedPaths in the dom walker caching tests.
