### PR TITLE
Fix/canvas resize cursors

### DIFF
--- a/editor/src/components/canvas/controls/parent-bounds.tsx
+++ b/editor/src/components/canvas/controls/parent-bounds.tsx
@@ -24,31 +24,32 @@ export const ParentBounds = React.memo(() => {
       {parentFrames.map((frame, i) => {
         return (
           <CanvasOffsetWrapper key={`parent-outline-${i}`}>
-            <CenteredCrossSVG
-              id='parent-cross-top-left'
-              centerX={frame.x}
-              centerY={frame.y}
-              scale={scale}
-            />
-
-            <CenteredCrossSVG
-              id='parent-cross-top-right'
-              centerX={frame.x + frame.width}
-              centerY={frame.y}
-              scale={scale}
-            />
-            <CenteredCrossSVG
-              id='parent-cross-bottom-right'
-              centerX={frame.x + frame.width}
-              centerY={frame.y + frame.height}
-              scale={scale}
-            />
-            <CenteredCrossSVG
-              id='parent-cross-bottom-left'
-              centerX={frame.x}
-              centerY={frame.y + frame.height}
-              scale={scale}
-            />
+            <div style={{ pointerEvents: 'none' }}>
+              <CenteredCrossSVG
+                id='parent-cross-top-left'
+                centerX={frame.x}
+                centerY={frame.y}
+                scale={scale}
+              />
+              <CenteredCrossSVG
+                id='parent-cross-top-right'
+                centerX={frame.x + frame.width}
+                centerY={frame.y}
+                scale={scale}
+              />
+              <CenteredCrossSVG
+                id='parent-cross-bottom-right'
+                centerX={frame.x + frame.width}
+                centerY={frame.y + frame.height}
+                scale={scale}
+              />
+              <CenteredCrossSVG
+                id='parent-cross-bottom-left'
+                centerX={frame.x}
+                centerY={frame.y + frame.height}
+                scale={scale}
+              />
+            </div>
           </CanvasOffsetWrapper>
         )
       })}

--- a/editor/src/components/canvas/controls/parent-outlines.tsx
+++ b/editor/src/components/canvas/controls/parent-outlines.tsx
@@ -34,6 +34,7 @@ export const ParentOutlines = React.memo(() => {
                 outlineStyle: 'dotted',
                 outlineColor: colorTheme.primary.value,
                 outlineWidth: 1 / scale,
+                pointerEvents: 'none',
               }}
             />
           </CanvasOffsetWrapper>

--- a/editor/src/components/canvas/controls/position-outline.tsx
+++ b/editor/src/components/canvas/controls/position-outline.tsx
@@ -192,6 +192,7 @@ const PinOutline = React.memo((props: PinOutlineProps): JSX.Element => {
         height: height,
         borderTop: borderTop,
         borderLeft: borderLeft,
+        pointerEvents: 'none',
       }}
     />
   )

--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -140,14 +140,12 @@ const ResizePoint = React.memo(
         ref={ref}
         style={{
           position: 'absolute',
+          pointerEvents: 'none',
         }}
-        onMouseDown={onPointMouseDown}
-        onMouseMove={onMouseMove}
       >
         <div
           style={{
             position: 'relative',
-            pointerEvents: 'initial',
             width: ResizePointSize / scale,
             height: ResizePointSize / scale,
             top: -ResizePointOffset / scale,
@@ -172,8 +170,11 @@ const ResizePoint = React.memo(
             top: -ResizePointMouseAreaSize / scale,
             left: -ResizePointMouseAreaOffset / scale,
             backgroundColor: 'transparent',
+            pointerEvents: 'initial',
             cursor: props.cursor,
           }}
+          onMouseDown={onPointMouseDown}
+          onMouseMove={onMouseMove}
         />
       </div>
     )


### PR DESCRIPTION
**Problem:**
It's possible to initiate resize without seeing the resize cursor. Resize cursor can also disappear on resize control mousedown, the resize trigger div is slightly different sized than the one which shows the cursor.

**Fix:**
I moved the mouse event handlers to the divs where the cursor is shown. Also changed the parent outline, parent bounds and pin lines to not interfere with mouse events as these are indicators only. 

**Commit Details:**
- mostly canvas control css changes adding `pointerEvents: 'none'`
