### PR TITLE
Added some tests for checking code and inspector changes stay in sync

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -135,6 +135,17 @@ const FailJestOnCanvasError = () => {
   return null
 }
 
+export interface EditorRenderResult {
+  dispatch: (actions: ReadonlyArray<EditorAction>, waitForDOMReport: boolean) => Promise<void>
+  getDispatchFollowUpActionsFinished: () => Promise<void>
+  getEditorState: () => EditorStorePatched
+  renderedDOM: RenderResult
+  getNumberOfCommits: () => number
+  getNumberOfRenders: () => number
+  clearRecordedActions: () => void
+  getRecordedActions: () => ReadonlyArray<EditorAction>
+}
+
 export async function renderTestEditorWithCode(
   appUiJsFileCode: string,
   awaitFirstDomReport: 'await-first-dom-report' | 'dont-await-first-dom-report',
@@ -155,16 +166,7 @@ export async function renderTestEditorWithModel(
   model: PersistentModel,
   awaitFirstDomReport: 'await-first-dom-report' | 'dont-await-first-dom-report',
   mockBuiltInDependencies?: BuiltInDependencies,
-): Promise<{
-  dispatch: (actions: ReadonlyArray<EditorAction>, waitForDOMReport: boolean) => Promise<void>
-  getDispatchFollowUpActionsFinished: () => Promise<void>
-  getEditorState: () => EditorStorePatched
-  renderedDOM: RenderResult
-  getNumberOfCommits: () => number
-  getNumberOfRenders: () => number
-  clearRecordedActions: () => void
-  getRecordedActions: () => ReadonlyArray<EditorAction>
-}> {
+): Promise<EditorRenderResult> {
   const renderCountBaseline = renderCount
   let recordedActions: Array<EditorAction> = []
 

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -59,7 +59,7 @@ async function setControlValue(
 ): Promise<void> {
   const control = await getControl(controlTestId, renderedDOM)
 
-  await act(async () => {
+  act(() => {
     fireEvent.focus(control)
     fireEvent.change(control, { target: { value: newValue } })
     fireEvent.blur(control)
@@ -70,11 +70,8 @@ async function dispatchActionsAndWaitUntilComplete(
   actionsToDispatch: readonly EditorAction[],
   renderResult: EditorRenderResult,
 ): Promise<void> {
-  await act(async () => {
-    const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
-    await renderResult.dispatch(actionsToDispatch, false)
-    await dispatchDone
-  })
+  act(() => renderResult.dispatch(actionsToDispatch, false))
+  await renderResult.getDispatchFollowUpActionsFinished()
 }
 
 async function selectElement(


### PR DESCRIPTION
**Problem:**
We had no integration tests for ensuring the changes made via the code editor will be reflected in the Inspector, and vice versa.

**Fix:**
Added a couple of tests for exactly that. I've also made sure to add helper functions to make this a lot easier in future.