### PR TITLE
Resize with keyboard only shows guidelines when fully aligned.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -6,6 +6,7 @@ import * as EP from '../../../core/shared/element-path'
 import { isFeatureEnabled, setFeatureEnabled } from '../../../utils/feature-switches'
 import { wait } from '../../../utils/utils.test-utils'
 import { selectComponents } from '../../editor/actions/action-creators'
+import { GuidelineWithSnappingVector } from '../guideline'
 import { getPrintedUiJsCode, renderTestEditorWithCode } from '../ui-jsx.test-utils'
 import { KeyboardInteractionTimeout } from './interaction-state'
 
@@ -41,17 +42,45 @@ describe('Keyboard Absolute Strategies E2E', () => {
   })
 
   it('Pressing Shift + ArrowRight 3 times', async () => {
-    const { expectElementLeftOnScreen, expectElementPropertiesInPrintedCode } = await setupTest(
-      defaultBBBProperties,
-    )
+    const { expectElementLeftOnScreen, expectElementPropertiesInPrintedCode, getCanvasGuidelines } =
+      await setupTest(defaultBBBProperties)
 
     pressArrowRightHoldingShift3x()
     expectElementLeftOnScreen(30)
+    expect(getCanvasGuidelines()).toEqual([])
 
     // tick the clock so useClearKeyboardInteraction is fired
     clock.tick(KeyboardInteractionTimeout)
     await expectElementPropertiesInPrintedCode({
       left: 30,
+      top: 100,
+      width: 122,
+      height: 101,
+    })
+  })
+
+  it('Pressing Shift + ArrowRight 3 times, then Shift + ArrowLeft 3 times', async () => {
+    const { expectElementLeftOnScreen, expectElementPropertiesInPrintedCode, getCanvasGuidelines } =
+      await setupTest(defaultBBBProperties)
+
+    pressArrowRightHoldingShift3x()
+    expectElementLeftOnScreen(30)
+    expect(getCanvasGuidelines()).toEqual([])
+
+    pressArrowLeftHoldingShift(3)
+    expectElementLeftOnScreen(0)
+    expect(getCanvasGuidelines()).toEqual([
+      {
+        guideline: { type: 'XAxisGuideline', x: 0, yTop: 0, yBottom: 812 },
+        snappingVector: { x: 0, y: 0 },
+        activateSnap: true,
+      },
+    ])
+
+    // tick the clock so useClearKeyboardInteraction is fired
+    clock.tick(KeyboardInteractionTimeout)
+    await expectElementPropertiesInPrintedCode({
+      left: 0,
       top: 100,
       width: 122,
       height: 101,
@@ -101,22 +130,37 @@ describe('Keyboard Absolute Strategies E2E', () => {
   })
 
   it('Pressing Cmd + ArrowRight 3 times, then pressing Cmd + ArrowLeft once', async () => {
-    const { expectElementWidthOnScreen, expectElementPropertiesInPrintedCode } = await setupTest(
-      defaultBBBProperties,
-    )
+    const {
+      expectElementWidthOnScreen,
+      expectElementPropertiesInPrintedCode,
+      getCanvasGuidelines,
+    } = await setupTest({
+      left: 10,
+      top: 100,
+      width: 28,
+      height: 101,
+    })
 
     pressArrowRightHoldingCmd(3)
     expectElementWidthOnScreen(3)
+    expect(getCanvasGuidelines()).toEqual([])
 
     pressArrowLeftHoldingCmd(1)
     expectElementWidthOnScreen(2)
+    expect(getCanvasGuidelines()).toEqual([
+      {
+        activateSnap: true,
+        guideline: { type: 'XAxisGuideline', x: 40, yBottom: 396, yTop: 300 },
+        snappingVector: { x: 0, y: 0 },
+      },
+    ])
 
     // tick the clock so useClearKeyboardInteraction is fired
     clock.tick(KeyboardInteractionTimeout)
     await expectElementPropertiesInPrintedCode({
-      left: 0,
+      left: 10,
       top: 100,
-      width: 124,
+      width: 30,
       height: 101,
     })
   })
@@ -326,11 +370,15 @@ async function setupTest(initialBBBProperties: { [key: string]: any }) {
       TestProjectDeluxeStallion(bbbProperties),
     )
   }
+  function getCanvasGuidelines(): Array<GuidelineWithSnappingVector> {
+    return renderResult.getEditorState().editor.canvas.controls.snappingGuidelines
+  }
   return {
     renderResult,
     expectElementLeftOnScreen,
     expectElementWidthOnScreen,
     expectElementPropertiesInPrintedCode,
+    getCanvasGuidelines,
   }
 }
 
@@ -355,6 +403,19 @@ function pressArrowLeftHoldingCmd(count: number) {
       )
       window.dispatchEvent(
         new KeyboardEvent('keyup', { key: 'ArrowLeft', keyCode: 37, metaKey: true }),
+      )
+    }
+  })
+}
+
+function pressArrowLeftHoldingShift(count: number) {
+  act(() => {
+    for (let step = 0; step < count; step++) {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowLeft', keyCode: 37, shiftKey: true }),
+      )
+      window.dispatchEvent(
+        new KeyboardEvent('keyup', { key: 'ArrowLeft', keyCode: 37, shiftKey: true }),
       )
     }
   })

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -1,14 +1,23 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { Keyboard, KeyCharacter } from '../../../utils/keyboard'
-import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
 import {
+  CanvasStrategy,
+  emptyStrategyApplicationResult,
+  InteractionCanvasState,
+} from './canvas-strategy-types'
+import {
+  CanvasRectangle,
+  canvasRectangle,
   CanvasVector,
   offsetPoint,
+  offsetRect,
   scaleVector,
   zeroCanvasPoint,
+  zeroRectangle,
 } from '../../../core/shared/math-utils'
 import {
   getAbsoluteMoveCommandsForSelectedElement,
+  getMultiselectBounds,
   snapDrag,
 } from './shared-absolute-move-strategy-helpers'
 import { AdjustCssLengthProperty } from '../commands/adjust-css-length-command'
@@ -19,8 +28,18 @@ import { CanvasCommand } from '../commands/commands'
 import {
   accumulatePresses,
   getDragDeltaFromKey,
+  getKeyboardStrategyGuidelines,
   getLastKeyPressState,
 } from './shared-keyboard-strategy-helpers'
+import { mapDropNulls } from '../../../core/shared/array-utils'
+import { defaultIfNull } from '../../../core/shared/optional-utils'
+import {
+  collectParentAndSiblingGuidelines,
+  oneGuidelinePerDimension,
+} from '../controls/guideline-helpers'
+import { GuidelineWithSnappingVector, Guidelines } from '../guideline'
+import Utils from '../../../utils/utils'
+import { StrategyState, InteractionSession } from './interaction-state'
 
 export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
   id: 'KEYBOARD_ABSOLUTE_MOVE',
@@ -84,20 +103,25 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
             sessionState,
           ),
         )
-        const { guidelinesWithSnappingVector } = snapDrag(
-          drag,
-          null,
-          interactionState.metadata,
+        const multiselectBounds = getMultiselectBounds(
+          sessionState.startingMetadata,
           canvasState.selectedElements,
-          canvasState.scale,
         )
-        const justSnappedGuidelines = guidelinesWithSnappingVector.filter((guideline) => {
-          return guideline.activateSnap
-        })
+        const draggedFrame = offsetRect(
+          defaultIfNull(canvasRectangle(zeroRectangle), multiselectBounds),
+          drag,
+        )
+
+        const guidelines = getKeyboardStrategyGuidelines(
+          sessionState,
+          canvasState,
+          interactionState,
+          draggedFrame,
+        )
 
         commands.push(...moveCommands)
         commands.push(updateHighlightedViews('transient', []))
-        commands.push(setSnappingGuidelines('transient', justSnappedGuidelines))
+        commands.push(setSnappingGuidelines('transient', guidelines))
         commands.push(setElementsToRerenderCommand(canvasState.selectedElements))
       }
       return {

--- a/editor/src/components/canvas/canvas-strategies/shared-keyboard-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-keyboard-strategy-helpers.ts
@@ -54,7 +54,7 @@ export function accumulatePresses(keyStates: Array<KeyState>): Array<Accumulated
   return result
 }
 
-export function getDragDeltaFromKey(key: KeyCharacter, modifiers: Modifiers): CanvasVector {
+export function getMovementDeltaFromKey(key: KeyCharacter, modifiers: Modifiers): CanvasVector {
   const step = modifiers.shift ? 10 : 1
   switch (key) {
     case 'left':


### PR DESCRIPTION
**Problem:**
Currently when resizing with the keyboard we have no guidelines, but we want them to appear similarly to when moving with the keyboard on full alignment.

**Fix:**
The logic for guidelines when moving with the keyboard was extracted into a function and used in the keyboard resize strategy.

**Commit Details:**
- Refactored out the guidelines logic from the keyboard absolute move strategy
  into a function called `getKeyboardStrategyGuidelines`.
- Keyboard absolute resize strategy calculates the new bounds of the
  resize so that the guidelines can be calculated using
  `getKeyboardStrategyGuidelines`.