### PR TITLE
Hide code editor when running perf tests

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -37,10 +37,20 @@ import { canvasPoint } from '../../core/shared/math-utils'
 import { InspectorWidthAtom } from '../inspector/common/inspector-atoms'
 import { useAtom } from 'jotai'
 import { CanvasStrategyInspector } from './canvas-strategies/canvas-strategy-inspector'
+import { getQueryParam } from '../../common/env-vars'
+import { when } from '../../utils/react-conditionals'
 
 interface NumberSize {
   width: number
   height: number
+}
+
+function isCodeEditorEnabled(): boolean {
+  if (typeof window !== 'undefined') {
+    return getQueryParam('code_editor_disabled') !== 'true'
+  } else {
+    return true
+  }
 }
 
 const TopMenuHeight = 35
@@ -153,6 +163,8 @@ const DesignPanelRootInner = React.memo(() => {
     'design panel root',
   )
 
+  const codeEditorEnabled = isCodeEditorEnabled()
+
   const isInsertMenuSelected = rightMenuSelectedTab === RightMenuTab.Insert
 
   const updateDeltaWidth = React.useCallback(
@@ -263,7 +275,7 @@ const DesignPanelRootInner = React.memo(() => {
               borderLeft: `1px solid ${colorTheme.subduedBorder.value}`,
             }}
           >
-            <CodeEditorWrapper />
+            {when(codeEditorEnabled, <CodeEditorWrapper />)}
             <ConsoleAndErrorsPane />
           </Resizable>
         </SimpleFlexColumn>

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -8,10 +8,12 @@ const fs = require('fs')
 const path = require('path')
 const moveFile = require('move-file')
 
-const BRANCH_NAME = process.env.BRANCH_NAME ? `?branch_name=${process.env.BRANCH_NAME}` : ''
-const STAGING_EDITOR_URL = process.env.EDITOR_URL ?? `https://utopia.pizza/p${BRANCH_NAME}`
+const BRANCH_NAME = process.env.BRANCH_NAME ? `&branch_name=${process.env.BRANCH_NAME}` : ''
+const STAGING_EDITOR_URL =
+  process.env.EDITOR_URL ?? `https://utopia.pizza/p?code_editor_disabled=true${BRANCH_NAME}`
 const MASTER_EDITOR_URL =
-  process.env.MASTER_EDITOR_URL ?? `https://utopia.pizza/p?branch_name=performance-test-target`
+  process.env.MASTER_EDITOR_URL ??
+  `https://utopia.pizza/p?code_editor_disabled=true&branch_name=performance-test-target`
 
 export function wait(timeout: number): Promise<void> {
   return new Promise((resolve) => {


### PR DESCRIPTION
**Problem:**
The code editor adds a lot of variance into the performance tests for no real gain, since we're not testing anything specific to the code editor anyway.

**Fix:**
Hide the code editor via a query param when running the performance tests