### PR TITLE
Double click fix for non-dom components

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -641,12 +641,10 @@ describe('Select Mode Double Clicking', () => {
 })
 
 describe('Select Mode Double Clicking With Fragments', () => {
-  // The below tests are to ensure we're not inadvertently handling clicks too many times,
-  // which could either mean focusing something that wasn't meant to be focused, or skipping
-  // over the target element and selecting something further down the hierarchy.
-  // Each double click should _either_ select the next element down the hierarchy, _or_ focus
-  // the currently selected element. Also, we specifically skip over Scenes, meaning a single
-  // double click with nothing selected will select the first child of a Scene
+  // The below tests are similar to tests in 'Select Mode Double Clicking', but
+  // they use a test project which contain components which renders fragment root
+  // elements. These are special cases because these fragments and their components
+  // do not appear in the dom.
 
   before(() => {
     viewport.set(2200, 1000)

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -640,6 +640,220 @@ describe('Select Mode Double Clicking', () => {
   })
 })
 
+describe('Select Mode Double Clicking With Fragments', () => {
+  // The below tests are to ensure we're not inadvertently handling clicks too many times,
+  // which could either mean focusing something that wasn't meant to be focused, or skipping
+  // over the target element and selecting something further down the hierarchy.
+  // Each double click should _either_ select the next element down the hierarchy, _or_ focus
+  // the currently selected element. Also, we specifically skip over Scenes, meaning a single
+  // double click with nothing selected will select the first child of a Scene
+
+  before(() => {
+    viewport.set(2200, 1000)
+  })
+
+  it('One double clicks to select Card Instance', async () => {
+    // prettier-ignore
+    const desiredPath = EP.fromString(
+      'sb' +            // Skipped as it's the storyboard
+      '/scene-2' +      // Skipped because we skip over Scenes
+      '/Card-instance', // <- First double click
+    )
+
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectAlpineClimb,
+      'await-first-dom-report',
+    )
+
+    const cardSceneRoot = renderResult.renderedDOM.getByTestId('card-scene')
+    const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const fireDoubleClickEvents = createDoubleClicker()
+
+    const doubleClick = async () => {
+      await act(async () => {
+        fireDoubleClickEvents(
+          canvasControlsLayer,
+          cardSceneRootBounds.left + 130,
+          cardSceneRootBounds.top + 220,
+        )
+      })
+    }
+
+    await doubleClick()
+
+    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+  })
+
+  it('Two double clicks to select Card Scene Root', async () => {
+    // prettier-ignore
+    const desiredPath = EP.fromString(
+      'sb' +             // Skipped as it's the storyboard
+      '/scene-2' +       // Skipped because we skip over Scenes
+      '/Card-instance' + // <- First double click
+      ':Card-Root',      // <- Second double click, as the instance is automatically focused by the scene
+    )
+
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectAlpineClimbWithFragments,
+      'await-first-dom-report',
+    )
+
+    const cardSceneRoot = renderResult.renderedDOM.getByTestId('card-scene')
+    const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const fireDoubleClickEvents = createDoubleClicker()
+
+    const doubleClick = async () => {
+      await act(async () => {
+        fireDoubleClickEvents(
+          canvasControlsLayer,
+          cardSceneRootBounds.left + 130,
+          cardSceneRootBounds.top + 220,
+        )
+      })
+    }
+
+    await doubleClick()
+    await doubleClick()
+
+    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+  })
+
+  it('Four double clicks to select Button on a Card Scene Root', async () => {
+    // prettier-ignore
+    const desiredPath = EP.fromString(
+      'sb' +                // Skipped as it's the storyboard
+      '/scene-2' +          // Skipped because we skip over Scenes
+      '/Card-instance' +    // <- First double click
+      ':Card-Root' +        // <- Second double click, as the instance is automatically focused by the scene
+      '/Card-Row-Buttons' + // <- Third double click
+      '/Card-Button-3',     // <- Fourth double click
+    )
+
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectAlpineClimbWithFragments,
+      'await-first-dom-report',
+    )
+
+    const cardSceneRoot = renderResult.renderedDOM.getByTestId('card-scene')
+    const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const fireDoubleClickEvents = createDoubleClicker()
+
+    const doubleClick = async () => {
+      await act(async () => {
+        fireDoubleClickEvents(
+          canvasControlsLayer,
+          cardSceneRootBounds.left + 130,
+          cardSceneRootBounds.top + 220,
+        )
+      })
+    }
+
+    await doubleClick()
+    await doubleClick()
+    await doubleClick()
+    await doubleClick()
+
+    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+  })
+
+  it('Five double clicks will focus a generated Card and select its root element', async () => {
+    // prettier-ignore
+    const desiredPath = EP.fromString(
+      'sb' +                 // Skipped as it's the storyboard
+      '/scene-CardList' +    // Skipped because we skip over Scenes
+      '/CardList-instance' + // <- First double click
+      ':CardList-Col' +      // <- Third double click
+      '/CardList-Card~~~1' + // <- Fourth *and* Fifth double click, as the Fifth is required to focus it
+      ':Card-Root',          // <- Sixth double click
+    )
+
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectAlpineClimbWithFragments,
+      'await-first-dom-report',
+    )
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const cardSceneRoot = renderResult.renderedDOM.getByTestId('generated-card-1')
+    const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
+
+    const fireDoubleClickEvents = createDoubleClicker()
+
+    const doubleClick = async () => {
+      await act(async () => {
+        fireDoubleClickEvents(
+          canvasControlsLayer,
+          cardSceneRootBounds.left + 130,
+          cardSceneRootBounds.top + 220,
+        )
+      })
+    }
+
+    await doubleClick()
+    await doubleClick()
+    await doubleClick()
+    await doubleClick()
+    await doubleClick()
+
+    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+  })
+
+  it('Seven double clicks will focus a generated Card and select the Button inside', async () => {
+    // prettier-ignore
+    const desiredPath = EP.fromString(
+      'sb' +                 // Skipped as it's the storyboard
+      '/scene-CardList' +    // Skipped because we skip over Scenes
+      '/CardList-instance' + // <- First double click
+      ':CardList-Col' +      // <- Third double click
+      '/CardList-Card~~~1' + // <- Fourth *and* Fifth double click, as the Fifth is required to focus it
+      ':Card-Root' +         // <- Sixth double click
+      '/Card-Row-Buttons' +  // <- Seventh double click
+      '/Card-Button-3',      // <- Eight double click
+    )
+
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectAlpineClimbWithFragments,
+      'await-first-dom-report',
+    )
+
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+
+    const cardSceneRoot = renderResult.renderedDOM.getByTestId('generated-card-1')
+    const cardSceneRootBounds = cardSceneRoot.getBoundingClientRect()
+
+    const fireDoubleClickEvents = createDoubleClicker()
+
+    const doubleClick = async () => {
+      await act(async () => {
+        fireDoubleClickEvents(
+          canvasControlsLayer,
+          cardSceneRootBounds.left + 130,
+          cardSceneRootBounds.top + 220,
+        )
+      })
+    }
+
+    await doubleClick()
+    await doubleClick()
+    await doubleClick()
+    await doubleClick()
+    await doubleClick()
+    await doubleClick()
+    await doubleClick()
+
+    expect(renderResult.getEditorState().editor.selectedViews).toEqual([desiredPath])
+  })
+})
+
 const TestProjectAlpineClimb = `
 import * as React from "react";
 import { Scene, Storyboard } from "utopia-api";
@@ -718,6 +932,395 @@ export const ManualCardList = (props) => {
         <Card data-uid="ManualCardList-Card-2" />
       </Col>
     </div>
+  );
+};
+
+export const Card = (props) => (
+  <div
+    style={{
+      display: "flex",
+      flexDirection: "column",
+      width: 364,
+      height: 250,
+      backgroundColor: "hsl(0,0%,95%)",
+      boxShadow: "0px 0px 0px 1px black",
+    }}
+    data-testid={props.testid}
+    data-uid="Card-Root"
+  >
+    <Row
+      style={{ minHeight: 200, position: "relative", overflow: "hidden" }}
+      data-uid="Card-Row"
+    >
+      <img
+        src="https://www.hackneycitizen.co.uk/wp-content/uploads/nerone-1-620.jpg"
+        data-uid="Card-img"
+      />
+      <LabelRow data-uid="Card-LabelRow" />
+    </Row>
+    <Row style={{ minHeight: 40, gap: 12 }} data-uid="Card-Row-Buttons">
+      <Button data-uid="Card-Button-1">Hello</Button>
+      <Button data-uid="Card-Button-2">Button</Button>
+      <Button data-uid="Card-Button-3">Button</Button>
+    </Row>
+  </div>
+);
+
+export const FlexRow = styled.div({
+  display: "flex",
+  alignItems: "center",
+});
+
+export const Row = styled(FlexRow)({});
+export const UIRow = styled.div({
+  minHeight: 34,
+  paddingLeft: 8,
+  paddingRight: 8,
+  display: "flex",
+  alignItems: "center",
+});
+
+export const UIListRow = styled(UIRow)({
+  height: 27,
+  minHeight: "initial",
+  "&:hover": {
+    color: "white",
+    background: "#007AFF",
+  },
+});
+export const UIListGridRow = styled(UIRow)({
+  height: 27,
+  minHeight: "initial",
+  display: "grid",
+  gridTemplateColumns: "28px 1fr",
+  minHeight: "initial",
+  "&:hover": {
+    color: "white",
+    background: "#007AFF",
+  },
+});
+
+export const UIContextMenuRow = styled(UIRow)({
+  height: 22,
+  borderRadius: 2,
+  minHeight: "initial",
+  display: "grid",
+  gridTemplateColumns: "1fr auto",
+  minHeight: "initial",
+  "&:hover": {
+    color: "white",
+    background: "#007AFF",
+  },
+});
+
+export const ContextMenu = (props) => {
+  return (
+    <div
+      style={{
+        borderRadius: 4,
+        padding: 4,
+        backgroundColor: "hsl(0,0%,95%)",
+        paddingTop: 4,
+        paddingBottom: 4,
+        width: 202,
+        fontFamily: "Inter",
+        fontSize: 11,
+        fontWeight: 400,
+        boxShadow:
+          "0px 2px 7px rgb(0, 0, 0, 0.12), 0px 0px 0px 1px rgb(0, 0, 0, 0.12)",
+      }}
+      data-uid="ContextMenu-Root"
+    >
+      <UIContextMenuRow data-uid="ContextMenu-Copy">
+        <span data-uid="918">Copy</span>
+        <span style={{ color: "hsl(0,0%,60%)" }} data-uid="f49">
+          ⌘+C
+        </span>
+      </UIContextMenuRow>
+      <UIContextMenuRow data-uid="ContextMenu-Cut">
+        <span data-uid="a3e">Cut</span>
+        <span style={{ color: "hsl(0,0%,60%)" }} data-uid="b34">
+          ⌘+X
+        </span>
+      </UIContextMenuRow>
+      <UIContextMenuRow data-uid="ContextMenu-Paste">
+        <span data-uid="09d">Paste</span>
+        <span style={{ color: "hsl(0,0%,60%)" }} data-uid="706">
+          ⌘+V
+        </span>
+      </UIContextMenuRow>
+      <UIContextMenuRow data-uid="ContextMenu-">
+        <span data-uid="821">Paste</span>
+        <span style={{ color: "hsl(0,0%,60%)" }} data-uid="46d">
+          ⌘+V
+        </span>
+      </UIContextMenuRow>
+      <hr
+        style={{
+          color: "yello",
+          background: "purple",
+          stroke: "grey",
+          backgroundColor: "/*rgb(128, 0, 128, 1)*/",
+          border: "0.5px solid rgb(255, 20, 20, 1)",
+          height: 1,
+        }}
+        data-uid="ContextMenu-hr"
+      />
+      <UIContextMenuRow data-uid="ContextMenu-Backward">
+        <span data-uid="ab9">Bring Backward</span>
+        <span style={{ color: "hsl(0,0%,60%)" }} data-uid="c2b">
+          ⌘+V
+        </span>
+      </UIContextMenuRow>
+      <UIContextMenuRow data-uid="ContextMenu-Forward">
+        <span data-uid="cb2">Bring Forward</span>
+        <span style={{ color: "hsl(0,0%,60%)" }} data-uid="07c">
+          ⌘+V
+        </span>
+      </UIContextMenuRow>
+    </div>
+  );
+};
+
+export var App = (props) => {
+  return (
+    <div
+      style={{
+        padding: 20,
+        width: "100%",
+        height: "100%",
+        backgroundColor: "#FFFFFF",
+        position: "relative",
+        fontFamily: "Inter",
+        fontSize: 11,
+        fontWeight: 400,
+        WebkitTextRendering: "subpixel-antialiased",
+      }}
+      data-uid="App-root"
+    >
+      <div
+        style={{
+          width: 270,
+          height: 215,
+          background: "hsl(0,0%,97%)",
+          backgroundColor: "rgb(247, 247, 247, 1)",
+          boxShadow:
+            "0px 2px 7px rgb(0, 0, 0, 0.12), 0px 0px 0px 1px rgb(0, 0, 0, 0.12)",
+          borderRadius: 3,
+        }}
+        data-uid="App-div"
+      >
+        <div
+          style={{
+            paddingLeft: 8,
+            paddingRight: 8,
+            fontFamily: "Inter",
+            fontSize: 11,
+            color: "hsl(0,0%,10%)",
+            display: "flex",
+            alignItems: "center",
+            height: 34,
+          }}
+          data-uid="App-div-div"
+        >
+          <span style={{ fontWeight: 600 }} data-uid="App-div-div-span">
+            Popup Menu
+          </span>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            paddingLeft: 8,
+            paddingRight: 8,
+          }}
+          data-uid="57e"
+        >
+          <UIListGridRow
+            style={{ gap: 8, borderRadius: 2, flexGrow: 1 }}
+            data-uid="App-Select"
+          >
+            <Row data-uid="681" />
+            <Row data-uid="04c">Select Elements</Row>
+          </UIListGridRow>
+          <UIListGridRow
+            style={{ gap: 8, borderRadius: 2, flexGrow: 1 }}
+            data-uid="App-Copy"
+          >
+            <div data-uid="2a2" />
+            <div data-uid="329">Copy</div>
+          </UIListGridRow>
+          <UIListGridRow
+            style={{ gap: 8, borderRadius: 2, flexGrow: 1 }}
+            data-uid="App-Pase"
+          >
+            <div data-uid="2ce" />
+            <div data-uid="1a3">Paste</div>
+          </UIListGridRow>
+          <UIListGridRow data-uid="App-Check">
+            <Row style={{ justifyContent: "center" }} data-uid="a1d">
+              ✓
+            </Row>
+            <Row data-uid="2d9">A little label</Row>
+          </UIListGridRow>
+          <UIListGridRow
+            style={{ gap: 8, borderRadius: 2, flexGrow: 1 }}
+            data-uid="App-Magic"
+          >
+            <div data-uid="765" />
+            <div data-uid="a20">Magic</div>
+          </UIListGridRow>
+        </div>
+      </div>
+    </div>
+  );
+};
+export var storyboard = (
+  <Storyboard data-uid="sb" >
+    <Scene
+      style={{ position: "absolute", left: 0, top: 0, width: 313, height: 261 }}
+      data-uid="scene-App"
+    >
+      <App data-uid="App-instance" />
+    </Scene>
+    <Scene
+      data-label="Scene 1"
+      style={{
+        position: "absolute",
+        padding: 20,
+        left: 0,
+        top: 299,
+        width: 280,
+        height: 196,
+      }}
+      data-uid="scene-1"
+    >
+      <ContextMenu data-uid="ContextMenu-instance" />
+    </Scene>
+    <Scene
+      data-label="Scene 2"
+      style={{
+        position: "absolute",
+        padding: 20,
+        left: 420,
+        top: -19,
+        width: 400,
+        height: 300,
+      }}
+      data-uid="scene-2"
+    >
+      <Card data-uid="Card-instance" testid="card-scene" />
+    </Scene>
+    <Scene
+      data-label="List of Cards"
+      style={{
+        position: "absolute",
+        padding: 20,
+        left: 420,
+        top: 350,
+        width: 500,
+        height: 400,
+      }}
+      data-uid="scene-CardList"
+    >
+      <CardList data-uid="CardList-instance" />
+    </Scene>
+    <Scene
+      data-label="Card component out of place for focus mode"
+      style={{
+        position: "absolute",
+        padding: 20,
+        left: 1060,
+        top: -31,
+        width: 500,
+        height: 400,
+      }}
+      data-uid="scene-ManualCardList"
+    >
+      <ManualCardList data-uid="ManualCardList-uid" />
+    </Scene>
+  </Storyboard>
+);
+`
+
+const TestProjectAlpineClimbWithFragments = `
+import * as React from "react";
+import { Scene, Storyboard } from "utopia-api";
+import styled from "@emotion/styled";
+
+export const Col = (props) => (
+  <div
+    style={{
+      display: "flex",
+      flexDirection: "column",
+      gap: 34,
+      padding: 12,
+      alignItems: "stretch",
+      backgroundColor: "yellow",
+    }}
+    data-uid="Col-Root"
+  >
+    {props.children}
+  </div>
+);
+
+export const LabelRow = (props) => (
+  <div
+    style={{
+      color: "white",
+      display: "flex",
+      alignItems: "center",
+      fontFamily: "sans-serif",
+      backdropFilter: "blur(6px) brightness(120%)",
+      paddingLeft: 12,
+      paddingRight: 12,
+      position: "absolute",
+      bottom: 0,
+      left: 0,
+      height: 34,
+      right: 0,
+    }}
+    data-uid="LabelRow-Root"
+  >
+    <div style={{ flex: "1 0 150px" }} data-uid="LabelRow-div">
+      Beautiful Hackney Street Arrrrt
+    </div>
+    <Button data-uid="LabelRow-Button">Hello</Button>
+  </div>
+);
+
+export const Button = styled.button({
+  minWidth: 40,
+  minHeight: 22,
+  boxShadow: "1px 1px 0px 1px black",
+  backgroundColor: "#00FFAA",
+  color: "black",
+});
+
+export const CardList = (props) => {
+  cards = [1, 2, 3, 4, 5];
+
+  return (
+    <>
+      <h2 data-uid="CardList-h2">List of available street art</h2>
+      <Col data-uid="CardList-Col">
+        {cards.map((card) => (
+          <Card data-uid="CardList-Card" testid={'generated-card-'+ card} />
+        ))}
+      </Col>
+    </>
+  );
+};
+
+export const ManualCardList = (props) => {
+  return (
+    <>
+      <h2 data-uid="ManualCardList-h2">List of available street art</h2>
+      <Col data-uid="ManualCardList-Col">
+        <Card data-uid="ManualCardList-Card-1" />
+        <Card data-uid="ManualCardList-Card-2" />
+      </Col>
+    </>
   );
 };
 

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -811,11 +811,11 @@ describe('Select Mode Double Clicking With Fragments', () => {
       'sb' +                 // Skipped as it's the storyboard
       '/scene-CardList' +    // Skipped because we skip over Scenes
       '/CardList-instance' + // <- First double click
-      ':CardList-Col' +      // <- Third double click
-      '/CardList-Card~~~1' + // <- Fourth *and* Fifth double click, as the Fifth is required to focus it
-      ':Card-Root' +         // <- Sixth double click
-      '/Card-Row-Buttons' +  // <- Seventh double click
-      '/Card-Button-3',      // <- Eight double click
+      ':CardList-Col' +      // <- Second double click
+      '/CardList-Card~~~1' + // <- Third *and* Fourth double click, as the Fifth is required to focus it
+      ':Card-Root' +         // <- Fifth double click
+      '/Card-Row-Buttons' +  // <- Sixth double click
+      '/Card-Button-3',      // <- Seventh double click
     )
 
     const renderResult = await renderTestEditorWithCode(

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -39,10 +39,38 @@ export function findFirstParentWithValidElementPath(
   validDynamicElementPathsForLookup: Set<string> | 'no-filter',
   target: Element,
 ): ElementPath | null {
+  const firstParentFromDom = findFirstParentWithValidElementPathInner(
+    validDynamicElementPathsForLookup,
+    target,
+    false,
+  )
+
+  const firstParentFromPath = findFirstParentWithValidElementPathInner(
+    validDynamicElementPathsForLookup,
+    target,
+    true,
+  )
+
+  if (firstParentFromDom == null || firstParentFromPath == null) {
+    return firstParentFromDom ?? firstParentFromPath ?? null
+  }
+
+  return EP.navigatorDepth(firstParentFromDom) < EP.navigatorDepth(firstParentFromPath)
+    ? firstParentFromPath
+    : firstParentFromDom
+}
+
+// Take a DOM element, and try to find the nearest selectable path for it
+export function findFirstParentWithValidElementPathInner(
+  validDynamicElementPathsForLookup: Set<string> | 'no-filter',
+  target: Element,
+  allowDescendantsFromPath: boolean,
+): ElementPath | null {
   const dynamicElementPaths = getPathsOnDomElement(target)
   const staticAndDynamicTargetElementPaths = dynamicElementPaths.map((p) => {
     return {
       static: EP.toString(EP.makeLastPartOfPathStatic(p)),
+      staticPath: EP.makeLastPartOfPathStatic(p),
       dynamic: p,
     }
   })
@@ -61,25 +89,43 @@ export function findFirstParentWithValidElementPath(
 
   const filteredValidPathsMappedToDynamic = mapDropNulls(
     (validPath: string) => {
-      return staticAndDynamicTargetElementPaths.find(
-        (staticAndDynamic) => staticAndDynamic.static === validPath,
-      )?.dynamic
+      if (allowDescendantsFromPath) {
+        for (const staticAndDynamic of staticAndDynamicTargetElementPaths) {
+          if (EP.isDescendantOfOrEqualTo(staticAndDynamic.staticPath, EP.fromString(validPath))) {
+            const depthDiff =
+              EP.navigatorDepth(staticAndDynamic.staticPath) -
+              EP.navigatorDepth(EP.fromString(validPath))
+            let ancestor = staticAndDynamic.dynamic
+            for (let i = 0; i < depthDiff; i++) {
+              ancestor = EP.parentPath(ancestor)
+            }
+            return ancestor
+          }
+        }
+
+        return null
+      } else {
+        return staticAndDynamicTargetElementPaths.find(
+          (staticAndDynamic) => staticAndDynamic.static === validPath,
+        )?.dynamic
+      }
     },
     [...validStaticElementPaths],
   )
 
   if (filteredValidPathsMappedToDynamic.length > 0) {
     const sortedFilteredPaths = filteredValidPathsMappedToDynamic.sort(
-      (l, r) => EP.depth(l) - EP.depth(r),
+      (l, r) => EP.navigatorDepth(l) - EP.navigatorDepth(r),
     )
     return last(sortedFilteredPaths) ?? null
   } else {
     if (target.parentElement == null) {
       return null
     } else {
-      return findFirstParentWithValidElementPath(
+      return findFirstParentWithValidElementPathInner(
         validDynamicElementPathsForLookup,
         target.parentElement,
+        allowDescendantsFromPath,
       )
     }
   }

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -96,11 +96,7 @@ export function findFirstParentWithValidElementPathInner(
               const depthDiff =
                 EP.navigatorDepth(staticAndDynamic.staticPath) -
                 EP.navigatorDepth(EP.fromString(validPath))
-              let ancestor = staticAndDynamic.dynamic
-              for (let i = 0; i < depthDiff; i++) {
-                ancestor = EP.parentPath(ancestor)
-              }
-              return ancestor
+              return EP.nthParentPath(staticAndDynamic.dynamic, depthDiff)
             }
           }
 

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -341,6 +341,16 @@ export function parentPath(path: ElementPath): ElementPath {
   }
 }
 
+export function nthParentPath(path: StaticElementPath, n: number): StaticElementPath
+export function nthParentPath(path: ElementPath, n: number): ElementPath
+export function nthParentPath(path: ElementPath, n: number): ElementPath {
+  let working = path
+  for (let i = 0; i < n; i++) {
+    working = parentPath(working)
+  }
+  return working
+}
+
 export function isParentComponentOf(maybeParent: ElementPath, maybeChild: ElementPath): boolean {
   return pathsEqual(maybeParent, dropLastPathPart(maybeChild))
 }


### PR DESCRIPTION
# Issue

If a component returns a fragment as the root element, the element _and_ the component do not appear in the DOM. This causes trouble with double-click to select, it is impossible to enter this component and select its children on the canvas with double click

# Root cause

Fragments do not appear in the dom. Moreover, when the root element of a component is a fragment, the component itself does not appear in the dom.
`getSelectionOrAllTargetsAtPoint`, which returns the possible targets for the mouse position only searches in the dom, so it can not find the component with the root fragment.

# Solution

The solution is not trivial, because searching statically using the ElementPath structure is incorrect, because we need to take z-order into account, which is hard to predict from the parsed model.
So we still need to rely on the dom, but somehow extend the search to other element paths, which do not appear in the dom. So I implemented a hybrid solution: with the old method I try to find the best target. However, that can be too high in the hierarchy.
I implemented another method, which tries to find a target which is not in the dom, but it has a descendant which is in the dom and is a good target.
The better target is the one which is deeper in the hierarchy.