### PR TITLE
Revert ElementPath equality function

### DIFF
--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -434,7 +434,15 @@ export function fullElementPathsEqual(l: ElementPathPart[], r: ElementPathPart[]
 }
 
 export function pathsEqual(l: ElementPath | null, r: ElementPath | null): boolean {
-  return l === r
+  if (l == null) {
+    return r == null
+  } else if (r == null) {
+    return false
+  } else if (l === r) {
+    return true
+  } else {
+    return fullElementPathsEqual(l.parts, r.parts)
+  }
 }
 
 export function containsPath(path: ElementPath, paths: Array<ElementPath>): boolean {


### PR DESCRIPTION
**Problem:**
Our equality function for `ElementPath`s was recently optimised based on the assumption we were only creating one instance for any given path, since the factory functions for creating them all read from a cache before creating them. However, the cache used is cleared on worker updates, making that assumption invalid.

**Fix:**
Restore the previous deep equality function
