### PR TITLE
fix(canvas) hide parent outline when the parent is the storyboard element

### DIFF
--- a/editor/src/components/canvas/controls/layout-parent-control.tsx
+++ b/editor/src/components/canvas/controls/layout-parent-control.tsx
@@ -41,7 +41,10 @@ export const LayoutParentControl = React.memo((): JSX.Element | null => {
   }, 'LayoutParentControl canvas')
   const { parentTarget, parentLayout, parentFrame, flexWrap, flexDirection, alignItems } =
     useEditorState((store) => {
-      if (store.editor.selectedViews.length !== 1) {
+      if (
+        store.editor.selectedViews.length !== 1 ||
+        store.editor.selectedViews.some((path) => EP.isStoryboardChild(path))
+      ) {
         return {
           parentTarget: null,
           parentLayout: null,

--- a/editor/src/components/canvas/controls/parent-bounds.tsx
+++ b/editor/src/components/canvas/controls/parent-bounds.tsx
@@ -13,7 +13,7 @@ export const ParentBounds = React.memo(() => {
       stripNulls(store.editor.selectedViews.map((view) => EP.parentPath(view))),
       EP.pathsEqual,
     )
-    if (targetParents.length === 1) {
+    if (targetParents.length === 1 && !EP.isStoryboardPath(targetParents[0])) {
       return MetadataUtils.findElementByElementPath(
         store.editor.jsxMetadata,
         store.editor.selectedViews[0],

--- a/editor/src/components/canvas/controls/parent-outlines.tsx
+++ b/editor/src/components/canvas/controls/parent-outlines.tsx
@@ -14,7 +14,7 @@ export const ParentOutlines = React.memo(() => {
       stripNulls(store.editor.selectedViews.map((view) => EP.parentPath(view))),
       EP.pathsEqual,
     )
-    if (targetParents.length === 1) {
+    if (targetParents.length === 1 && !EP.isStoryboardPath(targetParents[0])) {
       return MetadataUtils.findElementByElementPath(
         store.editor.jsxMetadata,
         store.editor.selectedViews[0],

--- a/editor/src/components/canvas/controls/position-outline.tsx
+++ b/editor/src/components/canvas/controls/position-outline.tsx
@@ -101,7 +101,7 @@ const usePropsOrJSXAttributes = (path: ElementPath): PropsOrJSXAttributes => {
 const useContainingFrameForElement = (path: ElementPath): CanvasRectangle | null => {
   return useEditorState((store) => {
     const metadata = MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, path)
-    if (metadata != null) {
+    if (metadata != null && !EP.isStoryboardChild(path)) {
       return metadata?.specialSizeMeasurements.coordinateSystemBounds
     } else {
       return null


### PR DESCRIPTION
**Problem:**
There are parent outlines and parent layout control visible on the canvas when selecting/moving a scene (or other storyboard children). Since it just shows lines and bounds at 0,0 it's not very useful.

**Fix:**
Hide parent and pin lines when the selected element is the direct child of the storyboard element.

**Commit Details:**
- update position outlines, parent outline, parent bounds and flex layout parent control
