### PR TITLE
fix(canvas) reparent strategy checks control type

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -46,6 +46,7 @@ export const absoluteReparentStrategy: CanvasStrategy = {
   fitness: (canvasState, interactionState) => {
     if (
       canvasState.selectedElements.length > 0 &&
+      interactionState.activeControl.type === 'BOUNDING_AREA' &&
       interactionState.interactionData.modifiers.cmd &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.interactionData.drag != null


### PR DESCRIPTION
**Problem:**
It's possible to trigger reparent strategy while resizing and pressing cmd.

**Fix:**
Other Absolute Move strategies are checking the active control type in their fitness functions, reparent missed this.

**Commit Details:**
- update `fitness` in `absolute-reparent-strategy` 
