### PR TITLE
Experiment: Explicitly set focus via an attribute 

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -57,6 +57,7 @@ import {
   findJSXElementChildAtPath,
   transformJSXComponentAtElementPath,
   isSceneElement,
+  getFocusedPropValue,
 } from '../../core/model/element-template-utils'
 import { generateUID } from '../../core/shared/uid-utils'
 import {
@@ -2876,7 +2877,11 @@ export function getValidElementPathsFromElement(
         ? null
         : EP.pathUpToElementPath(focusedElementPath, lastElementPathPart, 'static-path')
 
-    const isFocused = parentIsScene || matchingFocusedPathPart != null
+    const focusedPropValue = getFocusedPropValue(element)
+    const isExplicitlyFocused = focusedPropValue
+    const isImplicitlyFocused = parentIsScene && focusedPropValue === undefined
+
+    const isFocused = isExplicitlyFocused || isImplicitlyFocused || matchingFocusedPathPart != null
     if (isFocused) {
       paths.push(
         ...getValidElementPaths(

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4431,28 +4431,28 @@ export const UPDATE_FNS = {
     }
   },
   SET_FOCUSED_ELEMENT: (action: SetFocusedElement, editor: EditorModel): EditorModel => {
-    let shouldApplyChange: boolean = false
-    if (action.focusedElementPath == null) {
-      shouldApplyChange = true
-    } else if (MetadataUtils.isFocusableComponent(action.focusedElementPath, editor.jsxMetadata)) {
-      shouldApplyChange = true
-    }
-    if (EP.pathsEqual(editor.focusedElementPath, action.focusedElementPath)) {
-      shouldApplyChange = false
-    }
+    // let shouldApplyChange: boolean = false
+    // if (action.focusedElementPath == null) {
+    //   shouldApplyChange = true
+    // } else if (MetadataUtils.isFocusableComponent(action.focusedElementPath, editor.jsxMetadata)) {
+    //   shouldApplyChange = true
+    // }
+    // if (EP.pathsEqual(editor.focusedElementPath, action.focusedElementPath)) {
+    //   shouldApplyChange = false
+    // }
 
-    if (shouldApplyChange) {
-      return {
-        ...editor,
-        focusedElementPath: action.focusedElementPath,
-        canvas: {
-          ...editor.canvas,
-          domWalkerInvalidateCount: editor.canvas.domWalkerInvalidateCount + 1,
-        },
-      }
-    } else {
-      return editor
-    }
+    // if (shouldApplyChange) {
+    //   return {
+    //     ...editor,
+    //     focusedElementPath: action.focusedElementPath,
+    //     canvas: {
+    //       ...editor.canvas,
+    //       domWalkerInvalidateCount: editor.canvas.domWalkerInvalidateCount + 1,
+    //     },
+    //   }
+    // } else {
+    return editor
+    // }
   },
   SCROLL_TO_ELEMENT: (
     action: ScrollToElement,

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -9,6 +9,8 @@ import * as EP from '../../../core/shared/element-path'
 import * as PP from '../../../core/shared/property-path'
 import { useColorTheme, Button, Icons, SectionActionSheet } from '../../../uuiui'
 import { emptyComments, jsxAttributeValue } from '../../../core/shared/element-template'
+import { useEditorState } from '../../editor/store/store-hook'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 
 interface NavigatorHintProps {
   shouldBeShown: boolean
@@ -95,6 +97,7 @@ export const VisibilityIndicator: React.FunctionComponent<
 })
 
 interface FocusIndicatorProps {
+  canBeFocused: boolean
   explicitlyFocused: boolean | undefined
   selected: boolean
   onClick: () => void
@@ -102,6 +105,7 @@ interface FocusIndicatorProps {
 
 export const FocusIndicator: React.FunctionComponent<React.PropsWithChildren<FocusIndicatorProps>> =
   React.memo((props) => {
+    const shouldShow = props.canBeFocused || props.explicitlyFocused != undefined
     const color = props.selected ? 'on-highlight-main' : 'secondary'
 
     return (
@@ -111,6 +115,7 @@ export const FocusIndicator: React.FunctionComponent<React.PropsWithChildren<Foc
           marginRight: 4,
           height: 18,
           width: 18,
+          opacity: shouldShow ? 1 : 0,
         }}
       >
         {props.explicitlyFocused ? (
@@ -183,6 +188,13 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
     )
   }, [dispatch, props.explicitlyFocused, elementPath])
 
+  const canBeFocused = useEditorState(
+    (store) =>
+      !MetadataUtils.isProbablyScene(store.editor.jsxMetadata, elementPath) &&
+      MetadataUtils.isComponent(elementPath, store.editor.jsxMetadata),
+    'NavigatorItemActionSheet canBeFocused',
+  )
+
   return (
     <SectionActionSheet>
       <OriginalComponentNameLabel
@@ -198,6 +210,7 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
       />
       <FocusIndicator
         key={`focus-indicator-${EP.toVarSafeComponentId(elementPath)}`}
+        canBeFocused={canBeFocused}
         explicitlyFocused={props.explicitlyFocused}
         selected={props.selected}
         onClick={toggleFocused}

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -268,6 +268,10 @@ export const NavigatorItem: React.FunctionComponent<
     return MetadataUtils.isFocusableComponent(elementPath, store.editor.jsxMetadata)
   }, 'NavigatorItem isFocusable')
 
+  const explicitlyFocused = useEditorState((store) => {
+    return MetadataUtils.getExplicitFocusPropValue(elementPath, store.editor.jsxMetadata)
+  }, 'NavigatorItem explicitlyFocused')
+
   const childComponentCount = props.noOfChildren
 
   const isDynamic =
@@ -365,6 +369,7 @@ export const NavigatorItem: React.FunctionComponent<
         selected={selected}
         highlighted={isHighlighted}
         isVisibleOnCanvas={isElementVisible}
+        explicitlyFocused={explicitlyFocused}
         instanceOriginalComponentName={null}
         dispatch={dispatch}
       />

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1277,6 +1277,11 @@ export const MetadataUtils = {
       return this.findNearestAncestorFlexDirectionChange(elementMap, parentPath)
     }
   },
+  isComponent(path: ElementPath, metadata: ElementInstanceMetadataMap): boolean {
+    const element = MetadataUtils.findElementByElementPath(metadata, path)
+    const elementName = MetadataUtils.getJSXElementName(maybeEitherToMaybe(element?.element))
+    return elementName != null && !isIntrinsicElement(elementName)
+  },
   isFocusableComponentFromMetadata(element: ElementInstanceMetadata | null): boolean {
     const elementName = MetadataUtils.getJSXElementName(maybeEitherToMaybe(element?.element))
     if (element?.isEmotionOrStyledComponent) {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -60,6 +60,7 @@ import {
   ElementInstanceMetadataMap,
   isIntrinsicHTMLElement,
   getJSXAttribute,
+  isJSXAttributeValue,
 } from '../shared/element-template'
 import {
   getModifiableJSXAttributeAtPath,
@@ -1299,6 +1300,30 @@ export const MetadataUtils = {
   isFocusableComponent(path: ElementPath, metadata: ElementInstanceMetadataMap): boolean {
     const element = MetadataUtils.findElementByElementPath(metadata, path)
     return MetadataUtils.isFocusableComponentFromMetadata(element)
+  },
+  getExplicitFocusPropValue(
+    path: ElementPath,
+    metadata: ElementInstanceMetadataMap,
+  ): boolean | undefined {
+    const elementMetadata = MetadataUtils.findElementByElementPath(metadata, path)
+    if (elementMetadata == null) {
+      return undefined
+    } else {
+      return foldEither(
+        () => undefined,
+        (element) => {
+          if (isJSXElement(element)) {
+            const focusedProp = getJSXAttribute(element.props, 'data-focused')
+            if (focusedProp != null && isJSXAttributeValue(focusedProp)) {
+              return focusedProp.value
+            }
+          }
+
+          return undefined
+        },
+        elementMetadata.element,
+      )
+    }
   },
   isFocusableLeafComponent(path: ElementPath, metadata: ElementInstanceMetadataMap): boolean {
     return (

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -51,6 +51,17 @@ import {
 import { getStoryboardElementPath } from './scene-utils'
 import { TransientFilesState } from '../../components/editor/store/editor-state'
 
+export function getFocusedPropValue(element: JSXElementChild): boolean | undefined {
+  if (isJSXElement(element)) {
+    const focusedProp = getJSXAttribute(element.props, 'data-focused')
+    if (focusedProp != null && isJSXAttributeValue(focusedProp)) {
+      return focusedProp.value
+    }
+  }
+
+  return undefined
+}
+
 function getAllUniqueUidsInner(
   projectContents: ProjectContentTreeRoot,
   throwErrorWithSuspiciousActions?: string,


### PR DESCRIPTION
Explicitly enable or disable focus of an element via the attribute `data-focused`. The behaviour is as follows:
- `data-focused={true}` (or `data-focused`) - The element will be focused (though this will do nothing if it is inside a component that isn't focused)
- `data-focused={false}` - The element will not be focused (even if it is the child of a `Scene`)
- No attribute set - Fall back to the default behaviour, meaning it will only be focused if it is the child of a `Scene`.

I've disabled double clicking to set focus. To toggle the `data-focus` attribute here, click the new icon in the Navigator. The icon only shows for elements that can be focused (or elements that already have the attribute set). The icon can always be clicked, even if it isn't shown (I just wanted to see how that feels and how confusing it is).