### PR TITLE
Trim `deriveState`

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1830,7 +1830,7 @@ function getElementWarningsInner(
     // Build the warnings object and add it to the map.
     if (
       widthOrHeightZero !== defaultElementWarnings.widthOrHeightZero ||
-      widthOrHeightZero !== defaultElementWarnings.absoluteWithUnpositionedParent
+      absoluteWithUnpositionedParent !== defaultElementWarnings.absoluteWithUnpositionedParent
     ) {
       const warnings: ElementWarnings = {
         widthOrHeightZero: widthOrHeightZero,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1828,12 +1828,17 @@ function getElementWarningsInner(
     }
 
     // Build the warnings object and add it to the map.
-    const warnings: ElementWarnings = {
-      widthOrHeightZero: widthOrHeightZero,
-      absoluteWithUnpositionedParent: absoluteWithUnpositionedParent,
-      dynamicSceneChildWidthHeightPercentage: false,
+    if (
+      widthOrHeightZero !== defaultElementWarnings.widthOrHeightZero ||
+      widthOrHeightZero !== defaultElementWarnings.absoluteWithUnpositionedParent
+    ) {
+      const warnings: ElementWarnings = {
+        widthOrHeightZero: widthOrHeightZero,
+        absoluteWithUnpositionedParent: absoluteWithUnpositionedParent,
+        dynamicSceneChildWidthHeightPercentage: false,
+      }
+      result = addToComplexMap(toString, result, elementMetadata.elementPath, warnings)
     }
-    result = addToComplexMap(toString, result, elementMetadata.elementPath, warnings)
   })
   return result
 }

--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -19,35 +19,38 @@ export type ElementPathTreeRoot = Array<ElementPathTree>
 export function buildTree(elementPaths: Array<ElementPath>): ElementPathTreeRoot {
   let result: ElementPathTreeRoot = []
   let workingRoot: ElementPathTreeRoot = result
-  fastForEach(elementPaths, (elementPath) => {
+  let currentPathParts: Array<ElementPathPart> = []
+  // Loop over each and every path that needs to be added.
+  for (let elementPathIndex = 0; elementPathIndex < elementPaths.length; elementPathIndex++) {
+    const elementPath = elementPaths[elementPathIndex]
     workingRoot = result
-    const totalParts = elementPath.parts.reduce((workingCount, elem) => {
-      return workingCount + elem.length
-    }, 0)
-    for (let pathSize = 1; pathSize <= totalParts; pathSize++) {
-      let subElementPathParts: Array<ElementPathPart> = []
-      let workingCount = pathSize
-      fastForEach(elementPath.parts, (pathPart) => {
-        if (workingCount >= pathPart.length) {
-          subElementPathParts.push(pathPart)
-          workingCount = workingCount - pathPart.length
-        } else if (workingCount > 0) {
-          subElementPathParts.push(pathPart.slice(0, workingCount))
-          workingCount = 0
-        }
-      })
-      const subElementPath = EP.elementPath(subElementPathParts)
+    currentPathParts = []
+    // Loop over the array segments of the path that is being added.
+    for (let pathPartIndex = 0; pathPartIndex < elementPath.parts.length; pathPartIndex++) {
+      const pathPart = elementPath.parts[pathPartIndex]
+      currentPathParts[pathPartIndex] = []
+      let currentPathPart = currentPathParts[pathPartIndex]
+      // Loop over the parts of the of the path segment.
+      for (
+        let pathPartElementIndex = 0;
+        pathPartElementIndex < pathPart.length;
+        pathPartElementIndex++
+      ) {
+        const pathPartElement = pathPart[pathPartElementIndex]
+        currentPathPart.push(pathPartElement)
+        const subElementPath = EP.elementPath(currentPathParts)
 
-      // See if there's an already existing part of the tree with this path.
-      const foundTree = workingRoot.find((elem) => EP.pathsEqual(elem.path, subElementPath))
-      let treeToTarget = foundTree ?? emptyElementPathTree(subElementPath)
-      // Add this if it doesn't already exist.
-      if (foundTree == null) {
-        workingRoot.push(treeToTarget)
+        // See if there's an already existing part of the tree with this path.
+        const foundTree = workingRoot.find((elem) => EP.pathsEqual(elem.path, subElementPath))
+        let treeToTarget = foundTree ?? emptyElementPathTree(subElementPath)
+        // Add this if it doesn't already exist.
+        if (foundTree == null) {
+          workingRoot.push(treeToTarget)
+        }
+        workingRoot = treeToTarget.children
       }
-      workingRoot = treeToTarget.children
     }
-  })
+  }
   return result
 }
 

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -137,7 +137,7 @@ function newElementPath(fullElementPath: ElementPathPart[]): ElementPath
 function newElementPath(fullElementPath: ElementPathPart[]): ElementPath {
   return {
     type: 'elementpath',
-    parts: fullElementPath,
+    parts: [...fullElementPath.map((pathPart) => [...pathPart])],
   }
 }
 


### PR DESCRIPTION
**Problem:**
`deriveState` can run twice in a single frame, so any time saved there is beneficial.

**Fix:**
There are two aspects which have been improved:
- To reduce the amount of entries in there, `getElementWarningsInner` doesn't get added to if the value doesn't differ from the default.
- `buildTree` now builds element paths mutably, relying on the now safe `newElementPath` to construct a copy of the arrays for the path.
Locally these changes have at least halved the runtime of `deriveState` to just below 1ms.

**Commit Details:**
- `getElementWarningsInner` only adds to the map if the value does not
  equal the default.
- `buildTree` now builds paths mutably without resorting to more complicated
  slices.
- `newElementPath` made to be safe if mutably constructed arrays of
  `ElementPathPart` have been passed in.
