### PR TITLE
Reparent includes imports.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
@@ -1,0 +1,389 @@
+import {
+  EditorRenderResult,
+  formatTestProjectCode,
+  getPrintedUiJsCode,
+  renderTestEditorWithCode,
+  renderTestEditorWithProjectContent,
+  TestAppUID,
+  TestSceneUID,
+} from '../ui-jsx.test-utils'
+import { act, fireEvent } from '@testing-library/react'
+import { CanvasControlsContainerID } from '../controls/new-canvas-controls'
+import { offsetPoint, windowPoint, WindowPoint } from '../../../core/shared/math-utils'
+import { cmdModifier, Modifiers } from '../../../utils/modifiers'
+import { PrettierConfig } from 'utopia-vscode-common'
+import * as Prettier from 'prettier/standalone'
+import {
+  BakedInStoryboardVariableName,
+  BakedInStoryboardUID,
+} from '../../../core/model/scene-utils'
+import { wait } from '../../../core/model/performance-scripts'
+import {
+  contentsToTree,
+  getContentsTreeFileFromString,
+  ProjectContentTreeRoot,
+} from '../../../components/assets'
+import { codeFile, isTextFile } from '../../../core/shared/project-file-types'
+import { selectComponents, setFocusedElement } from '../../editor/actions/action-creators'
+import * as EP from '../../../core/shared/element-path'
+
+function dragElement(
+  renderResult: EditorRenderResult,
+  targetTestId: string,
+  dragDelta: WindowPoint,
+  modifiers: Modifiers,
+) {
+  const targetElement = renderResult.renderedDOM.getByTestId(targetTestId)
+  const targetElementBounds = targetElement.getBoundingClientRect()
+  const canvasControl = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+  const startPoint = windowPoint({
+    x: targetElementBounds.x + targetElementBounds.width / 2,
+    y: targetElementBounds.y + targetElementBounds.height / 2,
+  })
+  const endPoint = offsetPoint(startPoint, dragDelta)
+  fireEvent(
+    canvasControl,
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+      metaKey: true,
+      altKey: modifiers.alt,
+      shiftKey: modifiers.shift,
+      clientX: startPoint.x,
+      clientY: startPoint.y,
+      buttons: 1,
+    }),
+  )
+
+  fireEvent(
+    canvasControl,
+    new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+      metaKey: modifiers.cmd,
+      altKey: modifiers.alt,
+      shiftKey: modifiers.shift,
+      clientX: endPoint.x,
+      clientY: endPoint.y,
+      buttons: 1,
+    }),
+  )
+
+  fireEvent(
+    window,
+    new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+      metaKey: modifiers.cmd,
+      altKey: modifiers.alt,
+      shiftKey: modifiers.shift,
+      clientX: endPoint.x,
+      clientY: endPoint.y,
+    }),
+  )
+}
+
+const defaultAbsoluteChildCode = `
+export const AbsoluteChild = () => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 52,
+        top: 30,
+        width: 92,
+        height: 100,
+        borderWidth: 10,
+        borderColor: 'black',
+        borderStyle: 'solid',
+        backgroundColor: 'yellow',
+      }}
+      data-uid='absolutechild'
+      data-testid='absolutechild'
+    />
+  )
+}`
+
+const defaultAbsoluteParentCode = `
+import { AbsoluteChild } from './absolutechild'
+export const AbsoluteParent = () => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        width: 251,
+        height: 500,
+        left: 0,
+        top: 0,
+        backgroundColor: 'lightblue',
+      }}
+      data-uid='absoluteparent'
+      data-testid='absoluteparent'
+    >
+      <AbsoluteChild data-uid='absolutechildinparent' />
+    </div>
+  )
+}`
+
+const defaultAppCode = `
+import { AbsoluteParent } from './absoluteparent'
+import { FlexParent } from './flexparent'
+
+export var App = () => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        width: 700,
+        height: 600,
+        backgroundColor: 'white',
+      }}
+      data-uid='container'
+      data-testid='container'
+    >
+      <AbsoluteParent data-uid='absoluteparentinapp' />
+      <FlexParent data-uid='flexparentinapp' />
+    </div>
+  )
+}`
+
+const defaultFlexChildCode = `
+export const FlexChild1 = () => {
+  return (
+    <div
+      style={{
+        width: 100,
+        height: 100,
+        borderWidth: 10,
+        borderColor: 'black',
+        borderStyle: 'solid',
+        backgroundColor: 'teal',
+      }}
+      data-uid='flexchild1'
+      data-testid='flexchild1'
+    />
+  )
+}
+
+export const FlexChild2 = () => {
+  return (
+    <div
+      style={{
+        width: 100,
+        height: 100,
+        borderWidth: 10,
+        borderColor: 'black',
+        borderStyle: 'solid',
+        backgroundColor: 'red',
+      }}
+      data-uid='flexchild2'
+      data-testid='flexchild2'
+    />
+  )
+}`
+
+const defaultFlexParentCode = `
+import { FlexChild1, FlexChild2 } from './flexchild'
+export const FlexParent = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        position: 'absolute',
+        width: 250,
+        height: 500,
+        left: 350,
+        top: 0,
+        backgroundColor: 'lightgreen',
+      }}
+      data-uid='flexparent'
+      data-testid='flexparent'
+    >
+      <FlexChild1 data-uid='flexchild1inparent' />
+      <FlexChild2 data-uid='flexchild2inparent' />
+    </div>
+  )
+}`
+
+function makeTestProjectContents(): ProjectContentTreeRoot {
+  return contentsToTree({
+    ['/package.json']: codeFile(
+      `
+{
+  "name": "Utopia Project",
+  "version": "0.1.0",
+  "utopia": {
+    "main-ui": "utopia/storyboard.js",
+    "html": "public/index.html",
+    "js": "src/index.js"
+  },
+  "dependencies": {
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
+    "utopia-api": "0.4.1",
+    "react-spring": "8.0.27",
+    "@heroicons/react": "1.0.1",
+    "@emotion/react": "11.9.3"
+  }
+}`,
+      null,
+    ),
+    ['/src/absolutechild.js']: codeFile(defaultAbsoluteChildCode, null),
+    ['/src/absoluteparent.js']: codeFile(defaultAbsoluteParentCode, null),
+    ['/src/app.js']: codeFile(defaultAppCode, null),
+    ['/src/flexchild.js']: codeFile(defaultFlexChildCode, null),
+    ['/src/flexparent.js']: codeFile(defaultFlexParentCode, null),
+    ['/utopia/storyboard.js']: codeFile(
+      `
+import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+import { App } from '/src/app.js'
+
+export var storyboard = (
+  <Storyboard data-uid='storyboard'>
+    <Scene
+      style={{
+        width: 744,
+        height: 1133,
+        display: 'flex',
+        flexDirection: 'column',
+        left: -52,
+        top: 9,
+        position: 'absolute',
+      }}
+      data-label='Main Scene'
+      data-uid='mainscene'
+      data-testid='mainscene'
+    >
+      <App style={{}} data-uid='app' data-testid='app' />
+    </Scene>
+  </Storyboard>
+)`,
+      null,
+    ),
+  })
+}
+
+function getFileCode(renderResult: EditorRenderResult, filename: string): string {
+  const projectContents = renderResult.getEditorState().editor.projectContents
+  const possibleFile = getContentsTreeFileFromString(projectContents, filename)
+  if (possibleFile == null) {
+    throw new Error(`Could not find file ${filename}.`)
+  } else if (isTextFile(possibleFile)) {
+    return possibleFile.fileContents.code
+  } else {
+    throw new Error(`File ${filename} was an unexpected type: ${possibleFile.type}.`)
+  }
+}
+
+describe('Absolute Reparent Strategy (Multi-File)', () => {
+  beforeEach(() => {
+    viewport.set(2200, 1000)
+  })
+  it('reparents to the end', async () => {
+    const renderResult = await renderTestEditorWithProjectContent(
+      makeTestProjectContents(),
+      'await-first-dom-report',
+    )
+
+    await act(() => {
+      return renderResult.dispatch(
+        [
+          setFocusedElement(
+            EP.fromString('storyboard/mainscene/app:container/absoluteparentinapp'),
+          ),
+        ],
+        true,
+      )
+    })
+    await act(() => {
+      return renderResult.dispatch(
+        [
+          selectComponents(
+            [
+              EP.fromString(
+                'storyboard/mainscene/app:container/absoluteparentinapp:absoluteparent/absolutechildinparent',
+              ),
+            ],
+            false,
+          ),
+        ],
+        true,
+      )
+    })
+
+    const absoluteChild = await renderResult.renderedDOM.findByTestId('absolutechild')
+    const absoluteChildRect = absoluteChild.getBoundingClientRect()
+    const absoluteChildCenter = {
+      x: absoluteChildRect.x + absoluteChildRect.width / 2,
+      y: absoluteChildRect.y + absoluteChildRect.height / 2,
+    }
+    const flexParent = await renderResult.renderedDOM.findByTestId('flexparent')
+    const flexParentRect = flexParent.getBoundingClientRect()
+    const dropTargetPoint = {
+      x: flexParentRect.x - 10,
+      y: flexParentRect.y + 10,
+    }
+
+    const dragDelta = windowPoint({
+      x: dropTargetPoint.x - absoluteChildCenter.x,
+      y: dropTargetPoint.y - absoluteChildCenter.y,
+    })
+    act(() => dragElement(renderResult, 'absolutechild', dragDelta, cmdModifier))
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+    expect(getFileCode(renderResult, '/src/absolutechild.js')).toEqual(defaultAbsoluteChildCode)
+    expect(getFileCode(renderResult, '/src/absoluteparent.js')).toEqual(
+      `import { AbsoluteChild } from './absolutechild'
+export const AbsoluteParent = () => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        width: 251,
+        height: 500,
+        left: 0,
+        top: 0,
+        backgroundColor: 'lightblue',
+      }}
+      data-uid='absoluteparent'
+      data-testid='absoluteparent'
+    />
+  )
+}
+`,
+    )
+    expect(getFileCode(renderResult, '/src/app.js')).toEqual(
+      `import { AbsoluteParent } from './absoluteparent'
+import { FlexParent } from './flexparent'
+import { AbsoluteChild } from '/src/absolutechild.js'
+
+export var App = () => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        width: 700,
+        height: 600,
+        backgroundColor: 'white',
+      }}
+      data-uid='container'
+      data-testid='container'
+    >
+      <AbsoluteParent data-uid='absoluteparentinapp' />
+      <FlexParent data-uid='flexparentinapp' />
+      <AbsoluteChild
+        data-uid='absolutechildinparent'
+        style={{ left: 284, top: -50 }}
+      />
+    </div>
+  )
+}
+`,
+    )
+    expect(getFileCode(renderResult, '/src/flexchild.js')).toEqual(defaultFlexChildCode)
+    expect(getFileCode(renderResult, '/src/flexparent.js')).toEqual(defaultFlexParentCode)
+  })
+})

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -19,6 +19,7 @@ import {
 } from './shared-absolute-move-strategy-helpers'
 import { findReparentStrategy } from './reparent-strategy-helpers'
 import { offsetPoint } from '../../../core/shared/math-utils'
+import { getReparentCommands } from './reparent-utils'
 
 export const absoluteReparentStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_REPARENT',
@@ -88,7 +89,7 @@ export const absoluteReparentStrategy: CanvasStrategy = {
       interactionState.interactionData.drag,
     )
 
-    const { selectedElements, projectContents, openFile } = canvasState
+    const { selectedElements, projectContents, openFile, nodeModules } = canvasState
     const filteredSelectedElements = getDragTargets(selectedElements)
 
     const reparentResult = getReparentTarget(
@@ -124,7 +125,16 @@ export const absoluteReparentStrategy: CanvasStrategy = {
         const newPath = EP.appendToPath(newParent, EP.toUid(selectedElement))
         return {
           newPath: newPath,
-          commands: [...offsetCommands, reparentElement('permanent', selectedElement, newParent)],
+          commands: [
+            ...offsetCommands,
+            ...getReparentCommands(
+              projectContents,
+              nodeModules,
+              openFile,
+              selectedElement,
+              newParent,
+            ),
+          ],
         }
       })
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
@@ -28,6 +28,7 @@ import { CanvasCommand, foldAndApplyCommandsInner } from '../commands/commands'
 import { deleteProperties } from '../commands/delete-properties-command'
 import { updateSelectedViews } from '../commands/update-selected-views-command'
 import { findReparentStrategy, getReparentTargetForFlexElement } from './reparent-strategy-helpers'
+import { getReparentCommands } from './reparent-utils'
 
 const propertiesToRemove: Array<PropertyPath> = [
   PP.create(['style', 'position']),
@@ -123,12 +124,21 @@ export const absoluteReparentToFlexStrategy: CanvasStrategy = {
         const newParent = reparentResult.newParent
         // Reparent the element.
         const newPath = EP.appendToPath(reparentResult.newParent, EP.toUid(target))
-        const reparentCommand = reparentElement('permanent', target, reparentResult.newParent)
+        const reparentCommands = getReparentCommands(
+          canvasState.projectContents,
+          canvasState.nodeModules,
+          canvasState.openFile,
+          target,
+          reparentResult.newParent,
+        )
 
         // Strip the `position`, positional and dimension properties.
         const commandToRemoveProperties = deleteProperties('permanent', newPath, propertiesToRemove)
 
-        const commandsBeforeReorder = [reparentCommand, updateSelectedViews('permanent', [newPath])]
+        const commandsBeforeReorder = [
+          ...reparentCommands,
+          updateSelectedViews('permanent', [newPath]),
+        ]
 
         const commandsAfterReorder = [
           commandToRemoveProperties,

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -45,6 +45,7 @@ export function pickCanvasStateFromEditorState(editorState: EditorState): Intera
   return {
     selectedElements: editorState.selectedViews,
     projectContents: editorState.projectContents,
+    nodeModules: editorState.nodeModules.files,
     openFile: editorState.canvas.openFile?.filename,
     scale: editorState.canvas.scale,
     canvasOffset: editorState.canvas.roundedCanvasOffset,
@@ -65,13 +66,7 @@ function getApplicableStrategies(
 
 const getApplicableStrategiesSelector = createSelector(
   (store: EditorStorePatched): InteractionCanvasState => {
-    return {
-      selectedElements: store.editor.selectedViews,
-      projectContents: store.editor.projectContents,
-      openFile: store.editor.canvas.openFile?.filename,
-      scale: store.editor.canvas.scale,
-      canvasOffset: store.editor.canvas.roundedCanvasOffset,
-    }
+    return pickCanvasStateFromEditorState(store.editor)
   },
   (store: EditorStorePatched) => store.editor.canvas.interactionSession,
   (store: EditorStorePatched) => store.editor.jsxMetadata,

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -1,7 +1,7 @@
 import { AllElementProps } from 'src/components/editor/store/editor-state'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import { CanvasVector } from '../../../core/shared/math-utils'
-import { ElementPath } from '../../../core/shared/project-file-types'
+import { ElementPath, NodeModules } from '../../../core/shared/project-file-types'
 import { ProjectContentTreeRoot } from '../../assets'
 import { CanvasCommand } from '../commands/commands'
 import { InteractionSession, StrategyState } from './interaction-state'
@@ -43,6 +43,7 @@ export interface ControlWithKey {
 export interface InteractionCanvasState {
   selectedElements: Array<ElementPath>
   projectContents: ProjectContentTreeRoot
+  nodeModules: NodeModules
   openFile: string | null | undefined
   scale: number
   canvasOffset: CanvasVector

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -48,6 +48,7 @@ import {
   InteractionCanvasState,
 } from './canvas-strategy-types'
 import { DragInteractionData, InteractionSession, StrategyState } from './interaction-state'
+import { getReparentCommands } from './reparent-utils'
 import { areAllSelectedElementsNonAbsolute } from './shared-absolute-move-strategy-helpers'
 
 export const escapeHatchStrategy: CanvasStrategy = {
@@ -269,7 +270,15 @@ function collectSetLayoutPropCommands(
     )
     commands.push(...updatePinsCommands)
     if (shouldReparent) {
-      commands.push(reparentElement('permanent', path, targetParent))
+      commands.push(
+        ...getReparentCommands(
+          canvasState.projectContents,
+          canvasState.nodeModules,
+          canvasState.openFile,
+          path,
+          targetParent,
+        ),
+      )
     }
     return { commands: commands, intendedBounds: intendedBounds }
   } else {

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
@@ -15,6 +15,7 @@ import { DragOutlineControl } from '../controls/select-mode/drag-outline-control
 import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
 import { getReorderIndex } from './flex-reorder-strategy'
 import { findReparentStrategy, getReparentTargetForFlexElement } from './reparent-strategy-helpers'
+import { getReparentCommands } from './reparent-utils'
 import { getDragTargets } from './shared-absolute-move-strategy-helpers'
 
 export const flexReparentToFlexStrategy: CanvasStrategy = {
@@ -81,9 +82,18 @@ export const flexReparentToFlexStrategy: CanvasStrategy = {
         const newParent = reparentResult.newParent
         // Reparent the element.
         const newPath = EP.appendToPath(reparentResult.newParent, EP.toUid(target))
-        const reparentCommand = reparentElement('permanent', target, reparentResult.newParent)
+        const reparentCommands = getReparentCommands(
+          canvasState.projectContents,
+          canvasState.nodeModules,
+          canvasState.openFile,
+          target,
+          reparentResult.newParent,
+        )
 
-        const commandsBeforeReorder = [reparentCommand, updateSelectedViews('permanent', [newPath])]
+        const commandsBeforeReorder = [
+          ...reparentCommands,
+          updateSelectedViews('permanent', [newPath]),
+        ]
 
         const commandsAfterReorder = [
           setElementsToRerenderCommand([newPath]),

--- a/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
@@ -1,0 +1,118 @@
+import { ProjectContentTreeRoot } from '../../../components/assets'
+import {
+  addImport,
+  emptyImports,
+  mergeImports,
+} from '../../../core/workers/common/project-file-utils'
+import { withUnderlyingTarget } from '../../../components/editor/store/editor-state'
+import { ElementPath, Imports, NodeModules } from '../../../core/shared/project-file-types'
+import { CanvasCommand } from '../commands/commands'
+import { reparentElement } from '../commands/reparent-element-command'
+import {
+  isIntrinsicElement,
+  isJSXElement,
+  walkElement,
+} from '../../../core/shared/element-template'
+import * as EP from '../../../core/shared/element-path'
+import { getImportsFor, importedFromWhere } from '../../../components/editor/import-utils'
+import { forceNotNull } from '../../../core/shared/optional-utils'
+import { addImportsToFile } from '../commands/add-imports-to-file-command'
+
+export function getReparentCommands(
+  projectContents: ProjectContentTreeRoot,
+  nodeModules: NodeModules,
+  openFile: string | null | undefined,
+  selectedElement: ElementPath,
+  newParent: ElementPath,
+): Array<CanvasCommand> {
+  let result: Array<CanvasCommand> = []
+
+  const newTargetPath = forceNotNull(
+    `Unable to determine target path for ${EP.toString(newParent)}`,
+    withUnderlyingTarget(
+      newParent,
+      projectContents,
+      nodeModules,
+      openFile,
+      null,
+      (success, element, underlyingTarget, underlyingFilePath) => {
+        return underlyingFilePath
+      },
+    ),
+  )
+
+  // Determine what imports need to also be carried over to the new location.
+  const commandsToAddImports = withUnderlyingTarget<Array<CanvasCommand>>(
+    selectedElement,
+    projectContents,
+    nodeModules,
+    openFile,
+    [],
+    (success, element, underlyingTarget, underlyingFilePath) => {
+      const importsInOriginFile = success.imports
+      const topLevelElementsInOriginFile = success.topLevelElements
+      const lastPathPart =
+        EP.lastElementPathForPath(underlyingTarget) ?? EP.emptyStaticElementPathPart()
+
+      let importsToAdd: Imports = emptyImports()
+      // Walk down through the elements as elements within the element being reparented might also be imported.
+      walkElement(element, lastPathPart, 0, (elem, subPath, depth) => {
+        if (isJSXElement(elem)) {
+          // Straight up ignore intrinsic elements as they wont be imported.
+          if (!isIntrinsicElement(elem.name)) {
+            const importedFromResult = importedFromWhere(
+              underlyingFilePath,
+              elem.name.baseVariable,
+              topLevelElementsInOriginFile,
+              importsInOriginFile,
+            )
+
+            if (importedFromResult != null) {
+              switch (importedFromResult.type) {
+                case 'SAME_FILE_ORIGIN':
+                  importsToAdd = mergeImports(
+                    newTargetPath,
+                    importsToAdd,
+                    getImportsFor(
+                      importsInOriginFile,
+                      projectContents,
+                      nodeModules,
+                      underlyingFilePath,
+                      elem.name.baseVariable,
+                    ),
+                  )
+                  break
+                case 'IMPORTED_ORIGIN':
+                  if (importedFromResult.exportedName != null) {
+                    importsToAdd = mergeImports(
+                      newTargetPath,
+                      importsToAdd,
+                      getImportsFor(
+                        importsInOriginFile,
+                        projectContents,
+                        nodeModules,
+                        underlyingFilePath,
+                        importedFromResult.exportedName,
+                      ),
+                    )
+                  }
+                  break
+                default:
+                  const _exhaustiveCheck: never = importedFromResult
+                  throw new Error(
+                    `Unhandled imported from result ${JSON.stringify(importedFromResult)}`,
+                  )
+              }
+            }
+          }
+        }
+      })
+
+      return [addImportsToFile('permanent', newTargetPath, importsToAdd)]
+    },
+  )
+
+  result.push(reparentElement('permanent', selectedElement, newParent))
+  result.push(...commandsToAddImports)
+  return result
+}

--- a/editor/src/components/canvas/commands/add-imports-to-file-command.ts
+++ b/editor/src/components/canvas/commands/add-imports-to-file-command.ts
@@ -1,0 +1,92 @@
+import { mergeImports } from '../../../core/workers/common/project-file-utils'
+import {
+  EditorState,
+  modifyParseSuccessAtPath,
+  modifyUnderlyingForOpenFile,
+} from '../../../components/editor/store/editor-state'
+import {
+  Imports,
+  isParseSuccess,
+  isTextFile,
+  RevisionsState,
+  TextFile,
+} from '../../../core/shared/project-file-types'
+import { BaseCommand, TransientOrNot, CommandFunction, CommandFunctionResult } from './commands'
+import { Spec } from 'immutability-helper'
+import { ProjectContentTreeRoot } from '../../../components/assets'
+import { createProjectContentsPatch } from './patch-utils'
+
+export interface AddImportsToFile extends BaseCommand {
+  type: 'ADD_IMPORTS_TO_FILE'
+  targetFile: string
+  imports: Imports
+}
+
+export function addImportsToFile(
+  transient: TransientOrNot,
+  targetFile: string,
+  imports: Imports,
+): AddImportsToFile {
+  return {
+    type: 'ADD_IMPORTS_TO_FILE',
+    transient: transient,
+    targetFile: targetFile,
+    imports: imports,
+  }
+}
+
+export const runAddImportsToFile: CommandFunction<AddImportsToFile> = (
+  editorState: EditorState,
+  command: AddImportsToFile,
+): CommandFunctionResult => {
+  const updatedEditorState = modifyParseSuccessAtPath(
+    command.targetFile,
+    editorState,
+    (parseSuccess) => {
+      return {
+        ...parseSuccess,
+        imports: mergeImports(command.targetFile, parseSuccess.imports, command.imports),
+      }
+    },
+  )
+
+  const projectContentTreeRootPatch: Spec<ProjectContentTreeRoot> = createProjectContentsPatch(
+    command.targetFile,
+    editorState.projectContents,
+    (file) => {
+      if (isTextFile(file)) {
+        if (isParseSuccess(file.fileContents.parsed)) {
+          const updatedImports = mergeImports(
+            command.targetFile,
+            file.fileContents.parsed.imports,
+            command.imports,
+          )
+          const filePatch: Spec<TextFile> = {
+            fileContents: {
+              revisionsState: {
+                $set: RevisionsState.ParsedAhead,
+              },
+              parsed: {
+                imports: {
+                  $set: updatedImports,
+                },
+              },
+            },
+          }
+          return filePatch
+        }
+      }
+
+      return null
+    },
+  )
+
+  const editorStatePatch: Spec<EditorState> = {
+    projectContents: projectContentTreeRootPatch,
+  }
+
+  return {
+    editorStatePatches: [editorStatePatch],
+    commandDescription: `Added imports to ${command.targetFile}.`,
+  }
+}

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -38,6 +38,7 @@ import { DuplicateElement, runDuplicateElement } from './duplicate-element-comma
 import { runUpdateFunctionCommand, UpdateFunctionCommand } from './update-function-command'
 import { runPushIntendedBounds, PushIntendedBounds } from './push-intended-bounds-command'
 import { DeleteProperties, runDeleteProperties } from './delete-properties-command'
+import { AddImportsToFile, runAddImportsToFile } from './add-imports-to-file-command'
 
 export interface CommandFunctionResult {
   editorStatePatches: Array<EditorStatePatch>
@@ -71,6 +72,7 @@ export type CanvasCommand =
   | SetElementsToRerenderCommand
   | PushIntendedBounds
   | DeleteProperties
+  | AddImportsToFile
 
 export const runCanvasCommand = (
   editorState: EditorState,
@@ -114,6 +116,8 @@ export const runCanvasCommand = (
       return runPushIntendedBounds(editorState, command)
     case 'DELETE_PROPERTIES':
       return runDeleteProperties(editorState, command)
+    case 'ADD_IMPORTS_TO_FILE':
+      return runAddImportsToFile(editorState, command)
     default:
       const _exhaustiveCheck: never = command
       throw new Error(`Unhandled canvas command ${JSON.stringify(command)}`)

--- a/editor/src/components/canvas/commands/patch-utils.ts
+++ b/editor/src/components/canvas/commands/patch-utils.ts
@@ -1,0 +1,59 @@
+import { Spec } from 'immutability-helper'
+import { drop } from '../../../core/shared/array-utils'
+import {
+  getContentsTreeFileFromString,
+  getProjectContentKeyPathElements,
+  ProjectContentFile,
+  ProjectContentsTree,
+  ProjectContentTreeRoot,
+} from '../../../components/assets'
+import { isDirectory } from '../../../core/model/project-file-utils'
+
+export function createProjectContentsPatch(
+  target: string,
+  projectContents: ProjectContentTreeRoot,
+  createFilePatch: (
+    file: ProjectContentFile['content'],
+  ) => Spec<ProjectContentFile['content']> | null,
+): Spec<ProjectContentTreeRoot> {
+  const currentFile = getContentsTreeFileFromString(projectContents, target)
+  if (currentFile == null) {
+    return {}
+  } else {
+    if (isDirectory(currentFile)) {
+      return {}
+    } else {
+      const filePatch = createFilePatch(currentFile)
+      if (filePatch == null) {
+        return {}
+      } else {
+        const pathElements = getProjectContentKeyPathElements(target)
+        if (pathElements.length === 0) {
+          return {}
+        } else {
+          const remainderPath = drop(1, pathElements)
+          const contentsTreePatch: Spec<ProjectContentsTree> = {
+            content: filePatch,
+          }
+          const projectContentsTreePatch: Spec<ProjectContentsTree> = remainderPath.reduceRight(
+            (working: Spec<ProjectContentsTree>, pathPart: string) => {
+              return {
+                children: {
+                  [pathPart]: working,
+                },
+              }
+            },
+            contentsTreePatch,
+          )
+
+          // Finally patch the last part of the path in.
+          const projectContentTreeRootPatch: Spec<ProjectContentTreeRoot> = {
+            [pathElements[0]]: projectContentsTreePatch,
+          }
+          return projectContentTreeRootPatch
+        }
+      }
+    }
+  }
+  return {}
+}

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -83,6 +83,7 @@ import {
   saveDOMReport,
   setPanelVisibility,
   switchEditorMode,
+  updateNodeModulesContents,
 } from '../editor/actions/action-creators'
 import { EditorModes } from '../editor/editor-modes'
 import { useUpdateOnRuntimeErrors } from '../../core/shared/runtime-report-logs'
@@ -102,6 +103,7 @@ import {
 } from './dom-walker'
 import { flushSync } from 'react-dom'
 import { shouldInspectorUpdate } from '../inspector/inspector'
+import { SampleNodeModules } from '../custom-code/code-file.test-utils'
 
 // eslint-disable-next-line no-unused-expressions
 typeof process !== 'undefined' &&
@@ -359,6 +361,10 @@ export async function renderTestEditorWithModel(
       undefined,
       true,
     )
+  })
+
+  await act(async () => {
+    await asyncTestDispatch([updateNodeModulesContents(SampleNodeModules)], undefined, true)
   })
 
   return {

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -991,3 +991,7 @@ export function getOrderedPathsByDepth(elementPaths: Array<ElementPath>): Array<
     return depth(b) - depth(a)
   })
 }
+
+export function emptyStaticElementPathPart(): StaticElementPathPart {
+  return [] as unknown as StaticElementPathPart
+}

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1728,7 +1728,7 @@ export function walkElements(
   topLevelElements: Array<TopLevelElement>,
   forEach: (element: JSXElementChild, path: StaticElementPathPart) => void,
 ): void {
-  const emptyPath = [] as any as StaticElementPathPart // Oh my word
+  const emptyPath = EP.emptyStaticElementPathPart()
   fastForEach(topLevelElements, (rootComponent) => {
     if (isUtopiaJSXComponent(rootComponent)) {
       walkElement(rootComponent.rootElement, emptyPath, 0, forEach)


### PR DESCRIPTION
**Problem:**
Currently if an element is moved to a different file, it can potentially end up failing to render because a required import for the element is not in the file the element ends up in. Which terminates the reparenting interaction at that instant.

**Fix:**
The fix for the above issue is in essence pretty simple, which is to enumerate the imports used by the element being reparented and anything within it. Those imports are adjusted to use absolute paths and then added to the file being reparented into.

**Limitations:**
If a component is not exported and local to a file, but is used in an instance that gets moved, then currently this will still fail. Potentially a solution here is to make it exported, but this should be done in later work.

**Commit Details:**
- Added utility function `emptyStaticElementPathPart` to replace some inline type
  casting of empty arrays.
- Implemented `getImportsFor` which can produce an `Imports` value from
  an existing set of imports, to satisfy importing a particular value.
- Created `createProjectContentsPatch` to handle the difficulty of constructing
  a patch for the `ProjectContentsTreeRoot` type.
- Added a new canvas command of `AddImportsToFile`.
- Added `getReparentCommands` which includes the existing `ReparentElement` command
  as well as for adding imports via the `AddImportsToFile` command.
- Included a value of type `NodeModules` in `InteractionCanvasState` so that it
  can be included alongside `ProjectContentsTreeRoot` as a few functions require
  both.
- Incorporated `getReparentCommands` in various strategies which previously
  just created a `ReparentElement` command.
