### PR TITLE
Correct the ordering of setting the storedState during dispatches

### DIFF
--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -370,10 +370,10 @@ export class Editor {
         if (PerformanceMarks) {
           performance.mark(`update canvas ${updateId}`)
         }
-        ElementsToRerenderGLOBAL.current = dispatchResult.patchedEditor.canvas.elementsToRerender // Mutation!
+        ElementsToRerenderGLOBAL.current = this.storedState.patchedEditor.canvas.elementsToRerender // Mutation!
         ReactDOM.flushSync(() => {
           ReactDOM.unstable_batchedUpdates(() => {
-            this.updateCanvasStore(patchedStoreFromFullStore(dispatchResult))
+            this.updateCanvasStore(patchedStoreFromFullStore(this.storedState))
           })
         })
         if (PerformanceMarks) {

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -361,7 +361,8 @@ export class Editor {
         dispatchResult.patchedEditor,
       )
 
-      let dispatchResultWithMetadata = dispatchResult
+      this.storedState = dispatchResult
+      let entireUpdateFinished = dispatchResult.entireUpdateFinished
 
       if (!dispatchResult.nothingChanged) {
         const updateId = canvasUpdateId++
@@ -390,18 +391,18 @@ export class Editor {
 
         const domWalkerResult = runDomWalker({
           domWalkerMutableState: this.domWalkerMutableState,
-          selectedViews: dispatchResult.patchedEditor.selectedViews,
-          elementsToFocusOn: dispatchResult.patchedEditor.canvas.elementsToRerender,
-          scale: dispatchResult.patchedEditor.canvas.scale,
+          selectedViews: this.storedState.patchedEditor.selectedViews,
+          elementsToFocusOn: this.storedState.patchedEditor.canvas.elementsToRerender,
+          scale: this.storedState.patchedEditor.canvas.scale,
           additionalElementsToUpdate:
-            dispatchResult.patchedEditor.canvas.domWalkerAdditionalElementsToUpdate,
+            this.storedState.patchedEditor.canvas.domWalkerAdditionalElementsToUpdate,
           rootMetadataInStateRef: {
-            current: dispatchResult.patchedEditor.domMetadata,
+            current: this.storedState.patchedEditor.domMetadata,
           },
         })
 
         if (domWalkerResult != null) {
-          dispatchResultWithMetadata = editorDispatch(
+          const dispatchResultWithMetadata = editorDispatch(
             this.boundDispatch,
             [
               EditorActions.saveDOMReport(
@@ -410,9 +411,14 @@ export class Editor {
                 domWalkerResult.invalidatedPaths,
               ),
             ],
-            dispatchResult,
+            this.storedState,
             this.spyCollector,
           )
+          this.storedState = dispatchResultWithMetadata
+          entireUpdateFinished = Promise.all([
+            entireUpdateFinished,
+            dispatchResultWithMetadata.entireUpdateFinished,
+          ])
         }
 
         if (PerformanceMarks) {
@@ -420,9 +426,9 @@ export class Editor {
         }
         ReactDOM.flushSync(() => {
           ReactDOM.unstable_batchedUpdates(() => {
-            this.updateStore(patchedStoreFromFullStore(dispatchResultWithMetadata))
-            if (shouldInspectorUpdate(dispatchResultWithMetadata.strategyState)) {
-              this.updateInspectorStore(patchedStoreFromFullStore(dispatchResultWithMetadata))
+            this.updateStore(patchedStoreFromFullStore(this.storedState))
+            if (shouldInspectorUpdate(this.storedState.strategyState)) {
+              this.updateInspectorStore(patchedStoreFromFullStore(this.storedState))
             }
           })
         })
@@ -436,13 +442,8 @@ export class Editor {
         }
       }
 
-      this.storedState = dispatchResultWithMetadata
-
       return {
-        entireUpdateFinished: Promise.all([
-          dispatchResult.entireUpdateFinished,
-          dispatchResultWithMetadata.entireUpdateFinished,
-        ]),
+        entireUpdateFinished: entireUpdateFinished,
       }
     }
     if (PRODUCTION_ENV) {


### PR DESCRIPTION
**Problem:**
During the editor's `boundDispatch`, we trigger some zustand `updateStore` calls before updating the value of `this.storedState`. These `updateStore` calls can result in new renders, which can then in turn immediately dispatch new actions, which would be handled before `this.storedState` had been updated, meaning they would be handled based on a previous version of the editor store.

**Fix:**
Update `this.storedState` immediately, and ensure that we are always using that rather than a (potentially outdated) dispatch result throughout the rest of the `boundDispatch` function.

As a side note, we also realised that this is potentially a problem for all actions with handlers that use a passed in `boundDispatch` as they could then be updating the store in a way that would be immediately lost, but when digging into this we found that the only concrete cases of this were calling the passed in `boundDispatch` in an async manner, circumventing the issue.
