### PR TITLE
always clear jsxMetadata and domMetadata and spyMetadata in CLEAR_INT…

### DIFF
--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -385,10 +385,6 @@ export function runLocalCanvasAction(
       }
     case 'CLEAR_INTERACTION_SESSION':
       clearInterval(interactionSessionTimerHandle)
-      const metadataToKeep =
-        action.applyChanges && model.canvas.interactionSession != null
-          ? model.canvas.interactionSession.metadata
-          : model.jsxMetadata
       return {
         ...model,
         canvas: {
@@ -396,7 +392,9 @@ export function runLocalCanvasAction(
           interactionSession: null,
           domWalkerInvalidateCount: model.canvas.domWalkerInvalidateCount + 1,
         },
-        jsxMetadata: metadataToKeep,
+        jsxMetadata: {},
+        domMetadata: {},
+        spyMetadata: {},
       }
     case 'UPDATE_INTERACTION_SESSION':
       if (model.canvas.interactionSession == null) {


### PR DESCRIPTION
**Problem:**
1. Sometimes, after the selected view changes, we show a broken inspector with empty computedStyle
2. when double clicking on a component on the canvas, we set the component to Focused Mode, yet the inner elements of the component never appear in the navigator, and you can't click to select the elements of the component

**Wat**
I'm gonna write this down because it is fascinating.

First off, there's an `unpatchedEditor` and a `patchedEditor`. The intention is that `unpatchedEditor + strategy patches = patchedEditor` .
Second, there's `editor.domMetadata` (data from the dom-walker), `editor.spyMetadata` (data from the SpyWrapper) and then there's `editor.jsxMetadata` which is basically derived from domMetadata+spyMetadata, but it doesn't live in derived state.
EVERYTHING in the editor UI reads patchedEditor.jsxMetadata. If there's something wrong with the inspector or navigator or the controls, it means patchedEditor.jsxMetadata is wrong for some reason.

Turns out, the problem was that on mouse up we dispatch a CLEAR_INTERACTION_SESSION, which did this (I'm paraphrasing):
```typescript
jsxMetadata =
    action.applyChanges && unpatchedEditor.canvas.interactionSession != null
      ? unpatchedEditor.canvas.interactionSession.metadata
      : unpatchedEditor.jsxMetadata
```

Why? here's the timeline of what happens in the editor when clicking on an element on the canvas to select it.

When clicking or double clicking to select on the canvas, we initiate an interactionSession on mouse down, and clear the interaction session on mouse up. (aside: **yes, even if there was no mouse move**, even if no strategy was ever active, we would initiate a session and clear a session. This enables strategy behavior like setting cursors, transient editor state, etc on mouse down, before the mouse moved.)

So a click (or double click) to change the selected element looks like this:
* in the beginning, editorState.jsxMetadata shows that `calculatedStyle` for the element-to-be-selected is null, because for performance reasons, the dom-walker only calculates calculatedStyle for the selectedElement. 
* **mouse down** initiates an interactionSession.
* the selected view change logic dispatches a `SELECT_COMPONENTS` action (bad name, because this is the action to change the selected element paths that in the editor are called... `selectedViews`)
* dom walker runs and calculates `calculatedStyle` for the new selected element, this is what we want to eventually show in the Inspector
* SAVE_DOM_REPORT is dispatched, we generate a new domMetadata. `unpatchedEditor.domMetadata` doesn't deeply equal this new domMetadata` because the calculatedStyle is now calculated for the selected element. so we flag `metadataChanged` as true.
* Because of `metadataChanged === true`, we create a new `jsxMetadata` from `unpatchedState.domMetadata` and `unpatchedState.spyMetadata`
* because we are in an interaction session, this new `jsxMetadata` is stored in `unpatchedEditor.canvas.interactionSession.metadata`, but then the strategy code makes sure the final `patchedEditor.jsxMetadata` points to `unpatchedEditor.canvas.interactionSession.metadata` 
* if you hold the mouse down long enough you can see a _correct_ inspector renders using the correct `patchedEditor.jsxMetadata`
* then the **mouse up** event is fired
* mouse up dispatches `CLEAR_INTERACTION_SESSION`, which "restores" the jsxMetadata to be `unpatchedEditor.jsxMetadata`, and clears `unpatchedEditor.canvas.interactionSession.metadata`
* HOWEVER, it DOES NOT CLEAR OR RESET `unpatchedEditor.domMetadata` which was last updated a moment ago with the calculatedStyle for the selected element
* the dom-walker runs again, and again, correctly calculates the `calculatedStyle` for the selected element
* `SAVE_DOM_REPORT` is dispatched, and it finds that `unpatchedEditor.domMetadata` is the same as the fresh metadata, so returns with a flag that nothing happened
* the `metadataChanged` flag is false now, because the domMetadata didn't change
* which means we do not run the function that generates `jsxMetadata`
* which means unpatchedEditor.jsxMetadata will remain the one we had _before_ the interaction session started, with calculatedStyle being null
* because we are not in an interaction session anymore, patchedEditor.jsxMetadata will point to unpatchedEditor.jsxMetadata.
* The inspector re-renders with the "new" patchedEditor.jsxMetadata which points to the outdated and unfixed unpatchedEditor.jsxMetadata, which has a null for calculatedStyle, so the inspector becomes empty and sad

**So how did this ever work?**
Well, it turns out we had a problem with `ElementInstanceMetadataMapKeepDeepEquality` which was always failing for spied props coming from the SpyWrapper. Which means the spyMetadata would always flag `metadataChanged: true`, which means we would always calculate a new jsxMetadata.

**Fix**
- `CLEAR_INTERACTION_SESSION` now always clears `unpatchedEditor.jsxMetadata`, `unpatchedEditor.domMetadata` and `unpatchedEditor.spyMetadata`. This means that in the SAVE_DOM_REPORT after mouse up, we will flag metadataChanged as true.

**Long term TODO**
- [ ] I'm not sure if we need `unpatchedEditor.canvas.interactionSession.metadata`. the idea was that we could keep the unpatchedEditor.jsxMetadata in line with unpatchedEditor.projectContents, but I'm not sure if we actually rely on this behavior
- [ ] zooming out, I think jsxMetadata should live in derivedState, because it is a derivation of domMetadata + spyMetadata
- [ ] zooming further out, I don't think we need unpatchedDerivedState
- [ ] zooming further further out, I think the domMetadata and spyMetadata should be removed from the editor state, and derivedState.jsxMetadata should be populated in the new dispatch flow after we ran the dom-walker.