### PR TITLE
Keyboard tests reorganize + one new test

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -245,7 +245,7 @@ describe('Keyboard Strategies Escape Behavior', () => {
 describe('Keyboard Strategies Deletion Behavior', () => {
   const { clock } = configureSetupTeardown()
 
-  it('Pressing ArrowRight 3 times, then deleting the element: the element is deleted, but undoable', async () => {
+  it('Pressing ArrowRight 3 times, then immediately deleting the element: the element is deleted, but undoable', async () => {
     const {
       expectElementLeftOnScreen,
       expectElementPropertiesInPrintedCode,

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -253,6 +253,41 @@ describe('Keyboard Strategies Escape Behavior', () => {
   })
 })
 
+describe('Keyboard Strategies Deletion Behavior', () => {
+  const { clock } = configureSetupTeardown()
+
+  it('Pressing ArrowRight 3 times, then deleting the element: the element is deleted, but undoable', async () => {
+    const {
+      expectElementLeftOnScreen,
+      expectElementPropertiesInPrintedCode,
+      expectElementDoesntExist,
+      getCanvasGuidelines,
+    } = await setupTest(defaultBBBProperties)
+
+    pressArrowRight3x()
+    expectElementLeftOnScreen(3)
+
+    // delete the element
+    pressBackspace()
+
+    // the element is deleted
+    expectElementDoesntExist()
+    expect(getCanvasGuidelines()).toEqual([])
+
+    // undo the deletion
+    pressCmdZ()
+
+    // the element is back to +3, jumping back from the dead
+    expectElementLeftOnScreen(3)
+
+    // undo the move
+    pressCmdZ()
+
+    // the element is back to 0
+    expectElementLeftOnScreen(0)
+  })
+})
+
 describe('Keyboard Strategies Undo Behavior', () => {
   const { clock } = configureSetupTeardown()
 
@@ -351,12 +386,16 @@ describe('Keyboard Strategies Undo Behavior', () => {
   })
 })
 
+function elementExists(renderedDom: RenderResult, testId: string): boolean {
+  return renderedDom.queryByTestId(testId) != null
+}
+
 function elementLeft(renderedDom: RenderResult, testId: string): number {
-  return renderedDom.getByTestId('element-bbb').getBoundingClientRect().x
+  return renderedDom.getByTestId(testId).getBoundingClientRect().x
 }
 
 function elementWidth(renderedDom: RenderResult, testId: string): number {
-  return renderedDom.getByTestId('element-bbb').getBoundingClientRect().width
+  return renderedDom.getByTestId(testId).getBoundingClientRect().width
 }
 
 async function setupTest(initialBBBProperties: { [key: string]: any }) {
@@ -376,6 +415,11 @@ async function setupTest(initialBBBProperties: { [key: string]: any }) {
       bbbElementLeftAtStart + offset,
     )
   }
+
+  function expectElementDoesntExist() {
+    expect(elementExists(renderResult.renderedDOM, 'element-bbb')).toBeFalsy()
+  }
+
   function expectElementWidthOnScreen(offset: number) {
     expect(elementWidth(renderResult.renderedDOM, 'element-bbb')).toEqual(
       bbbElementWidthAtStart + offset,
@@ -395,6 +439,7 @@ async function setupTest(initialBBBProperties: { [key: string]: any }) {
     expectElementLeftOnScreen,
     expectElementWidthOnScreen,
     expectElementPropertiesInPrintedCode,
+    expectElementDoesntExist,
     getCanvasGuidelines,
   }
 }
@@ -487,6 +532,13 @@ function pressEsc() {
   act(() => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27 }))
     window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', keyCode: 27 }))
+  })
+}
+
+function pressBackspace() {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', keyCode: 8 }))
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Backspace', keyCode: 8 }))
   })
 }
 

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -253,27 +253,32 @@ describe('Keyboard Strategies Deletion Behavior', () => {
       getCanvasGuidelines,
     } = await setupTest(defaultBBBProperties)
 
+    // setting up the project
     pressArrowRight3x()
     expectElementLeftOnScreen(3)
+    clock.current.tick(KeyboardInteractionTimeout)
+
+    // the test begins
+    pressArrowRight3x()
+    expectElementLeftOnScreen(6)
 
     // delete the element
     pressBackspace()
 
     // the element is deleted
     expectElementDoesntExist()
-    expect(getCanvasGuidelines()).toEqual([])
 
     // undo the deletion
     pressCmdZ()
 
     // the element is back to +3, jumping back from the dead
-    expectElementLeftOnScreen(3)
+    expectElementLeftOnScreen(6)
 
     // undo the move
     pressCmdZ()
 
     // the element is back to 0
-    expectElementLeftOnScreen(0)
+    expectElementLeftOnScreen(3)
   })
 })
 

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -43,7 +43,7 @@ function configureSetupTeardown(): { clock: { current: SinonFakeTimers } } {
   return { clock: clock }
 }
 
-describe('Keyboard Absolute Strategies E2E', () => {
+describe('Keyboard Absolute Move E2E', () => {
   const { clock } = configureSetupTeardown()
 
   it('Pressing Shift + ArrowRight 3 times', async () => {
@@ -106,6 +106,30 @@ describe('Keyboard Absolute Strategies E2E', () => {
     })
   })
 
+  it('Pressing Shift + ArrowRight 3 times for element with missing left prop', async () => {
+    const { expectElementLeftOnScreen, expectElementPropertiesInPrintedCode } = await setupTest({
+      top: 100,
+      width: 122,
+      height: 101,
+    })
+
+    pressArrowRightHoldingShift3x()
+    expectElementLeftOnScreen(30)
+
+    // tick the clock so useClearKeyboardInteraction is fired
+    clock.current.tick(KeyboardInteractionTimeout)
+    await expectElementPropertiesInPrintedCode({
+      top: 100,
+      width: 122,
+      height: 101,
+      left: 30,
+    })
+  })
+})
+
+describe('Keyboard Absolute Resize E2E', () => {
+  const { clock } = configureSetupTeardown()
+
   it('Pressing Cmd + ArrowRight 3 times, then pressing Cmd + ArrowLeft once', async () => {
     const { expectElementWidthOnScreen, expectElementPropertiesInPrintedCode } = await setupTest(
       defaultBBBProperties,
@@ -126,27 +150,10 @@ describe('Keyboard Absolute Strategies E2E', () => {
       height: 101,
     })
   })
+})
 
-  it('Pressing Shift + ArrowRight 3 times for element with missing left prop', async () => {
-    const { expectElementLeftOnScreen, expectElementPropertiesInPrintedCode } = await setupTest({
-      top: 100,
-      width: 122,
-      height: 101,
-    })
-
-    pressArrowRightHoldingShift3x()
-    expectElementLeftOnScreen(30)
-
-    // tick the clock so useClearKeyboardInteraction is fired
-    clock.current.tick(KeyboardInteractionTimeout)
-    await expectElementPropertiesInPrintedCode({
-      top: 100,
-      width: 122,
-      height: 101,
-      left: 30,
-    })
-  })
-
+describe('Keyboard Strategies Escape Behavior', () => {
+  const { clock } = configureSetupTeardown()
   it('Pressing Shift + ArrowRight 3 times, then pressing Esc before the keyboard strategy timer succeeds will cancel the strategy', async () => {
     const { expectElementLeftOnScreen, expectElementPropertiesInPrintedCode } = await setupTest(
       defaultBBBProperties,
@@ -200,6 +207,10 @@ describe('Keyboard Absolute Strategies E2E', () => {
       height: 101,
     })
   })
+})
+
+describe('Keyboard Strategies Undo Behavior', () => {
+  const { clock } = configureSetupTeardown()
 
   it('Pressing Shift + ArrowRight 3 times, await keyboard strategy timeout, then press Cmd + Z to undo jumps back to original, but redoable', async () => {
     const { expectElementLeftOnScreen, expectElementPropertiesInPrintedCode } = await setupTest(

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 /* eslint-disable jest/expect-expect */
 import { act, RenderResult } from '@testing-library/react'
 import sinon, { SinonFakeTimers } from 'sinon'
@@ -16,7 +17,7 @@ const defaultBBBProperties = {
   height: 101,
 }
 
-describe('Keyboard Absolute Strategies E2E', () => {
+function configureSetupTeardown(): { clock: { current: SinonFakeTimers } } {
   let originalCanvasStrategiesFSValue: boolean
   before(() => {
     viewport.set(2200, 1000)
@@ -27,18 +28,23 @@ describe('Keyboard Absolute Strategies E2E', () => {
     setFeatureEnabled('Canvas Strategies', originalCanvasStrategiesFSValue)
   })
 
-  let clock: SinonFakeTimers
+  let clock: { current: SinonFakeTimers } = { current: null as any } // it will be non-null thanks to beforeEach
   beforeEach(function () {
     setFeatureEnabled('Canvas Strategies', true)
-    clock = sinon.useFakeTimers({
+    clock.current = sinon.useFakeTimers({
       // the timers will tick so the editor is not totally broken, but we can fast-forward time at will
       // WARNING: the Sinon fake timers will advance in 20ms increments
       shouldAdvanceTime: true,
     })
   })
   afterEach(function () {
-    clock.restore()
+    clock.current?.restore()
   })
+  return { clock: clock }
+}
+
+describe('Keyboard Absolute Strategies E2E', () => {
+  const { clock } = configureSetupTeardown()
 
   it('Pressing Shift + ArrowRight 3 times', async () => {
     const { expectElementLeftOnScreen, expectElementPropertiesInPrintedCode } = await setupTest(
@@ -49,7 +55,7 @@ describe('Keyboard Absolute Strategies E2E', () => {
     expectElementLeftOnScreen(30)
 
     // tick the clock so useClearKeyboardInteraction is fired
-    clock.tick(KeyboardInteractionTimeout)
+    clock.current.tick(KeyboardInteractionTimeout)
     await expectElementPropertiesInPrintedCode({
       left: 30,
       top: 100,
@@ -70,7 +76,7 @@ describe('Keyboard Absolute Strategies E2E', () => {
     expectElementLeftOnScreen(33)
 
     // tick the clock so useClearKeyboardInteraction is fired
-    clock.tick(KeyboardInteractionTimeout)
+    clock.current.tick(KeyboardInteractionTimeout)
     await expectElementPropertiesInPrintedCode({
       left: 33,
       top: 100,
@@ -91,7 +97,7 @@ describe('Keyboard Absolute Strategies E2E', () => {
     expectElementLeftOnScreen(27)
 
     // tick the clock so useClearKeyboardInteraction is fired
-    clock.tick(KeyboardInteractionTimeout)
+    clock.current.tick(KeyboardInteractionTimeout)
     await expectElementPropertiesInPrintedCode({
       left: 27,
       top: 100,
@@ -112,7 +118,7 @@ describe('Keyboard Absolute Strategies E2E', () => {
     expectElementWidthOnScreen(2)
 
     // tick the clock so useClearKeyboardInteraction is fired
-    clock.tick(KeyboardInteractionTimeout)
+    clock.current.tick(KeyboardInteractionTimeout)
     await expectElementPropertiesInPrintedCode({
       left: 0,
       top: 100,
@@ -132,7 +138,7 @@ describe('Keyboard Absolute Strategies E2E', () => {
     expectElementLeftOnScreen(30)
 
     // tick the clock so useClearKeyboardInteraction is fired
-    clock.tick(KeyboardInteractionTimeout)
+    clock.current.tick(KeyboardInteractionTimeout)
     await expectElementPropertiesInPrintedCode({
       top: 100,
       width: 122,
@@ -151,7 +157,7 @@ describe('Keyboard Absolute Strategies E2E', () => {
     expectElementLeftOnScreen(30)
 
     // tick the clock so useClearKeyboardInteraction is fired
-    clock.tick(KeyboardInteractionTimeout)
+    clock.current.tick(KeyboardInteractionTimeout)
 
     await expectElementPropertiesInPrintedCode({
       left: 30,
@@ -203,7 +209,7 @@ describe('Keyboard Absolute Strategies E2E', () => {
     // Setup: first we move the element 30 pixels to the right
     pressArrowRightHoldingShift3x()
     expectElementLeftOnScreen(30)
-    clock.tick(KeyboardInteractionTimeout)
+    clock.current.tick(KeyboardInteractionTimeout)
     await expectElementPropertiesInPrintedCode({
       left: 30,
       top: 100,
@@ -216,7 +222,7 @@ describe('Keyboard Absolute Strategies E2E', () => {
     expectElementLeftOnScreen(60)
 
     // tick the clock so useClearKeyboardInteraction is fired
-    clock.tick(KeyboardInteractionTimeout)
+    clock.current.tick(KeyboardInteractionTimeout)
     await expectElementPropertiesInPrintedCode({
       left: 60,
       top: 100,
@@ -252,7 +258,7 @@ describe('Keyboard Absolute Strategies E2E', () => {
     // Prepare the test, let's move the element by 30 and wait so we have a proper undo history entry
     pressArrowRightHoldingShift3x()
     expectElementLeftOnScreen(30)
-    clock.tick(KeyboardInteractionTimeout)
+    clock.current.tick(KeyboardInteractionTimeout)
     await expectElementPropertiesInPrintedCode({
       left: 30,
       top: 100,

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -208,7 +208,7 @@ describe('Keyboard Strategies Escape Behavior', () => {
     expectElementLeftOnScreen(30)
 
     // tick the clock so useClearKeyboardInteraction is fired
-    clock.tick(KeyboardInteractionTimeout)
+    clock.current.tick(KeyboardInteractionTimeout)
 
     await expectElementPropertiesInPrintedCode({
       left: 30,


### PR DESCRIPTION
I reorganized the keyboard karma tests so they consist of multiple describe blocks. I did a bit of refactoring so all describe blocks can reuse the same before/beforeAll/after/afterAll and initialization.

I also added a new test for deleting an element right after a keyboard interaction (as this was buggy prior to #2360 )