### PR TITLE
Workaround SIGSEGV when vscode-build runs yarn gulp compile-build

### DIFF
--- a/vscode-build/build.js
+++ b/vscode-build/build.js
@@ -33,9 +33,10 @@ child_process.execSync(`git apply ../vscode.patch`, {
 })
 
 child_process.execSync('yarn', { stdio: 'inherit' })
+child_process.execSync('npm rebuild', { stdio: 'inherit' })
 
 // Compile
-child_process.execSync('yarn gulp compile-build', { stdio: 'inherit' })
+child_process.execSync('npm run gulp compile-build', { stdio: 'inherit' })
 child_process.execSync('yarn gulp minify-vscode', { stdio: 'inherit' })
 child_process.execSync('yarn compile-web', { stdio: 'inherit' })
 


### PR DESCRIPTION
Fixes 

**Problem:**
When building vscode-build sometimes yarn and node will become unsynced. 

**Fix:**
Switch to using npm 

**Commit Details:**
This fix probably needs more testing because I don't fully understand the implications of doing this. Don't know if the npm rebuild is fully needed. 

