### PR TITLE
More absolute move tests!

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.browser2.tsx
@@ -1,0 +1,101 @@
+import {
+  getPrintedUiJsCode,
+  makeTestProjectCodeWithSnippet,
+  renderTestEditorWithCode,
+  TestScenePath,
+} from '../ui-jsx.test-utils'
+import { act, fireEvent } from '@testing-library/react'
+import * as EP from '../../../core/shared/element-path'
+import { selectComponents } from '../../editor/actions/action-creators'
+import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
+
+describe('Absolute Move Strategy', () => {
+  it('moves absolute positioned element', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 40, top: 50, width: 200, height: 120 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    const areaControl = renderResult.renderedDOM.getByTestId('bbb')
+    const areaControlBounds = areaControl.getBoundingClientRect()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    fireEvent(
+      canvasControlsLayer,
+      new MouseEvent('mousedown', {
+        bubbles: true,
+        cancelable: true,
+        metaKey: true,
+        clientX: areaControlBounds.left + 5,
+        clientY: areaControlBounds.top + 5,
+        buttons: 1,
+      }),
+    )
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      fireEvent(
+        canvasControlsLayer,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: areaControlBounds.left + 45,
+          clientY: areaControlBounds.top - 20,
+          buttons: 1,
+        }),
+      )
+      await dispatchDone
+    })
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      fireEvent(
+        canvasControlsLayer,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: areaControlBounds.left + 45,
+          clientY: areaControlBounds.top - 20,
+          buttons: 1,
+        }),
+      )
+      await dispatchDone
+    })
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      fireEvent(
+        window,
+        new MouseEvent('mouseup', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: areaControlBounds.left + 45,
+          clientY: areaControlBounds.top - 20,
+        }),
+      )
+      await dispatchDone
+    })
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 80, top: 25, width: 200, height: 120 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+    )
+  })
+})

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.browser2.tsx
@@ -98,4 +98,196 @@ describe('Absolute Move Strategy', () => {
       `),
     )
   })
+  it('moves absolute element with snapping', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#0091FFAA', width: 100, height: 30 }}
+            data-uid='ccc'
+          />
+          <div
+            style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 40, top: 50, width: 200, height: 120 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    const areaControl = renderResult.renderedDOM.getByTestId('bbb')
+    const areaControlBounds = areaControl.getBoundingClientRect()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    fireEvent(
+      canvasControlsLayer,
+      new MouseEvent('mousedown', {
+        bubbles: true,
+        cancelable: true,
+        metaKey: true,
+        clientX: areaControlBounds.left + 5,
+        clientY: areaControlBounds.top + 5,
+        buttons: 1,
+      }),
+    )
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      fireEvent(
+        canvasControlsLayer,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: areaControlBounds.left + 14,
+          clientY: areaControlBounds.top - 18,
+          buttons: 1,
+        }),
+      )
+      await dispatchDone
+    })
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      fireEvent(
+        canvasControlsLayer,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: areaControlBounds.left + 14,
+          clientY: areaControlBounds.top - 18,
+          buttons: 1,
+        }),
+      )
+      await dispatchDone
+    })
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      fireEvent(
+        window,
+        new MouseEvent('mouseup', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: false,
+          clientX: areaControlBounds.left + 14,
+          clientY: areaControlBounds.top - 18,
+        }),
+      )
+      await dispatchDone
+    })
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#0091FFAA', width: 100, height: 30 }}
+            data-uid='ccc'
+          />
+          <div
+            style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50, top: 30, width: 200, height: 120 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+    )
+  })
+  it('moves absolute element without snapping, pressing cmd', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#0091FFAA', width: 100, height: 30 }}
+            data-uid='ccc'
+          />
+          <div
+            style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 40, top: 50, width: 200, height: 120 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    const areaControl = renderResult.renderedDOM.getByTestId('bbb')
+    const areaControlBounds = areaControl.getBoundingClientRect()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    fireEvent(
+      canvasControlsLayer,
+      new MouseEvent('mousedown', {
+        bubbles: true,
+        cancelable: true,
+        metaKey: true,
+        clientX: areaControlBounds.left + 5,
+        clientY: areaControlBounds.top + 5,
+        buttons: 1,
+      }),
+    )
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      fireEvent(
+        canvasControlsLayer,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: true,
+          clientX: areaControlBounds.left + 14,
+          clientY: areaControlBounds.top - 18,
+          buttons: 1,
+        }),
+      )
+      await dispatchDone
+    })
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      fireEvent(
+        canvasControlsLayer,
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: true,
+          clientX: areaControlBounds.left + 14,
+          clientY: areaControlBounds.top - 18,
+          buttons: 1,
+        }),
+      )
+      await dispatchDone
+    })
+
+    await act(async () => {
+      const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+      fireEvent(
+        window,
+        new MouseEvent('mouseup', {
+          bubbles: true,
+          cancelable: true,
+          metaKey: true,
+          clientX: areaControlBounds.left + 14,
+          clientY: areaControlBounds.top - 18,
+        }),
+      )
+      await dispatchDone
+    })
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#0091FFAA', width: 100, height: 30 }}
+            data-uid='ccc'
+          />
+          <div
+            style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 49, top: 27, width: 200, height: 120 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+    )
+  })
 })

--- a/editor/src/components/canvas/controls/parent-bounds.tsx
+++ b/editor/src/components/canvas/controls/parent-bounds.tsx
@@ -22,7 +22,7 @@ export const ParentBounds = React.memo(() => {
 
   return frame != null ? (
     <CanvasOffsetWrapper key={`parent-outline`}>
-      <div style={{ pointerEvents: 'none' }}>
+      <div style={{ pointerEvents: 'none' }} data-testid='parent-bounds-control'>
         <CenteredCrossSVG
           id='parent-cross-top-left'
           centerX={frame.x}

--- a/editor/src/components/canvas/controls/parent-outlines.tsx
+++ b/editor/src/components/canvas/controls/parent-outlines.tsx
@@ -35,6 +35,7 @@ export const ParentOutlines = React.memo(() => {
           outlineWidth: 1 / scale,
           pointerEvents: 'none',
         }}
+        data-testid='parent-outlines-control'
       />
     </CanvasOffsetWrapper>
   ) : null

--- a/editor/src/components/canvas/controls/position-outline.tsx
+++ b/editor/src/components/canvas/controls/position-outline.tsx
@@ -77,7 +77,7 @@ export const PositionOutline = React.memo((props: PositionOutlineProps) => {
     return (
       <CanvasOffsetWrapper>
         {pins.map((pin) => (
-          <PinOutline {...pin} key={pin.key} />
+          <PinOutline {...pin} key={pin.name} />
         ))}
       </CanvasOffsetWrapper>
     )
@@ -122,7 +122,7 @@ const collectPinOutlines = (
   let pins: PinOutlineProps[] = []
   if (pinLeft != null) {
     pins.push({
-      key: 'left',
+      name: 'left',
       isHorizontalLine: true,
       size: frame.x - containingFrame.x,
       startX: containingFrame.x,
@@ -132,7 +132,7 @@ const collectPinOutlines = (
   }
   if (pinTop != null) {
     pins.push({
-      key: 'top',
+      name: 'top',
       isHorizontalLine: false,
       size: frame.y - containingFrame.y,
       startX: frame.x + frame.width / 2,
@@ -142,7 +142,7 @@ const collectPinOutlines = (
   }
   if (pinRight != null) {
     pins.push({
-      key: 'right',
+      name: 'right',
       isHorizontalLine: true,
       size: containingFrame.x + containingFrame.width - (frame.x + frame.width),
       startX: frame.width + frame.x,
@@ -152,7 +152,7 @@ const collectPinOutlines = (
   }
   if (pinBottom != null) {
     pins.push({
-      key: 'bottom',
+      name: 'bottom',
       isHorizontalLine: false,
       size: containingFrame.y + containingFrame.height - (frame.y + frame.height),
       startX: frame.x + frame.width / 2,
@@ -164,7 +164,7 @@ const collectPinOutlines = (
 }
 
 interface PinOutlineProps {
-  key: string
+  name: string
   isHorizontalLine: boolean
   startX: number
   startY: number
@@ -194,6 +194,7 @@ const PinOutline = React.memo((props: PinOutlineProps): JSX.Element => {
         borderLeft: borderLeft,
         pointerEvents: 'none',
       }}
+      data-testid={`pin-line-${props.name}`}
     />
   )
 })


### PR DESCRIPTION
**Fix:**
Added some UI tests for absolute move. So far these are for single select move, snapping, disabled snapping, canvas controls, canvas controls visible while dragging. 

**Commit Details:**
- data-testid on canvas controls
