### PR TITLE
Fix parent-child multiselect resize

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -28,7 +28,7 @@ import { ParentOutlines } from '../controls/parent-outlines'
 import { AbsoluteResizeControl } from '../controls/select-mode/absolute-resize-control'
 import { AbsolutePin, hasAtLeastTwoPinsPerSide } from './absolute-resize-helpers'
 import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
-import { getMultiselectBounds } from './shared-absolute-move-strategy-helpers'
+import { getDragTargets, getMultiselectBounds } from './shared-absolute-move-strategy-helpers'
 import {
   pickCursorFromEdgePosition,
   resizeBoundingBox,
@@ -41,9 +41,10 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
   name: 'Absolute Resize',
   isApplicable: (canvasState, interactionState, metadata, allElementProps) => {
+    const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
     if (
-      canvasState.selectedElements.length > 1 ||
-      (canvasState.selectedElements.length >= 1 &&
+      filteredSelectedElements.length > 1 ||
+      (filteredSelectedElements.length >= 1 &&
         (interactionState?.interactionData.modifiers.alt ||
           interactionState?.interactionData.modifiers.shift))
     ) {
@@ -89,9 +90,10 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
       const edgePosition = interactionState.activeControl.edgePosition
       if (interactionState.interactionData.drag != null) {
         const drag = interactionState.interactionData.drag
+        const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
         const originalBoundingBox = getMultiselectBounds(
           sessionState.startingMetadata,
-          canvasState.selectedElements,
+          filteredSelectedElements,
         )
         if (originalBoundingBox != null) {
           const keepAspectRatio = interactionState.interactionData.modifiers.shift
@@ -109,7 +111,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
             centerBased,
           )
           const { snappedBoundingBox, guidelinesWithSnappingVector } = snapBoundingBox(
-            canvasState.selectedElements,
+            filteredSelectedElements,
             sessionState.startingMetadata,
             edgePosition,
             newBoundingBox,
@@ -118,7 +120,8 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
             centerBased,
             sessionState.startingAllElementProps,
           )
-          const commandsForSelectedElements = canvasState.selectedElements.flatMap(
+
+          const commandsForSelectedElements = filteredSelectedElements.flatMap(
             (selectedElement) => {
               const element = getElementFromProjectContents(
                 selectedElement,


### PR DESCRIPTION
We need to filter out descendants from selection when resizing, otherwise the change in the parent coordinate system, and the change applied to the child itself add up and result in way too much moving/scaling:

![image](https://user-images.githubusercontent.com/127662/174063088-2c32e8ac-ef27-4bc6-ae84-66cc824f383d.png)

The solution is to filter out targets which are descendants.
Note: this simple solution keeps the selected children the same size as before. To scale/move them appropriately, so the overall selection keeps its relative dimensions, that is a bigger project and should be planned accordingly.