### PR TITLE
fix(inspector) fix overlapping array items

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -71,7 +71,7 @@ import {
 } from './property-control-controls'
 import { ComponentInfoBox } from './component-info-box'
 import { ExpandableIndicator } from '../../../navigator/navigator-item/expandable-indicator'
-import { when } from '../../../../utils/react-conditionals'
+import { unless, when } from '../../../../utils/react-conditionals'
 import { PropertyControlsSection } from './property-controls-section'
 import type { ReactEventHandlers } from 'react-use-gesture/dist/types'
 
@@ -263,6 +263,27 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
   )
 })
 
+function getSectionHeight(controlDescription: ArrayControlDescription): number {
+  const rowHeight = UtopiaTheme.layout.rowHeight.normal
+  return getSectionHeightFromPropControl(rowHeight, rowHeight, controlDescription.propertyControl)
+}
+
+function getSectionHeightFromPropControl(
+  accumulatedHeight: number,
+  baseHeight: number,
+  propertyControl: RegularControlDescription,
+): number {
+  if (propertyControl.control === 'object') {
+    return Object.values(propertyControl.object).reduce<number>(
+      (workingHeight, innerPropControl) =>
+        getSectionHeightFromPropControl(workingHeight + baseHeight, baseHeight, innerPropControl),
+      accumulatedHeight,
+    )
+  } else {
+    return accumulatedHeight
+  }
+}
+
 interface RowForArrayControlProps extends AbstractRowForControlProps {
   controlDescription: ArrayControlDescription
 }
@@ -276,9 +297,17 @@ const RowForArrayControl = React.memo((props: RowForArrayControlProps) => {
     controlDescription,
   )
 
-  const rowHeight = UtopiaTheme.layout.rowHeight.normal
+  const sectionHeight = React.useMemo(
+    () => getSectionHeight(controlDescription),
+    [controlDescription],
+  )
   const transformedValue = Array.isArray(value) ? value : [value]
-  const { springs, bind } = useArraySuperControl(transformedValue, onSubmitValue, rowHeight, false)
+  const { springs, bind } = useArraySuperControl(
+    transformedValue,
+    onSubmitValue,
+    sectionHeight,
+    false,
+  )
   const [insertingRow, setInsertingRow] = React.useState(false)
   const toggleInsertRow = React.useCallback(() => setInsertingRow((current) => !current), [])
 
@@ -314,7 +343,7 @@ const RowForArrayControl = React.memo((props: RowForArrayControlProps) => {
       </InspectorSectionHeader>
       <div
         style={{
-          height: rowHeight * springs.length,
+          height: sectionHeight * springs.length,
         }}
       >
         {springs.map((springStyle, index) => (
@@ -366,7 +395,6 @@ const ArrayControlItem = React.memo((props: ArrayControlItemProps) => {
   )
   const contextMenuItems = Utils.stripNulls([addOnUnsetValues([index], propMetadata.onUnsetValues)])
 
-  const rowHeight = UtopiaTheme.layout.rowHeight.normal
   return (
     <InspectorContextMenuWrapper
       id={`context-menu-for-${PP.toString(propPathWithIndex)}`}
@@ -380,7 +408,6 @@ const ArrayControlItem = React.memo((props: ArrayControlItemProps) => {
           ...springStyle,
           width: '100%',
           position: 'absolute',
-          height: rowHeight,
         }}
         css={{
           '& > .handle': {
@@ -398,6 +425,7 @@ const ArrayControlItem = React.memo((props: ArrayControlItemProps) => {
           setGlobalCursor={props.setGlobalCursor}
           indentationLevel={1}
           focusOnMount={props.focusOnMount && index === 0}
+          disableToggling={true}
         />
         <div
           style={{
@@ -539,11 +567,16 @@ const ObjectIndicator = (props: ObjectIndicatorProps) => {
 
 interface RowForObjectControlProps extends AbstractRowForControlProps {
   controlDescription: ObjectControlDescription
+  disableToggling: boolean
 }
 
 const RowForObjectControl = React.memo((props: RowForObjectControlProps) => {
   const [open, setOpen] = React.useState(true)
-  const handleOnClick = React.useCallback(() => setOpen(!open), [setOpen, open])
+  const handleOnClick = React.useCallback(() => {
+    if (!props.disableToggling) {
+      setOpen(!open)
+    }
+  }, [setOpen, open, props.disableToggling])
   const { propPath, controlDescription, isScene } = props
   const title = labelForControl(propPath, controlDescription)
   const indentation = props.indentationLevel * 8
@@ -556,8 +589,6 @@ const RowForObjectControl = React.memo((props: RowForObjectControlProps) => {
   return (
     <div
       css={{
-        marginTop: 8,
-        marginBottom: 8,
         '&:hover': {
           boxShadow: 'inset 1px 0px 0px 0px hsla(0,0%,0%,20%)',
           background: 'hsl(0,0%,0%,1%)',
@@ -585,11 +616,11 @@ const RowForObjectControl = React.memo((props: RowForObjectControlProps) => {
                 height: 34,
                 fontWeight: 500,
                 gap: 4,
-                cursor: 'pointer',
+                cursor: props.disableToggling ? 'default' : 'pointer',
               }}
             >
               {title}
-              <ObjectIndicator open={open} />
+              {unless(props.disableToggling, <ObjectIndicator open={open} />)}
             </PropertyLabel>
           </SimpleFlexRow>
         </InspectorContextMenuWrapper>
@@ -607,6 +638,7 @@ const RowForObjectControl = React.memo((props: RowForObjectControlProps) => {
               setGlobalCursor={props.setGlobalCursor}
               indentationLevel={props.indentationLevel + 1}
               focusOnMount={props.focusOnMount && index === 0}
+              disableToggling={props.disableToggling}
             />
           )
         }, controlDescription.object),
@@ -690,10 +722,11 @@ const RowForUnionControl = React.memo((props: RowForUnionControlProps) => {
 
 interface RowForControlProps extends AbstractRowForControlProps {
   controlDescription: RegularControlDescription
+  disableToggling?: boolean
 }
 
 export const RowForControl = React.memo((props: RowForControlProps) => {
-  const { controlDescription } = props
+  const { controlDescription, disableToggling } = props
   if (isBaseControlDescription(controlDescription)) {
     return <RowForBaseControl {...props} controlDescription={controlDescription} />
   } else {
@@ -701,7 +734,13 @@ export const RowForControl = React.memo((props: RowForControlProps) => {
       case 'array':
         return <RowForArrayControl {...props} controlDescription={controlDescription} />
       case 'object':
-        return <RowForObjectControl {...props} controlDescription={controlDescription} />
+        return (
+          <RowForObjectControl
+            {...props}
+            controlDescription={controlDescription}
+            disableToggling={disableToggling ?? false}
+          />
+        )
       case 'tuple':
         return <RowForTupleControl {...props} controlDescription={controlDescription} />
       case 'union':


### PR DESCRIPTION
**Problem:**
When using components with arrays in props containing objects the array control items are overlapping. 

**Fix:**
The array control items had a fixed 34px height which works nicely for numbers and string but not for objects. 
As toggling the object control closed state changes the size it interferes with the custom reorder logic, I removed the toggling for now (only if the object control is part of an array control).

**Commit Details:**
- update array row control and object control

