### PR TITLE
hide the canvas strategy debug panel by default

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-inspector.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-inspector.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { when } from '../../../utils/react-conditionals'
 import { useColorTheme } from '../../../uuiui'
 import { useEditorState } from '../../editor/store/store-hook'
@@ -15,7 +16,7 @@ export const CanvasStrategyInspector = React.memo(() => {
     'CanvasStrategyInspector accumulatedCommands',
   )
 
-  if (activeStrategy) {
+  if (activeStrategy && isFeatureEnabled('Canvas Strategies Debug Panel')) {
     return (
       <div
         style={{

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -13,6 +13,7 @@ export type FeatureName =
   | 'Click on empty canvas unfocuses'
   | 'Insertion Plus Button'
   | 'Canvas Strategies'
+  | 'Canvas Strategies Debug Panel'
   | 'Keyboard up clears interaction'
   | 'Canvas Selective Rerender'
 
@@ -27,6 +28,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Click on empty canvas unfocuses',
   'Insertion Plus Button',
   'Canvas Strategies',
+  'Canvas Strategies Debug Panel',
   'Keyboard up clears interaction',
   'Canvas Selective Rerender',
 ]
@@ -42,6 +44,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Click on empty canvas unfocuses': true,
   'Insertion Plus Button': true,
   'Canvas Strategies': true,
+  'Canvas Strategies Debug Panel': false,
   'Keyboard up clears interaction': false,
   'Canvas Selective Rerender': true,
 }


### PR DESCRIPTION
**Problem:**
When a strategy is active, we replace the inspector with a debug panel which looks extremely unfinished.

**Fix:**
Put the debug panel behind a new feature switch called **Canvas Strategies Debug Panel**. The switch is off by default.
