### PR TITLE
Enabled insertion tests and removed a thrown error

### DIFF
--- a/editor/src/components/canvas/controls/insert-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/insert-mode.spec.browser2.tsx
@@ -72,7 +72,7 @@ async function fireDragEvent(
   })
 }
 
-xdescribe('Inserting', () => {
+describe('Inserting', () => {
   before(() => {
     viewport.set(2200, 1000)
   })

--- a/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx
@@ -26,18 +26,19 @@ function useGetHighlightableViewsForInsertMode() {
   })
   return React.useCallback(() => {
     const { componentMetadata, mode } = storeRef.current
-    if (!isInsertMode(mode)) {
-      throw new Error('insert highlight callback was called oustide of insert mode')
+    if (isInsertMode(mode)) {
+      const allPaths = MetadataUtils.getAllPaths(componentMetadata)
+      const insertTargets = allPaths.filter((path) => {
+        return (
+          (insertionSubjectIsJSXElement(mode.subject) ||
+            insertionSubjectIsDragAndDrop(mode.subject)) &&
+          MetadataUtils.targetSupportsChildren(componentMetadata, path)
+        )
+      })
+      return insertTargets
+    } else {
+      return []
     }
-    const allPaths = MetadataUtils.getAllPaths(componentMetadata)
-    const insertTargets = allPaths.filter((path) => {
-      return (
-        (insertionSubjectIsJSXElement(mode.subject) ||
-          insertionSubjectIsDragAndDrop(mode.subject)) &&
-        MetadataUtils.targetSupportsChildren(componentMetadata, path)
-      )
-    })
-    return insertTargets
   }, [storeRef])
 }
 


### PR DESCRIPTION
**Problem:**
I had added insertion tests as part of some earlier work but left them disabled as they were waiting on a separate issue to be resolved. However, when enabling them I discovered that one of them fails when run as part of the entire test suite, but doesn't fail when run in isolation.

**Fix:**
The test fails when run as part of the full suite as it throws the error [here](https://github.com/concrete-utopia/utopia/blob/60640b609ef86b628b6e102f9679c3e0911a219c/editor/src/components/canvas/controls/select-mode/insert-mode-hooks.tsx#L30). The highlight callback is called upon completion of insertion (so the actions to insert the new element and then to change to Select mode have both been dispatched and have successfully updated the model), meaning that the highlight callback is called between that happening and [this hook](https://github.com/concrete-utopia/utopia/blob/60640b609ef86b628b6e102f9679c3e0911a219c/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx#L662) updating. I haven't gotten to the bottom of exactly why this happens during the test only, but the error throwing logic here seems a bit excessive so I have opted to remove that.