### PR TITLE
Experiment/scenes props style

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -28,6 +28,7 @@ import {
   getMultiselectBounds,
   snapDrag,
 } from './shared-absolute-move-strategy-helpers'
+import { AddStyleToRootDiv, addStyleToRootDiv } from '../commands/add-style-to-root-div'
 
 export const absoluteMoveStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_MOVE',
@@ -76,11 +77,11 @@ export const absoluteMoveStrategy: CanvasStrategy = {
       const getAdjustMoveCommands = (
         snappedDragVector: CanvasPoint,
       ): {
-        commands: Array<AdjustCssLengthProperty>
+        commands: Array<CanvasCommand>
         intendedBounds: Array<CanvasFrameAndTarget>
       } => {
         const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
-        let commands: Array<AdjustCssLengthProperty> = []
+        let commands: Array<CanvasCommand> = []
         let intendedBounds: Array<CanvasFrameAndTarget> = []
         filteredSelectedElements.forEach((selectedElement) => {
           const elementResult = getAbsoluteMoveCommandsForSelectedElement(
@@ -90,6 +91,7 @@ export const absoluteMoveStrategy: CanvasStrategy = {
             sessionState,
           )
           commands.push(...elementResult.commands)
+          commands.push(addStyleToRootDiv('permanent', selectedElement))
           intendedBounds.push(...elementResult.intendedBounds)
         })
         return { commands, intendedBounds }

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -42,8 +42,9 @@ export const absoluteMoveStrategy: CanvasStrategy = {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
         const elementProps = allElementProps[EP.toString(element)] ?? null
 
+        const isFocusedComponent = EP.pathsEqual(element, canvasState.focusedElement)
         return (
-          elementProps?.style?.position === 'absolute' ||
+          (elementProps?.style?.position === 'absolute' && isFocusedComponent) ||
           elementMetadata?.specialSizeMeasurements.position === 'absolute'
         )
       })

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -53,9 +53,9 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
       return filteredSelectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
         const elementProps = allElementProps[EP.toString(element)] ?? null
-
+        const isFocusedComponent = EP.pathsEqual(element, canvasState.focusedElement)
         return (
-          elementProps?.style?.position === 'absolute' ||
+          (elementProps?.style?.position === 'absolute' && isFocusedComponent) ||
           elementMetadata?.specialSizeMeasurements.position === 'absolute'
         )
       })

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -48,6 +48,7 @@ export function pickCanvasStateFromEditorState(editorState: EditorState): Intera
     openFile: editorState.canvas.openFile?.filename,
     scale: editorState.canvas.scale,
     canvasOffset: editorState.canvas.roundedCanvasOffset,
+    focusedElement: editorState.focusedElementPath,
   }
 }
 
@@ -71,6 +72,7 @@ const getApplicableStrategiesSelector = createSelector(
       openFile: store.editor.canvas.openFile?.filename,
       scale: store.editor.canvas.scale,
       canvasOffset: store.editor.canvas.roundedCanvasOffset,
+      focusedElement: store.editor.focusedElementPath,
     }
   },
   (store: EditorStorePatched) => store.editor.canvas.interactionSession,

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -46,6 +46,7 @@ export interface InteractionCanvasState {
   openFile: string | null | undefined
   scale: number
   canvasOffset: CanvasVector
+  focusedElement: ElementPath | null
 }
 
 export type CanvasStrategyId =

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -29,6 +29,7 @@ import { getElementFromProjectContents } from '../../editor/store/editor-state'
 import { FullFrame, getFullFrame } from '../../frame'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { CanvasFrameAndTarget, CSSCursor } from '../canvas-types'
+import { addStyleToRootDiv, runAddStyleToRootDiv } from '../commands/add-style-to-root-div'
 import { CanvasCommand } from '../commands/commands'
 import { ConvertToAbsolute, convertToAbsolute } from '../commands/convert-to-absolute-command'
 import { ReparentElement, reparentElement } from '../commands/reparent-element-command'
@@ -48,7 +49,10 @@ import {
   InteractionCanvasState,
 } from './canvas-strategy-types'
 import { DragInteractionData, InteractionSession, StrategyState } from './interaction-state'
-import { areAllSelectedElementsNonAbsolute } from './shared-absolute-move-strategy-helpers'
+import {
+  areAllSelectedElementsNonAbsolute,
+  rootDivStyleCommand,
+} from './shared-absolute-move-strategy-helpers'
 
 export const escapeHatchStrategy: CanvasStrategy = {
   id: 'ESCAPE_HATCH_STRATEGY',
@@ -208,7 +212,9 @@ function collectMoveCommandsForSelectedElements(
     canvasState,
   )
   commands.push(...descendantsInNewContainingBlock)
-
+  selectedElements.map((selected) => {
+    return commands.push(...rootDivStyleCommand(selected, canvasState.focusedElement, metadata))
+  })
   sortedElements.forEach((path) => {
     const elementResult = collectSetLayoutPropCommands(
       path,

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-move-strategy-helpers.ts
@@ -31,10 +31,12 @@ import {
 } from '../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
 import { CanvasFrameAndTarget } from '../canvas-types'
+import { addStyleToRootDiv } from '../commands/add-style-to-root-div'
 import {
   adjustCssLengthProperty,
   AdjustCssLengthProperty,
 } from '../commands/adjust-css-length-command'
+import { CanvasCommand } from '../commands/commands'
 import { runLegacyAbsoluteMoveSnapping } from '../controls/guideline-helpers'
 import { ConstrainedDragAxis, GuidelineWithSnappingVector } from '../guideline'
 import { AbsolutePin } from './absolute-resize-helpers'
@@ -338,5 +340,25 @@ export function areAllSelectedElementsNonAbsolute(
     })
   } else {
     return false
+  }
+}
+
+export function rootDivStyleCommand(
+  target: ElementPath,
+  focusedElementPath: ElementPath | null,
+  jsxMetadata: ElementInstanceMetadataMap,
+): CanvasCommand[] {
+  const isComponentOrScene =
+    EP.pathsEqual(target, focusedElementPath) || MetadataUtils.isProbablyScene(jsxMetadata, target)
+  const targetRoot = isComponentOrScene
+    ? Object.values(jsxMetadata).filter((possibleRoot) =>
+        EP.isRootElementOf(possibleRoot.elementPath, target),
+      )
+    : []
+
+  if (targetRoot.length > 0) {
+    return [addStyleToRootDiv('permanent', targetRoot[0].elementPath)]
+  } else {
+    return []
   }
 }

--- a/editor/src/components/canvas/commands/add-style-to-root-div.ts
+++ b/editor/src/components/canvas/commands/add-style-to-root-div.ts
@@ -1,0 +1,85 @@
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import * as EP from '../../../core/shared/element-path'
+import {
+  emptyComments,
+  jsxAttributeNestedObject,
+  jsxAttributeOtherJavaScript,
+  jsxSpreadAssignment,
+} from '../../../core/shared/element-template'
+import { ValueAtPath } from '../../../core/shared/jsx-attributes'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import * as PP from '../../../core/shared/property-path'
+import { jsxAttributeArbitrary } from '../../../core/workers/parser-printer/parser-printer.test-utils'
+import { EditorState } from '../../editor/store/editor-state'
+import { stylePropPathMappingFn } from '../../inspector/common/property-path-hooks'
+import { applyValuesAtPath } from './adjust-number-command'
+import { BaseCommand, CommandFunction, TransientOrNot } from './commands'
+
+export interface AddStyleToRootDiv extends BaseCommand {
+  type: 'ADD_STYLE_TO_ROOT_DIV'
+  target: ElementPath
+}
+
+export function addStyleToRootDiv(
+  transient: TransientOrNot,
+  target: ElementPath,
+): AddStyleToRootDiv {
+  return {
+    type: 'ADD_STYLE_TO_ROOT_DIV',
+    transient: transient,
+    target: target,
+  }
+}
+
+export const runAddStyleToRootDiv: CommandFunction<AddStyleToRootDiv> = (
+  editorState: EditorState,
+  command: AddStyleToRootDiv,
+) => {
+  const isComponentOrScene =
+    EP.pathsEqual(command.target, editorState.focusedElementPath) ||
+    MetadataUtils.isProbablyScene(editorState.jsxMetadata, command.target)
+  const targetRoot = isComponentOrScene
+    ? Object.values(editorState.jsxMetadata).filter((possibleRoot) =>
+        EP.isRootElementOf(possibleRoot.elementPath, command.target),
+      )
+    : []
+
+  if (targetRoot.length > 0) {
+    const propsToUpdate: Array<ValueAtPath> = [
+      {
+        path: PP.create(['style']),
+        value: jsxAttributeNestedObject(
+          [
+            jsxSpreadAssignment(
+              jsxAttributeOtherJavaScript(
+                'props.style',
+                'return props.style;',
+                ['props'],
+                null,
+                {},
+              ),
+              emptyComments,
+            ),
+          ],
+          emptyComments,
+        ),
+      },
+    ]
+
+    const { editorStatePatch: propertyUpdatePatch } = applyValuesAtPath(
+      editorState,
+      targetRoot[0].elementPath,
+      propsToUpdate,
+    )
+
+    return {
+      editorStatePatches: [propertyUpdatePatch],
+      commandDescription: 'Add Style to Root Div',
+    }
+  } else {
+    return {
+      editorStatePatches: [],
+      commandDescription: 'Add Style to Root Div',
+    }
+  }
+}

--- a/editor/src/components/canvas/commands/add-style-to-root-div.ts
+++ b/editor/src/components/canvas/commands/add-style-to-root-div.ts
@@ -35,51 +35,29 @@ export const runAddStyleToRootDiv: CommandFunction<AddStyleToRootDiv> = (
   editorState: EditorState,
   command: AddStyleToRootDiv,
 ) => {
-  const isComponentOrScene =
-    EP.pathsEqual(command.target, editorState.focusedElementPath) ||
-    MetadataUtils.isProbablyScene(editorState.jsxMetadata, command.target)
-  const targetRoot = isComponentOrScene
-    ? Object.values(editorState.jsxMetadata).filter((possibleRoot) =>
-        EP.isRootElementOf(possibleRoot.elementPath, command.target),
-      )
-    : []
+  const propsToUpdate: Array<ValueAtPath> = [
+    {
+      path: PP.create(['style']),
+      value: jsxAttributeNestedObject(
+        [
+          jsxSpreadAssignment(
+            jsxAttributeOtherJavaScript('props.style', 'return props.style;', ['props'], null, {}),
+            emptyComments,
+          ),
+        ],
+        emptyComments,
+      ),
+    },
+  ]
 
-  if (targetRoot.length > 0) {
-    const propsToUpdate: Array<ValueAtPath> = [
-      {
-        path: PP.create(['style']),
-        value: jsxAttributeNestedObject(
-          [
-            jsxSpreadAssignment(
-              jsxAttributeOtherJavaScript(
-                'props.style',
-                'return props.style;',
-                ['props'],
-                null,
-                {},
-              ),
-              emptyComments,
-            ),
-          ],
-          emptyComments,
-        ),
-      },
-    ]
+  const { editorStatePatch: propertyUpdatePatch } = applyValuesAtPath(
+    editorState,
+    command.target,
+    propsToUpdate,
+  )
 
-    const { editorStatePatch: propertyUpdatePatch } = applyValuesAtPath(
-      editorState,
-      targetRoot[0].elementPath,
-      propsToUpdate,
-    )
-
-    return {
-      editorStatePatches: [propertyUpdatePatch],
-      commandDescription: 'Add Style to Root Div',
-    }
-  } else {
-    return {
-      editorStatePatches: [],
-      commandDescription: 'Add Style to Root Div',
-    }
+  return {
+    editorStatePatches: [propertyUpdatePatch],
+    commandDescription: 'Add Style to Root Div',
   }
 }

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -38,6 +38,7 @@ import { DuplicateElement, runDuplicateElement } from './duplicate-element-comma
 import { runUpdateFunctionCommand, UpdateFunctionCommand } from './update-function-command'
 import { runPushIntendedBounds, PushIntendedBounds } from './push-intended-bounds-command'
 import { DeleteProperties, runDeleteProperties } from './delete-properties-command'
+import { AddStyleToRootDiv, runAddStyleToRootDiv } from './add-style-to-root-div'
 
 export interface CommandFunctionResult {
   editorStatePatches: Array<EditorStatePatch>
@@ -71,6 +72,7 @@ export type CanvasCommand =
   | SetElementsToRerenderCommand
   | PushIntendedBounds
   | DeleteProperties
+  | AddStyleToRootDiv
 
 export const runCanvasCommand = (
   editorState: EditorState,
@@ -114,6 +116,8 @@ export const runCanvasCommand = (
       return runPushIntendedBounds(editorState, command)
     case 'DELETE_PROPERTIES':
       return runDeleteProperties(editorState, command)
+    case 'ADD_STYLE_TO_ROOT_DIV':
+      return runAddStyleToRootDiv(editorState, command)
     default:
       const _exhaustiveCheck: never = command
       throw new Error(`Unhandled canvas command ${JSON.stringify(command)}`)


### PR DESCRIPTION
When a focused component is dragged/resized/converted to absolute its root div is changed to use `{...props.style}` automatically.

It's a very basic experiment, deleting other style prop the root div had before.

https://utopia.pizza/p/e643a1f5-unique-bearskin/?branch_name=experiment/scenes-props-style
