### PR TITLE
More Distinct Scene Styling

### DIFF
--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas-bugs.spec.tsx.snap
@@ -16,6 +16,16 @@ exports[`UiJsxCanvas #747 - DOM object constructor cannot be called as a functio
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 375px;

--- a/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
+++ b/editor/src/components/canvas/__snapshots__/ui-jsx-canvas.spec.tsx.snap
@@ -16,6 +16,16 @@ exports[`UiJsxCanvas render Label carried through for generated elements 1`] = `
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -981,6 +991,16 @@ exports[`UiJsxCanvas render Label carried through for normal elements 1`] = `
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -1494,6 +1514,16 @@ exports[`UiJsxCanvas render Renders input tag without errors 1`] = `
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -1920,6 +1950,16 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -2956,6 +2996,16 @@ exports[`UiJsxCanvas render arbitrary jsx block inside an element inside an arbi
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -5887,6 +5937,16 @@ exports[`UiJsxCanvas render class component is available from arbitrary block in
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -6582,6 +6642,16 @@ exports[`UiJsxCanvas render console logging does not do anything bizarre 1`] = `
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -7080,6 +7150,16 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are not the ap
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -8156,6 +8236,16 @@ exports[`UiJsxCanvas render does not crash if the metadata scenes are undefined 
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -9232,6 +9322,16 @@ exports[`UiJsxCanvas render function component is available from arbitrary block
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -9927,6 +10027,16 @@ exports[`UiJsxCanvas render function component works inside a map 1`] = `
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -10655,6 +10765,16 @@ exports[`UiJsxCanvas render handles a component that destructures its props obje
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         height: 200px;
         left: 59px;
         width: 200px;
@@ -11521,6 +11641,16 @@ exports[`UiJsxCanvas render handles a component that renames its props object 1`
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         height: 200px;
         left: 59px;
         width: 200px;
@@ -12386,6 +12516,16 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         height: 200px;
         left: 59px;
         width: 200px;
@@ -13348,6 +13488,16 @@ exports[`UiJsxCanvas render handles a component with a props object written by s
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         height: 200px;
         left: 59px;
         width: 200px;
@@ -14310,6 +14460,16 @@ exports[`UiJsxCanvas render handles chaining dependencies into the appropriate o
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -14735,6 +14895,16 @@ exports[`UiJsxCanvas render handles fragments in an arbitrary block 1`] = `
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 375px;
@@ -20091,6 +20261,16 @@ exports[`UiJsxCanvas render props can be accessed inside the arbitrary js block 
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -20850,6 +21030,16 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a class 
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -21341,6 +21531,16 @@ exports[`UiJsxCanvas render refs are handled and triggered correctly in a functi
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -21896,6 +22096,16 @@ exports[`UiJsxCanvas render renderrs correctly when a component is passed in via
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 375px;
@@ -22653,6 +22863,16 @@ exports[`UiJsxCanvas render renders a 1st party component with uids correctly, u
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -23549,6 +23769,16 @@ exports[`UiJsxCanvas render renders a canvas defined by a utopia storyboard comp
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         height: 200px;
         left: 59px;
         width: 200px;
@@ -24300,6 +24530,16 @@ exports[`UiJsxCanvas render renders a canvas reliant on another file that uses m
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         height: 200px;
         left: 59px;
         width: 200px;
@@ -25196,6 +25436,16 @@ exports[`UiJsxCanvas render renders a canvas testing a multitude of export style
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         height: 600px;
         left: 0;
         width: 600px;
@@ -28397,6 +28647,16 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -29473,6 +29733,16 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block corre
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -30553,6 +30823,16 @@ exports[`UiJsxCanvas render renders a component used in an arbitrary block with 
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -31636,6 +31916,16 @@ exports[`UiJsxCanvas render renders a component using the spread operator 1`] = 
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         height: 200px;
         left: 59px;
         width: 200px;
@@ -32345,6 +32635,16 @@ exports[`UiJsxCanvas render renders a component with a fragment at the root 1`] 
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 406px;
         top: 62px;
         width: 212px;
@@ -32861,6 +33161,16 @@ exports[`UiJsxCanvas render renders correctly with a context 1`] = `
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 375px;
@@ -33478,6 +33788,16 @@ exports[`UiJsxCanvas render renders correctly with a nested context in another c
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 375px;
@@ -33860,6 +34180,16 @@ exports[`UiJsxCanvas render renders fine with a valid registerModule call 1`] = 
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         height: 200px;
         left: 59px;
         width: 200px;
@@ -34455,6 +34785,16 @@ exports[`UiJsxCanvas render renders fine with two circularly referencing arbitra
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 375px;
@@ -34999,6 +35339,16 @@ exports[`UiJsxCanvas render renders fine with two components that reference each
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 375px;
@@ -35393,6 +35743,16 @@ exports[`UiJsxCanvas render renders fragments correctly 1`] = `
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         height: 812px;
         left: 0;
         width: 375px;
@@ -36610,6 +36970,16 @@ exports[`UiJsxCanvas render renders img tag 1`] = `
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -37207,6 +37577,16 @@ exports[`UiJsxCanvas render respects a jsx pragma 1`] = `
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -37635,6 +38015,16 @@ exports[`UiJsxCanvas render supports passing down the scope to children of compo
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -39289,6 +39679,16 @@ exports[`UiJsxCanvas render the canvas supports emotion CSS prop 1`] = `
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;
@@ -39717,6 +40117,16 @@ exports[`UiJsxCanvas render the spy wrapper is compatible with React.cloneElemen
         position: absolute;
         background-color: rgba(255, 255, 255, 1);
         box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+        background-image: linear-gradient(
+            to bottom left,
+            #e7e7e7 25%,
+            transparent 25%
+          ),
+          linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+          linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+          linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+        background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+        background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
         left: 0;
         top: 0;
         width: 400px;

--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -9,7 +9,6 @@ import { useColorTheme } from '../../../../uuiui'
 import { clearHighlightedViews, selectComponents } from '../../../editor/actions/action-creators'
 import { useEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
-import { ControlFontSize } from '../../canvas-controls-frame'
 import { boundingArea, createInteractionViaMouse } from '../../canvas-strategies/interaction-state'
 import { windowToCanvasCoordinates } from '../../dom-lookup'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
@@ -74,16 +73,19 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
     'SceneLabel canvasOffset',
   )
   const scale = useEditorState((store) => store.editor.canvas.scale, 'SceneLabel scale')
-  const scaledFontSize = ControlFontSize / scale
-  const offsetY = -(scaledFontSize * 1.5)
-  const offsetX = 3 / scale
+  const baseFontSize = 9
+  const scaledFontSize = baseFontSize / scale
+  const paddingY = scaledFontSize / 9
+  const offsetY = scaledFontSize
+  const offsetX = scaledFontSize
+  const borderRadius = 3 / scale
 
   const isSelected = useEditorState(
     (store) => store.editor.selectedViews.some((view) => EP.pathsEqual(props.target, view)),
     'SceneLabel isSelected',
   )
   const isHighlighted = useEditorState(
-    (store) => store.editor.selectedViews.some((view) => EP.pathsEqual(props.target, view)),
+    (store) => store.editor.highlightedViews.some((view) => EP.pathsEqual(props.target, view)),
     'SceneLabel isHighlighted',
   )
 
@@ -141,6 +143,12 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
     [dispatch],
   )
 
+  const highlightColor = colorTheme.fg9.value
+  const selectedColor = colorTheme.verySubduedForeground.value
+  const backgroundColor = isSelected ? selectedColor : highlightColor
+  const boxShadowWidth = 1.5 / scale
+  const boxShadow = `0px 0px 0px ${boxShadowWidth}px ${backgroundColor}`
+
   if (frame != null) {
     return (
       <CanvasOffsetWrapper>
@@ -156,18 +164,21 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
             pointerEvents: labelSelectable ? 'initial' : 'none',
             color: colorTheme.subduedForeground.value,
             position: 'absolute',
-            fontWeight: 500,
-            left: frame.x + offsetX,
-            top: frame.y + offsetY,
-            maxWidth: frame.width,
-            paddingBottom: '0px',
+            fontWeight: 600,
+            left: frame.x,
+            bottom: -frame.y + offsetY,
+            width: frame.width,
+            paddingLeft: offsetX,
+            paddingBottom: paddingY,
             fontFamily:
               '-apple-system, BlinkMacSystemFont, Helvetica, "Segoe UI", Roboto,  Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
             fontSize: scaledFontSize,
             whiteSpace: 'nowrap',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
-            textDecoration: isSelected || isHighlighted ? 'underline' : undefined,
+            boxShadow: boxShadow,
+            borderRadius: borderRadius,
+            backgroundColor: backgroundColor,
           }}
         >
           {label}

--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -87,6 +87,16 @@ export var storyboard = (
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
               box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              background-image: linear-gradient(
+                  to bottom left,
+                  #e7e7e7 25%,
+                  transparent 25%
+                ),
+                linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+                linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+                linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+              background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+              background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
               left: 0;
               top: 0;
               width: 375px;
@@ -152,6 +162,16 @@ export default function App(props) {
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
               box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              background-image: linear-gradient(
+                  to bottom left,
+                  #e7e7e7 25%,
+                  transparent 25%
+                ),
+                linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+                linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+                linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+              background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+              background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
               left: 0;
               top: 0;
               width: 375px;
@@ -250,6 +270,16 @@ export default function App(props) {
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
               box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              background-image: linear-gradient(
+                  to bottom left,
+                  #e7e7e7 25%,
+                  transparent 25%
+                ),
+                linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+                linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+                linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+              background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+              background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
               left: 0;
               top: 0;
               width: 375px;
@@ -273,6 +303,16 @@ export default function App(props) {
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
               box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              background-image: linear-gradient(
+                  to bottom left,
+                  #e7e7e7 25%,
+                  transparent 25%
+                ),
+                linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+                linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+                linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+              background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+              background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
               left: 400px;
               top: 0;
               width: 375px;
@@ -406,6 +446,16 @@ export default function () {
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
               box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              background-image: linear-gradient(
+                  to bottom left,
+                  #e7e7e7 25%,
+                  transparent 25%
+                ),
+                linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+                linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+                linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+              background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+              background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
               left: 0;
               top: 0;
               width: 375px;

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/scene-component.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
 import fastDeepEquals from 'fast-deep-equal'
-import { useContextSelector } from 'use-context-selector'
 import { Scene, SceneProps } from 'utopia-api'
 import { useColorTheme, UtopiaStyles } from '../../../uuiui'
-import { RerenderUtopiaCtxAtom } from './ui-jsx-canvas-contexts'
-import { DomWalkerInvalidatePathsCtxAtom, UiJsxCanvasCtxAtom } from '../ui-jsx-canvas'
+import { DomWalkerInvalidatePathsCtxAtom } from '../ui-jsx-canvas'
 import { UTOPIA_SCENE_ID_KEY } from '../../../core/model/utopia-constants'
 import { AlwaysTrue, usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
 
@@ -27,6 +25,7 @@ export const SceneComponent = React.memo(
       boxShadow: canvasIsLive
         ? UtopiaStyles.scene.live.boxShadow
         : UtopiaStyles.scene.editing.boxShadow,
+      ...UtopiaStyles.backgrounds.checkerboardBackground,
       ...style,
     }
 

--- a/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.spec.tsx
@@ -1281,6 +1281,16 @@ export var ${BakedInStoryboardVariableName} = (props) => {
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
               box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              background-image: linear-gradient(
+                  to bottom left,
+                  #e7e7e7 25%,
+                  transparent 25%
+                ),
+                linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+                linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+                linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+              background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+              background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
               left: 0;
               top: 0;
               width: 400px;
@@ -1380,6 +1390,16 @@ export var ${BakedInStoryboardVariableName} = (props) => {
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
               box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              background-image: linear-gradient(
+                  to bottom left,
+                  #e7e7e7 25%,
+                  transparent 25%
+                ),
+                linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+                linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+                linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+              background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+              background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
               left: 0;
               top: 0;
               width: 400px;
@@ -1888,6 +1908,16 @@ describe('UiJsxCanvas render multifile projects', () => {
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
               box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              background-image: linear-gradient(
+                  to bottom left,
+                  #e7e7e7 25%,
+                  transparent 25%
+                ),
+                linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+                linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+                linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+              background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+              background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
               height: 200px;
               left: 59px;
               width: 200px;
@@ -1973,6 +2003,16 @@ describe('UiJsxCanvas render multifile projects', () => {
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
               box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              background-image: linear-gradient(
+                  to bottom left,
+                  #e7e7e7 25%,
+                  transparent 25%
+                ),
+                linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+                linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+                linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+              background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+              background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
               height: 200px;
               left: 59px;
               width: 200px;
@@ -2060,6 +2100,16 @@ describe('UiJsxCanvas render multifile projects', () => {
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
               box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              background-image: linear-gradient(
+                  to bottom left,
+                  #e7e7e7 25%,
+                  transparent 25%
+                ),
+                linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+                linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+                linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+              background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+              background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
               height: 200px;
               left: 59px;
               width: 200px;
@@ -2132,6 +2182,16 @@ describe('UiJsxCanvas render multifile projects', () => {
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
               box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              background-image: linear-gradient(
+                  to bottom left,
+                  #e7e7e7 25%,
+                  transparent 25%
+                ),
+                linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+                linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+                linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+              background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+              background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
               height: 200px;
               left: 59px;
               width: 200px;
@@ -2217,6 +2277,16 @@ describe('UiJsxCanvas render multifile projects', () => {
               position: absolute;
               background-color: rgba(255, 255, 255, 1);
               box-shadow: 0px 0px 1px 0px rgba(26, 26, 26, 0.3);
+              background-image: linear-gradient(
+                  to bottom left,
+                  #e7e7e7 25%,
+                  transparent 25%
+                ),
+                linear-gradient(to bottom left, transparent 75%, #e7e7e7 75%),
+                linear-gradient(to bottom right, #e7e7e7 25%, transparent 25%),
+                linear-gradient(to bottom right, transparent 75%, #e7e7e7 75%);
+              background-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px;
+              background-position: -9px 0px, -3px -6px, 3px 6px, -3px 0;
               left: 0;
               top: 0;
               width: 400px;

--- a/editor/src/components/inspector/common/inspector-utils.tsx
+++ b/editor/src/components/inspector/common/inspector-utils.tsx
@@ -172,19 +172,6 @@ export const useHandleCloseOnESCOrEnter = (closePopup: (key: 'Escape' | 'Enter')
   }, [handleCloseOnESCOrEnter])
 }
 
-export const checkerboardBackground: Pick<
-  React.CSSProperties,
-  'backgroundImage' | 'backgroundSize' | 'backgroundPosition'
-> = {
-  backgroundImage: `
-    linear-gradient(to bottom left,   #e7e7e7 25%,  transparent 25%),
-    linear-gradient(to bottom left,   transparent 75%,  #e7e7e7 75%),
-    linear-gradient(to bottom right,  #e7e7e7 25%,  transparent 25%),
-    linear-gradient(to bottom right,  transparent 75%,  #e7e7e7 75%)`,
-  backgroundSize: '12px 12px, 12px 12px, 12px 12px, 12px 12px',
-  backgroundPosition: '-9px 0px, -3px -6px, 3px 6px, -3px 0',
-}
-
 export function clampString(value: string, maxLength: number) {
   return value.length > maxLength ? `${value.substring(0, maxLength)}…` : value
 }

--- a/editor/src/components/inspector/controls/color-picker.tsx
+++ b/editor/src/components/inspector/controls/color-picker.tsx
@@ -10,13 +10,14 @@ import {
   isHSL,
   isKeyword,
 } from '../common/css-utils'
-import { checkerboardBackground } from '../common/inspector-utils'
 import { inspectorEdgePadding } from '../sections/style-section/background-subsection/background-picker'
 import { InspectorModal } from '../widgets/inspector-modal'
 import { StringControl } from './string-control'
 import React from 'react'
 //TODO: switch to functional component and make use of 'useColorTheme':
 import { colorTheme, SimpleNumberInput, SimplePercentInput, UtopiaStyles } from '../../../uuiui'
+
+const checkerboardBackground = UtopiaStyles.backgrounds.checkerboardBackground
 
 export interface ColorPickerProps extends ColorPickerInnerProps {
   closePopup: () => void

--- a/editor/src/components/inspector/sections/style-section/background-subsection/gradient-stop-editor.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/gradient-stop-editor.tsx
@@ -9,10 +9,7 @@ import {
   orderStops,
   printLinearGradientBackgroundLayer,
 } from '../../../common/css-utils'
-import {
-  checkerboardBackground,
-  OnSubmitValueAndUpdateLocalState,
-} from '../../../common/inspector-utils'
+import { OnSubmitValueAndUpdateLocalState } from '../../../common/inspector-utils'
 import { UseSubmitValueFactory } from '../../../common/property-path-hooks'
 import {
   GradientPickerWidth,
@@ -22,7 +19,9 @@ import {
 } from '../../../controls/color-picker'
 import { inspectorEdgePadding } from './background-picker'
 import { clampValue } from '../../../../../core/shared/math-utils'
-import { useColorTheme, FlexColumn, UtopiaTheme } from '../../../../../uuiui'
+import { useColorTheme, FlexColumn, UtopiaStyles } from '../../../../../uuiui'
+
+const checkerboardBackground = UtopiaStyles.backgrounds.checkerboardBackground
 
 interface GradientStopProps {
   stop: CSSGradientStop

--- a/editor/src/components/inspector/sections/style-section/background-subsection/picker-image-preview.tsx
+++ b/editor/src/components/inspector/sections/style-section/background-subsection/picker-image-preview.tsx
@@ -1,8 +1,16 @@
 import React from 'react'
-import { useColorTheme, FlexRow, Icn, UtopiaTheme, SimpleFlexRow } from '../../../../../uuiui'
+import {
+  useColorTheme,
+  FlexRow,
+  Icn,
+  UtopiaTheme,
+  SimpleFlexRow,
+  UtopiaStyles,
+} from '../../../../../uuiui'
 import { MetadataEditorModalPreviewHeight } from '../../../controls/color-picker'
 import { CSSURLFunctionBackgroundLayer } from '../../../common/css-utils'
-import { checkerboardBackground } from '../../../common/inspector-utils'
+
+const checkerboardBackground = UtopiaStyles.backgrounds.checkerboardBackground
 
 interface PickerImagePreviewProps {
   value: CSSURLFunctionBackgroundLayer

--- a/editor/src/uuiui/styles/theme.ts
+++ b/editor/src/uuiui/styles/theme.ts
@@ -472,9 +472,23 @@ const popup: React.CSSProperties = {
   borderRadius: 4,
 }
 
+const checkerboardBackground: Pick<
+  React.CSSProperties,
+  'backgroundImage' | 'backgroundSize' | 'backgroundPosition'
+> = {
+  backgroundImage: `
+    linear-gradient(to bottom left,   #e7e7e7 25%,  transparent 25%),
+    linear-gradient(to bottom left,   transparent 75%,  #e7e7e7 75%),
+    linear-gradient(to bottom right,  #e7e7e7 25%,  transparent 25%),
+    linear-gradient(to bottom right,  transparent 75%,  #e7e7e7 75%)`,
+  backgroundSize: '12px 12px, 12px 12px, 12px 12px, 12px 12px',
+  backgroundPosition: '-9px 0px, -3px -6px, 3px 6px, -3px 0',
+}
+
 export const UtopiaStyles = {
   backgrounds: {
     ...backgroundURLs,
+    checkerboardBackground,
   },
   noticeStyles,
   textNoticeStyles,


### PR DESCRIPTION
This PR is based on the previous spike from #2404, but with a header that scales, and slightly different styling.

To be precise, whereas the spike used lighter styling for the header (and made the canvas background lighter to accommodate that), this implementation uses a slightly darker styling. It also removes the highlighting effect from the scene's header (giving the header a background at all times), but still uses a darker background for selection.

<img width="886" alt="image" src="https://user-images.githubusercontent.com/1044774/180023395-4d88f5ae-fc92-402d-91fe-693d4d4884a0.png">

I've extracted the `checkerboardBackground` from the Inspector and moved it into `UtopiaStyles` (which also includes other backgrounds) so that it could be used by the `SceneComponent`. This change meant having to update a billion snapshots, hence the size of the PR.

**Note:**
There is no scaling applied to the checkerboard background when zooming, meaning the squares will grow when zooming, like so:

<img width="546" alt="image" src="https://user-images.githubusercontent.com/1044774/180025295-94dec634-bd3c-41d6-82ea-861fc053a2f5.png">

We can apply scaling if we want to, but it would probably require storing the scale in an atom as the `SceneComponent` doesn't (and arguably shouldn't) have access to the `EditorState`.