### PR TITLE
Only show parent bounds and parent outline for a single parent

### DIFF
--- a/editor/src/components/canvas/controls/parent-bounds.tsx
+++ b/editor/src/components/canvas/controls/parent-bounds.tsx
@@ -21,35 +21,33 @@ export const ParentBounds = React.memo(() => {
   const frame = parentFrames.length === 1 ? parentFrames[0] : null
 
   return frame != null ? (
-    <>
-      <CanvasOffsetWrapper key={`parent-outline`}>
-        <div style={{ pointerEvents: 'none' }}>
-          <CenteredCrossSVG
-            id='parent-cross-top-left'
-            centerX={frame.x}
-            centerY={frame.y}
-            scale={scale}
-          />
-          <CenteredCrossSVG
-            id='parent-cross-top-right'
-            centerX={frame.x + frame.width}
-            centerY={frame.y}
-            scale={scale}
-          />
-          <CenteredCrossSVG
-            id='parent-cross-bottom-right'
-            centerX={frame.x + frame.width}
-            centerY={frame.y + frame.height}
-            scale={scale}
-          />
-          <CenteredCrossSVG
-            id='parent-cross-bottom-left'
-            centerX={frame.x}
-            centerY={frame.y + frame.height}
-            scale={scale}
-          />
-        </div>
-      </CanvasOffsetWrapper>
-    </>
+    <CanvasOffsetWrapper key={`parent-outline`}>
+      <div style={{ pointerEvents: 'none' }}>
+        <CenteredCrossSVG
+          id='parent-cross-top-left'
+          centerX={frame.x}
+          centerY={frame.y}
+          scale={scale}
+        />
+        <CenteredCrossSVG
+          id='parent-cross-top-right'
+          centerX={frame.x + frame.width}
+          centerY={frame.y}
+          scale={scale}
+        />
+        <CenteredCrossSVG
+          id='parent-cross-bottom-right'
+          centerX={frame.x + frame.width}
+          centerY={frame.y + frame.height}
+          scale={scale}
+        />
+        <CenteredCrossSVG
+          id='parent-cross-bottom-left'
+          centerX={frame.x}
+          centerY={frame.y + frame.height}
+          scale={scale}
+        />
+      </div>
+    </CanvasOffsetWrapper>
   ) : null
 })

--- a/editor/src/components/canvas/controls/parent-bounds.tsx
+++ b/editor/src/components/canvas/controls/parent-bounds.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { mapDropNulls, stripNulls, uniqBy } from '../../../core/shared/array-utils'
 import * as EP from '../../../core/shared/element-path'
-import { useColorTheme } from '../../../uuiui'
 import { useEditorState } from '../../editor/store/store-hook'
 import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 import { CenteredCrossSVG } from './outline-control'
@@ -19,40 +18,38 @@ export const ParentBounds = React.memo(() => {
     }, targetParents)
   }, 'ParentBounds frames')
 
-  return (
+  const frame = parentFrames.length === 1 ? parentFrames[0] : null
+
+  return frame != null ? (
     <>
-      {parentFrames.map((frame, i) => {
-        return (
-          <CanvasOffsetWrapper key={`parent-outline-${i}`}>
-            <div style={{ pointerEvents: 'none' }}>
-              <CenteredCrossSVG
-                id='parent-cross-top-left'
-                centerX={frame.x}
-                centerY={frame.y}
-                scale={scale}
-              />
-              <CenteredCrossSVG
-                id='parent-cross-top-right'
-                centerX={frame.x + frame.width}
-                centerY={frame.y}
-                scale={scale}
-              />
-              <CenteredCrossSVG
-                id='parent-cross-bottom-right'
-                centerX={frame.x + frame.width}
-                centerY={frame.y + frame.height}
-                scale={scale}
-              />
-              <CenteredCrossSVG
-                id='parent-cross-bottom-left'
-                centerX={frame.x}
-                centerY={frame.y + frame.height}
-                scale={scale}
-              />
-            </div>
-          </CanvasOffsetWrapper>
-        )
-      })}
+      <CanvasOffsetWrapper key={`parent-outline`}>
+        <div style={{ pointerEvents: 'none' }}>
+          <CenteredCrossSVG
+            id='parent-cross-top-left'
+            centerX={frame.x}
+            centerY={frame.y}
+            scale={scale}
+          />
+          <CenteredCrossSVG
+            id='parent-cross-top-right'
+            centerX={frame.x + frame.width}
+            centerY={frame.y}
+            scale={scale}
+          />
+          <CenteredCrossSVG
+            id='parent-cross-bottom-right'
+            centerX={frame.x + frame.width}
+            centerY={frame.y + frame.height}
+            scale={scale}
+          />
+          <CenteredCrossSVG
+            id='parent-cross-bottom-left'
+            centerX={frame.x}
+            centerY={frame.y + frame.height}
+            scale={scale}
+          />
+        </div>
+      </CanvasOffsetWrapper>
     </>
-  )
+  ) : null
 })

--- a/editor/src/components/canvas/controls/parent-outlines.tsx
+++ b/editor/src/components/canvas/controls/parent-outlines.tsx
@@ -19,27 +19,23 @@ export const ParentOutlines = React.memo(() => {
     }, targetParents)
   }, 'ParentOutlines frames')
 
-  return (
-    <>
-      {parentFrames.map((frame, i) => {
-        return (
-          <CanvasOffsetWrapper key={`parent-outline-${i}`}>
-            <div
-              style={{
-                position: 'absolute',
-                left: frame.x,
-                top: frame.y,
-                width: frame.width,
-                height: frame.height,
-                outlineStyle: 'dotted',
-                outlineColor: colorTheme.primary.value,
-                outlineWidth: 1 / scale,
-                pointerEvents: 'none',
-              }}
-            />
-          </CanvasOffsetWrapper>
-        )
-      })}
-    </>
-  )
+  const frame = parentFrames.length === 1 ? parentFrames[0] : null
+
+  return frame != null ? (
+    <CanvasOffsetWrapper key={`parent-outline`}>
+      <div
+        style={{
+          position: 'absolute',
+          left: frame.x,
+          top: frame.y,
+          width: frame.width,
+          height: frame.height,
+          outlineStyle: 'dotted',
+          outlineColor: colorTheme.primary.value,
+          outlineWidth: 1 / scale,
+          pointerEvents: 'none',
+        }}
+      />
+    </CanvasOffsetWrapper>
+  ) : null
 })


### PR DESCRIPTION
Parent outlines are confusing when there are multiple parents for a multiselection.
Only render parent outlines and bounds when there is a single parent.