### PR TITLE
Fix the snapping delta.

### DIFF
--- a/editor/src/components/canvas/controls/guideline-helpers.ts
+++ b/editor/src/components/canvas/controls/guideline-helpers.ts
@@ -162,7 +162,10 @@ export function getSnapDelta(
       return working
     }
   }, Utils.zeroPoint as CanvasPoint)
-  return { delta: Utils.roundPointTo(delta, 0), guidelinesWithSnappingVector: winningGuidelines }
+  return {
+    delta: Utils.roundPointToNearestHalf(delta),
+    guidelinesWithSnappingVector: winningGuidelines,
+  }
 }
 
 export function pointGuidelineToBoundsEdge(


### PR DESCRIPTION
**Problem:**
Sometimes the snapping can skip past or the guideline can show as snapping but the element isn't snapped to that line.

**Fix:**
Changed a call that was rounding the change to the drag to a whole number to one that rounds to the nearest 0.5, so that it aligns with the values that are changing.

**Commit Details:**
- `getSnapDelta` now rounds with `roundPointToNearestHalf`.
