### PR TITLE
fix(canvas) update outline offset when zoomed in

### DIFF
--- a/editor/src/components/canvas/controls/bounding-box-hooks.ts
+++ b/editor/src/components/canvas/controls/bounding-box-hooks.ts
@@ -12,13 +12,13 @@ interface NotNullRefObject<T> {
 
 export function useBoundingBox<T = HTMLDivElement>(
   selectedElements: Array<ElementPath>,
-  onChangeCallback: (ref: NotNullRefObject<T>, boundingBox: CanvasRectangle) => void,
+  onChangeCallback: (ref: NotNullRefObject<T>, boundingBox: CanvasRectangle, scale: number) => void,
 ): React.RefObject<T> {
   const controlRef = React.useRef<T>(null)
   const boundingBoxCallback = React.useCallback(
-    (boundingBox: CanvasRectangle | null) => {
+    (boundingBox: CanvasRectangle | null, scale: number) => {
       if (boundingBox != null && controlRef.current != null) {
-        onChangeCallback(controlRef as NotNullRefObject<T>, boundingBox)
+        onChangeCallback(controlRef as NotNullRefObject<T>, boundingBox, scale)
       }
     },
     [onChangeCallback],
@@ -30,9 +30,10 @@ export function useBoundingBox<T = HTMLDivElement>(
 
 function useBoundingBoxFromMetadataRef(
   selectedElements: Array<ElementPath>,
-  boundingBoxCallback: (boundingRectangle: CanvasRectangle | null) => void,
+  boundingBoxCallback: (boundingRectangle: CanvasRectangle | null, scale: number) => void,
 ): void {
   const metadataRef = useRefEditorState((store) => getMetadata(store.editor))
+  const scaleRef = useRefEditorState((store) => store.editor.canvas.scale)
 
   const boundingBoxCallbackRef = React.useRef(boundingBoxCallback)
   boundingBoxCallbackRef.current = boundingBoxCallback
@@ -48,12 +49,18 @@ function useBoundingBoxFromMetadataRef(
 
     const boundingBox = boundingRectangleArray(frames)
 
-    boundingBoxCallbackRef.current(boundingBox)
-  }, [selectedElements, metadataRef])
+    boundingBoxCallbackRef.current(boundingBox, scaleRef.current)
+  }, [selectedElements, metadataRef, scaleRef])
 
   useSelectorWithCallback(
     (store) => getMetadata(store.editor),
     (newMetadata) => {
+      innerCallback()
+    },
+  )
+  useSelectorWithCallback(
+    (store) => store.editor.canvas.scale,
+    (newScale) => {
       innerCallback()
     },
   )

--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -52,15 +52,15 @@ const OutlineControl = React.memo<OutlineControlProps>((props) => {
     )
   }, 'OutlineControl colors')
 
-  const outlineRef = useBoundingBox(targets, (ref, boundingBox) => {
+  const outlineRef = useBoundingBox(targets, (ref, boundingBox, canvasScale) => {
     if (isZeroSizedElement(boundingBox)) {
       ref.current.style.display = 'none'
     } else {
       ref.current.style.display = 'block'
-      ref.current.style.left = `${boundingBox.x + 0.5 / scale}px`
-      ref.current.style.top = `${boundingBox.y + 0.5 / scale}px`
-      ref.current.style.width = `${boundingBox.width - (0.5 / scale) * 3}px`
-      ref.current.style.height = `${boundingBox.height - (0.5 / scale) * 3}px`
+      ref.current.style.left = `${boundingBox.x + 0.5 / canvasScale}px`
+      ref.current.style.top = `${boundingBox.y + 0.5 / canvasScale}px`
+      ref.current.style.width = `${boundingBox.width - (0.5 / canvasScale) * 3}px`
+      ref.current.style.height = `${boundingBox.height - (0.5 / canvasScale) * 3}px`
     }
   })
 


### PR DESCRIPTION
**Problem:**
When zooming in the canvas outline looks offset. The offset is based on the canvas scale but it's using previous values.

**Fix:**
Update outline controls style when zooming in.

**Commit Details:**
- extending the bounding box hook with scale

This is how it looks like before the fix:
<img width="299" alt="Screenshot 2022-06-15 at 11 52 59" src="https://user-images.githubusercontent.com/4403069/173799367-d8cdcac7-257f-49b1-a804-5a703a1cf5e7.png">

