### PR TITLE
Fix aspect ratio locked resize when dragging over the opposite edge

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -123,6 +123,19 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
       },
     ],
     [
+      'top left corner, flipping over',
+      {
+        edgePosition: { x: 0, y: 0 } as EdgePosition,
+        drag: canvasPoint({
+          x: 350,
+          y: 400,
+        }),
+        modifiers: emptyModifiers,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 300, top: 350, width: 100, height: 100 },
+      },
+    ],
+    [
       'bottom left corner',
       {
         edgePosition: { x: 0, y: 1 } as EdgePosition,
@@ -328,6 +341,19 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
         modifiers: shiftModifier,
         bounding: { left: 50, top: 50, width: 250, height: 300 },
         expectedBounding: { left: 65, top: 68, width: 235, height: 282 },
+      },
+    ],
+    [
+      'top left corner, aspect ratio locked, flipping over',
+      {
+        edgePosition: { x: 0, y: 0 } as EdgePosition,
+        drag: canvasPoint({
+          x: 350,
+          y: 400,
+        }),
+        modifiers: shiftModifier,
+        bounding: { left: 50, top: 50, width: 250, height: 300 },
+        expectedBounding: { left: 300, top: 350, width: 100, height: 120 },
       },
     ],
     [

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
@@ -14,7 +14,6 @@ import {
   distance,
   offsetPoint,
   pointDifference,
-  rectangleDifference,
   rectFromTwoPoints,
   zeroCanvasPoint,
 } from '../../../core/shared/math-utils'

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -741,24 +741,6 @@ export function lineIntersection<C extends CoordinateMarker>(
   } as Point<C>
 }
 
-// Returns which side of the line is point b. If looking from lineA to lineB it is on the left, it returns the value 'left', etc.
-export function sideOfLine<C extends CoordinateMarker>(
-  lineA: Point<C>,
-  lineB: Point<C>,
-  p: Point<C>,
-): 'left' | 'right' | 'on-line' {
-  // For explanation see: https://math.stackexchange.com/questions/274712/calculate-on-which-side-of-a-straight-line-is-a-given-point-located
-  const d = (p.x - lineA.x) * (lineB.y - lineA.y) - (p.y - lineA.y) * (lineB.x - lineA.x)
-  if (d == 0) {
-    return 'on-line'
-  } else if (d < 0) {
-    return 'right'
-  } else {
-    // d > 0
-    return 'left'
-  }
-}
-
 export function roundPointTo<C extends CoordinateMarker>(p: Point<C>, precision: number): Point<C> {
   return {
     x: roundTo(p.x, precision),


### PR DESCRIPTION
# Issue

Holding down shift while resizing a mirrored element should apply the aspect ratio correctly - not move it to its original position. 

# Fix

I realized that there is a simpler way to implement aspect ratio locked resize. Instead of having a whole separate logic to handle aspect ratio lock we can just allow normal resize to calculate the rectangle, and then extend the resulting rectangle so it has the correct aspect ratio. We just have to be careful how do we position the resulting rectangle, it should always have a fixed edge/corner, which is the opposite from the dragged one.
This implementation doesn't have the bug described in the report.