### PR TITLE
Check drag threshold in all mouse strategies

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -92,6 +92,28 @@ function dragByPixels(
 }
 
 describe('Absolute Move Strategy', () => {
+  it('does not activate when drag treshold is not reached', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50, top: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = dragByPixels(initialEditor, canvasPoint({ x: 1, y: 1 }), emptyModifiers)
+
+    expect(finalEditor).toEqual(finalEditor)
+  })
   it('works with a TL pinned absolute element', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -112,7 +112,7 @@ describe('Absolute Move Strategy', () => {
 
     const finalEditor = dragByPixels(initialEditor, canvasPoint({ x: 1, y: 1 }), emptyModifiers)
 
-    expect(finalEditor).toEqual(finalEditor)
+    expect(finalEditor).toEqual(initialEditor)
   })
   it('works with a TL pinned absolute element', async () => {
     const targetElement = elementPath([

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -92,7 +92,7 @@ function dragByPixels(
 }
 
 describe('Absolute Move Strategy', () => {
-  it('does not activate when drag treshold is not reached', async () => {
+  it('does not activate when drag threshold is not reached', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'bbb'],

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -100,7 +100,7 @@ function dragByPixels(
 }
 
 describe('Absolute Reparent Strategy without new parent', () => {
-  it('does not activate when drag treshold is not reached', async () => {
+  it('does not activate when drag threshold is not reached', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'bbb'],

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -10,7 +10,7 @@ import {
   CanvasVector,
 } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import { cmdModifier, emptyModifiers, Modifiers } from '../../../utils/modifiers'
+import { cmdModifier, Modifiers } from '../../../utils/modifiers'
 import { EditorState } from '../../editor/store/editor-state'
 import { foldAndApplyCommands } from '../commands/commands'
 import {
@@ -100,6 +100,28 @@ function dragByPixels(
 }
 
 describe('Absolute Reparent Strategy without new parent', () => {
+  it('does not activate when drag treshold is not reached', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50, top: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = dragByPixels(initialEditor, canvasPoint({ x: 1, y: 1 }), cmdModifier)
+
+    expect(finalEditor).toEqual(initialEditor)
+  })
   it('works with a TL pinned absolute element', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -3,7 +3,7 @@ import {
   ElementInstanceMetadata,
   SpecialSizeMeasurements,
 } from '../../../core/shared/element-template'
-import { canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
+import { CanvasPoint, canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
 import { WindowMousePositionRaw } from '../../../utils/global-positions'
 import { EditorState } from '../../editor/store/editor-state'
 import { foldAndApplyCommands } from '../commands/commands'
@@ -35,13 +35,14 @@ jest.mock('../canvas-utils', () => ({
 function reparentElement(
   editorState: EditorState,
   targetParentWithSpecialContentBox: boolean,
+  dragVector: CanvasPoint = canvasPoint({ x: 15, y: 15 }),
 ): EditorState {
   const interactionSession: InteractionSession = {
     ...createMouseInteractionForTests(
       null as any, // the strategy does not use this
       { cmd: true, alt: false, shift: false, ctrl: false },
       null as any, // the strategy does not use this
-      canvasPoint({ x: 0, y: 0 }),
+      dragVector,
     ),
     metadata: null as any, // the strategy does not use this
     allElementProps: null as any, // the strategy does not use this
@@ -102,6 +103,52 @@ function reparentElement(
 }
 
 describe('Absolute Reparent Strategy', () => {
+  it('does not activate when drag treshold is not reached', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'ccc'],
+    ])
+
+    const initialEditor = getEditorStateWithSelectedViews(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+        }}
+      >
+        <div
+          data-uid='bbb'
+          style={{
+            position: 'absolute',
+            width: 250,
+            height: 200,
+            top: 60,
+            left: 50,
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={{
+            position: 'absolute',
+            width: 20,
+            height: 30,
+            top: 75,
+            left: 90,
+          }}
+        />
+      </div>
+      `),
+      [targetElement],
+    )
+
+    const finalEditor = reparentElement(initialEditor, false, canvasPoint({ x: 1, y: 1 }))
+
+    expect(finalEditor).toEqual(initialEditor)
+  })
   it('works with a TL pinned absolute element', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],
@@ -174,8 +221,8 @@ describe('Absolute Reparent Strategy', () => {
                 position: 'absolute',
                 width: 20,
                 height: 30,
-                top: 15,
-                left: 40,
+                top: 30,
+                left: 55,
               }}
             />
           </div>
@@ -254,10 +301,10 @@ describe('Absolute Reparent Strategy', () => {
               data-uid='ccc'
               style={{
                 position: 'absolute',
-                top: 15,
-                left: 40,
-                bottom: 155,
-                right: 190
+                top: 30,
+                left: 55,
+                bottom: 140,
+                right: 175
               }}
             />
           </div>
@@ -336,10 +383,10 @@ describe('Absolute Reparent Strategy', () => {
               data-uid='ccc'
               style={{
                 position: 'absolute',
-                top: 5,
-                left: 30,
-                bottom: 60,
-                right: 100,
+                top: 20,
+                left: 45,
+                bottom: 45,
+                right: 85,
               }}
             />
           </div>
@@ -431,8 +478,8 @@ describe('Absolute Reparent Strategy', () => {
                 position: 'absolute',
                 width: 20,
                 height: 30,
-                top: 15,
-                left: 40,
+                top: 30,
+                left: 55,
               }}
             >
               <div
@@ -540,8 +587,8 @@ describe('Absolute Reparent Strategy', () => {
                 position: 'absolute',
                 width: 20,
                 height: 30,
-                top: 15,
-                left: 40,
+                top: 30,
+                left: 55,
               }}
             />
             <div
@@ -550,8 +597,8 @@ describe('Absolute Reparent Strategy', () => {
                 position: 'absolute',
                 width: 10,
                 height: 10,
-                top: -30,
-                left: -10,
+                top: -15,
+                left: 5,
               }}
             />
           </div>
@@ -648,8 +695,8 @@ describe('Absolute Reparent Strategy', () => {
                 position: 'absolute',
                 width: 20,
                 height: 30,
-                top: 15,
-                left: 40,
+                top: 30,
+                left: 55,
               }}
             >
               <div

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -103,7 +103,7 @@ function reparentElement(
 }
 
 describe('Absolute Reparent Strategy', () => {
-  it('does not activate when drag treshold is not reached', async () => {
+  it('does not activate when drag threshold is not reached', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'ccc'],

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -48,13 +48,20 @@ export const absoluteReparentStrategy: CanvasStrategy = {
       canvasState.selectedElements.length > 0 &&
       interactionState.interactionData.modifiers.cmd &&
       interactionState.interactionData.type === 'DRAG' &&
-      interactionState.interactionData.dragThresholdPassed
+      interactionState.interactionData.drag != null
     ) {
       return 2
     }
     return 0
   },
   apply: (canvasState, interactionState, strategyState) => {
+    if (
+      interactionState.interactionData.type != 'DRAG' ||
+      interactionState.interactionData.drag == null
+    ) {
+      return emptyStrategyApplicationResult
+    }
+
     const { selectedElements, scale, canvasOffset, projectContents, openFile } = canvasState
     const filteredSelectedElements = getDragTargets(selectedElements)
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -97,6 +97,19 @@ const testMetadata: ElementInstanceMetadataMap = {
 describe('Absolute Resize Bounding Box Strategy single select', () => {
   it.each([
     [
+      'top left corner, drag treshold not reached',
+      {
+        edgePosition: { x: 0, y: 0 } as EdgePosition,
+        drag: canvasPoint({
+          x: 1,
+          y: 1,
+        }),
+        modifiers: emptyModifiers,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 50, top: 50, width: 250, height: 300 },
+      },
+    ],
+    [
       'top left corner',
       {
         edgePosition: { x: 0, y: 0 } as EdgePosition,

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -97,7 +97,7 @@ const testMetadata: ElementInstanceMetadataMap = {
 describe('Absolute Resize Bounding Box Strategy single select', () => {
   it.each([
     [
-      'top left corner, drag treshold not reached',
+      'top left corner, drag threshold not reached',
       {
         edgePosition: { x: 0, y: 0 } as EdgePosition,
         drag: canvasPoint({

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.spec.tsx
@@ -94,7 +94,7 @@ function resizeTestWithTLWH(
 }
 
 describe('Absolute Delta Resize Strategy TLWH', () => {
-  it('does not activate when drag treshold is not reached', async () => {
+  it('does not activate when drag threshold is not reached', async () => {
     const edgePosition: EdgePosition = { x: 0, y: 0 }
     const editorAfterStrategy = resizeTestWithTLWH(edgePosition, canvasPoint({ x: 1, y: 1 }))
     expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-delta-strategy.spec.tsx
@@ -3,7 +3,7 @@ import {
   ElementInstanceMetadata,
   SpecialSizeMeasurements,
 } from '../../../core/shared/element-template'
-import { canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
+import { CanvasPoint, canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
 import { emptyModifiers } from '../../../utils/modifiers'
 import { EditorState } from '../../editor/store/editor-state'
 import { EdgePosition } from '../canvas-types'
@@ -19,12 +19,16 @@ import { defaultCustomStrategyState } from './canvas-strategy-types'
 import { StrategyState } from './interaction-state'
 import { createMouseInteractionForTests } from './interaction-state.test-utils'
 
-function resizeElement(editor: EditorState, edgePosition: EdgePosition): EditorState {
+function resizeElement(
+  editor: EditorState,
+  edgePosition: EdgePosition,
+  drag: CanvasPoint = canvasPoint({ x: 15, y: 25 }),
+): EditorState {
   const interactionSessionWithoutMetadata = createMouseInteractionForTests(
     null as any, // the strategy does not use this
     emptyModifiers,
     { type: 'RESIZE_HANDLE', edgePosition: edgePosition },
-    canvasPoint({ x: 15, y: 25 }),
+    drag,
   )
 
   const strategyResult = absoluteResizeDeltaStrategy.apply(
@@ -60,6 +64,7 @@ function resizeElement(editor: EditorState, edgePosition: EdgePosition): EditorS
 function createTestEditorAndResizeElement(
   edgePosition: EdgePosition,
   snippet: string,
+  drag: CanvasPoint = canvasPoint({ x: 15, y: 25 }),
 ): EditorState {
   const targetElement = elementPath([
     ['scene-aaa', 'app-entity'],
@@ -70,10 +75,13 @@ function createTestEditorAndResizeElement(
     targetElement,
   ])
 
-  return resizeElement(initialEditor, edgePosition)
+  return resizeElement(initialEditor, edgePosition, drag)
 }
 
-function resizeTestWithTLWH(edgePosition: EdgePosition): EditorState {
+function resizeTestWithTLWH(
+  edgePosition: EdgePosition,
+  drag: CanvasPoint = canvasPoint({ x: 15, y: 25 }),
+): EditorState {
   const snippet = `
   <View style={{ ...(props.style || {}) }} data-uid='aaa'>
     <View
@@ -82,10 +90,23 @@ function resizeTestWithTLWH(edgePosition: EdgePosition): EditorState {
     />
   </View>
   `
-  return createTestEditorAndResizeElement(edgePosition, snippet)
+  return createTestEditorAndResizeElement(edgePosition, snippet, drag)
 }
 
 describe('Absolute Delta Resize Strategy TLWH', () => {
+  it('does not activate when drag treshold is not reached', async () => {
+    const edgePosition: EdgePosition = { x: 0, y: 0 }
+    const editorAfterStrategy = resizeTestWithTLWH(edgePosition, canvasPoint({ x: 1, y: 1 }))
+    expect(testPrintCodeFromEditorState(editorAfterStrategy)).toEqual(
+      makeTestProjectCodeWithSnippet(`<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '50px', top: 50, width: 250, height: 300 }}
+          data-uid='bbb'
+        />
+      </View>
+  `),
+    )
+  })
   it('works with element resized from TL corner', async () => {
     const edgePosition: EdgePosition = { x: 0, y: 0 }
     const editorAfterStrategy = resizeTestWithTLWH(edgePosition)

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
@@ -4,7 +4,7 @@ import {
   ElementInstanceMetadataMap,
   SpecialSizeMeasurements,
 } from '../../../core/shared/element-template'
-import { canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
+import { CanvasPoint, canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { emptyModifiers } from '../../../utils/modifiers'
 import { EditorState } from '../../editor/store/editor-state'
@@ -137,16 +137,21 @@ const mixedPinsMetadata = {
   } as ElementInstanceMetadata,
 }
 
-function dragBy15Pixels(
+function dragBy15Pixels(editorState: EditorState, metadata: ElementInstanceMetadataMap) {
+  return dragByPixels(editorState, metadata, canvasPoint({ x: 15, y: 15 }))
+}
+
+function dragByPixels(
   editorState: EditorState,
   metadata: ElementInstanceMetadataMap,
+  dragVector: CanvasPoint,
 ): EditorState {
   const interactionSession: InteractionSession = {
     ...createMouseInteractionForTests(
       null as any, // the strategy does not use this
       emptyModifiers,
       null as any, // the strategy does not use this
-      canvasPoint({ x: 15, y: 15 }),
+      dragVector,
     ),
     metadata: null as any, // the strategy does not use this
     allElementProps: null as any, // the strategy does not use this
@@ -182,6 +187,28 @@ function dragBy15Pixels(
 }
 
 describe('Escape Hatch Strategy', () => {
+  it('does not activate when drag treshold is not reached', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = dragByPixels(initialEditor, simpleMetadata, canvasPoint({ x: 1, y: 1 }))
+
+    expect(finalEditor).toEqual(initialEditor)
+  })
   it('works on a flow element without siblings', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
@@ -187,7 +187,7 @@ function dragByPixels(
 }
 
 describe('Escape Hatch Strategy', () => {
-  it('does not activate when drag treshold is not reached', async () => {
+  it('does not activate when drag threshold is not reached', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'bbb'],

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -109,7 +109,10 @@ export const escapeHatchStrategy: CanvasStrategy = {
     }
   },
   apply: (canvasState, interactionState, strategyState) => {
-    if (interactionState.interactionData.type === 'DRAG') {
+    if (
+      interactionState.interactionData.type === 'DRAG' &&
+      interactionState.interactionData.drag != null
+    ) {
       let shouldEscapeHatch = false
       let escapeHatchActivated = strategyState.customStrategyState.escapeHatchActivated ?? false
       if (interactionState.interactionData.modifiers.cmd) {

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -109,16 +109,14 @@ export const escapeHatchStrategy: CanvasStrategy = {
     }
   },
   apply: (canvasState, interactionState, strategyState) => {
-    if (
-      interactionState.interactionData.type === 'DRAG' &&
-      interactionState.interactionData.drag != null
-    ) {
+    if (interactionState.interactionData.type === 'DRAG') {
       let shouldEscapeHatch = false
       let escapeHatchActivated = strategyState.customStrategyState.escapeHatchActivated ?? false
-      if (interactionState.interactionData.modifiers.cmd) {
-        shouldEscapeHatch = true
-      } else {
-        if (
+      let dragThresholdPassed = interactionState.interactionData.drag != null
+      if (dragThresholdPassed) {
+        if (interactionState.interactionData.modifiers.cmd) {
+          shouldEscapeHatch = true
+        } else if (
           escapeHatchActivated ||
           interactionState.interactionData.globalTime - interactionState.lastInteractionTime >
             AnimationTimer

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
@@ -160,7 +160,7 @@ function reorderElement(
   dragStart: CanvasPoint,
   drag: CanvasPoint,
   metadata: ElementInstanceMetadataMap,
-  newIndex: number,
+  newIndex?: number,
 ): EditorState {
   const interactionSession: InteractionSession = {
     ...createMouseInteractionForTests(
@@ -203,6 +203,55 @@ function reorderElement(
 }
 
 describe('Flex Reorder Strategy', () => {
+  it('does not activate when drag treshold is not reached', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['app-outer-div', 'child-1'],
+    ])
+
+    const initialEditor = getEditorStateWithSelectedViews(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='app-outer-div'
+        style={{ display: 'flex', gap: 10 }}
+      >
+        <div
+          data-uid='child-0'
+          style={{
+            width: 50,
+            height: 50,
+            backgroundColor: 'green',
+          }}
+        />
+        <div
+          data-uid='child-1'
+          style={{
+            width: 50,
+            height: 50,
+            backgroundColor: 'blue',
+          }}
+        />
+        <div
+          data-uid='child-2'
+          style={{
+            width: 50,
+            height: 50,
+            backgroundColor: 'purple',
+          }}
+        />
+      </div>`),
+      [targetElement],
+    )
+
+    const finalEditor = reorderElement(
+      initialEditor,
+      canvasPoint({ x: 89, y: 27 }),
+      canvasPoint({ x: 1, y: 1 }),
+      getDefaultMetadata(),
+    )
+
+    expect(finalEditor).toEqual(initialEditor)
+  })
   it('works with normal direction', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
@@ -203,7 +203,7 @@ function reorderElement(
 }
 
 describe('Flex Reorder Strategy', () => {
-  it('does not activate when drag treshold is not reached', async () => {
+  it('does not activate when drag threshold is not reached', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],
       ['app-outer-div', 'child-1'],

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -3,7 +3,7 @@ import { ElementInstanceMetadataMap } from '../../../core/shared/element-templat
 import { offsetPoint, rectContainsPoint } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { reorderElement } from '../commands/reorder-element-command'
-import { CanvasStrategy } from './canvas-strategy-types'
+import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
 import {
   CanvasPoint,
   canvasPoint,
@@ -67,10 +67,7 @@ export const flexReorderStrategy: CanvasStrategy = {
       interactionState.interactionData.type !== 'DRAG' ||
       interactionState.interactionData.drag == null
     ) {
-      return {
-        commands: [],
-        customState: null,
-      }
+      return emptyStrategyApplicationResult
     }
 
     const { selectedElements } = canvasState

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -26,7 +26,6 @@ export interface DragInteractionData {
   dragStart: CanvasPoint
   drag: CanvasVector | null
   prevDrag: CanvasVector | null
-  dragThresholdPassed: boolean
   originalDragStart: CanvasPoint
   modifiers: Modifiers
   globalTime: number
@@ -142,7 +141,6 @@ export function createInteractionViaMouse(
       dragStart: mouseDownPoint,
       drag: null,
       prevDrag: null,
-      dragThresholdPassed: false,
       originalDragStart: mouseDownPoint,
       modifiers: modifiers,
       globalTime: Date.now(),
@@ -169,14 +167,13 @@ export function updateInteractionViaMouse(
 ): InteractionSessionWithoutMetadata {
   if (currentState.interactionData.type === 'DRAG') {
     const dragThresholdPassed =
-      currentState.interactionData.dragThresholdPassed || dragExceededThreshold(drag)
+      currentState.interactionData.drag != null || dragExceededThreshold(drag)
     return {
       interactionData: {
         type: 'DRAG',
         dragStart: currentState.interactionData.dragStart,
         drag: dragThresholdPassed ? drag : null,
         prevDrag: currentState.interactionData.drag,
-        dragThresholdPassed: dragThresholdPassed,
         originalDragStart: currentState.interactionData.originalDragStart,
         modifiers: modifiers,
         globalTime: Date.now(),
@@ -245,7 +242,6 @@ export function updateInteractionViaKeyboard(
           dragStart: currentState.interactionData.dragStart,
           drag: currentState.interactionData.drag,
           prevDrag: currentState.interactionData.prevDrag,
-          dragThresholdPassed: currentState.interactionData.dragThresholdPassed,
           originalDragStart: currentState.interactionData.originalDragStart,
           modifiers: modifiers,
           globalTime: Date.now(),

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -49,7 +49,7 @@ import { Modifier, Modifiers } from '../../../../utils/modifiers'
 import { pathsEqual } from '../../../../core/shared/element-path'
 import { EditorAction } from 'src/components/editor/action-types'
 
-const DRAG_START_TRESHOLD = 2
+const DRAG_START_THRESHOLD = 2
 
 export function isResizing(editorState: EditorState): boolean {
   // TODO retire isResizing and replace with isInteractionActive once we have the strategies turned on, and the old controls removed
@@ -384,7 +384,7 @@ export function useStartDragStateAfterDragExceedsThreshold(): (
 
       callbackAfterDragExceedsThreshold(
         nativeEvent,
-        DRAG_START_TRESHOLD,
+        DRAG_START_THRESHOLD,
         startDragState(foundTarget, startPoint),
       )
     },

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -242,7 +242,6 @@ describe('interactionStart', () => {
           "x": 100,
           "y": 200,
         },
-        "dragThresholdPassed": false,
         "globalTime": 1000,
         "modifiers": Object {
           "alt": false,
@@ -364,7 +363,6 @@ describe('interactionUpdatex', () => {
           "x": 100,
           "y": 200,
         },
-        "dragThresholdPassed": false,
         "globalTime": 1000,
         "modifiers": Object {
           "alt": false,
@@ -517,7 +515,6 @@ describe('interactionHardReset', () => {
           "x": 110,
           "y": 210,
         },
-        "dragThresholdPassed": false,
         "globalTime": 1000,
         "modifiers": Object {
           "alt": false,
@@ -734,7 +731,6 @@ describe('interactionUpdate with user changed strategy', () => {
           "x": 110,
           "y": 210,
         },
-        "dragThresholdPassed": false,
         "globalTime": 1000,
         "modifiers": Object {
           "alt": false,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1520,14 +1520,12 @@ export const ModifiersKeepDeepEquality: KeepDeepEqualityCall<Modifiers> = combin
 )
 
 export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInteractionData> =
-  combine7EqualityCalls(
+  combine6EqualityCalls(
     (data) => data.dragStart,
     CanvasPointKeepDeepEquality,
     (data) => data.drag,
     nullableDeepEquality(CanvasPointKeepDeepEquality),
     (data) => data.prevDrag,
-    nullableDeepEquality(CanvasPointKeepDeepEquality),
-    (data) => data.dragThresholdPassed,
     createCallWithTripleEquals(),
     (data) => data.originalDragStart,
     CanvasPointKeepDeepEquality,
@@ -1535,13 +1533,12 @@ export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInter
     ModifiersKeepDeepEquality,
     (data) => data.globalTime,
     createCallWithTripleEquals(),
-    (dragStart, drag, prevDrag, dragThresholdPassed, originalDragStart, modifiers, globalTime) => {
+    (dragStart, drag, prevDrag, originalDragStart, modifiers, globalTime) => {
       return {
         type: 'DRAG',
         dragStart: dragStart,
         drag: drag,
         prevDrag: prevDrag,
-        dragThresholdPassed: dragThresholdPassed,
         originalDragStart: originalDragStart,
         modifiers: modifiers,
         globalTime: globalTime,

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -183,7 +183,7 @@ function handleCanvasEvent(model: CanvasModel, event: CanvasMouseEvent): Array<E
         }
         if (model.editorState.canvas.interactionSession?.interactionData.type === 'DRAG') {
           const applyChanges =
-            model.editorState.canvas.interactionSession?.interactionData.dragThresholdPassed
+            model.editorState.canvas.interactionSession?.interactionData.drag != null
           optionalDragStateAction = [CanvasActions.clearInteractionSession(applyChanges)]
         }
         break


### PR DESCRIPTION
1. Not all strategies check the drag threshold
2. The drag threshold is stored redundantly in `DragInteractionData`:
- in `dragThresholdPassed`
- `drag` is `null` when the threshold is not passed
3. There are no tests to check that the strategies should not emit commands when the threshold is passed

I removed the `dragThresholdPassed` flag from `DragInteractionData`, fixed the problematic strategies, and added a new test cases for all mouse strategies.