### PR TITLE
Separate performance tests into 2 charts

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -230,10 +230,17 @@ jobs:
                 }
               },
               {
-                "title": "Chart:",
+                "title": "Frame Tests:",
                 "color": 2369839,
                 "image": {
-                  "url": $result_chart
+                  "url": $result_frames_chart
+                }
+              },
+              {
+                "title": "Interaction Tests:",
+                "color": 14540253,
+                "image": {
+                  "url": $result_interactions_chart
                 }
               }
             ]
@@ -241,9 +248,10 @@ jobs:
           HTML_URL: ${{ github.event.pull_request.html_url }}
           DESCRIPTION: 'Link to test editor: https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }} \n \n Results: \n ${{ steps.run-performance-test.outputs.perf-discord-message }}'
           REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-          RESULT_CHART: ${{ steps.run-performance-test.outputs.perf-chart }}
+          RESULT_FRAMES_CHART: ${{ steps.run-performance-test.outputs.perf-frames-chart }}
+          RESULT_INTERACTIONS_CHART: ${{ steps.run-performance-test.outputs.perf-interactions-chart }}
         run: |
-          echo "DISCORD_EMBEDS=$(jq -nc --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" --arg result_chart "$RESULT_CHART" "$TEMPLATE")" | sed 's/\\\\n/\\n/g' >> $GITHUB_ENV
+          echo "DISCORD_EMBEDS=$(jq -nc --arg title "$TITLE" --arg html_url "$HTML_URL" --arg description "$DESCRIPTION" --arg repo_full_name "$REPO_FULL_NAME" --arg result_frames_chart "$RESULT_FRAMES_CHART" --arg result_interactions_chart "$RESULT_INTERACTIONS_CHART" "$TEMPLATE")" | sed 's/\\\\n/\\n/g' >> $GITHUB_ENV
       - name: Send Discord Notification
         uses: Ilshidur/action-discord@0.3.2
         env:

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -84,35 +84,60 @@ function consoleMessageForResult(result: FrameResult, beforeOrAfter: 'Before' | 
   return `${beforeOrAfter}: ${result.analytics.percentile50}ms (${result.analytics.frameMin}-${result.analytics.frameMax}ms)`
 }
 
-type PerformanceResult = { [key: string]: FrameResult }
+type ResultsGroup = { [key: string]: FrameResult }
+type PerformanceResults = {
+  frameTests: ResultsGroup
+  interactionTests: ResultsGroup
+}
 
 export const testPerformance = async function () {
   const stagingResult = await testPerformanceInner(STAGING_EDITOR_URL)
   const masterResult = await testPerformanceInner(MASTER_EDITOR_URL)
 
-  const summaryImage = await uploadSummaryImage(stagingResult, masterResult)
+  const framesSummaryImage = await uploadSummaryImage(
+    stagingResult.frameTests,
+    masterResult.frameTests,
+    100,
+  )
+  const interactionsSummaryImage = await uploadSummaryImage(
+    stagingResult.interactionTests,
+    masterResult.interactionTests,
+    200,
+  )
 
-  const messageParts = Object.entries(stagingResult).flatMap(([k, result]) => {
-    const targetResult = masterResult[k]
+  const combinedStagingResult = { ...stagingResult.frameTests, ...stagingResult.interactionTests }
+  const combinedMasterResult = { ...masterResult.frameTests, ...masterResult.interactionTests }
+
+  const messageParts = Object.entries(combinedStagingResult).flatMap(([k, result]) => {
+    const targetResult = combinedMasterResult[k]
     const beforeMedian = targetResult.analytics.percentile50 ?? 1
     const afterMedian = result.analytics.percentile50 ?? 1
     const change = ((afterMedian - beforeMedian) / beforeMedian) * 100
-    return [
-      `**${result.title} (${Math.round(change)}%):**`,
-      consoleMessageForResult(targetResult, 'Before'),
-      consoleMessageForResult(result, 'After'),
-      '',
-    ]
+    const titleLine = `**${result.title} (${Math.round(change)}%):**`
+    const spacerLine = ''
+    if (Math.abs(change) > 5) {
+      return [
+        titleLine,
+        consoleMessageForResult(targetResult, 'Before'),
+        consoleMessageForResult(result, 'After'),
+        spacerLine,
+      ]
+    } else {
+      return [titleLine, spacerLine]
+    }
   })
 
   const message = messageParts.join('<br />')
   const discordMessage = messageParts.join('\\n')
 
-  console.info(`::set-output name=perf-result:: ${message} <br /> ![(Chart)](${summaryImage})`)
+  console.info(
+    `::set-output name=perf-result:: ${message} <br /> ![(Chart1)](${framesSummaryImage}) <br /> ![(Chart2)](${interactionsSummaryImage})`,
+  )
 
   // Output the individual parts for building a discord message
   console.info(`::set-output name=perf-discord-message:: ${discordMessage}`)
-  console.info(`::set-output name=perf-chart:: ${summaryImage}`)
+  console.info(`::set-output name=perf-frames-chart:: ${framesSummaryImage}`)
+  console.info(`::set-output name=perf-interactions-chart:: ${interactionsSummaryImage}`)
 }
 
 type PageToPromiseResult<T> = (page: puppeteer.Page) => Promise<T>
@@ -164,7 +189,7 @@ function frameObjectSuccess(frameObject: { [key: string]: FrameResult }): boolea
   return Object.values(frameObject).every(frameResultSuccess)
 }
 
-export const testPerformanceInner = async function (url: string): Promise<PerformanceResult> {
+export const testPerformanceInner = async function (url: string): Promise<PerformanceResults> {
   const highlightRegularResult = await retryPageCalls(
     url,
     testHighlightRegularPerformance,
@@ -207,16 +232,20 @@ export const testPerformanceInner = async function (url: string): Promise<Perfor
   )
 
   return {
-    highlightRegularResult: highlightRegularResult,
-    highlightAllElementsResult: highlightAllElementsResult,
-    selectionResult: selectionResult.selection,
-    deselectionResult: selectionResult.deselection,
-    scrollResult: scrollResult,
-    resizeResult: resizeResult,
-    absoluteMoveLargeInteractionResult: absoluteMoveLargeResult.interaction,
-    absoluteMoveLargeMoveResult: absoluteMoveLargeResult.move,
-    absoluteMoveSmallInteractionResult: absoluteMoveSmallResult.interaction,
-    absoluteMoveSmallMoveResult: absoluteMoveSmallResult.move,
+    frameTests: {
+      highlightRegularResult: highlightRegularResult,
+      highlightAllElementsResult: highlightAllElementsResult,
+      selectionResult: selectionResult.selection,
+      deselectionResult: selectionResult.deselection,
+      scrollResult: scrollResult,
+      resizeResult: resizeResult,
+      absoluteMoveLargeMoveResult: absoluteMoveLargeResult.move,
+      absoluteMoveSmallMoveResult: absoluteMoveSmallResult.move,
+    },
+    interactionTests: {
+      absoluteMoveLargeInteractionResult: absoluteMoveLargeResult.interaction,
+      absoluteMoveSmallInteractionResult: absoluteMoveSmallResult.interaction,
+    },
   }
 }
 
@@ -517,11 +546,12 @@ const getFrameData = (
 }
 
 async function uploadSummaryImage(
-  stagingResult: PerformanceResult,
-  masterResult: PerformanceResult,
+  stagingResult: ResultsGroup,
+  masterResult: ResultsGroup,
+  maxXValue: number,
 ): Promise<string> {
   const imageFileName = v4() + '.png'
-  const fileURI = await createSummaryPng(stagingResult, masterResult, imageFileName)
+  const fileURI = await createSummaryPng(stagingResult, masterResult, imageFileName, maxXValue)
 
   if (fileURI != null) {
     const s3FileUrl = await uploadPNGtoAWS(fileURI)
@@ -532,9 +562,10 @@ async function uploadSummaryImage(
 }
 
 async function createSummaryPng(
-  stagingResult: PerformanceResult,
-  masterResult: PerformanceResult,
+  stagingResult: ResultsGroup,
+  masterResult: ResultsGroup,
   testFileName: string,
+  maxXValue: number,
 ): Promise<string | null> {
   if (
     process.env.PERFORMANCE_GRAPHS_PLOTLY_USERNAME == null ||
@@ -612,7 +643,7 @@ async function createSummaryPng(
     ],
     xaxis: {
       title: 'lower is better, ms / frame (16.67 = 60fps), many runs, cutoff 200ms',
-      range: [0, 251],
+      range: [0, maxXValue],
       showgrid: true,
       zeroline: true,
       dtick: 16.67,


### PR DESCRIPTION
**Problem:**
The charts were too busy and difficult to read

**Fix:**
Separate the results into 2 charts based on the types of tests, since we have tests that are measuring entire interactions vs tests that are focused on a specific part of an interaction.