### PR TITLE
Disable controls and strategies when z is pressed

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -428,6 +428,8 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       : []
   }
 
+  const resizeStatus = getResizeStatus()
+
   return (
     <div
       id={CanvasControlsContainerID}
@@ -453,33 +455,38 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
         />,
       )}
       {when(
-        (isFeatureEnabled('Canvas Strategies') && props.editor.mode.type === 'select') ||
-          props.editor.mode.type === 'select-lite',
-        <PinLines />,
-      )}
-      {when(
-        (isFeatureEnabled('Canvas Strategies') && props.editor.mode.type === 'select') ||
-          props.editor.mode.type === 'select-lite',
-        <DistanceGuidelineControl />,
-      )}
-      {when(
-        (isFeatureEnabled('Canvas Strategies') &&
-          isFeatureEnabled('Insertion Plus Button') &&
-          props.editor.mode.type === 'select') ||
-          props.editor.mode.type === 'select-lite',
-        <InsertionControls />,
-      )}
-      {renderHighlightControls()}
-      <LayoutParentControl />
-      {when(
-        isFeatureEnabled('Canvas Strategies'),
-        <MultiSelectOutlineControl localSelectedElements={localSelectedViews} />,
-      )}
-      {when(isFeatureEnabled('Canvas Strategies'), <GuidelineControls />)}
-      <OutlineHighlightControl />
-      {when(
-        isFeatureEnabled('Canvas Strategies'),
-        <>{strategyControls.map((c) => React.createElement(c.control, { key: c.key }))}</>,
+        resizeStatus !== 'disabled',
+        <>
+          {when(
+            (isFeatureEnabled('Canvas Strategies') && props.editor.mode.type === 'select') ||
+              props.editor.mode.type === 'select-lite',
+            <PinLines />,
+          )}
+          {when(
+            (isFeatureEnabled('Canvas Strategies') && props.editor.mode.type === 'select') ||
+              props.editor.mode.type === 'select-lite',
+            <DistanceGuidelineControl />,
+          )}
+          {when(
+            (isFeatureEnabled('Canvas Strategies') &&
+              isFeatureEnabled('Insertion Plus Button') &&
+              props.editor.mode.type === 'select') ||
+              props.editor.mode.type === 'select-lite',
+            <InsertionControls />,
+          )}
+          {renderHighlightControls()}
+          <LayoutParentControl />
+          {when(
+            isFeatureEnabled('Canvas Strategies'),
+            <MultiSelectOutlineControl localSelectedElements={localSelectedViews} />,
+          )}
+          {when(isFeatureEnabled('Canvas Strategies'), <GuidelineControls />)}
+          <OutlineHighlightControl />
+          {when(
+            isFeatureEnabled('Canvas Strategies'),
+            <>{strategyControls.map((c) => React.createElement(c.control, { key: c.key }))}</>,
+          )}
+        </>,
       )}
     </div>
   )

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -620,13 +620,17 @@ export function useSelectAndHover(
   onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 } {
   const modeType = useEditorState((store) => store.editor.mode.type, 'useSelectAndHover mode')
+  const isZoomMode = useEditorState(
+    (store) => store.editor.keysPressed['z'] ?? false,
+    'useSelectAndHover isZoomMode',
+  )
   const hasInteractionSession = useEditorState(
     (store) => store.editor.canvas.interactionSession != null,
     'useSelectAndHover hasInteractionSession',
   )
   const selectModeCallbacks = useSelectOrLiveModeSelectAndHover(
-    modeType === 'select' || modeType === 'select-lite' || modeType === 'live',
-    modeType === 'select' || modeType === 'live',
+    (modeType === 'select' || modeType === 'select-lite' || modeType === 'live') && !isZoomMode,
+    (modeType === 'select' || modeType === 'live') && !isZoomMode,
     cmdPressed,
     setSelectedViewsForCanvasControlsOnly,
   )

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`436`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`437`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`499`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`500`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`578`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`579`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`650`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`651`)
   })
 })


### PR DESCRIPTION
# Issue

When `z` is pressed we are in "zoom mode", controls should disappear, and strategies should not work (e.g. dragging)

# Solution

First I thought that I should check if z pressed in the `isApplicable` functions of strategies. But it seems we surely don't wanna run any of the strategies, and it would be easy to forget about this in a new strategy. Furthermore, the information that which buttons are pressed is not available for the strategies.

This made me feel that maybe when z is down we are not even in select mode. But we barely create new modes, they are quite heavyweight, so I did not want to implement a new mode just for this small feature.

So I decided to just not allow select mode to create interaction sessions when z is pressed, which guarantees none of the strategies can be invoked, and also to disable rendering most of the controls then (we already had a helper function `getResizeStatus` for that for the old canvas controls, which I reused).