### PR TITLE
fix(canvas) update dom-walker while dragging

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -356,7 +356,10 @@ function runSelectiveDomWalker(
       }
     })
     const otherElementPaths = Object.keys(rootMetadataInStateRef.current).filter(
-      (path) => !elementsToFocusOn.some((focusPath) => EP.toString(focusPath) === path),
+      (path) =>
+        !Object.values(workingMetadata).some(
+          (metadata) => EP.toString(metadata.elementPath) === path,
+        ),
     )
     const rootMetadataForOtherElements = pick(otherElementPaths, rootMetadataInStateRef.current)
     mergeMetadataMapsWithFragments_MUTATE(rootMetadataForOtherElements, workingMetadata)


### PR DESCRIPTION
**Problem:**
While dragging a component root div the instance frame is wrong.

**Fix:**
Fix `runSelectiveDomWalker`, filter fresh metadata before merging. The dom-walker runs for the instance and the root div too, but the `elementsToFocusOn` only contains the root div. When the `otherElementPaths` is created it should contain all newly created paths.

**Commit Details:**
- update `runSelectiveDomWalker`
