### PR TITLE
Use a fixed version for comparing performance tests

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -53,7 +53,8 @@ jobs:
         id: extract_branch
       - name: Check out the repo
         uses: actions/checkout@v2
-        working-directory: branch/
+        with:
+          path: branch
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
@@ -70,9 +71,8 @@ jobs:
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run build-editor-staging-ci
       - name: Send webpack stats to RelativeCI
         uses: relative-ci/agent-action@v1.1.0
-        working-directory: branch/
         with:
-          webpackStatsFile: editor/lib/staging-stats.json
+          webpackStatsFile: branch/editor/lib/staging-stats.json
           key: ${{ secrets.RELATIVE_CI_KEY }}
           debug: false
       - name: Delete node_modules
@@ -102,9 +102,9 @@ jobs:
           AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
       - name: Check out target version of repo
         uses: actions/checkout@v2
-        working-directory: target/
         with:
           ref: 772e55d5999b26629fd97d7a6e5afc502674fd21
+          path: target
       - name: Build Target Version of Editor
         working-directory: target/
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -52,8 +52,8 @@ jobs:
           echo "##[set-output name=branch;]$FIXED_REF"
         id: extract_branch
       - name: Check out the repo
-        working-directory: branch/
         uses: actions/checkout@v2
+        working-directory: branch/
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
@@ -69,8 +69,8 @@ jobs:
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run build-editor-staging-ci
       - name: Send webpack stats to RelativeCI
-        working-directory: branch/
         uses: relative-ci/agent-action@v1.1.0
+        working-directory: branch/
         with:
           webpackStatsFile: editor/lib/staging-stats.json
           key: ${{ secrets.RELATIVE_CI_KEY }}
@@ -101,8 +101,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_BUNDLE_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
       - name: Check out target version of repo
-        working-directory: target/
         uses: actions/checkout@v2
+        working-directory: target/
         with:
           ref: 772e55d5999b26629fd97d7a6e5afc502674fd21
       - name: Build Target Version of Editor

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -53,8 +53,6 @@ jobs:
         id: extract_branch
       - name: Check out the repo
         uses: actions/checkout@v2
-        with:
-          path: branch
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:
@@ -65,18 +63,17 @@ jobs:
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
       - name: Build Editor
-        working-directory: branch/
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run build-editor-staging-ci
       - name: Send webpack stats to RelativeCI
         uses: relative-ci/agent-action@v1.1.0
         with:
-          webpackStatsFile: branch/editor/lib/staging-stats.json
+          webpackStatsFile: editor/lib/staging-stats.json
           key: ${{ secrets.RELATIVE_CI_KEY }}
           debug: false
       - name: Delete node_modules
-        working-directory: branch/editor/
+        working-directory: editor/
         run: |
           rm -rf ./node_modules
           cd ../utopia-api
@@ -87,12 +84,10 @@ jobs:
           rm -rf ./node_modules
           cd ../utopia-vscode-common
           rm -rf ./node_modules
-      - name: Create Editor Directory
-        run: mkdir editor
       - name: Create Editor Bundle
-        working-directory: branch/editor/lib/
+        working-directory: editor/lib/
         run: |
-          tar -czvf ../../../editor/performance-test-target.tar.gz *
+          tar -czvf ../${{ steps.extract_branch.outputs.branch }}.tar.gz *
       - name: Upload Editor Bundle
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
@@ -102,18 +97,39 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_BUNDLE_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_BUNDLE_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
+      - name: Flush Staging Branch Editor Bundle
+        shell: bash
+        run: |
+          curl -s -o /dev/null -w "FLUSH STAGING HTTP RESPONSE CODE: %{http_code}" -X DELETE 'https://${{ secrets.STAGING_SERVER }}/internal/branch?branch_name=${{ steps.extract_branch.outputs.branch }}'
+
+  deploy-target:
+    name: Deploy Target Editor
+    runs-on: ubuntu-latest
+    env:
+      UTOPIA_SHA: 772e55d5999b26629fd97d7a6e5afc502674fd21
+      AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
+      AUTH0_ENDPOINT: enter.utopia.app
+      AUTH0_REDIRECT_URI: https://utopia.pizza/authenticate
+    steps:
       - name: Check out target version of repo
         uses: actions/checkout@v2
         with:
-          ref: 772e55d5999b26629fd97d7a6e5afc502674fd21
-          path: target
+          ref: ${{ UTOPIA_SHA }}
+      - name: Cache .pnpm-store
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+      - name: Install nix
+        uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
       - name: Build Target Version of Editor
-        working-directory: target/
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run build-editor-staging-ci
-      - name: Delete Target Version node_modules
-        working-directory: target/editor/
+      - name: Delete node_modules
+        working-directory: editor/
         run: |
           rm -rf ./node_modules
           cd ../utopia-api
@@ -124,10 +140,10 @@ jobs:
           rm -rf ./node_modules
           cd ../utopia-vscode-common
           rm -rf ./node_modules
-      - name: Create Target Editor Bundle
-        working-directory: target/editor/lib/
+      - name: Create Editor Bundle
+        working-directory: editor/lib/
         run: |
-          tar -czvf ../../../editor/performance-test-target.tar.gz *
+          tar -czvf ../performance-test-target.tar.gz *
       - name: Upload Target Editor Bundle
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
@@ -137,10 +153,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_BUNDLE_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_BUNDLE_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
-      - name: Flush Staging Branch Editor Bundle
-        shell: bash
-        run: |
-          curl -s -o /dev/null -w "FLUSH STAGING HTTP RESPONSE CODE: %{http_code}" -X DELETE 'https://${{ secrets.STAGING_SERVER }}/internal/branch?branch_name=${{ steps.extract_branch.outputs.branch }}'
       - name: Flush Staging Target Editor Bundle
         shell: bash
         run: |

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -87,6 +87,8 @@ jobs:
           rm -rf ./node_modules
           cd ../utopia-vscode-common
           rm -rf ./node_modules
+      - name: Create Editor Directory
+        run: mkdir editor
       - name: Create Editor Bundle
         working-directory: editor/
         run: |

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Check out target version of repo
         uses: actions/checkout@v2
         with:
-          ref: ${{ UTOPIA_SHA }}
+          ref: ${{ env.UTOPIA_SHA }}
       - name: Cache .pnpm-store
         uses: actions/cache@v2
         with:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -90,9 +90,9 @@ jobs:
       - name: Create Editor Directory
         run: mkdir editor
       - name: Create Editor Bundle
-        working-directory: editor/
+        working-directory: branch/editor/lib/
         run: |
-          tar -czvf ${{ steps.extract_branch.outputs.branch }}.tar.gz ../branch/editor/lib/*
+          tar -czvf ../../../editor/performance-test-target.tar.gz *
       - name: Upload Editor Bundle
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
@@ -125,9 +125,9 @@ jobs:
           cd ../utopia-vscode-common
           rm -rf ./node_modules
       - name: Create Target Editor Bundle
-        working-directory: editor/
+        working-directory: target/editor/lib/
         run: |
-          tar -czvf performance-test-target.tar.gz ../target/editor/lib/*
+          tar -czvf ../../../editor/performance-test-target.tar.gz *
       - name: Upload Target Editor Bundle
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -161,7 +161,7 @@ jobs:
   performance-test:
     name: Run Performance Tests
     runs-on: self-hosted
-    needs: deploy-staging
+    needs: [deploy-staging, deploy-target]
     env:
       UTOPIA_SHA: ${{ github.sha }}
       AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -52,6 +52,7 @@ jobs:
           echo "##[set-output name=branch;]$FIXED_REF"
         id: extract_branch
       - name: Check out the repo
+        working-directory: branch/
         uses: actions/checkout@v2
       - name: Cache .pnpm-store
         uses: actions/cache@v2
@@ -63,17 +64,19 @@ jobs:
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
       - name: Build Editor
+        working-directory: branch/
         if: steps.cache-editor-tests.outputs.cache-hit != 'true'
         run: |
           nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run build-editor-staging-ci
       - name: Send webpack stats to RelativeCI
+        working-directory: branch/
         uses: relative-ci/agent-action@v1.1.0
         with:
           webpackStatsFile: editor/lib/staging-stats.json
           key: ${{ secrets.RELATIVE_CI_KEY }}
           debug: false
       - name: Delete node_modules
-        working-directory: editor/
+        working-directory: branch/editor/
         run: |
           rm -rf ./node_modules
           cd ../utopia-api
@@ -85,22 +88,56 @@ jobs:
           cd ../utopia-vscode-common
           rm -rf ./node_modules
       - name: Create Editor Bundle
-        working-directory: editor/lib/
+        working-directory: branch/editor/lib/
         run: |
           tar -czvf ../${{ steps.extract_branch.outputs.branch }}.tar.gz *
       - name: Upload Editor Bundle
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
-          args: --acl private --exclude '*' --include 'editor/${{ steps.extract_branch.outputs.branch }}.tar.gz'
+          args: --acl private --exclude '*' --include 'branch/editor/${{ steps.extract_branch.outputs.branch }}.tar.gz'
         env:
           AWS_S3_BUCKET: ${{ secrets.STAGING_BUNDLE_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_BUNDLE_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_BUNDLE_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
-      - name: Flush Staging Editor Bundle
+      - name: Check out target version of repo
+        working-directory: target/
+        uses: actions/checkout@v2
+        with:
+          ref: 772e55d5999b26629fd97d7a6e5afc502674fd21
+      - name: Build Target Version of Editor
+        working-directory: target/
+        if: steps.cache-editor-tests.outputs.cache-hit != 'true'
+        run: |
+          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run build-editor-staging-ci
+      - name: Delete Target Version node_modules
+        working-directory: target/editor/
+        run: |
+          rm -rf ./node_modules
+          cd ../utopia-api
+          rm -rf ./node_modules
+          cd ../website-next
+          rm -rf ./node_modules
+          cd ../utopia-vscode-extension
+          rm -rf ./node_modules
+          cd ../utopia-vscode-common
+          rm -rf ./node_modules
+      - name: Create Target Editor Bundle
+        working-directory: target/editor/lib/
+        run: |
+          tar -czvf ../performance-test-target.tar.gz *
+      - name: Upload Target Editor Bundle
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --acl private --exclude '*' --include 'target/editor/performance-test-target.tar.gz'
+      - name: Flush Staging Branch Editor Bundle
         shell: bash
         run: |
           curl -s -o /dev/null -w "FLUSH STAGING HTTP RESPONSE CODE: %{http_code}" -X DELETE 'https://${{ secrets.STAGING_SERVER }}/internal/branch?branch_name=${{ steps.extract_branch.outputs.branch }}'
+      - name: Flush Staging Target Editor Bundle
+        shell: bash
+        run: |
+          curl -s -o /dev/null -w "FLUSH STAGING HTTP RESPONSE CODE: %{http_code}" -X DELETE 'https://${{ secrets.STAGING_SERVER }}/internal/branch?branch_name=performance-test-target'
 
   performance-test:
     name: Run Performance Tests

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -130,6 +130,11 @@ jobs:
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --acl private --exclude '*' --include 'target/editor/performance-test-target.tar.gz'
+        env:
+          AWS_S3_BUCKET: ${{ secrets.STAGING_BUNDLE_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_BUNDLE_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_BUNDLE_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
       - name: Flush Staging Branch Editor Bundle
         shell: bash
         run: |

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -88,13 +88,13 @@ jobs:
           cd ../utopia-vscode-common
           rm -rf ./node_modules
       - name: Create Editor Bundle
-        working-directory: branch/editor/lib/
+        working-directory: editor/
         run: |
-          tar -czvf ../${{ steps.extract_branch.outputs.branch }}.tar.gz *
+          tar -czvf ${{ steps.extract_branch.outputs.branch }}.tar.gz ../branch/editor/lib/*
       - name: Upload Editor Bundle
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
-          args: --acl private --exclude '*' --include 'branch/editor/${{ steps.extract_branch.outputs.branch }}.tar.gz'
+          args: --acl private --exclude '*' --include 'editor/${{ steps.extract_branch.outputs.branch }}.tar.gz'
         env:
           AWS_S3_BUCKET: ${{ secrets.STAGING_BUNDLE_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_BUNDLE_ACCESS_KEY }}
@@ -123,13 +123,13 @@ jobs:
           cd ../utopia-vscode-common
           rm -rf ./node_modules
       - name: Create Target Editor Bundle
-        working-directory: target/editor/lib/
+        working-directory: editor/
         run: |
-          tar -czvf ../performance-test-target.tar.gz *
+          tar -czvf performance-test-target.tar.gz ../target/editor/lib/*
       - name: Upload Target Editor Bundle
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
-          args: --acl private --exclude '*' --include 'target/editor/performance-test-target.tar.gz'
+          args: --acl private --exclude '*' --include 'editor/performance-test-target.tar.gz'
         env:
           AWS_S3_BUCKET: ${{ secrets.STAGING_BUNDLE_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_BUNDLE_ACCESS_KEY }}

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -10,7 +10,8 @@ const moveFile = require('move-file')
 
 const BRANCH_NAME = process.env.BRANCH_NAME ? `?branch_name=${process.env.BRANCH_NAME}` : ''
 const STAGING_EDITOR_URL = process.env.EDITOR_URL ?? `https://utopia.pizza/p${BRANCH_NAME}`
-const MASTER_EDITOR_URL = process.env.MASTER_EDITOR_URL ?? `https://utopia.pizza/p`
+const MASTER_EDITOR_URL =
+  process.env.MASTER_EDITOR_URL ?? `https://utopia.pizza/p?branch_name=performance-test-target`
 
 export function wait(timeout: number): Promise<void> {
   return new Promise((resolve) => {


### PR DESCRIPTION
**Problem**
Small incremental regressions in the performance tests all too often will go unnoticed 

**Fix**
Rather than comparing them to the latest version on Staging, instead compare them to a specific checkpointed version. We can update the version if the performance results have improved.