### PR TITLE
Better defined handling for elements not permitted to be reparented.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -1,5 +1,10 @@
 import {
   ElementInstanceMetadata,
+  emptyComments,
+  jsxAttributesFromMap,
+  jsxAttributeValue,
+  jsxElement,
+  jsxElementName,
   SpecialSizeMeasurements,
 } from '../../../core/shared/element-template'
 import { CanvasPoint, canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
@@ -25,6 +30,7 @@ import {
 } from '../../../core/model/scene-utils'
 import { PrettierConfig } from 'utopia-vscode-common'
 import * as Prettier from 'prettier/standalone'
+import { right } from '../../../core/shared/either'
 
 jest.mock('../canvas-utils', () => ({
   ...jest.requireActual('../canvas-utils'),
@@ -90,6 +96,39 @@ function reparentElement(
             globalContentBox: targetParentWithSpecialContentBox
               ? canvasRectangle({ x: 90, y: 100, width: 170, height: 120 })
               : canvasRectangle({ x: 50, y: 60, width: 250, height: 200 }),
+          } as SpecialSizeMeasurements,
+        } as ElementInstanceMetadata,
+        'scene-aaa/app-entity:aaa/ccc': {
+          elementPath: EP.elementPath([
+            ['scene-aaa', 'app-entity'],
+            ['aaa', 'ccc'],
+          ]),
+          element: right(
+            jsxElement(
+              jsxElementName('div', []),
+              'ccc',
+              jsxAttributesFromMap({
+                style: jsxAttributeValue(
+                  {
+                    position: 'absolute',
+                    width: 20,
+                    height: 30,
+                    top: 75,
+                    left: 90,
+                  },
+                  emptyComments,
+                ),
+                'data-uid': jsxAttributeValue('ccc', emptyComments),
+              }),
+              [],
+            ),
+          ),
+          globalFrame: canvasRectangle({ x: 150, y: 160, width: 250, height: 200 }),
+          specialSizeMeasurements: {
+            immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            providesBoundsForAbsoluteChildren: true,
+            globalContentBox: canvasRectangle({ x: 150, y: 160, width: 250, height: 200 }),
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
       },

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -1,5 +1,10 @@
 import {
   ElementInstanceMetadata,
+  emptyComments,
+  jsxAttributesFromMap,
+  jsxAttributeValue,
+  jsxElement,
+  jsxElementName,
   SpecialSizeMeasurements,
 } from '../../../core/shared/element-template'
 import { CanvasPoint, canvasPoint, canvasRectangle } from '../../../core/shared/math-utils'
@@ -16,6 +21,7 @@ import { defaultCustomStrategyState } from './canvas-strategy-types'
 import { InteractionSession, StrategyState } from './interaction-state'
 import { createMouseInteractionForTests } from './interaction-state.test-utils'
 import * as EP from '../../../core/shared/element-path'
+import { right } from '../../../core/shared/either'
 
 jest.mock('../canvas-utils', () => ({
   ...jest.requireActual('../canvas-utils'),
@@ -87,6 +93,72 @@ function reparentElement(
             globalContentBox: targetParentWithSpecialContentBox
               ? canvasRectangle({ x: 90, y: 100, width: 170, height: 120 })
               : canvasRectangle({ x: 50, y: 60, width: 250, height: 200 }),
+          } as SpecialSizeMeasurements,
+        } as ElementInstanceMetadata,
+        'scene-aaa/app-entity:aaa/ccc': {
+          elementPath: EP.elementPath([
+            ['scene-aaa', 'app-entity'],
+            ['aaa', 'ccc'],
+          ]),
+          element: right(
+            jsxElement(
+              jsxElementName('div', []),
+              'ccc',
+              jsxAttributesFromMap({
+                style: jsxAttributeValue(
+                  {
+                    position: 'absolute',
+                    width: 20,
+                    height: 30,
+                    top: 75,
+                    left: 90,
+                  },
+                  emptyComments,
+                ),
+                'data-uid': jsxAttributeValue('ccc', emptyComments),
+              }),
+              [],
+            ),
+          ),
+          globalFrame: canvasRectangle({ x: 150, y: 160, width: 250, height: 200 }),
+          specialSizeMeasurements: {
+            immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            providesBoundsForAbsoluteChildren: true,
+            globalContentBox: canvasRectangle({ x: 150, y: 160, width: 250, height: 200 }),
+          } as SpecialSizeMeasurements,
+        } as ElementInstanceMetadata,
+        'scene-aaa/app-entity:aaa/ddd': {
+          elementPath: EP.elementPath([
+            ['scene-aaa', 'app-entity'],
+            ['aaa', 'ddd'],
+          ]),
+          element: right(
+            jsxElement(
+              jsxElementName('div', []),
+              'ddd',
+              jsxAttributesFromMap({
+                style: jsxAttributeValue(
+                  {
+                    position: 'absolute',
+                    width: 20,
+                    height: 30,
+                    top: 75,
+                    left: 90,
+                  },
+                  emptyComments,
+                ),
+                'data-uid': jsxAttributeValue('ddd', emptyComments),
+              }),
+              [],
+            ),
+          ),
+          globalFrame: canvasRectangle({ x: 150, y: 160, width: 250, height: 200 }),
+          specialSizeMeasurements: {
+            immediateParentBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            coordinateSystemBounds: canvasRectangle({ x: 0, y: 0, width: 400, height: 400 }),
+            providesBoundsForAbsoluteChildren: true,
+            globalContentBox: canvasRectangle({ x: 150, y: 160, width: 250, height: 200 }),
           } as SpecialSizeMeasurements,
         } as ElementInstanceMetadata,
       },

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -1,10 +1,7 @@
-import { foldEither } from '../../../core/shared/either'
-import { elementReferencesElsewhere } from '../../../core/shared/element-template'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
 import { CSSCursor } from '../canvas-types'
 import { getReparentTarget } from '../canvas-utils'
-import { reparentElement } from '../commands/reparent-element-command'
 import { setCursorCommand } from '../commands/set-cursor-command'
 import { setElementsToRerenderCommand } from '../commands/set-elements-to-rerender-command'
 import { updateSelectedViews } from '../commands/update-selected-views-command'
@@ -15,9 +12,8 @@ import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strateg
 import {
   getAbsoluteOffsetCommandsForSelectedElement,
   getDragTargets,
-  getFileOfElement,
 } from './shared-absolute-move-strategy-helpers'
-import { ifAllowedToReparent } from './reparent-helpers'
+import { ifAllowedToReparent, isAllowedToReparent } from './reparent-helpers'
 import { findReparentStrategy } from './reparent-strategy-helpers'
 import { offsetPoint } from '../../../core/shared/math-utils'
 import { getReparentCommands } from './reparent-utils'
@@ -36,19 +32,7 @@ export const absoluteReparentStrategy: CanvasStrategy = {
       return filteredSelectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
 
-        const referencesExternalValue =
-          elementMetadata == null
-            ? false
-            : foldEither(
-                (_) => false,
-                (elementFromMetadata) => elementReferencesElsewhere(elementFromMetadata),
-                elementMetadata.element,
-              )
-
-        return (
-          elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
-          !referencesExternalValue
-        )
+        return elementMetadata?.specialSizeMeasurements.position === 'absolute'
       })
     }
     return false
@@ -93,68 +77,70 @@ export const absoluteReparentStrategy: CanvasStrategy = {
     const { selectedElements, projectContents, openFile, nodeModules } = canvasState
     const filteredSelectedElements = getDragTargets(selectedElements)
 
-    return ifAllowedToReparent(canvasState, filteredSelectedElements, () => {
-      const reparentResult = getReparentTarget(
-        filteredSelectedElements,
-        filteredSelectedElements,
-        strategyState.startingMetadata,
-        [],
-        pointOnCanvas,
-        projectContents,
-        openFile,
-        strategyState.startingAllElementProps,
-      )
-      const newParent = reparentResult.newParent
-      const moveCommands = absoluteMoveStrategy.apply(canvasState, interactionState, strategyState)
-      const providesBoundsForAbsoluteChildren =
-        MetadataUtils.findElementByElementPath(strategyState.startingMetadata, newParent)
-          ?.specialSizeMeasurements.providesBoundsForAbsoluteChildren ?? false
-      const parentIsStoryboard = newParent == null ? false : EP.isStoryboardPath(newParent)
-
-      if (
-        reparentResult.shouldReparent &&
-        newParent != null &&
-        (providesBoundsForAbsoluteChildren || parentIsStoryboard)
-      ) {
-        const commands = filteredSelectedElements.map((selectedElement) => {
-          const offsetCommands = getAbsoluteOffsetCommandsForSelectedElement(
-            selectedElement,
-            newParent,
-            strategyState,
-            canvasState,
-          )
-
-          const newPath = EP.appendToPath(newParent, EP.toUid(selectedElement))
-          return {
-            newPath: newPath,
-            commands: [
-              ...offsetCommands,
-              ...getReparentCommands(
-                projectContents,
-                nodeModules,
-                openFile,
-                selectedElement,
-                newParent,
-              ),
-            ],
-          }
-        })
-
-        const newPaths = commands.map((c) => c.newPath)
-
-        return {
-          commands: [
-            ...moveCommands.commands,
-            ...commands.flatMap((c) => c.commands),
-            updateSelectedViews('permanent', newPaths),
-            setElementsToRerenderCommand(newPaths),
-            setCursorCommand('transient', CSSCursor.Move),
-          ],
-          customState: null,
-        }
-      } else {
-        return moveCommands
-      }
+    const reparentResult = getReparentTarget(
+      filteredSelectedElements,
+      filteredSelectedElements,
+      strategyState.startingMetadata,
+      [],
+      pointOnCanvas,
+      projectContents,
+      openFile,
+      strategyState.startingAllElementProps,
+    )
+    const newParent = reparentResult.newParent
+    const moveCommands = absoluteMoveStrategy.apply(canvasState, interactionState, strategyState)
+    const providesBoundsForAbsoluteChildren =
+      MetadataUtils.findElementByElementPath(strategyState.startingMetadata, newParent)
+        ?.specialSizeMeasurements.providesBoundsForAbsoluteChildren ?? false
+    const parentIsStoryboard = newParent == null ? false : EP.isStoryboardPath(newParent)
+    const allowedToReparent = filteredSelectedElements.every((selectedElement) => {
+      return isAllowedToReparent(canvasState, strategyState, selectedElement)
     })
+
+    if (
+      reparentResult.shouldReparent &&
+      newParent != null &&
+      (providesBoundsForAbsoluteChildren || parentIsStoryboard) &&
+      allowedToReparent
+    ) {
+      const commands = filteredSelectedElements.map((selectedElement) => {
+        const offsetCommands = getAbsoluteOffsetCommandsForSelectedElement(
+          selectedElement,
+          newParent,
+          strategyState,
+          canvasState,
+        )
+
+        const newPath = EP.appendToPath(newParent, EP.toUid(selectedElement))
+        return {
+          newPath: newPath,
+          commands: [
+            ...offsetCommands,
+            ...getReparentCommands(
+              projectContents,
+              nodeModules,
+              openFile,
+              selectedElement,
+              newParent,
+            ),
+          ],
+        }
+      })
+
+      const newPaths = commands.map((c) => c.newPath)
+
+      return {
+        commands: [
+          ...moveCommands.commands,
+          ...commands.flatMap((c) => c.commands),
+          updateSelectedViews('permanent', newPaths),
+          setElementsToRerenderCommand(newPaths),
+          setCursorCommand('transient', CSSCursor.Move),
+        ],
+        customState: null,
+      }
+    } else {
+      return moveCommands
+    }
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
@@ -106,7 +106,7 @@ export const absoluteReparentToFlexStrategy: CanvasStrategy = {
   ): StrategyApplicationResult {
     const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
 
-    return ifAllowedToReparent(canvasState, filteredSelectedElements, () => {
+    return ifAllowedToReparent(canvasState, strategyState, filteredSelectedElements, () => {
       if (
         interactionSession.interactionData.type == 'DRAG' &&
         interactionSession.interactionData.drag != null

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
@@ -14,6 +14,7 @@ import { ParentOutlines } from '../controls/parent-outlines'
 import { DragOutlineControl } from '../controls/select-mode/drag-outline-control'
 import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
 import { getReorderIndex } from './flex-reorder-strategy'
+import { ifAllowedToReparent } from './reparent-helpers'
 import { findReparentStrategy, getReparentTargetForFlexElement } from './reparent-strategy-helpers'
 import { getReparentCommands } from './reparent-utils'
 import { getDragTargets } from './shared-absolute-move-strategy-helpers'
@@ -61,79 +62,81 @@ export const flexReparentToFlexStrategy: CanvasStrategy = {
     return 0
   },
   apply: (canvasState, interactionSession, strategyState) => {
-    if (
-      interactionSession.interactionData.type == 'DRAG' &&
-      interactionSession.interactionData.drag != null
-    ) {
-      const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
-      const reparentResult = getReparentTargetForFlexElement(
-        filteredSelectedElements,
-        interactionSession,
-        canvasState,
-        strategyState,
-      )
-
+    const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
+    return ifAllowedToReparent(canvasState, strategyState, filteredSelectedElements, () => {
       if (
-        reparentResult.shouldReparent &&
-        reparentResult.newParent != null &&
-        filteredSelectedElements.length === 1
+        interactionSession.interactionData.type == 'DRAG' &&
+        interactionSession.interactionData.drag != null
       ) {
-        const target = filteredSelectedElements[0]
-        const newParent = reparentResult.newParent
-        // Reparent the element.
-        const newPath = EP.appendToPath(reparentResult.newParent, EP.toUid(target))
-        const reparentCommands = getReparentCommands(
-          canvasState.projectContents,
-          canvasState.nodeModules,
-          canvasState.openFile,
-          target,
-          reparentResult.newParent,
+        const reparentResult = getReparentTargetForFlexElement(
+          filteredSelectedElements,
+          interactionSession,
+          canvasState,
+          strategyState,
         )
 
-        const commandsBeforeReorder = [
-          ...reparentCommands,
-          updateSelectedViews('permanent', [newPath]),
-        ]
-
-        const commandsAfterReorder = [
-          setElementsToRerenderCommand([newPath]),
-          updateHighlightedViews('transient', []),
-          setCursorCommand('transient', CSSCursor.Move),
-        ]
-
-        let commands: Array<CanvasCommand>
-        if (reparentResult.shouldReorder) {
-          // Reorder the newly reparented element into the flex ordering.
-          const pointOnCanvas = offsetPoint(
-            interactionSession.interactionData.dragStart,
-            interactionSession.interactionData.drag,
+        if (
+          reparentResult.shouldReparent &&
+          reparentResult.newParent != null &&
+          filteredSelectedElements.length === 1
+        ) {
+          const target = filteredSelectedElements[0]
+          const newParent = reparentResult.newParent
+          // Reparent the element.
+          const newPath = EP.appendToPath(reparentResult.newParent, EP.toUid(target))
+          const reparentCommands = getReparentCommands(
+            canvasState.projectContents,
+            canvasState.nodeModules,
+            canvasState.openFile,
+            target,
+            reparentResult.newParent,
           )
 
-          const siblingsOfTarget = MetadataUtils.getChildrenPaths(
-            strategyState.startingMetadata,
-            newParent,
-          )
-
-          const newIndex = getReorderIndex(
-            strategyState.startingMetadata,
-            siblingsOfTarget,
-            pointOnCanvas,
-          )
-          commands = [
-            ...commandsBeforeReorder,
-            reorderElement('permanent', newPath, newIndex),
-            ...commandsAfterReorder,
+          const commandsBeforeReorder = [
+            ...reparentCommands,
+            updateSelectedViews('permanent', [newPath]),
           ]
-        } else {
-          commands = [...commandsBeforeReorder, ...commandsAfterReorder]
-        }
 
-        return {
-          commands: commands,
-          customState: strategyState.customStrategyState,
+          const commandsAfterReorder = [
+            setElementsToRerenderCommand([newPath]),
+            updateHighlightedViews('transient', []),
+            setCursorCommand('transient', CSSCursor.Move),
+          ]
+
+          let commands: Array<CanvasCommand>
+          if (reparentResult.shouldReorder) {
+            // Reorder the newly reparented element into the flex ordering.
+            const pointOnCanvas = offsetPoint(
+              interactionSession.interactionData.dragStart,
+              interactionSession.interactionData.drag,
+            )
+
+            const siblingsOfTarget = MetadataUtils.getChildrenPaths(
+              strategyState.startingMetadata,
+              newParent,
+            )
+
+            const newIndex = getReorderIndex(
+              strategyState.startingMetadata,
+              siblingsOfTarget,
+              pointOnCanvas,
+            )
+            commands = [
+              ...commandsBeforeReorder,
+              reorderElement('permanent', newPath, newIndex),
+              ...commandsAfterReorder,
+            ]
+          } else {
+            commands = [...commandsBeforeReorder, ...commandsAfterReorder]
+          }
+
+          return {
+            commands: commands,
+            customState: strategyState.customStrategyState,
+          }
         }
       }
-    }
-    return emptyStrategyApplicationResult
+      return emptyStrategyApplicationResult
+    })
   },
 }

--- a/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
@@ -1,8 +1,12 @@
+import { foldEither } from '../../../core/shared/either'
+import { elementReferencesElsewhere } from '../../../core/shared/element-template'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { CSSCursor } from '../canvas-types'
 import { setCursorCommand } from '../commands/set-cursor-command'
 import { InteractionCanvasState, StrategyApplicationResult } from './canvas-strategy-types'
+import { StrategyState } from './interaction-state'
+import * as EP from '../../../core/shared/element-path'
 
 export function isGeneratedElement(
   canvasState: InteractionCanvasState,
@@ -18,17 +22,32 @@ export function isGeneratedElement(
 
 export function isAllowedToReparent(
   canvasState: InteractionCanvasState,
+  strategyState: StrategyState,
   target: ElementPath,
 ): boolean {
-  return !isGeneratedElement(canvasState, target)
+  if (isGeneratedElement(canvasState, target)) {
+    return false
+  } else {
+    const metadata = MetadataUtils.findElementByElementPath(strategyState.startingMetadata, target)
+    if (metadata == null) {
+      return false
+    } else {
+      return foldEither(
+        (_) => true,
+        (elementFromMetadata) => !elementReferencesElsewhere(elementFromMetadata),
+        metadata.element,
+      )
+    }
+  }
 }
 
 export function ifAllowedToReparent(
   canvasState: InteractionCanvasState,
+  strategyState: StrategyState,
   targets: Array<ElementPath>,
   ifAllowed: () => StrategyApplicationResult,
 ): StrategyApplicationResult {
-  const allowed = targets.every((target) => isAllowedToReparent(canvasState, target))
+  const allowed = targets.every((target) => isAllowedToReparent(canvasState, strategyState, target))
   if (allowed) {
     return ifAllowed()
   } else {


### PR DESCRIPTION
**Problem:**
Some of the reparent strategies were taking account of elements that could be reparented and others weren't, resulting in a potentially confusing experience where an element might be reparented in one situation but not another.

**Fix:**
Moved the logic which checked if an element is permitted to be reparented entirely inside `isAllowedToReparent` and changed most of the strategies to use `ifAllowedToReparent`. The only case that doesn't use it is `absoluteReparentStrategy` because it already has some fallback handling which treats an invalid reparent as a move.

**Commit Details:**
- `isAllowedToReparent` now incorporates `elementReferencesElsewhere` to check
  for elements which will likely fail if they get moved because they refer to
  some external value.
- Most reparent strategies now use `ifAllowedToReparent` to provide the falback
  for elements which can't be reparented.
- Removed `elementReferencesElsewhere` logic from `absoluteReparentStrategy`.
