### PR TITLE
Explicitly handle element paths with empty parts

### DIFF
--- a/editor/src/components/canvas/dom-walker-caching.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker-caching.spec.browser2.tsx
@@ -118,9 +118,9 @@ describe('Dom-walker Caching', () => {
 
     expect(saveDomReportActions[1].invalidatedPaths).toEqual(['storyboard-entity/scene-1-entity'])
     expect(saveDomReportActions[1].cachedPaths).toEqual([
-      EP.fromString(':storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div'),
-      EP.fromString(':storyboard-entity/scene-2-entity/same-file-app-entity'),
-      EP.fromString(':storyboard-entity/scene-2-entity'),
+      EP.fromString('storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div'),
+      EP.fromString('storyboard-entity/scene-2-entity/same-file-app-entity'),
+      EP.fromString('storyboard-entity/scene-2-entity'),
     ])
 
     expect(saveDomReportActions[2].invalidatedPaths).toEqual([
@@ -131,16 +131,16 @@ describe('Dom-walker Caching', () => {
       'storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div',
     ])
     expect(saveDomReportActions[2].cachedPaths).toEqual([
-      EP.fromString(':storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div'),
-      EP.fromString(':storyboard-entity/scene-2-entity/same-file-app-entity'),
-      EP.fromString(':storyboard-entity/scene-2-entity'),
+      EP.fromString('storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div'),
+      EP.fromString('storyboard-entity/scene-2-entity/same-file-app-entity'),
+      EP.fromString('storyboard-entity/scene-2-entity'),
     ])
 
     expect(saveDomReportActions[3].invalidatedPaths).toEqual(['storyboard-entity/scene-1-entity'])
     expect(saveDomReportActions[3].cachedPaths).toEqual([
-      EP.fromString(':storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div'),
-      EP.fromString(':storyboard-entity/scene-2-entity/same-file-app-entity'),
-      EP.fromString(':storyboard-entity/scene-2-entity'),
+      EP.fromString('storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div'),
+      EP.fromString('storyboard-entity/scene-2-entity/same-file-app-entity'),
+      EP.fromString('storyboard-entity/scene-2-entity'),
     ])
   })
 
@@ -212,10 +212,10 @@ describe('Dom-walker Caching', () => {
 
     expect(saveDomReportActions[1].invalidatedPaths).toEqual(['storyboard-entity/scene-2-entity'])
     expect(saveDomReportActions[1].cachedPaths).toEqual([
-      EP.fromString(':storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance'),
-      EP.fromString(':storyboard-entity/scene-1-entity/app-entity:app-outer-div'),
-      EP.fromString(':storyboard-entity/scene-1-entity/app-entity'),
-      EP.fromString(':storyboard-entity/scene-1-entity'),
+      EP.fromString('storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance'),
+      EP.fromString('storyboard-entity/scene-1-entity/app-entity:app-outer-div'),
+      EP.fromString('storyboard-entity/scene-1-entity/app-entity'),
+      EP.fromString('storyboard-entity/scene-1-entity'),
     ])
 
     expect(saveDomReportActions[2].invalidatedPaths).toEqual([
@@ -226,18 +226,18 @@ describe('Dom-walker Caching', () => {
       'storyboard-entity/scene-2-entity/same-file-app-entity:same-file-app-div',
     ])
     expect(saveDomReportActions[2].cachedPaths).toEqual([
-      EP.fromString(':storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance'),
-      EP.fromString(':storyboard-entity/scene-1-entity/app-entity:app-outer-div'),
-      EP.fromString(':storyboard-entity/scene-1-entity/app-entity'),
-      EP.fromString(':storyboard-entity/scene-1-entity'),
+      EP.fromString('storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance'),
+      EP.fromString('storyboard-entity/scene-1-entity/app-entity:app-outer-div'),
+      EP.fromString('storyboard-entity/scene-1-entity/app-entity'),
+      EP.fromString('storyboard-entity/scene-1-entity'),
     ])
 
     expect(saveDomReportActions[3].invalidatedPaths).toEqual(['storyboard-entity/scene-2-entity'])
     expect(saveDomReportActions[3].cachedPaths).toEqual([
-      EP.fromString(':storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance'),
-      EP.fromString(':storyboard-entity/scene-1-entity/app-entity:app-outer-div'),
-      EP.fromString(':storyboard-entity/scene-1-entity/app-entity'),
-      EP.fromString(':storyboard-entity/scene-1-entity'),
+      EP.fromString('storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance'),
+      EP.fromString('storyboard-entity/scene-1-entity/app-entity:app-outer-div'),
+      EP.fromString('storyboard-entity/scene-1-entity/app-entity'),
+      EP.fromString('storyboard-entity/scene-1-entity'),
     ])
   })
 })

--- a/editor/src/core/shared/element-path.spec.ts
+++ b/editor/src/core/shared/element-path.spec.ts
@@ -420,6 +420,10 @@ describe('replaceIfAncestor', () => {
 })
 
 describe('fromString', () => {
+  beforeEach(() => {
+    EP.removePathsWithDeadUIDs(new Set())
+  })
+
   it('parses a simple path correctly', () => {
     const expectedResult = EP.elementPath([
       [BakedInStoryboardUID, 'scene-aaa'],
@@ -427,6 +431,39 @@ describe('fromString', () => {
     ])
     const actualResult = EP.fromString(EP.toComponentId(expectedResult))
     chaiExpect(actualResult).to.deep.equal(expectedResult)
+  })
+  it('Handles an empty path part prefix', () => {
+    const withEmptyPart = EP.elementPath([[], ['one', 'two'], ['three']])
+    const withEmptyPartAsString = EP.toString(withEmptyPart)
+    expect(withEmptyPartAsString).toEqual(':one/two:three')
+    expect(EP.fromString(withEmptyPartAsString)).toEqual(withEmptyPart)
+
+    const withoutEmptyPart = EP.elementPath([['one', 'two'], ['three']])
+    const withoutEmptyPartAsString = EP.toString(withoutEmptyPart)
+    expect(withoutEmptyPartAsString).toEqual('one/two:three')
+    expect(EP.fromString(withoutEmptyPartAsString)).toEqual(withoutEmptyPart)
+  })
+  it('Handles an empty path part in the middle', () => {
+    const withEmptyPart = EP.elementPath([['one', 'two'], [], ['three']])
+    const withEmptyPartAsString = EP.toString(withEmptyPart)
+    expect(withEmptyPartAsString).toEqual('one/two::three')
+    expect(EP.fromString(withEmptyPartAsString)).toEqual(withEmptyPart)
+
+    const withoutEmptyPart = EP.elementPath([['one', 'two'], ['three']])
+    const withoutEmptyPartAsString = EP.toString(withoutEmptyPart)
+    expect(withoutEmptyPartAsString).toEqual('one/two:three')
+    expect(EP.fromString(withoutEmptyPartAsString)).toEqual(withoutEmptyPart)
+  })
+  it('Handles an empty path part suffix', () => {
+    const withEmptyPart = EP.elementPath([['one', 'two'], ['three'], []])
+    const withEmptyPartAsString = EP.toString(withEmptyPart)
+    expect(withEmptyPartAsString).toEqual('one/two:three:')
+    expect(EP.fromString(withEmptyPartAsString)).toEqual(withEmptyPart)
+
+    const withoutEmptyPart = EP.elementPath([['one', 'two'], ['three']])
+    const withoutEmptyPartAsString = EP.toString(withoutEmptyPart)
+    expect(withoutEmptyPartAsString).toEqual('one/two:three')
+    expect(EP.fromString(withoutEmptyPartAsString)).toEqual(withoutEmptyPart)
   })
 })
 

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -110,14 +110,23 @@ export function removePathsWithDeadUIDs(existingUIDs: Set<string>) {
 function getElementPathCache(fullElementPath: ElementPathPart[]): ElementPathCache {
   let workingPathCache: ElementPathCache = globalElementPathCache
 
+  function shiftWorkingCache(cacheToUse: 'rootElementCaches' | 'childCaches', pathPart: string) {
+    if (workingPathCache[cacheToUse][pathPart] == null) {
+      workingPathCache[cacheToUse][pathPart] = emptyElementPathCache()
+    }
+
+    workingPathCache = workingPathCache[cacheToUse][pathPart]
+  }
+
   fastForEach(fullElementPath, (elementPathPart) => {
+    if (elementPathPart.length === 0) {
+      // Special cased handling for when the path part is empty
+      shiftWorkingCache('rootElementCaches', 'empty-path')
+    }
+
     fastForEach(elementPathPart, (pathPart, index) => {
       const cacheToUse = index === 0 ? 'rootElementCaches' : 'childCaches'
-      if (workingPathCache[cacheToUse][pathPart] == null) {
-        workingPathCache[cacheToUse][pathPart] = emptyElementPathCache()
-      }
-
-      workingPathCache = workingPathCache[cacheToUse][pathPart]
+      shiftWorkingCache(cacheToUse, pathPart)
     })
   })
 

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -638,19 +638,26 @@ export function replaceIfAncestor(
     const suffix = drop(replaceSearch.parts.length, oldParts)
     const lastReplaceSearchPartLength = last(replaceSearch.parts)?.length ?? 0
     const overlappingPart = oldParts[replaceSearch.parts.length - 1]
+    const dropEntireLastPart = overlappingPart.length === lastReplaceSearchPartLength
     const trimmedOverlappingPart =
-      overlappingPart == null ? null : drop(lastReplaceSearchPartLength, overlappingPart)
+      overlappingPart == null || dropEntireLastPart
+        ? null
+        : drop(lastReplaceSearchPartLength, overlappingPart)
 
-    let prefix: ElementPathPart[]
+    let updatedPathParts: ElementPathPart[] = []
     if (trimmedOverlappingPart == null) {
-      prefix = replaceWith == null ? [] : replaceWith.parts
+      if (replaceWith != null) {
+        updatedPathParts.push(...replaceWith.parts)
+      }
     } else if (replaceWith == null) {
-      prefix = [trimmedOverlappingPart]
+      updatedPathParts.push(trimmedOverlappingPart)
     } else {
-      prefix = appendPartToElementPathArray(replaceWith.parts, trimmedOverlappingPart)
+      updatedPathParts.push(
+        ...appendPartToElementPathArray(replaceWith.parts, trimmedOverlappingPart),
+      )
     }
 
-    const updatedPathParts = [...prefix, ...suffix]
+    updatedPathParts.push(...suffix)
     return elementPath(updatedPathParts)
   } else {
     return null


### PR DESCRIPTION
**Problem:**
Due to element path caching combined with no specific handling for empty element path parts, `EP.fromString(':aaa/bbb')` would evaluate to the same `ElementPath` as `EP.fromString('aaa/bbb')`, where the resultant path would be dependent on which path was added to the cache first.

**Fix:**
Add specific handling for empty path parts when performing cache reads and writes, plus some tests to verify that. This also exposed an edge case in `EP.replaceIfAncestor` which could prefix paths with an empty part, so that had to be fixed (as it broke an existing test). I've also removed some inconsistent `:` prefixing from paths in `dom-walker-caching.spec.browser2.tsx`