### PR TITLE
Reparent drag from absolute to flex.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.spec.browser2.tsx
@@ -1,0 +1,407 @@
+import {
+  EditorRenderResult,
+  formatTestProjectCode,
+  getPrintedUiJsCode,
+  renderTestEditorWithCode,
+  TestAppUID,
+  TestSceneUID,
+} from '../ui-jsx.test-utils'
+import { act, fireEvent } from '@testing-library/react'
+import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
+import { offsetPoint, windowPoint, WindowPoint } from '../../../core/shared/math-utils'
+import { cmdModifier, Modifiers } from '../../../utils/modifiers'
+import { PrettierConfig } from 'utopia-vscode-common'
+import * as Prettier from 'prettier/standalone'
+import {
+  BakedInStoryboardVariableName,
+  BakedInStoryboardUID,
+} from '../../../core/model/scene-utils'
+import { wait } from '../../../core/model/performance-scripts'
+
+function dragElement(
+  renderResult: EditorRenderResult,
+  targetTestId: string,
+  dragDelta: WindowPoint,
+  modifiers: Modifiers,
+) {
+  const targetElement = renderResult.renderedDOM.getByTestId(targetTestId)
+  const targetElementBounds = targetElement.getBoundingClientRect()
+  const canvasControl = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+  const startPoint = windowPoint({
+    x: targetElementBounds.x + targetElementBounds.width / 2,
+    y: targetElementBounds.y + targetElementBounds.height / 2,
+  })
+  const endPoint = offsetPoint(startPoint, dragDelta)
+  fireEvent(
+    canvasControl,
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+      metaKey: true,
+      altKey: modifiers.alt,
+      shiftKey: modifiers.shift,
+      clientX: startPoint.x,
+      clientY: startPoint.y,
+      buttons: 1,
+    }),
+  )
+
+  fireEvent(
+    canvasControl,
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      metaKey: modifiers.cmd,
+      altKey: modifiers.alt,
+      shiftKey: modifiers.shift,
+      clientX: endPoint.x,
+      clientY: endPoint.y,
+      buttons: 1,
+    }),
+  )
+
+  fireEvent(
+    window,
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+      metaKey: modifiers.cmd,
+      altKey: modifiers.alt,
+      shiftKey: modifiers.shift,
+      clientX: endPoint.x,
+      clientY: endPoint.y,
+    }),
+  )
+}
+
+const defaultTestCode = `
+  <div
+    style={{
+      position: 'absolute',
+      width: 700,
+      height: 600,
+    }}
+    data-uid='container'
+    data-testid='container'
+  >
+    <div
+      style={{
+        position: 'absolute',
+        width: 250,
+        height: 500,
+        left: 0,
+        top: 0,
+        backgroundColor: 'lightblue',
+      }}
+      data-uid='absoluteparent'
+      data-testid='absoluteparent'
+    >
+      <div
+        style={{
+          position: 'absolute',
+          left: 93.5,
+          top: 58,
+          width: 100,
+          height: 100,
+          borderWidth: 10,
+          borderColor: 'black',
+          borderStyle: 'solid',
+          backgroundColor: 'yellow',
+        }}
+        data-uid='absolutechild'
+        data-testid='absolutechild'
+      />
+    </div>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        position: 'absolute',
+        width: 250,
+        height: 500,
+        left: 350,
+        top: 0,
+        backgroundColor: 'lightgreen',
+      }}
+      data-uid='flexparent'
+      data-testid='flexparent'
+    >
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          borderWidth: 10,
+          borderColor: 'black',
+          borderStyle: 'solid',
+          backgroundColor: 'teal',
+        }}
+        data-uid='flexchild1'
+        data-testid='flexchild1'
+      />
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          borderWidth: 10,
+          borderColor: 'black',
+          borderStyle: 'solid',
+          backgroundColor: 'red',
+        }}
+        data-uid='flexchild2'
+        data-testid='flexchild2'
+      />
+    </div>
+  </div>
+`
+
+function makeTestProjectCodeWithComponentInnards(componentInnards: string): string {
+  const code = `
+  import * as React from 'react'
+  import { Scene, Storyboard, View } from 'utopia-api'
+
+  export var App = (props) => {
+${componentInnards}
+  }
+
+  export var ${BakedInStoryboardVariableName} = (props) => {
+    return (
+      <Storyboard data-uid='${BakedInStoryboardUID}'>
+        <Scene
+          style={{ left: 0, top: 0, width: 2000, height: 2000 }}
+          data-uid='${TestSceneUID}'
+        >
+          <App
+            data-uid='${TestAppUID}'
+            style={{ position: 'absolute', bottom: 0, left: 0, right: 0, top: 0 }}
+          />
+        </Scene>
+      </Storyboard>
+    )
+  }
+`
+  return formatTestProjectCode(code)
+}
+
+function makeTestProjectCodeWithSnippet(snippet: string): string {
+  return makeTestProjectCodeWithComponentInnards(`
+  return (
+${snippet}
+  )
+`)
+}
+
+describe('Absolute Reparent To Flex Strategy', () => {
+  beforeEach(() => {
+    viewport.set(2200, 1000)
+  })
+  it('reparents to the end', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(defaultTestCode),
+      'await-first-dom-report',
+    )
+    const absoluteChild = await renderResult.renderedDOM.findByTestId('absolutechild')
+    const absoluteChildRect = absoluteChild.getBoundingClientRect()
+    const absoluteChildCenter = {
+      x: absoluteChildRect.x + absoluteChildRect.width / 2,
+      y: absoluteChildRect.y + absoluteChildRect.height / 2,
+    }
+    const flexParent = await renderResult.renderedDOM.findByTestId('flexparent')
+    const flexParentRect = flexParent.getBoundingClientRect()
+    const flexParentCenter = {
+      x: flexParentRect.x + flexParentRect.width / 2,
+      y: flexParentRect.y + flexParentRect.height / 2,
+    }
+
+    const dragDelta = windowPoint({
+      x: flexParentCenter.x - absoluteChildCenter.x,
+      y: flexParentCenter.y - absoluteChildCenter.y,
+    })
+    act(() => dragElement(renderResult, 'absolutechild', dragDelta, cmdModifier))
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+  <div
+    style={{
+      position: 'absolute',
+      width: 700,
+      height: 600,
+    }}
+    data-uid='container'
+    data-testid='container'
+  >
+    <div
+      style={{
+        position: 'absolute',
+        width: 250,
+        height: 500,
+        left: 0,
+        top: 0,
+        backgroundColor: 'lightblue',
+      }}
+      data-uid='absoluteparent'
+      data-testid='absoluteparent'
+    />
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        position: 'absolute',
+        width: 250,
+        height: 500,
+        left: 350,
+        top: 0,
+        backgroundColor: 'lightgreen',
+      }}
+      data-uid='flexparent'
+      data-testid='flexparent'
+    >
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          borderWidth: 10,
+          borderColor: 'black',
+          borderStyle: 'solid',
+          backgroundColor: 'teal',
+        }}
+        data-uid='flexchild1'
+        data-testid='flexchild1'
+      />
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          borderWidth: 10,
+          borderColor: 'black',
+          borderStyle: 'solid',
+          backgroundColor: 'red',
+        }}
+        data-uid='flexchild2'
+        data-testid='flexchild2'
+      />
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          borderWidth: 10,
+          borderColor: 'black',
+          borderStyle: 'solid',
+          backgroundColor: 'yellow',
+        }}
+        data-uid='absolutechild'
+        data-testid='absolutechild'
+      />
+    </div>
+  </div>`),
+    )
+  })
+  it('reparents to between the two existing flex elements', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(defaultTestCode),
+      'await-first-dom-report',
+    )
+
+    const absoluteChild = await renderResult.renderedDOM.findByTestId('absolutechild')
+    const absoluteChildRect = absoluteChild.getBoundingClientRect()
+    const absoluteChildCenter = {
+      x: absoluteChildRect.x + absoluteChildRect.width / 2,
+      y: absoluteChildRect.y + absoluteChildRect.height / 2,
+    }
+    const firstFlexChild = await renderResult.renderedDOM.findByTestId('flexchild1')
+    const firstFlexChildRect = firstFlexChild.getBoundingClientRect()
+    const firstFlexChildCenter = {
+      x: firstFlexChildRect.x + firstFlexChildRect.width / 2,
+      y: firstFlexChildRect.y + firstFlexChildRect.height / 2,
+    }
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    const dragDelta = windowPoint({
+      x: firstFlexChildCenter.x - absoluteChildCenter.x,
+      y: firstFlexChildCenter.y - absoluteChildCenter.y,
+    })
+    act(() => dragElement(renderResult, 'absolutechild', dragDelta, cmdModifier))
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
+      makeTestProjectCodeWithSnippet(`
+  <div
+    style={{
+      position: 'absolute',
+      width: 700,
+      height: 600,
+    }}
+    data-uid='container'
+    data-testid='container'
+  >
+    <div
+      style={{
+        position: 'absolute',
+        width: 250,
+        height: 500,
+        left: 0,
+        top: 0,
+        backgroundColor: 'lightblue',
+      }}
+      data-uid='absoluteparent'
+      data-testid='absoluteparent'
+    />
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        position: 'absolute',
+        width: 250,
+        height: 500,
+        left: 350,
+        top: 0,
+        backgroundColor: 'lightgreen',
+      }}
+      data-uid='flexparent'
+      data-testid='flexparent'
+    >
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          borderWidth: 10,
+          borderColor: 'black',
+          borderStyle: 'solid',
+          backgroundColor: 'yellow',
+        }}
+        data-uid='absolutechild'
+        data-testid='absolutechild'
+      />
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          borderWidth: 10,
+          borderColor: 'black',
+          borderStyle: 'solid',
+          backgroundColor: 'teal',
+        }}
+        data-uid='flexchild1'
+        data-testid='flexchild1'
+      />
+      <div
+        style={{
+          width: 100,
+          height: 100,
+          borderWidth: 10,
+          borderColor: 'black',
+          borderStyle: 'solid',
+          backgroundColor: 'red',
+        }}
+        data-uid='flexchild2'
+        data-testid='flexchild2'
+      />
+    </div>
+  </div>`),
+    )
+  })
+})

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
@@ -41,7 +41,7 @@ function reparentTargetFromInteractionSession(
   const reparentResult = getReparentTarget(
     filteredSelectedElements,
     filteredSelectedElements,
-    interactionSession.metadata,
+    strategyState.startingMetadata,
     [],
     canvasState.scale,
     canvasState.canvasOffset,
@@ -59,7 +59,7 @@ function reparentTargetFromInteractionSession(
     if (
       MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
         reparentResult.newParent,
-        interactionSession.metadata,
+        strategyState.startingMetadata,
       )
     ) {
       return {
@@ -69,7 +69,7 @@ function reparentTargetFromInteractionSession(
       }
     } else {
       const metadata = MetadataUtils.findElementByElementPath(
-        interactionSession.metadata,
+        strategyState.startingMetadata,
         reparentResult.newParent,
       )
       // The target is a flex container.

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
@@ -55,7 +55,8 @@ function reparentTargetFromInteractionSession(
       shouldReorder: false,
     }
   } else {
-    // The target is in a flex container.
+    // The target is in a flex container, so we want the parent of the target to reparent
+    // into and reordering should be triggered because the pointer is over an existing flex element.
     if (
       MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
         reparentResult.newParent,
@@ -72,7 +73,9 @@ function reparentTargetFromInteractionSession(
         strategyState.startingMetadata,
         reparentResult.newParent,
       )
-      // The target is a flex container.
+      // The target is a flex container, so we want to use the target directly.
+      // But in this case no re-ordering should be triggered, the element should just be
+      // added to the end.
       if (MetadataUtils.isFlexLayoutedContainer(metadata)) {
         return {
           shouldReparent: true,

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
@@ -1,0 +1,248 @@
+import * as EP from '../../../core/shared/element-path'
+import * as PP from '../../../core/shared/property-path'
+import { AllElementProps } from '../../editor/store/editor-state'
+import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
+import {
+  CanvasStrategy,
+  emptyStrategyApplicationResult,
+  InteractionCanvasState,
+  StrategyApplicationResult,
+} from './canvas-strategy-types'
+import { InteractionSession, StrategyState } from './interaction-state'
+import { ParentBounds } from '../controls/parent-bounds'
+import { ParentOutlines } from '../controls/parent-outlines'
+import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { getDragTargets } from './shared-absolute-move-strategy-helpers'
+import { getReparentTarget } from '../canvas-utils'
+import { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
+import { reparentElement } from '../commands/reparent-element-command'
+import { getReorderIndex } from './flex-reorder-strategy'
+import { offsetPoint } from '../../../core/shared/math-utils'
+import { reorderElement } from '../commands/reorder-element-command'
+import { CSSCursor } from '../canvas-types'
+import { setCursorCommand } from '../commands/set-cursor-command'
+import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
+import { updateHighlightedViews } from '../commands/update-highlighted-views-command'
+import { CanvasCommand, foldAndApplyCommandsInner } from '../commands/commands'
+import { deleteProperties } from '../commands/delete-properties-command'
+import { updateSelectedViews } from '../commands/update-selected-views-command'
+
+function reparentTargetFromInteractionSession(
+  filteredSelectedElements: Array<ElementPath>,
+  interactionSession: InteractionSession,
+  canvasState: InteractionCanvasState,
+  strategyState: StrategyState,
+): {
+  shouldReparent: boolean
+  newParent: ElementPath | null
+  shouldReorder: boolean
+} {
+  const reparentResult = getReparentTarget(
+    filteredSelectedElements,
+    filteredSelectedElements,
+    interactionSession.metadata,
+    [],
+    canvasState.scale,
+    canvasState.canvasOffset,
+    canvasState.projectContents,
+    canvasState.openFile,
+    strategyState.startingAllElementProps,
+  )
+  if (reparentResult.newParent == null) {
+    return {
+      ...reparentResult,
+      shouldReorder: false,
+    }
+  } else {
+    // The target is in a flex container.
+    if (
+      MetadataUtils.isParentYogaLayoutedContainerAndElementParticipatesInLayout(
+        reparentResult.newParent,
+        interactionSession.metadata,
+      )
+    ) {
+      return {
+        shouldReparent: true,
+        newParent: EP.parentPath(reparentResult.newParent),
+        shouldReorder: true,
+      }
+    } else {
+      const metadata = MetadataUtils.findElementByElementPath(
+        interactionSession.metadata,
+        reparentResult.newParent,
+      )
+      // The target is a flex container.
+      if (MetadataUtils.isFlexLayoutedContainer(metadata)) {
+        return {
+          shouldReparent: true,
+          newParent: reparentResult.newParent,
+          shouldReorder: false,
+        }
+      } else {
+        return {
+          shouldReparent: false,
+          newParent: null,
+          shouldReorder: false,
+        }
+      }
+    }
+  }
+}
+
+const propertiesToRemove: Array<PropertyPath> = [
+  PP.create(['style', 'position']),
+  PP.create(['style', 'left']),
+  PP.create(['style', 'top']),
+  PP.create(['style', 'right']),
+  PP.create(['style', 'bottom']),
+]
+
+export const absoluteReparentToFlexStrategy: CanvasStrategy = {
+  id: 'ABSOLUTE_REPARENT_TO_FLEX',
+  name: 'Absolute Reparent to Flex',
+  isApplicable: function (
+    canvasState: InteractionCanvasState,
+    interactionSession: InteractionSession | null,
+    metadata: ElementInstanceMetadataMap,
+    allElementProps: AllElementProps,
+  ): boolean {
+    if (
+      canvasState.selectedElements.length === 1 &&
+      interactionSession != null &&
+      interactionSession.interactionData.type === 'DRAG' &&
+      interactionSession.interactionData.modifiers.cmd
+    ) {
+      const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
+      if (filteredSelectedElements.length === 1) {
+        const elementMetadata = MetadataUtils.findElementByElementPath(
+          metadata,
+          filteredSelectedElements[0],
+        )
+
+        return elementMetadata?.specialSizeMeasurements.position === 'absolute'
+      }
+    }
+    return false
+  },
+  controlsToRender: [
+    {
+      control: DragOutlineControl,
+      key: 'ghost-outline-control',
+      show: 'visible-only-while-active',
+    },
+    {
+      control: ParentOutlines,
+      key: 'parent-outlines-control',
+      show: 'visible-only-while-active',
+    },
+    {
+      control: ParentBounds,
+      key: 'parent-bounds-control',
+      show: 'visible-only-while-active',
+    },
+  ],
+  fitness: function (
+    canvasState: InteractionCanvasState,
+    interactionSession: InteractionSession,
+    strategyState: StrategyState,
+  ): number {
+    if (
+      absoluteReparentToFlexStrategy.isApplicable(
+        canvasState,
+        interactionSession,
+        strategyState.startingMetadata,
+        strategyState.startingAllElementProps,
+      ) &&
+      interactionSession.activeControl.type === 'BOUNDING_AREA'
+    ) {
+      const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
+      const reparentResult = reparentTargetFromInteractionSession(
+        filteredSelectedElements,
+        interactionSession,
+        canvasState,
+        strategyState,
+      )
+      if (reparentResult.shouldReparent && reparentResult.newParent) {
+        // Should exceed regular absolute strategy fitnesses.
+        return 5
+      }
+    }
+    return 0
+  },
+  apply: function (
+    canvasState: InteractionCanvasState,
+    interactionSession: InteractionSession,
+    strategyState: StrategyState,
+  ): StrategyApplicationResult {
+    if (
+      interactionSession.interactionData.type == 'DRAG' &&
+      interactionSession.interactionData.drag != null
+    ) {
+      const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
+      const reparentResult = reparentTargetFromInteractionSession(
+        filteredSelectedElements,
+        interactionSession,
+        canvasState,
+        strategyState,
+      )
+
+      if (
+        reparentResult.shouldReparent &&
+        reparentResult.newParent != null &&
+        filteredSelectedElements.length === 1
+      ) {
+        const target = filteredSelectedElements[0]
+        const newParent = reparentResult.newParent
+        // Reparent the element.
+        const newPath = EP.appendToPath(reparentResult.newParent, EP.toUid(target))
+        const reparentCommand = reparentElement('permanent', target, reparentResult.newParent)
+
+        // Strip the `position`, positional and dimension properties.
+        const commandToRemoveProperties = deleteProperties('permanent', newPath, propertiesToRemove)
+
+        const commandsBeforeReorder = [reparentCommand, updateSelectedViews('permanent', [newPath])]
+
+        const commandsAfterReorder = [
+          commandToRemoveProperties,
+          setElementsToRerenderCommand([newPath]),
+          updateHighlightedViews('transient', []),
+          setCursorCommand('transient', CSSCursor.Move),
+        ]
+
+        let commands: Array<CanvasCommand>
+        if (reparentResult.shouldReorder) {
+          // Reorder the newly reparented element into the flex ordering.
+          const pointOnCanvas = offsetPoint(
+            interactionSession.interactionData.dragStart,
+            interactionSession.interactionData.drag,
+          )
+
+          const siblingsOfTarget = MetadataUtils.getChildrenPaths(
+            strategyState.startingMetadata,
+            newParent,
+          )
+
+          const newIndex = getReorderIndex(
+            strategyState.startingMetadata,
+            siblingsOfTarget,
+            pointOnCanvas,
+          )
+          commands = [
+            ...commandsBeforeReorder,
+            reorderElement('permanent', newPath, newIndex),
+            ...commandsAfterReorder,
+          ]
+        } else {
+          commands = [...commandsBeforeReorder, ...commandsAfterReorder]
+        }
+
+        return {
+          commands: commands,
+          customState: strategyState.customStrategyState,
+        }
+      }
+    }
+    return emptyStrategyApplicationResult
+  },
+}

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -23,6 +23,7 @@ import { keyboardAbsoluteResizeStrategy } from './keyboard-absolute-resize-strat
 import { escapeHatchStrategy } from './escape-hatch-strategy'
 import { flexReorderStrategy } from './flex-reorder-strategy'
 import { absoluteDuplicateStrategy } from './absolute-duplicate-strategy'
+import { absoluteReparentToFlexStrategy } from './absolute-reparent-to-flex-strategy'
 
 export const RegisteredCanvasStrategies: Array<CanvasStrategy> = [
   absoluteMoveStrategy,
@@ -33,6 +34,7 @@ export const RegisteredCanvasStrategies: Array<CanvasStrategy> = [
   absoluteResizeBoundingBoxStrategy,
   flexReorderStrategy,
   escapeHatchStrategy,
+  absoluteReparentToFlexStrategy,
 ]
 
 export function pickCanvasStateFromEditorState(editorState: EditorState): InteractionCanvasState {

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -57,6 +57,7 @@ export type CanvasStrategyId =
   | 'KEYBOARD_ABSOLUTE_RESIZE'
   | 'ESCAPE_HATCH_STRATEGY'
   | 'FLEX_REORDER'
+  | 'ABSOLUTE_REPARENT_TO_FLEX'
 
 export interface CanvasStrategy {
   id: CanvasStrategyId // We'd need to do something to guarantee uniqueness here if using this for the commands' reason

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -121,7 +121,7 @@ export const flexReorderStrategy: CanvasStrategy = {
   },
 }
 
-function getReorderIndex(
+export function getReorderIndex(
   metadata: ElementInstanceMetadataMap,
   siblings: Array<ElementPath>,
   point: CanvasVector,

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -37,6 +37,7 @@ import {
 import { DuplicateElement, runDuplicateElement } from './duplicate-element-command'
 import { runUpdateFunctionCommand, UpdateFunctionCommand } from './update-function-command'
 import { runPushIntendedBounds, PushIntendedBounds } from './push-intended-bounds-command'
+import { DeleteProperties, runDeleteProperties } from './delete-properties-command'
 
 export interface CommandFunctionResult {
   editorStatePatches: Array<EditorStatePatch>
@@ -69,6 +70,7 @@ export type CanvasCommand =
   | SetCursorCommand
   | SetElementsToRerenderCommand
   | PushIntendedBounds
+  | DeleteProperties
 
 export const runCanvasCommand = (
   editorState: EditorState,
@@ -110,6 +112,8 @@ export const runCanvasCommand = (
       return runSetElementsToRerender(editorState, command)
     case 'PUSH_INTENDED_BOUNDS':
       return runPushIntendedBounds(editorState, command)
+    case 'DELETE_PROPERTIES':
+      return runDeleteProperties(editorState, command)
     default:
       const _exhaustiveCheck: never = command
       throw new Error(`Unhandled canvas command ${JSON.stringify(command)}`)

--- a/editor/src/components/canvas/commands/delete-properties-command.ts
+++ b/editor/src/components/canvas/commands/delete-properties-command.ts
@@ -1,0 +1,139 @@
+import { Spec } from 'immutability-helper'
+import { JSXElement } from '../../../core/shared/element-template'
+import {
+  ProjectContentFile,
+  getProjectContentKeyPathElements,
+  ProjectContentsTree,
+  ProjectContentTreeRoot,
+} from '../../../components/assets'
+import {
+  EditorState,
+  EditorStatePatch,
+  forUnderlyingTargetFromEditorState,
+  modifyUnderlyingForOpenFile,
+} from '../../../components/editor/store/editor-state'
+import { drop } from '../../../core/shared/array-utils'
+import { foldEither } from '../../../core/shared/either'
+import { unsetJSXValuesAtPaths } from '../../../core/shared/jsx-attributes'
+import { ElementPath, PropertyPath, RevisionsState } from '../../../core/shared/project-file-types'
+import { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+import * as EP from '../../../core/shared/element-path'
+import * as PP from '../../../core/shared/property-path'
+
+export interface DeleteProperties extends BaseCommand {
+  type: 'DELETE_PROPERTIES'
+  element: ElementPath
+  properties: Array<PropertyPath>
+}
+
+export function deleteProperties(
+  transient: TransientOrNot,
+  element: ElementPath,
+  properties: Array<PropertyPath>,
+): DeleteProperties {
+  return {
+    type: 'DELETE_PROPERTIES',
+    transient: transient,
+    element: element,
+    properties: properties,
+  }
+}
+
+export const runDeleteProperties: CommandFunction<DeleteProperties> = (
+  editorState: EditorState,
+  command: DeleteProperties,
+) => {
+  // Apply the update to the properties.
+  const { editorStatePatch: propertyUpdatePatch } = deleteValuesAtPath(
+    editorState,
+    command.element,
+    command.properties,
+  )
+
+  return {
+    editorStatePatches: [propertyUpdatePatch],
+    commandDescription: `Delete Properties ${command.properties
+      .map(PP.toString)
+      .join(',')} on ${EP.toUid(command.element)}`,
+  }
+}
+
+export function deleteValuesAtPath(
+  editorState: EditorState,
+  target: ElementPath,
+  properties: Array<PropertyPath>,
+): { editorStateWithChanges: EditorState; editorStatePatch: EditorStatePatch } {
+  let editorStatePatch: EditorStatePatch = {}
+
+  const workingEditorState = modifyUnderlyingForOpenFile(
+    target,
+    editorState,
+    (element: JSXElement) => {
+      return foldEither(
+        () => {
+          return element
+        },
+        (updatedProps) => {
+          return {
+            ...element,
+            props: updatedProps,
+          }
+        },
+        unsetJSXValuesAtPaths(element.props, properties),
+      )
+    },
+  )
+
+  forUnderlyingTargetFromEditorState(
+    target,
+    workingEditorState,
+    (success, underlyingElement, underlyingTarget, underlyingFilePath) => {
+      const projectContentFilePatch: Spec<ProjectContentFile> = {
+        content: {
+          fileContents: {
+            revisionsState: {
+              $set: RevisionsState.ParsedAhead,
+            },
+            parsed: {
+              topLevelElements: {
+                $set: success.topLevelElements,
+              },
+              imports: {
+                $set: success.imports,
+              },
+            },
+          },
+        },
+      }
+      // ProjectContentTreeRoot is a bit awkward to patch.
+      const pathElements = getProjectContentKeyPathElements(underlyingFilePath)
+      if (pathElements.length === 0) {
+        throw new Error('Invalid path length.')
+      }
+      const remainderPath = drop(1, pathElements)
+      const projectContentsTreePatch: Spec<ProjectContentsTree> = remainderPath.reduceRight(
+        (working: Spec<ProjectContentsTree>, pathPart: string) => {
+          return {
+            children: {
+              [pathPart]: working,
+            },
+          }
+        },
+        projectContentFilePatch,
+      )
+
+      // Finally patch the last part of the path in.
+      const projectContentTreeRootPatch: Spec<ProjectContentTreeRoot> = {
+        [pathElements[0]]: projectContentsTreePatch,
+      }
+
+      editorStatePatch = {
+        projectContents: projectContentTreeRootPatch,
+      }
+    },
+  )
+  return {
+    editorStateWithChanges: workingEditorState,
+    editorStatePatch: editorStatePatch,
+  }
+}

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -255,9 +255,9 @@ export function getAllTargetsAtPointAABB(
         )
   const elementsFromDOM = stripNulls(
     elementsUnderPoint.map((element) => {
-      const foundValidelementPath = findFirstParentWithValidElementPath(validPathsSet, element)
-      if (foundValidelementPath != null) {
-        return foundValidelementPath
+      const foundValidElementPath = findFirstParentWithValidElementPath(validPathsSet, element)
+      if (foundValidElementPath != null) {
+        return foundValidElementPath
       } else {
         return null
       }
@@ -266,10 +266,10 @@ export function getAllTargetsAtPointAABB(
 
   return getElementsUnderPointFromAABB
     .filter((foundElement) => {
-      if (!foundElement.canBeFilteredOut) {
-        return true
-      } else {
+      if (foundElement.canBeFilteredOut) {
         return elementsFromDOM.some((e) => EP.pathsEqual(e, foundElement.elementPath))
+      } else {
+        return true
       }
     })
     .map((e) => e.elementPath)

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -246,28 +246,19 @@ export function getAllTargetsAtPointAABB(
     allElementProps,
   )
 
-  const elementsUnderPoint = document.elementsFromPoint(point.x, point.y)
   const validPathsSet =
     validElementPathsForLookup == 'no-filter'
       ? 'no-filter'
       : new Set(
           validElementPathsForLookup.map((path) => EP.toString(EP.makeLastPartOfPathStatic(path))),
         )
-  const elementsFromDOM = stripNulls(
-    elementsUnderPoint.map((element) => {
-      const foundValidElementPath = findFirstParentWithValidElementPath(validPathsSet, element)
-      if (foundValidElementPath != null) {
-        return foundValidElementPath
-      } else {
-        return null
-      }
-    }),
-  )
 
   return getElementsUnderPointFromAABB
     .filter((foundElement) => {
       if (foundElement.canBeFilteredOut) {
-        return elementsFromDOM.some((e) => EP.pathsEqual(e, foundElement.elementPath))
+        return (
+          validPathsSet === 'no-filter' || validPathsSet.has(EP.toString(foundElement.elementPath))
+        )
       } else {
         return true
       }


### PR DESCRIPTION
**Problem:**
We want to be able to reparent from absolute layouts into a flex parent.

**Fix:**
This follows a combination of the reparent and the flex re-ordering strategies, by moving the element to the flex parent and then (if required) reordering it. Supporting both reordering into the flex elements _and_ a straight reparent into the flex container, the reparent logic attempts to identify if the pointer is hovering over a child of a flex container or a flex container itself.

**Commit Details:**
- Added `absoluteReparentToFlexStrategy` strategy.
- Added `DeleteProperties` canvas command for removing properties
  from a given element.
- Slight formatting tweaks in `dom-lookup.ts`.
- Exported `getReorderIndex`.
- Made `getAllTargetsAtPointAABB` immune to DOM changes.