### PR TITLE
Use toString for ElementPath equality checks

### DIFF
--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -479,16 +479,8 @@ export function appendPartToPath(path: ElementPath, next: ElementPathPart): Elem
   return elementPath(updatedPathParts)
 }
 
-export function notNullPathsEqual(l: ElementPath, r: ElementPath): boolean {
-  return fullElementPathsEqual(l.parts, r.parts)
-}
-
 function elementPathPartsEqual(l: ElementPathPart, r: ElementPathPart): boolean {
   return arrayEquals(l, r)
-}
-
-export function fullElementPathsEqual(l: ElementPathPart[], r: ElementPathPart[]): boolean {
-  return l === r || arrayEquals(l, r, elementPathPartsEqual)
 }
 
 function stringifiedPathsEqual(l: ElementPath, r: ElementPath): boolean {
@@ -509,7 +501,7 @@ export function pathsEqual(l: ElementPath | null, r: ElementPath | null): boolea
 
 export function containsPath(path: ElementPath, paths: Array<ElementPath>): boolean {
   for (const toCheck of paths) {
-    if (notNullPathsEqual(toCheck, path)) {
+    if (pathsEqual(toCheck, path)) {
       return true
     }
   }

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -491,6 +491,10 @@ export function fullElementPathsEqual(l: ElementPathPart[], r: ElementPathPart[]
   return l === r || arrayEquals(l, r, elementPathPartsEqual)
 }
 
+function stringifiedPathsEqual(l: ElementPath, r: ElementPath): boolean {
+  return toString(l) === toString(r)
+}
+
 export function pathsEqual(l: ElementPath | null, r: ElementPath | null): boolean {
   if (l == null) {
     return r == null
@@ -499,7 +503,7 @@ export function pathsEqual(l: ElementPath | null, r: ElementPath | null): boolea
   } else if (l === r) {
     return true
   } else {
-    return fullElementPathsEqual(l.parts, r.parts)
+    return stringifiedPathsEqual(l, r)
   }
 }
 


### PR DESCRIPTION
**Problem:**
The `ElementPath` equality check is expensive for near misses (e.g. sibling paths), and we can't necessarily guarantee reference equality.

**Fix:**
Fall back to string equality if reference equality fails, as we are caching the stringified versions too.
