### PR TITLE
Fix/reparent dom walker

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -1,11 +1,9 @@
-import { elementPath, parentPath } from '../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
   SpecialSizeMeasurements,
 } from '../../../core/shared/element-template'
 import { CanvasPoint, canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
 import { EditorState } from '../../editor/store/editor-state'
-import { EdgePositionKeepDeepEquality } from '../../editor/store/store-deep-equality-instances'
 import { foldAndApplyCommands } from '../commands/commands'
 import {
   getEditorStateWithSelectedViews,
@@ -34,7 +32,7 @@ jest.mock('../canvas-utils', () => ({
 }))
 
 // KEEP THIS IN SYNC WITH THE MOCK ABOVE
-const newParent = elementPath([
+const newParent = EP.elementPath([
   ['scene-aaa', 'app-entity'],
   ['aaa', 'bbb'],
 ])

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -65,7 +65,7 @@ function reparentElement(
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: {
         'scene-aaa/app-entity:aaa': {
-          elementPath: elementPath([['scene-aaa', 'app-entity'], ['aaa']]),
+          elementPath: EP.elementPath([['scene-aaa', 'app-entity'], ['aaa']]),
           globalFrame: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
           specialSizeMeasurements: {
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
@@ -74,7 +74,7 @@ function reparentElement(
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
         'scene-aaa/app-entity:aaa/bbb': {
-          elementPath: elementPath([
+          elementPath: EP.elementPath([
             ['scene-aaa', 'app-entity'],
             ['aaa', 'bbb'],
           ]),
@@ -119,7 +119,7 @@ function reparentElement(
 
 describe('Absolute Reparent Strategy', () => {
   it('does not activate when drag threshold is not reached', async () => {
-    const targetElement = elementPath([
+    const targetElement = EP.elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'ccc'],
     ])
@@ -165,7 +165,7 @@ describe('Absolute Reparent Strategy', () => {
     expect(finalEditor).toEqual(initialEditor)
   })
   it('works with a TL pinned absolute element', async () => {
-    const targetElement = elementPath([
+    const targetElement = EP.elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'ccc'],
     ])
@@ -248,7 +248,7 @@ describe('Absolute Reparent Strategy', () => {
   })
 
   it('works with a TLBR pinned absolute element', async () => {
-    const targetElement = elementPath([
+    const targetElement = EP.elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'ccc'],
     ])
@@ -328,7 +328,7 @@ describe('Absolute Reparent Strategy', () => {
     )
   })
   it('works with a TLBR pinned absolute element when the parent has padding and border', async () => {
-    const targetElement = elementPath([
+    const targetElement = EP.elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'ccc'],
     ])
@@ -411,7 +411,7 @@ describe('Absolute Reparent Strategy', () => {
   })
 
   it('works with a TL pinned absolute element with child', async () => {
-    const targetElement = elementPath([
+    const targetElement = EP.elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'ccc'],
     ])
@@ -516,12 +516,12 @@ describe('Absolute Reparent Strategy', () => {
   })
 
   it('works with TL pinned absolute elements in multiselection', async () => {
-    const targetElement1 = elementPath([
+    const targetElement1 = EP.elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'ccc'],
     ])
 
-    const targetElement2 = elementPath([
+    const targetElement2 = EP.elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'ddd'],
     ])
@@ -624,11 +624,11 @@ describe('Absolute Reparent Strategy', () => {
   })
 
   it('works with a TL pinned absolute elements in multiselection with descendant', async () => {
-    const targetElement = elementPath([
+    const targetElement = EP.elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'ccc'],
     ])
-    const targetElement2 = elementPath([
+    const targetElement2 = EP.elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'ccc', 'ddd'],
     ])

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -2,6 +2,7 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
 import { getReparentTarget } from '../canvas-utils'
 import { reparentElement } from '../commands/reparent-element-command'
+import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
 import { updateSelectedViews } from '../commands/update-selected-views-command'
 import { ParentBounds } from '../controls/parent-bounds'
 import { ParentOutlines } from '../controls/parent-outlines'
@@ -100,14 +101,14 @@ export const absoluteReparentStrategy: CanvasStrategy = {
         }
       })
 
+      const newPaths = commands.map((c) => c.newPath)
+
       return {
         commands: [
           ...moveCommands.commands,
           ...commands.flatMap((c) => c.commands),
-          updateSelectedViews(
-            'permanent',
-            commands.map((c) => c.newPath),
-          ),
+          updateSelectedViews('permanent', newPaths),
+          setElementsToRerenderCommand(newPaths),
         ],
         customState: null,
       }


### PR DESCRIPTION
Reparent creates new element paths, and those were not added to the elements to render list. This caused problems with rendering, dom walker and the navigator.

I added the necessary commands to the reparent strategy.