### PR TITLE
undoing should commit the current keyboard strategy into the undo his…

### DIFF
--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -711,6 +711,12 @@ export function handleKeyDown(
           : []
       },
       [UNDO_CHANGES_SHORTCUT]: () => {
+        if (editor.canvas.interactionSession?.interactionData.type === 'KEYBOARD') {
+          // if we are in a keyboard interaction session, we want cmd + z to finish the current interaction session, and then immediately undo it
+          // this is desired because the user might want to redo the changes
+          // Warning: Side Effect!
+          dispatch([CanvasActions.clearInteractionSession(true)])
+        }
         return [EditorActions.undo()]
       },
       [REDO_CHANGES_SHORTCUT]: () => {


### PR DESCRIPTION
**Problem:**
Currently (as of 4d80dac42), when pressing the arrow keys to nudge an object on the canvas with a Keyboard Strategy, there is a timer (currently with a long 3s timeout) to finish the strategy and make the changes permanent. This is the point where we also push an entry to the undo history. Pressing Cmd+Z after waiting for the timeout works as expected.

However, if you press the arrow keys and then rapidly press Cmd+Z, and the strategy finish timer did not run yet, we enter a buggy state: we undo the _previous_ action as if there never was a keyboard interaction, but the editor remains in active strategy state, it's all weird.

**Fix:**
Pressing undo should be similar to pressing Esc: it should finish the strategy. The difference is that Esc cancels the strategy and there's no way to re-do your changes, what undo should do is
1. finish the strategy and _save_ the changes
2. then immediately undo it
3. this means you can then press Redo and see your keyboard changes

**Commit Details:**
- UNDO_CHANGES_SHORTCUT in global-shortcuts first dispatches a `clearInteractionSession` and then dispatches an undo

**Note:**
Unfortunately I have to dispatch twice (synchronously). Dispatching a `clearInteractionSession` and `undo` in the same dispatch does not work as expected, because we push to the undo history at the end of the dispatch function, but `undo` pops from the history in the inner dispatch loop, which means the undo will pop first, and then we push the popped editor to the history, le 
I _think_ dispatching twice like this is fine, especially because this is fully synchronous now.
But if it turns out this is causing bugs, I think the solution is to move the history popping out of the inner loop – similarly to how the strategies work in the outer dispatch function.
