### PR TITLE
Cmd disables snapping

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -1,6 +1,7 @@
 import { elementPath } from '../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
+  ElementInstanceMetadataMap,
   SpecialSizeMeasurements,
 } from '../../../core/shared/element-template'
 import {
@@ -8,9 +9,10 @@ import {
   canvasPoint,
   canvasRectangle,
   CanvasVector,
+  localRectangle,
 } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
-import { emptyModifiers, Modifiers } from '../../../utils/modifiers'
+import { cmdModifier, emptyModifiers, Modifiers } from '../../../utils/modifiers'
 import { EditorState } from '../../editor/store/editor-state'
 import { foldAndApplyCommands } from '../commands/commands'
 import {
@@ -23,6 +25,60 @@ import { pickCanvasStateFromEditorState } from './canvas-strategies'
 import { defaultCustomStrategyState } from './canvas-strategy-types'
 import { InteractionSession, StrategyState } from './interaction-state'
 import { createMouseInteractionForTests } from './interaction-state.test-utils'
+
+const defaultMetadata: ElementInstanceMetadataMap = {
+  'scene-aaa': {
+    elementPath: elementPath([['scene-aaa']]),
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity': {
+    elementPath: elementPath([['scene-aaa', 'app-entity']]),
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity:aaa': {
+    elementPath: elementPath([['scene-aaa', 'app-entity'], ['aaa']]),
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity:aaa/bbb': {
+    elementPath: elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ]),
+    specialSizeMeasurements: {
+      immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+    } as SpecialSizeMeasurements,
+    globalFrame: canvasRectangle({ x: 50, y: 50, width: 250, height: 300 }),
+    localFrame: localRectangle({ x: 50, y: 50, width: 250, height: 300 }),
+  } as ElementInstanceMetadata,
+}
+
+const metadataWithSnapTarget: ElementInstanceMetadataMap = {
+  'scene-aaa': {
+    elementPath: elementPath([['scene-aaa']]),
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity': {
+    elementPath: elementPath([['scene-aaa', 'app-entity']]),
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity:aaa': {
+    elementPath: elementPath([['scene-aaa', 'app-entity'], ['aaa']]),
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity:aaa/bbb': {
+    elementPath: elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ]),
+    specialSizeMeasurements: {
+      immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+    } as SpecialSizeMeasurements,
+    globalFrame: canvasRectangle({ x: 50, y: 50, width: 250, height: 300 }),
+    localFrame: localRectangle({ x: 50, y: 50, width: 250, height: 300 }),
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity:aaa/ccc': {
+    elementPath: elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'ccc'],
+    ]),
+    globalFrame: canvasRectangle({ x: 66, y: 66, width: 250, height: 300 }),
+    localFrame: localRectangle({ x: 66, y: 66, width: 250, height: 300 }),
+  } as ElementInstanceMetadata,
+}
 
 function prepareEditorState(codeSnippet: string, selectedViews: Array<ElementPath>): EditorState {
   return {
@@ -39,6 +95,7 @@ function dragByPixels(
   editorState: EditorState,
   vector: CanvasVector,
   modifiers: Modifiers,
+  metadata: ElementInstanceMetadataMap = defaultMetadata,
 ): EditorState {
   const interactionSession: InteractionSession = {
     ...createMouseInteractionForTests(
@@ -61,17 +118,7 @@ function dragByPixels(
       accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
-      startingMetadata: {
-        'scene-aaa/app-entity:aaa/bbb': {
-          elementPath: elementPath([
-            ['scene-aaa', 'app-entity'],
-            ['aaa', 'bbb'],
-          ]),
-          specialSizeMeasurements: {
-            immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
-          } as SpecialSizeMeasurements,
-        } as ElementInstanceMetadata,
-      },
+      startingMetadata: metadata ?? defaultMetadata,
       startingAllElementProps: {},
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,
@@ -172,6 +219,99 @@ describe('Absolute Move Strategy', () => {
         <View
           style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '65px', top: 65, width: 250, height: 300 }}
           data-uid='bbb'
+        />
+      </View>`,
+      ),
+    )
+  })
+
+  it('works with a TL pinned absolute element with px values and snapping', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '50px', top: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '66px', top: 66, width: 250, height: 300 }}
+        data-uid='ccc'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = dragByPixels(
+      initialEditor,
+      canvasPoint({ x: 15, y: 15 }),
+      emptyModifiers,
+      metadataWithSnapTarget,
+    )
+
+    // We drag 'bbb' by 15 pixels, but it is moved by 16 pixels to snap to the other view ('ccc')
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '66px', top: 66, width: 250, height: 300 }}
+          data-uid='bbb'
+        />
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '66px', top: 66, width: 250, height: 300 }}
+          data-uid='ccc'
+        />
+      </View>`,
+      ),
+    )
+  })
+
+  it('works with a TL pinned absolute element with px values and disabled snapping', async () => {
+    const targetElement = elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '50px', top: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '66px', top: 66, width: 250, height: 300 }}
+        data-uid='ccc'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const finalEditor = dragByPixels(
+      initialEditor,
+      canvasPoint({ x: 15, y: 15 }),
+      cmdModifier,
+      metadataWithSnapTarget,
+    )
+
+    // We drag 'bbb' by 15 pixels, it should be snapped by 16 pixels to snap to the other  ('ccc') view, but it is not snapping because
+    // of the cmd modifier
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      makeTestProjectCodeWithSnippet(
+        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '65px', top: 65, width: 250, height: 300 }}
+          data-uid='bbb'
+        />
+        <View
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: '66px', top: 66, width: 250, height: 300 }}
+          data-uid='ccc'
         />
       </View>`,
       ),

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -99,28 +99,45 @@ export function applyAbsoluteMoveCommon(
   strategyState: StrategyState,
   getMoveCommands: (snappedDragVector: CanvasPoint) => Array<CanvasCommand>,
 ): StrategyApplicationResult {
-  if (interactionState.interactionData.type === 'DRAG') {
+  if (
+    interactionState.interactionData.type === 'DRAG' &&
+    interactionState.interactionData.drag != null
+  ) {
     const drag = interactionState.interactionData.drag
     const shiftKeyPressed = interactionState.interactionData.modifiers.shift
-    const constrainedDragAxis =
-      shiftKeyPressed && drag != null ? determineConstrainedDragAxis(drag) : null
-    const { snappedDragVector, guidelinesWithSnappingVector } = snapDrag(
-      drag,
-      constrainedDragAxis,
-      strategyState.startingMetadata,
-      canvasState.selectedElements,
-      canvasState.scale,
-    )
-    const commandsForSelectedElements = getMoveCommands(snappedDragVector)
-    return {
-      commands: [
-        ...commandsForSelectedElements,
-        updateHighlightedViews('transient', []),
-        setSnappingGuidelines('transient', guidelinesWithSnappingVector),
-        setElementsToRerenderCommand(canvasState.selectedElements),
-        setCursorCommand('transient', CSSCursor.Move),
-      ],
-      customState: null,
+    const cmdKeyPressed = interactionState.interactionData.modifiers.cmd
+    if (cmdKeyPressed) {
+      const commandsForSelectedElements = getMoveCommands(drag)
+      return {
+        commands: [
+          ...commandsForSelectedElements,
+          updateHighlightedViews('transient', []),
+          setElementsToRerenderCommand(canvasState.selectedElements),
+          setCursorCommand('transient', CSSCursor.Move),
+        ],
+        customState: null,
+      }
+    } else {
+      const constrainedDragAxis =
+        shiftKeyPressed && drag != null ? determineConstrainedDragAxis(drag) : null
+      const { snappedDragVector, guidelinesWithSnappingVector } = snapDrag(
+        drag,
+        constrainedDragAxis,
+        strategyState.startingMetadata,
+        canvasState.selectedElements,
+        canvasState.scale,
+      )
+      const commandsForSelectedElements = getMoveCommands(snappedDragVector)
+      return {
+        commands: [
+          ...commandsForSelectedElements,
+          updateHighlightedViews('transient', []),
+          setSnappingGuidelines('transient', guidelinesWithSnappingVector),
+          setElementsToRerenderCommand(canvasState.selectedElements),
+          setCursorCommand('transient', CSSCursor.Move),
+        ],
+        customState: null,
+      }
     }
   } else {
     // Fallback for when the checks above are not satisfied.


### PR DESCRIPTION
cmd disables snapping while dragging

Note:
Cmd-dragging is handled by the absolute-reparent strategy, but I still did not have to modify the absolute-reparent strategy itself. Why? Because the absolute-reparent strategy is a "higher order strategy", it gets the move commands from the absolute-move. 