### PR TITLE
Drag pan while space is pressed.

### DIFF
--- a/editor/src/components/canvas/canvas-panning.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-panning.spec.browser2.tsx
@@ -11,15 +11,15 @@ function createExampleProject(): Promise<EditorRenderResult> {
   )
 }
 
-describe(`pan while 'q' is held down`, () => {
-  it(`press 'q' first`, async () => {
+describe(`pan while 'space' is held down`, () => {
+  it(`press 'space' first`, async () => {
     const renderResult = await createExampleProject()
     const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
     const controlsBounds = canvasControlsLayer.getBoundingClientRect()
     const startingCanvasPosition = renderResult.getEditorState().editor.canvas.roundedCanvasOffset
 
     act(() => {
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'KeyQ', keyCode: 81 }))
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Space', keyCode: 32 }))
       fireEvent(
         canvasControlsLayer,
         new MouseEvent('mousedown', {
@@ -68,7 +68,7 @@ describe(`pan while 'q' is held down`, () => {
           buttons: 1,
         }),
       )
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'KeyQ', keyCode: 81 }))
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Space', keyCode: 32 }))
       fireEvent(
         canvasControlsLayer,
         new MouseEvent('mousemove', {

--- a/editor/src/components/canvas/canvas-panning.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-panning.spec.browser2.tsx
@@ -1,0 +1,91 @@
+import { act, fireEvent } from '@testing-library/react'
+import { createComplexDefaultProjectContents } from '../../sample-projects/sample-project-utils'
+import { contentsToTree } from '../assets'
+import { CanvasControlsContainerID } from './controls/new-canvas-controls'
+import { EditorRenderResult, renderTestEditorWithProjectContent } from './ui-jsx.test-utils'
+
+function createExampleProject(): Promise<EditorRenderResult> {
+  return renderTestEditorWithProjectContent(
+    contentsToTree(createComplexDefaultProjectContents()),
+    'await-first-dom-report',
+  )
+}
+
+describe(`pan while 'q' is held down`, () => {
+  it(`press 'q' first`, async () => {
+    const renderResult = await createExampleProject()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const controlsBounds = canvasControlsLayer.getBoundingClientRect()
+    const startingCanvasPosition = renderResult.getEditorState().editor.canvas.roundedCanvasOffset
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'KeyQ', keyCode: 81 }))
+      fireEvent(
+        canvasControlsLayer,
+        new MouseEvent('mousedown', {
+          detail: 1,
+          bubbles: true,
+          cancelable: true,
+          clientX: controlsBounds.x + controlsBounds.width / 2,
+          clientY: controlsBounds.y + controlsBounds.height / 2,
+          buttons: 1,
+        }),
+      )
+      fireEvent(
+        canvasControlsLayer,
+        new MouseEvent('mousemove', {
+          detail: 1,
+          bubbles: true,
+          cancelable: true,
+          clientX: controlsBounds.x + controlsBounds.width / 2 + 100,
+          clientY: controlsBounds.y + controlsBounds.height / 2 + 100,
+          movementX: 100,
+          movementY: 100,
+          buttons: 1,
+        }),
+      )
+    })
+
+    const endingCanvasPosition = renderResult.getEditorState().editor.canvas.roundedCanvasOffset
+    expect(endingCanvasPosition.x - startingCanvasPosition.x).toEqual(-100)
+    expect(endingCanvasPosition.y - startingCanvasPosition.y).toEqual(-100)
+  })
+  it(`start drag first`, async () => {
+    const renderResult = await createExampleProject()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const controlsBounds = canvasControlsLayer.getBoundingClientRect()
+    const startingCanvasPosition = renderResult.getEditorState().editor.canvas.roundedCanvasOffset
+
+    act(() => {
+      fireEvent(
+        canvasControlsLayer,
+        new MouseEvent('mousedown', {
+          detail: 1,
+          bubbles: true,
+          cancelable: true,
+          clientX: controlsBounds.x + controlsBounds.width / 2,
+          clientY: controlsBounds.y + controlsBounds.height / 2,
+          buttons: 1,
+        }),
+      )
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'KeyQ', keyCode: 81 }))
+      fireEvent(
+        canvasControlsLayer,
+        new MouseEvent('mousemove', {
+          detail: 1,
+          bubbles: true,
+          cancelable: true,
+          clientX: controlsBounds.x + controlsBounds.width / 2 + 100,
+          clientY: controlsBounds.y + controlsBounds.height / 2 + 100,
+          movementX: 100,
+          movementY: 100,
+          buttons: 1,
+        }),
+      )
+    })
+
+    const endingCanvasPosition = renderResult.getEditorState().editor.canvas.roundedCanvasOffset
+    expect(endingCanvasPosition.x - startingCanvasPosition.x).toEqual(-100)
+    expect(endingCanvasPosition.y - startingCanvasPosition.y).toEqual(-100)
+  })
+})

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -534,8 +534,8 @@ function useSelectOrLiveModeSelectAndHover(
 
   const onMouseMove = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      // Do not handle the mouse move in the regular style if 'q' is pressed.
-      if (!editorStoreRef.current.editor.keysPressed['q']) {
+      // Do not handle the mouse move in the regular style if 'space' is pressed.
+      if (!editorStoreRef.current.editor.keysPressed['space']) {
         innerOnMouseMove(event)
       }
     },
@@ -547,8 +547,8 @@ function useSelectOrLiveModeSelectAndHover(
       event: React.MouseEvent<HTMLDivElement>,
       preferAlreadySelected: 'prefer-selected' | 'dont-prefer-selected',
     ) => {
-      // Skip all of this handling if 'q' is pressed.
-      if (!editorStoreRef.current.editor.keysPressed['q']) {
+      // Skip all of this handling if 'space' is pressed.
+      if (!editorStoreRef.current.editor.keysPressed['space']) {
         const doubleClick = event.detail > 1 // we interpret a triple click as two double clicks, a quadruple click as three double clicks, etc  // TODO TEST ME
         const selectableViews = getSelectableViewsForSelectMode(event.metaKey, doubleClick)
         const foundTarget = findValidTarget(

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -520,7 +520,7 @@ function useSelectOrLiveModeSelectAndHover(
   //const startCanvasModeSession = useStartCanvasSession()
   const windowToCanvasCoordinates = useWindowToCanvasCoordinates()
 
-  const { onMouseMove } = useHighlightCallbacks(
+  const { onMouseMove: innerOnMouseMove } = useHighlightCallbacks(
     active,
     cmdPressed,
     false,
@@ -532,82 +532,98 @@ function useSelectOrLiveModeSelectAndHover(
     derived: store.derived,
   }))
 
+  const onMouseMove = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      // Do not handle the mouse move in the regular style if 'q' is pressed.
+      if (!editorStoreRef.current.editor.keysPressed['q']) {
+        innerOnMouseMove(event)
+      }
+    },
+    [innerOnMouseMove, editorStoreRef],
+  )
+
   const mouseHandler = React.useCallback(
     (
       event: React.MouseEvent<HTMLDivElement>,
       preferAlreadySelected: 'prefer-selected' | 'dont-prefer-selected',
     ) => {
-      const doubleClick = event.detail > 1 // we interpret a triple click as two double clicks, a quadruple click as three double clicks, etc  // TODO TEST ME
-      const selectableViews = getSelectableViewsForSelectMode(event.metaKey, doubleClick)
-      const foundTarget = findValidTarget(
-        selectableViews,
-        windowPoint(point(event.clientX, event.clientY)),
-        preferAlreadySelected,
-      )
+      // Skip all of this handling if 'q' is pressed.
+      if (!editorStoreRef.current.editor.keysPressed['q']) {
+        const doubleClick = event.detail > 1 // we interpret a triple click as two double clicks, a quadruple click as three double clicks, etc  // TODO TEST ME
+        const selectableViews = getSelectableViewsForSelectMode(event.metaKey, doubleClick)
+        const foundTarget = findValidTarget(
+          selectableViews,
+          windowPoint(point(event.clientX, event.clientY)),
+          preferAlreadySelected,
+        )
 
-      const isMultiselect = event.shiftKey
-      const isDeselect = foundTarget == null && !isMultiselect
-      let editorActions: Array<EditorAction> = []
+        const isMultiselect = event.shiftKey
+        const isDeselect = foundTarget == null && !isMultiselect
+        let editorActions: Array<EditorAction> = []
 
-      if (foundTarget != null || isDeselect) {
-        if (foundTarget != null && draggingAllowed) {
-          if (isFeatureEnabled('Canvas Strategies')) {
-            const start = windowToCanvasCoordinates(
-              windowPoint(point(event.clientX, event.clientY)),
-            ).canvasPositionRounded
-            if (event.button !== 2) {
-              editorActions.push(
-                CanvasActions.createInteractionSession(
-                  createInteractionViaMouse(start, Modifier.modifiersForEvent(event), {
-                    type: 'BOUNDING_AREA',
-                    target: foundTarget.elementPath,
-                  }),
-                ),
-              )
+        if (foundTarget != null || isDeselect) {
+          if (foundTarget != null && draggingAllowed) {
+            if (isFeatureEnabled('Canvas Strategies')) {
+              const start = windowToCanvasCoordinates(
+                windowPoint(point(event.clientX, event.clientY)),
+              ).canvasPositionRounded
+              if (event.button !== 2) {
+                editorActions.push(
+                  CanvasActions.createInteractionSession(
+                    createInteractionViaMouse(start, Modifier.modifiersForEvent(event), {
+                      type: 'BOUNDING_AREA',
+                      target: foundTarget.elementPath,
+                    }),
+                  ),
+                )
+              }
+            } else {
+              startDragStateAfterDragExceedsThreshold(event.nativeEvent, foundTarget.elementPath)
             }
-          } else {
-            startDragStateAfterDragExceedsThreshold(event.nativeEvent, foundTarget.elementPath)
           }
-        }
 
-        let updatedSelection: Array<ElementPath>
-        if (isMultiselect) {
-          updatedSelection = EP.addPathIfMissing(foundTarget!.elementPath, selectedViewsRef.current)
-        } else {
-          updatedSelection = foundTarget != null ? [foundTarget.elementPath] : []
-        }
-
-        if (foundTarget != null && doubleClick) {
-          // for components without passed children doubleclicking enters focus mode
-          const isFocusableLeaf = MetadataUtils.isFocusableLeafComponent(
-            foundTarget.elementPath,
-            editorStoreRef.current.editor.jsxMetadata,
-          )
-          if (isFocusableLeaf) {
-            editorActions.push(setFocusedElement(foundTarget.elementPath))
-          }
-        }
-
-        if (!(foundTarget?.isSelected ?? false)) {
-          // first we only set the selected views for the canvas controls
-          setSelectedViewsForCanvasControlsOnly(updatedSelection)
-
-          // then we set the selected views for the editor state, 1 frame later
-          if (updatedSelection.length === 0) {
-            const clearFocusedElementIfFeatureSwitchEnabled = isFeatureEnabled(
-              'Click on empty canvas unfocuses',
+          let updatedSelection: Array<ElementPath>
+          if (isMultiselect) {
+            updatedSelection = EP.addPathIfMissing(
+              foundTarget!.elementPath,
+              selectedViewsRef.current,
             )
-              ? [setFocusedElement(null)]
-              : []
-
-            editorActions.push(clearSelection())
-            editorActions.push(...clearFocusedElementIfFeatureSwitchEnabled)
           } else {
-            editorActions.push(selectComponents(updatedSelection, event.shiftKey))
+            updatedSelection = foundTarget != null ? [foundTarget.elementPath] : []
+          }
+
+          if (foundTarget != null && doubleClick) {
+            // for components without passed children doubleclicking enters focus mode
+            const isFocusableLeaf = MetadataUtils.isFocusableLeafComponent(
+              foundTarget.elementPath,
+              editorStoreRef.current.editor.jsxMetadata,
+            )
+            if (isFocusableLeaf) {
+              editorActions.push(setFocusedElement(foundTarget.elementPath))
+            }
+          }
+
+          if (!(foundTarget?.isSelected ?? false)) {
+            // first we only set the selected views for the canvas controls
+            setSelectedViewsForCanvasControlsOnly(updatedSelection)
+
+            // then we set the selected views for the editor state, 1 frame later
+            if (updatedSelection.length === 0) {
+              const clearFocusedElementIfFeatureSwitchEnabled = isFeatureEnabled(
+                'Click on empty canvas unfocuses',
+              )
+                ? [setFocusedElement(null)]
+                : []
+
+              editorActions.push(clearSelection())
+              editorActions.push(...clearFocusedElementIfFeatureSwitchEnabled)
+            } else {
+              editorActions.push(selectComponents(updatedSelection, event.shiftKey))
+            }
           }
         }
+        dispatch(editorActions)
       }
-      dispatch(editorActions)
     },
     [
       dispatch,

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -148,11 +148,15 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 
         // TODO: maybe we should not whitelist keys, just check if Keyboard.keyIsModifer(key) is false
         const existingInteractionSession = editorStoreRef.current.editor.canvas.interactionSession
-        if (key === 'q' && existingInteractionSession != null) {
-          editorStoreRef.current.dispatch(
-            [CanvasActions.clearInteractionSession(false)],
-            'everyone',
-          )
+        if (key === 'space') {
+          if (existingInteractionSession != null) {
+            editorStoreRef.current.dispatch(
+              [CanvasActions.clearInteractionSession(false)],
+              'everyone',
+            )
+          }
+          event.preventDefault()
+          event.stopPropagation()
         } else if (Keyboard.keyIsModifier(key) && existingInteractionSession != null) {
           editorStoreRef.current.dispatch(
             [

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -148,7 +148,12 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 
         // TODO: maybe we should not whitelist keys, just check if Keyboard.keyIsModifer(key) is false
         const existingInteractionSession = editorStoreRef.current.editor.canvas.interactionSession
-        if (Keyboard.keyIsModifier(key) && existingInteractionSession != null) {
+        if (key === 'q' && existingInteractionSession != null) {
+          editorStoreRef.current.dispatch(
+            [CanvasActions.clearInteractionSession(false)],
+            'everyone',
+          )
+        } else if (Keyboard.keyIsModifier(key) && existingInteractionSession != null) {
           editorStoreRef.current.dispatch(
             [
               CanvasActions.createInteractionSession(

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -116,7 +116,7 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
   ),
   [CYCLE_HIERACHY_TARGETS_SHORTCUT]: shortcut(
     'Cycle up and down the hierarchy of the currently selected element.',
-    key('space', []),
+    key('q', []),
   ),
   [CYCLE_FORWARD_SIBLING_TARGETS_SHORTCUT]: shortcut(
     'Cycle forward between siblings of the currently selected element.',

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -110,7 +110,7 @@ function cursorForKeysPressed(keysPressed: KeysPressed): CSSCursor | null {
   if (keysPressed['z']) {
     return keysPressed['alt'] ? CSSCursor.ZoomOut : CSSCursor.ZoomIn
   }
-  if (keysPressed['q']) {
+  if (keysPressed['space']) {
     return CSSCursor.Crosshair
   }
   return null
@@ -237,7 +237,7 @@ function on(
   canvasBounds: WindowRectangle | null,
 ): Array<EditorAction> {
   let additionalEvents: Array<EditorAction> = []
-  if (canvas.keysPressed['q']) {
+  if (canvas.keysPressed['space']) {
     if (event.event === 'MOVE' && event.nativeEvent.buttons === 1) {
       return [
         CanvasActions.scrollCanvas(
@@ -1082,7 +1082,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
       }
 
       if (event.button === 0) {
-        if (!this.props.model.keysPressed['z'] && !this.props.model.keysPressed['q']) {
+        if (!this.props.model.keysPressed['z'] && !this.props.model.keysPressed['space']) {
           this.handleEvent({
             ...canvasPositions,
             event: 'MOUSE_DOWN',
@@ -1123,7 +1123,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
   handleMouseMove = (event: MouseEvent) => {
     if (this.canvasSelected()) {
       const canvasPositions = this.getPosition(event)
-      if (this.props.model.keysPressed['q']) {
+      if (this.props.model.keysPressed['space']) {
         this.handleEvent({
           ...canvasPositions,
           event: 'MOVE',

--- a/editor/src/utils/keyboard.ts
+++ b/editor/src/utils/keyboard.ts
@@ -108,8 +108,8 @@ function getCachedKey(
 }
 
 // please don't add more keycharacters here, use them directly from keyboard events
-export const StoredKeyCharacters = ['alt', 'cmd', 'ctrl', 'shift', 'z', 'q']
-export type StoredKeyCharacter = Modifier | 'z' | 'q'
+export const StoredKeyCharacters = ['alt', 'cmd', 'ctrl', 'shift', 'z', 'space']
+export type StoredKeyCharacter = Modifier | 'z' | 'space'
 export type KeysPressed = { [key in StoredKeyCharacter]?: boolean }
 
 export type KeyDownOrUp = 'keydown' | 'keyup'

--- a/editor/src/utils/keyboard.ts
+++ b/editor/src/utils/keyboard.ts
@@ -108,8 +108,8 @@ function getCachedKey(
 }
 
 // please don't add more keycharacters here, use them directly from keyboard events
-export const StoredKeyCharacters = ['alt', 'cmd', 'ctrl', 'shift', 'z']
-export type StoredKeyCharacter = Modifier | 'z'
+export const StoredKeyCharacters = ['alt', 'cmd', 'ctrl', 'shift', 'z', 'q']
+export type StoredKeyCharacter = Modifier | 'z' | 'q'
 export type KeysPressed = { [key in StoredKeyCharacter]?: boolean }
 
 export type KeyDownOrUp = 'keydown' | 'keyup'


### PR DESCRIPTION
**Problem:**
We have no way currently to drag pan the canvas.

**Fix:**
While the first mouse button is held down with the `space` key also depressed, mouse moves will trigger our existing scroll canvas logic.

Any interaction that might have been started if the mouse down was applied first will be cancelled on the `space` key down. Along with any regular mouse handling being disabled while the `space` key is depressed.

**Commit Details:**
- In `useSelectOrLiveModeSelectAndHover` disable the handlers for
  onMouseMove/onMouseDown/onMouseUp if `space` is pressed down currently.
- In `EditorComponentInner` if `space` is pressed and an interaction session
  is in progress, clear the interaction session so that we don't pan
  and do whatever the interaction would've resulted in.
- Used the `Crosshair` cursor for now while pan dragging.
- In the `on` handler, if the first mouse button is held down along with
  `space`, then on a mouse move trigger the drag panning.
- Remapped the selection cycling previously assigned to the `space` key to the `q` key.

