### PR TITLE
Merge performance test results

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -171,6 +171,7 @@ jobs:
                 "description": $description,
                 "fields": [
                   {
+                    "name": "Results:",
                     "value": $result_message
                   }
                 ],

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -169,12 +169,6 @@ jobs:
                 "url": $html_url,
                 "color": 2369839,
                 "description": $description,
-                "fields": [
-                  {
-                    "name": "Results:",
-                    "value": $result_message
-                  }
-                ],
                 "footer": {
                   "text": $repo_full_name
                 }
@@ -189,12 +183,11 @@ jobs:
             ]
           TITLE: 'Performance Results for #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'
           HTML_URL: ${{ github.event.pull_request.html_url }}
-          DESCRIPTION: 'Link to test editor: https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }}'
+          DESCRIPTION: 'Link to test editor: https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }}<br /><br />Results:<br />${{ steps.run-performance-test.outputs.perf-message }}'
           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-          RESULT_MESSAGE: ${{ steps.run-performance-test.outputs.perf-message }}
           RESULT_CHART: ${{ steps.run-performance-test.outputs.perf-chart }}
         run: |
-          echo "DISCORD_EMBEDS=$(jq -nc --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" --arg result_message "$RESULT_MESSAGE" --arg result_chart "$RESULT_CHART" "$TEMPLATE")" >> $GITHUB_ENV
+          echo "DISCORD_EMBEDS=$(jq -nc --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" --arg result_chart "$RESULT_CHART" "$TEMPLATE")" >> $GITHUB_ENV
       - name: Send Discord Notification
         uses: Ilshidur/action-discord@0.3.2
         env:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -172,7 +172,7 @@ jobs:
                 "fields": [
                   {
                     "value": $result_message
-                  },
+                  }
                 ],
                 "footer": {
                   "text": $repo_full_name
@@ -184,7 +184,7 @@ jobs:
                 "image": {
                   "url": $result_chart
                 }
-              },
+              }
             ]
           TITLE: 'Performance Results for #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'
           HTML_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -171,43 +171,29 @@ jobs:
                 "description": $description,
                 "fields": [
                   {
-                    "name": "This PR:",
-                    "value": $staging_message
+                    "value": $result_message
                   },
-                  {
-                    "name": "Current Staging:",
-                    "value": $master_message
-                  }
                 ],
                 "footer": {
                   "text": $repo_full_name
                 }
               },
               {
-                "title": "This PR:",
+                "title": "Chart:",
                 "color": 2369839,
                 "image": {
-                  "url": $staging_chart
+                  "url": $result_chart
                 }
               },
-              {
-                "title": "Current Staging:",
-                "color": 14540253,
-                "image": {
-                  "url": $master_chart
-                }
-              }
             ]
           TITLE: 'Performance Results for #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'
           HTML_URL: ${{ github.event.pull_request.html_url }}
           DESCRIPTION: 'Link to test editor: https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }}'
           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-          STAGING_MESSAGE: ${{ steps.run-performance-test.outputs.perf-message-staging }}
-          STAGING_CHART: ${{ steps.run-performance-test.outputs.perf-chart-staging }}
-          MASTER_MESSAGE: ${{ steps.run-performance-test.outputs.perf-message-master }}
-          MASTER_CHART: ${{ steps.run-performance-test.outputs.perf-chart-master }}
+          RESULT_MESSAGE: ${{ steps.run-performance-test.outputs.perf-message }}
+          RESULT_CHART: ${{ steps.run-performance-test.outputs.perf-chart }}
         run: |
-          echo "DISCORD_EMBEDS=$(jq -nc --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" --arg staging_message "$STAGING_MESSAGE" --arg master_message "$MASTER_MESSAGE" --arg staging_chart "$STAGING_CHART" --arg master_chart "$MASTER_CHART" "$TEMPLATE")" >> $GITHUB_ENV
+          echo "DISCORD_EMBEDS=$(jq -nc --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" --arg result_message "$RESULT_MESSAGE" --arg result_chart "$RESULT_CHART" "$TEMPLATE")" >> $GITHUB_ENV
       - name: Send Discord Notification
         uses: Ilshidur/action-discord@0.3.2
         env:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -183,7 +183,7 @@ jobs:
             ]
           TITLE: 'Performance Results for #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'
           HTML_URL: ${{ github.event.pull_request.html_url }}
-          DESCRIPTION: 'Link to test editor: https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }}\n\nResults:\n${{ steps.run-performance-test.outputs.perf-discord-message }}'
+          DESCRIPTION: 'Link to test editor: https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }} \n \\n Results: \n ${{ steps.run-performance-test.outputs.perf-discord-message }}'
           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
           RESULT_CHART: ${{ steps.run-performance-test.outputs.perf-chart }}
         run: |

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -183,11 +183,11 @@ jobs:
             ]
           TITLE: 'Performance Results for #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'
           HTML_URL: ${{ github.event.pull_request.html_url }}
-          DESCRIPTION: 'Link to test editor: https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }} \n \\n Results: \n ${{ steps.run-performance-test.outputs.perf-discord-message }}'
+          DESCRIPTION: 'Link to test editor: https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }} \n \n Results: \n ${{ steps.run-performance-test.outputs.perf-discord-message }}'
           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
           RESULT_CHART: ${{ steps.run-performance-test.outputs.perf-chart }}
         run: |
-          echo "DISCORD_EMBEDS=$(jq -nc --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" --arg result_chart "$RESULT_CHART" "$TEMPLATE")" >> $GITHUB_ENV
+          echo "DISCORD_EMBEDS=$(jq -nc --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" --arg result_chart "$RESULT_CHART" "$TEMPLATE")" | sed 's/\\\\n/\\n/g' >> $GITHUB_ENV
       - name: Send Discord Notification
         uses: Ilshidur/action-discord@0.3.2
         env:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -183,7 +183,7 @@ jobs:
             ]
           TITLE: 'Performance Results for #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'
           HTML_URL: ${{ github.event.pull_request.html_url }}
-          DESCRIPTION: 'Link to test editor: https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }}<br /><br />Results:<br />${{ steps.run-performance-test.outputs.perf-message }}'
+          DESCRIPTION: 'Link to test editor: https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }}\n\nResults:\n${{ steps.run-performance-test.outputs.perf-discord-message }}'
           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
           RESULT_CHART: ${{ steps.run-performance-test.outputs.perf-chart }}
         run: |

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -79,7 +79,7 @@ function defer() {
 
 const ResizeButtonXPath = "//a[contains(., 'P R')]"
 
-function consoleMessageForResult(result: FrameResult, beforeOrAfter: 'before' | 'after'): string {
+function consoleMessageForResult(result: FrameResult, beforeOrAfter: 'Before' | 'After'): string {
   return `${beforeOrAfter}: ${result.analytics.percentile50}ms (${result.analytics.frameMin}-${result.analytics.frameMax}ms)`
 }
 
@@ -99,8 +99,8 @@ export const testPerformance = async function () {
       const change = ((afterMedian - beforeMedian) / beforeMedian) * 100
       return [
         result.title,
-        consoleMessageForResult(targetResult, 'before'),
-        consoleMessageForResult(result, 'after'),
+        consoleMessageForResult(targetResult, 'Before'),
+        consoleMessageForResult(result, 'After'),
         `Change: ${Math.round(change)}%`,
         '',
       ]
@@ -568,13 +568,15 @@ async function createSummaryPng(
 
   const numberOfTests = Object.keys(stagingResult).length * 2
 
-  const processedData = Object.entries(stagingResult).flatMap(([k, result]) => {
+  let processedData = Object.entries(stagingResult).flatMap(([k, result]) => {
     const targetResult = masterResult[k]
     return [
       boxPlotConfig(`${targetResult.title} (before)`, targetResult.timeSeries),
       boxPlotConfig(`${result.title} (after)`, result.timeSeries),
     ]
   })
+
+  processedData.reverse() // Plotly will produce the box plot in the reverse order
 
   const layout = {
     margin: {

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -105,7 +105,7 @@ export const testPerformance = async function () {
   })
 
   const message = messageParts.join('<br />')
-  const discordMessage = messageParts.join('\n')
+  const discordMessage = messageParts.join('\\n')
 
   console.info(`::set-output name=perf-result:: ${message} <br /> ![(Chart)](${summaryImage})`)
 

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -91,26 +91,26 @@ export const testPerformance = async function () {
 
   const summaryImage = await uploadSummaryImage(stagingResult, masterResult)
 
-  const message = Object.entries(stagingResult)
-    .flatMap(([k, result]) => {
-      const targetResult = masterResult[k]
-      const beforeMedian = targetResult.analytics.percentile50 ?? 1
-      const afterMedian = result.analytics.percentile50 ?? 1
-      const change = ((afterMedian - beforeMedian) / beforeMedian) * 100
-      return [
-        result.title,
-        consoleMessageForResult(targetResult, 'Before'),
-        consoleMessageForResult(result, 'After'),
-        `Change: ${Math.round(change)}%`,
-        '',
-      ]
-    })
-    .join('<br />')
+  const messageParts = Object.entries(stagingResult).flatMap(([k, result]) => {
+    const targetResult = masterResult[k]
+    const beforeMedian = targetResult.analytics.percentile50 ?? 1
+    const afterMedian = result.analytics.percentile50 ?? 1
+    const change = ((afterMedian - beforeMedian) / beforeMedian) * 100
+    return [
+      `**${result.title} (${Math.round(change)}%):**`,
+      consoleMessageForResult(targetResult, 'Before'),
+      consoleMessageForResult(result, 'After'),
+      '',
+    ]
+  })
+
+  const message = messageParts.join('<br />')
+  const discordMessage = messageParts.join('\\n')
 
   console.info(`::set-output name=perf-result:: ${message} <br /> ![(Chart)](${summaryImage})`)
 
   // Output the individual parts for building a discord message
-  console.info(`::set-output name=perf-message:: ${message}`)
+  console.info(`::set-output name=perf-discord-message:: ${discordMessage}`)
   console.info(`::set-output name=perf-chart:: ${summaryImage}`)
 }
 
@@ -658,7 +658,7 @@ testPerformance().catch((e) => {
   console.info(`::set-output name=perf-result::${errorMessage}`)
 
   // Output the individual parts for building a discord message
-  console.info(`::set-output name=perf-message:: ${errorMessage}`)
+  console.info(`::set-output name=perf-discord-message:: ${errorMessage}`)
   console.info(`::set-output name=perf-chart:: ""`)
   return
 })

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -80,7 +80,7 @@ function defer() {
 const ResizeButtonXPath = "//a[contains(., 'P R')]"
 
 function consoleMessageForResult(result: FrameResult, beforeOrAfter: 'before' | 'after'): string {
-  return `${result.title} (${beforeOrAfter}): ${result.analytics.percentile50}ms (${result.analytics.frameMin}-${result.analytics.frameMax}ms)`
+  return `${beforeOrAfter}: ${result.analytics.percentile50}ms (${result.analytics.frameMin}-${result.analytics.frameMax}ms)`
 }
 
 type PerformanceResult = { [key: string]: FrameResult }
@@ -98,9 +98,11 @@ export const testPerformance = async function () {
       const afterMedian = result.analytics.percentile50 ?? 1
       const change = ((afterMedian - beforeMedian) / beforeMedian) * 100
       return [
+        result.title,
         consoleMessageForResult(targetResult, 'before'),
         consoleMessageForResult(result, 'after'),
-        `${result.title} change: ${change}%`,
+        `Change: ${Math.round(change)}%`,
+        '',
       ]
     })
     .join('<br />')

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -94,9 +94,13 @@ export const testPerformance = async function () {
   const message = Object.entries(stagingResult)
     .flatMap(([k, result]) => {
       const targetResult = masterResult[k]
+      const beforeMedian = targetResult.analytics.percentile50 ?? 1
+      const afterMedian = result.analytics.percentile50 ?? 1
+      const change = ((afterMedian - beforeMedian) / beforeMedian) * 100
       return [
         consoleMessageForResult(targetResult, 'before'),
         consoleMessageForResult(result, 'after'),
+        `${result.title} change: ${change}%`,
       ]
     })
     .join('<br />')

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -618,7 +618,7 @@ async function createSummaryPng(
   const imgOpts = {
     format: 'png',
     width: 800,
-    height: 220,
+    height: 440,
   }
   const figure = { data: processedData, layout: layout }
 

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -105,7 +105,7 @@ export const testPerformance = async function () {
   })
 
   const message = messageParts.join('<br />')
-  const discordMessage = messageParts.join('\\n')
+  const discordMessage = messageParts.join('\n')
 
   console.info(`::set-output name=perf-result:: ${message} <br /> ![(Chart)](${summaryImage})`)
 


### PR DESCRIPTION
**Problem**
The output of the performance tests are hard to read, and require manual cross referencing across charts

**Fix**
A few fixes here:
- Put all results on a single chart, with "before" and "after" values adjacent to each other
- Likewise with the message output, and use line breaks, because why the hell were we using the '|' character here?!
- Also include a percentage change (of the median result) in the message output after each test