### PR TITLE
Fix/canvas strategies feature switch

### DIFF
--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser2.tsx
@@ -21,6 +21,9 @@ describe('moving a scene/rootview on the canvas', () => {
   beforeEach(() => {
     setFeatureEnabled('Canvas Strategies', false)
   })
+  afterEach(() => {
+    setFeatureEnabled('Canvas Strategies', true)
+  })
   // TODO Eni and Balazs look into why is this failing under Karma
   xit('dragging a scene child’s root view sets the root view position', async () => {
     const renderResult = await renderTestEditorWithCode(

--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser2.tsx
@@ -116,7 +116,7 @@ describe('moving a scene/rootview on the canvas', () => {
     )
   })
 
-  it('dragging a scene sets the scene position', async () => {
+  xit('dragging a scene sets the scene position', async () => {
     const testCode = Prettier.format(
       `
         import * as React from 'react'
@@ -258,7 +258,7 @@ describe('moving a scene/rootview on the canvas', () => {
 })
 
 describe('resizing a scene/rootview on the canvas', () => {
-  it('resizing a scene child’s root view sets the root view size', async () => {
+  xit('resizing a scene child’s root view sets the root view size', async () => {
     const testCode = Prettier.format(
       `
         import * as React from 'react'
@@ -382,7 +382,7 @@ describe('resizing a scene/rootview on the canvas', () => {
     )
   })
 
-  it('resizing a scene sets the scene size', async () => {
+  xit('resizing a scene sets the scene size', async () => {
     const testCode = Prettier.format(
       `
       import * as React from 'react'

--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser2.tsx
@@ -15,14 +15,16 @@ import { PrettierConfig } from 'utopia-vscode-common'
 import { BakedInStoryboardUID } from '../../core/model/scene-utils'
 import { CanvasControlsContainerID } from './controls/new-canvas-controls'
 import { wait } from '../../utils/utils.test-utils'
-import { setFeatureEnabled } from '../../utils/feature-switches'
+import { isFeatureEnabled, setFeatureEnabled } from '../../utils/feature-switches'
 
 describe('moving a scene/rootview on the canvas', () => {
+  let originalValue = isFeatureEnabled('Canvas Strategies')
   before(() => {
+    originalValue = isFeatureEnabled('Canvas Strategies')
     setFeatureEnabled('Canvas Strategies', false)
   })
   after(() => {
-    setFeatureEnabled('Canvas Strategies', true)
+    setFeatureEnabled('Canvas Strategies', originalValue)
   })
   // TODO Eni and Balazs look into why is this failing under Karma
   xit('dragging a scene child’s root view sets the root view position', async () => {
@@ -265,11 +267,13 @@ describe('moving a scene/rootview on the canvas', () => {
 })
 
 describe('resizing a scene/rootview on the canvas', () => {
+  let originalValue = isFeatureEnabled('Canvas Strategies')
   before(() => {
+    originalValue = isFeatureEnabled('Canvas Strategies')
     setFeatureEnabled('Canvas Strategies', false)
   })
   after(() => {
-    setFeatureEnabled('Canvas Strategies', true)
+    setFeatureEnabled('Canvas Strategies', originalValue)
   })
   it('resizing a scene child’s root view sets the root view size', async () => {
     const testCode = Prettier.format(

--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser2.tsx
@@ -15,8 +15,12 @@ import { PrettierConfig } from 'utopia-vscode-common'
 import { BakedInStoryboardUID } from '../../core/model/scene-utils'
 import { CanvasControlsContainerID } from './controls/new-canvas-controls'
 import { wait } from '../../utils/utils.test-utils'
+import { setFeatureEnabled } from '../../utils/feature-switches'
 
 describe('moving a scene/rootview on the canvas', () => {
+  beforeEach(() => {
+    setFeatureEnabled('Canvas Strategies', false)
+  })
   // TODO Eni and Balazs look into why is this failing under Karma
   xit('dragging a scene child’s root view sets the root view position', async () => {
     const renderResult = await renderTestEditorWithCode(
@@ -116,7 +120,7 @@ describe('moving a scene/rootview on the canvas', () => {
     )
   })
 
-  xit('dragging a scene sets the scene position', async () => {
+  it('dragging a scene sets the scene position', async () => {
     const testCode = Prettier.format(
       `
         import * as React from 'react'
@@ -258,7 +262,7 @@ describe('moving a scene/rootview on the canvas', () => {
 })
 
 describe('resizing a scene/rootview on the canvas', () => {
-  xit('resizing a scene child’s root view sets the root view size', async () => {
+  it('resizing a scene child’s root view sets the root view size', async () => {
     const testCode = Prettier.format(
       `
         import * as React from 'react'
@@ -382,7 +386,7 @@ describe('resizing a scene/rootview on the canvas', () => {
     )
   })
 
-  xit('resizing a scene sets the scene size', async () => {
+  it('resizing a scene sets the scene size', async () => {
     const testCode = Prettier.format(
       `
       import * as React from 'react'

--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser2.tsx
@@ -18,10 +18,10 @@ import { wait } from '../../utils/utils.test-utils'
 import { setFeatureEnabled } from '../../utils/feature-switches'
 
 describe('moving a scene/rootview on the canvas', () => {
-  beforeEach(() => {
+  before(() => {
     setFeatureEnabled('Canvas Strategies', false)
   })
-  afterEach(() => {
+  after(() => {
     setFeatureEnabled('Canvas Strategies', true)
   })
   // TODO Eni and Balazs look into why is this failing under Karma
@@ -265,6 +265,12 @@ describe('moving a scene/rootview on the canvas', () => {
 })
 
 describe('resizing a scene/rootview on the canvas', () => {
+  before(() => {
+    setFeatureEnabled('Canvas Strategies', false)
+  })
+  after(() => {
+    setFeatureEnabled('Canvas Strategies', true)
+  })
   it('resizing a scene child’s root view sets the root view size', async () => {
     const testCode = Prettier.format(
       `

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -14,6 +14,93 @@ import { setFocusedElement } from '../../../editor/actions/action-creators'
 import CanvasActions from '../../canvas-actions'
 import { CanvasControlsContainerID } from '../new-canvas-controls'
 
+function fireDoubleClickEvents(target: HTMLElement, clientX: number, clientY: number) {
+  fireEvent(
+    target,
+    new MouseEvent('mousedown', {
+      detail: 1,
+      bubbles: true,
+      cancelable: true,
+      metaKey: false,
+      clientX: clientX,
+      clientY: clientY,
+      buttons: 1,
+    }),
+  )
+  fireEvent(
+    target,
+    new MouseEvent('mouseup', {
+      detail: 1,
+      bubbles: true,
+      cancelable: true,
+      metaKey: false,
+      clientX: clientX,
+      clientY: clientY,
+      buttons: 1,
+    }),
+  )
+  fireEvent(
+    target,
+    new MouseEvent('click', {
+      detail: 1,
+      bubbles: true,
+      cancelable: true,
+      metaKey: false,
+      clientX: clientX,
+      clientY: clientY,
+      buttons: 1,
+    }),
+  )
+  fireEvent(
+    target,
+    new MouseEvent('mousedown', {
+      detail: 2,
+      bubbles: true,
+      cancelable: true,
+      metaKey: false,
+      clientX: clientX,
+      clientY: clientY,
+      buttons: 1,
+    }),
+  )
+  fireEvent(
+    target,
+    new MouseEvent('mouseup', {
+      detail: 2,
+      bubbles: true,
+      cancelable: true,
+      metaKey: false,
+      clientX: clientX,
+      clientY: clientY,
+      buttons: 1,
+    }),
+  )
+  fireEvent(
+    target,
+    new MouseEvent('click', {
+      detail: 2,
+      bubbles: true,
+      cancelable: true,
+      metaKey: false,
+      clientX: clientX,
+      clientY: clientY,
+      buttons: 1,
+    }),
+  )
+  fireEvent(
+    target,
+    new MouseEvent('dblclick', {
+      detail: 2,
+      bubbles: true,
+      cancelable: true,
+      metaKey: false,
+      clientX: clientX,
+      clientY: clientY,
+      buttons: 1,
+    }),
+  )
+}
+
 describe('Select Mode Selection', () => {
   before(() => {
     viewport.set(2200, 1000)
@@ -97,54 +184,12 @@ describe('Select Mode Selection', () => {
     const doubleClick = async () => {
       await act(async () => {
         const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
-        fireEvent(
+        fireDoubleClickEvents(
           canvasControlsLayer,
-          new MouseEvent('mousedown', {
-            detail: 1,
-            bubbles: true,
-            cancelable: true,
-            metaKey: false,
-            clientX: areaControlBounds.left + 20,
-            clientY: areaControlBounds.top + 20,
-            buttons: 1,
-          }),
+          areaControlBounds.left + 20,
+          areaControlBounds.top + 20,
         )
-        fireEvent(
-          canvasControlsLayer,
-          new MouseEvent('mouseup', {
-            detail: 1,
-            bubbles: true,
-            cancelable: true,
-            metaKey: false,
-            clientX: areaControlBounds.left + 20,
-            clientY: areaControlBounds.top + 20,
-            buttons: 1,
-          }),
-        )
-        fireEvent(
-          canvasControlsLayer,
-          new MouseEvent('mousedown', {
-            detail: 2,
-            bubbles: true,
-            cancelable: true,
-            metaKey: false,
-            clientX: areaControlBounds.left + 20,
-            clientY: areaControlBounds.top + 20,
-            buttons: 1,
-          }),
-        )
-        fireEvent(
-          canvasControlsLayer,
-          new MouseEvent('mouseup', {
-            detail: 1,
-            bubbles: true,
-            cancelable: true,
-            metaKey: false,
-            clientX: areaControlBounds.left + 20,
-            clientY: areaControlBounds.top + 20,
-            buttons: 1,
-          }),
-        )
+
         await dispatchDone
       })
     }
@@ -246,29 +291,10 @@ describe('Select Mode Advanced Cases', () => {
     const doubleClick = async () => {
       await act(async () => {
         const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
-        fireEvent(
+        fireDoubleClickEvents(
           canvasControlsLayer,
-          new MouseEvent('mousedown', {
-            detail: 1,
-            bubbles: true,
-            cancelable: true,
-            metaKey: false,
-            clientX: cardSceneRootBounds.left + 130,
-            clientY: cardSceneRootBounds.top + 220,
-            buttons: 1,
-          }),
-        )
-        fireEvent(
-          canvasControlsLayer,
-          new MouseEvent('mousedown', {
-            detail: 2,
-            bubbles: true,
-            cancelable: true,
-            metaKey: false,
-            clientX: cardSceneRootBounds.left + 130,
-            clientY: cardSceneRootBounds.top + 220,
-            buttons: 1,
-          }),
+          cardSceneRootBounds.left + 130,
+          cardSceneRootBounds.top + 220,
         )
         await dispatchDone
       })
@@ -315,29 +341,10 @@ describe('Select Mode Advanced Cases', () => {
     const doubleClick = async () => {
       await act(async () => {
         const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
-        fireEvent(
+        fireDoubleClickEvents(
           canvasControlsLayer,
-          new MouseEvent('mousedown', {
-            detail: 1,
-            bubbles: true,
-            cancelable: true,
-            metaKey: false,
-            clientX: cardSceneRootBounds.left + 130,
-            clientY: cardSceneRootBounds.top + 220,
-            buttons: 1,
-          }),
-        )
-        fireEvent(
-          canvasControlsLayer,
-          new MouseEvent('mousedown', {
-            detail: 2,
-            bubbles: true,
-            cancelable: true,
-            metaKey: false,
-            clientX: cardSceneRootBounds.left + 130,
-            clientY: cardSceneRootBounds.top + 220,
-            buttons: 1,
-          }),
+          cardSceneRootBounds.left + 130,
+          cardSceneRootBounds.top + 220,
         )
         await dispatchDone
       })

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`437`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`376`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`500`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`387`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`579`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`524`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`651`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`596`)
   })
 })

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -41,7 +41,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Performance Test Triggers': !(PRODUCTION_CONFIG as boolean),
   'Click on empty canvas unfocuses': true,
   'Insertion Plus Button': true,
-  'Canvas Strategies': false,
+  'Canvas Strategies': true,
   'Keyboard up clears interaction': false,
   'Canvas Selective Rerender': true,
 }


### PR DESCRIPTION
**Fix:**
Enabling the canvas strategies feature switch.

**Commit Details:**
- disable feature switch with scene tests where the strategy implementation is missing
- fix mouseevents for double click in selection test to match [mdn](https://developer.mozilla.org/en-US/docs/Web/API/Element/dblclick_event)
