### PR TITLE
Fix/canvas cursor mousedown

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -67,8 +67,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
       canvasState.selectedElements.length > 0 &&
       interactionState.interactionData.type === 'DRAG' &&
       interactionState.activeControl.type === 'BOUNDING_AREA' &&
-      interactionState.interactionData.modifiers.alt &&
-      interactionState.interactionData.drag != null
+      interactionState.interactionData.modifiers.alt
     ) {
       return 2
     }
@@ -130,9 +129,13 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
           duplicatedElementNewUids: duplicatedElementNewUids,
         },
       }
+    } else {
+      // Fallback for when the checks above are not satisfied.
+      return {
+        commands: [setCursorCommand('transient', CSSCursor.Duplicate)],
+        customState: null,
+      }
     }
-    // Fallback for when the checks above are not satisfied.
-    return emptyStrategyApplicationResult
   },
 }
 

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -63,59 +63,65 @@ export const flexReorderStrategy: CanvasStrategy = {
       : 0
   },
   apply: (canvasState, interactionState, strategyState) => {
-    if (
-      interactionState.interactionData.type !== 'DRAG' ||
-      interactionState.interactionData.drag == null
-    ) {
+    if (interactionState.interactionData.type !== 'DRAG') {
       return emptyStrategyApplicationResult
     }
 
-    const { selectedElements } = canvasState
-    const target = selectedElements[0]
+    if (interactionState.interactionData.drag != null) {
+      const { selectedElements } = canvasState
+      const target = selectedElements[0]
 
-    const siblingsOfTarget = MetadataUtils.getSiblings(strategyState.startingMetadata, target).map(
-      (element) => element.elementPath,
-    )
+      const siblingsOfTarget = MetadataUtils.getSiblings(
+        strategyState.startingMetadata,
+        target,
+      ).map((element) => element.elementPath)
 
-    const pointOnCanvas = offsetPoint(
-      interactionState.interactionData.dragStart,
-      interactionState.interactionData.drag,
-    )
+      const pointOnCanvas = offsetPoint(
+        interactionState.interactionData.dragStart,
+        interactionState.interactionData.drag,
+      )
 
-    const unpatchedIndex = siblingsOfTarget.findIndex((sibling) => EP.pathsEqual(sibling, target))
-    const lastReorderIdx = strategyState.customStrategyState.lastReorderIdx ?? unpatchedIndex
+      const unpatchedIndex = siblingsOfTarget.findIndex((sibling) => EP.pathsEqual(sibling, target))
+      const lastReorderIdx = strategyState.customStrategyState.lastReorderIdx ?? unpatchedIndex
 
-    const newIndex = getReorderIndex(
-      strategyState.startingMetadata,
-      siblingsOfTarget,
-      pointOnCanvas,
-    )
+      const newIndex = getReorderIndex(
+        strategyState.startingMetadata,
+        siblingsOfTarget,
+        pointOnCanvas,
+      )
 
-    const realNewIndex = newIndex > -1 ? newIndex : lastReorderIdx
+      const realNewIndex = newIndex > -1 ? newIndex : lastReorderIdx
 
-    if (realNewIndex === unpatchedIndex) {
-      return {
-        commands: [
-          updateHighlightedViews('transient', []),
-          setCursorCommand('transient', CSSCursor.Move),
-        ],
-        customState: {
-          ...strategyState.customStrategyState,
-          lastReorderIdx: realNewIndex,
-        },
+      if (realNewIndex === unpatchedIndex) {
+        return {
+          commands: [
+            updateHighlightedViews('transient', []),
+            setCursorCommand('transient', CSSCursor.Move),
+          ],
+          customState: {
+            ...strategyState.customStrategyState,
+            lastReorderIdx: realNewIndex,
+          },
+        }
+      } else {
+        return {
+          commands: [
+            reorderElement('permanent', target, realNewIndex),
+            setElementsToRerenderCommand([target]),
+            updateHighlightedViews('transient', []),
+            setCursorCommand('transient', CSSCursor.Move),
+          ],
+          customState: {
+            ...strategyState.customStrategyState,
+            lastReorderIdx: realNewIndex,
+          },
+        }
       }
     } else {
+      // Fallback for when the checks above are not satisfied.
       return {
-        commands: [
-          reorderElement('permanent', target, realNewIndex),
-          setElementsToRerenderCommand([target]),
-          updateHighlightedViews('transient', []),
-          setCursorCommand('transient', CSSCursor.Move),
-        ],
-        customState: {
-          ...strategyState.customStrategyState,
-          lastReorderIdx: realNewIndex,
-        },
+        commands: [setCursorCommand('transient', CSSCursor.Move)],
+        customState: null,
       }
     }
   },

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -72,6 +72,7 @@ import { InsertionControls } from './insertion-plus-button'
 import { DistanceGuidelineControl } from './select-mode/distance-guideline-control'
 import { SceneLabelControl } from './select-mode/scene-label'
 import { PinLines } from './position-outline'
+import { EditorCursorComponent } from '../../editor/editor-component'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -487,6 +488,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           )}
         </>,
       )}
+      <EditorCursorComponent />
     </div>
   )
 }

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -72,7 +72,6 @@ import { InsertionControls } from './insertion-plus-button'
 import { DistanceGuidelineControl } from './select-mode/distance-guideline-control'
 import { SceneLabelControl } from './select-mode/scene-label'
 import { PinLines } from './position-outline'
-import { EditorCursorComponent } from '../../editor/editor-component'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -488,7 +487,6 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           )}
         </>,
       )}
-      <EditorCursorComponent />
     </div>
   )
 }

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -72,7 +72,7 @@ import { InsertionControls } from './insertion-plus-button'
 import { DistanceGuidelineControl } from './select-mode/distance-guideline-control'
 import { SceneLabelControl } from './select-mode/scene-label'
 import { PinLines } from './position-outline'
-import { EditorCursorComponent } from '../../editor/editor-component'
+import { CursorOverlay } from './select-mode/cursor-overlay'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -488,7 +488,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           )}
         </>,
       )}
-      <EditorCursorComponent />
+      <CursorOverlay />
     </div>
   )
 }

--- a/editor/src/components/canvas/controls/select-mode/cursor-overlay.tsx
+++ b/editor/src/components/canvas/controls/select-mode/cursor-overlay.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import { Utils } from '../../../../uuiui-deps'
+import { useEditorState } from '../../../editor/store/store-hook'
+import { getCursorFromDragState } from '../../canvas-utils'
+
+export const CursorOverlay = React.memo(() => {
+  const cursor = useEditorState((store) => {
+    return Utils.defaultIfNull(store.editor.canvas.cursor, getCursorFromDragState(store.editor))
+  }, 'CursorOverlay cursor')
+
+  const styleProps = React.useMemo(() => {
+    let workingStyleProps: React.CSSProperties = {
+      position: 'fixed',
+      left: 0,
+      top: 0,
+      width: '100vw',
+      height: '100vh',
+      pointerEvents: 'none',
+      zIndex: 9999999,
+    }
+    if (cursor != null) {
+      workingStyleProps.cursor = cursor
+      workingStyleProps.pointerEvents = 'all'
+    }
+    return workingStyleProps
+  }, [cursor])
+  const portalDiv = document.getElementById('cursor-overlay-portal')
+  if (portalDiv == null) {
+    return null
+  }
+  return ReactDOM.createPortal(
+    <div key='cursor-area' id='cursor-overlay' style={styleProps} />,
+    portalDiv,
+  )
+})

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -547,9 +547,15 @@ function useSelectOrLiveModeSelectAndHover(
       event: React.MouseEvent<HTMLDivElement>,
       preferAlreadySelected: 'prefer-selected' | 'dont-prefer-selected',
     ) => {
-      // Skip all of this handling if 'space' is pressed.
-      if (!editorStoreRef.current.editor.keysPressed['space']) {
-        const doubleClick = event.detail > 1 // we interpret a triple click as two double clicks, a quadruple click as three double clicks, etc  // TODO TEST ME
+      const doubleClick = event.detail > 1 // we interpret a triple click as two double clicks, a quadruple click as three double clicks, etc  // TODO TEST ME
+      const isSpacePressed = editorStoreRef.current.editor.keysPressed['space']
+      const hasInteractionSessionWithMouseMoved =
+        editorStoreRef.current.editor.canvas.interactionSession?.interactionData?.type === 'DRAG'
+          ? editorStoreRef.current.editor.canvas.interactionSession?.interactionData?.drag != null
+          : false
+
+      // Skip all of this handling if 'space' is pressed or a mousemove happened in an interaction
+      if (!(isSpacePressed || hasInteractionSessionWithMouseMoved)) {
         const selectableViews = getSelectableViewsForSelectMode(event.metaKey, doubleClick)
         const foundTarget = findValidTarget(
           selectableViews,

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -567,7 +567,7 @@ function useSelectOrLiveModeSelectAndHover(
               const start = windowToCanvasCoordinates(
                 windowPoint(point(event.clientX, event.clientY)),
               ).canvasPositionRounded
-              if (event.button !== 2) {
+              if (event.button !== 2 && event.type !== 'mouseup') {
                 editorActions.push(
                   CanvasActions.createInteractionSession(
                     createInteractionViaMouse(start, Modifier.modifiersForEvent(event), {

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -565,12 +565,11 @@ function useSelectOrLiveModeSelectAndHover(
           ? editorStoreRef.current.editor.canvas.interactionSession?.interactionData?.drag != null
           : false
 
-      const doubleClick = event.detail > 1 // we interpret a triple click as two double clicks, a quadruple click as three double clicks, etc
-      const preferAlreadySelected = getPreferredSelectionForEvent(event.type, doubleClick)
-
       // Skip all of this handling if 'space' is pressed or a mousemove happened in an interaction
       if (!(isSpacePressed || hasInteractionSessionWithMouseMoved)) {
+        const doubleClick = event.detail > 1 // we interpret a triple click as two double clicks, a quadruple click as three double clicks, etc
         const selectableViews = getSelectableViewsForSelectMode(event.metaKey, doubleClick)
+        const preferAlreadySelected = getPreferredSelectionForEvent(event.type, doubleClick)
         const foundTarget = findValidTarget(
           selectableViews,
           windowPoint(point(event.clientX, event.clientY)),

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -4,7 +4,6 @@
 import { jsx } from '@emotion/react'
 import { ResizeDirection } from 're-resizable'
 import React from 'react'
-import * as ReactDOM from 'react-dom'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import Utils from '../../utils/utils'
@@ -421,6 +420,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
         </SimpleFlexColumn>
         <ModalComponent />
         <ToastRenderer />
+        <EditorCursorComponent />
       </SimpleFlexRow>
     </>
   )
@@ -456,7 +456,7 @@ export function EditorComponent(props: EditorProps) {
   )
 }
 
-export const EditorCursorComponent = React.memo(() => {
+const EditorCursorComponent = React.memo(() => {
   const cursor = useEditorState((store) => {
     return Utils.defaultIfNull(store.editor.canvas.cursor, getCursorFromDragState(store.editor))
   }, 'EditorCursorComponent cursor')
@@ -477,14 +477,8 @@ export const EditorCursorComponent = React.memo(() => {
     }
     return workingStyleProps
   }, [cursor])
-  const portalDiv = document.getElementById('cursor-overlay-portal')
-  if (portalDiv == null) {
-    return null
-  }
-  return ReactDOM.createPortal(
-    <div key='cursor-area' id='cursor-overlay' style={styleProps} />,
-    portalDiv,
-  )
+
+  return <div key='cursor-area' id='cursor-overlay' style={styleProps} />
 })
 
 const ToastRenderer = React.memo(() => {

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -4,6 +4,7 @@
 import { jsx } from '@emotion/react'
 import { ResizeDirection } from 're-resizable'
 import React from 'react'
+import * as ReactDOM from 'react-dom'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import Utils from '../../utils/utils'
@@ -420,7 +421,6 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
         </SimpleFlexColumn>
         <ModalComponent />
         <ToastRenderer />
-        <EditorCursorComponent />
       </SimpleFlexRow>
     </>
   )
@@ -456,7 +456,7 @@ export function EditorComponent(props: EditorProps) {
   )
 }
 
-const EditorCursorComponent = React.memo(() => {
+export const EditorCursorComponent = React.memo(() => {
   const cursor = useEditorState((store) => {
     return Utils.defaultIfNull(store.editor.canvas.cursor, getCursorFromDragState(store.editor))
   }, 'EditorCursorComponent cursor')
@@ -477,8 +477,14 @@ const EditorCursorComponent = React.memo(() => {
     }
     return workingStyleProps
   }, [cursor])
-
-  return <div key='cursor-area' id='cursor-overlay' style={styleProps} />
+  const portalDiv = document.getElementById('cursor-overlay-portal')
+  if (portalDiv == null) {
+    return null
+  }
+  return ReactDOM.createPortal(
+    <div key='cursor-area' id='cursor-overlay' style={styleProps} />,
+    portalDiv,
+  )
 })
 
 const ToastRenderer = React.memo(() => {

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -456,37 +456,6 @@ export function EditorComponent(props: EditorProps) {
   )
 }
 
-export const EditorCursorComponent = React.memo(() => {
-  const cursor = useEditorState((store) => {
-    return Utils.defaultIfNull(store.editor.canvas.cursor, getCursorFromDragState(store.editor))
-  }, 'EditorCursorComponent cursor')
-
-  const styleProps = React.useMemo(() => {
-    let workingStyleProps: React.CSSProperties = {
-      position: 'fixed',
-      left: 0,
-      top: 0,
-      width: '100vw',
-      height: '100vh',
-      pointerEvents: 'none',
-      zIndex: 9999999,
-    }
-    if (cursor != null) {
-      workingStyleProps.cursor = cursor
-      workingStyleProps.pointerEvents = 'all'
-    }
-    return workingStyleProps
-  }, [cursor])
-  const portalDiv = document.getElementById('cursor-overlay-portal')
-  if (portalDiv == null) {
-    return null
-  }
-  return ReactDOM.createPortal(
-    <div key='cursor-area' id='cursor-overlay' style={styleProps} />,
-    portalDiv,
-  )
-})
-
 const ToastRenderer = React.memo(() => {
   const toasts = useEditorState((store) => store.editor.toasts, 'ToastRenderer')
 

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`402`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`404`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {
@@ -124,7 +124,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`391`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`393`)
   })
 
   it('Changing the selected view with a simple project', async () => {
@@ -178,7 +178,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`641`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`642`)
   })
 
   it('Changing the selected view with a less simple project', async () => {
@@ -242,6 +242,6 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`713`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`714`)
   })
 })

--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -132,5 +132,6 @@
         </div>
       </div>
     </div>
+    <div id="cursor-overlay-portal"></div>
   </body>
 </html>

--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -132,6 +132,5 @@
         </div>
       </div>
     </div>
-    <div id="cursor-overlay-portal"></div>
   </body>
 </html>


### PR DESCRIPTION
**Problem:**
Starting an absolute drag without moving a mouse and pressing alt doesn't switch the cursor to show the duplicate cursor.
If an interaction changes the cursor on mousedown double click selection will stop selecting further elements.

**Fix:**
Fix strategy fitness functions to allow changing the cursor without passing the drag threshold.
The selection fix is a bit trickier, since we allow dragging when there are overlapping siblings and there is already one selected mousedown on it should allow dragging instead of selecting the top element, in this case the selection updates only on mouseup. This is a bit problematic for double click selection in a hierarchy, for this mousedown should be event that updates the selection. To fix that mouseup won't change selection after an interaction is to check the drag threshold is passed already.
I also found a problem of the select-mode-hook where the mouseup created a fresh interaction session.

**Commit Details:**
- added duplicate strategy and flex reorder strategy cursor command without drag threshold
- updated select mode hook
- moved the cursor component to the canvas controls
- to have the cursor component with full screen size it uses a portal 