### PR TITLE
Fix: canvas selection z-index 

### DIFF
--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -152,16 +152,7 @@ export function getAllTargetsAtPoint(
     }),
   )
 
-  // return getElementsUnderPointFromAABB
-  //   .filter((foundElement) => {
-  //     if (!foundElement.canBeFilteredOut) {
-  //       return true
-  //     } else {
-  //       return elementsFromDOM.some((e) => EP.pathsEqual(e, foundElement.elementPath))
-  //     }
-  //   })
-  //   .map((e) => e.elementPath)
-
+  // TODO FIXME we should take the zero-sized elements from getElementsUnderPointFromAABB, and insert them (in a correct-enough order) here
   return elementsFromDOM
 }
 

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -152,15 +152,17 @@ export function getAllTargetsAtPoint(
     }),
   )
 
-  return getElementsUnderPointFromAABB
-    .filter((foundElement) => {
-      if (!foundElement.canBeFilteredOut) {
-        return true
-      } else {
-        return elementsFromDOM.some((e) => EP.pathsEqual(e, foundElement.elementPath))
-      }
-    })
-    .map((e) => e.elementPath)
+  // return getElementsUnderPointFromAABB
+  //   .filter((foundElement) => {
+  //     if (!foundElement.canBeFilteredOut) {
+  //       return true
+  //     } else {
+  //       return elementsFromDOM.some((e) => EP.pathsEqual(e, foundElement.elementPath))
+  //     }
+  //   })
+  //   .map((e) => e.elementPath)
+
+  return elementsFromDOM
 }
 
 export function windowToCanvasCoordinates(

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -123,17 +123,6 @@ export function getAllTargetsAtPoint(
   if (point == null) {
     return []
   }
-  const pointOnCanvas = windowToCanvasCoordinates(canvasScale, canvasOffset, point)
-  const getElementsUnderPointFromAABB = Canvas.getAllTargetsAtPoint(
-    componentMetadata,
-    selectedViews,
-    hiddenInstances,
-    pointOnCanvas.canvasPositionRaw,
-    [TargetSearchType.All],
-    true,
-    'loose',
-    allElementProps,
-  )
   const elementsUnderPoint = document.elementsFromPoint(point.x, point.y)
   const validPathsSet =
     validElementPathsForLookup == 'no-filter'
@@ -152,7 +141,7 @@ export function getAllTargetsAtPoint(
     }),
   )
 
-  // TODO FIXME we should take the zero-sized elements from getElementsUnderPointFromAABB, and insert them (in a correct-enough order) here
+  // TODO FIXME we should take the zero-sized elements from Canvas.getAllTargetsAtPoint, and insert them (in a correct-enough order) here. See PR for context https://github.com/concrete-utopia/utopia/pull/2345
   return elementsFromDOM
 }
 


### PR DESCRIPTION
**Problem:**
Selection on the canvas doesn't respect the visible z-order of elements, instead it uses the code-order.

**Fix:**
We already had an array called `elementsFromDOM`, that contains the elements under the mouse ordered by their actual visual z-index, thanks to the DOM API `document.elementsFromPoint`. 
But currently we only use that array to filter and return the code-ordered `getElementsUnderPointFromAABB`. 
The reason for this is [zero-sized element support](https://github.com/concrete-utopia/utopia/issues/868), elements without two dimensions _only_ exist in `getElementsUnderPointFromAABB`. But it seems like zero-sized element support is already broken, so this code is not really doing anything at the moment.

The quick fix for the z-index problem is to just return `elementsFromDOM` directly. 

Once we get around to fixing zero-sized element dragging, we can consider coming back here and reinstating the old code, or we could just come up with alternative controls / ways to achieve the same goal. The original solution was a bit of a hack to begin with.