### PR TITLE
useEffect dispatch fixes

### DIFF
--- a/editor/src/components/canvas/controls/classname-select.tsx
+++ b/editor/src/components/canvas/controls/classname-select.tsx
@@ -174,7 +174,10 @@ export const ClassNameSelect = React.memo(
 
     React.useEffect(() => {
       return function cleanup() {
-        dispatch([EditorActions.clearTransientProps()], 'canvas')
+        setTimeout(() => {
+          // wrapping in a setTimeout so we don't dispatch from inside React lifecycle
+          dispatch([EditorActions.clearTransientProps()], 'canvas')
+        }, 0)
       }
       /** deps is explicitly empty */
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/editor/src/components/canvas/controls/property-target-selector.tsx
+++ b/editor/src/components/canvas/controls/property-target-selector.tsx
@@ -73,7 +73,13 @@ export const PropertyTargetSelector = React.memo(
 
     // Update the current options to be the ones listed against this control
     React.useEffect(() => {
-      dispatch([setResizeOptionsTargetOptions(props.options, defaultSelectedOptionIndex)], 'canvas')
+      setTimeout(() => {
+        // wrapping in a setTimeout so we don't dispatch from inside React lifecycle
+        dispatch(
+          [setResizeOptionsTargetOptions(props.options, defaultSelectedOptionIndex)],
+          'canvas',
+        )
+      }, 0)
       // important! the array is empty because it should only run once
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -319,12 +319,15 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
   let evaluatedFileNames = React.useRef<Array<string>>([]) // evaluated (i.e. not using a cached evaluation) this render
   evaluatedFileNames.current = [uiFilePath]
   React.useEffect(() => {
-    validateControlsToCheck(
-      dispatch,
-      propertyControlsInfo,
-      resolvedFileNames.current,
-      evaluatedFileNames.current,
-    )
+    setTimeout(() => {
+      // wrapping in a setTimeout so we don't dispatch from inside React lifecycle
+      validateControlsToCheck(
+        dispatch,
+        propertyControlsInfo,
+        resolvedFileNames.current,
+        evaluatedFileNames.current,
+      )
+    }, 0)
   })
 
   // FIXME This is illegal! The two lines below are triggering a re-render

--- a/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/className-subsection/className-subsection.tsx
@@ -211,7 +211,10 @@ const ClassNameControl = React.memo(() => {
 
   React.useEffect(() => {
     return function cleanup() {
-      dispatch([EditorActions.clearTransientProps()], 'canvas')
+      setTimeout(() => {
+        // wrapping in a setTimeout so we don't dispatch from inside React lifecycle
+        dispatch([EditorActions.clearTransientProps()], 'canvas')
+      }, 0)
     }
     /** deps is explicitly empty */
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -3,6 +3,7 @@ import { renderTestEditorWithCode, TestAppUID } from '../../components/canvas/ui
 import { BakedInStoryboardUID } from '../model/scene-utils'
 import { TestScene0UID } from '../model/test-ui-js-file.test-utils'
 import * as Prettier from 'prettier/standalone'
+import { wait } from '../model/performance-scripts'
 
 describe('registered property controls', () => {
   it('registered controls are in editor state', async () => {
@@ -64,6 +65,7 @@ describe('registered property controls', () => {
     )
 
     const renderResult = await renderTestEditorWithCode(testCode, 'dont-await-first-dom-report')
+    await wait(10) // this is quite ugly but we want to wait for a timeout(0) in ui-jsx-canvas before calling validateControlsToCheck
     const editorState = renderResult.getEditorState().editor
 
     expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`


### PR DESCRIPTION
**Problem:**
We can't dispatch from a useEffect anymore since #2208. But there's still a few places where I didn't fix the code.

**Fix:**
The fix is to wrap the dispatch to a setTimeout(0), so it will execute outside of a react lifecycle function.
