### PR TITLE
Do not show resize controls in insert mode

### DIFF
--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -457,9 +457,9 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       {when(
         resizeStatus !== 'disabled',
         <>
-          {when(isCanvasStrategyInSelectOrSelectLiteMode(props.editor.mode), <PinLines />)}
+          {when(isCanvasStrategyOnAndSelectOrSelectLiteMode(props.editor.mode), <PinLines />)}
           {when(
-            isCanvasStrategyInSelectOrSelectLiteMode(props.editor.mode),
+            isCanvasStrategyOnAndSelectOrSelectLiteMode(props.editor.mode),
             <DistanceGuidelineControl />,
           )}
           {when(
@@ -478,7 +478,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           {when(isFeatureEnabled('Canvas Strategies'), <GuidelineControls />)}
           <OutlineHighlightControl />
           {when(
-            isCanvasStrategyInSelectOrSelectLiteMode(props.editor.mode),
+            isCanvasStrategyOnAndSelectOrSelectLiteMode(props.editor.mode),
             <>{strategyControls.map((c) => React.createElement(c.control, { key: c.key }))}</>,
           )}
         </>,
@@ -487,7 +487,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
   )
 }
 
-function isCanvasStrategyInSelectOrSelectLiteMode(mode: Mode): boolean {
+function isCanvasStrategyOnAndSelectOrSelectLiteMode(mode: Mode): boolean {
   return (
     (isFeatureEnabled('Canvas Strategies') && mode.type === 'select') || mode.type === 'select-lite'
   )

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -30,7 +30,7 @@ import {
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { isAspectRatioLockedNew } from '../../aspect-ratio'
 import { ElementContextMenu } from '../../element-context-menu'
-import { isLiveMode, EditorModes, isSelectLiteMode } from '../../editor/editor-modes'
+import { isLiveMode, EditorModes, isSelectLiteMode, Mode } from '../../editor/editor-modes'
 import { DropTargetHookSpec, ConnectableElement, useDrop, DndProvider } from 'react-dnd'
 import { FileBrowserItemProps } from '../../filebrowser/fileitem'
 import { forceNotNull } from '../../../core/shared/optional-utils'
@@ -457,14 +457,9 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
       {when(
         resizeStatus !== 'disabled',
         <>
+          {when(isCanvasStrategyInSelectOrSelectLiteMode(props.editor.mode), <PinLines />)}
           {when(
-            (isFeatureEnabled('Canvas Strategies') && props.editor.mode.type === 'select') ||
-              props.editor.mode.type === 'select-lite',
-            <PinLines />,
-          )}
-          {when(
-            (isFeatureEnabled('Canvas Strategies') && props.editor.mode.type === 'select') ||
-              props.editor.mode.type === 'select-lite',
+            isCanvasStrategyInSelectOrSelectLiteMode(props.editor.mode),
             <DistanceGuidelineControl />,
           )}
           {when(
@@ -483,11 +478,17 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           {when(isFeatureEnabled('Canvas Strategies'), <GuidelineControls />)}
           <OutlineHighlightControl />
           {when(
-            isFeatureEnabled('Canvas Strategies'),
+            isCanvasStrategyInSelectOrSelectLiteMode(props.editor.mode),
             <>{strategyControls.map((c) => React.createElement(c.control, { key: c.key }))}</>,
           )}
         </>,
       )}
     </div>
+  )
+}
+
+function isCanvasStrategyInSelectOrSelectLiteMode(mode: Mode): boolean {
+  return (
+    (isFeatureEnabled('Canvas Strategies') && mode.type === 'select') || mode.type === 'select-lite'
   )
 }


### PR DESCRIPTION
# Issue
When inserting an element the selected elements resize control is still visible and mousedown on it can start a resize which fails to clear on mouseup

# Fix
Do not render strategy controls in insert mode