### PR TITLE
Align the selection outline correctly with the element.

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/simple-outline-control.tsx
@@ -57,10 +57,10 @@ const OutlineControl = React.memo<OutlineControlProps>((props) => {
       ref.current.style.display = 'none'
     } else {
       ref.current.style.display = 'block'
-      ref.current.style.left = `${boundingBox.x + 0.5 / canvasScale}px`
-      ref.current.style.top = `${boundingBox.y + 0.5 / canvasScale}px`
-      ref.current.style.width = `${boundingBox.width - (0.5 / canvasScale) * 3}px`
-      ref.current.style.height = `${boundingBox.height - (0.5 / canvasScale) * 3}px`
+      ref.current.style.left = `${boundingBox.x - 0.5 / canvasScale}px`
+      ref.current.style.top = `${boundingBox.y - 0.5 / canvasScale}px`
+      ref.current.style.width = `${boundingBox.width + 1 / canvasScale}px`
+      ref.current.style.height = `${boundingBox.height + 1 / canvasScale}px`
     }
   })
 
@@ -74,8 +74,9 @@ const OutlineControl = React.memo<OutlineControlProps>((props) => {
         className='role-outline'
         style={{
           position: 'absolute',
-          boxSizing: 'border-box',
-          boxShadow: `0px 0px 0px ${1 / scale}px ${color}`,
+          borderColor: color,
+          borderWidth: `${1 / scale}px`,
+          borderStyle: 'solid',
           pointerEvents: 'none',
         }}
       />


### PR DESCRIPTION
**Problem:**
The selection outline isn't aligned correctly with the element and the resize controls:
![image](https://user-images.githubusercontent.com/217400/174125363-e26412ba-d14e-4c30-a629-3d64e2d52c97.png)

**Fix:**
Slightly changed the styling fields used to make the div to make it simpler and easier to position correctly.

**Commit Details:**
- Use `border` fields instead of `box` fields for the div to get
  simpler positioning.
- Adjusted the LTWH fields so that it sits one pixel outside the bounds
  of the element.
