### PR TITLE
A fix for Strategy Undo/Redo

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -401,7 +401,23 @@ export function editorDispatch(
     (action) => action.action === 'UPDATE_FROM_WORKER',
   )
 
-  const editorFilteredForFiles = filterEditorForFiles(result.unpatchedEditor)
+  const { unpatchedEditorState, patchedEditorState, newStrategyState, patchedDerivedState } =
+    isFeatureEnabled('Canvas Strategies')
+      ? handleStrategies(
+          RegisteredCanvasStrategies,
+          dispatchedActions,
+          storedState,
+          result,
+          storedState.patchedDerived,
+        )
+      : {
+          unpatchedEditorState: result.unpatchedEditor,
+          patchedEditorState: result.unpatchedEditor,
+          newStrategyState: result.strategyState,
+          patchedDerivedState: result.unpatchedDerived,
+        }
+
+  const editorFilteredForFiles = filterEditorForFiles(unpatchedEditorState)
 
   const frozenDerivedState = result.unpatchedDerived
 
@@ -420,22 +436,6 @@ export function editorDispatch(
     !isLoadAction &&
     (!transientOrNoChange || anyUndoOrRedo || (anyWorkerUpdates && alreadySaved)) &&
     isBrowserEnvironment
-
-  const { unpatchedEditorState, patchedEditorState, newStrategyState, patchedDerivedState } =
-    isFeatureEnabled('Canvas Strategies')
-      ? handleStrategies(
-          RegisteredCanvasStrategies,
-          dispatchedActions,
-          storedState,
-          result,
-          storedState.patchedDerived,
-        )
-      : {
-          unpatchedEditorState: result.unpatchedEditor,
-          patchedEditorState: result.unpatchedEditor,
-          newStrategyState: result.strategyState,
-          patchedDerivedState: result.unpatchedDerived,
-        }
 
   const editorWithModelChecked =
     !anyUndoOrRedo && transientOrNoChange && !workerUpdatedModel


### PR DESCRIPTION
**Problem:**
When doing mouse-based keyboard strategy interactions, we observed weirdly inconsistent undo behavior. Sometimes things would be added to the undo stack, other times multiple distinct mouse interactions would become a single undo item. Undoing sometimes worked only for _redo_ to not actually work correctly then!

**Investigation:**
Turns out, we were running the strategy handler and the undo history manager in the wrong order. When an interaction is finished on mouse up, we run `interactionFinished` which creates the final `unpatchedEditorState`, capturing all the changes we want persisted, discarding the "transient" commands. But by the time we call `handleStrategies`, we already pushed an unpatchedEditorState to the undo stack!!! Many times that pushed editor is actually unchanged from the previous one, so it doesn't even create an undo entry.

**Fix:**
The fix is simple, run `handleStrategies` first, then run `History.add` second, using the final unpatchedEditor.

**Commit Details:**
- Switch order of `History.add` and `handleStrategies`
- Use the final `unpatchedEditorState` and push that to History
