### PR TITLE
When reparenting cater for imports of built-in dependencies.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.spec.tsx
@@ -18,6 +18,7 @@ import { altModifier, Modifiers } from '../../../utils/modifiers'
 import { pickCanvasStateFromEditorState } from './canvas-strategies'
 import { InteractionSession } from './interaction-state'
 import { createMouseInteractionForTests } from './interaction-state.test-utils'
+import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 
 function prepareEditorState(codeSnippet: string, selectedViews: Array<ElementPath>): EditorState {
   return {
@@ -71,7 +72,7 @@ function dragByPixelsIsApplicable(
   }
 
   return absoluteDuplicateStrategy.isApplicable(
-    pickCanvasStateFromEditorState(editorState),
+    pickCanvasStateFromEditorState(editorState, createBuiltInDependenciesList(null)),
     interactionSession,
     metadata,
     editorState.allElementProps,

--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -1,3 +1,4 @@
+import { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { generateUidWithExistingComponents } from '../../../core/model/element-template-utils'
 import * as EP from '../../../core/shared/element-path'
@@ -113,6 +114,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
           updateSelectedViews('permanent', newPaths),
           updateFunctionCommand('permanent', (editorState, transient) =>
             runMoveStrategyForFreshlyDuplicatedElements(
+              canvasState.builtInDependencies,
               editorState,
               {
                 ...strategyState,
@@ -140,12 +142,13 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
 }
 
 function runMoveStrategyForFreshlyDuplicatedElements(
+  builtInDependencies: BuiltInDependencies,
   editorState: EditorState,
   strategyState: StrategyState,
   interactionState: InteractionSession,
   transient: TransientOrNot,
 ): Array<EditorStatePatch> {
-  const canvasState = pickCanvasStateFromEditorState(editorState)
+  const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 
   const moveCommands = absoluteMoveStrategy.apply(
     canvasState,

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -1,3 +1,4 @@
+import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { elementPath } from '../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
@@ -111,7 +112,7 @@ function dragByPixels(
   }
 
   const strategyResult = absoluteMoveStrategy.apply(
-    pickCanvasStateFromEditorState(editorState),
+    pickCanvasStateFromEditorState(editorState, createBuiltInDependenciesList(null)),
     interactionSession,
     {
       currentStrategy: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -31,6 +31,7 @@ import {
 import { PrettierConfig } from 'utopia-vscode-common'
 import * as Prettier from 'prettier/standalone'
 import { right } from '../../../core/shared/either'
+import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 
 jest.mock('../canvas-utils', () => ({
   ...jest.requireActual('../canvas-utils'),
@@ -63,7 +64,7 @@ function reparentElement(
   }
 
   const strategyResult = absoluteReparentStrategy.apply(
-    pickCanvasStateFromEditorState(editorState),
+    pickCanvasStateFromEditorState(editorState, createBuiltInDependenciesList(null)),
     interactionSession,
     {
       currentStrategy: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
@@ -85,6 +85,7 @@ function dragElement(
 }
 
 const defaultAbsoluteChildCode = `
+import * as React from 'react'
 export const AbsoluteChild = () => {
   return (
     <div
@@ -106,6 +107,7 @@ export const AbsoluteChild = () => {
 }`
 
 const defaultAbsoluteParentCode = `
+import * as React from 'react'
 import { AbsoluteChild } from './absolutechild'
 export const AbsoluteParent = () => {
   return (
@@ -127,6 +129,7 @@ export const AbsoluteParent = () => {
 }`
 
 const defaultAppCode = `
+import * as React from 'react'
 import { AbsoluteParent } from './absoluteparent'
 import { FlexParent } from './flexparent'
 
@@ -149,6 +152,7 @@ export var App = () => {
 }`
 
 const defaultFlexChildCode = `
+import * as React from 'react'
 export const FlexChild1 = () => {
   return (
     <div
@@ -184,6 +188,7 @@ export const FlexChild2 = () => {
 }`
 
 const defaultFlexParentCode = `
+import * as React from 'react'
 import { FlexChild1, FlexChild2 } from './flexchild'
 export const FlexParent = () => {
   return (
@@ -336,7 +341,8 @@ describe('Absolute Reparent Strategy (Multi-File)', () => {
     await renderResult.getDispatchFollowUpActionsFinished()
     expect(getFileCode(renderResult, '/src/absolutechild.js')).toEqual(defaultAbsoluteChildCode)
     expect(getFileCode(renderResult, '/src/absoluteparent.js')).toEqual(
-      `import { AbsoluteChild } from './absolutechild'
+      `import * as React from 'react'
+import { AbsoluteChild } from './absolutechild'
 export const AbsoluteParent = () => {
   return (
     <div
@@ -356,7 +362,8 @@ export const AbsoluteParent = () => {
 `,
     )
     expect(getFileCode(renderResult, '/src/app.js')).toEqual(
-      `import { AbsoluteParent } from './absoluteparent'
+      `import * as React from 'react'
+import { AbsoluteParent } from './absoluteparent'
 import { FlexParent } from './flexparent'
 import { AbsoluteChild } from '/src/absolutechild.js'
 

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-multi-file.spec.browser2.tsx
@@ -228,7 +228,7 @@ function makeTestProjectContents(): ProjectContentTreeRoot {
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "utopia-api": "0.4.1",
-    "react-spring": "8.0.27",
+    "non-existant-dummy-library": "8.0.27",
     "@heroicons/react": "1.0.1",
     "@emotion/react": "11.9.3"
   }

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -1,3 +1,4 @@
+import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { elementPath } from '../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
@@ -60,7 +61,7 @@ function dragByPixels(
   }
 
   const strategyResult = absoluteMoveStrategy.apply(
-    pickCanvasStateFromEditorState(editorState),
+    pickCanvasStateFromEditorState(editorState, createBuiltInDependenciesList(null)),
     interactionSession,
     {
       currentStrategy: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.tsx
@@ -22,6 +22,7 @@ import { InteractionSession, StrategyState } from './interaction-state'
 import { createMouseInteractionForTests } from './interaction-state.test-utils'
 import * as EP from '../../../core/shared/element-path'
 import { right } from '../../../core/shared/either'
+import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 
 jest.mock('../canvas-utils', () => ({
   ...jest.requireActual('../canvas-utils'),
@@ -60,7 +61,7 @@ function reparentElement(
   }
 
   const strategyResult = absoluteReparentStrategy.apply(
-    pickCanvasStateFromEditorState(editorState),
+    pickCanvasStateFromEditorState(editorState, createBuiltInDependenciesList(null)),
     interactionSession,
     {
       currentStrategy: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -117,6 +117,7 @@ export const absoluteReparentStrategy: CanvasStrategy = {
           commands: [
             ...offsetCommands,
             ...getReparentCommands(
+              canvasState.builtInDependencies,
               projectContents,
               nodeModules,
               openFile,

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
@@ -128,6 +128,7 @@ export const absoluteReparentToFlexStrategy: CanvasStrategy = {
           // Reparent the element.
           const newPath = EP.appendToPath(reparentResult.newParent, EP.toUid(target))
           const reparentCommands = getReparentCommands(
+            canvasState.builtInDependencies,
             canvasState.projectContents,
             canvasState.nodeModules,
             canvasState.openFile,

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -27,6 +27,7 @@ import { StrategyState } from './interaction-state'
 import { createMouseInteractionForTests } from './interaction-state.test-utils'
 import { absoluteResizeBoundingBoxStrategy } from './absolute-resize-bounding-box-strategy'
 import { defaultCustomStrategyState } from './canvas-strategy-types'
+import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 
 function multiselectResizeElements(
   snippet: string,
@@ -49,7 +50,7 @@ function multiselectResizeElements(
   )
 
   const strategyResult = absoluteResizeBoundingBoxStrategy.apply(
-    pickCanvasStateFromEditorState(initialEditor),
+    pickCanvasStateFromEditorState(initialEditor, createBuiltInDependenciesList(null)),
     { ...interactionSessionWithoutMetadata, metadata: {}, allElementProps: {} },
     {
       currentStrategy: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
@@ -164,7 +164,10 @@ describe('Strategy Fitness', () => {
 
     const canvasStrategy = findCanvasStrategy(
       RegisteredCanvasStrategies,
-      pickCanvasStateFromEditorState(renderResult.getEditorState().editor),
+      pickCanvasStateFromEditorState(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().builtInDependencies,
+      ),
       interactionSession,
       baseStrategyState(
         renderResult.getEditorState().editor.jsxMetadata,
@@ -212,7 +215,10 @@ describe('Strategy Fitness', () => {
 
     const canvasStrategy = findCanvasStrategy(
       RegisteredCanvasStrategies,
-      pickCanvasStateFromEditorState(renderResult.getEditorState().editor),
+      pickCanvasStateFromEditorState(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().builtInDependencies,
+      ),
       interactionSession,
       baseStrategyState(
         renderResult.getEditorState().editor.jsxMetadata,
@@ -264,7 +270,10 @@ describe('Strategy Fitness', () => {
 
     const canvasStrategy = findCanvasStrategy(
       RegisteredCanvasStrategies,
-      pickCanvasStateFromEditorState(renderResult.getEditorState().editor),
+      pickCanvasStateFromEditorState(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().builtInDependencies,
+      ),
       interactionSession,
       baseStrategyState(
         renderResult.getEditorState().editor.jsxMetadata,
@@ -316,7 +325,10 @@ describe('Strategy Fitness', () => {
 
     const canvasStrategy = findCanvasStrategy(
       RegisteredCanvasStrategies,
-      pickCanvasStateFromEditorState(renderResult.getEditorState().editor),
+      pickCanvasStateFromEditorState(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().builtInDependencies,
+      ),
       interactionSession,
       baseStrategyState(
         renderResult.getEditorState().editor.jsxMetadata,
@@ -364,7 +376,10 @@ describe('Strategy Fitness', () => {
 
     const canvasStrategy = findCanvasStrategy(
       RegisteredCanvasStrategies,
-      pickCanvasStateFromEditorState(renderResult.getEditorState().editor),
+      pickCanvasStateFromEditorState(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().builtInDependencies,
+      ),
       interactionSession,
       baseStrategyState(
         renderResult.getEditorState().editor.jsxMetadata,
@@ -412,7 +427,10 @@ describe('Strategy Fitness', () => {
 
     const canvasStrategy = findCanvasStrategy(
       RegisteredCanvasStrategies,
-      pickCanvasStateFromEditorState(renderResult.getEditorState().editor),
+      pickCanvasStateFromEditorState(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().builtInDependencies,
+      ),
       interactionSession,
       baseStrategyState(
         renderResult.getEditorState().editor.jsxMetadata,

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -26,6 +26,7 @@ import { absoluteDuplicateStrategy } from './absolute-duplicate-strategy'
 import { absoluteReparentToFlexStrategy } from './absolute-reparent-to-flex-strategy'
 import { flexReparentToAbsoluteStrategy } from './flex-reparent-to-absolute-strategy'
 import { flexReparentToFlexStrategy } from './flex-reparent-to-flex-strategy'
+import { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 
 export const RegisteredCanvasStrategies: Array<CanvasStrategy> = [
   absoluteMoveStrategy,
@@ -41,8 +42,12 @@ export const RegisteredCanvasStrategies: Array<CanvasStrategy> = [
   absoluteReparentToFlexStrategy,
 ]
 
-export function pickCanvasStateFromEditorState(editorState: EditorState): InteractionCanvasState {
+export function pickCanvasStateFromEditorState(
+  editorState: EditorState,
+  builtInDependencies: BuiltInDependencies,
+): InteractionCanvasState {
   return {
+    builtInDependencies: builtInDependencies,
     selectedElements: editorState.selectedViews,
     projectContents: editorState.projectContents,
     nodeModules: editorState.nodeModules.files,
@@ -66,7 +71,7 @@ function getApplicableStrategies(
 
 const getApplicableStrategiesSelector = createSelector(
   (store: EditorStorePatched): InteractionCanvasState => {
-    return pickCanvasStateFromEditorState(store.editor)
+    return pickCanvasStateFromEditorState(store.editor, store.builtInDependencies)
   },
   (store: EditorStorePatched) => store.editor.canvas.interactionSession,
   (store: EditorStorePatched) => store.editor.jsxMetadata,
@@ -133,7 +138,7 @@ function getApplicableStrategiesOrderedByFitness(
 
 const getApplicableStrategiesOrderedByFitnessSelector = createSelector(
   (store: EditorStorePatched): InteractionCanvasState => {
-    return pickCanvasStateFromEditorState(store.editor)
+    return pickCanvasStateFromEditorState(store.editor, store.builtInDependencies)
   },
   (store: EditorStorePatched) => store.editor.canvas.interactionSession,
   (store: EditorStorePatched) => store.strategyState,

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -1,4 +1,5 @@
-import { AllElementProps } from 'src/components/editor/store/editor-state'
+import { AllElementProps } from '../../../components/editor/store/editor-state'
+import { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import { CanvasVector } from '../../../core/shared/math-utils'
 import { ElementPath, NodeModules } from '../../../core/shared/project-file-types'
@@ -44,6 +45,7 @@ export interface InteractionCanvasState {
   selectedElements: Array<ElementPath>
   projectContents: ProjectContentTreeRoot
   nodeModules: NodeModules
+  builtInDependencies: BuiltInDependencies
   openFile: string | null | undefined
   scale: number
   canvasOffset: CanvasVector

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.spec.tsx
@@ -1,3 +1,4 @@
+import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { elementPath } from '../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
@@ -178,7 +179,7 @@ function dragByPixels(
   }
 
   const strategyResult = escapeHatchStrategy.apply(
-    pickCanvasStateFromEditorState(editorState),
+    pickCanvasStateFromEditorState(editorState, createBuiltInDependenciesList(null)),
     interactionSession,
     {
       currentStrategy: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -272,6 +272,7 @@ function collectSetLayoutPropCommands(
     if (shouldReparent) {
       commands.push(
         ...getReparentCommands(
+          canvasState.builtInDependencies,
           canvasState.projectContents,
           canvasState.nodeModules,
           canvasState.openFile,

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
@@ -1,3 +1,4 @@
+import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { elementPath } from '../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
@@ -174,7 +175,7 @@ function reorderElement(
   }
 
   const strategyResult = flexReorderStrategy.apply(
-    pickCanvasStateFromEditorState(editorState),
+    pickCanvasStateFromEditorState(editorState, createBuiltInDependenciesList(null)),
     interactionSession,
     {
       currentStrategy: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
@@ -1,3 +1,4 @@
+import { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { canvasPoint, offsetPoint, rectContainsPoint } from '../../../core/shared/math-utils'
 import { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
@@ -84,6 +85,7 @@ export const flexReparentToAbsoluteStrategy: CanvasStrategy = {
           ...escapeHatchCommands,
           updateFunctionCommand('permanent', (editorState, transient): Array<EditorStatePatch> => {
             return runAbsoluteReparentStrategyForFreshlyConvertedElement(
+              canvasState.builtInDependencies,
               editorState,
               strategyState,
               interactionState,
@@ -98,12 +100,13 @@ export const flexReparentToAbsoluteStrategy: CanvasStrategy = {
 }
 
 function runAbsoluteReparentStrategyForFreshlyConvertedElement(
+  builtInDependencies: BuiltInDependencies,
   editorState: EditorState,
   strategyState: StrategyState,
   interactionState: InteractionSession,
   transient: TransientOrNot,
 ): Array<EditorStatePatch> {
-  const canvasState = pickCanvasStateFromEditorState(editorState)
+  const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
 
   const reparentCommands = absoluteReparentStrategy.apply(
     canvasState,

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
@@ -85,6 +85,7 @@ export const flexReparentToFlexStrategy: CanvasStrategy = {
           // Reparent the element.
           const newPath = EP.appendToPath(reparentResult.newParent, EP.toUid(target))
           const reparentCommands = getReparentCommands(
+            canvasState.builtInDependencies,
             canvasState.projectContents,
             canvasState.nodeModules,
             canvasState.openFile,

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -1,3 +1,4 @@
+import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { elementPath } from '../../../core/shared/element-path'
 import {
   ElementInstanceMetadata,
@@ -46,7 +47,7 @@ export function pressKeys(
   }
 
   const strategyResult = strategy.apply(
-    pickCanvasStateFromEditorState(editorState),
+    pickCanvasStateFromEditorState(editorState, createBuiltInDependenciesList(null)),
     interactionSession,
     {
       currentStrategy: null as any, // the strategy does not use this

--- a/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
@@ -17,8 +17,10 @@ import * as EP from '../../../core/shared/element-path'
 import { getImportsFor, importedFromWhere } from '../../../components/editor/import-utils'
 import { forceNotNull } from '../../../core/shared/optional-utils'
 import { addImportsToFile } from '../commands/add-imports-to-file-command'
+import { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 
 export function getReparentCommands(
+  builtInDependencies: BuiltInDependencies,
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
   openFile: string | null | undefined,
@@ -74,6 +76,7 @@ export function getReparentCommands(
                     newTargetPath,
                     importsToAdd,
                     getImportsFor(
+                      builtInDependencies,
                       importsInOriginFile,
                       projectContents,
                       nodeModules,
@@ -88,6 +91,7 @@ export function getReparentCommands(
                       newTargetPath,
                       importsToAdd,
                       getImportsFor(
+                        builtInDependencies,
                         importsInOriginFile,
                         projectContents,
                         nodeModules,

--- a/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/shared-absolute-resize-strategy-helpers.ts
@@ -1,4 +1,4 @@
-import { AllElementProps } from 'src/components/editor/store/editor-state'
+import { AllElementProps } from '../../../components/editor/store/editor-state'
 import { isHorizontalPoint } from 'utopia-api/core'
 import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
 import { framePointForPinnedProp } from '../../../core/layout/layout-helpers-new'

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -30,7 +30,7 @@ import {
   InteractionSessionWithoutMetadata,
 } from './canvas-strategies/interaction-state'
 import { CanvasStrategyId } from './canvas-strategies/canvas-strategy-types'
-import { MouseButtonsPressed } from 'src/utils/mouse'
+import { MouseButtonsPressed } from '../../utils/mouse'
 
 export const CanvasContainerID = 'canvas-container'
 

--- a/editor/src/components/canvas/canvas-utils-scene.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-utils-scene.spec.browser2.tsx
@@ -16,6 +16,7 @@ import { BakedInStoryboardUID } from '../../core/model/scene-utils'
 import { CanvasControlsContainerID } from './controls/new-canvas-controls'
 import { wait } from '../../utils/utils.test-utils'
 import { isFeatureEnabled, setFeatureEnabled } from '../../utils/feature-switches'
+import { resetMouseStatus } from '../mouse-move'
 
 describe('moving a scene/rootview on the canvas', () => {
   let originalValue = isFeatureEnabled('Canvas Strategies')
@@ -200,7 +201,7 @@ describe('moving a scene/rootview on the canvas', () => {
 
     // Ensures that the two mouse moves are handled without the check against
     // didWeHandleMouseMoveForThisFrame not triggering.
-    await wait(5)
+    resetMouseStatus()
 
     await act(async () => {
       const dispatchDone = renderResult.getDispatchFollowUpActionsFinished()

--- a/editor/src/components/canvas/canvas-utils-unit-tests.spec.tsx
+++ b/editor/src/components/canvas/canvas-utils-unit-tests.spec.tsx
@@ -18,7 +18,7 @@ describe('updateFramesOfScenesAndComponents - multi-file', () => {
     const targetPath = EP.elementPath([
       ['storyboard-entity', 'scene-1-entity', 'app-entity'],
       ['app-outer-div', 'card-instance'],
-      ['card-outer-div', 'card-inner-rectangle'],
+      ['card-outer-div', 'card-inner-spring'],
     ])
 
     const pinChange = singleResizeChange(
@@ -31,7 +31,7 @@ describe('updateFramesOfScenesAndComponents - multi-file', () => {
 
     expect(testPrintCodeFromEditorState(updatedProject, '/src/card.js')).toMatchInlineSnapshot(`
       "import * as React from 'react'
-      import { Rectangle } from 'utopia-api'
+      import { Spring } from 'react-spring'
       export var Card = (props) => {
         return (
           <div
@@ -49,9 +49,9 @@ describe('updateFramesOfScenesAndComponents - multi-file', () => {
                 backgroundColor: 'red',
               }}
             />
-            <Rectangle
-              data-uid='card-inner-rectangle'
-              data-testid='rectangle'
+            <Spring
+              data-uid='card-inner-spring'
+              data-testid='spring'
               style={{
                 position: 'absolute',
                 left: 100,
@@ -73,7 +73,7 @@ describe('updateFramesOfScenesAndComponents - multi-file', () => {
     const targetPath = EP.elementPath([
       ['storyboard-entity', 'scene-1-entity', 'app-entity'],
       ['app-outer-div', 'card-instance'],
-      ['card-outer-div', 'card-inner-rectangle'],
+      ['card-outer-div', 'card-inner-spring'],
     ])
 
     const pinChange = pinMoveChange(targetPath, { x: 60, y: 40 } as CanvasVector)
@@ -82,7 +82,7 @@ describe('updateFramesOfScenesAndComponents - multi-file', () => {
 
     expect(testPrintCodeFromEditorState(updatedProject, '/src/card.js')).toMatchInlineSnapshot(`
       "import * as React from 'react'
-      import { Rectangle } from 'utopia-api'
+      import { Spring } from 'react-spring'
       export var Card = (props) => {
         return (
           <div
@@ -100,9 +100,9 @@ describe('updateFramesOfScenesAndComponents - multi-file', () => {
                 backgroundColor: 'red',
               }}
             />
-            <Rectangle
-              data-uid='card-inner-rectangle'
-              data-testid='rectangle'
+            <Spring
+              data-uid='card-inner-spring'
+              data-testid='spring'
               style={{
                 position: 'absolute',
                 left: 160,

--- a/editor/src/components/canvas/canvas-utils-unit-tests.spec.tsx
+++ b/editor/src/components/canvas/canvas-utils-unit-tests.spec.tsx
@@ -31,7 +31,7 @@ describe('updateFramesOfScenesAndComponents - multi-file', () => {
 
     expect(testPrintCodeFromEditorState(updatedProject, '/src/card.js')).toMatchInlineSnapshot(`
       "import * as React from 'react'
-      import { Spring } from 'react-spring'
+      import { Spring } from 'non-existant-dummy-library'
       export var Card = (props) => {
         return (
           <div
@@ -82,7 +82,7 @@ describe('updateFramesOfScenesAndComponents - multi-file', () => {
 
     expect(testPrintCodeFromEditorState(updatedProject, '/src/card.js')).toMatchInlineSnapshot(`
       "import * as React from 'react'
-      import { Spring } from 'react-spring'
+      import { Spring } from 'non-existant-dummy-library'
       export var Card = (props) => {
         return (
           <div

--- a/editor/src/components/canvas/commands/duplicate-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/duplicate-element-command.spec.tsx
@@ -21,7 +21,7 @@ describe('runDuplicateElement', () => {
     const targetPath = EP.elementPath([
       ['storyboard-entity', 'scene-1-entity', 'app-entity'],
       ['app-outer-div', 'card-instance'],
-      ['card-outer-div', 'card-inner-rectangle'],
+      ['card-outer-div', 'card-inner-spring'],
     ])
 
     const originalEditorState = renderResult.getEditorState().editor

--- a/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
+++ b/editor/src/components/canvas/commands/reparent-element-command.spec.tsx
@@ -17,7 +17,7 @@ describe('runReparentElement', () => {
     const targetPath = EP.elementPath([
       ['storyboard-entity', 'scene-1-entity', 'app-entity'],
       ['app-outer-div', 'card-instance'],
-      ['card-outer-div', 'card-inner-rectangle'],
+      ['card-outer-div', 'card-inner-spring'],
     ])
 
     const newParentPath = EP.elementPath([
@@ -68,7 +68,7 @@ describe('runReparentElement', () => {
     const targetPath = EP.elementPath([
       ['storyboard-entity', 'scene-1-entity', 'app-entity'],
       ['app-outer-div', 'card-instance'],
-      ['card-outer-div', 'card-inner-rectangle'],
+      ['card-outer-div', 'card-inner-spring'],
     ])
 
     const newParentPath = EP.elementPath([

--- a/editor/src/components/canvas/commands/update-selected-views-command.spec.tsx
+++ b/editor/src/components/canvas/commands/update-selected-views-command.spec.tsx
@@ -17,7 +17,7 @@ describe('updateSelectedViews', () => {
     const targetPath = EP.elementPath([
       ['storyboard-entity', 'scene-1-entity', 'app-entity'],
       ['app-outer-div', 'card-instance'],
-      ['card-outer-div', 'card-inner-rectangle'],
+      ['card-outer-div', 'card-inner-spring'],
     ])
 
     const originalEditorState = renderResult.getEditorState().editor

--- a/editor/src/components/canvas/controls/component-area-control.tsx
+++ b/editor/src/components/canvas/controls/component-area-control.tsx
@@ -12,7 +12,7 @@ import { ControlFontSize } from '../canvas-controls-frame'
 import { CanvasPositions } from '../canvas-types'
 //TODO: switch to functional component and make use of 'useColorTheme':
 import { UtopiaTheme, colorTheme } from '../../../uuiui'
-import { AllElementProps } from 'src/components/editor/store/editor-state'
+import { AllElementProps } from '../../../components/editor/store/editor-state'
 
 interface ComponentAreaControlProps {
   mouseEnabled: boolean

--- a/editor/src/components/canvas/controls/property-target-selector.tsx
+++ b/editor/src/components/canvas/controls/property-target-selector.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ElementProps } from 'src/components/editor/store/editor-state'
+import { ElementProps } from '../../../components/editor/store/editor-state'
 import { useContextSelector } from 'use-context-selector'
 import { LayoutTargetableProp, StyleLayoutProp } from '../../../core/layout/layout-helpers-new'
 import { getSimpleAttributeAtPath } from '../../../core/model/element-metadata-utils'

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -47,7 +47,7 @@ import {
 } from '../../canvas-strategies/interaction-state'
 import { Modifier, Modifiers } from '../../../../utils/modifiers'
 import { pathsEqual } from '../../../../core/shared/element-path'
-import { EditorAction } from 'src/components/editor/action-types'
+import { EditorAction } from '../../../../components/editor/action-types'
 
 const DRAG_START_THRESHOLD = 2
 

--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -391,6 +391,8 @@ export var App = (props) => {
 }`,
         '/src/card.js': `import * as React from 'react'
 import { Rectangle } from 'utopia-api'
+import { Spring } from 'react-spring'
+console.log('Spring', Spring)
 export var Card = (props) => {
   return (
     <div
@@ -408,8 +410,8 @@ export var Card = (props) => {
           backgroundColor: 'red',
         }}
       />
-      <Rectangle
-        data-uid='card-inner-rectangle'
+      <Spring
+        data-uid='card-inner-spring'
         style={{
           position: 'absolute',
           left: 100,
@@ -498,6 +500,7 @@ export default function () {
                   data-path=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-div\\"
                 ></div>
                 <div
+                  data-uid=\\"card-inner-spring\\"
                   style=\\"
                     position: absolute;
                     left: 100px;
@@ -506,9 +509,7 @@ export default function () {
                     height: 50px;
                     background-color: blue;
                   \\"
-                  data-path=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle\\"
-                  data-uid=\\"card-inner-rectangle\\"
-                  data-utopia-do-not-traverse=\\"true\\"
+                  data-path=\\"storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-spring\\"
                 ></div>
               </div>
               hello

--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -392,7 +392,6 @@ export var App = (props) => {
         '/src/card.js': `import * as React from 'react'
 import { Rectangle } from 'utopia-api'
 import { Spring } from 'react-spring'
-console.log('Spring', Spring)
 export var Card = (props) => {
   return (
     <div

--- a/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-bugs.spec.tsx
@@ -391,7 +391,7 @@ export var App = (props) => {
 }`,
         '/src/card.js': `import * as React from 'react'
 import { Rectangle } from 'utopia-api'
-import { Spring } from 'react-spring'
+import { Spring } from 'non-existant-dummy-library'
 export var Card = (props) => {
   return (
     <div

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper-third-party.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-spy-wrapper-third-party.spec.browser2.tsx
@@ -22,7 +22,7 @@ import { matchInlineSnapshotBrowser } from '../../../../test/karma-snapshots'
 import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { NO_OP } from '../../../core/shared/utils'
 import CanvasActions from '../canvas-actions'
-import { CanvasVector } from 'src/core/shared/math-utils'
+import { CanvasVector } from '../../../core/shared/math-utils'
 
 const builtInDependencies = createBuiltInDependenciesList(null)
 builtInDependencies.push({

--- a/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.test-utils.tsx
@@ -28,7 +28,7 @@ import { emptyImports } from '../../core/workers/common/project-file-utils'
 import { testParseCode } from '../../core/workers/parser-printer/parser-printer.test-utils'
 import { Utils } from '../../uuiui-deps'
 import { normalizeName } from '../custom-code/custom-code-utils'
-import { ConsoleLog, deriveState } from '../editor/store/editor-state'
+import { ConsoleLog, deriveState, EditorState } from '../editor/store/editor-state'
 import {
   UiJsxCanvasProps,
   UiJsxCanvasContextData,
@@ -49,6 +49,9 @@ import { getRequireFn } from '../../core/es-modules/package-manager/package-mana
 import type { ScriptLine } from '../../third-party/react-error-overlay/utils/stack-frame'
 import type { CurriedResolveFn } from '../custom-code/code-file'
 import * as path from 'path'
+import { SampleNodeModules } from '../custom-code/code-file.test-utils'
+import { UPDATE_FNS } from '../editor/actions/actions'
+import { updateNodeModulesContents } from '../editor/actions/action-creators'
 
 export interface PartialCanvasProps {
   hiddenInstances: UiJsxCanvasProps['hiddenInstances']
@@ -165,13 +168,13 @@ export function renderCanvasReturnResultAndError(
     getRequireFn(
       NO_OP,
       innerProjectContents,
-      {},
+      SampleNodeModules,
       {},
       storeHookForTest.useStore().builtInDependencies,
     )
 
   storeHookForTest.updateStore((store) => {
-    const updatedEditor = {
+    let updatedEditor: EditorState = {
       ...store.editor,
       canvas: {
         ...store.editor.canvas,
@@ -181,6 +184,12 @@ export function renderCanvasReturnResultAndError(
       },
       projectContents: updatedContents,
     }
+    updatedEditor = UPDATE_FNS.UPDATE_NODE_MODULES_CONTENTS(
+      updateNodeModulesContents(SampleNodeModules),
+      updatedEditor,
+      store.dispatch,
+      store.builtInDependencies,
+    )
     return {
       ...store,
       editor: updatedEditor,

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -322,7 +322,7 @@ export async function renderTestEditorWithModel(
         numberOfCommits++
       }}
     >
-      <FailJestOnCanvasError />
+      {/* <FailJestOnCanvasError /> */}
       <EditorRoot
         api={storeHook}
         useStore={storeHook}
@@ -340,7 +340,16 @@ export async function renderTestEditorWithModel(
       load(
         async (actions) => {
           try {
-            await asyncTestDispatch(actions, undefined, true)
+            await asyncTestDispatch(
+              [
+                ...actions,
+                switchEditorMode(EditorModes.selectMode()),
+                setPanelVisibility('codeEditor', false),
+                updateNodeModulesContents(SampleNodeModules),
+              ],
+              undefined,
+              true,
+            )
             resolve()
           } catch (e) {
             reject(e)
@@ -353,18 +362,6 @@ export async function renderTestEditorWithModel(
         false,
       )
     })
-  })
-
-  await act(async () => {
-    await asyncTestDispatch(
-      [
-        switchEditorMode(EditorModes.selectMode()),
-        setPanelVisibility('codeEditor', false),
-        updateNodeModulesContents(SampleNodeModules),
-      ],
-      undefined,
-      true,
-    )
   })
 
   return {

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -322,7 +322,7 @@ export async function renderTestEditorWithModel(
         numberOfCommits++
       }}
     >
-      {/* <FailJestOnCanvasError /> */}
+      <FailJestOnCanvasError />
       <EditorRoot
         api={storeHook}
         useStore={storeHook}

--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -556,7 +556,7 @@ describe('normalisePathToUnderlyingTarget', () => {
         'storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-spring:spring-inner-div',
       ),
     )
-    const expectedResult = normalisePathEndsAtDependency('react-spring')
+    const expectedResult = normalisePathEndsAtDependency('non-existant-dummy-library')
     expect(actualResult).toEqual(expectedResult)
   })
 })

--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -553,10 +553,10 @@ describe('normalisePathToUnderlyingTarget', () => {
       SampleNodeModules,
       StoryboardFilePath,
       EP.fromString(
-        'storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-rectangle:rectangle-inner-div',
+        'storyboard-entity/scene-1-entity/app-entity:app-outer-div/card-instance:card-outer-div/card-inner-spring:spring-inner-div',
       ),
     )
-    const expectedResult = normalisePathEndsAtDependency('utopia-api')
+    const expectedResult = normalisePathEndsAtDependency('react-spring')
     expect(actualResult).toEqual(expectedResult)
   })
 })

--- a/editor/src/components/custom-code/code-file.test-utils.ts
+++ b/editor/src/components/custom-code/code-file.test-utils.ts
@@ -22,45 +22,28 @@ import { emptySet } from '../../core/shared/set-utils'
 import { parseProjectContents } from '../../sample-projects/sample-project-utils.test-utils'
 
 export const SampleNodeModules: NodeModules = {
-  '/node_modules/utopia-api/index.js': esCodeFile(
-    `export {}`,
+  '/node_modules/react-spring/index.js': esCodeFile(
+    `import * as React from 'react'
+export const Spring = (props) => {
+  return <div {...props} />
+}`,
     'NODE_MODULES',
-    '/node_modules/utopia-api/index.js',
+    '/node_modules/react-spring/index.js',
   ),
-  '/node_modules/utopia-api/package.json': esCodeFile(
+  '/node_modules/react-spring/package.json': esCodeFile(
     JSON.stringify({ main: './index.js' }),
     'NODE_MODULES',
-    '/node_modules/utopia-api/package.json',
+    '/node_modules/react-spring/package.json',
   ),
-  '/node_modules/uuiui/index.js': esCodeFile(
+  '/node_modules/@emotion/react/index.js': esCodeFile(
     `export {}`,
     'NODE_MODULES',
-    '/node_modules/uuiui/index.js',
+    '/node_modules/@emotion/react/index.js',
   ),
-  '/node_modules/uuiui/package.json': esCodeFile(
+  '/node_modules/@emotion/react/package.json': esCodeFile(
     JSON.stringify({ main: './index.js' }),
     'NODE_MODULES',
-    '/node_modules/uuiui/package.json',
-  ),
-  '/node_modules/react/index.js': esCodeFile(
-    `export {}`,
-    'NODE_MODULES',
-    '/node_modules/react/index.js',
-  ),
-  '/node_modules/react/package.json': esCodeFile(
-    JSON.stringify({ main: './index.js' }),
-    'NODE_MODULES',
-    '/node_modules/react/package.json',
-  ),
-  '/node_modules/react-dom/index.js': esCodeFile(
-    `export {}`,
-    'NODE_MODULES',
-    '/node_modules/react-dom/index.js',
-  ),
-  '/node_modules/react-dom/package.json': esCodeFile(
-    JSON.stringify({ main: './index.js' }),
-    'NODE_MODULES',
-    '/node_modules/react-dom/package.json',
+    '/node_modules/@emotion/react/package.json',
   ),
 }
 

--- a/editor/src/components/custom-code/code-file.test-utils.ts
+++ b/editor/src/components/custom-code/code-file.test-utils.ts
@@ -22,18 +22,18 @@ import { emptySet } from '../../core/shared/set-utils'
 import { parseProjectContents } from '../../sample-projects/sample-project-utils.test-utils'
 
 export const SampleNodeModules: NodeModules = {
-  '/node_modules/react-spring/index.js': esCodeFile(
+  '/node_modules/non-existant-dummy-library/index.js': esCodeFile(
     `import * as React from 'react'
 export const Spring = (props) => {
   return <div {...props} />
 }`,
     'NODE_MODULES',
-    '/node_modules/react-spring/index.js',
+    '/node_modules/non-existant-dummy-library/index.js',
   ),
-  '/node_modules/react-spring/package.json': esCodeFile(
+  '/node_modules/non-existant-dummy-library/package.json': esCodeFile(
     JSON.stringify({ main: './index.js' }),
     'NODE_MODULES',
-    '/node_modules/react-spring/package.json',
+    '/node_modules/non-existant-dummy-library/package.json',
   ),
   '/node_modules/@emotion/react/index.js': esCodeFile(
     `export {}`,

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -546,7 +546,9 @@ function lookupElementImport(
             }
           }
         case 'RESOLVE_NOT_PRESENT':
-          return normalisePathError(`Unable to find resolve path at ${importedFrom}`)
+          return normalisePathError(
+            `Unable to find resolve path at ${JSON.stringify(importedFrom)}`,
+          )
         case 'RESOLVE_SUCCESS_IGNORE_MODULE':
           return normalisePathEndsAtIgnoredDependency(importedFrom.filePath)
         default:

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -129,6 +129,7 @@ import { forceNotNull } from '../../../core/shared/optional-utils'
 import { complexDefaultProjectPreParsed } from '../../../sample-projects/sample-project-utils.test-utils'
 import { DefaultThirdPartyControlDefinitions } from '../../../core/third-party/third-party-controls'
 import { cssNumber } from '../../inspector/common/css-utils'
+import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 const chaiExpect = Chai.expect
 
 function storyboardComponent(numberOfScenes: number): UtopiaJSXComponent {
@@ -983,7 +984,7 @@ describe('UPDATE_FILE_PATH', () => {
         ],
         "/src2/card.js": Array [
           "react",
-          "utopia-api",
+          "react-spring",
         ],
         "/src2/index.js": Array [
           "./app.js",
@@ -1054,7 +1055,7 @@ describe('INSERT_INSERTABLE', () => {
         )
         expect(printedCode).toMatchInlineSnapshot(`
           "import * as React from 'react'
-          import { Rectangle } from 'utopia-api'
+          import { Spring } from 'react-spring'
           import { Menu } from 'antd'
           import 'antd/dist/antd.css'
           export var Card = (props) => {
@@ -1070,8 +1071,8 @@ describe('INSERT_INSERTABLE', () => {
                     backgroundColor: 'red',
                   }}
                 />
-                <Rectangle
-                  data-testid='rectangle'
+                <Spring
+                  data-testid='spring'
                   style={{
                     position: 'absolute',
                     left: 100,
@@ -1158,7 +1159,7 @@ describe('INSERT_INSERTABLE', () => {
         )
         expect(printedCode).toMatchInlineSnapshot(`
           "import * as React from 'react'
-          import { Rectangle } from 'utopia-api'
+          import { Spring } from 'react-spring'
           import { Menu } from 'antd'
           import 'antd/dist/antd.css'
           export var Card = (props) => {
@@ -1174,8 +1175,8 @@ describe('INSERT_INSERTABLE', () => {
                     backgroundColor: 'red',
                   }}
                 />
-                <Rectangle
-                  data-testid='rectangle'
+                <Spring
+                  data-testid='spring'
                   style={{
                     position: 'absolute',
                     left: 100,
@@ -1261,7 +1262,7 @@ describe('INSERT_INSERTABLE', () => {
         )
         expect(printedCode).toMatchInlineSnapshot(`
           "import * as React from 'react'
-          import { Rectangle } from 'utopia-api'
+          import { Spring } from 'react-spring'
           export var Card = (props) => {
             return (
               <div style={{ ...props.style }}>
@@ -1275,8 +1276,8 @@ describe('INSERT_INSERTABLE', () => {
                     backgroundColor: 'red',
                   }}
                 />
-                <Rectangle
-                  data-testid='rectangle'
+                <Spring
+                  data-testid='spring'
                   style={{
                     position: 'absolute',
                     left: 100,
@@ -1350,7 +1351,7 @@ describe('INSERT_INSERTABLE', () => {
         )
         expect(printedCode).toMatchInlineSnapshot(`
           "import * as React from 'react'
-          import { Rectangle } from 'utopia-api'
+          import { Spring } from 'react-spring'
           export var Card = (props) => {
             return (
               <div style={{ ...props.style }}>
@@ -1368,8 +1369,8 @@ describe('INSERT_INSERTABLE', () => {
                     backgroundColor: 'red',
                   }}
                 />
-                <Rectangle
-                  data-testid='rectangle'
+                <Spring
+                  data-testid='spring'
                   style={{
                     position: 'absolute',
                     left: 100,
@@ -1437,7 +1438,7 @@ describe('INSERT_INSERTABLE', () => {
         )
         expect(printedCode).toMatchInlineSnapshot(`
           "import * as React from 'react'
-          import { Rectangle } from 'utopia-api'
+          import { Spring } from 'react-spring'
           export var Card = (props) => {
             return (
               <div style={{ ...props.style }}>
@@ -1452,8 +1453,8 @@ describe('INSERT_INSERTABLE', () => {
                       backgroundColor: 'red',
                     }}
                   />
-                  <Rectangle
-                    data-testid='rectangle'
+                  <Spring
+                    data-testid='spring'
                     style={{
                       position: 'absolute',
                       left: 100,
@@ -1584,7 +1585,11 @@ describe('RUN_ESCAPE_HATCH', () => {
 
     const action = runEscapeHatch([targetElement])
 
-    const updatedEditorState = UPDATE_FNS.RUN_ESCAPE_HATCH(action, editorState)
+    const updatedEditorState = UPDATE_FNS.RUN_ESCAPE_HATCH(
+      action,
+      editorState,
+      createBuiltInDependenciesList(null),
+    )
 
     expect(testPrintCodeFromEditorState(updatedEditorState)).toEqual(
       makeTestProjectCodeWithSnippet(

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -983,8 +983,8 @@ describe('UPDATE_FILE_PATH', () => {
           "react",
         ],
         "/src2/card.js": Array [
+          "non-existant-dummy-library",
           "react",
-          "react-spring",
         ],
         "/src2/index.js": Array [
           "./app.js",
@@ -1055,7 +1055,7 @@ describe('INSERT_INSERTABLE', () => {
         )
         expect(printedCode).toMatchInlineSnapshot(`
           "import * as React from 'react'
-          import { Spring } from 'react-spring'
+          import { Spring } from 'non-existant-dummy-library'
           import { Menu } from 'antd'
           import 'antd/dist/antd.css'
           export var Card = (props) => {
@@ -1159,7 +1159,7 @@ describe('INSERT_INSERTABLE', () => {
         )
         expect(printedCode).toMatchInlineSnapshot(`
           "import * as React from 'react'
-          import { Spring } from 'react-spring'
+          import { Spring } from 'non-existant-dummy-library'
           import { Menu } from 'antd'
           import 'antd/dist/antd.css'
           export var Card = (props) => {
@@ -1262,7 +1262,7 @@ describe('INSERT_INSERTABLE', () => {
         )
         expect(printedCode).toMatchInlineSnapshot(`
           "import * as React from 'react'
-          import { Spring } from 'react-spring'
+          import { Spring } from 'non-existant-dummy-library'
           export var Card = (props) => {
             return (
               <div style={{ ...props.style }}>
@@ -1351,7 +1351,7 @@ describe('INSERT_INSERTABLE', () => {
         )
         expect(printedCode).toMatchInlineSnapshot(`
           "import * as React from 'react'
-          import { Spring } from 'react-spring'
+          import { Spring } from 'non-existant-dummy-library'
           export var Card = (props) => {
             return (
               <div style={{ ...props.style }}>
@@ -1438,7 +1438,7 @@ describe('INSERT_INSERTABLE', () => {
         )
         expect(printedCode).toMatchInlineSnapshot(`
           "import * as React from 'react'
-          import { Spring } from 'react-spring'
+          import { Spring } from 'non-existant-dummy-library'
           export var Card = (props) => {
             return (
               <div style={{ ...props.style }}>

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2,7 +2,6 @@ import { produce } from 'immer'
 import update from 'immutability-helper'
 import React from 'react'
 import localforage from 'localforage'
-import { CursorPosition } from 'src/components/code-editor/code-editor-utils'
 import { FramePoint, LayoutSystem } from 'utopia-api/core'
 import {
   SampleFileBuildResult,
@@ -4894,8 +4893,12 @@ export const UPDATE_FNS = {
       forceParseFiles: editor.forceParseFiles.concat(action.filePath),
     }
   },
-  RUN_ESCAPE_HATCH: (action: RunEscapeHatch, editor: EditorModel): EditorModel => {
-    const canvasState = pickCanvasStateFromEditorState(editor)
+  RUN_ESCAPE_HATCH: (
+    action: RunEscapeHatch,
+    editor: EditorModel,
+    builtInDependencies: BuiltInDependencies,
+  ): EditorModel => {
+    const canvasState = pickCanvasStateFromEditorState(editor, builtInDependencies)
     if (areAllSelectedElementsNonAbsolute(action.targets, editor.jsxMetadata)) {
       const commands = getEscapeHatchCommands(
         action.targets,

--- a/editor/src/components/editor/import-utils.ts
+++ b/editor/src/components/editor/import-utils.ts
@@ -1,4 +1,4 @@
-import { resolveModulePath } from '../../core/es-modules/package-manager/module-resolution'
+import { resolveModulePathIncludingBuiltIns } from '../../core/es-modules/package-manager/module-resolution'
 import { foldEither } from '../../core/shared/either'
 import { emptyImports } from '../../core/workers/common/project-file-utils'
 import { TopLevelElement } from '../../core/shared/element-template'
@@ -11,6 +11,7 @@ import {
   NodeModules,
 } from '../../core/shared/project-file-types'
 import { ProjectContentTreeRoot } from '../assets'
+import { BuiltInDependencies } from '../../core/es-modules/package-manager/built-in-dependencies-list'
 
 interface SameFileOrigin {
   type: 'SAME_FILE_ORIGIN'
@@ -100,6 +101,7 @@ export function getTopLevelName(
 }
 
 export function getImportsFor(
+  builtInDependencies: BuiltInDependencies,
   currentImports: Imports,
   projectContents: ProjectContentTreeRoot,
   nodeModules: NodeModules,
@@ -108,7 +110,13 @@ export function getImportsFor(
 ): Imports {
   for (const fileKey of Object.keys(currentImports)) {
     const details = currentImports[fileKey]
-    const importPath = resolveModulePath(projectContents, nodeModules, importOrigin, fileKey)
+    const importPath = resolveModulePathIncludingBuiltIns(
+      builtInDependencies,
+      projectContents,
+      nodeModules,
+      importOrigin,
+      fileKey,
+    )
     const resolvedImportPath = foldEither(
       (failure) => {
         throw new Error(`Could not resolve ${fileKey} to a path because: ${failure}`)

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -31,6 +31,7 @@ import { isFeatureEnabled } from '../../../utils/feature-switches'
 import { PERFORMANCE_MARKS_ALLOWED } from '../../../common/env-vars'
 import { saveDOMReport } from '../actions/action-creators'
 import { last } from '../../../core/shared/array-utils'
+import { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 
 interface HandleStrategiesResult {
   unpatchedEditorState: EditorState
@@ -48,7 +49,10 @@ export function interactionFinished(
     newEditorState.canvas.interactionSession?.metadata ?? newEditorState.jsxMetadata,
     newEditorState.canvas.interactionSession?.allElementProps ?? newEditorState.allElementProps,
   )
-  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
+  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState,
+    result.builtInDependencies,
+  )
   const interactionSession = storedState.unpatchedEditor.canvas.interactionSession
   if (interactionSession == null) {
     return {
@@ -109,7 +113,10 @@ export function interactionHardReset(
     ...storedState.strategyState,
     startingMetadata: storedState.unpatchedEditor.jsxMetadata,
   }
-  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
+  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState,
+    result.builtInDependencies,
+  )
   const interactionSession = newEditorState.canvas.interactionSession
   if (interactionSession == null) {
     return {
@@ -182,7 +189,10 @@ export function interactionUpdate(
   actionType: 'interaction-create-or-update' | 'non-interaction',
 ): HandleStrategiesResult {
   const newEditorState = result.unpatchedEditor
-  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
+  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState,
+    result.builtInDependencies,
+  )
   const interactionSession = newEditorState.canvas.interactionSession
   if (interactionSession == null) {
     return {
@@ -206,6 +216,7 @@ export function interactionUpdate(
         storedState.unpatchedEditor.canvas.interactionSession?.userPreferredStrategy
       if (userChangedStrategy) {
         return handleUserChangedStrategy(
+          result.builtInDependencies,
           newEditorState,
           storedState.patchedEditor,
           result.strategyState,
@@ -222,6 +233,7 @@ export function interactionUpdate(
       strategy?.strategy !== previousStrategy?.strategy
     ) {
       return handleAccumulatingKeypresses(
+        result.builtInDependencies,
         newEditorState,
         storedState.patchedEditor,
         result.strategyState,
@@ -231,6 +243,7 @@ export function interactionUpdate(
       )
     }
     return handleUpdate(
+      result.builtInDependencies,
       newEditorState,
       storedState.patchedEditor,
       result.strategyState,
@@ -251,7 +264,10 @@ export function interactionStart(
     newEditorState.canvas.interactionSession?.metadata ?? newEditorState.jsxMetadata,
     newEditorState.canvas.interactionSession?.allElementProps ?? newEditorState.allElementProps,
   )
-  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
+  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState,
+    result.builtInDependencies,
+  )
   const interactionSession = newEditorState.canvas.interactionSession
   if (interactionSession == null) {
     return {
@@ -333,6 +349,7 @@ export function interactionCancel(
 }
 
 function handleUserChangedStrategy(
+  builtInDependencies: BuiltInDependencies,
   newEditorState: EditorState,
   storedEditorState: EditorState,
   strategyState: StrategyState,
@@ -340,7 +357,10 @@ function handleUserChangedStrategy(
   previousStrategy: StrategyWithFitness | null,
   sortedApplicableStrategies: Array<CanvasStrategy>,
 ): HandleStrategiesResult {
-  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
+  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState,
+    builtInDependencies,
+  )
 
   // If there is a current strategy, produce the commands from it.
   if (strategy != null && newEditorState.canvas.interactionSession != null) {
@@ -400,6 +420,7 @@ function handleUserChangedStrategy(
 }
 
 function handleAccumulatingKeypresses(
+  builtInDependencies: BuiltInDependencies,
   newEditorState: EditorState,
   storedEditorState: EditorState,
   strategyState: StrategyState,
@@ -407,7 +428,10 @@ function handleAccumulatingKeypresses(
   previousStrategy: StrategyWithFitness | null,
   sortedApplicableStrategies: Array<CanvasStrategy>,
 ): HandleStrategiesResult {
-  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
+  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState,
+    builtInDependencies,
+  )
   // If there is a current strategy, produce the commands from it.
   if (newEditorState.canvas.interactionSession != null) {
     const interactionData = newEditorState.canvas.interactionSession.interactionData
@@ -475,6 +499,7 @@ function handleAccumulatingKeypresses(
 }
 
 function handleUpdate(
+  builtInDependencies: BuiltInDependencies,
   newEditorState: EditorState,
   storedEditorState: EditorState,
   strategyState: StrategyState,
@@ -482,7 +507,10 @@ function handleUpdate(
   previousStrategy: StrategyWithFitness | null,
   sortedApplicableStrategies: Array<CanvasStrategy>,
 ): HandleStrategiesResult {
-  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(newEditorState)
+  const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState,
+    builtInDependencies,
+  )
   // If there is a current strategy, produce the commands from it.
   if (newEditorState.canvas.interactionSession != null) {
     const strategyResult =

--- a/editor/src/components/editor/store/editor-state.spec.ts
+++ b/editor/src/components/editor/store/editor-state.spec.ts
@@ -118,7 +118,7 @@ describe('modifyUnderlyingTarget', () => {
       expect(parsed.imports).toEqual(
         addImport(
           '',
-          'react-spring',
+          'non-existant-dummy-library',
           null,
           [importAlias('Spring')],
           null,
@@ -149,7 +149,7 @@ describe('modifyUnderlyingTarget', () => {
     const resultingCode = getCodeForFile(actualResult, '/src/card.js')
     expect(resultingCode).toMatchInlineSnapshot(`
       "import * as React from 'react'
-      import { Spring } from 'react-spring'
+      import { Spring } from 'non-existant-dummy-library'
       export var Card = (props) => {
         return (
           <div style={{ ...props.style }}>

--- a/editor/src/components/editor/store/editor-state.spec.ts
+++ b/editor/src/components/editor/store/editor-state.spec.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../core/shared/element-template'
 import { printCode, printCodeOptions } from '../../../core/workers/parser-printer/parser-printer'
 import {
+  importAlias,
   Imports,
   isParseSuccess,
   parseSuccess,
@@ -114,7 +115,16 @@ describe('modifyUnderlyingTarget', () => {
     const codeFile = getTextFileByPath(actualResult.projectContents, '/src/card.js')
     const parsed = codeFile.fileContents.parsed
     if (isParseSuccess(parsed)) {
-      expect(parsed.imports).toEqual(addImport('', 'react', null, [], 'React', emptyImports()))
+      expect(parsed.imports).toEqual(
+        addImport(
+          '',
+          'react-spring',
+          null,
+          [importAlias('Spring')],
+          null,
+          addImport('', 'react', null, [], 'React', emptyImports()),
+        ),
+      )
     } else {
       throw new Error('No parsed version of the file.')
     }
@@ -139,7 +149,7 @@ describe('modifyUnderlyingTarget', () => {
     const resultingCode = getCodeForFile(actualResult, '/src/card.js')
     expect(resultingCode).toMatchInlineSnapshot(`
       "import * as React from 'react'
-      import { Rectangle } from 'utopia-api'
+      import { Spring } from 'react-spring'
       export var Card = (props) => {
         return (
           <div style={{ ...props.style }}>
@@ -154,8 +164,8 @@ describe('modifyUnderlyingTarget', () => {
               }}
               data-thing='a thing'
             />
-            <Rectangle
-              data-testid='rectangle'
+            <Spring
+              data-testid='spring'
               style={{
                 position: 'absolute',
                 left: 100,

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -343,7 +343,7 @@ export function runSimpleLocalEditorAction(
     case 'FORCE_PARSE_FILE':
       return UPDATE_FNS.FORCE_PARSE_FILE(action, state)
     case 'RUN_ESCAPE_HATCH':
-      return UPDATE_FNS.RUN_ESCAPE_HATCH(action, state)
+      return UPDATE_FNS.RUN_ESCAPE_HATCH(action, state, builtInDependencies)
     default:
       return state
   }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -419,7 +419,7 @@ import {
 } from '../../inspector/common/css-utils'
 import { projectListing, ProjectListing } from '../action-types'
 import { UtopiaVSCodeConfig } from 'utopia-vscode-common'
-import { MouseButtonsPressed } from 'src/utils/mouse'
+import { MouseButtonsPressed } from '../../../utils/mouse'
 
 export function TransientCanvasStateFilesStateKeepDeepEquality(
   oldValue: TransientFilesState,

--- a/editor/src/components/inspector/common/inspector-utils.tsx
+++ b/editor/src/components/inspector/common/inspector-utils.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ElementPath } from 'src/core/shared/project-file-types'
+import { ElementPath } from '../../../core/shared/project-file-types'
 import * as EP from '../../../core/shared/element-path'
 import { fastForEach } from '../../../core/shared/utils'
 import { useColorTheme } from '../../../uuiui'

--- a/editor/src/components/inspector/common/property-controls-hooks.ts
+++ b/editor/src/components/inspector/common/property-controls-hooks.ts
@@ -69,7 +69,7 @@ import {
 import { arrayDeepEquality } from '../../../utils/deep-equality'
 import { omit } from '../../../core/shared/object-utils'
 import { PropertyControls } from 'utopia-api/core'
-import { AllElementProps } from 'src/components/editor/store/editor-state'
+import { AllElementProps } from '../../../components/editor/store/editor-state'
 import * as EP from '../../../core/shared/element-path'
 
 type RawValues = Either<string, ModifiableAttribute>[]

--- a/editor/src/components/inspector/sections/layout-section/layout-section.spec.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-section.spec.tsx
@@ -1,6 +1,5 @@
 import { act, render } from '@testing-library/react'
 import React from 'react'
-import { PropertyPath } from 'src/core/shared/project-file-types'
 import { LayoutSystem } from 'utopia-api/core'
 import {
   enableWhyDidYouRenderOnComponent,

--- a/editor/src/components/mouse-move.ts
+++ b/editor/src/components/mouse-move.ts
@@ -13,8 +13,21 @@ export function mouseWheelHandled() {
   didWeHandleWheelForThisFrame = true
 }
 
-export function resetMouseStatus() {
+let resetMouseStatusCallbackIdentifier: number | null = null
+
+export function resetMouseStatus(): void {
+  stopResettingMouseStatus()
+  innerResetMouseStatus()
+}
+
+export function stopResettingMouseStatus(): void {
+  if (resetMouseStatusCallbackIdentifier != null) {
+    cancelAnimationFrame(resetMouseStatusCallbackIdentifier)
+  }
+}
+
+function innerResetMouseStatus(): void {
   didWeHandleMouseMoveForThisFrame = false
   didWeHandleWheelForThisFrame = false
-  requestAnimationFrame(resetMouseStatus)
+  resetMouseStatusCallbackIdentifier = requestAnimationFrame(innerResetMouseStatus)
 }

--- a/editor/src/core/es-modules/package-manager/module-resolution.ts
+++ b/editor/src/core/es-modules/package-manager/module-resolution.ts
@@ -32,6 +32,7 @@ import { getPartsFromPath, makePathFromParts, normalizePath } from '../../../uti
 import type { MapLike } from 'typescript'
 
 import LRU from 'lru-cache'
+import { BuiltInDependencies } from './built-in-dependencies-list'
 
 const partialPackageJsonCache: LRU<string, ParseResult<PartialPackageJsonDefinition>> = new LRU({
   max: 20,
@@ -514,4 +515,20 @@ export function resolveModulePath(
   } else {
     return left(`Cannot find module ${toImport}`)
   }
+}
+
+export function resolveModulePathIncludingBuiltIns(
+  builtInDependencies: BuiltInDependencies,
+  projectContents: ProjectContentTreeRoot,
+  nodeModules: NodeModules,
+  importOrigin: string,
+  toImport: string,
+): Either<string, string> {
+  // Resolve against the built in dependencies before falling back to `resolveModulePath`.
+  for (const builtInDependency of builtInDependencies) {
+    if (builtInDependency.moduleName === toImport) {
+      return right(builtInDependency.moduleName)
+    }
+  }
+  return resolveModulePath(projectContents, nodeModules, importOrigin, toImport)
 }

--- a/editor/src/core/layout/layout-utils.spec.browser2.tsx
+++ b/editor/src/core/layout/layout-utils.spec.browser2.tsx
@@ -22,7 +22,6 @@ import {
 import { FOR_TESTS_setNextGeneratedUid } from '../model/element-template-utils'
 import { left, right } from '../shared/either'
 import { CanvasRectangle, LocalRectangle } from '../shared/math-utils'
-import { ElementProps } from 'src/components/editor/store/editor-state'
 
 const NewUID = 'catdog'
 

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -64,7 +64,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`382`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`404`)
   })
 
   it('Clicking on opacity slider with a less simple project', async () => {

--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -351,7 +351,7 @@ function createBeachesProjectContents(): ProjectContentTreeRoot {
         lastParseSuccess: null,
         lastSavedContents: null,
         fileContents: {
-          code: '{\n  "name": "Utopia Project",\n  "version": "0.1.0",\n  "utopia": {\n    "main-ui": "utopia/storyboard.js",\n    "html": "public/index.html",\n    "js": "src/index.js"\n  },\n  "dependencies": {\n    "react": "16.13.1",\n    "react-dom": "16.13.1",\n    "utopia-api": "0.4.1",\n    "non-existant-dummy-library": "8.0.27",\n    "@heroicons/react": "1.0.1",\n    "@emotion/react": "11.9.3"\n  }\n}',
+          code: '{\n  "name": "Utopia Project",\n  "version": "0.1.0",\n  "utopia": {\n    "main-ui": "utopia/storyboard.js",\n    "html": "public/index.html",\n    "js": "src/index.js"\n  },\n  "dependencies": {\n    "react": "16.13.1",\n    "react-dom": "16.13.1",\n    "utopia-api": "0.4.1",\n    "react-spring": "8.0.27",\n    "@heroicons/react": "1.0.1",\n    "@emotion/react": "11.9.3"\n  }\n}',
           parsed: {
             type: 'UNPARSED',
           },

--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -124,11 +124,11 @@ export var App = (props) => {
     '/src/card.js': createCodeFile(
       '/src/card.js',
       `import * as React from 'react'
-import { Rectangle } from 'utopia-api'
+import { Spring } from 'react-spring'
 export var Card = (props) => {
   return <div data-uid='card-outer-div' style={{...props.style}}>
     <div data-uid='card-inner-div' style={{ position: 'absolute', left: 0, top: 0, width: 50, height: 50, backgroundColor: 'red' }} />
-    <Rectangle data-uid='card-inner-rectangle' data-testid='rectangle' style={{ position: 'absolute', left: 100, top: 200, width: 50, height: 50, backgroundColor: 'blue' }} />
+    <Spring data-uid='card-inner-spring' data-testid='spring' style={{ position: 'absolute', left: 100, top: 200, width: 50, height: 50, backgroundColor: 'blue' }} />
   </div>
 }`,
     ),

--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -124,7 +124,7 @@ export var App = (props) => {
     '/src/card.js': createCodeFile(
       '/src/card.js',
       `import * as React from 'react'
-import { Spring } from 'react-spring'
+import { Spring } from 'non-existant-dummy-library'
 export var Card = (props) => {
   return <div data-uid='card-outer-div' style={{...props.style}}>
     <div data-uid='card-inner-div' style={{ position: 'absolute', left: 0, top: 0, width: 50, height: 50, backgroundColor: 'red' }} />
@@ -351,7 +351,7 @@ function createBeachesProjectContents(): ProjectContentTreeRoot {
         lastParseSuccess: null,
         lastSavedContents: null,
         fileContents: {
-          code: '{\n  "name": "Utopia Project",\n  "version": "0.1.0",\n  "utopia": {\n    "main-ui": "utopia/storyboard.js",\n    "html": "public/index.html",\n    "js": "src/index.js"\n  },\n  "dependencies": {\n    "react": "16.13.1",\n    "react-dom": "16.13.1",\n    "utopia-api": "0.4.1",\n    "react-spring": "8.0.27",\n    "@heroicons/react": "1.0.1",\n    "@emotion/react": "11.9.3"\n  }\n}',
+          code: '{\n  "name": "Utopia Project",\n  "version": "0.1.0",\n  "utopia": {\n    "main-ui": "utopia/storyboard.js",\n    "html": "public/index.html",\n    "js": "src/index.js"\n  },\n  "dependencies": {\n    "react": "16.13.1",\n    "react-dom": "16.13.1",\n    "utopia-api": "0.4.1",\n    "non-existant-dummy-library": "8.0.27",\n    "@heroicons/react": "1.0.1",\n    "@emotion/react": "11.9.3"\n  }\n}',
           parsed: {
             type: 'UNPARSED',
           },

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -44,7 +44,6 @@ import {
 import {
   BaseSnappingThreshold,
   CanvasCursor,
-  ConsoleLog,
   DerivedState,
   EditorState,
   editorStateCanvasControls,


### PR DESCRIPTION
**Problem:**
When reparenting an element across files, if the file it was being reparented from had an import which related to a built in dependency the reparent operation would throw an exception. This was due to a function being unable to identify the path for the module because built in dependencies do not exist inside the `NodeModules` object.

**Fix:**
The primary fix for this was to create `resolveModulePathIncludingBuiltIns` to allow for these built in dependency cases. However it highlighted that `SampleNodeModules` used in a lot of tests did not represent what `NodeModules` would look like in the running editor as it was full of built in dependencies and no regular dependencies. A sample project needed updating to use a regular dependency so this case was tested project. Our `renderTestEditorWithModel` test function was then also tweaked to handle rendering the project without throwing an exception due to the new requirement on a non-builtin dependency,

Mysteriously with all this a test relating to resizing a scene started breaking again, so the previous fix was reworked to avoid the timing pitfalls of `await wait(10)`.

**Commit Details:**
- Added `resolveModulePathIncludingBuiltIns` to extend on `resolveModulePath`
  as built in dependencies sit outside regular modules in our editor.
- Modified `getImportsFor` to use `resolveModulePathIncludingBuiltIns` so
  that dependencies using imports like `react` don't fail to find them.
- Passed through the `BuiltInDependencies` into a multitude of places
  in the canvas strategies code.
- `renderTestEditorWithModel` was tweaked to incorporate updating the node modules
  alongside loading the project to prevent errors that might occur after the project was
  loaded but didn't have the node modules update yet.
- Fixed some imports that were done from the root by my editor.
- Changed `resetMouseStatus` so that it stops the old request animation
  from and starts another.
- Instead of pausing for an arbitrary amount of time, have a test trigger
  `resetMouseStatus` instead.
- Made the sample project used in a lot of tests use a pretend
  `react-spring` component.
- `SampleNodeModules` is now representative of what would be loaded in
  a real loaded editor, as it previously held a bunch of elements which
  related to built in dependencies.
- Small fixes mostly relating to element paths in tests.
