### PR TITLE
Fix/escape hatch contextmenu enabled

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -53,14 +53,7 @@ export const escapeHatchStrategy: CanvasStrategy = {
   id: 'ESCAPE_HATCH_STRATEGY',
   name: 'Absolute Move',
   isApplicable: (canvasState, _interactionState, metadata) => {
-    if (canvasState.selectedElements.length > 0) {
-      return canvasState.selectedElements.every((element) => {
-        const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
-        return !MetadataUtils.isPositionAbsolute(elementMetadata)
-      })
-    } else {
-      return false
-    }
+    return areAllSelectedElementsNonAbsolute(canvasState.selectedElements, metadata)
   },
   controlsToRender: [
     {
@@ -538,4 +531,18 @@ function getFrameWithoutMargin(
     y: -(margin?.top ?? 0),
   } as LocalPoint
   return offsetRect(frame, marginPoint)
+}
+
+export function areAllSelectedElementsNonAbsolute(
+  selectedElements: Array<ElementPath>,
+  metadata: ElementInstanceMetadataMap,
+) {
+  if (selectedElements.length > 0) {
+    return selectedElements.every((element) => {
+      const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
+      return !MetadataUtils.isPositionAbsolute(elementMetadata)
+    })
+  } else {
+    return false
+  }
 }

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -48,6 +48,7 @@ import {
   InteractionCanvasState,
 } from './canvas-strategy-types'
 import { DragInteractionData, InteractionSession, StrategyState } from './interaction-state'
+import { areAllSelectedElementsNonAbsolute } from './shared-absolute-move-strategy-helpers'
 
 export const escapeHatchStrategy: CanvasStrategy = {
   id: 'ESCAPE_HATCH_STRATEGY',
@@ -531,18 +532,4 @@ function getFrameWithoutMargin(
     y: -(margin?.top ?? 0),
   } as LocalPoint
   return offsetRect(frame, marginPoint)
-}
-
-export function areAllSelectedElementsNonAbsolute(
-  selectedElements: Array<ElementPath>,
-  metadata: ElementInstanceMetadataMap,
-) {
-  if (selectedElements.length > 0) {
-    return selectedElements.every((element) => {
-      const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
-      return !MetadataUtils.isPositionAbsolute(elementMetadata)
-    })
-  } else {
-    return false
-  }
 }

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -56,13 +56,7 @@ export const escapeHatchStrategy: CanvasStrategy = {
     if (canvasState.selectedElements.length > 0) {
       return canvasState.selectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
-        return (
-          elementMetadata?.specialSizeMeasurements.position === 'static' ||
-          MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
-            element,
-            metadata,
-          )
-        )
+        return !MetadataUtils.isPositionAbsolute(elementMetadata)
       })
     } else {
       return false

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
@@ -326,3 +326,17 @@ function ensureAtLeastOnePinPerDimension(props: PropsOrJSXAttributes): {
     extendedPins: [...horizontalPinsToAdd, ...verticalPinsToAdd],
   }
 }
+
+export function areAllSelectedElementsNonAbsolute(
+  selectedElements: Array<ElementPath>,
+  metadata: ElementInstanceMetadataMap,
+) {
+  if (selectedElements.length > 0) {
+    return selectedElements.every((element) => {
+      const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
+      return !MetadataUtils.isPositionAbsolute(elementMetadata)
+    })
+  } else {
+    return false
+  }
+}

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -344,7 +344,12 @@ export const rename: ContextMenuItem<CanvasData> = {
 
 export const escapeHatch: ContextMenuItem<CanvasData> = {
   name: 'Convert to Absolute Layout',
-  enabled: true,
+  enabled: (data) => {
+    return data.selectedViews.every((element) => {
+      const elementMetadata = MetadataUtils.findElementByElementPath(data.jsxMetadata, element)
+      return !MetadataUtils.isPositionAbsolute(elementMetadata)
+    })
+  },
   action: (data, dispatch?: EditorDispatch) => {
     if (data.selectedViews.length > 0) {
       requireDispatch(dispatch)([EditorActions.runEscapeHatch(data.selectedViews)], 'everyone')

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -24,7 +24,7 @@ import {
   toggleStylePropPath,
   toggleStylePropPaths,
 } from './inspector/common/css-utils'
-import { areAllSelectedElementsNonAbsolute } from './canvas/canvas-strategies/escape-hatch-strategy'
+import { areAllSelectedElementsNonAbsolute } from './canvas/canvas-strategies/shared-absolute-move-strategy-helpers'
 
 export interface ContextMenuItem<T> {
   name: string | React.ReactNode

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -24,6 +24,7 @@ import {
   toggleStylePropPath,
   toggleStylePropPaths,
 } from './inspector/common/css-utils'
+import { areAllSelectedElementsNonAbsolute } from './canvas/canvas-strategies/escape-hatch-strategy'
 
 export interface ContextMenuItem<T> {
   name: string | React.ReactNode
@@ -345,10 +346,7 @@ export const rename: ContextMenuItem<CanvasData> = {
 export const escapeHatch: ContextMenuItem<CanvasData> = {
   name: 'Convert to Absolute Layout',
   enabled: (data) => {
-    return data.selectedViews.every((element) => {
-      const elementMetadata = MetadataUtils.findElementByElementPath(data.jsxMetadata, element)
-      return !MetadataUtils.isPositionAbsolute(elementMetadata)
-    })
+    return areAllSelectedElementsNonAbsolute(data.selectedViews, data.jsxMetadata)
   },
   action: (data, dispatch?: EditorDispatch) => {
     if (data.selectedViews.length > 0) {

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -1577,6 +1577,7 @@ describe('RUN_ESCAPE_HATCH', () => {
         specialSizeMeasurements: {
           immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
           coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+          position: 'static',
         } as SpecialSizeMeasurements,
       } as ElementInstanceMetadata,
     } as ElementInstanceMetadataMap

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4894,7 +4894,7 @@ export const UPDATE_FNS = {
   },
   RUN_ESCAPE_HATCH: (action: RunEscapeHatch, editor: EditorModel): EditorModel => {
     const canvasState = pickCanvasStateFromEditorState(editor)
-    if (areAllSelectedElementsNonAbsolute(editor.selectedViews, editor.jsxMetadata)) {
+    if (areAllSelectedElementsNonAbsolute(action.targets, editor.jsxMetadata)) {
       const commands = getEscapeHatchCommands(
         action.targets,
         editor.jsxMetadata,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -526,7 +526,7 @@ import { NavigatorStateKeepDeepEquality } from '../../../utils/deep-equality-ins
 import type { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import {
-  escapeHatchStrategy,
+  areAllSelectedElementsNonAbsolute,
   getEscapeHatchCommands,
 } from '../../../components/canvas/canvas-strategies/escape-hatch-strategy'
 import { pickCanvasStateFromEditorState } from '../../canvas/canvas-strategies/canvas-strategies'
@@ -4896,14 +4896,7 @@ export const UPDATE_FNS = {
   },
   RUN_ESCAPE_HATCH: (action: RunEscapeHatch, editor: EditorModel): EditorModel => {
     const canvasState = pickCanvasStateFromEditorState(editor)
-    if (
-      escapeHatchStrategy.isApplicable(
-        canvasState,
-        null,
-        editor.jsxMetadata,
-        editor.allElementProps,
-      )
-    ) {
+    if (areAllSelectedElementsNonAbsolute(editor.selectedViews, editor.jsxMetadata)) {
       const commands = getEscapeHatchCommands(
         action.targets,
         editor.jsxMetadata,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -525,14 +525,12 @@ import { uniqToasts } from './toast-helpers'
 import { NavigatorStateKeepDeepEquality } from '../../../utils/deep-equality-instances'
 import type { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
-import {
-  areAllSelectedElementsNonAbsolute,
-  getEscapeHatchCommands,
-} from '../../../components/canvas/canvas-strategies/escape-hatch-strategy'
+import { getEscapeHatchCommands } from '../../../components/canvas/canvas-strategies/escape-hatch-strategy'
 import { pickCanvasStateFromEditorState } from '../../canvas/canvas-strategies/canvas-strategies'
 import { foldAndApplyCommandsSimple, runCanvasCommand } from '../../canvas/commands/commands'
 import { setElementsToRerenderCommand } from '../../canvas/commands/set-elements-to-rerender-command'
 import { addButtonPressed, MouseButtonsPressed, removeButtonPressed } from '../../../utils/mouse'
+import { areAllSelectedElementsNonAbsolute } from '../../canvas/canvas-strategies/shared-absolute-move-strategy-helpers'
 
 export function updateSelectedLeftMenuTab(editorState: EditorState, tab: LeftMenuTab): EditorState {
   return {

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -525,7 +525,10 @@ import { uniqToasts } from './toast-helpers'
 import { NavigatorStateKeepDeepEquality } from '../../../utils/deep-equality-instances'
 import type { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
-import { getEscapeHatchCommands } from '../../../components/canvas/canvas-strategies/escape-hatch-strategy'
+import {
+  escapeHatchStrategy,
+  getEscapeHatchCommands,
+} from '../../../components/canvas/canvas-strategies/escape-hatch-strategy'
 import { pickCanvasStateFromEditorState } from '../../canvas/canvas-strategies/canvas-strategies'
 import { foldAndApplyCommandsSimple, runCanvasCommand } from '../../canvas/commands/commands'
 import { setElementsToRerenderCommand } from '../../canvas/commands/set-elements-to-rerender-command'
@@ -4893,13 +4896,24 @@ export const UPDATE_FNS = {
   },
   RUN_ESCAPE_HATCH: (action: RunEscapeHatch, editor: EditorModel): EditorModel => {
     const canvasState = pickCanvasStateFromEditorState(editor)
-    const commands = getEscapeHatchCommands(
-      action.targets,
-      editor.jsxMetadata,
-      canvasState,
-      null,
-    ).commands
-    return foldAndApplyCommandsSimple(editor, commands)
+    if (
+      escapeHatchStrategy.isApplicable(
+        canvasState,
+        null,
+        editor.jsxMetadata,
+        editor.allElementProps,
+      )
+    ) {
+      const commands = getEscapeHatchCommands(
+        action.targets,
+        editor.jsxMetadata,
+        canvasState,
+        null,
+      ).commands
+      return foldAndApplyCommandsSimple(editor, commands)
+    } else {
+      return editor
+    }
   },
   SET_ELEMENTS_TO_RERENDER: (action: SetElementsToRerender, editor: EditorModel): EditorModel => {
     return foldAndApplyCommandsSimple(editor, [setElementsToRerenderCommand(action.value)])


### PR DESCRIPTION
**Problem:**
It's possible to click on the context menu `convert to absolute` when the element already has position absolute.

**Fix:**
Disable the context menu item. Check if elements are non absolute in the conversion action.

**Commit Details:**
- disable context menu item
- helper function for non-absolute
