### PR TITLE
Invert panning direction for mouse down with space held.

### DIFF
--- a/editor/src/components/canvas/canvas-panning.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-panning.spec.browser2.tsx
@@ -47,8 +47,8 @@ describe(`pan while 'space' is held down`, () => {
     })
 
     const endingCanvasPosition = renderResult.getEditorState().editor.canvas.roundedCanvasOffset
-    expect(endingCanvasPosition.x - startingCanvasPosition.x).toEqual(-100)
-    expect(endingCanvasPosition.y - startingCanvasPosition.y).toEqual(-100)
+    expect(endingCanvasPosition.x - startingCanvasPosition.x).toEqual(100)
+    expect(endingCanvasPosition.y - startingCanvasPosition.y).toEqual(100)
   })
   it(`start drag first`, async () => {
     const renderResult = await createExampleProject()
@@ -85,7 +85,7 @@ describe(`pan while 'space' is held down`, () => {
     })
 
     const endingCanvasPosition = renderResult.getEditorState().editor.canvas.roundedCanvasOffset
-    expect(endingCanvasPosition.x - startingCanvasPosition.x).toEqual(-100)
-    expect(endingCanvasPosition.y - startingCanvasPosition.y).toEqual(-100)
+    expect(endingCanvasPosition.x - startingCanvasPosition.x).toEqual(100)
+    expect(endingCanvasPosition.y - startingCanvasPosition.y).toEqual(100)
   })
 })

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -241,7 +241,7 @@ function on(
     if (event.event === 'MOVE' && event.nativeEvent.buttons === 1) {
       return [
         CanvasActions.scrollCanvas(
-          canvasPoint({ x: event.nativeEvent.movementX, y: event.nativeEvent.movementY }),
+          canvasPoint({ x: -event.nativeEvent.movementX, y: -event.nativeEvent.movementY }),
         ),
       ]
     } else {


### PR DESCRIPTION
**Problem:**
Drag panning should feel like the surface of the canvas is being shifted as if held by the mouse.

**Fix:**
Invert the panning direction of the canvas from how it was originally implemented.

**Commit Details:**
- Flip the direction that the canvas is scrolled in each axis in the
  `on` event handler in `editor-canvas.tsx`.
