### PR TITLE
Remove onMouseDown requestAnimationFrame chain.

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -521,8 +521,6 @@ function useSelectOrLiveModeSelectAndHover(
     derived: store.derived,
   }))
 
-  const innerAnimationFrameRef = React.useRef<number | null>(null)
-
   const onMouseDown = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       const doubleClick = event.detail > 1 // we interpret a triple click as two double clicks, a quadruple click as three double clicks, etc  // TODO TEST ME
@@ -566,25 +564,18 @@ function useSelectOrLiveModeSelectAndHover(
           // first we only set the selected views for the canvas controls
           setSelectedViewsForCanvasControlsOnly(updatedSelection)
 
-          requestAnimationFrame(() => {
-            if (innerAnimationFrameRef.current != null) {
-              window.cancelAnimationFrame(innerAnimationFrameRef.current)
-            }
-            innerAnimationFrameRef.current = requestAnimationFrame(() => {
-              // then we set the selected views for the editor state, 1 frame later
-              if (updatedSelection.length === 0) {
-                const clearFocusedElementIfFeatureSwitchEnabled = isFeatureEnabled(
-                  'Click on empty canvas unfocuses',
-                )
-                  ? [setFocusedElement(null)]
-                  : []
+          // then we set the selected views for the editor state, 1 frame later
+          if (updatedSelection.length === 0) {
+            const clearFocusedElementIfFeatureSwitchEnabled = isFeatureEnabled(
+              'Click on empty canvas unfocuses',
+            )
+              ? [setFocusedElement(null)]
+              : []
 
-                dispatch([clearSelection(), ...clearFocusedElementIfFeatureSwitchEnabled])
-              } else {
-                dispatch([selectComponents(updatedSelection, event.shiftKey)])
-              }
-            })
-          })
+            dispatch([clearSelection(), ...clearFocusedElementIfFeatureSwitchEnabled])
+          } else {
+            dispatch([selectComponents(updatedSelection, event.shiftKey)])
+          }
         }
       }
     },

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -111,6 +111,18 @@ describe('Select Mode Selection', () => {
         )
         fireEvent(
           canvasControlsLayer,
+          new MouseEvent('mouseup', {
+            detail: 1,
+            bubbles: true,
+            cancelable: true,
+            metaKey: false,
+            clientX: areaControlBounds.left + 20,
+            clientY: areaControlBounds.top + 20,
+            buttons: 1,
+          }),
+        )
+        fireEvent(
+          canvasControlsLayer,
           new MouseEvent('mousedown', {
             detail: 2,
             bubbles: true,
@@ -121,15 +133,21 @@ describe('Select Mode Selection', () => {
             buttons: 1,
           }),
         )
+        fireEvent(
+          canvasControlsLayer,
+          new MouseEvent('mouseup', {
+            detail: 1,
+            bubbles: true,
+            cancelable: true,
+            metaKey: false,
+            clientX: areaControlBounds.left + 20,
+            clientY: areaControlBounds.top + 20,
+            buttons: 1,
+          }),
+        )
         await dispatchDone
       })
-      await waitForAnimationFrame()
     }
-
-    await doubleClick()
-
-    const selectedViews1 = renderResult.getEditorState().editor.selectedViews
-    expect(selectedViews1).toEqual([EP.elementPath([[BakedInStoryboardUID, TestSceneUID]])])
 
     await doubleClick()
 


### PR DESCRIPTION
**Problem:**
The chain of mouse down and up calls that occur while changing selection are quite costly in all of the renders that they incur.

**Fix:**
Removed the nesting of some dispatches within nested `requestAnimationFrame` calls during the mouse down callback, this has had the following effects:
- Cutting about 4/5 frames worth of processing time for the combination of mouse down and mouse up events.
- One less render being triggered, which visually means the component in the inspector that shows the result of the canvas strategies doesn't render with a slightly different value to what it then renders with immediately afterwards while the mouse is held down.

**Commit Details:**
- Inside the `onMouseDown` callback of `useSelectOrLiveModeSelectAndHover`
  the two nested `requestAnimationFrame` calls have been unwound and the
  inner code left in their place.
