### PR TITLE
Make keyboard strategies resilient to repeated invocation.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -24,6 +24,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
     if (
       canvasState.selectedElements.length > 0 &&
       interactionState != null &&
+      interactionState.interactionData.type === 'DRAG' &&
       interactionState.interactionData.modifiers.alt
     ) {
       const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
@@ -61,9 +62,9 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
   fitness: (canvasState, interactionState) => {
     if (
       canvasState.selectedElements.length > 0 &&
-      interactionState.interactionData.modifiers.alt &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.activeControl.type === 'BOUNDING_AREA' &&
+      interactionState.interactionData.modifiers.alt &&
       interactionState.interactionData.drag != null
     ) {
       return 2

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -21,6 +21,7 @@ export const absoluteReparentStrategy: CanvasStrategy = {
     if (
       canvasState.selectedElements.length > 0 &&
       interactionState != null &&
+      interactionState.interactionData.type === 'DRAG' &&
       interactionState.interactionData.modifiers.cmd
     ) {
       const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
@@ -48,8 +49,8 @@ export const absoluteReparentStrategy: CanvasStrategy = {
     if (
       canvasState.selectedElements.length > 0 &&
       interactionState.activeControl.type === 'BOUNDING_AREA' &&
-      interactionState.interactionData.modifiers.cmd &&
       interactionState.interactionData.type === 'DRAG' &&
+      interactionState.interactionData.modifiers.cmd &&
       interactionState.interactionData.drag != null
     ) {
       return 2

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -51,6 +51,8 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
     } else {
       return false
     }
+
+    return false
   },
   controlsToRender: [
     { control: AbsoluteResizeControl, key: 'absolute-resize-control', show: 'always-visible' },

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -51,8 +51,6 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
     } else {
       return false
     }
-
-    return false
   },
   controlsToRender: [
     { control: AbsoluteResizeControl, key: 'absolute-resize-control', show: 'always-visible' },

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -37,13 +37,6 @@ export interface KeyState {
   modifiers: Modifiers
 }
 
-export function keyStatesEqual(first: KeyState, second: KeyState): boolean {
-  return (
-    setsEqual(first.keysPressed, second.keysPressed) &&
-    Modifier.equal(first.modifiers, second.modifiers)
-  )
-}
-
 export interface KeyboardInteractionData {
   type: 'KEYBOARD'
   keyStates: Array<KeyState>
@@ -336,32 +329,6 @@ export function hasDragModifiersChanged(
       interactionData.modifiers.ctrl !== prevInteractionData.modifiers.ctrl ||
       interactionData.modifiers.shift !== prevInteractionData.modifiers.shift)
   )
-}
-
-export function hasKeyboardModifierChanged(
-  prevInteractionData: InputData | null,
-  interactionData: InputData | null,
-): boolean {
-  if (prevInteractionData?.type === 'KEYBOARD' && interactionData?.type === 'KEYBOARD') {
-    const lastKeyState = last(interactionData.keyStates)
-    const secondToLastKeyState = last(prevInteractionData.keyStates)
-    if (lastKeyState == null) {
-      return false
-    } else {
-      if (secondToLastKeyState == null) {
-        return (
-          lastKeyState.modifiers.shift ||
-          lastKeyState.modifiers.ctrl ||
-          lastKeyState.modifiers.cmd ||
-          lastKeyState.modifiers.alt
-        )
-      } else {
-        return !Modifier.equal(lastKeyState.modifiers, secondToLastKeyState.modifiers)
-      }
-    }
-  } else {
-    return false
-  }
 }
 
 export interface BoundingArea {

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -44,6 +44,34 @@ describe('Keyboard Absolute Strategies E2E', () => {
     await expectElementLeftInPrintedCode(30)
   })
 
+  it('Pressing Shift + ArrowRight 3 times, then pressing ArrowRight 3 times', async () => {
+    const { expectElementLeftOnScreen, expectElementLeftInPrintedCode } = await setupTest()
+
+    pressArrowRightHoldingShift3x()
+    expectElementLeftOnScreen(30)
+
+    pressArrowRight3x()
+    expectElementLeftOnScreen(33)
+
+    // tick the clock so useClearKeyboardInteraction is fired
+    clock.tick(KeyboardInteractionTimeout)
+    await expectElementLeftInPrintedCode(33)
+  })
+
+  it('Pressing Shift + ArrowRight 3 times, then pressing ArrowLeft 3 times', async () => {
+    const { expectElementLeftOnScreen, expectElementLeftInPrintedCode } = await setupTest()
+
+    pressArrowRightHoldingShift3x()
+    expectElementLeftOnScreen(30)
+
+    pressArrowLeft3x()
+    expectElementLeftOnScreen(27)
+
+    // tick the clock so useClearKeyboardInteraction is fired
+    clock.tick(KeyboardInteractionTimeout)
+    await expectElementLeftInPrintedCode(27)
+  })
+
   it('Pressing Shift + ArrowRight 3 times, then pressing Esc before the keyboard strategy timer succeeds will cancel the strategy', async () => {
     const { expectElementLeftOnScreen, expectElementLeftInPrintedCode } = await setupTest()
 
@@ -169,23 +197,56 @@ function pressArrowRightHoldingShift3x() {
       new KeyboardEvent('keydown', { key: 'ArrowRight', keyCode: 39, shiftKey: true }),
     )
     window.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'ArrowRight', keyCode: 39, shiftKey: true }),
+      new KeyboardEvent('keyup', { key: 'ArrowRight', keyCode: 39, shiftKey: true }),
     )
     window.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'ArrowRight', keyCode: 39, shiftKey: true }),
     )
+    window.dispatchEvent(
+      new KeyboardEvent('keyup', { key: 'ArrowRight', keyCode: 39, shiftKey: true }),
+    )
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', keyCode: 39, shiftKey: true }),
+    )
+    window.dispatchEvent(
+      new KeyboardEvent('keyup', { key: 'ArrowRight', keyCode: 39, shiftKey: true }),
+    )
+  })
+}
+
+function pressArrowRight3x() {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', keyCode: 39 }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight', keyCode: 39 }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', keyCode: 39 }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight', keyCode: 39 }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', keyCode: 39 }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight', keyCode: 39 }))
+  })
+}
+
+function pressArrowLeft3x() {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', keyCode: 37 }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowLeft', keyCode: 37 }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', keyCode: 37 }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowLeft', keyCode: 37 }))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', keyCode: 37 }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowLeft', keyCode: 37 }))
   })
 }
 
 function pressEsc() {
   act(() => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27 }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', keyCode: 27 }))
   })
 }
 
 function pressCmdZ() {
   act(() => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', keyCode: 90, metaKey: true }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'z', keyCode: 90, metaKey: true }))
   })
 }
 
@@ -193,6 +254,9 @@ function pressCmdShiftZ() {
   act(() => {
     window.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'z', keyCode: 90, metaKey: true, shiftKey: true }),
+    )
+    window.dispatchEvent(
+      new KeyboardEvent('keyup', { key: 'z', keyCode: 90, metaKey: true, shiftKey: true }),
     )
   })
 }

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -1,8 +1,12 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { Keyboard, KeyCharacter } from '../../../utils/keyboard'
 import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
-import { Modifiers } from '../../../utils/modifiers'
-import { CanvasVector } from '../../../core/shared/math-utils'
+import {
+  CanvasVector,
+  offsetPoint,
+  scaleVector,
+  zeroCanvasPoint,
+} from '../../../core/shared/math-utils'
 import {
   getAbsoluteMoveCommandsForSelectedElement,
   snapDrag,
@@ -12,10 +16,15 @@ import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerend
 import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
 import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
 import { CanvasCommand } from '../commands/commands'
+import {
+  accumulatePresses,
+  getDragDeltaFromKey,
+  getLastKeyPressState,
+} from './shared-keyboard-strategy-helpers'
 
 export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
   id: 'KEYBOARD_ABSOLUTE_MOVE',
-  name: 'Keyboard absolute Move',
+  name: 'Keyboard Absolute Move',
   isApplicable: (canvasState, _interactionState, metadata) => {
     if (canvasState.selectedElements.length > 0) {
       return canvasState.selectedElements.every((element) => {
@@ -40,89 +49,63 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
     ) {
       const { interactionData } = interactionState
 
-      const arrowKeyPressed = interactionData.keysPressed.some(Keyboard.keyIsArrow)
-      // 'Alt' determines if the distance guidelines should be shown.
-      const shiftOrNoModifier =
-        !interactionState.interactionData.modifiers.cmd &&
-        !interactionState.interactionData.modifiers.ctrl
+      const lastKeyState = getLastKeyPressState(interactionData.keyStates)
+      if (lastKeyState != null) {
+        // 'Alt' determines if the distance guidelines should be shown.
+        const shiftOrNoModifier = !lastKeyState.modifiers.cmd && !lastKeyState.modifiers.ctrl
 
-      if (arrowKeyPressed && shiftOrNoModifier) {
-        return 1
+        if (shiftOrNoModifier) {
+          return 1
+        }
       }
     }
     return 0
   },
   apply: (canvasState, interactionState, sessionState) => {
     if (interactionState.interactionData.type === 'KEYBOARD') {
-      return {
-        commands: interactionState.interactionData.keysPressed.flatMap((key) => {
-          if (key == null) {
-            return []
-          }
-          const drag = getDragDeltaFromKey(key, interactionState.interactionData.modifiers)
-          if (drag.x !== 0 || drag.y !== 0) {
-            const moveCommands = canvasState.selectedElements.flatMap((selectedElement) =>
-              getAbsoluteMoveCommandsForSelectedElement(
-                selectedElement,
-                drag,
-                canvasState,
-                sessionState,
-              ),
-            )
-            const { guidelinesWithSnappingVector } = snapDrag(
-              drag,
-              null,
-              interactionState.metadata,
-              canvasState.selectedElements,
-              canvasState.scale,
-            )
-            const justSnappedGuidelines = guidelinesWithSnappingVector.filter((guideline) => {
-              return guideline.activateSnap
-            })
+      const accumulatedPresses = accumulatePresses(interactionState.interactionData.keyStates)
+      let commands: Array<CanvasCommand> = []
+      let drag: CanvasVector = zeroCanvasPoint
+      accumulatedPresses.forEach((accumulatedPress) => {
+        accumulatedPress.keysPressed.forEach((key) => {
+          const keyPressDrag = scaleVector(
+            getDragDeltaFromKey(key, accumulatedPress.modifiers),
+            accumulatedPress.count,
+          )
+          drag = offsetPoint(drag, keyPressDrag)
+        })
+      })
+      if (drag.x !== 0 || drag.y !== 0) {
+        const moveCommands = canvasState.selectedElements.flatMap((selectedElement) =>
+          getAbsoluteMoveCommandsForSelectedElement(
+            selectedElement,
+            drag,
+            canvasState,
+            sessionState,
+          ),
+        )
+        const { guidelinesWithSnappingVector } = snapDrag(
+          drag,
+          null,
+          interactionState.metadata,
+          canvasState.selectedElements,
+          canvasState.scale,
+        )
+        const justSnappedGuidelines = guidelinesWithSnappingVector.filter((guideline) => {
+          return guideline.activateSnap
+        })
 
-            return [
-              ...moveCommands,
-              updateHighlightedViews('transient', []),
-              setSnappingGuidelines('transient', justSnappedGuidelines),
-            ]
-          } else {
-            return []
-          }
-        }),
+        commands.push(...moveCommands)
+        commands.push(updateHighlightedViews('transient', []))
+        commands.push(setSnappingGuidelines('transient', justSnappedGuidelines))
+        commands.push(setElementsToRerenderCommand(canvasState.selectedElements))
+      }
+      return {
+        commands: commands,
         customState: null,
       }
+    } else {
+      return emptyStrategyApplicationResult
     }
-    return emptyStrategyApplicationResult
   },
-}
-
-function getDragDeltaFromKey(key: KeyCharacter, modifiers: Modifiers): CanvasVector {
-  const step = modifiers.shift ? 10 : 1
-  switch (key) {
-    case 'left':
-      return {
-        x: -step,
-        y: 0,
-      } as CanvasVector
-    case 'right':
-      return {
-        x: step,
-        y: 0,
-      } as CanvasVector
-    case 'up':
-      return {
-        x: 0,
-        y: -step,
-      } as CanvasVector
-    case 'down':
-      return {
-        x: 0,
-        y: step,
-      } as CanvasVector
-    default:
-      return {
-        x: 0,
-        y: 0,
-      } as CanvasVector
-  }
 }

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -2,7 +2,7 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { Keyboard, KeyCharacter } from '../../../utils/keyboard'
 import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
 import { Modifiers } from '../../../utils/modifiers'
-import { CanvasVector } from '../../../core/shared/math-utils'
+import { CanvasVector, offsetPoint, scaleVector } from '../../../core/shared/math-utils'
 import { AdjustCssLengthProperty } from '../commands/adjust-css-length-command'
 import { createResizeCommands } from './shared-absolute-resize-strategy-helpers'
 import { withUnderlyingTarget } from '../../editor/store/editor-state'
@@ -12,6 +12,53 @@ import {
   SetElementsToRerenderCommand,
   setElementsToRerenderCommand,
 } from '../commands/set-elements-to-rerender-command'
+import { CanvasCommand } from '../commands/commands'
+import { last } from '../../../core/shared/array-utils'
+import {
+  AccumulatedPresses,
+  accumulatePresses,
+  getDragDeltaFromKey,
+  getLastKeyPressState,
+} from './shared-keyboard-strategy-helpers'
+
+interface VectorAndEdge {
+  drag: CanvasVector
+  edge: EdgePosition
+}
+
+function pressesToVectorAndEdges(
+  accumulatedPresses: Array<AccumulatedPresses>,
+): Array<VectorAndEdge> {
+  let result: Array<VectorAndEdge> = []
+
+  accumulatedPresses.forEach((accumulatedPress) => {
+    accumulatedPress.keysPressed.forEach((key) => {
+      const keyPressDrag = scaleVector(
+        getDragDeltaFromKey(key, accumulatedPress.modifiers),
+        accumulatedPress.count,
+      )
+      const edgePosition = getEdgePositionFromKey(key)
+      if (edgePosition != null) {
+        let foundVectorAndEdge: VectorAndEdge | null = null
+        for (let vectorAndEdge of result) {
+          if (vectorAndEdge.edge.x === edgePosition.x && vectorAndEdge.edge.y === edgePosition.y) {
+            foundVectorAndEdge = vectorAndEdge
+          }
+        }
+        if (foundVectorAndEdge == null) {
+          result.push({
+            drag: keyPressDrag,
+            edge: edgePosition,
+          })
+        } else {
+          foundVectorAndEdge.drag = offsetPoint(foundVectorAndEdge.drag, keyPressDrag)
+        }
+      }
+    })
+  })
+
+  return result
+}
 
 export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
   id: 'KEYBOARD_ABSOLUTE_RESIZE',
@@ -41,96 +88,61 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
       interactionState.interactionData.type === 'KEYBOARD'
     ) {
       const { interactionData } = interactionState
+      const lastKeyPress = getLastKeyPressState(interactionData.keyStates)
+      if (lastKeyPress != null) {
+        const cmdAndOptionallyShiftModifier =
+          lastKeyPress.modifiers.cmd && !lastKeyPress.modifiers.alt && !lastKeyPress.modifiers.ctrl
 
-      const arrowKeyPressed = interactionData.keysPressed.some(Keyboard.keyIsArrow)
-      const cmdAndOptionallyShiftModifier =
-        interactionState.interactionData.modifiers.cmd &&
-        !interactionState.interactionData.modifiers.alt &&
-        !interactionState.interactionData.modifiers.ctrl
-
-      if (arrowKeyPressed && cmdAndOptionallyShiftModifier) {
-        return 1
+        if (cmdAndOptionallyShiftModifier) {
+          return 1
+        }
       }
     }
     return 0
   },
   apply: (canvasState, interactionState, sessionState) => {
     if (interactionState.interactionData.type === 'KEYBOARD') {
-      return {
-        commands: interactionState.interactionData.keysPressed.flatMap((key) => {
-          if (key == null) {
-            return []
-          }
-          const drag = getDragDeltaFromKey(key, interactionState.interactionData.modifiers)
-          const edgePosition = getEdgePositionFromKey(key)
-          if (drag.x !== 0 || drag.y !== 0) {
-            const resizeCommands = canvasState.selectedElements.flatMap((selectedElement) => {
-              const element = withUnderlyingTarget(
-                selectedElement,
-                canvasState.projectContents,
-                {},
-                canvasState.openFile,
-                null,
-                (_, e) => e,
-              )
-              const elementParentBounds =
-                MetadataUtils.findElementByElementPath(
-                  sessionState.startingMetadata,
-                  selectedElement,
-                )?.specialSizeMeasurements.immediateParentBounds ?? null
+      const accumulatedPresses = accumulatePresses(interactionState.interactionData.keyStates)
+      const dragsWithEdges = pressesToVectorAndEdges(accumulatedPresses)
+      let commands: Array<CanvasCommand> = []
+      dragsWithEdges.forEach((dragWithEdge) => {
+        if (dragWithEdge.drag.x !== 0 || dragWithEdge.drag.y !== 0) {
+          canvasState.selectedElements.forEach((selectedElement) => {
+            const element = withUnderlyingTarget(
+              selectedElement,
+              canvasState.projectContents,
+              {},
+              canvasState.openFile,
+              null,
+              (_, e) => e,
+            )
+            const elementParentBounds =
+              MetadataUtils.findElementByElementPath(sessionState.startingMetadata, selectedElement)
+                ?.specialSizeMeasurements.immediateParentBounds ?? null
 
-              if (element == null || edgePosition == null) {
-                return []
-              }
-              return createResizeCommands(
-                element,
-                selectedElement,
-                edgePosition,
-                drag,
-                elementParentBounds,
+            if (element != null) {
+              commands.push(
+                ...createResizeCommands(
+                  element,
+                  selectedElement,
+                  dragWithEdge.edge,
+                  dragWithEdge.drag,
+                  elementParentBounds,
+                ),
               )
-            })
-            return [...resizeCommands, setElementsToRerenderCommand(canvasState.selectedElements)]
-          } else {
-            return []
-          }
-        }),
+            }
+          })
+        }
+      })
+      commands.push(setElementsToRerenderCommand(canvasState.selectedElements))
+      return {
+        commands: commands,
         customState: null,
       }
+    } else {
+      return emptyStrategyApplicationResult
     }
-    return emptyStrategyApplicationResult
   },
-}
-
-function getDragDeltaFromKey(key: KeyCharacter, modifiers: Modifiers): CanvasVector {
-  const step = modifiers.shift ? 10 : 1
-  switch (key) {
-    case 'left':
-      return {
-        x: -step,
-        y: 0,
-      } as CanvasVector
-    case 'right':
-      return {
-        x: step,
-        y: 0,
-      } as CanvasVector
-    case 'up':
-      return {
-        x: 0,
-        y: -step,
-      } as CanvasVector
-    case 'down':
-      return {
-        x: 0,
-        y: step,
-      } as CanvasVector
-    default:
-      return {
-        x: 0,
-        y: 0,
-      } as CanvasVector
-  }
 }
 
 function getEdgePositionFromKey(key: KeyCharacter): EdgePosition | null {

--- a/editor/src/components/canvas/canvas-strategies/shared-keyboard-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-keyboard-strategy-helpers.ts
@@ -1,0 +1,79 @@
+import { KeyState } from './interaction-state'
+import { setsEqual } from '../../../core/shared/set-utils'
+import { last } from '../../../core/shared/array-utils'
+import { Modifier, Modifiers } from '../../../utils/modifiers'
+import { CanvasVector } from '../../../core/shared/math-utils'
+import Keyboard, { KeyCharacter } from '../../../utils/keyboard'
+
+export interface AccumulatedPresses extends KeyState {
+  count: number
+}
+
+export function getLastKeyPressState(keyStates: Array<KeyState>): KeyState | null {
+  for (let index = keyStates.length - 1; index >= 0; index--) {
+    const state = keyStates[index]
+    if (Array.from(state.keysPressed).some(Keyboard.keyIsArrow)) {
+      return state
+    }
+  }
+  return null
+}
+
+export function accumulatePresses(keyStates: Array<KeyState>): Array<AccumulatedPresses> {
+  let result: Array<AccumulatedPresses> = []
+  for (const keyState of keyStates) {
+    if (keyState.keysPressed.size !== 0) {
+      const latestAccumulatedValue = last(result)
+      if (latestAccumulatedValue == null) {
+        result.push({
+          ...keyState,
+          count: 1,
+        })
+      } else {
+        if (
+          setsEqual(keyState.keysPressed, latestAccumulatedValue.keysPressed) &&
+          Modifier.equal(keyState.modifiers, latestAccumulatedValue.modifiers)
+        ) {
+          latestAccumulatedValue.count += 1
+        } else {
+          result.push({
+            ...keyState,
+            count: 1,
+          })
+        }
+      }
+    }
+  }
+  return result
+}
+
+export function getDragDeltaFromKey(key: KeyCharacter, modifiers: Modifiers): CanvasVector {
+  const step = modifiers.shift ? 10 : 1
+  switch (key) {
+    case 'left':
+      return {
+        x: -step,
+        y: 0,
+      } as CanvasVector
+    case 'right':
+      return {
+        x: step,
+        y: 0,
+      } as CanvasVector
+    case 'up':
+      return {
+        x: 0,
+        y: -step,
+      } as CanvasVector
+    case 'down':
+      return {
+        x: 0,
+        y: step,
+      } as CanvasVector
+    default:
+      return {
+        x: 0,
+        y: 0,
+      } as CanvasVector
+  }
+}

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
-import { uniqBy } from '../../../../core/shared/array-utils'
+import { last, uniqBy } from '../../../../core/shared/array-utils'
 import { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
 import {
   boundingRectangleArray,
@@ -715,16 +715,16 @@ export function useAutomaticKeyUp(editorStoreRef: { readonly current: EditorStor
         delete keyupTimeoutHandler.current[key]
 
         const { interactionSession } = editorStoreRef.current.editor.canvas
-        if (
-          interactionSession?.interactionData.type === 'KEYBOARD' &&
-          interactionSession?.interactionData.keysPressed.indexOf(key) > -1
-        ) {
-          const action = CanvasActions.createInteractionSession(
-            updateInteractionViaKeyboard(interactionSession, [], [key], modifiers, {
-              type: 'KEYBOARD_CATCHER_CONTROL',
-            }),
-          )
-          editorStoreRef.current.dispatch([action], 'everyone')
+        if (interactionSession?.interactionData.type === 'KEYBOARD') {
+          const latestKeyState = last(interactionSession.interactionData.keyStates)
+          if (latestKeyState != null && latestKeyState.keysPressed.has(key)) {
+            const action = CanvasActions.createInteractionSession(
+              updateInteractionViaKeyboard(interactionSession, [], [key], modifiers, {
+                type: 'KEYBOARD_CATCHER_CONTROL',
+              }),
+            )
+            editorStoreRef.current.dispatch([action], 'everyone')
+          }
         }
       }
 

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -582,8 +582,7 @@ describe('interactionUpdate with accumulating keypresses', () => {
     )
 
     const editorStore = createEditorStore(interactionSession)
-
-    editorStore.strategyState.currentStrategy = 'TEST_STRATEGY' as CanvasStrategyId
+    editorStore.strategyState.currentStrategy = 'PREVIOUS_STRATEGY' as CanvasStrategyId
     // the currentStrategyCommands should be added to accumulatedCommands
     editorStore.strategyState.currentStrategyCommands = [
       wildcardPatch('permanent', { selectedViews: { $set: [EP.elementPath([['aaa']])] } }),

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -7,7 +7,6 @@ import {
 import {
   createEmptyStrategyState,
   hasDragModifiersChanged,
-  hasKeyboardModifierChanged,
   InteractionSession,
   interactionSessionHardReset,
   isKeyboardInteractionData,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -7,9 +7,12 @@ import {
 import {
   createEmptyStrategyState,
   hasDragModifiersChanged,
+  hasKeyboardModifierChanged,
+  InteractionSession,
   interactionSessionHardReset,
+  isKeyboardInteractionData,
+  KeyboardInteractionData,
   StrategyState,
-  strategySwitchInteractionSessionReset,
 } from '../../canvas/canvas-strategies/interaction-state'
 import { foldAndApplyCommands } from '../../canvas/commands/commands'
 import { strategySwitched } from '../../canvas/commands/strategy-switched-command'
@@ -28,6 +31,7 @@ import {
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { PERFORMANCE_MARKS_ALLOWED } from '../../../common/env-vars'
 import { saveDOMReport } from '../actions/action-creators'
+import { last } from '../../../core/shared/array-utils'
 
 interface HandleStrategiesResult {
   unpatchedEditorState: EditorState
@@ -215,7 +219,8 @@ export function interactionUpdate(
 
     if (
       result.unpatchedEditor.canvas.interactionSession?.interactionData.type === 'KEYBOARD' &&
-      actionType === 'interaction-create-or-update'
+      actionType === 'interaction-create-or-update' &&
+      strategy?.strategy !== previousStrategy?.strategy
     ) {
       return handleAccumulatingKeypresses(
         newEditorState,
@@ -406,49 +411,67 @@ function handleAccumulatingKeypresses(
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
   // If there is a current strategy, produce the commands from it.
   if (newEditorState.canvas.interactionSession != null) {
-    const strategyResult =
-      strategy != null
-        ? applyCanvasStrategy(
-            strategy.strategy,
-            canvasState,
-            newEditorState.canvas.interactionSession,
-            strategyState,
-          )
-        : {
-            commands: [],
-            customState: strategyState.customStrategyState,
-          }
-    const commandResult = foldAndApplyCommands(
-      newEditorState,
-      storedEditorState,
-      strategyState.accumulatedPatches,
-      strategyState.currentStrategyCommands,
-      strategyResult.commands,
-      'transient',
-    )
-    const newStrategyState: StrategyState = {
-      currentStrategy: strategy?.strategy.id ?? null,
-      currentStrategyFitness: strategy?.fitness ?? 0,
-      currentStrategyCommands: strategyResult.commands,
-      accumulatedPatches: commandResult.accumulatedPatches,
-      commandDescriptions: commandResult.commandDescriptions,
-      sortedApplicableStrategies: sortedApplicableStrategies,
-      startingMetadata: strategyState.startingMetadata,
-      customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
-      startingAllElementProps: strategyState.startingAllElementProps,
-    }
+    const interactionData = newEditorState.canvas.interactionSession.interactionData
+    if (isKeyboardInteractionData(interactionData)) {
+      const lastKeyState = last(interactionData.keyStates)
+      const updatedInteractionData: KeyboardInteractionData = {
+        ...interactionData,
+        keyStates: lastKeyState == null ? [] : [lastKeyState],
+      }
+      const updatedInteractionSession: InteractionSession = {
+        ...newEditorState.canvas.interactionSession,
+        interactionData: updatedInteractionData,
+      }
+      const updatedEditorState = {
+        ...newEditorState,
+        canvas: {
+          ...newEditorState.canvas,
+          interactionSession: updatedInteractionSession,
+        },
+      }
+      const strategyResult =
+        strategy != null
+          ? applyCanvasStrategy(
+              strategy.strategy,
+              canvasState,
+              updatedInteractionSession,
+              strategyState,
+            )
+          : {
+              commands: [],
+              customState: strategyState.customStrategyState,
+            }
+      const commandResult = foldAndApplyCommands(
+        updatedEditorState,
+        storedEditorState,
+        strategyState.accumulatedPatches,
+        strategyState.currentStrategyCommands,
+        strategyResult.commands,
+        'transient',
+      )
+      const newStrategyState: StrategyState = {
+        currentStrategy: strategy?.strategy.id ?? null,
+        currentStrategyFitness: strategy?.fitness ?? 0,
+        currentStrategyCommands: strategyResult.commands,
+        accumulatedPatches: commandResult.accumulatedPatches,
+        commandDescriptions: commandResult.commandDescriptions,
+        sortedApplicableStrategies: sortedApplicableStrategies,
+        startingMetadata: strategyState.startingMetadata,
+        customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
+        startingAllElementProps: strategyState.startingAllElementProps,
+      }
 
-    return {
-      unpatchedEditorState: newEditorState,
-      patchedEditorState: commandResult.editorState,
-      newStrategyState: newStrategyState,
+      return {
+        unpatchedEditorState: updatedEditorState,
+        patchedEditorState: commandResult.editorState,
+        newStrategyState: newStrategyState,
+      }
     }
-  } else {
-    return {
-      unpatchedEditorState: newEditorState,
-      patchedEditorState: newEditorState,
-      newStrategyState: strategyState,
-    }
+  }
+  return {
+    unpatchedEditorState: newEditorState,
+    patchedEditorState: newEditorState,
+    newStrategyState: strategyState,
   }
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -327,6 +327,7 @@ import {
   keyboardCatcherControl,
   KeyboardCatcherControl,
   KeyboardInteractionData,
+  KeyState,
   resizeHandle,
   ResizeHandle,
 } from '../../canvas/canvas-strategies/interaction-state'
@@ -1546,17 +1547,27 @@ export const DragInteractionDataKeepDeepEquality: KeepDeepEqualityCall<DragInter
     },
   )
 
+export const KeyStateKeepDeepEquality: KeepDeepEqualityCall<KeyState> = combine2EqualityCalls(
+  (keyState) => keyState.keysPressed,
+  createCallWithDeepEquals(),
+  (keyState) => keyState.modifiers,
+  ModifiersKeepDeepEquality,
+  (keysPressed, modifiers) => {
+    return {
+      keysPressed: keysPressed,
+      modifiers: modifiers,
+    }
+  },
+)
+
 export const KeyboardInteractionDataKeepDeepEquality: KeepDeepEqualityCall<KeyboardInteractionData> =
-  combine2EqualityCalls(
-    (data) => data.keysPressed,
-    arrayDeepEquality(createCallWithTripleEquals()),
-    (data) => data.modifiers,
-    ModifiersKeepDeepEquality,
-    (keysPressed, modifiers) => {
+  combine1EqualityCall(
+    (data) => data.keyStates,
+    arrayDeepEquality(KeyStateKeepDeepEquality),
+    (keyStates) => {
       return {
         type: 'KEYBOARD',
-        keysPressed: keysPressed,
-        modifiers: modifiers,
+        keyStates: keyStates,
       }
     },
   )

--- a/editor/src/core/shared/set-utils.ts
+++ b/editor/src/core/shared/set-utils.ts
@@ -3,3 +3,20 @@
 export function emptySet<T extends string | boolean | number | null | undefined>(): Set<T> {
   return new Set()
 }
+
+export function setsEqual<T>(first: Set<T>, second: Set<T>): boolean {
+  if (first === second) {
+    return true
+  } else {
+    if (first.size === second.size) {
+      for (const firstValue of first) {
+        if (!second.has(firstValue)) {
+          return false
+        }
+      }
+      return true
+    } else {
+      return false
+    }
+  }
+}

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -369,9 +369,11 @@ export function runLocalCanvasAction(
     }
     case 'CREATE_INTERACTION_SESSION':
       clearInterval(interactionSessionTimerHandle)
-      interactionSessionTimerHandle = setInterval(() => {
-        dispatch([CanvasActions.updateDragInteractionData({ globalTime: Date.now() })])
-      }, 200)
+      if (action.interactionSession.interactionData.type === 'DRAG') {
+        interactionSessionTimerHandle = setInterval(() => {
+          dispatch([CanvasActions.updateDragInteractionData({ globalTime: Date.now() })])
+        }, 200)
+      }
       return {
         ...model,
         canvas: {

--- a/editor/src/utils/modifiers.ts
+++ b/editor/src/utils/modifiers.ts
@@ -77,4 +77,16 @@ export const Modifier = {
   none: function (modifiers: Modifiers): boolean {
     return !(modifiers.alt || modifiers.cmd || modifiers.ctrl || modifiers.shift)
   },
+  equal: function (first: Modifiers, second: Modifiers): boolean {
+    if (first === second) {
+      return true
+    } else {
+      return (
+        first.shift === second.shift &&
+        first.ctrl === second.ctrl &&
+        first.cmd === second.cmd &&
+        first.alt === second.alt
+      )
+    }
+  },
 }


### PR DESCRIPTION
**Problem:**
Currently the keyboard strategies are implemented in an instantaneous style, such that they handle a keypress at a point in time. This can cause issues however when the strategies are invoked more than once when for example a modifier is pressed or released as it may cause the logic to internally move something a second time and then remove a guideline that was being shown.

**Fix:**
The primary change here is to record all the changes that happen to the keypresses since the interaction started. Then both the absolute move and resize strategies have a pass that accumulates repeated presses with counts. That is then followed by a strategy specific approach to combine those accumulated keypresses into a minimum number of commands for the strategy.

**Commit Details:**
- `KeyboardInteractionData` now records an array of `KeyState` elements,
  which include all the keypresses triggered since the interaction was first
  started.
- `interactionDataHardReset` now prunes the keyboard interaction key states
  to the latest.
- Extracted out `getDragDeltaFromKey` function from the two keyboard strategies.
- Added shared utility functions `getLastKeyPressState` and `accumulatePresses`.
- The move and resize strategies now accumulate repeated presses, populating a
  count of how many repeated presses for identical keypresses there are. Then
  the resultant drag is accumulated from those changes, so that the minimum of
  commands is produced by the strategy.
- Modified a few conditionals to correctly handle the case that now there is
  not a common `modifiers` field on both keyboard and mouse interactions.
- `handleAccumulatingKeypresses` now also culls the key states so that they
  are not carried over into a different strategy.
- Added some `keyup` dispatches to some test code, because we were firing repeated `keydown`
  events which to our logic looks like they are still depressed when we press
  another key.