### PR TITLE
Use a WeakMap for the stringified element path cache

### DIFF
--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -479,16 +479,12 @@ export function appendPartToPath(path: ElementPath, next: ElementPathPart): Elem
   return elementPath(updatedPathParts)
 }
 
-export function notNullPathsEqual(l: ElementPath, r: ElementPath): boolean {
-  return fullElementPathsEqual(l.parts, r.parts)
-}
-
 function elementPathPartsEqual(l: ElementPathPart, r: ElementPathPart): boolean {
   return arrayEquals(l, r)
 }
 
-export function fullElementPathsEqual(l: ElementPathPart[], r: ElementPathPart[]): boolean {
-  return l === r || arrayEquals(l, r, elementPathPartsEqual)
+function stringifiedPathsEqual(l: ElementPath, r: ElementPath): boolean {
+  return toString(l) === toString(r)
 }
 
 export function pathsEqual(l: ElementPath | null, r: ElementPath | null): boolean {
@@ -499,13 +495,13 @@ export function pathsEqual(l: ElementPath | null, r: ElementPath | null): boolea
   } else if (l === r) {
     return true
   } else {
-    return fullElementPathsEqual(l.parts, r.parts)
+    return stringifiedPathsEqual(l, r)
   }
 }
 
 export function containsPath(path: ElementPath, paths: Array<ElementPath>): boolean {
   for (const toCheck of paths) {
-    if (notNullPathsEqual(toCheck, path)) {
+    if (pathsEqual(toCheck, path)) {
       return true
     }
   }

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -22,7 +22,6 @@ export function toVarSafeComponentId(path: ElementPath): string {
 
 interface ElementPathCache {
   cached: ElementPath | null
-  cachedToString: string | null
   childCaches: { [key: string]: ElementPathCache }
   rootElementCaches: { [key: string]: ElementPathCache }
 }
@@ -30,12 +29,12 @@ interface ElementPathCache {
 function emptyElementPathCache(): ElementPathCache {
   return {
     cached: null,
-    cachedToString: null,
     childCaches: {},
     rootElementCaches: {},
   }
 }
 
+let pathToStringCache: WeakMap<ElementPath, string> = new WeakMap()
 let dynamicToStaticPathCache: Map<ElementPath, StaticElementPath> = new Map()
 let dynamicToStaticLastElementPathPartCache: Map<ElementPath, ElementPath> = new Map()
 let dynamicElementPathToStaticElementPathCache: Map<ElementPathPart, StaticElementPathPart> =
@@ -163,12 +162,14 @@ export function elementPathPartToString(path: ElementPathPart): string {
 }
 
 export function toString(target: ElementPath): string {
-  const pathCache = getElementPathCache(target.parts)
-  if (pathCache.cachedToString == null) {
-    pathCache.cachedToString = target.parts.map(elementPathPartToString).join(SceneSeparator)
+  const cachedToString = pathToStringCache.get(target)
+  if (cachedToString == null) {
+    const stringifiedPath = target.parts.map(elementPathPartToString).join(SceneSeparator)
+    pathToStringCache.set(target, stringifiedPath)
+    return stringifiedPath
+  } else {
+    return cachedToString
   }
-
-  return pathCache.cachedToString
 }
 
 export const emptyElementPathPart: StaticElementPathPart = staticElementPath([])


### PR DESCRIPTION
Rather than having to traverse the `ElementPathCache` tree to find a cached stringified path, we can instead store them in a `WeakMap`, which will be garbage collected when the paths no longer exist.