### PR TITLE
Support absolute reparent to the canvas.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -1,0 +1,231 @@
+import {
+  ElementInstanceMetadata,
+  SpecialSizeMeasurements,
+} from '../../../core/shared/element-template'
+import { CanvasPoint, canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
+import { EditorState } from '../../editor/store/editor-state'
+import { foldAndApplyCommands } from '../commands/commands'
+import {
+  getEditorStateWithSelectedViews,
+  makeTestProjectCodeWithSnippet,
+  TestAppUID,
+  testPrintCodeFromEditorState,
+  TestSceneUID,
+} from '../ui-jsx.test-utils'
+import { absoluteReparentStrategy } from './absolute-reparent-strategy'
+import { pickCanvasStateFromEditorState } from './canvas-strategies'
+import { defaultCustomStrategyState } from './canvas-strategy-types'
+import { InteractionSession, StrategyState } from './interaction-state'
+import { createMouseInteractionForTests } from './interaction-state.test-utils'
+import * as EP from '../../../core/shared/element-path'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import {
+  BakedInStoryboardUID,
+  BakedInStoryboardVariableName,
+} from '../../../core/model/scene-utils'
+import { PrettierConfig } from 'utopia-vscode-common'
+import * as Prettier from 'prettier/standalone'
+
+jest.mock('../canvas-utils', () => ({
+  ...jest.requireActual('../canvas-utils'),
+  getReparentTarget: () => ({
+    shouldReparent: true,
+    newParent: {
+      type: 'elementpath',
+      parts: [['utopia-storyboard-uid']],
+    },
+  }),
+}))
+
+// KEEP THIS IN SYNC WITH THE MOCK ABOVE
+const newParent = EP.elementPath([[BakedInStoryboardUID]])
+
+function reparentElement(
+  editorState: EditorState,
+  targetParentWithSpecialContentBox: boolean,
+  dragVector: CanvasPoint = canvasPoint({ x: 15, y: 15 }),
+): EditorState {
+  const interactionSession: InteractionSession = {
+    ...createMouseInteractionForTests(
+      null as any, // the strategy does not use this
+      { cmd: true, alt: false, shift: false, ctrl: false },
+      null as any, // the strategy does not use this
+      dragVector,
+    ),
+    metadata: null as any, // the strategy does not use this
+    allElementProps: null as any, // the strategy does not use this
+  }
+
+  const strategyResult = absoluteReparentStrategy.apply(
+    pickCanvasStateFromEditorState(editorState),
+    interactionSession,
+    {
+      currentStrategy: null as any, // the strategy does not use this
+      currentStrategyFitness: null as any, // the strategy does not use this
+      currentStrategyCommands: null as any, // the strategy does not use this
+      accumulatedPatches: null as any, // the strategy does not use this
+      commandDescriptions: null as any, // the strategy does not use this
+      sortedApplicableStrategies: null as any, // the strategy does not use this
+      startingMetadata: {
+        'scene-aaa/app-entity:aaa': {
+          elementPath: EP.elementPath([['scene-aaa', 'app-entity'], ['aaa']]),
+          globalFrame: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+          specialSizeMeasurements: {
+            immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            providesBoundsForAbsoluteChildren: true,
+            globalContentBox: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+          } as SpecialSizeMeasurements,
+        } as ElementInstanceMetadata,
+        'scene-aaa/app-entity:aaa/bbb': {
+          elementPath: EP.elementPath([
+            ['scene-aaa', 'app-entity'],
+            ['aaa', 'bbb'],
+          ]),
+          globalFrame: canvasRectangle({ x: 50, y: 60, width: 250, height: 200 }),
+          specialSizeMeasurements: {
+            immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            providesBoundsForAbsoluteChildren: true,
+            globalContentBox: targetParentWithSpecialContentBox
+              ? canvasRectangle({ x: 90, y: 100, width: 170, height: 120 })
+              : canvasRectangle({ x: 50, y: 60, width: 250, height: 200 }),
+          } as SpecialSizeMeasurements,
+        } as ElementInstanceMetadata,
+      },
+      startingAllElementProps: {},
+      customStrategyState: defaultCustomStrategyState(),
+    } as StrategyState,
+  )
+
+  expect(strategyResult.customState).toBeNull()
+
+  // Check if there are set SetElementsToRerenderCommands with the new parent path
+  expect(
+    strategyResult.commands.find(
+      (c) =>
+        c.type === 'SET_ELEMENTS_TO_RERENDER_COMMAND' &&
+        c.value !== 'rerender-all-elements' &&
+        c.value.every((p) => EP.pathsEqual(EP.parentPath(p), newParent)),
+    ),
+  ).not.toBeNull()
+
+  const finalEditor = foldAndApplyCommands(
+    editorState,
+    editorState,
+    [],
+    [],
+    strategyResult.commands,
+    'permanent',
+  ).editorState
+
+  return finalEditor
+}
+
+describe('Absolute Reparent Strategy', () => {
+  it('reparents an element to the canvas', async () => {
+    const targetElement = EP.elementPath([
+      ['scene-aaa', 'app-entity'],
+      ['aaa', 'ccc'],
+    ])
+
+    const initialEditor = getEditorStateWithSelectedViews(
+      makeTestProjectCodeWithSnippet(`
+      <div
+        data-uid='aaa'
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          backgroundColor: '#FFFFFF',
+        }}
+      >
+        <div
+          data-uid='bbb'
+          style={{
+            position: 'absolute',
+            width: 250,
+            height: 200,
+            top: 60,
+            left: 50,
+          }}
+        />
+        <div
+          data-uid='ccc'
+          style={{
+            position: 'absolute',
+            width: 20,
+            height: 30,
+            top: 75,
+            left: 90,
+          }}
+        />
+      </div>
+      `),
+      [targetElement],
+    )
+
+    const finalEditor = reparentElement(initialEditor, false, canvasPoint({ x: -1000, y: -1000 }))
+
+    expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
+      Prettier.format(
+        `
+  import * as React from 'react'
+  import { Scene, Storyboard, View } from 'utopia-api'
+
+  export var App = (props) => {
+    return (
+      <div
+      data-uid='aaa'
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        backgroundColor: '#FFFFFF',
+      }}
+      >
+        <div
+          data-uid='bbb'
+          style={{
+            position: 'absolute',
+            width: 250,
+            height: 200,
+            top: 60,
+            left: 50,
+          }}
+        />
+      </div>
+    )
+  }
+
+  export var ${BakedInStoryboardVariableName} = (props) => {
+    return (
+      <Storyboard data-uid='${BakedInStoryboardUID}'>
+        <Scene
+          style={{ left: 0, top: 0, width: 400, height: 400 }}
+          data-uid='${TestSceneUID}'
+        >
+          <App
+            data-uid='${TestAppUID}'
+            style={{ position: 'absolute', bottom: 0, left: 0, right: 0, top: 0 }}
+          />
+        </Scene>
+        <div
+          data-uid='ccc'
+          style={{
+            position: 'absolute',
+            width: 20,
+            height: 30,
+            top: -925,
+            left: -910,
+          }}
+        />
+      </Storyboard>
+    )
+  }
+`,
+        PrettierConfig,
+      ),
+    )
+  })
+})

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -1,0 +1,131 @@
+import {
+  EditorRenderResult,
+  getPrintedUiJsCode,
+  makeTestProjectCodeWithSnippet,
+  renderTestEditorWithCode,
+  TestAppUID,
+  TestSceneUID,
+} from '../ui-jsx.test-utils'
+import { act, fireEvent } from '@testing-library/react'
+import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
+import { offsetPoint, windowPoint, WindowPoint } from '../../../core/shared/math-utils'
+import { cmdModifier, Modifiers } from '../../../utils/modifiers'
+import { PrettierConfig } from 'utopia-vscode-common'
+import * as Prettier from 'prettier/standalone'
+import {
+  BakedInStoryboardVariableName,
+  BakedInStoryboardUID,
+} from '../../../core/model/scene-utils'
+
+function dragElement(
+  renderResult: EditorRenderResult,
+  targetTestId: string,
+  dragDelta: WindowPoint,
+  modifiers: Modifiers,
+) {
+  const targetElement = renderResult.renderedDOM.getByTestId(targetTestId)
+  const targetElementBounds = targetElement.getBoundingClientRect()
+  const canvasControl = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+  const startPoint = windowPoint({ x: targetElementBounds.x + 5, y: targetElementBounds.y + 5 })
+  const endPoint = offsetPoint(startPoint, dragDelta)
+  fireEvent(
+    canvasControl,
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+      metaKey: true,
+      altKey: modifiers.alt,
+      shiftKey: modifiers.shift,
+      clientX: startPoint.x,
+      clientY: startPoint.y,
+      buttons: 1,
+    }),
+  )
+
+  fireEvent(
+    canvasControl,
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      metaKey: modifiers.cmd,
+      altKey: modifiers.alt,
+      shiftKey: modifiers.shift,
+      clientX: endPoint.x,
+      clientY: endPoint.y,
+      buttons: 1,
+    }),
+  )
+
+  fireEvent(
+    window,
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+      metaKey: modifiers.cmd,
+      altKey: modifiers.alt,
+      shiftKey: modifiers.shift,
+      clientX: endPoint.x,
+      clientY: endPoint.y,
+    }),
+  )
+}
+
+describe('Absolute Reparent Strategy', () => {
+  it('reparents to the canvas root', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`
+        <div style={{ width: '100%', height: '100%' }} data-uid='aaa'>
+          <div
+            style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: 40, top: 50, width: 200, height: 120 }}
+            data-uid='bbb'
+            data-testid='bbb'
+          />
+        </div>
+      `),
+      'await-first-dom-report',
+    )
+
+    const dragDelta = windowPoint({ x: -1000, y: -1000 })
+    act(() => dragElement(renderResult, 'bbb', dragDelta, cmdModifier))
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      Prettier.format(
+        `
+  import * as React from 'react'
+  import { Scene, Storyboard, View } from 'utopia-api'
+
+  export var App = (props) => {
+    return (
+      <div style={{width: '100%', height: '100%'}} data-uid='aaa' />
+    )
+  }
+
+  export var ${BakedInStoryboardVariableName} = (props) => {
+    return (
+      <Storyboard data-uid='${BakedInStoryboardUID}'>
+        <Scene
+          style={{ left: 0, top: 0, width: 400, height: 400 }}
+          data-uid='${TestSceneUID}'
+        >
+          <App
+            data-uid='${TestAppUID}'
+            style={{ position: 'absolute', bottom: 0, left: 0, right: 0, top: 0 }}
+          />
+        </Scene>
+        <div
+          style={{ backgroundColor: '#0091FFAA', position: 'absolute', left: -960, top: -950, width: 200, height: 120 }}
+          data-uid='bbb'
+          data-testid='bbb'
+        />
+      </Storyboard>
+    )
+  }
+`,
+        PrettierConfig,
+      ),
+    )
+  })
+})

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -83,12 +83,16 @@ export const absoluteReparentStrategy: CanvasStrategy = {
     )
     const newParent = reparentResult.newParent
     const moveCommands = absoluteMoveStrategy.apply(canvasState, interactionState, strategyState)
-    const providesBoundsForAbsoluteChildren = MetadataUtils.findElementByElementPath(
-      strategyState.startingMetadata,
-      newParent,
-    )?.specialSizeMeasurements.providesBoundsForAbsoluteChildren
+    const providesBoundsForAbsoluteChildren =
+      MetadataUtils.findElementByElementPath(strategyState.startingMetadata, newParent)
+        ?.specialSizeMeasurements.providesBoundsForAbsoluteChildren ?? false
+    const parentIsStoryboard = newParent == null ? false : EP.isStoryboardPath(newParent)
 
-    if (reparentResult.shouldReparent && newParent != null && providesBoundsForAbsoluteChildren) {
+    if (
+      reparentResult.shouldReparent &&
+      newParent != null &&
+      (providesBoundsForAbsoluteChildren || parentIsStoryboard)
+    ) {
       const commands = filteredSelectedElements.map((selectedElement) => {
         const offsetCommands = getAbsoluteOffsetCommandsForSelectedElement(
           selectedElement,

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1958,21 +1958,24 @@ export function getReparentTarget(
     toReparent.map((view) => MetadataUtils.getParent(componentMeta, view)),
   )
   let parentSupportsChild = true
-  if (possibleNewParent != null) {
-    parentSupportsChild = MetadataUtils.targetSupportsChildren(componentMeta, possibleNewParent)
-  } else {
+  if (possibleNewParent == null) {
     // a null template path means Canvas, let's translate that to the storyboard component
     const storyboardComponent = getStoryboardElementPath(projectContents, openFile ?? null)
     return {
       shouldReparent: storyboardComponent != null,
       newParent: storyboardComponent,
     }
+  } else {
+    parentSupportsChild = MetadataUtils.targetSupportsChildren(componentMeta, possibleNewParent)
   }
+  const hasNoCurrentParentsButHasANewParent =
+    currentParents.length === 0 && possibleNewParent != null
+  const newParentIsAChangeFromTheExistingOnes =
+    currentParents.length > 0 &&
+    currentParents.every((parent) => !EP.pathsEqual(possibleNewParent, parent.elementPath))
   if (
     parentSupportsChild &&
-    ((currentParents.length === 0 && possibleNewParent != null) ||
-      (currentParents.length > 0 &&
-        currentParents.every((parent) => !EP.pathsEqual(possibleNewParent, parent.elementPath))))
+    (hasNoCurrentParentsButHasANewParent || newParentIsAChangeFromTheExistingOnes)
   ) {
     return {
       shouldReparent: true,


### PR DESCRIPTION
**Problem:**
We want to support absolute reparenting to the canvas.

**Fix:**
Extended the current absolute strategy to support also reparenting to the storyboard root.

**Commit Details:**
- Added an additional case for `absoluteReparentStrategy.apply` to
  allow the reparent target parent if it is a storyboard path.
- Slightly reworked `getReparentTarget` to make the conditionals
  easier to read.
- Added a test case for reparenting to the canvas in a separate file
  because jest mocks don't appear to be easily reconfigured or factorable
  into a function.