### PR TITLE
Handle disappearing reparented elements

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-duplicate-strategy.tsx
@@ -16,7 +16,11 @@ import { ParentBounds } from '../controls/parent-bounds'
 import { ParentOutlines } from '../controls/parent-outlines'
 import { absoluteMoveStrategy } from './absolute-move-strategy'
 import { pickCanvasStateFromEditorState } from './canvas-strategies'
-import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
+import {
+  CanvasStrategy,
+  defaultCustomStrategyState,
+  emptyStrategyApplicationResult,
+} from './canvas-strategy-types'
 import { InteractionSession, interactionSession, StrategyState } from './interaction-state'
 import { getDragTargets } from './shared-absolute-move-strategy-helpers'
 
@@ -135,7 +139,7 @@ export const absoluteDuplicateStrategy: CanvasStrategy = {
       // Fallback for when the checks above are not satisfied.
       return {
         commands: [setCursorCommand('transient', CSSCursor.Duplicate)],
-        customState: null,
+        customState: defaultCustomStrategyState,
       }
     }
   },

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.spec.tsx
@@ -123,11 +123,11 @@ function dragByPixels(
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: metadata ?? defaultMetadata,
       startingAllElementProps: {},
-      customStrategyState: defaultCustomStrategyState(),
+      customStrategyState: defaultCustomStrategyState,
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customState).toEqual(defaultCustomStrategyState)
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -17,6 +17,7 @@ import { determineConstrainedDragAxis } from '../controls/select-mode/move-utils
 import { ConstrainedDragAxis, GuidelineWithSnappingVector } from '../guideline'
 import {
   CanvasStrategy,
+  defaultCustomStrategyState,
   emptyStrategyApplicationResult,
   InteractionCanvasState,
   StrategyApplicationResult,
@@ -132,7 +133,7 @@ export function applyAbsoluteMoveCommon(
           setElementsToRerenderCommand(canvasState.selectedElements),
           setCursorCommand('transient', CSSCursor.Select),
         ],
-        customState: null,
+        customState: defaultCustomStrategyState,
       }
     } else {
       const constrainedDragAxis =
@@ -154,7 +155,7 @@ export function applyAbsoluteMoveCommon(
           setElementsToRerenderCommand(canvasState.selectedElements),
           setCursorCommand('transient', CSSCursor.Select),
         ],
-        customState: null,
+        customState: defaultCustomStrategyState,
       }
     }
   } else {

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -51,6 +51,7 @@ function reparentElement(
   editorState: EditorState,
   targetParentWithSpecialContentBox: boolean,
   dragVector: CanvasPoint = canvasPoint({ x: 15, y: 15 }),
+  reparentedToPaths: Array<ElementPath> = [],
 ): EditorState {
   const interactionSession: InteractionSession = {
     ...createMouseInteractionForTests(
@@ -134,11 +135,14 @@ function reparentElement(
         } as ElementInstanceMetadata,
       },
       startingAllElementProps: {},
-      customStrategyState: defaultCustomStrategyState(),
+      customStrategyState: defaultCustomStrategyState,
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customState).toEqual({
+    ...defaultCustomStrategyState,
+    reparentedToPaths: reparentedToPaths,
+  })
 
   // Check if there are set SetElementsToRerenderCommands with the new parent path
   expect(
@@ -205,7 +209,9 @@ describe('Absolute Reparent Strategy', () => {
       [targetElement],
     )
 
-    const finalEditor = reparentElement(initialEditor, false, canvasPoint({ x: -1000, y: -1000 }))
+    const finalEditor = reparentElement(initialEditor, false, canvasPoint({ x: -1000, y: -1000 }), [
+      EP.elementPath([['utopia-storyboard-uid', 'ccc']]),
+    ])
 
     expect(testPrintCodeFromEditorState(finalEditor)).toEqual(
       Prettier.format(

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy-only-move.spec.tsx
@@ -83,11 +83,11 @@ function dragByPixels(
         } as ElementInstanceMetadata,
       },
       startingAllElementProps: {},
-      customStrategyState: defaultCustomStrategyState(),
+      customStrategyState: defaultCustomStrategyState,
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customState).toEqual(defaultCustomStrategyState)
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.spec.browser2.tsx
@@ -16,12 +16,19 @@ import {
   BakedInStoryboardVariableName,
   BakedInStoryboardUID,
 } from '../../../core/model/scene-utils'
+import { getCursorForOverlay } from '../controls/select-mode/cursor-overlay'
+import { CSSCursor } from '../canvas-types'
+
+interface CheckCursor {
+  cursor: CSSCursor | null
+}
 
 function dragElement(
   renderResult: EditorRenderResult,
   targetTestId: string,
   dragDelta: WindowPoint,
   modifiers: Modifiers,
+  checkCursor: CheckCursor | null,
 ) {
   const targetElement = renderResult.renderedDOM.getByTestId(targetTestId)
   const targetElementBounds = targetElement.getBoundingClientRect()
@@ -57,6 +64,15 @@ function dragElement(
     }),
   )
 
+  if (checkCursor != null) {
+    expect(
+      getCursorForOverlay(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().strategyState,
+      ),
+    ).toEqual(checkCursor.cursor)
+  }
+
   fireEvent(
     window,
     new MouseEvent('mouseup', {
@@ -71,7 +87,81 @@ function dragElement(
   )
 }
 
+function getChildrenHiderProjectCode(shouldHide: boolean): string {
+  return `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export const ChildrenHider = (props) => {
+  return (
+    <div data-uid='33d' style={{ ...props.style }}>
+      {props.shouldHide ? null : props.children}
+    </div>
+  )
+}
+
+export var ${BakedInStoryboardVariableName} = (
+  <Storyboard data-uid='${BakedInStoryboardUID}'>
+    <Scene
+      style={{
+        backgroundColor: 'white',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 700,
+      }}
+      data-uid='${TestSceneUID}'
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 400,
+          height: 700,
+        }}
+        data-uid='outer-div'
+      >
+        <ChildrenHider
+          style={{
+            backgroundColor: '#0091FFAA',
+            position: 'absolute',
+            left: 41,
+            top: 37,
+            width: 338,
+            height: 144,
+            gap: 10,
+          }}
+          data-uid='children-hider'
+          shouldHide={${shouldHide}}
+        >
+          Test
+        </ChildrenHider>
+        <div
+          style={{
+            backgroundColor: '#0091FFAA',
+            height: 65,
+            width: 66,
+            position: 'absolute',
+            left: 190,
+            top: 211,
+          }}
+          data-uid='child-to-reparent'
+          data-testid='child-to-reparent'
+        >
+          drag me
+        </div>
+      </div>
+    </Scene>
+  </Storyboard>
+)`
+}
+
 describe('Absolute Reparent Strategy', () => {
+  beforeEach(() => {
+    viewport.set(2200, 1000)
+  })
   it('reparents to the canvas root', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
@@ -87,7 +177,7 @@ describe('Absolute Reparent Strategy', () => {
     )
 
     const dragDelta = windowPoint({ x: -1000, y: -1000 })
-    act(() => dragElement(renderResult, 'bbb', dragDelta, cmdModifier))
+    act(() => dragElement(renderResult, 'bbb', dragDelta, cmdModifier, null))
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
@@ -174,12 +264,65 @@ describe('Absolute Reparent Strategy', () => {
     )
 
     const dragDelta = windowPoint({ x: -1000, y: -1000 })
-    act(() => dragElement(renderResult, 'bbb', dragDelta, cmdModifier))
+    act(() => dragElement(renderResult, 'bbb', dragDelta, cmdModifier, null))
 
     await renderResult.getDispatchFollowUpActionsFinished()
 
     expect(getPrintedUiJsCode(renderResult.getEditorState())).toEqual(
       createCodeForProject(-960, -950),
     )
+  })
+
+  it('renders correctly with ChildrenHider set to hide children', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      getChildrenHiderProjectCode(true),
+      'await-first-dom-report',
+    )
+
+    const dragDelta = windowPoint({ x: 0, y: -150 })
+    act(() =>
+      dragElement(renderResult, 'child-to-reparent', dragDelta, cmdModifier, {
+        cursor: CSSCursor.ReparentNotPermitted,
+      }),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(Object.keys(renderResult.getEditorState().editor.spyMetadata)).toEqual([
+      'utopia-storyboard-uid',
+      'utopia-storyboard-uid/scene-aaa',
+      'utopia-storyboard-uid/scene-aaa/outer-div',
+      'utopia-storyboard-uid/scene-aaa/outer-div/children-hider',
+    ])
+  })
+  it('renders correctly with ChildrenHider set to show children', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      getChildrenHiderProjectCode(false),
+      'await-first-dom-report',
+    )
+
+    const dragDelta = windowPoint({ x: 0, y: -150 })
+    act(() =>
+      dragElement(renderResult, 'child-to-reparent', dragDelta, cmdModifier, {
+        cursor: CSSCursor.Move,
+      }),
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(Object.keys(renderResult.getEditorState().editor.spyMetadata)).toEqual([
+      'utopia-storyboard-uid',
+      'utopia-storyboard-uid/scene-aaa',
+      'utopia-storyboard-uid/scene-aaa/outer-div',
+      'utopia-storyboard-uid/scene-aaa/outer-div/children-hider',
+      'utopia-storyboard-uid/scene-aaa/outer-div/children-hider/child-to-reparent',
+    ])
+
+    expect(
+      getCursorForOverlay(
+        renderResult.getEditorState().editor,
+        renderResult.getEditorState().strategyState,
+      ),
+    ).toEqual(null)
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-strategy.tsx
@@ -8,7 +8,11 @@ import { updateSelectedViews } from '../commands/update-selected-views-command'
 import { ParentBounds } from '../controls/parent-bounds'
 import { ParentOutlines } from '../controls/parent-outlines'
 import { absoluteMoveStrategy } from './absolute-move-strategy'
-import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
+import {
+  CanvasStrategy,
+  defaultCustomStrategyState,
+  emptyStrategyApplicationResult,
+} from './canvas-strategy-types'
 import {
   getAbsoluteOffsetCommandsForSelectedElement,
   getDragTargets,
@@ -138,7 +142,10 @@ export const absoluteReparentStrategy: CanvasStrategy = {
           setElementsToRerenderCommand(newPaths),
           setCursorCommand('transient', CSSCursor.Move),
         ],
-        customState: null,
+        customState: {
+          ...defaultCustomStrategyState,
+          reparentedToPaths: newPaths,
+        },
       }
     } else {
       return moveCommands

--- a/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-reparent-to-flex-strategy.tsx
@@ -184,7 +184,10 @@ export const absoluteReparentToFlexStrategy: CanvasStrategy = {
 
           return {
             commands: commands,
-            customState: strategyState.customStrategyState,
+            customState: {
+              ...strategyState.customStrategyState,
+              reparentedToPaths: [newPath],
+            },
           }
         }
       }

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -60,11 +60,11 @@ function multiselectResizeElements(
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: metadata,
-      customStrategyState: defaultCustomStrategyState(),
+      customStrategyState: defaultCustomStrategyState,
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customState).toEqual(defaultCustomStrategyState)
 
   return foldAndApplyCommands(
     initialEditor,

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -27,7 +27,11 @@ import { ParentBounds } from '../controls/parent-bounds'
 import { ParentOutlines } from '../controls/parent-outlines'
 import { AbsoluteResizeControl } from '../controls/select-mode/absolute-resize-control'
 import { AbsolutePin, ensureAtLeastTwoPinsForEdgePosition } from './absolute-resize-helpers'
-import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
+import {
+  CanvasStrategy,
+  defaultCustomStrategyState,
+  emptyStrategyApplicationResult,
+} from './canvas-strategy-types'
 import { getDragTargets, getMultiselectBounds } from './shared-absolute-move-strategy-helpers'
 import {
   pickCursorFromEdgePosition,
@@ -162,7 +166,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
               setCursorCommand('transient', pickCursorFromEdgePosition(edgePosition)),
               setElementsToRerenderCommand(canvasState.selectedElements),
             ],
-            customState: null,
+            customState: defaultCustomStrategyState,
           }
         }
       } else {
@@ -171,7 +175,7 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
             setCursorCommand('transient', pickCursorFromEdgePosition(edgePosition)),
             updateHighlightedViews('transient', []),
           ],
-          customState: null,
+          customState: defaultCustomStrategyState,
         }
       }
     }

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -12,24 +12,24 @@ export interface CustomStrategyState {
   escapeHatchActivated: boolean
   lastReorderIdx: number | null
   duplicatedElementNewUids: { [elementPath: string]: string }
+  reparentedToPaths: Array<ElementPath>
 }
 
-export function defaultCustomStrategyState(): CustomStrategyState {
-  return {
-    escapeHatchActivated: false,
-    lastReorderIdx: null,
-    duplicatedElementNewUids: {},
-  }
+export const defaultCustomStrategyState: CustomStrategyState = {
+  escapeHatchActivated: false,
+  lastReorderIdx: null,
+  duplicatedElementNewUids: {},
+  reparentedToPaths: [],
 }
 
 export interface StrategyApplicationResult {
   commands: Array<CanvasCommand>
-  customState: CustomStrategyState | null // null means the previous custom strategy state should be kept
+  customState: CustomStrategyState
 }
 
-export const emptyStrategyApplicationResult = {
+export const emptyStrategyApplicationResult: StrategyApplicationResult = {
   commands: [],
-  customState: null,
+  customState: defaultCustomStrategyState,
 }
 
 export interface ControlWithKey {

--- a/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/escape-hatch-strategy.tsx
@@ -44,6 +44,7 @@ import { ZeroSizeResizeControlWrapper } from '../controls/zero-sized-element-con
 import { applyAbsoluteMoveCommon } from './absolute-move-strategy'
 import {
   CanvasStrategy,
+  defaultCustomStrategyState,
   emptyStrategyApplicationResult,
   InteractionCanvasState,
 } from './canvas-strategy-types'
@@ -153,7 +154,7 @@ export const escapeHatchStrategy: CanvasStrategy = {
       } else {
         return {
           commands: [setCursorCommand('transient', CSSCursor.Move)],
-          customState: null,
+          customState: defaultCustomStrategyState,
         }
       }
     }

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.spec.tsx
@@ -161,7 +161,7 @@ function reorderElement(
   dragStart: CanvasPoint,
   drag: CanvasPoint,
   metadata: ElementInstanceMetadataMap,
-  newIndex?: number,
+  newIndex: number | null = null,
 ): EditorState {
   const interactionSession: InteractionSession = {
     ...createMouseInteractionForTests(
@@ -185,7 +185,7 @@ function reorderElement(
       commandDescriptions: null as any, // the strategy does not use this
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: metadata,
-      customStrategyState: defaultCustomStrategyState(),
+      customStrategyState: defaultCustomStrategyState,
     } as StrategyState,
   )
 

--- a/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reorder-strategy.tsx
@@ -3,7 +3,11 @@ import { ElementInstanceMetadataMap } from '../../../core/shared/element-templat
 import { offsetPoint, rectContainsPoint } from '../../../core/shared/math-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { reorderElement } from '../commands/reorder-element-command'
-import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
+import {
+  CanvasStrategy,
+  defaultCustomStrategyState,
+  emptyStrategyApplicationResult,
+} from './canvas-strategy-types'
 import {
   CanvasPoint,
   canvasPoint,
@@ -121,7 +125,7 @@ export const flexReorderStrategy: CanvasStrategy = {
       // Fallback for when the checks above are not satisfied.
       return {
         commands: [setCursorCommand('transient', CSSCursor.Move)],
-        customState: null,
+        customState: defaultCustomStrategyState,
       }
     }
   },

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-absolute-strategy.tsx
@@ -11,6 +11,7 @@ import { absoluteReparentStrategy } from './absolute-reparent-strategy'
 import { pickCanvasStateFromEditorState } from './canvas-strategies'
 import {
   CanvasStrategy,
+  defaultCustomStrategyState,
   emptyStrategyApplicationResult,
   InteractionCanvasState,
   StrategyApplicationResult,
@@ -93,7 +94,7 @@ export const flexReparentToAbsoluteStrategy: CanvasStrategy = {
             )
           }),
         ],
-        customState: null,
+        customState: defaultCustomStrategyState,
       }
     })
   },

--- a/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/flex-reparent-to-flex-strategy.tsx
@@ -133,7 +133,10 @@ export const flexReparentToFlexStrategy: CanvasStrategy = {
 
           return {
             commands: commands,
-            customState: strategyState.customStrategyState,
+            customState: {
+              ...strategyState.customStrategyState,
+              reparentedToPaths: [newPath],
+            },
           }
         }
       }

--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -128,7 +128,7 @@ export function createEmptyStrategyState(
     commandDescriptions: [],
     sortedApplicableStrategies: [],
     startingMetadata: metadata,
-    customStrategyState: defaultCustomStrategyState(),
+    customStrategyState: defaultCustomStrategyState,
     startingAllElementProps: allElementProps,
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -2,6 +2,7 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { Keyboard, KeyCharacter } from '../../../utils/keyboard'
 import {
   CanvasStrategy,
+  defaultCustomStrategyState,
   emptyStrategyApplicationResult,
   InteractionCanvasState,
 } from './canvas-strategy-types'
@@ -131,7 +132,7 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
       commands.push(setElementsToRerenderCommand(canvasState.selectedElements))
       return {
         commands: commands,
-        customState: null,
+        customState: defaultCustomStrategyState,
       }
     } else {
       return emptyStrategyApplicationResult

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -1,6 +1,10 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { Keyboard, KeyCharacter } from '../../../utils/keyboard'
-import { CanvasStrategy, emptyStrategyApplicationResult } from './canvas-strategy-types'
+import {
+  CanvasStrategy,
+  defaultCustomStrategyState,
+  emptyStrategyApplicationResult,
+} from './canvas-strategy-types'
 import { Modifiers } from '../../../utils/modifiers'
 import {
   canvasRectangle,
@@ -178,7 +182,7 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
       commands.push(setElementsToRerenderCommand(canvasState.selectedElements))
       return {
         commands: commands,
-        customState: null,
+        customState: defaultCustomStrategyState,
       }
     } else {
       return emptyStrategyApplicationResult

--- a/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-interaction.test-utils.tsx
@@ -58,11 +58,11 @@ export function pressKeys(
       sortedApplicableStrategies: null as any, // the strategy does not use this
       startingMetadata: metadata,
       startingAllElementProps: { 'scene-aaa/app-entity:aaa/bbb': {} },
-      customStrategyState: defaultCustomStrategyState(),
+      customStrategyState: defaultCustomStrategyState,
     } as StrategyState,
   )
 
-  expect(strategyResult.customState).toBeNull()
+  expect(strategyResult.customState).toEqual(defaultCustomStrategyState)
 
   const finalEditor = foldAndApplyCommands(
     editorState,

--- a/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-helpers.ts
@@ -4,7 +4,11 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { ElementPath } from '../../../core/shared/project-file-types'
 import { CSSCursor } from '../canvas-types'
 import { setCursorCommand } from '../commands/set-cursor-command'
-import { InteractionCanvasState, StrategyApplicationResult } from './canvas-strategy-types'
+import {
+  defaultCustomStrategyState,
+  InteractionCanvasState,
+  StrategyApplicationResult,
+} from './canvas-strategy-types'
 import { StrategyState } from './interaction-state'
 import * as EP from '../../../core/shared/element-path'
 
@@ -53,7 +57,7 @@ export function ifAllowedToReparent(
   } else {
     return {
       commands: [setCursorCommand('transient', CSSCursor.ReparentNotPermitted)],
-      customState: null,
+      customState: defaultCustomStrategyState,
     }
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
@@ -9,6 +9,7 @@ import { ElementPath, Imports, NodeModules } from '../../../core/shared/project-
 import { CanvasCommand } from '../commands/commands'
 import { reparentElement } from '../commands/reparent-element-command'
 import {
+  ElementInstanceMetadataMap,
   isIntrinsicElement,
   isJSXElement,
   walkElement,
@@ -18,6 +19,8 @@ import { getImportsFor, importedFromWhere } from '../../../components/editor/imp
 import { forceNotNull } from '../../../core/shared/optional-utils'
 import { addImportsToFile } from '../commands/add-imports-to-file-command'
 import { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
+import { CustomStrategyState } from './canvas-strategy-types'
+import { CSSCursor } from '../canvas-types'
 
 export function getReparentCommands(
   builtInDependencies: BuiltInDependencies,
@@ -119,4 +122,30 @@ export function getReparentCommands(
   result.push(reparentElement('permanent', selectedElement, newParent))
   result.push(...commandsToAddImports)
   return result
+}
+
+export function removeReparentedToPaths(
+  customStrategyState: CustomStrategyState,
+): CustomStrategyState {
+  if (customStrategyState.reparentedToPaths.length > 0) {
+    return {
+      ...customStrategyState,
+      reparentedToPaths: [],
+    }
+  } else {
+    return customStrategyState
+  }
+}
+
+export function cursorForMissingReparentedItems(
+  customStrategyState: CustomStrategyState,
+  spyMetadata: ElementInstanceMetadataMap,
+): CSSCursor | null {
+  for (const reparentedToPath of customStrategyState.reparentedToPaths) {
+    if (!(EP.toString(reparentedToPath) in spyMetadata)) {
+      return CSSCursor.ReparentNotPermitted
+    }
+  }
+
+  return null
 }

--- a/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/reparent-utils.ts
@@ -124,19 +124,6 @@ export function getReparentCommands(
   return result
 }
 
-export function removeReparentedToPaths(
-  customStrategyState: CustomStrategyState,
-): CustomStrategyState {
-  if (customStrategyState.reparentedToPaths.length > 0) {
-    return {
-      ...customStrategyState,
-      reparentedToPaths: [],
-    }
-  } else {
-    return customStrategyState
-  }
-}
-
 export function cursorForMissingReparentedItems(
   customStrategyState: CustomStrategyState,
   spyMetadata: ElementInstanceMetadataMap,

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -28,6 +28,7 @@ import {
   DragInteractionData,
   InteractionSession,
   InteractionSessionWithoutMetadata,
+  StrategyState,
 } from './canvas-strategies/interaction-state'
 import { CanvasStrategyId } from './canvas-strategies/canvas-strategy-types'
 import { MouseButtonsPressed } from '../../utils/mouse'

--- a/editor/src/components/canvas/controls/select-mode/cursor-overlay.tsx
+++ b/editor/src/components/canvas/controls/select-mode/cursor-overlay.tsx
@@ -1,20 +1,28 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
+import { EditorState } from 'src/components/editor/store/editor-state'
 import { useEditorState } from '../../../editor/store/store-hook'
+import { StrategyState } from '../../canvas-strategies/interaction-state'
 import { cursorForMissingReparentedItems } from '../../canvas-strategies/reparent-utils'
+import { CSSCursor } from '../../canvas-types'
 import { getCursorFromDragState } from '../../canvas-utils'
+
+export function getCursorForOverlay(
+  editorState: EditorState,
+  strategyState: StrategyState,
+): CSSCursor | null {
+  const forMissingReparentedItems = cursorForMissingReparentedItems(
+    strategyState.customStrategyState,
+    editorState.spyMetadata,
+  )
+  return (
+    forMissingReparentedItems ?? getCursorFromDragState(editorState) ?? editorState.canvas.cursor
+  )
+}
 
 export const CursorOverlay = React.memo(() => {
   const cursor = useEditorState((store) => {
-    const forMissingReparentedItems = cursorForMissingReparentedItems(
-      store.strategyState.customStrategyState,
-      store.editor.spyMetadata,
-    )
-    return (
-      forMissingReparentedItems ??
-      getCursorFromDragState(store.editor) ??
-      store.editor.canvas.cursor
-    )
+    return getCursorForOverlay(store.editor, store.strategyState)
   }, 'CursorOverlay cursor')
 
   const styleProps = React.useMemo(() => {
@@ -38,7 +46,7 @@ export const CursorOverlay = React.memo(() => {
     return null
   }
   return ReactDOM.createPortal(
-    <div key='cursor-area' id='cursor-overlay' style={styleProps} />,
+    <div key='cursor-area' id='cursor-overlay' data-testid='cursor-overlay' style={styleProps} />,
     portalDiv,
   )
 })

--- a/editor/src/components/canvas/controls/select-mode/cursor-overlay.tsx
+++ b/editor/src/components/canvas/controls/select-mode/cursor-overlay.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
-import { Utils } from '../../../../uuiui-deps'
 import { useEditorState } from '../../../editor/store/store-hook'
 import { cursorForMissingReparentedItems } from '../../canvas-strategies/reparent-utils'
 import { getCursorFromDragState } from '../../canvas-utils'
@@ -13,8 +12,8 @@ export const CursorOverlay = React.memo(() => {
     )
     return (
       forMissingReparentedItems ??
-      store.editor.canvas.cursor ??
-      getCursorFromDragState(store.editor)
+      getCursorFromDragState(store.editor) ??
+      store.editor.canvas.cursor
     )
   }, 'CursorOverlay cursor')
 

--- a/editor/src/components/canvas/controls/select-mode/cursor-overlay.tsx
+++ b/editor/src/components/canvas/controls/select-mode/cursor-overlay.tsx
@@ -2,11 +2,20 @@ import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { Utils } from '../../../../uuiui-deps'
 import { useEditorState } from '../../../editor/store/store-hook'
+import { cursorForMissingReparentedItems } from '../../canvas-strategies/reparent-utils'
 import { getCursorFromDragState } from '../../canvas-utils'
 
 export const CursorOverlay = React.memo(() => {
   const cursor = useEditorState((store) => {
-    return Utils.defaultIfNull(store.editor.canvas.cursor, getCursorFromDragState(store.editor))
+    const forMissingReparentedItems = cursorForMissingReparentedItems(
+      store.strategyState.customStrategyState,
+      store.editor.spyMetadata,
+    )
+    return (
+      forMissingReparentedItems ??
+      store.editor.canvas.cursor ??
+      getCursorFromDragState(store.editor)
+    )
   }, 'CursorOverlay cursor')
 
   const styleProps = React.useMemo(() => {

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -166,7 +166,7 @@ const testStrategy: CanvasStrategy = {
   ): StrategyApplicationResult {
     return {
       commands: [wildcardPatch('permanent', { canvas: { scale: { $set: 100 } } })],
-      customState: defaultCustomStrategyState(),
+      customState: defaultCustomStrategyState,
     }
   },
 }
@@ -219,6 +219,7 @@ describe('interactionStart', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "reparentedToPaths": Array [],
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -278,6 +279,7 @@ describe('interactionStart', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "reparentedToPaths": Array [],
         },
         "sortedApplicableStrategies": Array [],
         "startingAllElementProps": Object {},
@@ -342,6 +344,7 @@ describe('interactionUpdatex', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "reparentedToPaths": Array [],
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -402,6 +405,7 @@ describe('interactionUpdatex', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "reparentedToPaths": Array [],
         },
         "sortedApplicableStrategies": Array [],
         "startingAllElementProps": Object {},
@@ -494,6 +498,7 @@ describe('interactionHardReset', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "reparentedToPaths": Array [],
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -559,6 +564,7 @@ describe('interactionHardReset', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "reparentedToPaths": Array [],
         },
         "sortedApplicableStrategies": Array [],
         "startingAllElementProps": Object {},
@@ -712,6 +718,7 @@ describe('interactionUpdate with user changed strategy', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "reparentedToPaths": Array [],
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -778,6 +785,7 @@ describe('interactionUpdate with user changed strategy', () => {
           "duplicatedElementNewUids": Object {},
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
+          "reparentedToPaths": Array [],
         },
         "sortedApplicableStrategies": Array [],
         "startingAllElementProps": Object {},

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -163,7 +163,7 @@ export function interactionHardReset(
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: resetStrategyState.startingMetadata,
-        customStrategyState: strategyResult.customState ?? result.strategyState.customStrategyState,
+        customStrategyState: strategyResult.customState,
         startingAllElementProps: resetStrategyState.startingAllElementProps,
       }
 
@@ -310,7 +310,7 @@ export function interactionStart(
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: newEditorState.canvas.interactionSession.metadata,
-        customStrategyState: strategyResult.customState ?? result.strategyState.customStrategyState,
+        customStrategyState: strategyResult.customState,
         startingAllElementProps: newEditorState.canvas.interactionSession.allElementProps,
       }
 
@@ -401,7 +401,7 @@ function handleUserChangedStrategy(
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
-      customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
+      customStrategyState: strategyResult.customState,
       startingAllElementProps: strategyState.startingAllElementProps,
     }
 
@@ -480,7 +480,7 @@ function handleAccumulatingKeypresses(
         commandDescriptions: commandResult.commandDescriptions,
         sortedApplicableStrategies: sortedApplicableStrategies,
         startingMetadata: strategyState.startingMetadata,
-        customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
+        customStrategyState: strategyResult.customState,
         startingAllElementProps: strategyState.startingAllElementProps,
       }
 
@@ -541,7 +541,7 @@ function handleUpdate(
       commandDescriptions: commandResult.commandDescriptions,
       sortedApplicableStrategies: sortedApplicableStrategies,
       startingMetadata: strategyState.startingMetadata,
-      customStrategyState: strategyResult.customState ?? strategyState.customStrategyState,
+      customStrategyState: strategyResult.customState,
       startingAllElementProps: strategyState.startingAllElementProps,
     }
     return {


### PR DESCRIPTION
**Problem:**
Sometimes when reparenting an element it ends up inside a component that doesn't render its children, potentially based on some condition. So even though we might detect that it utilises the `children` property those children aren't rendered.

**Fix:**
If the element(s) reparented cannot be detected when they have been reparented then the cursor will change to indicate this. The detection is done against the `spyMetadata`, as that loses elements that have not been rendered, by checking against an array produced by the strategy.

**Commit Details:**
- Added `reparentedToPaths` to `CustomStrategyState`.
- Removed the null part of the type union for
  `StrategyApplicationResult.customState`, if a strategy
  wants to return the current custom state it's simpler
  to return it. The `null` made it difficult to clean up
  a value like `reparentedToPaths` if the strategy changed.
- Added `cursorForMissingReparentedItems` to perform the lookup
  associated with a reparented element suddenly not being rendered
  anymore.
- `CursorOverlay` now takes account of the missing reparented item
  case.
