### PR TITLE
For absolute moves and resizes, check that the target supports style property.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-move-strategy.tsx
@@ -28,6 +28,7 @@ import {
   getMultiselectBounds,
   snapDrag,
 } from './shared-absolute-move-strategy-helpers'
+import { supportsStyle } from './absolute-utils'
 
 export const absoluteMoveStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_MOVE',
@@ -38,7 +39,10 @@ export const absoluteMoveStrategy: CanvasStrategy = {
       return filteredSelectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
 
-        return elementMetadata?.specialSizeMeasurements.position === 'absolute'
+        return (
+          elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
+          supportsStyle(canvasState, element)
+        )
       })
     } else {
       return false

--- a/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/absolute-resize-bounding-box-strategy.tsx
@@ -38,6 +38,7 @@ import * as EP from '../../../core/shared/element-path'
 import { ZeroSizeResizeControlWrapper } from '../controls/zero-sized-element-controls'
 import { SetCssLengthProperty, setCssLengthProperty } from '../commands/set-css-length-command'
 import { pushIntendedBounds } from '../commands/push-intended-bounds-command'
+import { supportsStyle } from './absolute-utils'
 
 export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
   id: 'ABSOLUTE_RESIZE_BOUNDING_BOX',
@@ -47,7 +48,10 @@ export const absoluteResizeBoundingBoxStrategy: CanvasStrategy = {
       const filteredSelectedElements = getDragTargets(canvasState.selectedElements)
       return filteredSelectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
-        return elementMetadata?.specialSizeMeasurements.position === 'absolute'
+        return (
+          elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
+          supportsStyle(canvasState, element)
+        )
       })
     } else {
       return false

--- a/editor/src/components/canvas/canvas-strategies/absolute-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/absolute-utils.ts
@@ -1,0 +1,12 @@
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { ElementPath } from '../../../core/shared/project-file-types'
+import { InteractionCanvasState } from './canvas-strategy-types'
+
+export function supportsStyle(canvasState: InteractionCanvasState, element: ElementPath): boolean {
+  return MetadataUtils.targetUsesProperty(
+    canvasState.projectContents,
+    canvasState.openFile,
+    element,
+    'style',
+  )
+}

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-move-strategy.ts
@@ -42,6 +42,7 @@ import Utils from '../../../utils/utils'
 import { StrategyState, InteractionSession } from './interaction-state'
 import { pushIntendedBounds } from '../commands/push-intended-bounds-command'
 import { CanvasFrameAndTarget } from '../canvas-types'
+import { supportsStyle } from './absolute-utils'
 
 export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
   id: 'KEYBOARD_ABSOLUTE_MOVE',
@@ -50,8 +51,10 @@ export const keyboardAbsoluteMoveStrategy: CanvasStrategy = {
     if (canvasState.selectedElements.length > 0) {
       return canvasState.selectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
-
-        return elementMetadata?.specialSizeMeasurements.position === 'absolute'
+        return (
+          elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
+          supportsStyle(canvasState, element)
+        )
       })
     } else {
       return false

--- a/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/keyboard-absolute-resize-strategy.tsx
@@ -30,6 +30,7 @@ import {
 import { getMultiselectBounds } from './shared-absolute-move-strategy-helpers'
 import { setSnappingGuidelines } from '../commands/set-snapping-guidelines-command'
 import { pushIntendedBounds } from '../commands/push-intended-bounds-command'
+import { supportsStyle } from './absolute-utils'
 
 interface VectorAndEdge {
   movement: CanvasVector
@@ -77,8 +78,10 @@ export const keyboardAbsoluteResizeStrategy: CanvasStrategy = {
     if (canvasState.selectedElements.length > 0) {
       return canvasState.selectedElements.every((element) => {
         const elementMetadata = MetadataUtils.findElementByElementPath(metadata, element)
-
-        return elementMetadata?.specialSizeMeasurements.position === 'absolute'
+        return (
+          elementMetadata?.specialSizeMeasurements.position === 'absolute' &&
+          supportsStyle(canvasState, element)
+        )
       })
     } else {
       return false

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -615,22 +615,12 @@ export const MetadataUtils = {
               isGivenUtopiaElementFromMetadata(instance, 'Text')
             )
           } else {
-            if (openFile == null) {
-              return false
-            } else {
-              const underlyingComponent = findUnderlyingTargetComponentImplementation(
-                projectContents,
-                {},
-                openFile,
-                instance.elementPath,
-              )
-              if (underlyingComponent == null) {
-                // Could be an external third party component, assuming true for now.
-                return true
-              } else {
-                return componentUsesProperty(underlyingComponent, 'children')
-              }
-            }
+            return MetadataUtils.targetUsesProperty(
+              projectContents,
+              openFile,
+              instance.elementPath,
+              'children',
+            )
           }
         }
         // We don't know at this stage
@@ -649,6 +639,29 @@ export const MetadataUtils = {
     return instance == null
       ? false
       : MetadataUtils.targetElementSupportsChildren(projectContents, openFile, instance)
+  },
+  targetUsesProperty(
+    projectContents: ProjectContentTreeRoot,
+    openFile: string | null | undefined,
+    target: ElementPath,
+    property: string,
+  ): boolean {
+    if (openFile == null) {
+      return false
+    } else {
+      const underlyingComponent = findUnderlyingTargetComponentImplementation(
+        projectContents,
+        {},
+        openFile,
+        target,
+      )
+      if (underlyingComponent == null) {
+        // Could be an external third party component, assuming true for now.
+        return true
+      } else {
+        return componentUsesProperty(underlyingComponent, property)
+      }
+    }
   },
   getTextContentOfElement(element: ElementInstanceMetadata): string | null {
     if (isRight(element.element) && isJSXElement(element.element.value)) {


### PR DESCRIPTION
**Problem:**
Components which don't pass through the `style` property in any way means that those cannot be repositioned/resized by changing the `style` props assigned to an instance of that component.

**Fix:**
The absolute strategies now have an additional filter to their `isApplicable` check which is that the underlying components use the `style` property.

**Commit Details:**
- Added `supportsStyle` utility function to make it convenient
  to check for supporting the style prop in canvas strategies.
- Slightly refactored some code to create the `targetUsesProperty`
  function in `MetadataUtils`.
- Added a `supportsStyle` invocation to all the absolute canvas strategies.
- Added a test case that confirms that resize is disabled for the
  absolute cases.
