### PR TITLE
getReparentTargetAtPosition doesn't use WindowMousePosition anymore

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -47,7 +47,7 @@ function reparentElement(
 ): EditorState {
   const interactionSession: InteractionSession = {
     ...createMouseInteractionForTests(
-      null as any, // the strategy does not use this
+      canvasPoint({ x: 0, y: 0 }),
       { cmd: true, alt: false, shift: false, ctrl: false },
       null as any, // the strategy does not use this
       dragVector,

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -50,7 +50,7 @@ function dragByPixels(
 ): EditorState {
   const interactionSession: InteractionSession = {
     ...createMouseInteractionForTests(
-      null as any, // the strategy does not use this
+      canvasPoint({ x: 0, y: 0 }),
       modifiers,
       null as any, // the strategy does not use this
       vector,

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -44,7 +44,7 @@ function reparentElement(
 ): EditorState {
   const interactionSession: InteractionSession = {
     ...createMouseInteractionForTests(
-      null as any, // the strategy does not use this
+      canvasPoint({ x: 0, y: 0 }),
       { cmd: true, alt: false, shift: false, ctrl: false },
       null as any, // the strategy does not use this
       dragVector,

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -17,6 +17,7 @@ import {
   getDragTargets,
   getFileOfElement,
 } from './shared-absolute-move-strategy-helpers'
+import { offsetPoint } from '../../../core/shared/math-utils'
 
 export const absoluteReparentStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_REPARENT',
@@ -81,7 +82,12 @@ export const absoluteReparentStrategy: CanvasStrategy = {
       return emptyStrategyApplicationResult
     }
 
-    const { selectedElements, scale, canvasOffset, projectContents, openFile } = canvasState
+    const pointOnCanvas = offsetPoint(
+      interactionState.interactionData.dragStart,
+      interactionState.interactionData.drag,
+    )
+
+    const { selectedElements, projectContents, openFile } = canvasState
     const filteredSelectedElements = getDragTargets(selectedElements)
 
     const reparentResult = getReparentTarget(
@@ -89,8 +95,7 @@ export const absoluteReparentStrategy: CanvasStrategy = {
       filteredSelectedElements,
       strategyState.startingMetadata,
       [],
-      scale,
-      canvasOffset,
+      pointOnCanvas,
       projectContents,
       openFile,
       strategyState.startingAllElementProps,

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
@@ -38,13 +38,27 @@ function reparentTargetFromInteractionSession(
   newParent: ElementPath | null
   shouldReorder: boolean
 } {
+  if (
+    interactionSession.interactionData.type !== 'DRAG' ||
+    interactionSession.interactionData.drag == null
+  ) {
+    return {
+      shouldReparent: false,
+      newParent: null,
+      shouldReorder: false,
+    }
+  }
+
+  const pointOnCanvas = offsetPoint(
+    interactionSession.interactionData.originalDragStart,
+    interactionSession.interactionData.drag,
+  )
   const reparentResult = getReparentTarget(
     filteredSelectedElements,
     filteredSelectedElements,
     strategyState.startingMetadata,
     [],
-    canvasState.scale,
-    canvasState.canvasOffset,
+    pointOnCanvas,
     canvasState.projectContents,
     canvasState.openFile,
     strategyState.startingAllElementProps,

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -1890,8 +1890,7 @@ function getReparentTargetAtPosition(
   componentMeta: ElementInstanceMetadataMap,
   selectedViews: Array<ElementPath>,
   hiddenInstances: Array<ElementPath>,
-  canvasScale: number,
-  canvasOffset: CanvasVector,
+  pointOnCanvas: CanvasPoint,
   allElementProps: AllElementProps,
 ): ElementPath | undefined {
   const allTargets = getAllTargetsAtPointAABB(
@@ -1899,9 +1898,7 @@ function getReparentTargetAtPosition(
     selectedViews,
     hiddenInstances,
     'no-filter',
-    WindowMousePositionRaw,
-    canvasScale,
-    canvasOffset,
+    pointOnCanvas,
     allElementProps,
   )
   // filtering for non-selected views from alltargets
@@ -1922,8 +1919,7 @@ export function getReparentTargetFromState(
     toReparent,
     editorState.jsxMetadata,
     editorState.hiddenInstances,
-    editorState.canvas.scale,
-    editorState.canvas.realCanvasOffset,
+    position,
     editorState.projectContents,
     editorState.canvas.openFile?.filename,
     editorState.allElementProps,
@@ -1935,8 +1931,7 @@ export function getReparentTarget(
   toReparent: Array<ElementPath>,
   componentMeta: ElementInstanceMetadataMap,
   hiddenInstances: Array<ElementPath>,
-  canvasScale: number,
-  canvasOffset: CanvasVector,
+  pointOnCanvas: CanvasPoint,
   projectContents: ProjectContentTreeRoot,
   openFile: string | null | undefined,
   allElementProps: AllElementProps,
@@ -1948,8 +1943,7 @@ export function getReparentTarget(
     componentMeta,
     selectedViews,
     hiddenInstances,
-    canvasScale,
-    canvasOffset,
+    pointOnCanvas,
     allElementProps,
   )
 

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -3,6 +3,7 @@ import { getDOMAttribute } from '../../core/shared/dom-utils'
 import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import {
   boundingRectangleArray,
+  CanvasPoint,
   canvasPoint,
   CanvasVector,
   negate,
@@ -225,21 +226,19 @@ export function getAllTargetsAtPointAABB(
   selectedViews: Array<ElementPath>,
   hiddenInstances: Array<ElementPath>,
   validElementPathsForLookup: Array<ElementPath> | 'no-filter',
-  point: WindowPoint | null,
-  canvasScale: number,
-  canvasOffset: CanvasVector,
+  pointOnCanvas: CanvasPoint | null,
   allElementProps: AllElementProps,
 ): Array<ElementPath> {
-  if (point == null) {
+  if (pointOnCanvas == null) {
     return []
   }
 
-  const pointOnCanvas = windowToCanvasCoordinates(canvasScale, canvasOffset, point)
+  const canvasPositionRaw = pointOnCanvas
   const getElementsUnderPointFromAABB = Canvas.getAllTargetsAtPoint(
     componentMetadata,
     selectedViews,
     hiddenInstances,
-    pointOnCanvas.canvasPositionRaw,
+    canvasPositionRaw,
     [TargetSearchType.All],
     true,
     'loose',


### PR DESCRIPTION
**Problem:**
As I was debugging tests for #2420 I realized that deep in the reparent code we use the globally stored variable for the current mouse position. This is _incredibly_ bad, because it means the tests do not control this key parameter. This probably also led to some flaky tests, especially when running multiple tests in the same session.

**Fix:**
Just use a property instead.

**Commit Details:**
- Asking for `pointOnCanvas` instead of calculating the point from WindowMousePositionRaw + canvasScale + canvasOffset
- fixing absolute reparent strategy tests that broke because they didn't provide a dragStart value. these were the only tests that failed
