### PR TITLE
Align snapping guidelines.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
@@ -1,6 +1,6 @@
 import { elementPath } from '../../../core/shared/element-path'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
-import { canvasPoint } from '../../../core/shared/math-utils'
+import { canvasPoint, Rectangle, SimpleRectangle } from '../../../core/shared/math-utils'
 import { cmdModifier, emptyModifiers } from '../../../utils/modifiers'
 import {
   findCanvasStrategy,
@@ -10,8 +10,13 @@ import {
 import { InteractionSession, StrategyState } from './interaction-state'
 import { createMouseInteractionForTests } from './interaction-state.test-utils'
 import { act } from '@testing-library/react'
-import { makeTestProjectCodeWithSnippet, renderTestEditorWithCode } from '../ui-jsx.test-utils'
+import {
+  EditorRenderResult,
+  makeTestProjectCodeWithSnippet,
+  renderTestEditorWithCode,
+} from '../ui-jsx.test-utils'
 import { selectComponents } from '../../editor/actions/action-creators'
+import CanvasActions from '../canvas-actions'
 
 const baseStrategyState = (metadata: ElementInstanceMetadataMap) =>
   ({
@@ -27,6 +32,94 @@ const baseStrategyState = (metadata: ElementInstanceMetadataMap) =>
       lastReorderIdx: null,
     },
   } as StrategyState)
+
+interface StyleRectangle {
+  left: string
+  top: string
+  width: string
+  height: string
+}
+
+async function getGuidelineDimensions(
+  renderResult: EditorRenderResult,
+  testId: string,
+): Promise<StyleRectangle> {
+  const guideline = await renderResult.renderedDOM.findByTestId(testId)
+  return {
+    left: guideline.style.left,
+    top: guideline.style.top,
+    width: guideline.style.width,
+    height: guideline.style.height,
+  }
+}
+
+async function getGuidelineRenderResult(scale: number) {
+  const targetElement = elementPath([
+    ['utopia-storyboard-uid', 'scene-aaa', 'app-entity'],
+    ['div-parent', 'first-div'],
+  ])
+
+  const renderResult = await renderTestEditorWithCode(
+    makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='div-parent'
+        data-testid='div-parent'>
+        <div
+          data-uid='first-div'
+          data-testid='first-div'
+          style={{
+            position: 'absolute',
+            left: 50.5,
+            top: 146.5,
+            width: 50,
+            height: 50,
+            backgroundColor: 'red',
+          }}
+        />
+        <div
+          data-uid='second-div'
+          data-testid='second-div'
+          style={{
+            position: 'absolute',
+            left: 110.5,
+            top: 206.5,
+            width: 7,
+            height: 9,
+            backgroundColor: 'blue',
+          }}
+        />
+      </div>
+      `),
+    'await-first-dom-report',
+  )
+
+  await act(async () => {
+    const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+    await renderResult.dispatch(
+      [selectComponents([targetElement], false), CanvasActions.zoom(scale)],
+      false,
+    )
+    await dispatchDone
+  })
+
+  const interactionSession: InteractionSession = {
+    ...createMouseInteractionForTests(
+      canvasPoint({ x: 60, y: 150 }),
+      emptyModifiers,
+      { type: 'BOUNDING_AREA', target: targetElement },
+      canvasPoint({ x: 10, y: 10 }),
+    ),
+    metadata: renderResult.getEditorState().editor.jsxMetadata,
+    allElementProps: renderResult.getEditorState().editor.allElementProps,
+  }
+
+  await act(async () => {
+    const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()
+    await renderResult.dispatch([CanvasActions.createInteractionSession(interactionSession)], false)
+    await dispatchDone
+  })
+  return renderResult
+}
 
 describe('Strategy Fitness', () => {
   it('fits Escape Hatch Strategy when dragging a flow element', async () => {
@@ -306,5 +399,181 @@ describe('Strategy Fitness', () => {
     )
 
     expect(canvasStrategy.strategy?.strategy.id).toEqual('ABSOLUTE_RESIZE_BOUNDING_BOX')
+  })
+})
+
+describe('Snapping guidelines for absolutely moved element', () => {
+  it('should line up appropriately with a scale of 1', async () => {
+    const renderResult = await getGuidelineRenderResult(1)
+
+    expect(await getGuidelineDimensions(renderResult, 'guideline-0')).toEqual({
+      left: '110px',
+      top: '156px',
+      width: '0px',
+      height: '59px',
+    })
+    expect(await getGuidelineDimensions(renderResult, 'guideline-1')).toEqual({
+      left: '60px',
+      top: '206px',
+      width: '57px',
+      height: '0px',
+    })
+    expect(await getGuidelineDimensions(renderResult, 'guideline-2')).toEqual({
+      left: '',
+      top: '',
+      width: '',
+      height: '',
+    })
+    expect(await getGuidelineDimensions(renderResult, 'guideline-3')).toEqual({
+      left: '',
+      top: '',
+      width: '',
+      height: '',
+    })
+
+    expect(renderResult.getEditorState().editor.canvas.controls.snappingGuidelines).toEqual([
+      {
+        activateSnap: true,
+        guideline: {
+          type: 'XAxisGuideline',
+          x: 110.5,
+          yBottom: 215.5,
+          yTop: 156.5,
+        },
+        snappingVector: {
+          x: 0,
+          y: 0,
+        },
+      },
+      {
+        activateSnap: true,
+        guideline: {
+          type: 'YAxisGuideline',
+          xLeft: 60.5,
+          xRight: 117.5,
+          y: 206.5,
+        },
+        snappingVector: {
+          x: 0,
+          y: 0,
+        },
+      },
+    ])
+  })
+
+  it('should line up appropriately with a scale of 4', async () => {
+    const renderResult = await getGuidelineRenderResult(4)
+
+    expect(await getGuidelineDimensions(renderResult, 'guideline-0')).toEqual({
+      left: '110.375px',
+      top: '156.375px',
+      width: '0px',
+      height: '59px',
+    })
+    expect(await getGuidelineDimensions(renderResult, 'guideline-1')).toEqual({
+      left: '60.375px',
+      top: '206.375px',
+      width: '57px',
+      height: '0px',
+    })
+    expect(await getGuidelineDimensions(renderResult, 'guideline-2')).toEqual({
+      left: '',
+      top: '',
+      width: '',
+      height: '',
+    })
+    expect(await getGuidelineDimensions(renderResult, 'guideline-3')).toEqual({
+      left: '',
+      top: '',
+      width: '',
+      height: '',
+    })
+
+    expect(renderResult.getEditorState().editor.canvas.controls.snappingGuidelines).toEqual([
+      {
+        activateSnap: true,
+        guideline: {
+          type: 'XAxisGuideline',
+          x: 110.5,
+          yBottom: 215.5,
+          yTop: 156.5,
+        },
+        snappingVector: {
+          x: 0,
+          y: 0,
+        },
+      },
+      {
+        activateSnap: true,
+        guideline: {
+          type: 'YAxisGuideline',
+          xLeft: 60.5,
+          xRight: 117.5,
+          y: 206.5,
+        },
+        snappingVector: {
+          x: 0,
+          y: 0,
+        },
+      },
+    ])
+  })
+
+  it('should line up appropriately with a scale of 0.25', async () => {
+    const renderResult = await getGuidelineRenderResult(0.25)
+
+    expect(await getGuidelineDimensions(renderResult, 'guideline-0')).toEqual({
+      left: '108px',
+      top: '154px',
+      width: '0px',
+      height: '60px',
+    })
+    expect(await getGuidelineDimensions(renderResult, 'guideline-1')).toEqual({
+      left: '58px',
+      top: '204px',
+      width: '58px',
+      height: '0px',
+    })
+    expect(await getGuidelineDimensions(renderResult, 'guideline-2')).toEqual({
+      left: '',
+      top: '',
+      width: '',
+      height: '',
+    })
+    expect(await getGuidelineDimensions(renderResult, 'guideline-3')).toEqual({
+      left: '',
+      top: '',
+      width: '',
+      height: '',
+    })
+
+    expect(renderResult.getEditorState().editor.canvas.controls.snappingGuidelines).toEqual([
+      {
+        activateSnap: true,
+        guideline: {
+          type: 'XAxisGuideline',
+          x: 110,
+          yBottom: 216,
+          yTop: 156,
+        },
+        snappingVector: {
+          x: 0,
+          y: 0,
+        },
+      },
+      {
+        activateSnap: true,
+        guideline: {
+          type: 'YAxisGuideline',
+          xLeft: 60,
+          xRight: 118,
+          y: 206,
+        },
+        snappingVector: {
+          x: 0,
+          y: 0,
+        },
+      },
+    ])
   })
 })

--- a/editor/src/components/canvas/controls/guideline-controls.tsx
+++ b/editor/src/components/canvas/controls/guideline-controls.tsx
@@ -38,8 +38,8 @@ const GuidelineControl = React.memo<GuidelineProps>((props) => {
           controlRef.current.style.setProperty('display', 'none')
         } else {
           controlRef.current.style.setProperty('display', 'block')
-          controlRef.current.style.setProperty('left', `${result.frame.x}px`)
-          controlRef.current.style.setProperty('top', `${result.frame.y}px`)
+          controlRef.current.style.setProperty('left', `${result.frame.x - 0.5 / scale}px`)
+          controlRef.current.style.setProperty('top', `${result.frame.y - 0.5 / scale}px`)
           controlRef.current.style.setProperty('width', `${result.frame.width}px`)
           controlRef.current.style.setProperty('height', `${result.frame.height}px`)
           controlRef.current.style.setProperty(

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -275,7 +275,7 @@ export function interactionStart(
         strategy.strategy,
         canvasState,
         newEditorState.canvas.interactionSession,
-        result.strategyState,
+        withClearedSession,
       )
       const commandResult = foldAndApplyCommands(
         newEditorState,


### PR DESCRIPTION
**Problem:**
The snapping guidelines don't quite line up with where they should be, visually they're slightly unaligned and zooming makes that worse.

**Fix:**
The position of the guideline elements has been slightly adjusted, taking account of the canvas scaling.

**Commit Details:**
- With a guideline with of 2 pixels, shift the frame of the guideline
  so one pixel is inside the bounds of the element and the other is
  outside the bounds of the element.
- Use `withClearedSession` when applying the strategy on `interactionStart`
  so that the starting metadata carries through.
- Added tests for different scaling levels of the canvas drag to
  capture the snapping guidelines.