### PR TITLE
Fix globalFrame and localFrame for components with root fragments

### DIFF
--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1,28 +1,10 @@
 import * as OPI from 'object-path-immutable'
-import { FlexLength, LayoutSystem, Sides } from 'utopia-api/core'
+import { FlexLength, Sides } from 'utopia-api/core'
 import { getReorderDirection } from '../../components/canvas/controls/select-mode/yoga-utils'
 import { getImageSize, scaleImageDimensions } from '../../components/images'
-import {
-  foldThese,
-  makeThat,
-  makeThis,
-  makeThisAndThat,
-  mergeThese,
-  setThat,
-  These,
-} from '../../utils/these'
-import Utils, { IndexPosition } from '../../utils/utils'
+import Utils from '../../utils/utils'
 import { getLayoutProperty } from '../layout/getLayoutProperty'
-import { FlexLayoutHelpers, LayoutHelpers } from '../layout/layout-helpers'
-import {
-  flattenArray,
-  mapDropNulls,
-  pluck,
-  stripNulls,
-  flatMapArray,
-  uniqBy,
-  reverse,
-} from '../shared/array-utils'
+import { mapDropNulls, pluck, stripNulls, flatMapArray, uniqBy } from '../shared/array-utils'
 import { intrinsicHTMLElementNamesThatSupportChildren } from '../shared/dom-utils'
 import {
   alternativeEither,
@@ -31,21 +13,14 @@ import {
   flatMapEither,
   foldEither,
   forEachRight,
-  isLeft,
   isRight,
-  left,
-  mapEither,
   right,
-  traverseEither,
-  Left,
-  Right,
   maybeEitherToMaybe,
 } from '../shared/either'
 import {
   ElementInstanceMetadata,
   ElementsByUID,
   getJSXElementNameLastPart,
-  getJSXElementNameNoPathName,
   isJSXArbitraryBlock,
   isJSXElement,
   isJSXTextBlock,
@@ -56,27 +31,19 @@ import {
   JSXElementName,
   getJSXElementNameAsString,
   isIntrinsicElement,
-  jsxElementName,
   ElementInstanceMetadataMap,
   isIntrinsicHTMLElement,
-  getJSXAttribute,
 } from '../shared/element-template'
 import {
   getModifiableJSXAttributeAtPath,
   jsxSimpleAttributeToValue,
 } from '../shared/jsx-attributes'
 import {
-  boundingRectangle,
-  CanvasPoint,
+  boundingRectangleArray,
   CanvasRectangle,
-  canvasRectangle,
   canvasRectangleToLocalRectangle,
   LocalRectangle,
-  localRectangle,
-  SimpleRectangle,
   Size,
-  zeroCanvasRect,
-  zeroLocalRect,
 } from '../shared/math-utils'
 import { optionalMap } from '../shared/optional-utils'
 import {
@@ -93,19 +60,16 @@ import {
   componentUsesProperty,
   findJSXElementChildAtPath,
   getUtopiaID,
-  isSceneElement,
 } from './element-template-utils'
 import {
   isImportedComponent,
   isAnimatedElement,
-  isGivenUtopiaAPIElement,
   isUtopiaAPIComponent,
   getUtopiaJSXComponentsFromSuccess,
   isViewLikeFromMetadata,
   isSceneFromMetadata,
   isUtopiaAPIComponentFromMetadata,
   isGivenUtopiaElementFromMetadata,
-  isImportedComponentNPM,
 } from './project-file-utils'
 import { ResizesContentProp } from './scene-utils'
 import { fastForEach } from '../shared/utils'
@@ -1413,30 +1377,12 @@ function fillSpyOnlyMetadataWithFramesFromChildren(
     if (children.length === 0) {
       return
     }
-    let workingMetadata: ElementInstanceMetadata = { ...spyElem }
 
-    fastForEach(children, (childMetadata) => {
-      const globalFrame =
-        workingMetadata.globalFrame != null
-          ? boundingRectangle(
-              workingMetadata.globalFrame ?? zeroCanvasRect,
-              childMetadata.globalFrame ?? zeroCanvasRect,
-            )
-          : childMetadata.globalFrame ?? zeroCanvasRect
-      const localFrame =
-        workingMetadata.localFrame != null
-          ? boundingRectangle(
-              workingMetadata.localFrame ?? zeroLocalRect,
-              childMetadata.localFrame ?? zeroLocalRect,
-            )
-          : childMetadata.localFrame ?? zeroLocalRect
-      workingMetadata = {
-        ...workingMetadata,
-        globalFrame: globalFrame,
-        localFrame: localFrame,
-      }
-      workingElements[pathStr] = workingMetadata
-    })
+    workingElements[pathStr] = {
+      ...spyElem,
+      globalFrame: boundingRectangleArray(pluck(children, 'globalFrame')),
+      localFrame: boundingRectangleArray(pluck(children, 'localFrame')),
+    }
   })
 
   return workingElements

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1370,6 +1370,8 @@ export const MetadataUtils = {
   },
 }
 
+// Those elements which are not in the dom have empty globalFrame and localFrame
+// This function calculates the frames from their children (or deeper descendants), which appear in the dom
 function fillSpyOnlyMetadataWithFramesFromChildren(
   fromSpy: ElementInstanceMetadataMap,
   fromDOM: ElementInstanceMetadataMap,
@@ -1401,8 +1403,6 @@ function fillSpyOnlyMetadataWithFramesFromChildren(
     return children
   }
 
-  // those elements which are not in the dom need calculated localFrame and globalFrame
-  // from their children (or deeper descendants)
   const elementsWithoutDomMetadata = Object.keys(fromSpy).filter((p) => fromDOM[p] == null)
 
   const workingElements: ElementInstanceMetadataMap = {}

--- a/editor/src/core/model/element-metadata.spec.browser2.tsx
+++ b/editor/src/core/model/element-metadata.spec.browser2.tsx
@@ -1,0 +1,197 @@
+/// <reference types="karma-viewport" />
+
+import { renderTestEditorWithCode } from '../../components/canvas/ui-jsx.test-utils'
+import { canvasRectangle, localRectangle } from '../shared/math-utils'
+
+describe('Frame calculation for fragments', () => {
+  // Components with root fragments do not appear in the DOM, so the dom walker does not find them, and they
+  // do not appear in the dom metadata.
+  // To make sure they still have globalFrame and localFrame in the jsxMetadata, we calculate the frames from
+  // their descendants which are rendered in the dom (see mergeComponentMetadata function)
+
+  before(() => {
+    viewport.set(2200, 1000)
+  })
+
+  it('Frames of component with root fragment is union of its children', async () => {
+    const fragmentComponentPath = 'story/scene/app:frag'
+
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectWithFragment,
+      'await-first-dom-report',
+    )
+
+    expect(
+      renderResult.getEditorState().editor.jsxMetadata[fragmentComponentPath].localFrame,
+    ).toEqual(
+      localRectangle({
+        x: 64,
+        y: 114,
+        height: 363,
+        width: 210,
+      }),
+    )
+    expect(
+      renderResult.getEditorState().editor.jsxMetadata[fragmentComponentPath].globalFrame,
+    ).toEqual(
+      canvasRectangle({
+        x: 101,
+        y: 179,
+        height: 363,
+        width: 210,
+      }),
+    )
+  })
+  it('Frames of component with root fragment and map inside is union of its children', async () => {
+    const fragmentComponentPath = 'story/scene/app:frag'
+
+    const renderResult = await renderTestEditorWithCode(
+      TestProjectWithFragmentAndMap,
+      'await-first-dom-report',
+    )
+
+    expect(
+      renderResult.getEditorState().editor.jsxMetadata[fragmentComponentPath].localFrame,
+    ).toEqual(
+      localRectangle({
+        x: 64,
+        y: 114,
+        height: 90,
+        width: 10,
+      }),
+    )
+    expect(
+      renderResult.getEditorState().editor.jsxMetadata[fragmentComponentPath].globalFrame,
+    ).toEqual(
+      canvasRectangle({
+        x: 101,
+        y: 179,
+        height: 90,
+        width: 10,
+      }),
+    )
+  })
+})
+
+const TestProjectWithFragment = `
+import * as React from 'react'
+import { Scene, Storyboard } from "utopia-api";
+
+export var App = (props) => {
+  return (
+    <Frag data-uid='frag'>
+      <div
+        style={{
+          left: 64,
+          top: 114,
+          width: 210,
+          height: 199,
+          position: 'absolute',
+          backgroundColor: '#d3d3d3',
+        }}
+      >
+        <div
+          style={{
+            left: 33,
+            top: 91,
+            width: 97,
+            height: 94,
+            position: 'absolute',
+            backgroundColor: '#FFFFFF',
+            border: '0px solid rgb(0, 0, 0, 1)',
+          }}
+        />
+      </div>
+      <div
+        style={{
+          left: 95,
+          top: 356,
+          width: 148,
+          height: 121,
+          position: 'absolute',
+          backgroundColor: '#F76565',
+        }}
+      >
+        <div
+          style={{
+            left: 35,
+            top: 29,
+            width: 48,
+            height: 48,
+          }}
+          data-uid='3bb'
+        />
+      </div>
+    </Frag>
+  )
+}
+
+const Frag = (props) => {
+  return <>{props.children}</>
+}
+
+export var storyboard = (
+  <Storyboard data-uid='story'>
+    <Scene
+      style={{
+        position: 'absolute',
+        left: 37,
+        top: 65,
+        width: 375,
+        height: 812,
+      }}
+      data-uid='scene'
+    >
+      <App data-uid='app' />
+    </Scene>
+  </Storyboard>
+);
+`
+
+const TestProjectWithFragmentAndMap = `
+import * as React from 'react'
+import { Scene, Storyboard } from "utopia-api";
+
+export var App = (props) => {
+  const arr = [0, 1, 2, 3, 4]
+  return (
+    <Frag data-uid='frag'>
+      {arr.map((idx) => {
+        return (
+          <div
+            style={{
+              left: 64,
+              top: 114 + idx * 20,
+              width: 10,
+              height: 10,
+              position: 'absolute',
+              backgroundColor: '#d3d3d3',
+            }}
+          />
+        )
+      })}
+    </Frag>
+  )
+}
+
+const Frag = (props) => {
+  return <>{props.children}</>
+}
+
+export var storyboard = (
+  <Storyboard data-uid='story'>
+    <Scene
+      style={{
+        position: 'absolute',
+        left: 37,
+        top: 65,
+        width: 375,
+        height: 812,
+      }}
+      data-uid='scene'
+    >
+      <App data-uid='app' />
+    </Scene>
+  </Storyboard>
+);
+`


### PR DESCRIPTION
# Issue

If a component returns a fragment as the root element, the element and the component do not appear in the DOM. This means the dom walker can not reach these elements, and they do not appear in the `domMetadata`
Without `domMetadata`, they don't have `localFrame` and `globalFrame` neither.

# Solution

The solution is to extend the merge logic in `mergeComponentMetadata`.
If an element is not in the dom metadata, but available in the spy metadata, we try to reconstruct its bounding box from its children (or deeper descendants) in the dom.

