### PR TITLE
Fix/canvas absolute resize controls

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -114,6 +114,7 @@ const ResizePointOffset = ResizePointSize / 2
 const ResizePoint = React.memo(
   React.forwardRef<HTMLDivElement, ResizePointProps>((props, ref) => {
     const colorTheme = useColorTheme()
+    const { maybeClearHighlightsOnHoverEnd } = useMaybeHighlightElement()
     const scale = useEditorState((store) => store.editor.canvas.scale, 'ResizeEdge scale')
     const dispatch = useEditorState((store) => store.dispatch, 'ResizeEdge dispatch')
     const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
@@ -125,6 +126,14 @@ const ResizePoint = React.memo(
       [dispatch, props.position, canvasOffsetRef, scale],
     )
 
+    const onMouseMove = React.useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        maybeClearHighlightsOnHoverEnd()
+        event.stopPropagation()
+      },
+      [maybeClearHighlightsOnHoverEnd],
+    )
+
     return (
       <div
         ref={ref}
@@ -134,6 +143,7 @@ const ResizePoint = React.memo(
           height: ResizePointSize / scale,
         }}
         onMouseDown={onPointMouseDown}
+        onMouseMove={onMouseMove}
       >
         <div
           style={{
@@ -183,12 +193,21 @@ const ResizeEdge = React.memo(
     const scale = useEditorState((store) => store.editor.canvas.scale, 'ResizeEdge scale')
     const dispatch = useEditorState((store) => store.dispatch, 'ResizeEdge dispatch')
     const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
+    const { maybeClearHighlightsOnHoverEnd } = useMaybeHighlightElement()
 
     const onEdgeMouseDown = React.useCallback(
       (event: React.MouseEvent<HTMLDivElement>) => {
         startResizeInteraction(event, dispatch, props.position, canvasOffsetRef.current, scale)
       },
       [dispatch, props.position, canvasOffsetRef, scale],
+    )
+
+    const onMouseMove = React.useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        maybeClearHighlightsOnHoverEnd()
+        event.stopPropagation()
+      },
+      [maybeClearHighlightsOnHoverEnd],
     )
 
     const lineSize = ResizeMouseAreaSize / scale
@@ -209,6 +228,7 @@ const ResizeEdge = React.memo(
           transform: `translate(${offsetLeft}, ${offsetTop})`,
         }}
         onMouseDown={onEdgeMouseDown}
+        onMouseMove={onMouseMove}
       />
     )
   }),

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -13,6 +13,7 @@ import { windowToCanvasCoordinates } from '../../dom-lookup'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import { isZeroSizedElement } from '../outline-utils'
+import { useMaybeHighlightElement } from './select-mode-hooks'
 
 const selectedElementsSelector = (store: EditorStorePatched) => store.editor.selectedViews
 export const AbsoluteResizeControl = React.memo((props) => {
@@ -139,8 +140,6 @@ const ResizePoint = React.memo(
         ref={ref}
         style={{
           position: 'absolute',
-          width: ResizePointSize / scale,
-          height: ResizePointSize / scale,
         }}
         onMouseDown={onPointMouseDown}
         onMouseMove={onMouseMove}
@@ -149,8 +148,8 @@ const ResizePoint = React.memo(
           style={{
             position: 'relative',
             pointerEvents: 'initial',
-            width: '100%',
-            height: '100%',
+            width: ResizePointSize / scale,
+            height: ResizePointSize / scale,
             top: -ResizePointOffset / scale,
             left: -ResizePointOffset / scale,
             boxSizing: 'border-box',
@@ -170,7 +169,7 @@ const ResizePoint = React.memo(
             position: 'relative',
             width: ResizePointMouseAreaSize / scale,
             height: ResizePointMouseAreaSize / scale,
-            top: -ResizePointMouseAreaOffset / scale,
+            top: -ResizePointMouseAreaSize / scale,
             left: -ResizePointMouseAreaOffset / scale,
             backgroundColor: 'transparent',
             cursor: props.cursor,


### PR DESCRIPTION
**Problem:**
Mouseover on absolute resize controls shouldn't trigger parent highlights, and the corner cursor position is wrong too.

**Fix:**
Disable highlights on mouseover and fix position.

**Commit Details:**
- updating `ResizePoint` and `ResizeEdge` 
