### PR TITLE
Prevent mouseup on scene label from de-selecting scenes

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -23,6 +23,8 @@ interface SceneLabelProps extends SceneLabelControlProps {
   target: ElementPath
 }
 
+export const SceneLabelTestID = 'scene-label'
+
 export const SceneLabelControl = React.memo<SceneLabelControlProps>((props) => {
   const sceneTargets = useEditorState(
     (store) =>
@@ -131,6 +133,14 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
     [dispatch, scale, canvasOffset, props.target],
   )
 
+  const onMouseUp = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation()
+      dispatch([CanvasActions.clearInteractionSession(true)], 'canvas')
+    },
+    [dispatch],
+  )
+
   if (frame != null) {
     return (
       <CanvasOffsetWrapper>
@@ -138,7 +148,9 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
           onMouseOver={labelSelectable ? onMouseOver : NO_OP}
           onMouseOut={labelSelectable ? onMouseLeave : NO_OP}
           onMouseDown={labelSelectable ? onMouseDown : NO_OP}
+          onMouseUp={labelSelectable ? onMouseUp : NO_OP}
           onMouseMove={labelSelectable ? onMouseMove : NO_OP}
+          data-testid={SceneLabelTestID}
           className='roleComponentName'
           style={{
             pointerEvents: labelSelectable ? 'initial' : 'none',

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -414,6 +414,10 @@ export const TestSceneElementPaths = [[BakedInStoryboardUID, TestSceneUID, TestA
 export const TestScenePath = elementPath(TestSceneElementPaths)
 export const TestStaticScenePath = testStaticElementPath(TestSceneElementPaths)
 
+export function formatTestProjectCode(code: string): string {
+  return Prettier.format(code, PrettierConfig)
+}
+
 export function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
   const code = `
   import * as React from 'react'
@@ -439,7 +443,7 @@ ${componentInnards}
     )
   }
 `
-  return Prettier.format(code, PrettierConfig)
+  return formatTestProjectCode(code)
 }
 
 export function makeTestProjectCodeWithSnippet(snippet: string): string {
@@ -479,7 +483,7 @@ ${snippet}
     )
   }
 `
-  return Prettier.format(code, PrettierConfig)
+  return formatTestProjectCode(code)
 }
 
 export function getTestParseSuccess(fileContents: string): ParseSuccess {


### PR DESCRIPTION
**Problem:**
#2389 Added some necessary code to update selection on a `mouseup` event, but unfortunately that code wasn't compatible with scene labels.

**Fix:**
After trying a few approaches here, I've ended up having to add an `onMouseUp` event handler to the scene label which suppresses bubbling of the event, but also dispatches a `CanvasActions.clearInteractionSession(true)` so that it doesn't break interactions. We're already taking a similar approach with the `onMouseDown` handler for selecting the scene.

I've also added a couple of tests for ensuring that both selection and dragging still function as desired.