### PR TITLE
fix(insertion) insert menu should add the same props as shortcuts

### DIFF
--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -7,6 +7,7 @@ import {
   JSXElementChildren,
   emptyComments,
   jsxTextBlock,
+  JSXAttribute,
 } from '../../core/shared/element-template'
 import { NormalisedFrame } from 'utopia-api/core'
 
@@ -19,16 +20,30 @@ export function defaultSceneElement(
   const props = jsxAttributesFromMap({
     'data-uid': jsxAttributeValue(uid, emptyComments),
     'data-label': jsxAttributeValue(label, emptyComments),
-    style: jsxAttributeValue(
-      {
-        position: 'absolute',
-        ...frame,
-      },
-      emptyComments,
-    ),
+    style: defaultSceneElementStyle(frame),
   })
 
   return jsxElement(jsxElementName('Scene', []), uid, props, children)
+}
+
+export function defaultSceneElementStyle(frame: NormalisedFrame | null): JSXAttribute {
+  return jsxAttributeValue(
+    {
+      position: 'absolute',
+      ...frame,
+    },
+    emptyComments,
+  )
+}
+
+export function defaultViewElementStyle(): JSXAttribute {
+  return jsxAttributeValue(
+    {
+      backgroundColor: '#0091FFAA',
+      position: 'absolute',
+    },
+    emptyComments,
+  )
 }
 
 export function defaultViewElement(uid: string): JSXElement {
@@ -36,13 +51,7 @@ export function defaultViewElement(uid: string): JSXElement {
     jsxElementName('View', []),
     uid,
     jsxAttributesFromMap({
-      style: jsxAttributeValue(
-        {
-          backgroundColor: '#0091FFAA',
-          position: 'absolute',
-        },
-        emptyComments,
-      ),
+      style: defaultViewElementStyle(),
       'data-uid': jsxAttributeValue(uid, emptyComments),
     }),
     [],
@@ -83,17 +92,21 @@ export function defaultTransparentViewElement(uid: string): JSXElement {
   )
 }
 
+export function defaultTextElementStyle(): JSXAttribute {
+  return jsxAttributeValue(
+    {
+      fontSize: 16,
+    },
+    emptyComments,
+  )
+}
+
 export function defaultTextElement(uid: string): JSXElement {
   return jsxElement(
     jsxElementName('Text', []),
     uid,
     jsxAttributesFromMap({
-      style: jsxAttributeValue(
-        {
-          fontSize: 16,
-        },
-        emptyComments,
-      ),
+      style: defaultTextElementStyle(),
       'data-uid': jsxAttributeValue(uid, emptyComments),
     }),
     [jsxTextBlock('Text')],
@@ -149,5 +162,14 @@ export function defaultDivElement(uid: string): JSXElement {
       'data-uid': jsxAttributeValue(uid, emptyComments),
     }),
     [],
+  )
+}
+
+export function defaultFlexRowOrColStyle(): JSXAttribute {
+  return jsxAttributeValue(
+    {
+      position: 'absolute',
+    },
+    emptyComments,
   )
 }

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -118,12 +118,7 @@ export function defaultRectangleElement(uid: string): JSXElement {
     jsxElementName('Rectangle', []),
     uid,
     jsxAttributesFromMap({
-      style: jsxAttributeValue(
-        {
-          backgroundColor: '#0091FFAA',
-        },
-        emptyComments,
-      ),
+      style: defaultViewElementStyle(),
       'data-uid': jsxAttributeValue(uid, emptyComments),
     }),
     [],
@@ -135,12 +130,7 @@ export function defaultEllipseElement(uid: string): JSXElement {
     jsxElementName('Ellipse', []),
     uid,
     jsxAttributesFromMap({
-      style: jsxAttributeValue(
-        {
-          backgroundColor: '#0091FFAA',
-        },
-        emptyComments,
-      ),
+      style: defaultViewElementStyle(),
       'data-uid': jsxAttributeValue(uid, emptyComments),
     }),
     [],
@@ -152,13 +142,7 @@ export function defaultDivElement(uid: string): JSXElement {
     jsxElementName('div', []),
     uid,
     jsxAttributesFromMap({
-      style: jsxAttributeValue(
-        {
-          backgroundColor: '#0091FFAA',
-          position: 'absolute',
-        },
-        emptyComments,
-      ),
+      style: defaultViewElementStyle(),
       'data-uid': jsxAttributeValue(uid, emptyComments),
     }),
     [],

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -2,9 +2,23 @@ import {
   ComponentDescriptor,
   ComponentDescriptorsForFile,
 } from '../../components/custom-code/code-file'
-import { jsxElementWithoutUID } from '../shared/element-template'
+import {
+  defaultFlexRowOrColStyle,
+  defaultSceneElementStyle,
+  defaultTextElementStyle,
+  defaultViewElementStyle,
+} from '../../components/editor/defaults'
+import {
+  emptyComments,
+  JSXAttribute,
+  jsxAttributesEntry,
+  jsxElementWithoutUID,
+} from '../shared/element-template'
 
-const BasicUtopiaComponentDescriptor = (name: string): ComponentDescriptor => {
+const BasicUtopiaComponentDescriptor = (
+  name: string,
+  styleProp: JSXAttribute,
+): ComponentDescriptor => {
   return {
     properties: {
       style: {
@@ -26,18 +40,22 @@ const BasicUtopiaComponentDescriptor = (name: string): ComponentDescriptor => {
             importedAs: null,
           },
         },
-        elementToInsert: jsxElementWithoutUID(name, [], []),
+        elementToInsert: jsxElementWithoutUID(
+          name,
+          [jsxAttributesEntry('style', styleProp, emptyComments)],
+          [],
+        ),
       },
     ],
   }
 }
 
 export const UtopiaApiComponents: ComponentDescriptorsForFile = {
-  Ellipse: BasicUtopiaComponentDescriptor('Ellipse'),
-  Rectangle: BasicUtopiaComponentDescriptor('Rectangle'),
-  Text: BasicUtopiaComponentDescriptor('Text'),
-  View: BasicUtopiaComponentDescriptor('View'),
-  FlexRow: BasicUtopiaComponentDescriptor('FlexRow'),
-  FlexCol: BasicUtopiaComponentDescriptor('FlexCol'),
-  Scene: BasicUtopiaComponentDescriptor('Scene'),
+  Ellipse: BasicUtopiaComponentDescriptor('Ellipse', defaultViewElementStyle()),
+  Rectangle: BasicUtopiaComponentDescriptor('Rectangle', defaultViewElementStyle()),
+  Text: BasicUtopiaComponentDescriptor('Text', defaultTextElementStyle()),
+  View: BasicUtopiaComponentDescriptor('View', defaultViewElementStyle()),
+  FlexRow: BasicUtopiaComponentDescriptor('FlexRow', defaultFlexRowOrColStyle()),
+  FlexCol: BasicUtopiaComponentDescriptor('FlexCol', defaultFlexRowOrColStyle()),
+  Scene: BasicUtopiaComponentDescriptor('Scene', defaultSceneElementStyle(null)),
 }


### PR DESCRIPTION
**Problem:**
When you insert a View from the insert menu `position: absolute` is missing from the style props.

**Fix:**
The solution is to use the same default style on shortcut insertion and in insert menu too. 

**Commit Details:**
- update utopia-api component descriptor
