### PR TITLE
Trim outliers from the performance graphs.

### DIFF
--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -477,8 +477,8 @@ const getFrameData = (
 
   let frameTimesFixed = frameTimes.map((x) => Number(x.toFixed(1)))
   const sortedFrameTimes = frameTimesFixed.sort((a, b) => a - b)
-  // Trims the top 5% off.
-  let withoutOutliersLength = Math.round(sortedFrameTimes.length * 0.95)
+  // Trims the top 20% off.
+  let withoutOutliersLength = Math.round(sortedFrameTimes.length * 0.8)
   // Ensure we always have at least one result.
   if (withoutOutliersLength <= 0) {
     withoutOutliersLength = 1

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -484,7 +484,9 @@ const getFrameData = (
     withoutOutliersLength = 1
   }
   const frameTimesWithoutOutliers = sortedFrameTimes.slice(0, withoutOutliersLength)
-  let totalFrameTimes = 0
+  const totalFrameTimes = frameTimesWithoutOutliers.reduce((working, currentValue) => {
+    return working + currentValue
+  }, 0)
 
   const analytics = {
     frameMin: frameTimesWithoutOutliers[0]!,


### PR DESCRIPTION
**Problem:**
We see a lot of variance in the performance tests, which can result in those results being very noisy.

**Fix:**
Trim off a percentage of the frame times, so that those outliers are ignored.

**Commit Details:**
- In `getFrameData`, only take the bottom 95% of the frame times.
