### PR TITLE
Open and closed hand cursors for pan drag.

### DIFF
--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -30,6 +30,7 @@ import {
   InteractionSessionWithoutMetadata,
 } from './canvas-strategies/interaction-state'
 import { CanvasStrategyId } from './canvas-strategies/canvas-strategy-types'
+import { MouseButtonsPressed } from 'src/utils/mouse'
 
 export const CanvasContainerID = 'canvas-container'
 
@@ -57,6 +58,7 @@ export enum CSSCursor {
   TextInsert = 'text',
   BrowserAuto = 'auto',
   Duplicate = "-webkit-image-set( url( '/editor/cursors/cursor-duplicate.png ') 1x, url( '/editor/cursors/cursor-duplicate@2x.png ') 2x ) 4 4, default",
+  OpenHand = "-webkit-image-set( url( '/editor/cursors/cursor-open-hand.png ') 1x, url( '/editor/cursors/cursor-open-hand@2x.png ') 2x ) 4 4, default",
 }
 
 export type VerticalRectangles = {
@@ -705,6 +707,7 @@ export interface CanvasModel {
   controls: Array<HigherOrderControl>
   dragState: DragState | null
   keysPressed: KeysPressed
+  mouseButtonsPressed: MouseButtonsPressed
   mode: Mode
   scale: number
   highlightedviews: Array<ElementPath>

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -387,6 +387,12 @@ export type UpdateKeysPressed = {
   keys: KeysPressed
 }
 
+export interface UpdateMouseButtonsPressed {
+  action: 'UPDATE_MOUSE_BUTTONS_PRESSED'
+  added: number | null
+  removed: number | null
+}
+
 export type HideModal = {
   action: 'HIDE_MODAL'
 }
@@ -994,6 +1000,7 @@ export type EditorAction =
   | SetHighlightedView
   | ClearHighlightedViews
   | UpdateKeysPressed
+  | UpdateMouseButtonsPressed
   | HideModal
   | ShowModal
   | ResizeInterfaceDesignerCodePane

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -208,6 +208,7 @@ import type {
   ForceParseFile,
   RemoveFromNodeModulesContents,
   RunEscapeHatch,
+  UpdateMouseButtonsPressed,
 } from '../action-types'
 import {
   EditorModes,
@@ -518,6 +519,17 @@ export function updateKeys(keys: KeysPressed): UpdateKeysPressed {
   return {
     action: 'UPDATE_KEYS_PRESSED',
     keys: keys,
+  }
+}
+
+export function updateMouseButtonsPressed(
+  added: number | null,
+  removed: number | null,
+): UpdateMouseButtonsPressed {
+  return {
+    action: 'UPDATE_MOUSE_BUTTONS_PRESSED',
+    added: added,
+    removed: removed,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -13,6 +13,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'ZOOMUI':
     case 'SHOW_CONTEXT_MENU':
     case 'UPDATE_KEYS_PRESSED':
+    case 'UPDATE_MOUSE_BUTTONS_PRESSED':
     case 'SET_SELECTION_CONTROLS_VISIBILITY':
     case 'SCROLL_CANVAS':
     case 'POSITION_CANVAS':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -373,6 +373,7 @@ import {
   RemoveFromNodeModulesContents,
   RunEscapeHatch,
   SetElementsToRerender,
+  UpdateMouseButtonsPressed,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -528,6 +529,7 @@ import { getEscapeHatchCommands } from '../../../components/canvas/canvas-strate
 import { pickCanvasStateFromEditorState } from '../../canvas/canvas-strategies/canvas-strategies'
 import { foldAndApplyCommandsSimple, runCanvasCommand } from '../../canvas/commands/commands'
 import { setElementsToRerenderCommand } from '../../canvas/commands/set-elements-to-rerender-command'
+import { addButtonPressed, MouseButtonsPressed, removeButtonPressed } from '../../../utils/mouse'
 
 export function updateSelectedLeftMenuTab(editorState: EditorState, tab: LeftMenuTab): EditorState {
   return {
@@ -940,6 +942,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     mode: EditorModes.selectMode(),
     focusedPanel: currentEditor.focusedPanel,
     keysPressed: {},
+    mouseButtonsPressed: emptySet(),
     openPopupId: null,
     toasts: currentEditor.toasts,
     cursorStack: {
@@ -2921,6 +2924,22 @@ export const UPDATE_FNS = {
     return update(editor, {
       keysPressed: { $set: action.keys },
     })
+  },
+  UPDATE_MOUSE_BUTTONS_PRESSED: (
+    action: UpdateMouseButtonsPressed,
+    editor: EditorModel,
+  ): EditorModel => {
+    let mouseButtonsPressed: MouseButtonsPressed = editor.mouseButtonsPressed
+    if (action.added != null) {
+      mouseButtonsPressed = addButtonPressed(mouseButtonsPressed, action.added)
+    }
+    if (action.removed != null) {
+      mouseButtonsPressed = removeButtonPressed(mouseButtonsPressed, action.removed)
+    }
+    return {
+      ...editor,
+      mouseButtonsPressed: mouseButtonsPressed,
+    }
   },
   HIDE_MODAL: (action: HideModal, editor: EditorModel): EditorModel => {
     return update(editor, {

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -99,8 +99,21 @@ function useDelayedValueHook(inputValue: boolean, delayMs: number): boolean {
 export const EditorComponentInner = React.memo((props: EditorProps) => {
   const editorStoreRef = useRefEditorState((store) => store)
   const colorTheme = useColorTheme()
+  const onWindowMouseUp = React.useCallback(
+    (event: MouseEvent) => {
+      editorStoreRef.current.dispatch(
+        [EditorActions.updateMouseButtonsPressed(null, event.button)],
+        'everyone',
+      )
+    },
+    [editorStoreRef],
+  )
   const onWindowMouseDown = React.useCallback(
     (event: MouseEvent) => {
+      editorStoreRef.current.dispatch(
+        [EditorActions.updateMouseButtonsPressed(event.button, null)],
+        'everyone',
+      )
       const popupId = editorStoreRef.current.editor.openPopupId
       if (popupId != null) {
         const popupElement = document.getElementById(popupId)
@@ -233,16 +246,18 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 
   React.useEffect(() => {
     window.addEventListener('mousedown', onWindowMouseDown, true)
+    window.addEventListener('mouseup', onWindowMouseUp, true)
     window.addEventListener('keydown', onWindowKeyDown)
     window.addEventListener('keyup', onWindowKeyUp)
     window.addEventListener('contextmenu', preventDefault)
     return function cleanup() {
       window.removeEventListener('mousedown', onWindowMouseDown, true)
+      window.removeEventListener('mouseup', onWindowMouseUp, true)
       window.removeEventListener('keydown', onWindowKeyDown)
       window.removeEventListener('keyup', onWindowKeyUp)
       window.removeEventListener('contextmenu', preventDefault)
     }
-  }, [onWindowMouseDown, onWindowKeyDown, onWindowKeyUp, preventDefault])
+  }, [onWindowMouseDown, onWindowMouseUp, onWindowKeyDown, onWindowKeyUp, preventDefault])
 
   const dispatch = useEditorState((store) => store.dispatch, 'EditorComponentInner dispatch')
   const projectName = useEditorState(

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -161,6 +161,8 @@ import { Spec } from 'immutability-helper'
 import { memoize } from '../../../core/shared/memoize'
 import { InteractionSession, StrategyState } from '../../canvas/canvas-strategies/interaction-state'
 import { Guideline, GuidelineWithSnappingVector } from '../../canvas/guideline'
+import { MouseButtonsPressed } from '../../../utils/mouse'
+import { emptySet } from '../../../core/shared/set-utils'
 
 const ObjectPathImmutable: any = OPI
 
@@ -846,6 +848,7 @@ export interface EditorState {
   mode: Mode
   focusedPanel: EditorPanel | null
   keysPressed: KeysPressed
+  mouseButtonsPressed: MouseButtonsPressed
   openPopupId: string | null
   toasts: ReadonlyArray<Notice>
   cursorStack: CanvasCursor
@@ -910,6 +913,7 @@ export function editorState(
   mode: Mode,
   focusedPanel: EditorPanel | null,
   keysPressed: KeysPressed,
+  mouseButtonsPressed: MouseButtonsPressed,
   openPopupId: string | null,
   toasts: ReadonlyArray<Notice>,
   cursorStack: CanvasCursor,
@@ -973,6 +977,7 @@ export function editorState(
     mode: mode,
     focusedPanel: focusedPanel,
     keysPressed: keysPressed,
+    mouseButtonsPressed: mouseButtonsPressed,
     openPopupId: openPopupId,
     toasts: toasts,
     cursorStack: cursorStack,
@@ -1678,6 +1683,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     mode: EditorModes.selectLiteMode(),
     focusedPanel: 'canvas',
     keysPressed: {},
+    mouseButtonsPressed: emptySet(),
     openPopupId: null,
     toasts: [],
     cursorStack: {
@@ -1916,6 +1922,7 @@ export function createCanvasModelKILLME(
     controls: derivedState.controls,
     dragState: editor.canvas.dragState,
     keysPressed: editor.keysPressed,
+    mouseButtonsPressed: editor.mouseButtonsPressed,
     mode: editor.mode,
     scale: editor.canvas.scale,
     highlightedviews: editor.highlightedViews,
@@ -1966,6 +1973,7 @@ export function editorModelFromPersistentModel(
     mode: EditorModes.selectLiteMode(),
     focusedPanel: 'canvas',
     keysPressed: {},
+    mouseButtonsPressed: emptySet(),
     openPopupId: null,
     toasts: [],
     cursorStack: {

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -145,6 +145,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.CLEAR_HIGHLIGHTED_VIEWS(action, state)
     case 'UPDATE_KEYS_PRESSED':
       return UPDATE_FNS.UPDATE_KEYS_PRESSED(action, state)
+    case 'UPDATE_MOUSE_BUTTONS_PRESSED':
+      return UPDATE_FNS.UPDATE_MOUSE_BUTTONS_PRESSED(action, state)
     case 'HIDE_MODAL':
       return UPDATE_FNS.HIDE_MODAL(action, state)
     case 'SHOW_MODAL':

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -419,6 +419,7 @@ import {
 } from '../../inspector/common/css-utils'
 import { projectListing, ProjectListing } from '../action-types'
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
+import { MouseButtonsPressed } from 'src/utils/mouse'
 
 export function TransientCanvasStateFilesStateKeepDeepEquality(
   oldValue: TransientFilesState,
@@ -2990,6 +2991,10 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     oldValue.keysPressed,
     newValue.keysPressed,
   )
+  const mouseButtonsPressedResult = createCallFromIntrospectiveKeepDeep<MouseButtonsPressed>()(
+    oldValue.mouseButtonsPressed,
+    newValue.mouseButtonsPressed,
+  )
   const openPopupIdResult = NullableStringKeepDeepEquality(
     oldValue.openPopupId,
     newValue.openPopupId,
@@ -3137,6 +3142,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     modeResult.areEqual &&
     focusedPanelResult.areEqual &&
     keysPressedResult.areEqual &&
+    mouseButtonsPressedResult.areEqual &&
     openPopupIdResult.areEqual &&
     toastsResults.areEqual &&
     canvasCursorResults.areEqual &&
@@ -3203,6 +3209,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       modeResult.value,
       focusedPanelResult.value,
       keysPressedResult.value,
+      mouseButtonsPressedResult.value,
       openPopupIdResult.value,
       toastsResults.value,
       canvasCursorResults.value,

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -94,6 +94,7 @@ import {
 } from '../utils/global-positions'
 import { last, reverse } from '../core/shared/array-utils'
 import { updateInteractionViaMouse } from '../components/canvas/canvas-strategies/interaction-state'
+import { MouseButtonsPressed } from '../utils/mouse'
 
 const webFrame = PROBABLY_ELECTRON ? requireElectron().webFrame : null
 
@@ -106,12 +107,20 @@ let unhandledWheelDeltaY = 0
 
 resetMouseStatus()
 
-function cursorForKeysPressed(keysPressed: KeysPressed): CSSCursor | null {
+function cursorForKeysPressed(
+  keysPressed: KeysPressed,
+  mouseButtonsPressed: MouseButtonsPressed,
+): CSSCursor | null {
   if (keysPressed['z']) {
     return keysPressed['alt'] ? CSSCursor.ZoomOut : CSSCursor.ZoomIn
   }
   if (keysPressed['space']) {
-    return CSSCursor.Crosshair
+    // Primary button pressed.
+    if (mouseButtonsPressed.has(0)) {
+      return CSSCursor.Move
+    } else {
+      return CSSCursor.OpenHand
+    }
   }
   return null
 }
@@ -475,6 +484,7 @@ export interface ControlDependencies {
   dragState: DragState | null
   mode: Mode
   keysPressed: KeysPressed
+  mouseButtonsPressed: MouseButtonsPressed
   scale: number
   snappingThreshold: number
   componentMetadata: ElementInstanceMetadataMap
@@ -498,6 +508,7 @@ export function collectControlsDependencies(
     dragState: editor.canvas.dragState,
     mode: editor.mode,
     keysPressed: editor.keysPressed,
+    mouseButtonsPressed: editor.mouseButtonsPressed,
     scale: editor.canvas.scale,
     snappingThreshold: editor.canvas.snappingThreshold,
     componentMetadata: editor.jsxMetadata,
@@ -779,7 +790,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
     const cursor =
       modeOverrideCursor ??
       dragStateCursor ??
-      cursorForKeysPressed(this.props.model.keysPressed) ??
+      cursorForKeysPressed(this.props.model.keysPressed, this.props.model.mouseButtonsPressed) ??
       cursorForHoveredControl(this.props.model.controls, CanvasMousePositionRaw) ??
       getNewCanvasControlsCursor(this.props.editor.cursorStack) ??
       getDefaultCursorForMode(this.props.editor.mode)

--- a/editor/src/utils/mouse.ts
+++ b/editor/src/utils/mouse.ts
@@ -1,0 +1,19 @@
+export type MouseButtonsPressed = Set<number>
+
+export function addButtonPressed(
+  buttonsPressed: MouseButtonsPressed,
+  button: number,
+): MouseButtonsPressed {
+  let result: MouseButtonsPressed = new Set(buttonsPressed)
+  result.add(button)
+  return result
+}
+
+export function removeButtonPressed(
+  buttonsPressed: MouseButtonsPressed,
+  button: number,
+): MouseButtonsPressed {
+  let result: MouseButtonsPressed = new Set(buttonsPressed)
+  result.delete(button)
+  return result
+}


### PR DESCRIPTION
**Problem:**
We want a clearer indication of the drag to pan functionality.

**Fix:**
The functionality implemented shows an open hand cursor when the space bar is held down on the canvas, and the hand closes when the primary mouse button is also held down simultaneously to indicate that pan to drag is activated.

Due to how cursors are currently set for the canvas however it became necessary to implement a sister value to `keysPressed` in `EditorState` for mouse buttons as the state needs to be checked during the render function of a React component. In all previous uses of the mouse buttons this has been possible to do during a mouse event handler, but not in this case in the way `keysPressed` is already used to assign cursors.

**Commit Details:**
- Added `OpenHand` entry to `CSSCursor`.
- Added `UpdateMouseButtonsPressed` editor action.
- Added `UPDATE_MOUSE_BUTTONS_PRESSED` action handler.
- Added a dispatch of `updateMouseButtonsPressed` to the existing
  `mousedown` handler for `EditorComponentInner`.
- Added a dispatch of `updateMouseButtonsPressed` to a new
  `mouseup` handler added to `EditorComponentInner`.
- Added `mouseButtonsPressed` property to `EditorState`.
- Updated `cursorForKeysPressed` to include `mouseButtonsPressed`.
- Implemented functions for maintaining `MouseButtonsPressed` in
  `mouse.ts`.
