### PR TITLE
fix(keyboard) increase timeout

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -315,7 +315,7 @@ export function interactionSessionHardReset(
   }
 }
 
-export const KeyboardInteractionTimeout = 400
+export const KeyboardInteractionTimeout = 600
 
 export function hasDragModifiersChanged(
   prevInteractionData: InputData | null,


### PR DESCRIPTION
**Problem:**
When moving an element with the keyboard and pressing 2 directions (like top and left) the element only moves in one direction.

**Fix:**
This is because the repeat keyboard event arrives later then the keyboard session timeout so it resets. The repeat keydown event arrives after 500ms, so the timeout is set to 600 now.

