### PR TITLE
fix(inspector) add all missing props on conversion

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
+++ b/editor/src/components/inspector/sections/layout-section/self-layout-subsection/self-layout-subsection.tsx
@@ -31,7 +31,7 @@ import {
   useInitialSizeSectionState,
 } from '../flex-element-subsection/flex-element-subsection'
 import { GiganticSizePinsSubsection } from './gigantic-size-pins-subsection'
-import { selectComponents } from '../../../../editor/actions/action-creators'
+import { runEscapeHatch, selectComponents } from '../../../../editor/actions/action-creators'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
 import { unless, when } from '../../../../../utils/react-conditionals'
 import {
@@ -199,25 +199,18 @@ function useDeleteAllSelfLayoutConfig() {
   }, [onUnsetValue, propertyTarget])
 }
 
-function useAddPositionAbsolute() {
-  const propertyTarget = useContextSelector(InspectorPropsContext, (contextData) => {
-    return contextData.targetPath
-  })
-  const { onSubmitValue } = React.useContext(InspectorCallbackContext)
-  return React.useCallback(() => {
-    onSubmitValue(
-      jsxAttributeValue('absolute', emptyComments),
-      stylePropPathMappingFn('position', propertyTarget),
-      false,
-    )
-  }, [onSubmitValue, propertyTarget])
-}
-
 const LayoutSectionHeader = React.memo((props: LayoutSectionHeaderProps) => {
   const colorTheme = useColorTheme()
   const { layoutType, selfLayoutSectionOpen, toggleSection } = props
   const onDeleteAllConfig = useDeleteAllSelfLayoutConfig()
-  const onAbsoluteButtonClick = useAddPositionAbsolute()
+
+  const dispatch = useRefEditorState((store) => store.dispatch)
+  const selectedViews = useContextSelector(InspectorPropsContext, (contextData) => {
+    return contextData.selectedViews
+  })
+  const onAbsoluteButtonClick = React.useCallback(() => {
+    dispatch.current([runEscapeHatch(selectedViews)], 'everyone')
+  }, [dispatch, selectedViews])
 
   return (
     <InspectorSubsectionHeader>

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`634`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`641`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`706`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`713`)
   })
 })


### PR DESCRIPTION
**Problem:**
Converting to absolute with the 'Use Absolute Position' button in the inspector will not keep visual position. 

**Fix:**
With this button only the `position: absolute` is added to the selected elements but not left and top, with multiselection this causes the elements to collapse.

**Commit Details:**
- clicking the inspector button dispatches the escape hatch action (same as the context-menu) 
