### PR TITLE
do not re-run handleStrategiesInner on SAVE_DOM_REPORT

### DIFF
--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -14,6 +14,7 @@ import * as History from '../history'
 import { DummyPersistenceMachine } from '../persistence/persistence.test-utils'
 import { DispatchResult, editorDispatch } from './dispatch'
 import {
+  handleStrategies,
   interactionCancel,
   interactionHardReset,
   interactionStart,
@@ -23,6 +24,8 @@ import { createEditorState, deriveState, EditorStoreFull } from './editor-state'
 import * as EP from '../../../core/shared/element-path'
 import * as PP from '../../../core/shared/property-path'
 import {
+  ElementInstanceMetadata,
+  elementInstanceMetadata,
   ElementInstanceMetadataMap,
   emptyComments,
   jsxAttributeValue,
@@ -45,6 +48,8 @@ import {
 import { canvasPoint } from '../../../core/shared/math-utils'
 import { wildcardPatch } from '../../canvas/commands/wildcard-patch-command'
 import { runCanvasCommand } from '../../canvas/commands/commands'
+import { saveDOMReport } from '../actions/action-creators'
+import { RegisteredCanvasStrategies } from '../../canvas/canvas-strategies/canvas-strategies'
 
 beforeAll(() => {
   return jest.spyOn(Date, 'now').mockReturnValue(new Date(1000).getTime())
@@ -778,5 +783,95 @@ describe('interactionUpdate with user changed strategy', () => {
     expect(
       actualResult.patchedEditorState.canvas.interactionSession?.interactionData,
     ).toMatchInlineSnapshot(`undefined`)
+  })
+})
+
+describe('only update metadata on SAVE_DOM_REPORT', () => {
+  // eslint-disable-next-line jest/expect-expect
+  it('no canvas.interactionSession', () => {
+    const oldEditorStore = createEditorStore(null)
+
+    const newMetadata: ElementInstanceMetadataMap = {
+      'new-entry': {
+        elementPath: EP.fromString('new-entry'),
+        specialSizeMeasurements: { position: 'absolute' },
+      } as ElementInstanceMetadata,
+    }
+
+    const newEditorStore: EditorStoreFull = {
+      ...oldEditorStore,
+      unpatchedEditor: { ...oldEditorStore.unpatchedEditor, jsxMetadata: newMetadata },
+      patchedEditor: oldEditorStore.patchedEditor,
+    }
+
+    // when new metadata is dispatched in SAVE_DOM_REPORT, only the unpatchedEditor is updated
+    // we see that newEditorState's unpatchedEditor has the new metadata
+    expect(newEditorStore.unpatchedEditor.jsxMetadata).not.toBe(
+      oldEditorStore.unpatchedEditor.jsxMetadata,
+    )
+    // but newEditorState's patchedEditor has the old metadata
+    expect(newEditorStore.patchedEditor.jsxMetadata).toBe(oldEditorStore.patchedEditor.jsxMetadata)
+
+    // the job of handleStrategies in this case is to update the metadata of patchedEditor, without running any strategies
+    const actualResult = handleStrategies(
+      RegisteredCanvasStrategies,
+      [saveDOMReport(newMetadata, [], [])],
+      oldEditorStore,
+      dispatchResultFromEditorStore(newEditorStore),
+      oldEditorStore.patchedDerived,
+    )
+
+    expect(actualResult.patchedEditorState.jsxMetadata).toBe(
+      newEditorStore.unpatchedEditor.jsxMetadata,
+    )
+  })
+
+  it('has non-null canvas.interactionSession', () => {
+    const oldEditorStore = createEditorStore(
+      createInteractionViaMouse(
+        canvasPoint({ x: 100, y: 200 }),
+        { alt: false, shift: false, ctrl: false, cmd: false },
+        { type: 'BOUNDING_AREA', target: EP.elementPath([['aaa']]) },
+      ),
+    )
+
+    const newMetadata: ElementInstanceMetadataMap = {
+      'new-entry': {
+        elementPath: EP.fromString('new-entry'),
+        specialSizeMeasurements: { position: 'absolute' },
+      } as ElementInstanceMetadata,
+    }
+
+    if (oldEditorStore.unpatchedEditor.canvas.interactionSession == null) {
+      throw new Error('interactionSession cannot be null')
+    }
+
+    const newEditorStore: EditorStoreFull = {
+      ...oldEditorStore,
+      unpatchedEditor: {
+        ...oldEditorStore.unpatchedEditor,
+        canvas: {
+          ...oldEditorStore.unpatchedEditor.canvas,
+          interactionSession: {
+            ...oldEditorStore.unpatchedEditor.canvas.interactionSession,
+            metadata: newMetadata,
+          },
+        },
+      },
+      patchedEditor: oldEditorStore.patchedEditor,
+    }
+
+    // the job of handleStrategies in this case is to update the jsxMetadata of patchedEditor using unpatchedEditor.canvas.interactionSession.metadata, without running any strategies
+    const actualResult = handleStrategies(
+      RegisteredCanvasStrategies,
+      [saveDOMReport(newMetadata, [], [])],
+      oldEditorStore,
+      dispatchResultFromEditorStore(newEditorStore),
+      oldEditorStore.patchedDerived,
+    )
+
+    expect(actualResult.patchedEditorState.jsxMetadata).toBe(
+      newEditorStore.unpatchedEditor.canvas.interactionSession?.metadata,
+    )
   })
 })

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../canvas/canvas-strategies/canvas-strategy-types'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { PERFORMANCE_MARKS_ALLOWED } from '../../../common/env-vars'
+import { saveDOMReport } from '../actions/action-creators'
 
 interface HandleStrategiesResult {
   unpatchedEditorState: EditorState
@@ -563,13 +564,22 @@ function handleStrategiesInner(
   storedState: EditorStoreFull,
   result: InnerDispatchResult,
 ): HandleStrategiesResult {
+  const isSaveDomReport = dispatchedActions.some((a) => a.action === 'SAVE_DOM_REPORT')
+
   const makeChangesPermanent = dispatchedActions.some(shouldApplyClearInteractionSessionResult)
   const cancelInteraction =
     dispatchedActions.some(isClearInteractionSession) && !makeChangesPermanent
   const isInteractionAction = dispatchedActions.some(isCreateOrUpdateInteractionSession)
     ? 'interaction-create-or-update'
     : 'non-interaction'
-  if (storedState.unpatchedEditor.canvas.interactionSession == null) {
+
+  if (isSaveDomReport) {
+    return {
+      unpatchedEditorState: result.unpatchedEditor,
+      patchedEditorState: result.unpatchedEditor,
+      newStrategyState: result.strategyState,
+    }
+  } else if (storedState.unpatchedEditor.canvas.interactionSession == null) {
     if (result.unpatchedEditor.canvas.interactionSession == null) {
       return {
         unpatchedEditorState: result.unpatchedEditor,


### PR DESCRIPTION
**Problem:**
For every action dispatched, we run handleStrategies twice: first for the actual action, then again for the SAVE_DOM_REPORT "action" which updates the metadatas.

**Fix:**
When a SAVE_DOM_REPORT is dispathced, always short-circuit handleStrategies and skip running handleStrategiesInner

