### PR TITLE
Fix selective rendering

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -269,6 +269,9 @@ export function createComponentRendererComponent(params: {
 }
 
 // Checks if the element with the given elementPath is rendered in the props.children subtree
+// LIMITATION: this function only checks props.children, so if the given element is rendered, but from a
+// different prop, isElementInChildrenPropTree will return false
+// If we will support renderProps, this should be updated to check other props which receive react elements
 function isElementInChildrenPropTree(elementPath: string, props: any): boolean {
   const childrenArr = React.Children.toArray(props.children).filter(React.isValidElement)
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -95,11 +95,34 @@ export function createComponentRendererComponent(params: {
     const instancePath: ElementPath | null = tryToGetInstancePath(instancePathAny, pathsString)
 
     function shouldUpdate() {
+      // Checks if the element with the given elementPath is rendered in the props.children subtree
+      function isElementRenderedAsChildPropRecursive(elementPath: string, props: any): boolean {
+        const childrenArr = React.Children.toArray(props.children).filter(React.isValidElement)
+
+        if (childrenArr.length === 0) {
+          return false
+        }
+        const elementIsChild = childrenArr.some(
+          (c) => (c.props as any)[UTOPIA_PATH_KEY] === elementPath,
+        )
+        if (elementIsChild) {
+          return true
+        } else {
+          return childrenArr.some((c) =>
+            isElementRenderedAsChildPropRecursive(elementPath, c.props),
+          )
+        }
+      }
+
       return (
         !isFeatureEnabled('Canvas Selective Rerender') ||
         ElementsToRerenderGLOBAL.current === 'rerender-all-elements' ||
         ElementsToRerenderGLOBAL.current.some((er) => {
-          return instancePath != null && EP.isDescendantOfOrEqualTo(er, instancePath)
+          return (
+            (instancePath != null &&
+              (EP.pathsEqual(er, instancePath) || EP.isParentComponentOf(instancePath, er))) ||
+            isElementRenderedAsChildPropRecursive(EP.toString(er), realPassedProps)
+          )
         })
       )
     }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -99,10 +99,7 @@ export function createComponentRendererComponent(params: {
         !isFeatureEnabled('Canvas Selective Rerender') ||
         ElementsToRerenderGLOBAL.current === 'rerender-all-elements' ||
         ElementsToRerenderGLOBAL.current.some((er) => {
-          return (
-            instancePath != null &&
-            (EP.pathsEqual(instancePath, er) || EP.isParentComponentOf(instancePath, er))
-          )
+          return instancePath != null && EP.isDescendantOfOrEqualTo(er, instancePath)
         })
       )
     }
@@ -181,7 +178,7 @@ export function createComponentRendererComponent(params: {
       })
     }
 
-    if (utopiaJsxComponent.arbitraryJSBlock != null && shouldUpdate) {
+    if (utopiaJsxComponent.arbitraryJSBlock != null && shouldUpdate()) {
       const lookupRenderer = createLookupRender(
         rootElementPath,
         scope,


### PR DESCRIPTION
# Bug

Selective rendering doesn't render the element when it has a component ancestor which just renders the element from props.children

# Root cause

We filtered rendering too heavily: elements were only rendered when they were explicitly mentioned in the elementsToRender list or their parent component was explicitly there.
This could cause problems, e.g this case:

```javascript
export var App = (props) => {
  return (
    <div data-uid='div'>
      <span
        style={{ position: 'absolute'}}
        data-uid='sp'
      >
        Drag me around!
      </span>
    </div>
  )
}
```

We drag the text, `storyboard/scene/a:div/sp` is added to the elementsToRender list.

Everything works well, `storyboard/scene/a` is the parent component to render, and it is going to be rendered.

But if we switch the root div to a real component, e.g.:

```javascript
export var App = (props) => {
  return (
    <FlexCol data-uid='fc'>
      <span
        style={{ position: 'absolute'}}
        data-uid='sp'
      >
        Drag me around!
      </span>
    </FlexCol>
  )
}
```

And we have a problem here, because `storyboard/scene/a:fc` is the parent component, and it is not gonna be rendered! `storyboard/scene/a` still going to be rendered, but that doesn't help, `storyboard/scene/a:fc/sp` is not going to update on the screen.

Even worse case:

```javascript
export var App = (props) => {
  return (
    <FlexCol data-uid='fc'>
      <span
        style={{ position: 'absolute'}}
        data-uid='sp'
      >
        Drag me around!
      </span>
    </FlexCol>
  )
}

export var FlexCol = (props) => {
  return (
    <Flex data-uid='flex' style={{flexDirection: 'col', ...props.style}}>
      {props.children}
    </Flex>
  )
}

export var Flex = (props) => {
  return (
    <div data-uid='div' style={{display: 'flex', ...props.style}}>
      {props.children}
    </div>
  )
}
```

In this case `storyboard/scene/a:fc:flex` is not rendered, so the changes won't be visible.
Why? Because `storyboard/scene/a:fc:flex` is not the parent component of ``storyboard/scene/a:fc/sp`, it is not even a descendant.

# Fix

In the above problematic cases the selectively rendered element was passed in as props.children.
So we somehow need to detect if the selectively rendered element is rendered in the props.children subtree. We can do that by checking the `realPassedProps`

Note: if the component is passed in with a different prop name (not children) and rendered inside, selective rendering will still be broken. However, because in that case navigator and selection is broken too for the element, this is not a bottleneck now.
In the future, if we will support renderProps, this should be updated to check other props which receive react elements.