### PR TITLE
Cancel keyboard interaction on all keyboard shortcuts

### DIFF
--- a/editor/src/components/editor/global-shortcuts.ts
+++ b/editor/src/components/editor/global-shortcuts.ts
@@ -711,12 +711,6 @@ export function handleKeyDown(
           : []
       },
       [UNDO_CHANGES_SHORTCUT]: () => {
-        if (editor.canvas.interactionSession?.interactionData.type === 'KEYBOARD') {
-          // if we are in a keyboard interaction session, we want cmd + z to finish the current interaction session, and then immediately undo it
-          // this is desired because the user might want to redo the changes
-          // Warning: Side Effect!
-          dispatch([CanvasActions.clearInteractionSession(true)])
-        }
         return [EditorActions.undo()]
       },
       [REDO_CHANGES_SHORTCUT]: () => {
@@ -806,7 +800,15 @@ export function handleKeyDown(
   // Build the actions to dispatch.
   let actions: Array<EditorAction> = [updateKeysAction]
   if (editorTargeted) {
-    actions.push(...getShortcutActions())
+    const shortCutActions = getShortcutActions()
+    if (shortCutActions.length > 0) {
+      if (editor.canvas.interactionSession?.interactionData.type === 'KEYBOARD') {
+        // if we are in a keyboard interaction session, we want keyboard shortcuts to finish the current interaction session,
+        // so the effect of the shortcut is not combined into the undo of the interaction
+        dispatch([CanvasActions.clearInteractionSession(true)])
+      }
+      actions.push(...shortCutActions)
+    }
   }
 
   dispatch(actions, 'everyone')


### PR DESCRIPTION
# Issue

When there is an active keyboard interaction, other keyboard shortcuts (e.g. delete, paste, etc) dispatch their actions, but the interaction goes one, and everything is mixed into a single big undo step.

# Fix

This was already fixed for undo in https://github.com/concrete-utopia/utopia/pull/2342
I believe the best is to just cancel the keyboard interaction on any keyboard shortcuts. Although some of the do not have any effect on undo (e.g. zoom out), but it doesn't hurt to restart the interaction after a shortcut like that.