### PR TITLE
tailwind-options: using refEditorState for allElementProps

### DIFF
--- a/editor/src/core/tailwind/tailwind-options.tsx
+++ b/editor/src/core/tailwind/tailwind-options.tsx
@@ -299,11 +299,7 @@ export function useGetSelectedClasses(): {
     'ClassNameSelect elementPaths',
   )
 
-  const allElementProps = useEditorState(
-    (store) => store.editor.allElementProps,
-    'ClassNameSelect allElementProps',
-    (oldProps, newProps) => oldProps === newProps,
-  )
+  const allElementPropsRef = useRefEditorState((store) => store.editor.allElementProps)
 
   const classNamesFromAttributesOrProps = React.useMemo(
     () =>
@@ -318,12 +314,12 @@ export function useGetSelectedClasses(): {
             elementPath,
           )
           return {
-            value: allElementProps[EP.toString(elementPath)]?.className,
+            value: allElementPropsRef.current[EP.toString(elementPath)]?.className,
             isSettable: fromAttributes.isSettable,
           }
         }
       }),
-    [elements, elementPaths, metadataRef, allElementProps],
+    [elements, elementPaths, metadataRef, allElementPropsRef],
   )
 
   const isSettable =


### PR DESCRIPTION
**Problem:**
#2282 was a big refactor which moved the element props out of the the jsxMetadata into its own map. It had to touch all the places that are using the element props. 

While looking at #2348 I noticed that `tailwind-options.tsx` used to use a metadata ref and went to a straight useEditorState for the allElementProps.

**Fix:**
I use a refEditorState for allElementProps.
 
This _may_ also fix #2348 but I can't tell for sure.