### PR TITLE
Fix pin toggling when last set pin is invalid

### DIFF
--- a/editor/src/components/inspector/common/layout-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/layout-hooks.spec.tsx
@@ -76,4 +76,39 @@ describe('changePin', () => {
     expect(pinsToUnset.length).toEqual(1)
     expect(pinsToUnset[0]?.pin).toEqual('right')
   })
+
+  it('Gracefully falls back if the last set pin is incorrect', () => {
+    const pins = TLWHSimplePins
+    const { pinsToSet, pinsToUnset } = changePin(
+      'width',
+      pinsInfoForPins(pins),
+      [frameInfoForPins(pins)],
+      'right',
+      'top',
+    )
+
+    expect(pinsToSet.length).toEqual(1)
+    expect(pinsToSet[0]?.pin).toEqual('width')
+    expect(pinsToSet[0]?.value).toEqual('100%')
+
+    expect(pinsToUnset.length).toEqual(0)
+  })
+
+  it('Gracefully falls back if the last set pin is incorrect and matches the new pin', () => {
+    const pins = TLWHSimplePins
+    const { pinsToSet, pinsToUnset } = changePin(
+      'right',
+      pinsInfoForPins(pins),
+      [frameInfoForPins(pins)],
+      'right',
+      'top',
+    )
+
+    expect(pinsToSet.length).toEqual(1)
+    expect(pinsToSet[0]?.pin).toEqual('right')
+    expect(pinsToSet[0]?.value).toEqual(-10)
+
+    expect(pinsToUnset.length).toEqual(1)
+    expect(pinsToUnset[0]?.pin).toEqual('width')
+  })
 })

--- a/editor/src/components/inspector/common/layout-property-path-hooks.ts
+++ b/editor/src/components/inspector/common/layout-property-path-hooks.ts
@@ -95,18 +95,16 @@ type PinInspectorInfo = InspectorInfo<CSSNumber | undefined>
 
 export type PinsInfo = { [key in LayoutPinnedProp]: PinInspectorInfo }
 
-function getOtherHorizontalPin(
-  newPin: LayoutPinnedProp,
+function getLastSetPinOrNull(
   lastSetPin: LayoutPinnedProp | null,
+  pinsInfo: PinsInfo,
 ): LayoutPinnedProp | null {
-  return lastSetPin
-}
-
-function getOtherVerticalPin(
-  newPin: LayoutPinnedProp,
-  lastSetPin: LayoutPinnedProp | null,
-): LayoutPinnedProp | null {
-  return lastSetPin
+  if (lastSetPin == null) {
+    return null
+  } else {
+    const lastSetPinIsValid = pinsInfo[lastSetPin].value != null
+    return lastSetPinIsValid ? lastSetPin : null
+  }
 }
 
 export function changePin(
@@ -116,14 +114,11 @@ export function changePin(
   lastHorizontalProp: LayoutPinnedProp | null,
   lastVerticalProp: LayoutPinnedProp | null,
 ): ChangePinResult {
-  const otherHorizontalProp: LayoutPinnedProp | null = getOtherHorizontalPin(
-    newFrameProp,
+  const otherHorizontalProp: LayoutPinnedProp | null = getLastSetPinOrNull(
     lastHorizontalProp,
+    pinsInfo,
   )
-  const otherVerticalProp: LayoutPinnedProp | null = getOtherVerticalPin(
-    newFrameProp,
-    lastVerticalProp,
-  )
+  const otherVerticalProp: LayoutPinnedProp | null = getLastSetPinOrNull(lastVerticalProp, pinsInfo)
 
   const newFramePoint = framePointForPinnedProp(newFrameProp)
   const pinInfoForProp = pinsInfo[newFrameProp]


### PR DESCRIPTION
Follow on from #2334 

**Problem:**
The pins section of the Inspector had a bug whereby all other pins for a given dimension would be removed if the `lastHorizontalProp` (or `lastVerticalProp`) was incorrectly a pin that hadn't been set (which was surfaced by the section not re-mounting when a new element was selected). Though this was now impossible to reproduce in the editor after merging #2334, the incorrect code still existed.

**Fix:**
Check if the provided last set pin is actually a valid value, and disregard it if not.
