### PR TITLE
Fix dragging absolute position element with missing pins

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -193,7 +193,7 @@ describe('Absolute Move Strategy', () => {
     )
   })
 
-  it('works with a T pinned absolute element, assumes L to 0', async () => {
+  it('works with a T pinned absolute element, assumes L to localframe position in metadata', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],
       ['aaa', 'bbb'],
@@ -217,7 +217,7 @@ describe('Absolute Move Strategy', () => {
       makeTestProjectCodeWithSnippet(
         `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
         <View
-          style={{ backgroundColor: '#0091FFAA', position: 'absolute', top: 65, width: 250, height: 300, left: 15 }}
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', top: 65, width: 250, height: 300, left: 65 }}
           data-uid='bbb'
         />
       </View>`,

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -43,6 +43,7 @@ const defaultMetadata: ElementInstanceMetadataMap = {
     ]),
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
     globalFrame: canvasRectangle({ x: 50, y: 50, width: 250, height: 300 }),
     localFrame: localRectangle({ x: 50, y: 50, width: 250, height: 300 }),
@@ -66,6 +67,7 @@ const metadataWithSnapTarget: ElementInstanceMetadataMap = {
     ]),
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
     globalFrame: canvasRectangle({ x: 50, y: 50, width: 250, height: 300 }),
     localFrame: localRectangle({ x: 50, y: 50, width: 250, height: 300 }),

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -193,38 +193,6 @@ describe('Absolute Move Strategy', () => {
     )
   })
 
-  it('works with a T pinned absolute element, assumes L to localframe position in metadata', async () => {
-    const targetElement = elementPath([
-      ['scene-aaa', 'app-entity'],
-      ['aaa', 'bbb'],
-    ])
-
-    const initialEditor: EditorState = prepareEditorState(
-      `
-    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
-      <View
-        style={{ backgroundColor: '#0091FFAA', position: 'absolute', top: 50, width: 250, height: 300 }}
-        data-uid='bbb'
-      />
-    </View>
-    `,
-      [targetElement],
-    )
-
-    const finalEditor = dragBy15Pixels(initialEditor)
-
-    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
-      makeTestProjectCodeWithSnippet(
-        `<View style={{ ...(props.style || {}) }} data-uid='aaa'>
-        <View
-          style={{ backgroundColor: '#0091FFAA', position: 'absolute', top: 65, width: 250, height: 300, left: 65 }}
-          data-uid='bbb'
-        />
-      </View>`,
-      ),
-    )
-  })
-
   it('works with a TL pinned absolute element with px values', async () => {
     const targetElement = elementPath([
       ['scene-aaa', 'app-entity'],

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -77,6 +77,7 @@ function dragByPixels(
           ]),
           specialSizeMeasurements: {
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
       },

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -69,6 +69,7 @@ function reparentElement(
           globalFrame: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
           specialSizeMeasurements: {
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
             providesBoundsForChildren: true,
             globalContentBox: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
           } as SpecialSizeMeasurements,
@@ -81,6 +82,7 @@ function reparentElement(
           globalFrame: canvasRectangle({ x: 50, y: 60, width: 250, height: 200 }),
           specialSizeMeasurements: {
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
             providesBoundsForChildren: true,
             globalContentBox: targetParentWithSpecialContentBox
               ? canvasRectangle({ x: 90, y: 100, width: 170, height: 120 })

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -81,6 +81,7 @@ const testMetadata: ElementInstanceMetadataMap = {
     element: left('div'),
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
     globalFrame: { height: 120, width: 100, x: 30, y: 50 },
   } as ElementInstanceMetadata,
@@ -89,6 +90,7 @@ const testMetadata: ElementInstanceMetadataMap = {
     element: left('div'),
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
     globalFrame: { height: 110, width: 100, x: 90, y: 40 },
   } as ElementInstanceMetadata,
@@ -580,6 +582,7 @@ describe('Absolute Resize Bounding Box Strategy single select', () => {
             element: left('div'),
             specialSizeMeasurements: {
               immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+              coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
             } as SpecialSizeMeasurements,
             globalFrame: {
               height: bounding.height,
@@ -1441,6 +1444,7 @@ describe('Absolute Resize Strategy with missing props', () => {
           element: left('div'),
           specialSizeMeasurements: {
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
           } as SpecialSizeMeasurements,
           globalFrame: { x: 30, y: 50, width: 100, height: 80 },
         } as ElementInstanceMetadata,
@@ -1449,6 +1453,7 @@ describe('Absolute Resize Strategy with missing props', () => {
           element: left('div'),
           specialSizeMeasurements: {
             immediateParentBounds: canvasRectangle({ x: 30, y: 50, width: 100, height: 80 }),
+            coordinateSystemBounds: canvasRectangle({ x: 30, y: 50, width: 100, height: 80 }),
           } as SpecialSizeMeasurements,
           globalFrame: { x: 30, y: 50, width: 100, height: 80 },
         } as ElementInstanceMetadata,
@@ -1584,6 +1589,7 @@ describe('Absolute Resize Strategy with missing props', () => {
           element: left('div'),
           specialSizeMeasurements: {
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
           } as SpecialSizeMeasurements,
           globalFrame: { x: 0, y: 0, width: 100, height: 80 },
         } as ElementInstanceMetadata,
@@ -1592,6 +1598,7 @@ describe('Absolute Resize Strategy with missing props', () => {
           element: left('div'),
           specialSizeMeasurements: {
             immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 100, height: 80 }),
+            coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 100, height: 80 }),
           } as SpecialSizeMeasurements,
           globalFrame: { x: 0, y: 0, width: 100, height: 80 },
         } as ElementInstanceMetadata,

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
@@ -35,6 +35,7 @@ const simpleMetadata = {
     localFrame: { x: 0, y: 0, width: 250, height: 300 },
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
   } as ElementInstanceMetadata,
 }
@@ -47,6 +48,7 @@ const simpleMetadataPercentValue = {
     localFrame: { x: 0, y: 0, width: 200, height: 80 },
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
   } as ElementInstanceMetadata,
 }
@@ -60,6 +62,7 @@ const complexMetadata = {
     localFrame: { x: 0, y: 0, width: 250, height: 100 },
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
   } as ElementInstanceMetadata,
   'scene-aaa/app-entity:aaa/ccc': {
@@ -70,6 +73,7 @@ const complexMetadata = {
     localFrame: { x: 15, y: 115, width: 125, height: 50 },
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
   } as ElementInstanceMetadata,
   'scene-aaa/app-entity:aaa/ddd': {
@@ -80,6 +84,7 @@ const complexMetadata = {
     localFrame: { x: 0, y: 280, width: 100, height: 50 },
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
   } as ElementInstanceMetadata,
 }
@@ -93,6 +98,7 @@ const mixedPinsMetadata = {
     localFrame: { x: 0, y: 0, width: 400, height: 19 },
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
   } as ElementInstanceMetadata,
   'scene-aaa/app-entity:aaa/ccc': {
@@ -103,6 +109,7 @@ const mixedPinsMetadata = {
     localFrame: { x: 0, y: 19, width: 65, height: 50 },
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
   } as ElementInstanceMetadata,
   'scene-aaa/app-entity:aaa/ddd': {
@@ -113,6 +120,7 @@ const mixedPinsMetadata = {
     localFrame: { x: 0, y: 69, width: 65, height: 50 },
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
   } as ElementInstanceMetadata,
   'scene-aaa/app-entity:aaa/eee': {
@@ -123,6 +131,7 @@ const mixedPinsMetadata = {
     localFrame: { x: 0, y: 119, width: 65, height: 50 },
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
   } as ElementInstanceMetadata,
   'scene-aaa/app-entity:aaa/fff': {
@@ -133,6 +142,7 @@ const mixedPinsMetadata = {
     localFrame: { x: 0, y: 169, width: 65, height: 50 },
     specialSizeMeasurements: {
       immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
     } as SpecialSizeMeasurements,
   } as ElementInstanceMetadata,
 }

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -31,6 +31,7 @@ export function pressKeys(
       ]),
       specialSizeMeasurements: {
         immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+        coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
       } as SpecialSizeMeasurements,
     } as ElementInstanceMetadata,
   }

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
@@ -270,7 +270,10 @@ export function snapDrag(
 const horizontalPins: Array<AbsolutePin> = ['left', 'right']
 const verticalPins: Array<AbsolutePin> = ['top', 'bottom']
 
-function ensureAtLeastOnePinPerDimension(props: PropsOrJSXAttributes) {
+function ensureAtLeastOnePinPerDimension(props: PropsOrJSXAttributes): {
+  existingPins: Array<AbsolutePin>
+  extendedPins: Array<AbsolutePin>
+} {
   const existingHorizontalPins = horizontalPins.filter((p) => {
     const prop = getLayoutProperty(p, props, ['style'])
     return isRight(prop) && prop.value != null

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
@@ -10,13 +10,17 @@ import {
   boundingRectangleArray,
   CanvasPoint,
   canvasPoint,
+  canvasRectangle,
   CanvasRectangle,
   CanvasVector,
   localRectangle,
   LocalRectangle,
+  offsetRect,
   pointDifference,
+  rectangleDifference,
   zeroCanvasPoint,
   zeroCanvasRect,
+  canvasRectangleToLocalRectangle,
 } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { ProjectContentTreeRoot } from '../../assets'
@@ -53,9 +57,13 @@ export function getAbsoluteMoveCommandsForSelectedElement(
     selectedElement,
   )
 
-  const elementParentBounds = elementMetadata?.specialSizeMeasurements.immediateParentBounds ?? null // TODO this should probably be coordinateSystemBounds
+  const elementParentBounds =
+    elementMetadata?.specialSizeMeasurements.coordinateSystemBounds ?? null
 
-  const localFrame = elementMetadata?.localFrame ?? null
+  const localFrame = MetadataUtils.getLocalFrameFromSpecialSizeMeasurements(
+    selectedElement,
+    sessionState.startingMetadata,
+  )
 
   if (element == null) {
     return []

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -1575,6 +1575,7 @@ describe('RUN_ESCAPE_HATCH', () => {
         localFrame: { x: 0, y: 0, width: 250, height: 300 },
         specialSizeMeasurements: {
           immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+          coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
         } as SpecialSizeMeasurements,
       } as ElementInstanceMetadata,
     } as ElementInstanceMetadataMap

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1295,10 +1295,10 @@ export const MetadataUtils = {
   ): LocalRectangle | null {
     const element = MetadataUtils.findElementByElementPath(metadata, path)
     const globalFrame = element?.globalFrame ?? null
-    const elementParentBounds = element?.specialSizeMeasurements.coordinateSystemBounds ?? null
+    const elementContainerBounds = element?.specialSizeMeasurements.coordinateSystemBounds ?? null
     const localFrame =
-      globalFrame != null && elementParentBounds != null
-        ? canvasRectangleToLocalRectangle(globalFrame, elementParentBounds)
+      globalFrame != null && elementContainerBounds != null
+        ? canvasRectangleToLocalRectangle(globalFrame, elementContainerBounds)
         : null
     return localFrame
   },

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -69,6 +69,7 @@ import {
   CanvasPoint,
   CanvasRectangle,
   canvasRectangle,
+  canvasRectangleToLocalRectangle,
   LocalRectangle,
   localRectangle,
   SimpleRectangle,
@@ -1286,6 +1287,20 @@ export const MetadataUtils = {
   isEmotionOrStyledComponent(path: ElementPath, metadata: ElementInstanceMetadataMap): boolean {
     const element = MetadataUtils.findElementByElementPath(metadata, path)
     return element?.isEmotionOrStyledComponent ?? false
+  },
+  // localFrame is stored in the metadata root, but it is not correct in all cases. Calculating it from specialSizeMeasurements is more reliable
+  getLocalFrameFromSpecialSizeMeasurements(
+    path: ElementPath,
+    metadata: ElementInstanceMetadataMap,
+  ): LocalRectangle | null {
+    const element = MetadataUtils.findElementByElementPath(metadata, path)
+    const globalFrame = element?.globalFrame ?? null
+    const elementParentBounds = element?.specialSizeMeasurements.coordinateSystemBounds ?? null
+    const localFrame =
+      globalFrame != null && elementParentBounds != null
+        ? canvasRectangleToLocalRectangle(globalFrame, elementParentBounds)
+        : null
+    return localFrame
   },
 }
 

--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -954,3 +954,16 @@ export function clamp(min: number, max: number, value: number): number {
     return value
   }
 }
+
+export function canvasRectangleToLocalRectangle(
+  canvasRect: CanvasRectangle,
+  parentRect: CanvasRectangle,
+): LocalRectangle {
+  const diff = pointDifference(parentRect, canvasRect)
+  return localRectangle({
+    x: diff.x,
+    y: diff.y,
+    width: canvasRect.width,
+    height: canvasRect.height,
+  })
+}


### PR DESCRIPTION
# Issue

When the position of an absolute positioned element is not fully defined (horizontally or vertically), we add the missing `top`/`left` props on dragging, see https://github.com/concrete-utopia/utopia/pull/2346
However, this PR was buggy, because it assumed that the missing prop can be initialized with 0. But `absolute` elements with missing props can behave as `static` ones in layouting, so their position can be non-zero.

# Fix

Read the real position from the metadata (`localFrame`), and offset the drag coordinates with that.