### PR TITLE
performance(editor) Assorted tuning, mostly relating to file paths.

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -142,6 +142,7 @@
     "jszip": "3.5.0",
     "localforage": "1.7.3",
     "lodash.clamp": "4.0.3",
+    "lru-cache": "7.10.1",
     "matter-js": "git://github.com/liabru/matter-js.git#e909b0466cea2051267bab92a38ccaa9bf7f154e",
     "mime-types": "2.1.24",
     "moize": "5.4.7",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -165,6 +165,7 @@ specifiers:
   livereloadify: 2.0.0
   localforage: 1.7.3
   lodash.clamp: 4.0.3
+  lru-cache: 7.10.1
   matter-js: git://github.com/liabru/matter-js.git#e909b0466cea2051267bab92a38ccaa9bf7f154e
   mime-types: 2.1.24
   minimatch: 3.0.4
@@ -312,6 +313,7 @@ dependencies:
   jszip: 3.5.0
   localforage: 1.7.3
   lodash.clamp: 4.0.3
+  lru-cache: 7.10.1
   matter-js: github.com/liabru/matter-js/e909b0466cea2051267bab92a38ccaa9bf7f154e
   mime-types: 2.1.24
   moize: 5.4.7
@@ -5856,7 +5858,7 @@ packages:
     dev: true
 
   /component-classes/1.2.6:
-    resolution: {integrity: sha1-xkI5TDYYpNiwuJGe/Mu9kw5c1pE=}
+    resolution: {integrity: sha512-hPFGULxdwugu1QWW3SvVOCUHLzO34+a2J6Wqy0c5ASQkfi9/8nZcBB0ZohaEbXOQlCflMAEMmEWk7u7BVs4koA==}
     dependencies:
       component-indexof: 0.0.3
     dev: false
@@ -6029,7 +6031,7 @@ packages:
     dev: false
 
   /core-js/1.2.7:
-    resolution: {integrity: sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=}
+    resolution: {integrity: sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==}
     deprecated: core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
     dev: false
 
@@ -10227,7 +10229,7 @@ packages:
     dev: true
 
   /js-tokens/3.0.2:
-    resolution: {integrity: sha1-mGbfOVECEw449/mWvOtlRDIJwls=}
+    resolution: {integrity: sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==}
     dev: true
 
   /js-tokens/4.0.0:
@@ -10891,7 +10893,7 @@ packages:
     dev: false
 
   /lru-cache/2.7.3:
-    resolution: {integrity: sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=}
+    resolution: {integrity: sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==}
     dev: true
 
   /lru-cache/5.1.1:
@@ -10905,6 +10907,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+
+  /lru-cache/7.10.1:
+    resolution: {integrity: sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==}
+    engines: {node: '>=12'}
+    dev: false
 
   /lz-string/1.4.4:
     resolution: {integrity: sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=}
@@ -11522,7 +11529,7 @@ packages:
     dev: true
 
   /object-assign/4.1.1:
-    resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
   /object-copy/0.1.0:

--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -343,12 +343,10 @@ export function getContentsTreeFileFromElements(
   if (pathElements.length === 0) {
     throw new Error(`Invalid pathElements.`)
   } else {
-    function getFileWithIndex(
-      currentTree: ProjectContentTreeRoot,
-      index: number,
-    ): ProjectFile | null {
+    let workingTree: ProjectContentTreeRoot = tree
+    for (let index = 0; index < pathElements.length; index++) {
       const pathPart = pathElements[index]
-      const treePart = currentTree[pathPart]
+      const treePart = workingTree[pathPart]
       if (treePart == null) {
         return null
       } else {
@@ -356,14 +354,14 @@ export function getContentsTreeFileFromElements(
           return getProjectFileFromTree(treePart)
         } else {
           if (treePart.type === 'PROJECT_CONTENT_DIRECTORY') {
-            return getFileWithIndex(treePart.children, index + 1)
+            workingTree = treePart.children
           } else {
             return null
           }
         }
       }
     }
-    return getFileWithIndex(tree, 0)
+    return null
   }
 }
 

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -278,14 +278,15 @@ function useClearSpyMetadataOnRemount(
 }
 
 function clearSpyCollectorInvalidPaths(
-  validPaths: Array<ElementPath>,
+  validPaths: Set<ElementPath>,
   spyCollectorContextRef: UiJsxCanvasContextData,
 ): void {
   const spyKeys = Object.keys(spyCollectorContextRef.current.spyValues.metadata)
   fastForEach(spyKeys, (elementPathString) => {
-    const elementPath = EP.fromString(elementPathString)
+    const elementPath =
+      spyCollectorContextRef.current.spyValues.metadata[elementPathString].elementPath
     const staticElementPath = EP.makeLastPartOfPathStatic(elementPath)
-    if (validPaths.every((validPath) => !EP.pathsEqual(validPath, staticElementPath))) {
+    if (!validPaths.has(staticElementPath)) {
       // we found a path that is no longer valid. let's delete it from the spy accumulator!
       delete spyCollectorContextRef.current.spyValues.metadata[elementPathString]
     }
@@ -451,21 +452,26 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
 
   const topLevelElementsMap = useKeepReferenceEqualityIfPossible(new Map(topLevelJsxComponents))
 
-  const { StoryboardRootComponent, rootValidPaths, storyboardRootElementPath, rootInstancePath } =
-    useGetStoryboardRoot(
-      props.focusedElementPath,
-      topLevelElementsMap,
-      executionScope,
-      projectContents,
-      uiFilePath,
-      transientFilesState,
-      resolve,
-    )
+  const {
+    StoryboardRootComponent,
+    rootValidPathsArray,
+    rootValidPathsSet,
+    storyboardRootElementPath,
+    rootInstancePath,
+  } = useGetStoryboardRoot(
+    props.focusedElementPath,
+    topLevelElementsMap,
+    executionScope,
+    projectContents,
+    uiFilePath,
+    transientFilesState,
+    resolve,
+  )
 
-  clearSpyCollectorInvalidPaths(rootValidPaths, metadataContext)
+  clearSpyCollectorInvalidPaths(rootValidPathsSet, metadataContext)
 
   const sceneLevelUtopiaContextValue = useKeepReferenceEqualityIfPossible({
-    validPaths: new Set(rootValidPaths.map((path) => EP.makeLastPartOfPathStatic(path))),
+    validPaths: rootValidPathsSet,
   })
 
   const rerenderUtopiaContextValue = useKeepShallowReferenceEquality({
@@ -498,7 +504,7 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
       <RerenderUtopiaCtxAtom.Provider value={rerenderUtopiaContextValue}>
         <UtopiaProjectCtxAtom.Provider value={utopiaProjectContextValue}>
           <CanvasContainer
-            validRootPaths={rootValidPaths}
+            validRootPaths={rootValidPathsArray}
             canvasRootElementElementPath={storyboardRootElementPath}
           >
             <SceneLevelUtopiaCtxAtom.Provider value={sceneLevelUtopiaContextValue}>
@@ -693,7 +699,8 @@ function useGetStoryboardRoot(
 ): {
   StoryboardRootComponent: ComponentRendererComponent | undefined
   storyboardRootElementPath: ElementPath
-  rootValidPaths: Array<ElementPath>
+  rootValidPathsSet: Set<ElementPath>
+  rootValidPathsArray: Array<ElementPath>
   rootInstancePath: ElementPath
 } {
   const StoryboardRootComponent = executionScope[BakedInStoryboardVariableName] as
@@ -717,10 +724,14 @@ function useGetStoryboardRoot(
     validPaths[0] ?? EP.emptyElementPath,
   )
 
+  const rootValidPathsArray = validPaths.map(EP.makeLastPartOfPathStatic)
+  const rootValidPathsSet = new Set(rootValidPathsArray)
+
   return {
     StoryboardRootComponent: StoryboardRootComponent,
     storyboardRootElementPath: storyboardRootElementPath,
-    rootValidPaths: validPaths,
+    rootValidPathsSet: rootValidPathsSet,
+    rootValidPathsArray: rootValidPathsArray,
     rootInstancePath: EP.emptyElementPath,
   }
 }

--- a/editor/src/components/editor/npm-dependency/npm-dependency.ts
+++ b/editor/src/components/editor/npm-dependency/npm-dependency.ts
@@ -523,10 +523,7 @@ export function importResultFromImports(
     if (requireResult == null) {
       console.warn(`Could not find ${importSource} with a require call.`)
     } else {
-      result = {
-        ...result,
-        ...importResultFromModule(imports[importSource], requireResult),
-      }
+      Object.assign(result, importResultFromModule(imports[importSource], requireResult))
     }
   })
   return result

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -434,15 +434,7 @@ export function fullElementPathsEqual(l: ElementPathPart[], r: ElementPathPart[]
 }
 
 export function pathsEqual(l: ElementPath | null, r: ElementPath | null): boolean {
-  if (l == null) {
-    return r == null
-  } else if (r == null) {
-    return false
-  } else if (l === r) {
-    return true
-  } else {
-    return fullElementPathsEqual(l.parts, r.parts)
-  }
+  return l === r
 }
 
 export function containsPath(path: ElementPath, paths: Array<ElementPath>): boolean {

--- a/editor/src/core/webpack-loaders/default-loader.ts
+++ b/editor/src/core/webpack-loaders/default-loader.ts
@@ -1,9 +1,15 @@
 import { LoadModule, loadModuleResult, MatchFile, ModuleLoader } from './loader-types'
 
+const acceptableExtensions: Set<string> = new Set(['cjs', 'mjs', 'js', 'jsx', 'ts', 'tsx'])
+
 const matchFile: MatchFile = (filename: string) => {
-  return ['.cjs', '.mjs', '.js', '.jsx', '.ts', '.tsx', '.d.ts'].some((extension) =>
-    filename.endsWith(extension),
-  )
+  const lastDot = filename.lastIndexOf('.')
+  if (lastDot < 0) {
+    return false
+  } else {
+    const extension = filename.slice(lastDot + 1)
+    return acceptableExtensions.has(extension)
+  }
 }
 
 const loadModule: LoadModule = (filename: string, contents: string) => {

--- a/editor/src/core/webpack-loaders/json-loader.ts
+++ b/editor/src/core/webpack-loaders/json-loader.ts
@@ -1,7 +1,7 @@
 import { LoadModule, loadModuleResult, MatchFile, ModuleLoader } from './loader-types'
 
 const matchFile: MatchFile = (filename: string) => {
-  return ['.json'].some((extension) => filename.endsWith(extension))
+  return filename.endsWith('.json')
 }
 
 const loadModule: LoadModule = (filename: string, contents: string) => {


### PR DESCRIPTION
**Problem:**
There were still some places during the early parts of a canvas render which were a little wasteful.

**Fix:**
This has a collection of fixes, the main highlights are:
- Exploiting identity equality for `ElementPath` values because there should be no value which is identical equals but not deeply value equals.
- Using a LRU cache to hold the result of parsing `package.json` files.
- Caching constructed file paths in a structure similar to that which is done currently with `ElementPath`.

**Commit Details:**
- Added `lru-cache` dependency.
- `getContentsTreeFileFromElements` now loops instead of calling a
  recursive function.
- `clearSpyCollectorInvalidPaths` now takes a `Set<ElementPath` instead
  of an `Array<ElementPath>`.
- `useGetStoryboardRoot` returns both an `Array<ElementPath>` and
  a `Set<ElementPath`, as the former is more useful for generating
  a `string` of valid paths.
- Use `Object.assign` in `importResultFromImports` rather than
  spreading itself into the new object.
- `module-resolution.ts` now caches the result of parsing a `package.json`
  file rather than incurring a `JSON.parse` and then our internal parser
  near constantly.
- `normalizePath` now allows for entries containing an `Array<string` as well
  as a `string`, so that arrays need not be spread to be passed into the function.
- Created a couple of common values in places like `resolveNonRelativeModule` so
  as to not create the same array multiple times.
- Make `pathsEqual` for `ElementPath` just do an idendity check as there
  should never be values for which they are not identity equal if they
  are deeply value equals.
- `matchFile` in `default-loader.ts` now obtains the extension and then checks
  if it is in a stored `Set` of extensions.
- `matchFile` in `json-loader.ts` now doesn't create an unnecessary array.
- `makePathFromParts` now caches paths so as to not create the same string repeatedly.