### PR TITLE
Fixes some keyboard absolute move guideline bugs.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -24,6 +24,7 @@ import {
   getAbsoluteMoveCommandsForSelectedElement,
   getDragTargets,
   getMultiselectBounds,
+  snapDrag,
 } from './shared-absolute-move-strategy-helpers'
 
 export const absoluteMoveStrategy: CanvasStrategy = {
@@ -143,33 +144,4 @@ export function applyAbsoluteMoveCommon(
     // Fallback for when the checks above are not satisfied.
     return emptyStrategyApplicationResult
   }
-}
-
-function snapDrag(
-  drag: CanvasPoint | null,
-  constrainedDragAxis: ConstrainedDragAxis | null,
-  jsxMetadata: ElementInstanceMetadataMap,
-  selectedElements: Array<ElementPath>,
-  canvasScale: number,
-): {
-  snappedDragVector: CanvasPoint
-  guidelinesWithSnappingVector: Array<GuidelineWithSnappingVector>
-} {
-  if (drag == null) {
-    return { snappedDragVector: zeroCanvasPoint, guidelinesWithSnappingVector: [] }
-  }
-  const multiselectBounds = getMultiselectBounds(jsxMetadata, selectedElements)
-
-  // This is the entry point to extend the list of snapping strategies, if we want to add more
-
-  const { snappedDragVector, guidelinesWithSnappingVector } = runLegacyAbsoluteMoveSnapping(
-    drag,
-    constrainedDragAxis,
-    jsxMetadata,
-    selectedElements,
-    canvasScale,
-    multiselectBounds,
-  )
-
-  return { snappedDragVector, guidelinesWithSnappingVector }
 }

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -1,6 +1,7 @@
 import { elementPath } from '../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
+  ElementInstanceMetadataMap,
   SpecialSizeMeasurements,
 } from '../../../core/shared/element-template'
 import { canvasRectangle } from '../../../core/shared/math-utils'
@@ -22,13 +23,24 @@ export function pressKeys(
   keys: Array<KeyCharacter>,
   modifiers: Modifiers,
 ): EditorState {
+  const metadata: ElementInstanceMetadataMap = {
+    'scene-aaa/app-entity:aaa/bbb': {
+      elementPath: elementPath([
+        ['scene-aaa', 'app-entity'],
+        ['aaa', 'bbb'],
+      ]),
+      specialSizeMeasurements: {
+        immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      } as SpecialSizeMeasurements,
+    } as ElementInstanceMetadata,
+  }
   const interactionSession: InteractionSession = {
     ...createInteractionViaKeyboard(
       keys,
       modifiers,
       null as any, // the strategy does not use this
     ),
-    metadata: null as any, // the strategy does not use this
+    metadata: metadata,
     allElementProps: null as any,
   }
 
@@ -42,17 +54,7 @@ export function pressKeys(
       accumulatedPatches: null as any, // the strategy does not use this
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
-      startingMetadata: {
-        'scene-aaa/app-entity:aaa/bbb': {
-          elementPath: elementPath([
-            ['scene-aaa', 'app-entity'],
-            ['aaa', 'bbb'],
-          ]),
-          specialSizeMeasurements: {
-            immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
-          } as SpecialSizeMeasurements,
-        } as ElementInstanceMetadata,
-      },
+      startingMetadata: metadata,
       startingAllElementProps: { 'scene-aaa/app-entity:aaa/bbb': {} },
       customStrategyState: defaultCustomStrategyState(),
     } as StrategyState,

--- a/editor/src/components/canvas/commands/commands.spec.ts
+++ b/editor/src/components/canvas/commands/commands.spec.ts
@@ -1,0 +1,42 @@
+import { createEditorState } from '../../editor/store/editor-state'
+import { NO_OP } from '../../../core/shared/utils'
+import { CSSCursor } from '../canvas-types'
+import { foldAndApplyCommands } from './commands'
+import { setCursorCommand } from './set-cursor-command'
+
+describe('foldAndApplyCommands', () => {
+  it('should accumulate commands that are permanent', () => {
+    const editorState = createEditorState(NO_OP)
+    const result = foldAndApplyCommands(
+      editorState,
+      editorState,
+      [],
+      [setCursorCommand('permanent', CSSCursor.Move)],
+      [],
+      'permanent',
+    )
+    expect(result.accumulatedPatches).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "canvas": Object {
+            "cursor": Object {
+              "$set": "-webkit-image-set( url( '/editor/cursors/cursor-moving.png ') 1x, url( '/editor/cursors/cursor-moving@2x.png ') 2x ) 4 4, default",
+            },
+          },
+        },
+      ]
+    `)
+  })
+  it('should not accumulate commands that are transient', () => {
+    const editorState = createEditorState(NO_OP)
+    const result = foldAndApplyCommands(
+      editorState,
+      editorState,
+      [],
+      [setCursorCommand('transient', CSSCursor.Move)],
+      [],
+      'permanent',
+    )
+    expect(result.accumulatedPatches).toMatchInlineSnapshot(`Array []`)
+  })
+})

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -144,7 +144,8 @@ export function foldAndApplyCommands(
       workingEditorState = updateEditorStateWithPatches(workingEditorState, statePatch)
       // Collate the patches.
       statePatches.push(...statePatch)
-      if (shouldAccumulatePatches) {
+      // Do not accumulate commands that are not permanent.
+      if (shouldAccumulatePatches && command.transient === 'permanent') {
         accumulatedPatches.push(...statePatch)
       }
       workingCommandDescriptions.push({

--- a/editor/src/components/canvas/controls/guideline-controls.tsx
+++ b/editor/src/components/canvas/controls/guideline-controls.tsx
@@ -50,8 +50,11 @@ const GuidelineControl = React.memo<GuidelineProps>((props) => {
       }
     },
   )
+  const key = `guideline-${props.index}`
   return (
     <div
+      id={key}
+      key={key}
       ref={controlRef}
       style={{
         position: 'absolute',

--- a/editor/src/components/canvas/controls/select-mode/distance-guideline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/distance-guideline-control.tsx
@@ -7,6 +7,7 @@ import { CanvasRectangle } from '../../../../core/shared/math-utils'
 import { ElementPath } from '../../../../core/shared/project-file-types'
 import { fastForEach } from '../../../../core/shared/utils'
 import { useEditorState } from '../../../editor/store/store-hook'
+import { isDragInteractionData } from '../../canvas-strategies/interaction-state'
 import { getMultiselectBounds } from '../../canvas-strategies/shared-absolute-move-strategy-helpers'
 import { Guideline, Guidelines } from '../../guideline'
 import { DistanceGuideline } from '../distance-guideline'
@@ -24,10 +25,12 @@ function getDistanceGuidelines(
 }
 
 export const DistanceGuidelineControl = React.memo(() => {
-  const isInteractionActive = useEditorState(
-    (store) => store.editor.canvas.interactionSession != null,
-    'DistanceGuidelineControl isInteractionActive',
-  )
+  const isDisallowedInteractionActive = useEditorState((store) => {
+    return (
+      store.editor.canvas.interactionSession != null &&
+      isDragInteractionData(store.editor.canvas.interactionSession.interactionData)
+    )
+  }, 'DistanceGuidelineControl isInteractionActive')
   const altKeyPressed = useEditorState(
     (store) => store.editor.keysPressed['alt'],
     'DistanceGuidelineControl altKeyPressed',
@@ -36,7 +39,7 @@ export const DistanceGuidelineControl = React.memo(() => {
     (store) => store.editor.selectedViews,
     'DistanceGuidelineControl selectedElements',
   )
-  if (selectedElements.length > 0 && !isInteractionActive && altKeyPressed) {
+  if (selectedElements.length > 0 && !isDisallowedInteractionActive && altKeyPressed) {
     return <DistanceGuidelineControlInner />
   } else {
     return null

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -47,6 +47,7 @@ import {
   ConsoleLog,
   DerivedState,
   EditorState,
+  editorStateCanvasControls,
   isOpenFileUiJs,
 } from '../components/editor/store/editor-state'
 import {
@@ -391,6 +392,7 @@ export function runLocalCanvasAction(
           ...model.canvas,
           interactionSession: null,
           domWalkerInvalidateCount: model.canvas.domWalkerInvalidateCount + 1,
+          controls: editorStateCanvasControls([], []),
         },
         jsxMetadata: {},
         domMetadata: {},


### PR DESCRIPTION
**Problem:**
There are some minor issues with the absolute keyboard move strategy:
- Pressing the `alt` key prevents moving with the keyboard completely.
- Once a move has been started pressing the `alt` key doesn't show the distance guidelines.
- The snapping guidelines don't show at all when moving with the keyboard.

**Fix:**
The fixes for the above respectively are:
- Remove the check on the `alt` key from the fitness function of the strategy.
- Changed the check in the guidelines which prevented them from showing up if any interaction has been started.
- Used some existing code for creating guidelines from the mouse absolute move strategy to include the appropriate guidelines during a keyboard move.

Additionally an issue was found when the timeout cleared the interaction strategy but resulted in the snapping guidelines persisting because `foldAndApplyCommands` was accumulating the transient patches as well as permanent ones.

**Commit Details:**
- The `alt` key is now ignored by `keyboardAbsoluteMoveStrategy`, as it should
  be independent of toggling the distance guidelines.
- Includes the `activateSnap` guidelines while moving with the keyboard
  without snapping to them.
- `snapDrag` moved into `shared-absolute-move-strategy-helpers.ts`.
- `foldAndApplyCommands` does not accumulate patches for commands that are transient.
- Added `key` and `id` to the element underlying `GuidelineControl`.
- `DistanceGuidelineControl` changed from not displaying on any interaction being
  active, to not displaying on a drag interaction being active.
- `CLEAR_INTERACTION_SESSION` now wipes the entire `controls` field of
  `EditorStateCanvas`.