### PR TITLE
fix(canvas) absolute move default cursor

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -4,8 +4,10 @@ import * as EP from '../../../core/shared/element-path'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import { CSSCursor } from '../canvas-types'
 import { foldAndApplyCommandsInner, TransientOrNot } from '../commands/commands'
 import { DuplicateElement, duplicateElement } from '../commands/duplicate-element-command'
+import { setCursorCommand } from '../commands/set-cursor-command'
 import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
 import { updateFunctionCommand } from '../commands/update-function-command'
 import { updateSelectedViews } from '../commands/update-selected-views-command'
@@ -120,6 +122,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
               transient,
             ),
           ),
+          setCursorCommand('transient', CSSCursor.Duplicate),
         ],
         customState: {
           ...strategyState.customStrategyState,

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -114,7 +114,7 @@ export function applyAbsoluteMoveCommon(
           ...commandsForSelectedElements,
           updateHighlightedViews('transient', []),
           setElementsToRerenderCommand(canvasState.selectedElements),
-          setCursorCommand('transient', CSSCursor.Move),
+          setCursorCommand('transient', CSSCursor.Select),
         ],
         customState: null,
       }
@@ -135,7 +135,7 @@ export function applyAbsoluteMoveCommon(
           updateHighlightedViews('transient', []),
           setSnappingGuidelines('transient', guidelinesWithSnappingVector),
           setElementsToRerenderCommand(canvasState.selectedElements),
-          setCursorCommand('transient', CSSCursor.Move),
+          setCursorCommand('transient', CSSCursor.Select),
         ],
         customState: null,
       }

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -1,7 +1,9 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
+import { CSSCursor } from '../canvas-types'
 import { getReparentTarget } from '../canvas-utils'
 import { reparentElement } from '../commands/reparent-element-command'
+import { setCursorCommand } from '../commands/set-cursor-command'
 import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
 import { updateSelectedViews } from '../commands/update-selected-views-command'
 import { ParentBounds } from '../controls/parent-bounds'
@@ -110,6 +112,7 @@ export const absoluteReparentStrategy: CanvasStrategy = {
           ...commands.flatMap((c) => c.commands),
           updateSelectedViews('permanent', newPaths),
           setElementsToRerenderCommand(newPaths),
+          setCursorCommand('transient', CSSCursor.Move),
         ],
         customState: null,
       }


### PR DESCRIPTION
**Fix:**
Updating the cursors for strategies. Absolute move uses the default cursor, duplicate has the new duplicate cursor and reparent and reorder are using the hands.

**Commit Details:**
- update strategies
