### PR TITLE
fix(canvas) start keyboard interaction only if its not input

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -19,7 +19,7 @@ import { PreviewColumn } from '../preview/preview-pane'
 import { ReleaseNotesContent } from '../documentation/release-notes'
 import { EditorDispatch, LoginState } from './action-types'
 import * as EditorActions from './actions/action-creators'
-import { handleKeyDown, handleKeyUp } from './global-shortcuts'
+import { editorIsTarget, handleKeyDown, handleKeyUp } from './global-shortcuts'
 import { StateHistory } from './history'
 import { LoginStatusBar, BrowserInfoBar } from './notification-bar'
 import {
@@ -143,7 +143,10 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 
   const onWindowKeyDown = React.useCallback(
     (event: KeyboardEvent) => {
-      if (isFeatureEnabled('Canvas Strategies')) {
+      if (
+        isFeatureEnabled('Canvas Strategies') &&
+        editorIsTarget(event, editorStoreRef.current.editor)
+      ) {
         const key = Keyboard.keyCharacterForCode(event.keyCode)
         const modifiers = Modifier.modifiersForKeyboardEvent(event)
 

--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -161,7 +161,7 @@ function isEventFromInput(target: any) {
   return target.tagName?.toLowerCase() === 'input' || target.tagName?.toLowerCase() === 'textarea'
 }
 
-function editorIsTarget(event: KeyboardEvent, editor: EditorState): boolean {
+export function editorIsTarget(event: KeyboardEvent, editor: EditorState): boolean {
   return !isEventFromInput(event.target) && editor.modal == null
 }
 


### PR DESCRIPTION
**Problem:**
When you press the keyboard arrow left/right in an inspector input field it starts a keyboard interaction session.

**Fix:**
Check if the source of the event is not an input before starting it.

