### PR TITLE
make Beaches the default project in production too

### DIFF
--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -430,7 +430,7 @@ function beachesDefaultProject(): PersistentModel {
 
 export function defaultProject(): PersistentModel {
   if (process.env.NODE_ENV === 'production') {
-    return simpleDefaultProject()
+    return beachesDefaultProject()
   } else {
     return beachesDefaultProject()
   }


### PR DESCRIPTION
(I've meant to make these changes in my previous PR, but I messed something up)

This PR switches the Beaches project on for production as well. We talked about this on discord and everyone agreed to do this change.

The main reasons are:
1. it brings more attention to the default project, forcing us to fix problems with it and make it better faster
2. it makes debugging easier because if we use the same project in production and development it's easier to reproduce issues that e.g. affect a specific part of the sample project. Currently it's a pain to reproduce a localhost bug on pizza because you have to take your project contents json and import it.