### PR TITLE
Ensure that undo updates propagate to the code editor.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-resize.spec.browser2.tsx
@@ -365,13 +365,12 @@ describe('Keyboard Strategies Undo Behavior', () => {
     expect(renderResult.getEditorState().editor.canvas.interactionSession).toBeNull() // the interaction session is cleared
     expectElementLeftOnScreen(30)
 
-    // TODO FIXME WE HAVE A BUG, We PRINT THE WRONG CODE!! this assertion should be true:
-    // await expectElementPropertiesInPrintedCode({
-    //   left: 30, // the printed happily stays 30
-    //   top: 100,
-    //   width: 122,
-    //   height: 101,
-    // })
+    await expectElementPropertiesInPrintedCode({
+      left: 30, // the printed happily stays 30
+      top: 100,
+      width: 122,
+      height: 101,
+    })
 
     // pressing Redo brings back the interaction
     pressCmdShiftZ()


### PR DESCRIPTION
**Problem:**
Triggering an undo immediately after moving an element results in the code editor not getting updated to look as it was before the interaction.

**Fix:**
Removed a conditional, which doesn't appear to be useful anymore or potentially never was, which was causing the `UPDATE_FROM_WORKER` action containing the code update to be skipped.

**Commit Details:**
- Remove a check against `parseOrPrintInFlight` from the action
  handler for `UPDATE_FROM_WORKER` as it's blocking updates from
  an undo that occurs close to an interaction session in time.
- Uncommented test code that covers the above condition.