### PR TITLE
Fix adding classes on mouse move when className input focused

### DIFF
--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -99,7 +99,6 @@ const menu: styleFn = (base) => ({
 })
 
 const AlwaysTrue = () => true
-let queuedDispatchTimeout: number | undefined = undefined
 let queuedFocusTimeout: number | undefined = undefined
 
 const focusedOptionAtom = atomWithPubSub<string | null>({
@@ -260,11 +259,6 @@ const ClassNameControl = React.memo(() => {
 
       const newValue = valueTypeAsArray(newValueType)
       if (elementPath != null) {
-        if (queuedDispatchTimeout != null) {
-          window.clearTimeout(queuedDispatchTimeout)
-          queuedDispatchTimeout = undefined
-        }
-
         dispatch(
           [
             EditorActions.setProp_UNSAFE(
@@ -441,21 +435,16 @@ const ClassNameControl = React.memo(() => {
         const oldClassNameString =
           selectedOptions == null ? '' : selectedOptions.map((v) => v.value).join(' ') + ' '
         const newClassNameString = oldClassNameString + value
-        if (queuedDispatchTimeout != null) {
-          window.clearTimeout(queuedDispatchTimeout)
-        }
-        queuedDispatchTimeout = window.setTimeout(() => {
-          dispatch(
-            [
-              EditorActions.setPropTransient(
-                targets[0],
-                PP.create(['className']),
-                jsxAttributeValue(newClassNameString, emptyComments),
-              ),
-            ],
-            'canvas',
-          )
-        }, 10)
+        dispatch(
+          [
+            EditorActions.setPropTransient(
+              targets[0],
+              PP.create(['className']),
+              jsxAttributeValue(newClassNameString, emptyComments),
+            ),
+          ],
+          'canvas',
+        )
 
         updateFocusedOption(value)
       }


### PR DESCRIPTION
Fixes #2348 

**Problem:**
Moving mouse while typing classname selects class

**Fix:**
Remove the deffered setState

**Commit Details:**
- Remove the deffered setState
