### PR TITLE
Spike: arbitrary blocks in navigator

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2914,17 +2914,21 @@ export function getValidElementPathsFromElement(
     //     <AppAsVariable />
     //   </div>
     // }
-    let paths: Array<ElementPath> = []
+    const uid = getUtopiaID(element)
+    const path = parentIsInstance
+      ? EP.appendNewElementPath(parentPath, uid)
+      : EP.appendToPath(parentPath, uid)
+    let paths = [path]
     fastForEach(Object.values(element.elementsWithin), (e) =>
       paths.push(
         ...getValidElementPathsFromElement(
           focusedElementPath,
           e,
-          parentPath,
+          path,
           projectContents,
           filePath,
-          parentIsScene,
-          parentIsInstance,
+          false,
+          false,
           transientFilesState,
           resolve,
         ),

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -80,16 +80,7 @@ export function createLookupRender(
       jsxAttributeValue(generatedUID, emptyComments),
     )
 
-    // TODO BALAZS should this be here? or should the arbitrary block never have a template path with that last generated element?
-    const elementPathWithoutTheLastElementBecauseThatsAWeirdGeneratedUID = optionalMap(
-      EP.parentPath,
-      elementPath,
-    )
-
-    const innerPath = optionalMap(
-      (path) => EP.appendToPath(path, generatedUID),
-      elementPathWithoutTheLastElementBecauseThatsAWeirdGeneratedUID,
-    )
+    const innerPath = optionalMap((path) => EP.appendToPath(path, generatedUID), elementPath)
 
     let augmentedInnerElement = element
     forEachRight(withGeneratedUID, (attrs) => {

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -892,9 +892,6 @@ export const MetadataUtils = {
                   if (isJSXTextBlock(firstChild)) {
                     return firstChild.text
                   }
-                  if (isJSXArbitraryBlock(firstChild)) {
-                    return `{${firstChild.originalJavascript}}`
-                  }
                 }
               }
               // With images, take their alt and src properties as possible names first.

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -253,6 +253,29 @@ function transformAtPathOptionally(
         }
       }
     } else if (isJSXArbitraryBlock(element)) {
+      if (getUtopiaID(element) === firstUIDOrIndex) {
+        let childrenUpdated: boolean = false
+        const updatedChildren = Object.values(element.elementsWithin).reduce(
+          (acc, child): ElementsWithin => {
+            const updated = findAndTransformAtPathInner(child, tailPath)
+            if (updated != null && isJSXElement(updated)) {
+              childrenUpdated = true
+              return {
+                ...acc,
+                [child.uid]: updated,
+              }
+            }
+            return acc
+          },
+          element.elementsWithin,
+        )
+        if (childrenUpdated) {
+          return {
+            ...element,
+            elementsWithin: updatedChildren,
+          }
+        }
+      }
       if (firstUIDOrIndex in element.elementsWithin) {
         const updated = findAndTransformAtPathInner(
           element.elementsWithin[firstUIDOrIndex],
@@ -337,6 +360,23 @@ export function findJSXElementChildAtPath(
         }
       }
     } else if (isJSXArbitraryBlock(element)) {
+      const uid = getUtopiaID(element)
+      if (uid === firstUIDOrIndex) {
+        const tailPath = workingPath.slice(1)
+        if (tailPath.length === 0) {
+          // this is the element we want
+          return element
+        } else {
+          // we will want to delve into the children
+          const children = Object.values(element.elementsWithin)
+          for (const child of children) {
+            const childResult = findAtPathInner(child, tailPath)
+            if (childResult != null) {
+              return childResult
+            }
+          }
+        }
+      }
       if (firstUIDOrIndex in element.elementsWithin) {
         const elementWithin = element.elementsWithin[firstUIDOrIndex]
         const withinResult = findAtPathInner(elementWithin, workingPath)


### PR DESCRIPTION
In this spike arbitrary blocks appear in the navigator.

# Notes:
- arbitrary blocks happear in the elementpath hierarchy, they are addressable (using their uniqueId, which is long, but works for now)
- arbitrary block uid is not persistent (needs parser-printer modifications) and can not be set in the project code
- arbitrary blocks do not appear in the metadata, because neither the spy nor the dom walker use them
- they still appear in the navigator, but they don't have bounds, so nothing happens on hover
- you can drag/resize children (if they are absolute), just like on master, that affects all the children
- you can select arbitrary blocks in the navigator, which is useful to delete, copy paste, but has problematic side effects (e.g. you can try to rename, or set properties using the inspector. If you do these, there will be exceptions and nothing will happen)