### PR TITLE
Tests for clicking on overlapping canvas elements.

### DIFF
--- a/editor/src/components/canvas/canvas-selection.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-selection.spec.browser2.tsx
@@ -122,7 +122,45 @@ async function checkOverlappingElements(
   act(() => {
     fireEvent(
       canvasControlsLayer,
+      new MouseEvent('mousemove', {
+        detail: 1,
+        bubbles: true,
+        cancelable: true,
+        metaKey: cmdPressed,
+        clientX: targetDivBounds.left + x,
+        clientY: targetDivBounds.top + y,
+        movementX: targetDivBounds.left + x,
+        movementY: targetDivBounds.top + y,
+        buttons: 1,
+      }),
+    )
+    fireEvent(
+      canvasControlsLayer,
       new MouseEvent('mousedown', {
+        detail: 1,
+        bubbles: true,
+        cancelable: true,
+        metaKey: cmdPressed,
+        clientX: targetDivBounds.left + x,
+        clientY: targetDivBounds.top + y,
+        buttons: 1,
+      }),
+    )
+    fireEvent(
+      canvasControlsLayer,
+      new MouseEvent('click', {
+        detail: 1,
+        bubbles: true,
+        cancelable: true,
+        metaKey: cmdPressed,
+        clientX: targetDivBounds.left + x,
+        clientY: targetDivBounds.top + y,
+        buttons: 1,
+      }),
+    )
+    fireEvent(
+      canvasControlsLayer,
+      new MouseEvent('mouseup', {
         detail: 1,
         bubbles: true,
         cancelable: true,


### PR DESCRIPTION
**Problem:**
It can be easy to break the canvas behaviour around selecting elements, especially those that are overlapping.

**Fix:**
Add a bunch of tests that check canvas selection by mouse event.

**Commit Details:**
- Added a series of test cases for clicking on overlapping canvas elements.
