### PR TITLE
Correctly handle which intrinsics support children.

### DIFF
--- a/editor/src/core/model/element-metadata-utils.spec.ts
+++ b/editor/src/core/model/element-metadata-utils.spec.ts
@@ -317,30 +317,55 @@ describe('targetElementSupportsChildren', () => {
     }
   }
 
-  it('Returns true for a utopia-api View', () => {
+  it('returns true for a utopia-api View', () => {
     const element = dummyInstanceDataForElementType('View')
     const actualResult = MetadataUtils.targetElementSupportsChildren(element)
-    expect(actualResult).toBeTruthy()
+    expect(actualResult).toEqual(true)
   })
-  it('Returns true for a button', () => {
+  it('returns true for an unparsed button', () => {
     const element = dummyInstanceDataForElementType('button')
     const actualResult = MetadataUtils.targetElementSupportsChildren(element)
-    expect(actualResult).toBeTruthy()
+    expect(actualResult).toEqual(true)
   })
-  it('Returns true for a div', () => {
+  it('returns true for a parsed button', () => {
+    const element = dummyInstanceDataForElementType(jsxElementName('button', []))
+    const actualResult = MetadataUtils.targetElementSupportsChildren(element)
+    expect(actualResult).toEqual(true)
+  })
+  it('returns true for an unparsed div', () => {
     const element = dummyInstanceDataForElementType('div')
     const actualResult = MetadataUtils.targetElementSupportsChildren(element)
-    expect(actualResult).toBeTruthy()
+    expect(actualResult).toEqual(true)
   })
-  it('Returns true for a span', () => {
+  it('returns true for a parsed div', () => {
+    const element = dummyInstanceDataForElementType(jsxElementName('div', []))
+    const actualResult = MetadataUtils.targetElementSupportsChildren(element)
+    expect(actualResult).toEqual(true)
+  })
+  it('returns true for an unparsed span', () => {
     const element = dummyInstanceDataForElementType('span')
     const actualResult = MetadataUtils.targetElementSupportsChildren(element)
-    expect(actualResult).toBeTruthy()
+    expect(actualResult).toEqual(true)
   })
-  it('Returns true for an animated.div', () => {
+  it('returns true for a parsed span', () => {
+    const element = dummyInstanceDataForElementType(jsxElementName('span', []))
+    const actualResult = MetadataUtils.targetElementSupportsChildren(element)
+    expect(actualResult).toEqual(true)
+  })
+  it('returns true for an animated.div', () => {
     const element = dummyInstanceDataForElementType(jsxElementName('animated', ['div']))
     const actualResult = MetadataUtils.targetElementSupportsChildren(element)
-    expect(actualResult).toBeTruthy()
+    expect(actualResult).toEqual(true)
+  })
+  it('returns false for an unparsed img', () => {
+    const element = dummyInstanceDataForElementType('img')
+    const actualResult = MetadataUtils.targetElementSupportsChildren(element)
+    expect(actualResult).toEqual(false)
+  })
+  it('returns false for a parsed img', () => {
+    const element = dummyInstanceDataForElementType(jsxElementName('img', []))
+    const actualResult = MetadataUtils.targetElementSupportsChildren(element)
+    expect(actualResult).toEqual(false)
   })
 })
 

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -623,25 +623,26 @@ export const MetadataUtils = {
     }
   },
   targetElementSupportsChildren(instance: ElementInstanceMetadata): boolean {
-    // FIXME Replace with a property controls check
-    const elementEither = instance.element
-
-    if (isLeft(elementEither)) {
-      return intrinsicHTMLElementNamesThatSupportChildren.includes(elementEither.value)
-    } else {
-      const element = elementEither.value
-      if (isJSXElement(element) && isUtopiaAPIComponentFromMetadata(instance)) {
-        // Explicitly prevent components / elements that we *know* don't support children
-        return (
-          isViewLikeFromMetadata(instance) ||
-          isSceneFromMetadata(instance) ||
-          isGivenUtopiaElementFromMetadata(instance, 'Text')
-        )
-      } else {
+    return foldEither(
+      (elementString) => intrinsicHTMLElementNamesThatSupportChildren.includes(elementString),
+      (element) => {
+        if (isJSXElement(element)) {
+          if (isIntrinsicElement(element.name)) {
+            return intrinsicHTMLElementNamesThatSupportChildren.includes(element.name.baseVariable)
+          } else if (isUtopiaAPIComponentFromMetadata(instance)) {
+            // Explicitly prevent components / elements that we *know* don't support children
+            return (
+              isViewLikeFromMetadata(instance) ||
+              isSceneFromMetadata(instance) ||
+              isGivenUtopiaElementFromMetadata(instance, 'Text')
+            )
+          }
+        }
         // We don't know at this stage
         return true
-      }
-    }
+      },
+      instance.element,
+    )
   },
   targetSupportsChildren(metadata: ElementInstanceMetadataMap, target: ElementPath): boolean {
     const instance = MetadataUtils.findElementByElementPath(metadata, target)

--- a/editor/src/core/shared/dom-utils.ts
+++ b/editor/src/core/shared/dom-utils.ts
@@ -200,6 +200,7 @@ export const intrinsicHTMLElementNamesThatSupportChildren: Array<string> = [
   'menu',
   'nav',
   'section',
+  'span',
 ]
 
 export function getDOMAttribute(element: Element, attributeName: string): string | null {


### PR DESCRIPTION
**Problem:**
Elements like `img` can be inserted into in the editor which is not correct and causes the content to not show with an error in it's place.

**Fix:**
Prevent the parsed as well as unparsed variants of intrinsic elements that don't support children from being treated as if they can have children.

**Commit Details:**
- In `targetElementSupportsChildren` expand the checking of intrinsic elements
  to parsed HTML elements.
- Added `span` to intrinsincHTMLElementNamesThatSupportChildren`.
- Expanded the tests covering `targetElementSupportsChildren` to include
  parsed as well as unparsed elements.