### PR TITLE
Distinguish between item double clicks and label double clicks.

### DIFF
--- a/editor/src/components/navigator/navigator-item/item-label.tsx
+++ b/editor/src/components/navigator/navigator-item/item-label.tsx
@@ -12,7 +12,7 @@ interface ItemLabelProps {
   dispatch: EditorDispatch
   target: ElementPath
   isDynamic: boolean
-  canRename: boolean
+  selected: boolean
   name: string
   suffix?: string
   inputVisible: boolean
@@ -90,8 +90,8 @@ export class ItemLabel extends Component<ItemLabelProps, ItemLabelState> {
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
         }}
-        onDoubleClick={(e) => {
-          if (!this.props.isDynamic) {
+        onDoubleClick={(event) => {
+          if (!this.props.isDynamic && event.altKey) {
             this.props.dispatch(
               [EditorActions.setNavigatorRenamingTarget(this.props.target)],
               'leftpane',

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -311,11 +311,14 @@ export const NavigatorItem: React.FunctionComponent<
     () => highlightItem(dispatch, elementPath, selected, isHighlighted),
     [dispatch, elementPath, selected, isHighlighted],
   )
-  const focusComponent = React.useCallback(() => {
-    if (isFocusableComponent) {
-      dispatch([EditorActions.setFocusedElement(elementPath)])
-    }
-  }, [dispatch, elementPath, isFocusableComponent])
+  const focusComponent = React.useCallback(
+    (event: React.MouseEvent) => {
+      if (isFocusableComponent && !event.altKey) {
+        dispatch([EditorActions.setFocusedElement(elementPath)])
+      }
+    },
+    [dispatch, elementPath, isFocusableComponent],
+  )
 
   const containerStyle: React.CSSProperties = React.useMemo(() => {
     return {
@@ -400,7 +403,7 @@ const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         name={props.label}
         isDynamic={props.isDynamic}
         target={props.elementPath}
-        canRename={props.selected}
+        selected={props.selected}
         dispatch={props.dispatch}
         inputVisible={EP.pathsEqual(props.renamingTarget, props.elementPath)}
         elementOriginType={props.elementOriginType}


### PR DESCRIPTION
**Problem:**
Currently double clicking on the navigator item label activates an `onDoubleClick` handler for both the label and the item, which focuses it and activates renaming.

**Fix:**
The renaming is now tied to the `alt` key as a modified, whereas the focusing on the item only works if the `alt` key is not pressed down.

**Notes:**
This will function slightly weirdly until https://github.com/concrete-utopia/utopia/pull/2468 is merged.

**Commit Details:**
- Renamed `ItemLabelProps.canRename` to `ItemLabelProps.selected` as
  that's what it actually represents.
- `ItemLabel` `onDoubleClick` handler requires the alt key to be depressed.
- `NavigatorItem` `onDoubleClick` handler requires that the alt key is not
  depressed to work.
