### PR TITLE
Feature/canvas controls pins

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -71,6 +71,7 @@ import { OutlineHighlightControl } from './select-mode/outline-highlight-control
 import { InsertionControls } from './insertion-plus-button'
 import { DistanceGuidelineControl } from './select-mode/distance-guideline-control'
 import { SceneLabelControl } from './select-mode/scene-label'
+import { PinLines } from './position-outline'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -450,6 +451,11 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           maybeHighlightOnHover={maybeHighlightOnHover}
           maybeClearHighlightsOnHoverEnd={maybeClearHighlightsOnHoverEnd}
         />,
+      )}
+      {when(
+        (isFeatureEnabled('Canvas Strategies') && props.editor.mode.type === 'select') ||
+          props.editor.mode.type === 'select-lite',
+        <PinLines />,
       )}
       {when(
         (isFeatureEnabled('Canvas Strategies') && props.editor.mode.type === 'select') ||

--- a/editor/src/components/canvas/controls/outline-control.tsx
+++ b/editor/src/components/canvas/controls/outline-control.tsx
@@ -351,7 +351,6 @@ export const OutlineControls = (props: OutlineControlsProps) => {
           frame={rect}
           path={selectedView}
           scale={props.scale}
-          canvasOffset={props.canvasOffset}
         />,
       )
     }

--- a/editor/src/components/canvas/controls/position-outline.tsx
+++ b/editor/src/components/canvas/controls/position-outline.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
 import { MetadataUtils, PropsOrJSXAttributes } from '../../../core/model/element-metadata-utils'
+import { mapDropNulls } from '../../../core/shared/array-utils'
 import { eitherToMaybe, isRight, left, right } from '../../../core/shared/either'
 import * as EP from '../../../core/shared/element-path'
 import { isJSXElement } from '../../../core/shared/element-template'
@@ -8,11 +9,42 @@ import { CanvasPoint, CanvasRectangle } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { useColorTheme } from '../../../uuiui'
 import { useEditorState } from '../../editor/store/store-hook'
+import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
+
+export const PinLines = React.memo(() => {
+  const scale = useEditorState((store) => store.editor.canvas.scale, 'PinLines scale')
+  const elementsAndFrames = useEditorState((store) => {
+    return mapDropNulls((path) => {
+      const element = MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, path)
+      const isAbsolute = MetadataUtils.isPositionAbsolute(element)
+      const frame = element?.globalFrame
+      if (isAbsolute && frame != null) {
+        return {
+          path: path,
+          frame: frame,
+        }
+      } else {
+        return null
+      }
+    }, store.editor.selectedViews)
+  }, 'PinLines')
+  return (
+    <>
+      {elementsAndFrames.map((frameInfo) => (
+        <PositionOutline
+          key={EP.toString(frameInfo.path)}
+          frame={frameInfo.frame}
+          path={frameInfo.path}
+          scale={scale}
+        />
+      ))}
+    </>
+  )
+})
 
 interface PositionOutlineProps {
   path: ElementPath
   frame: CanvasRectangle
-  canvasOffset: CanvasPoint
   scale: number
 }
 
@@ -24,15 +56,14 @@ export const PositionOutline = React.memo((props: PositionOutlineProps) => {
       attributes,
       props.frame,
       containingFrame,
-      props.canvasOffset,
       props.scale,
     )
     return (
-      <div key={EP.toString(props.path)}>
+      <CanvasOffsetWrapper>
         {pins.map((pin) => (
           <PinOutline {...pin} key={pin.key} />
         ))}
-      </div>
+      </CanvasOffsetWrapper>
     )
   } else {
     return null
@@ -66,7 +97,6 @@ const collectPinOutlines = (
   attributes: PropsOrJSXAttributes,
   frame: CanvasRectangle,
   containingFrame: CanvasRectangle,
-  canvasOffset: CanvasPoint,
   scale: number,
 ): PinOutlineProps[] => {
   const pinLeft = eitherToMaybe(getLayoutProperty('left', attributes, ['style']))
@@ -79,8 +109,8 @@ const collectPinOutlines = (
       key: 'left',
       isHorizontalLine: true,
       size: frame.x - containingFrame.x,
-      startX: containingFrame.x + canvasOffset.x,
-      startY: frame.y + frame.height / 2 + canvasOffset.y,
+      startX: containingFrame.x,
+      startY: frame.y + frame.height / 2,
       scale: scale,
     })
   }
@@ -89,8 +119,8 @@ const collectPinOutlines = (
       key: 'top',
       isHorizontalLine: false,
       size: frame.y - containingFrame.y,
-      startX: frame.x + frame.width / 2 + canvasOffset.x,
-      startY: containingFrame.y + canvasOffset.y,
+      startX: frame.x + frame.width / 2,
+      startY: containingFrame.y,
       scale: scale,
     })
   }
@@ -99,8 +129,8 @@ const collectPinOutlines = (
       key: 'right',
       isHorizontalLine: true,
       size: containingFrame.x + containingFrame.width - (frame.x + frame.width),
-      startX: frame.width + frame.x + canvasOffset.x,
-      startY: frame.y + frame.height / 2 + canvasOffset.y,
+      startX: frame.width + frame.x,
+      startY: frame.y + frame.height / 2,
       scale: scale,
     })
   }
@@ -109,8 +139,8 @@ const collectPinOutlines = (
       key: 'bottom',
       isHorizontalLine: false,
       size: containingFrame.y + containingFrame.height - (frame.y + frame.height),
-      startX: frame.x + frame.width / 2 + canvasOffset.x,
-      startY: frame.height + frame.y + canvasOffset.y,
+      startX: frame.x + frame.width / 2,
+      startY: frame.height + frame.y,
       scale: scale,
     })
   }

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`435`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`436`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`498`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`499`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`577`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`578`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`649`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`650`)
   })
 })


### PR DESCRIPTION
**Problem:**
Pin lines are missing when the strategies are active. It was part of the big OutlineControls component.

**Commit Details:**
- updated position lines to use canvas offset wrapper
- added a new component that collects the props from useEditorState
