### PR TITLE
Forcibly re-mount pins section on selection change

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -122,12 +122,17 @@ export const LayoutSubsection = React.memo((props: SelfLayoutSubsectionProps) =>
 
 export const LayoutSubsectionContent = React.memo((props: SelfLayoutSubsectionProps) => {
   const [activeTab, setActiveTab] = useActiveLayoutTab(props.position, props.parentLayoutSystem)
+
+  const selectedViews = useContextSelector(InspectorPropsContext, (contextData) => {
+    return contextData.selectedViews
+  })
   return (
     <>
       {when(activeTab === 'flex', <FlexInfoBox />)}
       {unless(
         activeTab === 'flex',
         <GiganticSizePinsSubsection
+          key={selectedViews.map(EP.toString).join(',')}
           layoutType={activeTab}
           parentFlexDirection={props.parentFlexDirection}
           aspectRatioLocked={props.aspectRatioLocked}

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`437`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`441`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`500`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`504`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`579`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`689`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`651`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`761`)
   })
 })


### PR DESCRIPTION
**Problem:**
The pins section of the Inspector has internal state that was previously cleared on a selection change, but no longer is.

**Fix:**
Add a key prop to `GiganticSizePinsSubsection` to force it to re-mount on selection change.

Note that this is a workaround fix, as it is highly likely that there are other controls in the Inspector that suffer from the same issue. That requires further investigation.