### PR TITLE
Spike: fragment support

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2852,7 +2852,7 @@ export function getValidElementPathsFromElement(
   transientFilesState: TransientFilesState | null,
   resolve: (importOrigin: string, toImport: string) => Either<string, string>,
 ): Array<ElementPath> {
-  if (isJSXElement(element)) {
+  if (isJSXElement(element) || isJSXFragment(element)) {
     const isScene = isSceneElement(element, filePath, projectContents)
     const uid = getUtopiaID(element)
     const path = parentIsInstance
@@ -2875,7 +2875,7 @@ export function getValidElementPathsFromElement(
       ),
     )
 
-    const name = getJSXElementNameAsString(element.name)
+    const name = isJSXElement(element) ? getJSXElementNameAsString(element.name) : 'Fragment'
     const lastElementPathPart = EP.lastElementPathForPath(path)
     const matchingFocusedPathPart =
       focusedElementPath == null || lastElementPathPart == null
@@ -2916,24 +2916,6 @@ export function getValidElementPathsFromElement(
     // }
     let paths: Array<ElementPath> = []
     fastForEach(Object.values(element.elementsWithin), (e) =>
-      paths.push(
-        ...getValidElementPathsFromElement(
-          focusedElementPath,
-          e,
-          parentPath,
-          projectContents,
-          filePath,
-          parentIsScene,
-          parentIsInstance,
-          transientFilesState,
-          resolve,
-        ),
-      ),
-    )
-    return paths
-  } else if (isJSXFragment(element)) {
-    let paths: Array<ElementPath> = []
-    fastForEach(Object.values(element.children), (e) =>
       paths.push(
         ...getValidElementPathsFromElement(
           focusedElementPath,

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -4,7 +4,6 @@ import { PropertyControls } from 'utopia-api/core'
 import { getUtopiaID } from '../../../core/model/element-template-utils'
 import {
   JSXElementChild,
-  isJSXFragment,
   isUtopiaJSXComponent,
   UtopiaJSXComponent,
 } from '../../../core/shared/element-template'
@@ -217,42 +216,38 @@ export function createComponentRendererComponent(params: {
     }
 
     function buildComponentRenderResult(element: JSXElementChild): React.ReactElement {
-      if (isJSXFragment(element)) {
-        return <>{element.children.map(buildComponentRenderResult)}</>
+      const ownElementPath = optionalMap(
+        (path) => EP.appendNewElementPath(path, getUtopiaID(element)),
+        instancePath,
+      )
+
+      const renderedCoreElement = renderCoreElement(
+        element,
+        ownElementPath,
+        mutableContext.rootScope,
+        scope,
+        realPassedProps,
+        mutableContext.requireResult,
+        hiddenInstances,
+        mutableContext.fileBlobs,
+        sceneContext.validPaths,
+        realPassedProps['data-uid'],
+        undefined,
+        metadataContext,
+        updateInvalidatedPaths,
+        mutableContext.jsxFactoryFunctionName,
+        codeError,
+        shouldIncludeCanvasRootInTheSpy,
+        params.filePath,
+        imports,
+        code,
+        highlightBounds,
+      )
+
+      if (typeof renderedCoreElement === 'string' || typeof renderedCoreElement === 'number') {
+        return <>{renderedCoreElement}</>
       } else {
-        const ownElementPath = optionalMap(
-          (path) => EP.appendNewElementPath(path, getUtopiaID(element)),
-          instancePath,
-        )
-
-        const renderedCoreElement = renderCoreElement(
-          element,
-          ownElementPath,
-          mutableContext.rootScope,
-          scope,
-          realPassedProps,
-          mutableContext.requireResult,
-          hiddenInstances,
-          mutableContext.fileBlobs,
-          sceneContext.validPaths,
-          realPassedProps['data-uid'],
-          undefined,
-          metadataContext,
-          updateInvalidatedPaths,
-          mutableContext.jsxFactoryFunctionName,
-          codeError,
-          shouldIncludeCanvasRootInTheSpy,
-          params.filePath,
-          imports,
-          code,
-          highlightBounds,
-        )
-
-        if (typeof renderedCoreElement === 'string' || typeof renderedCoreElement === 'number') {
-          return <>{renderedCoreElement}</>
-        } else {
-          return renderedCoreElement
-        }
+        return renderedCoreElement
       }
     }
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -272,7 +272,7 @@ export function renderCoreElement(
       let renderedChildren: Array<React.ReactChild> = []
       fastForEach(element.children, (child) => {
         const childPath = optionalMap(
-          (path) => EP.appendToPath(EP.parentPath(path), getUtopiaID(child)),
+          (path) => EP.appendToPath(path, getUtopiaID(child)),
           elementPath,
         )
         const renderResult = renderCoreElement(
@@ -299,7 +299,11 @@ export function renderCoreElement(
         )
         renderedChildren.push(renderResult)
       })
-      return <>{renderedChildren}</>
+      return (
+        <Fragment data-uid={element.uniqueID} data-path={elementPath}>
+          {renderedChildren}
+        </Fragment>
+      )
     }
     case 'JSX_TEXT_BLOCK': {
       return element.text
@@ -308,6 +312,10 @@ export function renderCoreElement(
       const _exhaustiveCheck: never = element
       throw new Error(`Unhandled type ${JSON.stringify(element)}`)
   }
+}
+
+export var Fragment: React.FunctionComponent<React.PropsWithChildren<any>> = ({ children }) => {
+  return <>{children}</>
 }
 
 function renderJSXElement(


### PR DESCRIPTION
This spike investigates whether it is possible to support fragments in the following way:

We define our own Fragment components, and use it in `renderCoreElement` to render fragments. This way we can provide an element paths for fragments.

Note: In this spike I just used the `JSXFragment.uniqueId` in the `path`, because it was already there. It is ugly though, because it is long id.

TODO:
[x] render the fragments with our own Fragment component in `renderCoreElement`
[x] make sure `renderCoreElement` actually runs for fragments :)
Note: after this all element paths include the fragment uids too in them, but the metadata does not contain the fragment and its subtree

[x] allow paths from the subtree under fragment to appear in `data-utopia-valid-paths` by modifying `getValidElementPaths`
Note:
- after this the metadata includes the subtree under the fragment, but not the fragment
- We can already see the fragment and the children in the navigator, but the fragment has the name `Element`

[ ] Fragment should be in the metadata: spy should run for the fragment too
[ ] navigator should work well for fragments (proper name, expanding, etc)

This way the fragment