### PR TITLE
Experiment/scenes toggle selection

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -172,8 +172,15 @@ export function getSelectableViews(
     const allRoots = MetadataUtils.getAllCanvasRootPaths(componentMetadata).filter((rootPath) => {
       return !rootElementsToFilter.some((path) => EP.pathsEqual(rootPath, path))
     })
+
+    // So we can support locking scenes
+    const lockedRoots = allRoots.filter((path) =>
+      lockedElements.some((lockedPath) => EP.pathsEqual(path, lockedPath)),
+    )
+    const pathsToIterate = [...selectedViews, ...lockedRoots]
+
     let siblings: Array<ElementPath> = []
-    Utils.fastForEach(selectedViews, (view) => {
+    Utils.fastForEach(pathsToIterate, (view) => {
       function addChildrenAndUnfurledFocusedComponents(paths: Array<ElementPath>) {
         Utils.fastForEach(paths, (ancestor) => {
           const { children, unfurledComponents } =

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -147,6 +147,7 @@ export function getSelectableViews(
   allElementsDirectlySelectable: boolean,
   childrenSelectable: boolean,
   allElementProps: AllElementProps,
+  lockedElements: Array<ElementPath>,
 ): ElementPath[] {
   let candidateViews: Array<ElementPath>
 
@@ -193,7 +194,8 @@ export function getSelectableViews(
     candidateViews = uniqueSelectableViews
   }
 
-  return filterHiddenInstances(hiddenInstances, candidateViews)
+  const nonSelectableElements = [...hiddenInstances, ...lockedElements]
+  return filterHiddenInstances(nonSelectableElements, candidateViews)
 }
 
 function useFindValidTarget(): (
@@ -410,12 +412,13 @@ export function useGetSelectableViewsForSelectMode() {
       hiddenInstances: store.editor.hiddenInstances,
       focusedElementPath: store.editor.focusedElementPath,
       allElementProps: store.editor.allElementProps,
+      lockedElements: store.editor.lockedElements,
     }
   })
 
   return React.useCallback(
     (allElementsDirectlySelectable: boolean, childrenSelectable: boolean) => {
-      const { componentMetadata, selectedViews, hiddenInstances, allElementProps } =
+      const { componentMetadata, selectedViews, hiddenInstances, allElementProps, lockedElements } =
         storeRef.current
       const selectableViews = getSelectableViews(
         componentMetadata,
@@ -424,6 +427,7 @@ export function useGetSelectableViewsForSelectMode() {
         allElementsDirectlySelectable,
         childrenSelectable,
         allElementProps,
+        lockedElements,
       )
       return selectableViews
     },

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -175,6 +175,10 @@ export type ToggleHidden = {
   action: 'TOGGLE_HIDDEN'
   targets: Array<ElementPath>
 }
+export type ToggleSelectionLock = {
+  action: 'TOGGLE_SELECTION_LOCK'
+  targets: Array<ElementPath>
+}
 
 export type UnsetProperty = {
   action: 'UNSET_PROPERTY'
@@ -1105,6 +1109,7 @@ export type EditorAction =
   | ForceParseFile
   | RunEscapeHatch
   | SetElementsToRerender
+  | ToggleSelectionLock
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -209,6 +209,7 @@ import type {
   RemoveFromNodeModulesContents,
   RunEscapeHatch,
   UpdateMouseButtonsPressed,
+  ToggleSelectionLock,
 } from '../action-types'
 import {
   EditorModes,
@@ -278,6 +279,12 @@ export function unsetProperty(element: ElementPath, property: PropertyPath): Uns
 export function toggleHidden(targets: Array<ElementPath> = []): ToggleHidden {
   return {
     action: 'TOGGLE_HIDDEN',
+    targets: targets,
+  }
+}
+export function toggleSelectionLock(targets: Array<ElementPath> = []): ToggleSelectionLock {
+  return {
+    action: 'TOGGLE_SELECTION_LOCK',
     targets: targets,
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -113,6 +113,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_DRAG_INTERACTION_DATA':
     case 'SET_USERS_PREFERRED_STRATEGY':
     case 'SET_ELEMENTS_TO_RERENDER':
+    case 'TOGGLE_SELECTION_LOCK':
       return true
 
     case 'NEW':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -374,6 +374,7 @@ import {
   RunEscapeHatch,
   SetElementsToRerender,
   UpdateMouseButtonsPressed,
+  ToggleSelectionLock,
 } from '../action-types'
 import { defaultTransparentViewElement, defaultSceneElement } from '../defaults'
 import {
@@ -940,6 +941,7 @@ function restoreEditorState(currentEditor: EditorModel, history: StateHistory): 
     highlightedViews: currentEditor.highlightedViews,
     hiddenInstances: poppedEditor.hiddenInstances,
     warnedInstances: poppedEditor.warnedInstances,
+    lockedElements: poppedEditor.lockedElements,
     mode: EditorModes.selectMode(),
     focusedPanel: currentEditor.focusedPanel,
     keysPressed: {},
@@ -4908,6 +4910,22 @@ export const UPDATE_FNS = {
   },
   SET_ELEMENTS_TO_RERENDER: (action: SetElementsToRerender, editor: EditorModel): EditorModel => {
     return foldAndApplyCommandsSimple(editor, [setElementsToRerenderCommand(action.value)])
+  },
+  TOGGLE_SELECTION_LOCK: (action: ToggleSelectionLock, editor: EditorModel): EditorModel => {
+    const targets = action.targets.length > 0 ? action.targets : editor.selectedViews
+    return targets.reduce((working, target) => {
+      if (working.lockedElements.some((element) => EP.pathsEqual(element, target))) {
+        return update(working, {
+          lockedElements: {
+            $set: working.lockedElements.filter((element) => !EP.pathsEqual(element, target)),
+          },
+        })
+      } else {
+        return update(working, {
+          lockedElements: { $set: working.lockedElements.concat(target) },
+        })
+      }
+    }, editor)
   },
 }
 

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -846,6 +846,7 @@ export interface EditorState {
   highlightedViews: Array<ElementPath>
   hiddenInstances: Array<ElementPath>
   warnedInstances: Array<ElementPath>
+  lockedElements: Array<ElementPath>
   mode: Mode
   focusedPanel: EditorPanel | null
   keysPressed: KeysPressed
@@ -911,6 +912,7 @@ export function editorState(
   highlightedViews: Array<ElementPath>,
   hiddenInstances: Array<ElementPath>,
   warnedInstances: Array<ElementPath>,
+  lockedElements: Array<ElementPath>,
   mode: Mode,
   focusedPanel: EditorPanel | null,
   keysPressed: KeysPressed,
@@ -975,6 +977,7 @@ export function editorState(
     highlightedViews: highlightedViews,
     hiddenInstances: hiddenInstances,
     warnedInstances: warnedInstances,
+    lockedElements: lockedElements,
     mode: mode,
     focusedPanel: focusedPanel,
     keysPressed: keysPressed,
@@ -1681,6 +1684,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     highlightedViews: [],
     hiddenInstances: [],
     warnedInstances: [],
+    lockedElements: [],
     mode: EditorModes.selectMode(),
     focusedPanel: 'canvas',
     keysPressed: {},
@@ -1971,6 +1975,7 @@ export function editorModelFromPersistentModel(
     highlightedViews: [],
     hiddenInstances: persistentModel.hiddenInstances,
     warnedInstances: [],
+    lockedElements: [],
     mode: EditorModes.selectMode(),
     focusedPanel: 'canvas',
     keysPressed: {},

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -344,6 +344,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.FORCE_PARSE_FILE(action, state)
     case 'RUN_ESCAPE_HATCH':
       return UPDATE_FNS.RUN_ESCAPE_HATCH(action, state)
+    case 'TOGGLE_SELECTION_LOCK':
+      return UPDATE_FNS.TOGGLE_SELECTION_LOCK(action, state)
     default:
       return state
   }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -2989,6 +2989,10 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     oldValue.warnedInstances,
     newValue.warnedInstances,
   )
+  const lockedElementsResult = ElementPathArrayKeepDeepEquality(
+    oldValue.lockedElements,
+    newValue.lockedElements,
+  )
   const modeResult = ModeKeepDeepEquality(oldValue.mode, newValue.mode)
   const focusedPanelResult = createCallWithTripleEquals<EditorPanel | null>()(
     oldValue.focusedPanel,
@@ -3146,6 +3150,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     highlightedViewsResult.areEqual &&
     hiddenInstancesResult.areEqual &&
     warnedInstancesResult.areEqual &&
+    lockedElementsResult.areEqual &&
     modeResult.areEqual &&
     focusedPanelResult.areEqual &&
     keysPressedResult.areEqual &&
@@ -3213,6 +3218,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       highlightedViewsResult.value,
       hiddenInstancesResult.value,
       warnedInstancesResult.value,
+      lockedElementsResult.value,
       modeResult.value,
       focusedPanelResult.value,
       keysPressedResult.value,


### PR DESCRIPTION
Experiment where canvas selection can be disabled for elements via the navigator.
It can be toggled with the lock icon on the right side of the navigator item. 

Children of locked elements can be selected with cmd + click.
