### PR TITLE
Revert feature/performance-tests-pinned-target

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -102,66 +102,10 @@ jobs:
         run: |
           curl -s -o /dev/null -w "FLUSH STAGING HTTP RESPONSE CODE: %{http_code}" -X DELETE 'https://${{ secrets.STAGING_SERVER }}/internal/branch?branch_name=${{ steps.extract_branch.outputs.branch }}'
 
-  deploy-target:
-    name: Deploy Target Editor
-    runs-on: ubuntu-latest
-    env:
-      UTOPIA_SHA: e55437e6ffafde6c4727264812a4d8b78bf33c6d
-      AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266
-      AUTH0_ENDPOINT: enter.utopia.app
-      AUTH0_REDIRECT_URI: https://utopia.pizza/authenticate
-    steps:
-      - name: Check out target version of repo
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ env.UTOPIA_SHA }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v2
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-      - name: Install nix
-        uses: cachix/install-nix-action@v12
-        with:
-          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/6120ac5cd201f6cb593d1b80e861be0342495be9.tar.gz
-      - name: Build Target Version of Editor
-        if: steps.cache-editor-tests.outputs.cache-hit != 'true'
-        run: |
-          nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run build-editor-staging-ci
-      - name: Delete node_modules
-        working-directory: editor/
-        run: |
-          rm -rf ./node_modules
-          cd ../utopia-api
-          rm -rf ./node_modules
-          cd ../website-next
-          rm -rf ./node_modules
-          cd ../utopia-vscode-extension
-          rm -rf ./node_modules
-          cd ../utopia-vscode-common
-          rm -rf ./node_modules
-      - name: Create Editor Bundle
-        working-directory: editor/lib/
-        run: |
-          tar -czvf ../performance-test-target.tar.gz *
-      - name: Upload Target Editor Bundle
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        with:
-          args: --acl private --exclude '*' --include 'editor/performance-test-target.tar.gz'
-        env:
-          AWS_S3_BUCKET: ${{ secrets.STAGING_BUNDLE_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_BUNDLE_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_BUNDLE_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.STAGING_BUNDLE_REGION }}
-      - name: Flush Staging Target Editor Bundle
-        shell: bash
-        run: |
-          curl -s -o /dev/null -w "FLUSH STAGING HTTP RESPONSE CODE: %{http_code}" -X DELETE 'https://${{ secrets.STAGING_SERVER }}/internal/branch?branch_name=performance-test-target'
-
   performance-test:
     name: Run Performance Tests
     runs-on: self-hosted
-    needs: [deploy-staging, deploy-target]
+    needs: [deploy-staging]
     env:
       UTOPIA_SHA: ${{ github.sha }}
       AUTH0_CLIENT_ID: KB7euFO46rVYeOaWmrEdktdhAFxEO266

--- a/puppeteer-tests/src/performance-test.ts
+++ b/puppeteer-tests/src/performance-test.ts
@@ -9,11 +9,14 @@ const path = require('path')
 const moveFile = require('move-file')
 
 const BRANCH_NAME = process.env.BRANCH_NAME ? `&branch_name=${process.env.BRANCH_NAME}` : ''
+const TARGET_BRANCH_NAME = process.env.TARGET_BRANCH_NAME
+  ? `&branch_name=${process.env.TARGET_BRANCH_NAME}`
+  : ''
 const STAGING_EDITOR_URL =
   process.env.EDITOR_URL ?? `https://utopia.pizza/p?code_editor_disabled=true${BRANCH_NAME}`
 const MASTER_EDITOR_URL =
   process.env.MASTER_EDITOR_URL ??
-  `https://utopia.pizza/p?code_editor_disabled=true&branch_name=performance-test-target`
+  `https://utopia.pizza/p?code_editor_disabled=true${TARGET_BRANCH_NAME}`
 
 export function wait(timeout: number): Promise<void> {
   return new Promise((resolve) => {


### PR DESCRIPTION
**Problem:**
Having the pinned target for performance tests was a great idea until we all collectively forgot that we'd made that change.

**Fix:**
Revert the behaviour by reverting #2305. I've instead put in a `TARGET_BRANCH_NAME`, because I'd like to add a workflow for manually comparing 2 branches / commits, which will be easy enough to add using the changes from #2305 as a template.