### PR TITLE
Protect against reparenting when a value is defined elsewhere.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -1,3 +1,5 @@
+import { foldEither } from '../../../core/shared/either'
+import { elementReferencesElsewhere } from '../../../core/shared/element-template'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
 import { CSSCursor } from '../canvas-types'
@@ -30,7 +32,19 @@ export const absoluteReparentStrategy: CanvasStrategy = {
       return filteredSelectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
 
-        return elementMetadata?.specialSizeMeasurements.position === 'absolute'
+        const referencesExternalValue =
+          elementMetadata == null
+            ? false
+            : foldEither(
+                (_) => false,
+                (elementFromMetadata) => elementReferencesElsewhere(elementFromMetadata),
+                elementMetadata.element,
+              )
+
+        return (
+          elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
+          !referencesExternalValue
+        )
       })
     }
     return false

--- a/editor/src/core/shared/element-template.spec.ts
+++ b/editor/src/core/shared/element-template.spec.ts
@@ -88,46 +88,6 @@ describe('attributeReferencesElsewhere', () => {
       attributeReferencesElsewhere(jsxAttributeOtherJavaScript('5', 'return 5', [], null, {})),
     ).toEqual(false)
   })
-  it('ATTRIBUTE_OTHER_JAVASCRIPT returns true if the elementsWithin contain a definedElsewhere entry', () => {
-    expect(
-      attributeReferencesElsewhere(
-        jsxAttributeOtherJavaScript('5', 'return 5', [], null, {
-          aaa: jsxElement(
-            'div',
-            'aaa',
-            [
-              jsxAttributesEntry(
-                'style',
-                jsxAttributeOtherJavaScript(
-                  'otherThing',
-                  'return otherThing',
-                  ['otherThing'],
-                  null,
-                  {},
-                ),
-                emptyComments,
-              ),
-            ],
-            [],
-          ),
-        }),
-      ),
-    ).toEqual(true)
-  })
-  it('ATTRIBUTE_OTHER_JAVASCRIPT returns false if the elementsWithin do not contain a definedElsewhere entry', () => {
-    expect(
-      attributeReferencesElsewhere(
-        jsxAttributeOtherJavaScript('5', 'return 5', [], null, {
-          aaa: jsxElement(
-            'div',
-            'aaa',
-            [jsxAttributesEntry('style', jsxAttributeValue({}, emptyComments), emptyComments)],
-            [],
-          ),
-        }),
-      ),
-    ).toEqual(false)
-  })
   it('ATTRIBUTE_NESTED_ARRAY returns true if it has a definedElsewhere entry', () => {
     expect(
       attributeReferencesElsewhere(

--- a/editor/src/core/shared/element-template.spec.ts
+++ b/editor/src/core/shared/element-template.spec.ts
@@ -1,9 +1,17 @@
 import {
+  attributeReferencesElsewhere,
   deleteJSXAttribute,
   emptyComments,
+  jsxArrayValue,
+  jsxAttributeFunctionCall,
+  jsxAttributeNestedArray,
+  jsxAttributeNestedObject,
+  jsxAttributeOtherJavaScript,
   jsxAttributesEntry,
   jsxAttributesSpread,
   jsxAttributeValue,
+  jsxElement,
+  jsxPropertyAssignment,
   setJSXAttributesAttribute,
 } from './element-template'
 
@@ -61,5 +69,158 @@ describe('deleteJSXAttribute', () => {
     const expected = [startingAttributesSpread]
     const actual = deleteJSXAttribute(startingAttributes, existingKey)
     expect(actual).toEqual(expected)
+  })
+})
+
+describe('attributeReferencesElsewhere', () => {
+  it('ATTRIBUTE_VALUE always returns false', () => {
+    expect(attributeReferencesElsewhere(jsxAttributeValue(12, emptyComments))).toEqual(false)
+  })
+  it('ATTRIBUTE_OTHER_JAVASCRIPT returns true if it has a definedElsewhere entry', () => {
+    expect(
+      attributeReferencesElsewhere(
+        jsxAttributeOtherJavaScript('otherThing', 'return otherThing', ['otherThing'], null, {}),
+      ),
+    ).toEqual(true)
+  })
+  it('ATTRIBUTE_OTHER_JAVASCRIPT returns false if it does not have a definedElsewhere entry', () => {
+    expect(
+      attributeReferencesElsewhere(jsxAttributeOtherJavaScript('5', 'return 5', [], null, {})),
+    ).toEqual(false)
+  })
+  it('ATTRIBUTE_OTHER_JAVASCRIPT returns true if the elementsWithin contain a definedElsewhere entry', () => {
+    expect(
+      attributeReferencesElsewhere(
+        jsxAttributeOtherJavaScript('5', 'return 5', [], null, {
+          aaa: jsxElement(
+            'div',
+            'aaa',
+            [
+              jsxAttributesEntry(
+                'style',
+                jsxAttributeOtherJavaScript(
+                  'otherThing',
+                  'return otherThing',
+                  ['otherThing'],
+                  null,
+                  {},
+                ),
+                emptyComments,
+              ),
+            ],
+            [],
+          ),
+        }),
+      ),
+    ).toEqual(true)
+  })
+  it('ATTRIBUTE_OTHER_JAVASCRIPT returns false if the elementsWithin do not contain a definedElsewhere entry', () => {
+    expect(
+      attributeReferencesElsewhere(
+        jsxAttributeOtherJavaScript('5', 'return 5', [], null, {
+          aaa: jsxElement(
+            'div',
+            'aaa',
+            [jsxAttributesEntry('style', jsxAttributeValue({}, emptyComments), emptyComments)],
+            [],
+          ),
+        }),
+      ),
+    ).toEqual(false)
+  })
+  it('ATTRIBUTE_NESTED_ARRAY returns true if it has a definedElsewhere entry', () => {
+    expect(
+      attributeReferencesElsewhere(
+        jsxAttributeNestedArray(
+          [
+            jsxArrayValue(
+              jsxAttributeOtherJavaScript(
+                'otherThing',
+                'return otherThing',
+                ['otherThing'],
+                null,
+                {},
+              ),
+              emptyComments,
+            ),
+          ],
+          emptyComments,
+        ),
+      ),
+    ).toEqual(true)
+  })
+  it('ATTRIBUTE_NESTED_ARRAY returns false if it does not have a definedElsewhere entry', () => {
+    expect(
+      attributeReferencesElsewhere(
+        jsxAttributeNestedArray(
+          [
+            jsxArrayValue(
+              jsxAttributeOtherJavaScript('5', 'return 5', [], null, {}),
+              emptyComments,
+            ),
+          ],
+          emptyComments,
+        ),
+      ),
+    ).toEqual(false)
+  })
+  it('ATTRIBUTE_NESTED_OBJECT returns true if it has a definedElsewhere entry', () => {
+    expect(
+      attributeReferencesElsewhere(
+        jsxAttributeNestedObject(
+          [
+            jsxPropertyAssignment(
+              'someKey',
+              jsxAttributeOtherJavaScript(
+                'otherThing',
+                'return otherThing',
+                ['otherThing'],
+                null,
+                {},
+              ),
+              emptyComments,
+              emptyComments,
+            ),
+          ],
+          emptyComments,
+        ),
+      ),
+    ).toEqual(true)
+  })
+  it('ATTRIBUTE_NESTED_OBJECT returns false if it does not have a definedElsewhere entry', () => {
+    expect(
+      attributeReferencesElsewhere(
+        jsxAttributeNestedObject(
+          [
+            jsxPropertyAssignment(
+              'someKey',
+              jsxAttributeOtherJavaScript('5', 'return 5', [], null, {}),
+              emptyComments,
+              emptyComments,
+            ),
+          ],
+          emptyComments,
+        ),
+      ),
+    ).toEqual(false)
+  })
+
+  it('ATTRIBUTE_FUNCTION_CALL returns true if it has a definedElsewhere entry', () => {
+    expect(
+      attributeReferencesElsewhere(
+        jsxAttributeFunctionCall('someFn', [
+          jsxAttributeOtherJavaScript('otherThing', 'return otherThing', ['otherThing'], null, {}),
+        ]),
+      ),
+    ).toEqual(true)
+  })
+  it('ATTRIBUTE_FUNCTION_CALL returns false if it does not have a definedElsewhere entry', () => {
+    expect(
+      attributeReferencesElsewhere(
+        jsxAttributeFunctionCall('someFn', [
+          jsxAttributeOtherJavaScript('5', 'return 5', [], null, {}),
+        ]),
+      ),
+    ).toEqual(false)
   })
 })

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -768,12 +768,7 @@ export function attributeReferencesElsewhere(attribute: JSXAttribute): boolean {
     case 'ATTRIBUTE_VALUE':
       return false
     case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-      return (
-        attribute.definedElsewhere.length > 0 ||
-        Object.values(attribute.elementsWithin).some((element) => {
-          return elementReferencesElsewhere(element)
-        })
-      )
+      return attribute.definedElsewhere.length > 0
     case 'ATTRIBUTE_NESTED_OBJECT':
       return attribute.content.some((subAttr) => {
         return attributeReferencesElsewhere(subAttr.value)


### PR DESCRIPTION
**Problem:**
If an element refers to a value defined externally to the element, then reparenting the element is almost guaranteed to fail as the variable will not exist in the scope of the new location.

**Fix:**
For any potential target of the reparenting logic, first check if the element has any values defined elsewhere.

**Commit Details:**
- Added `attributeReferencesElsewhere`, `jsxAttributesPartReferencesElsewhere`,
  and `elementReferencesElsewhere` functions to capture if any value is defined
  outside of an element.
- `absoluteReparentStrategy` checks if the element attempting to be dragged has
  any values defined elsewhere via `elementReferencesElsewhere`.
