### PR TITLE
Use ElementInstanceMetadataMap everywhere in dom walker.

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -207,7 +207,7 @@ export interface DomWalkerProps {
 // it adds elementMetadata to metadataToMutate in way that it merges fragments with the same elementpath
 function mergeElementMetadataToMapWithFragments_MUTATE(
   metadataToMutate: ElementInstanceMetadataMap,
-  elementMetadata: ElementInstanceMetadata,
+  elementMetadata: Readonly<ElementInstanceMetadata>,
 ): void {
   const pathString = EP.toString(elementMetadata.elementPath)
   const existingMetadata = metadataToMutate[pathString]
@@ -244,7 +244,7 @@ function mergeElementMetadataToMapWithFragments_MUTATE(
 // it merges otherMetadata into metadataToMutate in way that it merges fragments with the same elementpath
 function mergeMetadataMapsWithFragments_MUTATE(
   metadataToMutate: ElementInstanceMetadataMap,
-  otherMetadata: ElementInstanceMetadataMap,
+  otherMetadata: Readonly<ElementInstanceMetadataMap>,
 ): void {
   fastForEach(Object.values(otherMetadata), (elementMetadata) => {
     mergeElementMetadataToMapWithFragments_MUTATE(metadataToMutate, elementMetadata)

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -613,11 +613,16 @@ function collectMetadata(
   invalidated: boolean,
   selectedViews: Array<ElementPath>,
   additionalElementsToUpdate: Array<ElementPath>,
-): { collectedMetadata: ElementInstanceMetadataMap; cachedPaths: Array<ElementPath> } {
+): {
+  collectedMetadata: ElementInstanceMetadataMap
+  cachedPaths: Array<ElementPath>
+  collectedPaths: Array<ElementPath>
+} {
   if (pathsForElement.length === 0) {
     return {
       collectedMetadata: {},
       cachedPaths: [],
+      collectedPaths: [],
     }
   }
   const shouldCollect =
@@ -646,6 +651,7 @@ function collectMetadata(
       return {
         collectedMetadata: cachedMetadata,
         cachedPaths: pathsForElement,
+        collectedPaths: pathsForElement,
       }
     } else {
       // If any path is missing cached metadata we must forcibly invalidate the element
@@ -711,6 +717,7 @@ function collectAndCreateMetadataForElement(
   return {
     collectedMetadata: collectedMetadata,
     cachedPaths: [],
+    collectedPaths: pathsForElement,
   }
 }
 
@@ -1175,7 +1182,7 @@ function walkElements(
 
     const uniqueChildPaths = uniqBy(childPaths, EP.pathsEqual)
 
-    const { collectedMetadata, cachedPaths } = collectMetadata(
+    const { collectedMetadata, cachedPaths, collectedPaths } = collectMetadata(
       element,
       pluck(foundValidPaths, 'path'),
       pluck(foundValidPaths, 'asString'),
@@ -1195,7 +1202,7 @@ function walkElements(
     cachedPathsAccumulator = [...cachedPathsAccumulator, ...cachedPaths]
     return {
       rootMetadata: rootMetadataAccumulator,
-      childPaths: Object.values(collectedMetadata).map((metadata) => metadata.elementPath), // TODO why not extract childPaths from the metadata?
+      childPaths: collectedPaths,
       cachedPaths: cachedPathsAccumulator,
     }
   } else {

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -205,6 +205,7 @@ export interface DomWalkerProps {
 
 // For performance reasons this function mutates the first parameter:
 // it adds elementMetadata to metadataToMutate in way that it merges fragments with the same elementpath
+// Note: it only mutates the map itself, it should never mutate the metadata instances inside the map!
 function mergeElementMetadataToMapWithFragments_MUTATE(
   metadataToMutate: ElementInstanceMetadataMap,
   elementMetadata: Readonly<ElementInstanceMetadata>,
@@ -242,6 +243,7 @@ function mergeElementMetadataToMapWithFragments_MUTATE(
 
 // For performance reasons this function mutates the first parameter:
 // it merges otherMetadata into metadataToMutate in way that it merges fragments with the same elementpath
+// Note: it only mutates the map itself, it should never mutate the metadata instances inside the map!
 function mergeMetadataMapsWithFragments_MUTATE(
   metadataToMutate: ElementInstanceMetadataMap,
   otherMetadata: Readonly<ElementInstanceMetadataMap>,

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -203,10 +203,11 @@ export interface DomWalkerProps {
   additionalElementsToUpdate: Array<ElementPath>
 }
 
-// For performance reasons this function mutates the first parameter:
-// it adds elementMetadata to metadataToMutate in way that it merges fragments with the same elementpath
-// Note: it only mutates the map itself, it should never mutate the metadata instances inside the map!
-function mergeElementMetadataToMapWithFragments_MUTATE(
+// This function adds elementMetadata to the metadataToMutate map. If a metadata instance with the same element path
+// already existed in the map, it adds the metadata of a fragment which contains both the existing and the new element.
+// NOTE: For performance reasons this function mutates the first parameter and writes the result there. It only mutates the
+// map itself, it should never mutate the metadata instances inside the map!
+function addElementMetadataToMapWithFragments_MUTATE(
   metadataToMutate: ElementInstanceMetadataMap,
   elementMetadata: Readonly<ElementInstanceMetadata>,
 ): void {
@@ -241,15 +242,16 @@ function mergeElementMetadataToMapWithFragments_MUTATE(
   }
 }
 
-// For performance reasons this function mutates the first parameter:
-// it merges otherMetadata into metadataToMutate in way that it merges fragments with the same elementpath
-// Note: it only mutates the map itself, it should never mutate the metadata instances inside the map!
+// This function merges metadataToMutate and otherMetadata maps. If metadata instances with the same element path
+// exist in both maps, it adds the metadata of a fragment which contains both the elements.
+// NOTE: For performance reasons this function mutates the first parameter and writes the result there. It only mutates
+// the map itself, it should never mutate the metadata instances inside the map!
 function mergeMetadataMapsWithFragments_MUTATE(
   metadataToMutate: ElementInstanceMetadataMap,
   otherMetadata: Readonly<ElementInstanceMetadataMap>,
 ): void {
   fastForEach(Object.values(otherMetadata), (elementMetadata) => {
-    mergeElementMetadataToMapWithFragments_MUTATE(metadataToMutate, elementMetadata)
+    addElementMetadataToMapWithFragments_MUTATE(metadataToMutate, elementMetadata)
   })
 }
 
@@ -947,7 +949,7 @@ function walkCanvasRootFragment(
       null, // this comes from the Spy Wrapper
     )
 
-    mergeElementMetadataToMapWithFragments_MUTATE(rootMetadata, metadata)
+    addElementMetadataToMapWithFragments_MUTATE(rootMetadata, metadata)
 
     return { metadata: rootMetadata, cachedPaths: cachedPaths }
   }

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -204,7 +204,7 @@ export interface DomWalkerProps {
 }
 
 // For performance reasons this function mutates the first parameter:
-// it adds elementMetadata to metadataToMutate in way that it merges fragments
+// it adds elementMetadata to metadataToMutate in way that it merges fragments with the same elementpath
 function mergeElementMetadataToMapWithFragments_MUTATE(
   metadataToMutate: ElementInstanceMetadataMap,
   elementMetadata: ElementInstanceMetadata,
@@ -241,7 +241,7 @@ function mergeElementMetadataToMapWithFragments_MUTATE(
 }
 
 // For performance reasons this function mutates the first parameter:
-// it merges otherMetadata into metadataToMutate in way that it merges fragments
+// it merges otherMetadata into metadataToMutate in way that it merges fragments with the same elementpath
 function mergeMetadataMapsWithFragments_MUTATE(
   metadataToMutate: ElementInstanceMetadataMap,
   otherMetadata: ElementInstanceMetadataMap,

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -224,7 +224,7 @@ export async function renderTestEditorWithModel(
       additionalElementsToUpdate:
         workingEditorState.patchedEditor.canvas.domWalkerAdditionalElementsToUpdate,
       rootMetadataInStateRef: {
-        current: Object.values(workingEditorState.patchedEditor.domMetadata),
+        current: workingEditorState.patchedEditor.domMetadata,
       },
     })
 

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1456,7 +1456,7 @@ export type ComputedStyle = { [key: string]: string }
 export type StyleAttributeMetadataEntry = { fromStyleSheet: boolean } // TODO rename me to StyleAttributeMetadata, the other one to StyleAttributeMetadataMap
 export type StyleAttributeMetadata = { [key: string]: StyleAttributeMetadataEntry | undefined }
 
-export type ElementInstanceMetadataMap = { [key: string]: ElementInstanceMetadata }
+export type ElementInstanceMetadataMap = { [key: string]: Readonly<ElementInstanceMetadata> }
 export const emptyJsxMetadata: ElementInstanceMetadataMap = {}
 
 export type FoundImportInfo = {

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -396,7 +396,7 @@ export class Editor {
           additionalElementsToUpdate:
             dispatchResult.patchedEditor.canvas.domWalkerAdditionalElementsToUpdate,
           rootMetadataInStateRef: {
-            current: Object.values(dispatchResult.patchedEditor.domMetadata), // TODO: use directly the map here
+            current: dispatchResult.patchedEditor.domMetadata,
           },
         })
 


### PR DESCRIPTION
Inside the dom walker we use `ElementInstanceMetadata` arrays to access the old and collect the new metadata. However, in EditorState domMetadata is stored as an `ElementInstanceMetadataMap`. So when we run the dom walker and process its results, we need to convert the metadata from array to map and back.

So it makes sense to use maps everywhere in the dom walker, because then
1. We don't need to convert back and forth between arrays and maps
2. Accessing an element metadata is faster, and that is needed when merging the metadata of fragments

Originally all the metadata was collected in an array, and merged at the end. In this PR I continuously merge in the working metadata map, because I can not store multiple metadatas for the same element path in a map (unlike in an array, where it is possible). I wanted to make sure this will be performant with big metadata maps, so I implemented the merging with mutation. This is not absolutely necessary, but I wanted to be on the safe side regarding performance.

According to my measurements the performance is better, full dom walk was 8-9 ms before this PR, and it is around 6 ms after these changes