### PR TITLE
Handle object fields in an array correctly for property controls.

### DIFF
--- a/editor/src/components/inspector/common/property-controls.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/property-controls.spec.browser2.tsx
@@ -1,0 +1,186 @@
+import { selectComponents } from '../../editor/actions/action-creators'
+import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
+import { EditorRenderResult, renderTestEditorWithModel } from '../../canvas/ui-jsx.test-utils'
+import {
+  StoryboardFilePath,
+  withUnderlyingTargetFromEditorState,
+} from '../../editor/store/editor-state'
+import * as EP from '../../../core/shared/element-path'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import { fireEvent } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+import {
+  emptyComments,
+  getJSXAttribute,
+  jsxAttributeValue,
+} from '../../../core/shared/element-template'
+
+function exampleProject(): string {
+  return `import * as React from "react";
+import { Scene, Storyboard, jsx } from "utopia-api";
+export var App = (props) => {
+  return (
+    <div
+      data-uid="other-app-root"
+      data-testid="other-app-root"
+      style={{
+        width: "100%",
+        height: "100%",
+        backgroundColor: "#FFFFFF",
+        position: "relative",
+      }}
+    >
+      {JSON.stringify(props.cards)}
+    </div>
+  );
+};
+export var storyboard = (
+  <Storyboard data-uid="storyboard">
+    <Scene
+      data-uid="scene"
+      data-testid="scene"
+      style={{ position: "absolute", left: 0, top: 0, width: 375, height: 812 }}
+    >
+      <App
+        data-uid="app"
+        data-testid="app"
+        cards={[
+          { hello: 'bello', n: 1 },
+          { hello: 'yes', n: 5 },
+        ]}
+      />
+    </Scene>
+  </Storyboard>
+);
+`
+}
+
+function createAndRenderModifiedProject(modifiedFiles: {
+  [filename: string]: string
+}): Promise<EditorRenderResult> {
+  const project = createModifiedProject(modifiedFiles)
+  return renderTestEditorWithModel(project, 'await-first-dom-report')
+}
+
+function createExampleProject(): Promise<EditorRenderResult> {
+  return createAndRenderModifiedProject({
+    [StoryboardFilePath]: exampleProject(),
+  })
+}
+
+const appElementPath: ElementPath = EP.elementPath([['storyboard', 'scene', 'app']])
+
+function downClickUp(targetElement: HTMLElement, mouseEventInit: MouseEventInit) {
+  fireEvent(targetElement, new MouseEvent('mousedown', mouseEventInit))
+  fireEvent(targetElement, new MouseEvent('click', mouseEventInit))
+  fireEvent(targetElement, new MouseEvent('mouseup', mouseEventInit))
+}
+
+describe('Automatically derived property controls', () => {
+  it('should support adding an additional entry', async () => {
+    // Setup the editor.
+    const renderResult = await createExampleProject()
+    await renderResult.dispatch([selectComponents([appElementPath], false)], true)
+
+    // Add another entry using the plus button.
+    const toggleInsertCardsButton = await renderResult.renderedDOM.findByTestId(
+      'toggle-insert-cards',
+    )
+    const toggleInsertCardsButtonBounds = toggleInsertCardsButton.getBoundingClientRect()
+    act(() => {
+      downClickUp(toggleInsertCardsButton, {
+        detail: 1,
+        bubbles: true,
+        cancelable: true,
+        clientX: toggleInsertCardsButtonBounds.x + 3,
+        clientY: toggleInsertCardsButtonBounds.y + 3,
+        buttons: 1,
+      })
+    })
+
+    // Assume the third one of these is the just added input for the "hello" field.
+    const allInputsForHello = await renderResult.renderedDOM.findAllByTestId(
+      'hello-string-input-property-control',
+    )
+    expect(allInputsForHello.length).toEqual(3)
+    const latestHelloInput = allInputsForHello[2]
+    const latestHelloInputBounds = latestHelloInput.getBoundingClientRect()
+
+    // Click inside the input box and enter the value "x" into the input box.
+    act(() => {
+      downClickUp(latestHelloInput, {
+        detail: 1,
+        bubbles: true,
+        cancelable: true,
+        clientX: latestHelloInputBounds.x + latestHelloInputBounds.width / 2,
+        clientY: latestHelloInputBounds.y + latestHelloInputBounds.height / 2,
+        buttons: 1,
+      })
+      fireEvent.change(latestHelloInput, { target: { value: 'abc' } })
+      fireEvent.blur(latestHelloInput)
+    })
+
+    // Assume the third one of these is the just added input for the "n" field.
+    const allInputsForN = await renderResult.renderedDOM.findAllByTestId(
+      'n-number-input-property-control',
+    )
+    expect(allInputsForN.length).toEqual(3)
+    const latestNInput = allInputsForN[2]
+    const latestNInputBounds = latestNInput.getBoundingClientRect()
+
+    // Click inside the input box.
+    act(() => {
+      downClickUp(latestNInput, {
+        detail: 1,
+        bubbles: true,
+        cancelable: true,
+        clientX: latestNInputBounds.x + latestNInputBounds.width / 2,
+        clientY: latestNInputBounds.y + latestNInputBounds.height / 2,
+        buttons: 1,
+      })
+    })
+
+    // Assume the third one of these is the just added input for the "n" field, which should
+    // still exist at this point.
+    const allInputsForNSecondTime = await renderResult.renderedDOM.findAllByTestId(
+      'n-number-input-property-control',
+    )
+    expect(allInputsForNSecondTime.length).toEqual(3)
+    const latestNInputForTheSecondTime = allInputsForNSecondTime[2]
+
+    // Change the content of the 'n' field.
+    act(() => {
+      fireEvent.change(latestNInputForTheSecondTime, { target: { value: '50' } })
+      fireEvent.blur(latestNInputForTheSecondTime)
+    })
+
+    // Check the result that has been set into
+    const element = withUnderlyingTargetFromEditorState(
+      EP.fromString('storyboard/scene/app'),
+      renderResult.getEditorState().editor,
+      null,
+      (_success, underlyingElement) => {
+        return underlyingElement
+      },
+    )
+    if (element == null) {
+      throw new Error('Element could not be found.')
+    } else {
+      const cardsAttribute = getJSXAttribute(element.props, 'cards')
+      if (cardsAttribute == null) {
+        throw new Error("The 'cards' attribute does not exist.")
+      } else {
+        expect(cardsAttribute).toEqual(
+          jsxAttributeValue(
+            [
+              { hello: 'bello', n: 1 },
+              { hello: 'yes', n: 5 },
+              { hello: 'abc', n: 50 },
+            ],
+            emptyComments,
+          ),
+        )
+      }
+    }
+  })
+})

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -454,7 +454,7 @@ export const StringInputPropertyControl = React.memo(
 
     return (
       <StringControl
-        key={propName}
+        key={controlId}
         id={controlId}
         testId={controlId}
         value={value ?? ''}


### PR DESCRIPTION
**Problems:**
- With an attribute containing an array of objects, when adding a new entry once one field has been entered and the blur triggers the value in the model is updated. As this leaves a partially filled value, when the parse for the field runs it fails for the entry and the whole array in turn. This causes the inspector to lose all but the first entry.
- When clicking from the first field in a complex object held in the array control, a click into the second field appears to be wormholed to nowhere.

**Fixes:**
- The parser for object values has been made slightly less strict, allowing objects with a missing key to succeed.
- Handling for insertion was changed to create an extended array and use that in the inspector, instead of creating a special insertion row in the control. The click was being wormholed as a result of the special insertion row being removed and replaced with the new entry from the updated array, this meant that while nothing visually changed the input field is structurally different and React has destroyed the old HTML element and created a new one.

**Commit Details:**
- Change `RowForArrayControl` to instead use an extended array when inserting a
  new value instead of creating a structurally distinct insertion row.
- `unwrapAndParseObjectValues` checks for the case that the key is missing and
  if it is does not fail the parse and lets the parse continue without that key.
- Added `property-controls.spec.browser2.tsx`.