### PR TITLE
Highlight elements which will selected on mouse up

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -443,7 +443,7 @@ export function useCalculateHighlightedViews(
   return React.useCallback(
     (targetPoint: WindowPoint, eventCmdPressed: boolean) => {
       const selectableViews: Array<ElementPath> = getHighlightableViews(eventCmdPressed, false)
-      const validElementPath = findValidTarget(selectableViews, targetPoint, 'prefer-selected')
+      const validElementPath = findValidTarget(selectableViews, targetPoint, 'dont-prefer-selected')
       if (
         validElementPath == null ||
         (!allowHoverOnSelectedView && validElementPath.isSelected) // we remove highlights if the hovered element is selected


### PR DESCRIPTION
Since https://github.com/concrete-utopia/utopia/pull/2389 selection behavior changed, and inside an already selected selection area we only select elements on mouse up.
We also don't have highlight effects on these elements, only on those which are selectable by mouse down.

However, this feels wrong, because you can still select on mouse up, but there is no feedback that you can actually try. 

So in this PR I added back highlight on hover for these elements (and this behavior is in sync with figma too)