### PR TITLE
Prevent duplication of root component elements.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.spec.tsx
@@ -1,0 +1,105 @@
+import { EditorState } from '../../editor/store/editor-state'
+import { elementPath } from '../../../core/shared/element-path'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import { getEditorState, makeTestProjectCodeWithSnippet } from '../ui-jsx.test-utils'
+import { absoluteDuplicateStrategy } from './absolute-duplicate-strategy'
+import {
+  ElementInstanceMetadata,
+  ElementInstanceMetadataMap,
+  SpecialSizeMeasurements,
+} from '../../../core/shared/element-template'
+import {
+  canvasPoint,
+  canvasRectangle,
+  CanvasVector,
+  localRectangle,
+} from '../../../core/shared/math-utils'
+import { altModifier, Modifiers } from '../../../utils/modifiers'
+import { pickCanvasStateFromEditorState } from './canvas-strategies'
+import { InteractionSession } from './interaction-state'
+import { createMouseInteractionForTests } from './interaction-state.test-utils'
+
+function prepareEditorState(codeSnippet: string, selectedViews: Array<ElementPath>): EditorState {
+  return {
+    ...getEditorState(makeTestProjectCodeWithSnippet(codeSnippet)),
+    selectedViews: selectedViews,
+  }
+}
+
+const defaultMetadata: ElementInstanceMetadataMap = {
+  'scene-aaa': {
+    elementPath: elementPath([['scene-aaa']]),
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity': {
+    elementPath: elementPath([['scene-aaa', 'app-entity']]),
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity:aaa': {
+    elementPath: elementPath([['scene-aaa', 'app-entity'], ['aaa']]),
+    specialSizeMeasurements: {
+      position: 'absolute',
+    } as SpecialSizeMeasurements,
+  } as ElementInstanceMetadata,
+  'scene-aaa/app-entity:aaa/bbb': {
+    elementPath: elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'bbb'],
+    ]),
+    specialSizeMeasurements: {
+      immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+      coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+    } as SpecialSizeMeasurements,
+    globalFrame: canvasRectangle({ x: 50, y: 50, width: 250, height: 300 }),
+    localFrame: localRectangle({ x: 50, y: 50, width: 250, height: 300 }),
+  } as ElementInstanceMetadata,
+}
+
+function dragByPixelsIsApplicable(
+  editorState: EditorState,
+  vector: CanvasVector,
+  modifiers: Modifiers,
+  metadata: ElementInstanceMetadataMap,
+): boolean {
+  const interactionSession: InteractionSession = {
+    ...createMouseInteractionForTests(
+      null as any, // the strategy does not use this
+      modifiers,
+      null as any, // the strategy does not use this
+      vector,
+    ),
+    metadata: null as any, // the strategy does not use this
+    allElementProps: null as any, // the strategy does not use this
+  }
+
+  return absoluteDuplicateStrategy.isApplicable(
+    pickCanvasStateFromEditorState(editorState),
+    interactionSession,
+    metadata,
+    editorState.allElementProps,
+  )
+}
+
+describe('absoluteDuplicateStrategy', () => {
+  it('does not apply for elements that are the root element of an instance', () => {
+    const targetElement = elementPath([['scene-aaa', 'app-entity'], ['aaa']])
+
+    const initialEditor: EditorState = prepareEditorState(
+      `
+    <View style={{ ...(props.style || {}) }} data-uid='aaa'>
+      <View
+        style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 50, top: 50, width: 250, height: 300 }}
+        data-uid='bbb'
+      />
+    </View>
+    `,
+      [targetElement],
+    )
+
+    const actualResult = dragByPixelsIsApplicable(
+      initialEditor,
+      canvasPoint({ x: 1, y: 1 }),
+      altModifier,
+      defaultMetadata,
+    )
+    expect(actualResult).toEqual(false)
+  })
+})

--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -43,7 +43,8 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
 
         return (
           elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
-          allDraggedElementsHaveTheSameParent
+          allDraggedElementsHaveTheSameParent &&
+          !EP.isRootElementOfInstance(element)
         )
       })
     }

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2642,19 +2642,22 @@ export function duplicate(
             })
           }
 
-          utopiaComponents = insertElementAtPath(
-            workingEditorState.projectContents,
-            workingEditorState.canvas.openFile?.filename ?? null,
-            newParentPath,
-            newElement,
-            utopiaComponents,
-            null,
-          )
+          // Where the parent is a different component to the element being duplicated.
+          const duplicatingComponentRootElement = EP.isRootElementOfInstance(path)
 
-          if (newElement == null) {
+          if (newElement == null || duplicatingComponentRootElement) {
             console.warn(`Could not duplicate ${EP.toVarSafeComponentId(path)}`)
             return success
           } else {
+            utopiaComponents = insertElementAtPath(
+              workingEditorState.projectContents,
+              workingEditorState.canvas.openFile?.filename ?? null,
+              newParentPath,
+              newElement,
+              utopiaComponents,
+              null,
+            )
+
             newSelectedViews.push(newPath)
             // duplicating and inserting the metadata to ensure we're not working with stale metadata
             // this is used for drag + duplicate on the canvas

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -55,10 +55,14 @@ export function requireDispatch(dispatch: EditorDispatch | null | undefined): Ed
 
 export const duplicateElement: ContextMenuItem<CanvasData> = {
   name: 'Duplicate Element',
-  enabled: true,
   shortcut: '⌘D',
   action: (data, dispatch?: EditorDispatch) => {
     requireDispatch(dispatch)([duplicateSelected()], 'everyone')
+  },
+  enabled: (data) => {
+    return data.selectedViews.every((view) => {
+      return !EP.isRootElementOfInstance(view)
+    })
   },
 }
 

--- a/editor/src/components/editor/store/editor-update.spec.tsx
+++ b/editor/src/components/editor/store/editor-update.spec.tsx
@@ -473,6 +473,23 @@ describe('action DUPLICATE_SPECIFIC_ELEMENTS', () => {
       chaiExpect.fail('src/app.js file was the wrong type.')
     }
   })
+  it('does not duplicate a root element of an instance', () => {
+    const element1 = EP.appendNewElementPath(ScenePathForTestUiJsFile, ['aaa'])
+    const { editor, derivedState, dispatch } = createEditorStates([element1])
+    const duplicateAction = duplicateSelected()
+    const updatedEditor = runLocalEditorAction(
+      editor,
+      derivedState,
+      defaultUserState,
+      workers,
+      duplicateAction,
+      History.init(editor, derivedState),
+      dispatch,
+      emptyUiJsxCanvasContextData(),
+      builtInDependencies,
+    )
+    expect(updatedEditor.projectContents).toEqual(editor.projectContents)
+  })
 })
 
 describe('action DELETE_SELECTED', () => {


### PR DESCRIPTION
**Problem:**
Duplication of root component elements does not make any sense and currently throws exceptions in the editor if it is triggered.

**Fix:**
Guard against invoking the duplication logic against an element that should not be duplicated as well as disabling the context menu item for it if an element is not eligible.

**Commit Details:**
- `absoluteDuplicateStrategy` now checks the selected elements with
  `isRootElementOfInstance`.
- `duplicate` validates paths against `isRootElementOfInstance`.
- `duplicateElement` context menu item is only enabled for elements
  that do not return true from `isRootElementOfInstance`.
