### PR TITLE
Fix/canvas strategies controls zero size element

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -35,6 +35,7 @@ import {
   runLegacyAbsoluteResizeSnapping,
 } from './shared-absolute-resize-strategy-helpers'
 import * as EP from '../../../core/shared/element-path'
+import { ZeroSizeResizeControlWrapper } from '../controls/zero-sized-element-controls'
 
 export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
@@ -60,6 +61,11 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
   },
   controlsToRender: [
     { control: AbsoluteResizeControl, key: 'absolute-resize-control', show: 'always-visible' },
+    {
+      control: ZeroSizeResizeControlWrapper,
+      key: 'zero-size-resize-control',
+      show: 'always-visible',
+    },
     { control: ParentOutlines, key: 'parent-outlines-control', show: 'visible-only-while-active' },
     { control: ParentBounds, key: 'parent-bounds-control', show: 'visible-only-while-active' },
   ],

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.tsx
@@ -11,6 +11,7 @@ import { updateHighlightedViews } from '../commands/update-highlighted-views-com
 import { ParentBounds } from '../controls/parent-bounds'
 import { ParentOutlines } from '../controls/parent-outlines'
 import { AbsoluteResizeControl } from '../controls/select-mode/absolute-resize-control'
+import { ZeroSizeResizeControlWrapper } from '../controls/zero-sized-element-controls'
 import { GuidelineWithSnappingVector } from '../guideline'
 import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
 import { getMultiselectBounds } from './shared-absolute-move-strategy-helpers'
@@ -41,6 +42,11 @@ export const absoluteResizeDeltaStrategy: CanvasStrategy = {
   },
   controlsToRender: [
     { control: AbsoluteResizeControl, key: 'absolute-resize-control', show: 'always-visible' },
+    {
+      control: ZeroSizeResizeControlWrapper,
+      key: 'zero-size-resize-control',
+      show: 'always-visible',
+    },
     { control: ParentOutlines, key: 'parent-outlines-control', show: 'visible-only-while-active' },
     { control: ParentBounds, key: 'parent-bounds-control', show: 'visible-only-while-active' },
   ],

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -33,6 +33,7 @@ import { ParentBounds } from '../controls/parent-bounds'
 import { ParentOutlines } from '../controls/parent-outlines'
 import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
 import { AnimationTimer, PieTimerControl } from '../controls/select-mode/pie-timer'
+import { ZeroSizeResizeControlWrapper } from '../controls/zero-sized-element-controls'
 import { applyAbsoluteMoveCommon } from './absolute-move-strategy'
 import {
   CanvasStrategy,
@@ -61,6 +62,11 @@ export const escapeHatchStrategy: CanvasStrategy = {
     }
   },
   controlsToRender: [
+    {
+      control: ZeroSizeResizeControlWrapper,
+      key: 'zero-size-resize-control',
+      show: 'always-visible',
+    },
     {
       control: DragOutlineControl,
       key: 'ghost-outline-control',

--- a/editor/src/components/canvas/controls/outline.tsx
+++ b/editor/src/components/canvas/controls/outline.tsx
@@ -26,7 +26,6 @@ export class Outline extends React.Component<OutlineProps> {
       return (
         <ZeroSizeOutlineControl
           frame={this.props.rect}
-          canvasOffset={this.props.offset}
           scale={this.props.scale}
           color={this.props.color}
         />

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -12,6 +12,7 @@ import { CSSCursor, EdgePosition } from '../../canvas-types'
 import { windowToCanvasCoordinates } from '../../dom-lookup'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
+import { isZeroSizedElement } from '../outline-utils'
 
 const selectedElementsSelector = (store: EditorStorePatched) => store.editor.selectedViews
 export const AbsoluteResizeControl = React.memo((props) => {
@@ -21,10 +22,15 @@ export const AbsoluteResizeControl = React.memo((props) => {
   )
 
   const controlRef = useBoundingBox(selectedElements, (ref, boundingBox) => {
-    ref.current.style.left = boundingBox.x + 'px'
-    ref.current.style.top = boundingBox.y + 'px'
-    ref.current.style.width = boundingBox.width + 'px'
-    ref.current.style.height = boundingBox.height + 'px'
+    if (isZeroSizedElement(boundingBox)) {
+      ref.current.style.display = 'none'
+    } else {
+      ref.current.style.display = 'block'
+      ref.current.style.left = boundingBox.x + 'px'
+      ref.current.style.top = boundingBox.y + 'px'
+      ref.current.style.width = boundingBox.width + 'px'
+      ref.current.style.height = boundingBox.height + 'px'
+    }
   })
 
   const leftRef = useBoundingBox(selectedElements, (ref, boundingBox) => {

--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -7,6 +7,7 @@ import { useEditorState } from '../../../editor/store/store-hook'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import { getSelectionColor } from '../outline-control'
+import { isZeroSizedElement } from '../outline-utils'
 
 interface MultiSelectOutlineControlProps {
   localSelectedElements: Array<ElementPath>
@@ -52,10 +53,15 @@ const OutlineControl = React.memo<OutlineControlProps>((props) => {
   }, 'OutlineControl colors')
 
   const outlineRef = useBoundingBox(targets, (ref, boundingBox) => {
-    ref.current.style.left = `${boundingBox.x + 0.5 / scale}px`
-    ref.current.style.top = `${boundingBox.y + 0.5 / scale}px`
-    ref.current.style.width = `${boundingBox.width - (0.5 / scale) * 3}px`
-    ref.current.style.height = `${boundingBox.height - (0.5 / scale) * 3}px`
+    if (isZeroSizedElement(boundingBox)) {
+      ref.current.style.display = 'none'
+    } else {
+      ref.current.style.display = 'block'
+      ref.current.style.left = `${boundingBox.x + 0.5 / scale}px`
+      ref.current.style.top = `${boundingBox.y + 0.5 / scale}px`
+      ref.current.style.width = `${boundingBox.width - (0.5 / scale) * 3}px`
+      ref.current.style.height = `${boundingBox.height - (0.5 / scale) * 3}px`
+    }
   })
 
   const color =

--- a/editor/src/components/canvas/controls/size-box.tsx
+++ b/editor/src/components/canvas/controls/size-box.tsx
@@ -592,7 +592,6 @@ export class ResizeRectangle extends React.Component<ResizeRectangleProps> {
       return (
         <ZeroSizeResizeControl
           frame={this.props.measureSize}
-          canvasOffset={this.props.canvasOffset}
           scale={this.props.scale}
           color={null}
           dispatch={this.props.dispatch}

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -24,6 +24,7 @@ import { stylePropPathMappingFn } from '../../inspector/common/property-path-hoo
 import { useEditorState } from '../../editor/store/store-hook'
 import { mapDropNulls } from '../../../core/shared/array-utils'
 import { useMaybeHighlightElement } from './select-mode/select-mode-hooks'
+import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 
 const EmptyChildren: ElementInstanceMetadata[] = []
 export const ZeroSizedElementControls = React.memo(() => {
@@ -169,25 +170,29 @@ export const ZeroSizeHighlightControl = React.memo((props: ZeroSizeControlProps)
   )
 })
 
-export const ZeroSizeOutlineControl = React.memo((props: ZeroSizeControlProps) => {
-  const colorTheme = useColorTheme()
-  const controlSize = 1 / props.scale
+export const ZeroSizeOutlineControl = React.memo(
+  (props: Omit<ZeroSizeControlProps, 'canvasOffset'>) => {
+    const colorTheme = useColorTheme()
+    const controlSize = 1 / props.scale
 
-  return (
-    <div
-      className='role-outline-no-size'
-      style={{
-        position: 'absolute',
-        left: props.frame.x + props.canvasOffset.x - ZeroControlSize / 2,
-        top: props.frame.y + props.canvasOffset.y - ZeroControlSize / 2,
-        width: props.frame.width + ZeroControlSize,
-        height: props.frame.height + ZeroControlSize,
-        borderRadius: ZeroControlSize / 2,
-        boxShadow: `0px 0px 0px ${controlSize}px ${colorTheme.primary.value}, inset 0px 0px 0px ${controlSize}px ${colorTheme.primary.value}`,
-      }}
-    />
-  )
-})
+    return (
+      <CanvasOffsetWrapper>
+        <div
+          className='role-outline-no-size'
+          style={{
+            position: 'absolute',
+            left: props.frame.x - ZeroControlSize / 2,
+            top: props.frame.y - ZeroControlSize / 2,
+            width: props.frame.width + ZeroControlSize,
+            height: props.frame.height + ZeroControlSize,
+            borderRadius: ZeroControlSize / 2,
+            boxShadow: `0px 0px 0px ${controlSize}px ${colorTheme.primary.value}, inset 0px 0px 0px ${controlSize}px ${colorTheme.primary.value}`,
+          }}
+        />
+      </CanvasOffsetWrapper>
+    )
+  },
+)
 
 export const ZeroSizeResizeControlWrapper = React.memo(() => {
   const { maybeHighlightOnHover, maybeClearHighlightsOnHoverEnd } = useMaybeHighlightElement()
@@ -211,27 +216,18 @@ export const ZeroSizeResizeControlWrapper = React.memo(() => {
     (store) => store.editor.canvas.scale,
     'ZeroSizeResizeControlWrapper scale',
   )
-  const canvasOffset = useEditorState(
-    (store) => store.editor.canvas.realCanvasOffset,
-    'ZeroSizeResizeControlWrapper canvasOffset',
-  )
+
   return (
     <React.Fragment>
       {zeroSizeElements.map((element) => {
         if (element.globalFrame != null) {
           return (
             <React.Fragment>
-              <ZeroSizeOutlineControl
-                frame={element.globalFrame}
-                canvasOffset={canvasOffset}
-                scale={scale}
-                color={null}
-              />
+              <ZeroSizeOutlineControl frame={element.globalFrame} scale={scale} color={null} />
               <ZeroSizeResizeControl
                 element={element}
                 frame={element.globalFrame}
                 dispatch={dispatch}
-                canvasOffset={canvasOffset}
                 scale={scale}
                 color={null}
                 maybeClearHighlightsOnHoverEnd={maybeClearHighlightsOnHoverEnd}
@@ -246,7 +242,10 @@ export const ZeroSizeResizeControlWrapper = React.memo(() => {
   )
 })
 
-interface ZeroSizeResizeControlProps extends ZeroSizeControlProps {
+interface ZeroSizeResizeControlProps {
+  frame: CanvasRectangle
+  scale: number
+  color: string | null | undefined
   element: ElementInstanceMetadata | null
   dispatch: EditorDispatch
   maybeClearHighlightsOnHoverEnd: () => void
@@ -323,18 +322,20 @@ export const ZeroSizeResizeControl = React.memo((props: ZeroSizeResizeControlPro
   }, [dispatch, element, props.frame])
 
   return (
-    <div
-      onMouseMove={onControlMouseMove}
-      onMouseDown={onControlStopPropagation}
-      onDoubleClick={onControlDoubleClick}
-      className='role-resize-no-size'
-      style={{
-        position: 'absolute',
-        left: props.frame.x + props.canvasOffset.x - ZeroControlSize / 2,
-        top: props.frame.y + props.canvasOffset.y - ZeroControlSize / 2,
-        width: props.frame.width + ZeroControlSize,
-        height: props.frame.height + ZeroControlSize,
-      }}
-    />
+    <CanvasOffsetWrapper>
+      <div
+        onMouseMove={onControlMouseMove}
+        onMouseDown={onControlStopPropagation}
+        onDoubleClick={onControlDoubleClick}
+        className='role-resize-no-size'
+        style={{
+          position: 'absolute',
+          left: props.frame.x - ZeroControlSize / 2,
+          top: props.frame.y - ZeroControlSize / 2,
+          width: props.frame.width + ZeroControlSize,
+          height: props.frame.height + ZeroControlSize,
+        }}
+      />
+    </CanvasOffsetWrapper>
   )
 })

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`424`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`425`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`487`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`488`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`576`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`577`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`648`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`649`)
   })
 })


### PR DESCRIPTION
**Problem:**
When an element has 0 width, 0 height I see the absolute resize controls, the zero size resize control and outline is missing when the strategies feature flag is active.

**Fix:**
Made a wrapper component for them that works with the strategies `controlToRender`. The normal resize box and 1px sized outline are hidden.

**Commit Details:**
- hiding the resize box and outline
- added new control for zero size elements
- added the new control for absolute resize strategy and escape hatch strategy (it would be better in flex resize and flow resize in the future as not all flow elements work nicely with width (span))
