### PR TITLE
Restore previous applyUIDMonkeyPatch flow

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -1,4 +1,4 @@
-import { PatchedReact as React } from '../../../utils/canvas-react-utils'
+import React from 'react'
 import { MapLike } from 'typescript'
 import { getUtopiaID } from '../../../core/model/element-template-utils'
 import {

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -1,5 +1,7 @@
 const Prettier = jest != null ? require('prettier') : require('prettier/standalone') // TODO split these files, standalone prettier is not working in unit tests
-import { PatchedReact as React } from '../../utils/canvas-react-utils'
+import React from 'react'
+import { applyUIDMonkeyPatch } from '../../utils/canvas-react-utils'
+applyUIDMonkeyPatch()
 import * as ReactDOMServer from 'react-dom/server'
 
 import { FancyError, processErrorWithSourceMap } from '../../core/shared/code-exec-utils'

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -85,6 +85,7 @@ import {
 } from './ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils'
 import { ProjectContentTreeRoot, getContentsTreeFileFromString, walkContentsTree } from '../assets'
 import { createExecutionScope } from './ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope'
+import { applyUIDMonkeyPatch } from '../../utils/canvas-react-utils'
 import { getParseSuccessOrTransientForFilePath, getValidElementPaths } from './canvas-utils'
 import { fastForEach, NO_OP } from '../../core/shared/utils'
 import { useTwind } from '../../core/tailwind/tailwind'
@@ -102,6 +103,8 @@ import {
 } from '../../core/shared/code-exec-utils'
 import { emptySet } from '../../core/shared/set-utils'
 import { forceNotNull } from '../../core/shared/optional-utils'
+
+applyUIDMonkeyPatch()
 
 const emptyFileBlobs: UIFileBase64Blobs = {}
 

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -12,18 +12,16 @@ try {
   disableStoredStateforTests()
 }
 
-import RealReact from 'react'
+import React from 'react'
 
 ///// IMPORTANT NOTE - THIS MUST BE BELOW THE REACT IMPORT AND ABOVE ALL OTHER IMPORTS
-const realCreateElement = RealReact.createElement
+const realCreateElement = React.createElement
 let renderCount = 0
 const monkeyCreateElement = (...params: any[]) => {
   renderCount++
   return (realCreateElement as any)(...params)
 }
-;(RealReact as any).createElement = monkeyCreateElement
-
-import { PatchedReact as React } from '../../utils/canvas-react-utils'
+;(React as any).createElement = monkeyCreateElement
 
 try {
   jest.setTimeout(10000) // in milliseconds

--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -9,11 +9,13 @@ import * as EmotionStyled from '@emotion/styled'
 
 import editorPackageJSON from '../../../../package.json'
 import utopiaAPIPackageJSON from '../../../../../utopia-api/package.json'
-import { PatchedReact } from '../../../utils/canvas-react-utils'
+import { applyUIDMonkeyPatch } from '../../../utils/canvas-react-utils'
 import { createRegisterModuleFunction } from '../../property-controls/property-controls-local'
 import type { EditorDispatch } from '../../../components/editor/action-types'
 import type { EditorState } from '../../../components/editor/store/editor-state'
 import { UtopiaTsWorkers } from '../../workers/common/worker-types'
+
+applyUIDMonkeyPatch()
 
 export interface BuiltInDependency {
   moduleName: string
@@ -64,7 +66,7 @@ export function createBuiltInDependenciesList(
     builtInDependency('uuiui', UUIUI, editorPackageJSON.version),
     builtInDependency('uuiui-deps', UUIUIDeps, editorPackageJSON.version),
     builtInDependency('react/jsx-runtime', ReactJsxRuntime, editorPackageJSON.dependencies.react),
-    builtInDependency('react', PatchedReact, editorPackageJSON.dependencies.react),
+    builtInDependency('react', React, editorPackageJSON.dependencies.react),
     builtInDependency('react-dom', ReactDOM, editorPackageJSON.dependencies['react-dom']),
     builtInDependency(
       '@emotion/react',

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`424`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`434`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`487`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`497`)
   })
 
   it('Changing the selected view with a simple project', async () => {

--- a/editor/src/templates/editor-entry-point.tsx
+++ b/editor/src/templates/editor-entry-point.tsx
@@ -32,6 +32,9 @@ const editorCSS = [
 editorCSS.forEach((url) => addStyleSheetToPage(url, true))
 
 import { Editor } from './editor'
+import { applyUIDMonkeyPatch } from '../utils/canvas-react-utils'
+
+applyUIDMonkeyPatch()
 
 // eslint-disable-next-line
 const EditorRunner = new Editor()

--- a/editor/src/utils/canvas-react-utils.spec.tsx
+++ b/editor/src/utils/canvas-react-utils.spec.tsx
@@ -1,4 +1,6 @@
-import { PatchedReact as React } from './canvas-react-utils'
+import React from 'react'
+import { applyUIDMonkeyPatch } from './canvas-react-utils'
+applyUIDMonkeyPatch()
 import * as PropTypes from 'prop-types'
 import * as ReactDOMServer from 'react-dom/server'
 import * as Prettier from 'prettier'

--- a/editor/src/utils/canvas-react-utils.ts
+++ b/editor/src/utils/canvas-react-utils.ts
@@ -16,6 +16,16 @@ const fragmentSymbol = Symbol.for('react.fragment')
 const providerSymbol = Symbol.for('react.provider')
 const contextSymbol = Symbol.for('react.context')
 
+let uidMonkeyPatchApplied: boolean = false
+
+export function applyUIDMonkeyPatch(): void {
+  if (!uidMonkeyPatchApplied) {
+    uidMonkeyPatchApplied = true
+    ;(React as any).createElement = patchedCreateReactElement
+    ;(React as any).monkeyPatched = true
+  }
+}
+
 function getDisplayName(type: any): string {
   // taken from https://github.com/facebook/react/blob/7e405d458d6481fb1c04dfca6afab0651e6f67cd/packages/react/src/ReactElement.js#L415
   if (typeof type === 'function') {
@@ -313,9 +323,4 @@ export function isHooksErrorMessage(message: string): boolean {
       'Rendered fewer hooks than expected. This may be caused by an accidental early return statement.' ||
     message === 'Should have a queue. This is likely a bug in React. Please file an issue.'
   )
-}
-
-export const PatchedReact: typeof React = {
-  ...React,
-  createElement: patchedCreateReactElement,
 }


### PR DESCRIPTION
**Problem:**
As mentioned in #2278, the removal of the older `applyUIDMonkeyPatch()` flow in #2265 meant there were a bunch of cases where the patched version `createElement` wasn't being called when rendering elements in the canvas, and I've been unable to fully nail down some unknown amount of them. This isn't causing any issues prior to #2278 as that only happens when rendering a component that Utopia has wrapped (and was therefore providing a data-path to separately), but it prevents paths from being correctly built as part of the patched `createElement`.

**Fix:**
This PR simply reverts #2265 (without breaking the render count test)
